### PR TITLE
Add async call stacks to the public API, use it in `wasi:http`

### DIFF
--- a/crates/component-macro/tests/expanded/char.rs
+++ b/crates/component-macro/tests/expanded/char.rs
@@ -332,32 +332,42 @@ pub mod exports {
                     }
                 }
                 impl Guest {
+                    pub fn func_take_char(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(char,), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (char,),
+                                (),
+                            >::new_unchecked(self.take_char)
+                        }
+                    }
                     /// A function that accepts a character
                     pub fn call_take_char<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                         arg0: char,
                     ) -> wasmtime::Result<()> {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (char,),
-                                (),
-                            >::new_unchecked(self.take_char)
-                        };
+                        let callee = self.func_take_char();
                         let () = callee.call(store.as_context_mut(), (arg0,))?;
                         Ok(())
+                    }
+                    pub fn func_return_char(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(), (char,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (char,),
+                            >::new_unchecked(self.return_char)
+                        }
                     }
                     /// A function that returns a character
                     pub fn call_return_char<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                     ) -> wasmtime::Result<char> {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (char,),
-                            >::new_unchecked(self.return_char)
-                        };
+                        let callee = self.func_return_char();
                         let (ret0,) = callee.call(store.as_context_mut(), ())?;
                         Ok(ret0)
                     }

--- a/crates/component-macro/tests/expanded/char_async.rs
+++ b/crates/component-macro/tests/expanded/char_async.rs
@@ -346,6 +346,16 @@ pub mod exports {
                     }
                 }
                 impl Guest {
+                    pub fn func_take_char(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(char,), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (char,),
+                                (),
+                            >::new_unchecked(self.take_char)
+                        }
+                    }
                     /// A function that accepts a character
                     pub async fn call_take_char<S: wasmtime::AsContextMut>(
                         &self,
@@ -355,16 +365,21 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (char,),
-                                (),
-                            >::new_unchecked(self.take_char)
-                        };
+                        let callee = self.func_take_char();
                         let () = callee
                             .call_async(store.as_context_mut(), (arg0,))
                             .await?;
                         Ok(())
+                    }
+                    pub fn func_return_char(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(), (char,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (char,),
+                            >::new_unchecked(self.return_char)
+                        }
                     }
                     /// A function that returns a character
                     pub async fn call_return_char<S: wasmtime::AsContextMut>(
@@ -374,12 +389,7 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (char,),
-                            >::new_unchecked(self.return_char)
-                        };
+                        let callee = self.func_return_char();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), ())
                             .await?;

--- a/crates/component-macro/tests/expanded/char_concurrent.rs
+++ b/crates/component-macro/tests/expanded/char_concurrent.rs
@@ -325,6 +325,16 @@ pub mod exports {
                     }
                 }
                 impl Guest {
+                    pub fn func_take_char(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(char,), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (char,),
+                                (),
+                            >::new_unchecked(self.take_char)
+                        }
+                    }
                     /// A function that accepts a character
                     pub async fn call_take_char<_T, _D>(
                         &self,
@@ -335,14 +345,19 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (char,),
-                                (),
-                            >::new_unchecked(self.take_char)
-                        };
+                        let callee = self.func_take_char();
                         let () = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(())
+                    }
+                    pub fn func_return_char(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(), (char,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (char,),
+                            >::new_unchecked(self.return_char)
+                        }
                     }
                     /// A function that returns a character
                     pub async fn call_return_char<_T, _D>(
@@ -353,12 +368,7 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (char,),
-                            >::new_unchecked(self.return_char)
-                        };
+                        let callee = self.func_return_char();
                         let (ret0,) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
                     }

--- a/crates/component-macro/tests/expanded/char_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/char_tracing_async.rs
@@ -375,6 +375,16 @@ pub mod exports {
                     }
                 }
                 impl Guest {
+                    pub fn func_take_char(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(char,), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (char,),
+                                (),
+                            >::new_unchecked(self.take_char)
+                        }
+                    }
                     /// A function that accepts a character
                     pub async fn call_take_char<S: wasmtime::AsContextMut>(
                         &self,
@@ -389,17 +399,22 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/chars", function = "take-char",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (char,),
-                                (),
-                            >::new_unchecked(self.take_char)
-                        };
+                        let callee = self.func_take_char();
                         let () = callee
                             .call_async(store.as_context_mut(), (arg0,))
                             .instrument(span.clone())
                             .await?;
                         Ok(())
+                    }
+                    pub fn func_return_char(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(), (char,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (char,),
+                            >::new_unchecked(self.return_char)
+                        }
                     }
                     /// A function that returns a character
                     pub async fn call_return_char<S: wasmtime::AsContextMut>(
@@ -414,12 +429,7 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/chars", function = "return-char",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (char,),
-                            >::new_unchecked(self.return_char)
-                        };
+                        let callee = self.func_return_char();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), ())
                             .instrument(span.clone())

--- a/crates/component-macro/tests/expanded/conventions.rs
+++ b/crates/component-macro/tests/expanded/conventions.rs
@@ -626,109 +626,153 @@ pub mod exports {
                     }
                 }
                 impl Guest {
-                    pub fn call_kebab_case<S: wasmtime::AsContextMut>(
+                    pub fn func_kebab_case(
                         &self,
-                        mut store: S,
-                    ) -> wasmtime::Result<()> {
-                        let callee = unsafe {
+                    ) -> wasmtime::component::TypedFunc<(), ()> {
+                        unsafe {
                             wasmtime::component::TypedFunc::<
                                 (),
                                 (),
                             >::new_unchecked(self.kebab_case)
-                        };
+                        }
+                    }
+                    pub fn call_kebab_case<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<()> {
+                        let callee = self.func_kebab_case();
                         let () = callee.call(store.as_context_mut(), ())?;
                         Ok(())
+                    }
+                    pub fn func_foo(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(LudicrousSpeed,), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (LudicrousSpeed,),
+                                (),
+                            >::new_unchecked(self.foo)
+                        }
                     }
                     pub fn call_foo<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                         arg0: LudicrousSpeed,
                     ) -> wasmtime::Result<()> {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (LudicrousSpeed,),
-                                (),
-                            >::new_unchecked(self.foo)
-                        };
+                        let callee = self.func_foo();
                         let () = callee.call(store.as_context_mut(), (arg0,))?;
                         Ok(())
+                    }
+                    pub fn func_function_with_dashes(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (),
+                            >::new_unchecked(self.function_with_dashes)
+                        }
                     }
                     pub fn call_function_with_dashes<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                     ) -> wasmtime::Result<()> {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (),
-                            >::new_unchecked(self.function_with_dashes)
-                        };
+                        let callee = self.func_function_with_dashes();
                         let () = callee.call(store.as_context_mut(), ())?;
                         Ok(())
                     }
-                    pub fn call_function_with_no_weird_characters<
-                        S: wasmtime::AsContextMut,
-                    >(&self, mut store: S) -> wasmtime::Result<()> {
-                        let callee = unsafe {
+                    pub fn func_function_with_no_weird_characters(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(), ()> {
+                        unsafe {
                             wasmtime::component::TypedFunc::<
                                 (),
                                 (),
                             >::new_unchecked(self.function_with_no_weird_characters)
-                        };
+                        }
+                    }
+                    pub fn call_function_with_no_weird_characters<
+                        S: wasmtime::AsContextMut,
+                    >(&self, mut store: S) -> wasmtime::Result<()> {
+                        let callee = self.func_function_with_no_weird_characters();
                         let () = callee.call(store.as_context_mut(), ())?;
                         Ok(())
+                    }
+                    pub fn func_apple(&self) -> wasmtime::component::TypedFunc<(), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (),
+                            >::new_unchecked(self.apple)
+                        }
                     }
                     pub fn call_apple<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                     ) -> wasmtime::Result<()> {
-                        let callee = unsafe {
+                        let callee = self.func_apple();
+                        let () = callee.call(store.as_context_mut(), ())?;
+                        Ok(())
+                    }
+                    pub fn func_apple_pear(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(), ()> {
+                        unsafe {
                             wasmtime::component::TypedFunc::<
                                 (),
                                 (),
-                            >::new_unchecked(self.apple)
-                        };
-                        let () = callee.call(store.as_context_mut(), ())?;
-                        Ok(())
+                            >::new_unchecked(self.apple_pear)
+                        }
                     }
                     pub fn call_apple_pear<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                     ) -> wasmtime::Result<()> {
-                        let callee = unsafe {
+                        let callee = self.func_apple_pear();
+                        let () = callee.call(store.as_context_mut(), ())?;
+                        Ok(())
+                    }
+                    pub fn func_apple_pear_grape(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(), ()> {
+                        unsafe {
                             wasmtime::component::TypedFunc::<
                                 (),
                                 (),
-                            >::new_unchecked(self.apple_pear)
-                        };
-                        let () = callee.call(store.as_context_mut(), ())?;
-                        Ok(())
+                            >::new_unchecked(self.apple_pear_grape)
+                        }
                     }
                     pub fn call_apple_pear_grape<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                     ) -> wasmtime::Result<()> {
-                        let callee = unsafe {
+                        let callee = self.func_apple_pear_grape();
+                        let () = callee.call(store.as_context_mut(), ())?;
+                        Ok(())
+                    }
+                    pub fn func_a0(&self) -> wasmtime::component::TypedFunc<(), ()> {
+                        unsafe {
                             wasmtime::component::TypedFunc::<
                                 (),
                                 (),
-                            >::new_unchecked(self.apple_pear_grape)
-                        };
-                        let () = callee.call(store.as_context_mut(), ())?;
-                        Ok(())
+                            >::new_unchecked(self.a0)
+                        }
                     }
                     pub fn call_a0<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                     ) -> wasmtime::Result<()> {
-                        let callee = unsafe {
+                        let callee = self.func_a0();
+                        let () = callee.call(store.as_context_mut(), ())?;
+                        Ok(())
+                    }
+                    pub fn func_is_xml(&self) -> wasmtime::component::TypedFunc<(), ()> {
+                        unsafe {
                             wasmtime::component::TypedFunc::<
                                 (),
                                 (),
-                            >::new_unchecked(self.a0)
-                        };
-                        let () = callee.call(store.as_context_mut(), ())?;
-                        Ok(())
+                            >::new_unchecked(self.is_xml)
+                        }
                     }
                     /// Comment out identifiers that collide when mapped to snake_case, for now; see
                     ///  https://github.com/WebAssembly/component-model/issues/118
@@ -739,52 +783,60 @@ pub mod exports {
                         &self,
                         mut store: S,
                     ) -> wasmtime::Result<()> {
-                        let callee = unsafe {
+                        let callee = self.func_is_xml();
+                        let () = callee.call(store.as_context_mut(), ())?;
+                        Ok(())
+                    }
+                    pub fn func_explicit(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(), ()> {
+                        unsafe {
                             wasmtime::component::TypedFunc::<
                                 (),
                                 (),
-                            >::new_unchecked(self.is_xml)
-                        };
-                        let () = callee.call(store.as_context_mut(), ())?;
-                        Ok(())
+                            >::new_unchecked(self.explicit)
+                        }
                     }
                     pub fn call_explicit<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                     ) -> wasmtime::Result<()> {
-                        let callee = unsafe {
+                        let callee = self.func_explicit();
+                        let () = callee.call(store.as_context_mut(), ())?;
+                        Ok(())
+                    }
+                    pub fn func_explicit_kebab(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(), ()> {
+                        unsafe {
                             wasmtime::component::TypedFunc::<
                                 (),
                                 (),
-                            >::new_unchecked(self.explicit)
-                        };
-                        let () = callee.call(store.as_context_mut(), ())?;
-                        Ok(())
+                            >::new_unchecked(self.explicit_kebab)
+                        }
                     }
                     pub fn call_explicit_kebab<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                     ) -> wasmtime::Result<()> {
-                        let callee = unsafe {
+                        let callee = self.func_explicit_kebab();
+                        let () = callee.call(store.as_context_mut(), ())?;
+                        Ok(())
+                    }
+                    pub fn func_bool(&self) -> wasmtime::component::TypedFunc<(), ()> {
+                        unsafe {
                             wasmtime::component::TypedFunc::<
                                 (),
                                 (),
-                            >::new_unchecked(self.explicit_kebab)
-                        };
-                        let () = callee.call(store.as_context_mut(), ())?;
-                        Ok(())
+                            >::new_unchecked(self.bool)
+                        }
                     }
                     /// Identifiers with the same name as keywords are quoted.
                     pub fn call_bool<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                     ) -> wasmtime::Result<()> {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (),
-                            >::new_unchecked(self.bool)
-                        };
+                        let callee = self.func_bool();
                         let () = callee.call(store.as_context_mut(), ())?;
                         Ok(())
                     }

--- a/crates/component-macro/tests/expanded/conventions_async.rs
+++ b/crates/component-macro/tests/expanded/conventions_async.rs
@@ -684,6 +684,16 @@ pub mod exports {
                     }
                 }
                 impl Guest {
+                    pub fn func_kebab_case(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (),
+                            >::new_unchecked(self.kebab_case)
+                        }
+                    }
                     pub async fn call_kebab_case<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
@@ -691,14 +701,19 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (),
-                            >::new_unchecked(self.kebab_case)
-                        };
+                        let callee = self.func_kebab_case();
                         let () = callee.call_async(store.as_context_mut(), ()).await?;
                         Ok(())
+                    }
+                    pub fn func_foo(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(LudicrousSpeed,), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (LudicrousSpeed,),
+                                (),
+                            >::new_unchecked(self.foo)
+                        }
                     }
                     pub async fn call_foo<S: wasmtime::AsContextMut>(
                         &self,
@@ -708,16 +723,21 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (LudicrousSpeed,),
-                                (),
-                            >::new_unchecked(self.foo)
-                        };
+                        let callee = self.func_foo();
                         let () = callee
                             .call_async(store.as_context_mut(), (arg0,))
                             .await?;
                         Ok(())
+                    }
+                    pub fn func_function_with_dashes(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (),
+                            >::new_unchecked(self.function_with_dashes)
+                        }
                     }
                     pub async fn call_function_with_dashes<S: wasmtime::AsContextMut>(
                         &self,
@@ -726,14 +746,19 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
+                        let callee = self.func_function_with_dashes();
+                        let () = callee.call_async(store.as_context_mut(), ()).await?;
+                        Ok(())
+                    }
+                    pub fn func_function_with_no_weird_characters(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(), ()> {
+                        unsafe {
                             wasmtime::component::TypedFunc::<
                                 (),
                                 (),
-                            >::new_unchecked(self.function_with_dashes)
-                        };
-                        let () = callee.call_async(store.as_context_mut(), ()).await?;
-                        Ok(())
+                            >::new_unchecked(self.function_with_no_weird_characters)
+                        }
                     }
                     pub async fn call_function_with_no_weird_characters<
                         S: wasmtime::AsContextMut,
@@ -741,14 +766,17 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
+                        let callee = self.func_function_with_no_weird_characters();
+                        let () = callee.call_async(store.as_context_mut(), ()).await?;
+                        Ok(())
+                    }
+                    pub fn func_apple(&self) -> wasmtime::component::TypedFunc<(), ()> {
+                        unsafe {
                             wasmtime::component::TypedFunc::<
                                 (),
                                 (),
-                            >::new_unchecked(self.function_with_no_weird_characters)
-                        };
-                        let () = callee.call_async(store.as_context_mut(), ()).await?;
-                        Ok(())
+                            >::new_unchecked(self.apple)
+                        }
                     }
                     pub async fn call_apple<S: wasmtime::AsContextMut>(
                         &self,
@@ -757,14 +785,19 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
+                        let callee = self.func_apple();
+                        let () = callee.call_async(store.as_context_mut(), ()).await?;
+                        Ok(())
+                    }
+                    pub fn func_apple_pear(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(), ()> {
+                        unsafe {
                             wasmtime::component::TypedFunc::<
                                 (),
                                 (),
-                            >::new_unchecked(self.apple)
-                        };
-                        let () = callee.call_async(store.as_context_mut(), ()).await?;
-                        Ok(())
+                            >::new_unchecked(self.apple_pear)
+                        }
                     }
                     pub async fn call_apple_pear<S: wasmtime::AsContextMut>(
                         &self,
@@ -773,14 +806,19 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
+                        let callee = self.func_apple_pear();
+                        let () = callee.call_async(store.as_context_mut(), ()).await?;
+                        Ok(())
+                    }
+                    pub fn func_apple_pear_grape(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(), ()> {
+                        unsafe {
                             wasmtime::component::TypedFunc::<
                                 (),
                                 (),
-                            >::new_unchecked(self.apple_pear)
-                        };
-                        let () = callee.call_async(store.as_context_mut(), ()).await?;
-                        Ok(())
+                            >::new_unchecked(self.apple_pear_grape)
+                        }
                     }
                     pub async fn call_apple_pear_grape<S: wasmtime::AsContextMut>(
                         &self,
@@ -789,14 +827,17 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
+                        let callee = self.func_apple_pear_grape();
+                        let () = callee.call_async(store.as_context_mut(), ()).await?;
+                        Ok(())
+                    }
+                    pub fn func_a0(&self) -> wasmtime::component::TypedFunc<(), ()> {
+                        unsafe {
                             wasmtime::component::TypedFunc::<
                                 (),
                                 (),
-                            >::new_unchecked(self.apple_pear_grape)
-                        };
-                        let () = callee.call_async(store.as_context_mut(), ()).await?;
-                        Ok(())
+                            >::new_unchecked(self.a0)
+                        }
                     }
                     pub async fn call_a0<S: wasmtime::AsContextMut>(
                         &self,
@@ -805,14 +846,17 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
+                        let callee = self.func_a0();
+                        let () = callee.call_async(store.as_context_mut(), ()).await?;
+                        Ok(())
+                    }
+                    pub fn func_is_xml(&self) -> wasmtime::component::TypedFunc<(), ()> {
+                        unsafe {
                             wasmtime::component::TypedFunc::<
                                 (),
                                 (),
-                            >::new_unchecked(self.a0)
-                        };
-                        let () = callee.call_async(store.as_context_mut(), ()).await?;
-                        Ok(())
+                            >::new_unchecked(self.is_xml)
+                        }
                     }
                     /// Comment out identifiers that collide when mapped to snake_case, for now; see
                     ///  https://github.com/WebAssembly/component-model/issues/118
@@ -826,14 +870,19 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
+                        let callee = self.func_is_xml();
+                        let () = callee.call_async(store.as_context_mut(), ()).await?;
+                        Ok(())
+                    }
+                    pub fn func_explicit(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(), ()> {
+                        unsafe {
                             wasmtime::component::TypedFunc::<
                                 (),
                                 (),
-                            >::new_unchecked(self.is_xml)
-                        };
-                        let () = callee.call_async(store.as_context_mut(), ()).await?;
-                        Ok(())
+                            >::new_unchecked(self.explicit)
+                        }
                     }
                     pub async fn call_explicit<S: wasmtime::AsContextMut>(
                         &self,
@@ -842,14 +891,19 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
+                        let callee = self.func_explicit();
+                        let () = callee.call_async(store.as_context_mut(), ()).await?;
+                        Ok(())
+                    }
+                    pub fn func_explicit_kebab(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(), ()> {
+                        unsafe {
                             wasmtime::component::TypedFunc::<
                                 (),
                                 (),
-                            >::new_unchecked(self.explicit)
-                        };
-                        let () = callee.call_async(store.as_context_mut(), ()).await?;
-                        Ok(())
+                            >::new_unchecked(self.explicit_kebab)
+                        }
                     }
                     pub async fn call_explicit_kebab<S: wasmtime::AsContextMut>(
                         &self,
@@ -858,14 +912,17 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
+                        let callee = self.func_explicit_kebab();
+                        let () = callee.call_async(store.as_context_mut(), ()).await?;
+                        Ok(())
+                    }
+                    pub fn func_bool(&self) -> wasmtime::component::TypedFunc<(), ()> {
+                        unsafe {
                             wasmtime::component::TypedFunc::<
                                 (),
                                 (),
-                            >::new_unchecked(self.explicit_kebab)
-                        };
-                        let () = callee.call_async(store.as_context_mut(), ()).await?;
-                        Ok(())
+                            >::new_unchecked(self.bool)
+                        }
                     }
                     /// Identifiers with the same name as keywords are quoted.
                     pub async fn call_bool<S: wasmtime::AsContextMut>(
@@ -875,12 +932,7 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (),
-                            >::new_unchecked(self.bool)
-                        };
+                        let callee = self.func_bool();
                         let () = callee.call_async(store.as_context_mut(), ()).await?;
                         Ok(())
                     }

--- a/crates/component-macro/tests/expanded/conventions_concurrent.rs
+++ b/crates/component-macro/tests/expanded/conventions_concurrent.rs
@@ -632,6 +632,16 @@ pub mod exports {
                     }
                 }
                 impl Guest {
+                    pub fn func_kebab_case(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (),
+                            >::new_unchecked(self.kebab_case)
+                        }
+                    }
                     pub async fn call_kebab_case<_T, _D>(
                         &self,
                         accessor: &wasmtime::component::Accessor<_T, _D>,
@@ -640,14 +650,19 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (),
-                            >::new_unchecked(self.kebab_case)
-                        };
+                        let callee = self.func_kebab_case();
                         let () = callee.call_concurrent(accessor, ()).await?;
                         Ok(())
+                    }
+                    pub fn func_foo(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(LudicrousSpeed,), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (LudicrousSpeed,),
+                                (),
+                            >::new_unchecked(self.foo)
+                        }
                     }
                     pub async fn call_foo<_T, _D>(
                         &self,
@@ -658,14 +673,19 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (LudicrousSpeed,),
-                                (),
-                            >::new_unchecked(self.foo)
-                        };
+                        let callee = self.func_foo();
                         let () = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(())
+                    }
+                    pub fn func_function_with_dashes(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (),
+                            >::new_unchecked(self.function_with_dashes)
+                        }
                     }
                     pub async fn call_function_with_dashes<_T, _D>(
                         &self,
@@ -675,14 +695,19 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
+                        let callee = self.func_function_with_dashes();
+                        let () = callee.call_concurrent(accessor, ()).await?;
+                        Ok(())
+                    }
+                    pub fn func_function_with_no_weird_characters(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(), ()> {
+                        unsafe {
                             wasmtime::component::TypedFunc::<
                                 (),
                                 (),
-                            >::new_unchecked(self.function_with_dashes)
-                        };
-                        let () = callee.call_concurrent(accessor, ()).await?;
-                        Ok(())
+                            >::new_unchecked(self.function_with_no_weird_characters)
+                        }
                     }
                     pub async fn call_function_with_no_weird_characters<_T, _D>(
                         &self,
@@ -692,14 +717,17 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
+                        let callee = self.func_function_with_no_weird_characters();
+                        let () = callee.call_concurrent(accessor, ()).await?;
+                        Ok(())
+                    }
+                    pub fn func_apple(&self) -> wasmtime::component::TypedFunc<(), ()> {
+                        unsafe {
                             wasmtime::component::TypedFunc::<
                                 (),
                                 (),
-                            >::new_unchecked(self.function_with_no_weird_characters)
-                        };
-                        let () = callee.call_concurrent(accessor, ()).await?;
-                        Ok(())
+                            >::new_unchecked(self.apple)
+                        }
                     }
                     pub async fn call_apple<_T, _D>(
                         &self,
@@ -709,14 +737,19 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
+                        let callee = self.func_apple();
+                        let () = callee.call_concurrent(accessor, ()).await?;
+                        Ok(())
+                    }
+                    pub fn func_apple_pear(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(), ()> {
+                        unsafe {
                             wasmtime::component::TypedFunc::<
                                 (),
                                 (),
-                            >::new_unchecked(self.apple)
-                        };
-                        let () = callee.call_concurrent(accessor, ()).await?;
-                        Ok(())
+                            >::new_unchecked(self.apple_pear)
+                        }
                     }
                     pub async fn call_apple_pear<_T, _D>(
                         &self,
@@ -726,14 +759,19 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
+                        let callee = self.func_apple_pear();
+                        let () = callee.call_concurrent(accessor, ()).await?;
+                        Ok(())
+                    }
+                    pub fn func_apple_pear_grape(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(), ()> {
+                        unsafe {
                             wasmtime::component::TypedFunc::<
                                 (),
                                 (),
-                            >::new_unchecked(self.apple_pear)
-                        };
-                        let () = callee.call_concurrent(accessor, ()).await?;
-                        Ok(())
+                            >::new_unchecked(self.apple_pear_grape)
+                        }
                     }
                     pub async fn call_apple_pear_grape<_T, _D>(
                         &self,
@@ -743,14 +781,17 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
+                        let callee = self.func_apple_pear_grape();
+                        let () = callee.call_concurrent(accessor, ()).await?;
+                        Ok(())
+                    }
+                    pub fn func_a0(&self) -> wasmtime::component::TypedFunc<(), ()> {
+                        unsafe {
                             wasmtime::component::TypedFunc::<
                                 (),
                                 (),
-                            >::new_unchecked(self.apple_pear_grape)
-                        };
-                        let () = callee.call_concurrent(accessor, ()).await?;
-                        Ok(())
+                            >::new_unchecked(self.a0)
+                        }
                     }
                     pub async fn call_a0<_T, _D>(
                         &self,
@@ -760,14 +801,17 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
+                        let callee = self.func_a0();
+                        let () = callee.call_concurrent(accessor, ()).await?;
+                        Ok(())
+                    }
+                    pub fn func_is_xml(&self) -> wasmtime::component::TypedFunc<(), ()> {
+                        unsafe {
                             wasmtime::component::TypedFunc::<
                                 (),
                                 (),
-                            >::new_unchecked(self.a0)
-                        };
-                        let () = callee.call_concurrent(accessor, ()).await?;
-                        Ok(())
+                            >::new_unchecked(self.is_xml)
+                        }
                     }
                     /// Comment out identifiers that collide when mapped to snake_case, for now; see
                     ///  https://github.com/WebAssembly/component-model/issues/118
@@ -782,14 +826,19 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
+                        let callee = self.func_is_xml();
+                        let () = callee.call_concurrent(accessor, ()).await?;
+                        Ok(())
+                    }
+                    pub fn func_explicit(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(), ()> {
+                        unsafe {
                             wasmtime::component::TypedFunc::<
                                 (),
                                 (),
-                            >::new_unchecked(self.is_xml)
-                        };
-                        let () = callee.call_concurrent(accessor, ()).await?;
-                        Ok(())
+                            >::new_unchecked(self.explicit)
+                        }
                     }
                     pub async fn call_explicit<_T, _D>(
                         &self,
@@ -799,14 +848,19 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
+                        let callee = self.func_explicit();
+                        let () = callee.call_concurrent(accessor, ()).await?;
+                        Ok(())
+                    }
+                    pub fn func_explicit_kebab(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(), ()> {
+                        unsafe {
                             wasmtime::component::TypedFunc::<
                                 (),
                                 (),
-                            >::new_unchecked(self.explicit)
-                        };
-                        let () = callee.call_concurrent(accessor, ()).await?;
-                        Ok(())
+                            >::new_unchecked(self.explicit_kebab)
+                        }
                     }
                     pub async fn call_explicit_kebab<_T, _D>(
                         &self,
@@ -816,14 +870,17 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
+                        let callee = self.func_explicit_kebab();
+                        let () = callee.call_concurrent(accessor, ()).await?;
+                        Ok(())
+                    }
+                    pub fn func_bool(&self) -> wasmtime::component::TypedFunc<(), ()> {
+                        unsafe {
                             wasmtime::component::TypedFunc::<
                                 (),
                                 (),
-                            >::new_unchecked(self.explicit_kebab)
-                        };
-                        let () = callee.call_concurrent(accessor, ()).await?;
-                        Ok(())
+                            >::new_unchecked(self.bool)
+                        }
                     }
                     /// Identifiers with the same name as keywords are quoted.
                     pub async fn call_bool<_T, _D>(
@@ -834,12 +891,7 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (),
-                            >::new_unchecked(self.bool)
-                        };
+                        let callee = self.func_bool();
                         let () = callee.call_concurrent(accessor, ()).await?;
                         Ok(())
                     }

--- a/crates/component-macro/tests/expanded/conventions_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/conventions_tracing_async.rs
@@ -844,6 +844,16 @@ pub mod exports {
                     }
                 }
                 impl Guest {
+                    pub fn func_kebab_case(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (),
+                            >::new_unchecked(self.kebab_case)
+                        }
+                    }
                     pub async fn call_kebab_case<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
@@ -856,17 +866,22 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/conventions", function = "kebab-case",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (),
-                            >::new_unchecked(self.kebab_case)
-                        };
+                        let callee = self.func_kebab_case();
                         let () = callee
                             .call_async(store.as_context_mut(), ())
                             .instrument(span.clone())
                             .await?;
                         Ok(())
+                    }
+                    pub fn func_foo(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(LudicrousSpeed,), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (LudicrousSpeed,),
+                                (),
+                            >::new_unchecked(self.foo)
+                        }
                     }
                     pub async fn call_foo<S: wasmtime::AsContextMut>(
                         &self,
@@ -881,17 +896,22 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/conventions", function = "foo",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (LudicrousSpeed,),
-                                (),
-                            >::new_unchecked(self.foo)
-                        };
+                        let callee = self.func_foo();
                         let () = callee
                             .call_async(store.as_context_mut(), (arg0,))
                             .instrument(span.clone())
                             .await?;
                         Ok(())
+                    }
+                    pub fn func_function_with_dashes(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (),
+                            >::new_unchecked(self.function_with_dashes)
+                        }
                     }
                     pub async fn call_function_with_dashes<S: wasmtime::AsContextMut>(
                         &self,
@@ -905,17 +925,22 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/conventions", function = "function-with-dashes",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (),
-                            >::new_unchecked(self.function_with_dashes)
-                        };
+                        let callee = self.func_function_with_dashes();
                         let () = callee
                             .call_async(store.as_context_mut(), ())
                             .instrument(span.clone())
                             .await?;
                         Ok(())
+                    }
+                    pub fn func_function_with_no_weird_characters(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (),
+                            >::new_unchecked(self.function_with_no_weird_characters)
+                        }
                     }
                     pub async fn call_function_with_no_weird_characters<
                         S: wasmtime::AsContextMut,
@@ -929,17 +954,20 @@ pub mod exports {
                             "foo:foo/conventions", function =
                             "function-with-no-weird-characters",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (),
-                            >::new_unchecked(self.function_with_no_weird_characters)
-                        };
+                        let callee = self.func_function_with_no_weird_characters();
                         let () = callee
                             .call_async(store.as_context_mut(), ())
                             .instrument(span.clone())
                             .await?;
                         Ok(())
+                    }
+                    pub fn func_apple(&self) -> wasmtime::component::TypedFunc<(), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (),
+                            >::new_unchecked(self.apple)
+                        }
                     }
                     pub async fn call_apple<S: wasmtime::AsContextMut>(
                         &self,
@@ -953,17 +981,22 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/conventions", function = "apple",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (),
-                            >::new_unchecked(self.apple)
-                        };
+                        let callee = self.func_apple();
                         let () = callee
                             .call_async(store.as_context_mut(), ())
                             .instrument(span.clone())
                             .await?;
                         Ok(())
+                    }
+                    pub fn func_apple_pear(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (),
+                            >::new_unchecked(self.apple_pear)
+                        }
                     }
                     pub async fn call_apple_pear<S: wasmtime::AsContextMut>(
                         &self,
@@ -977,17 +1010,22 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/conventions", function = "apple-pear",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (),
-                            >::new_unchecked(self.apple_pear)
-                        };
+                        let callee = self.func_apple_pear();
                         let () = callee
                             .call_async(store.as_context_mut(), ())
                             .instrument(span.clone())
                             .await?;
                         Ok(())
+                    }
+                    pub fn func_apple_pear_grape(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (),
+                            >::new_unchecked(self.apple_pear_grape)
+                        }
                     }
                     pub async fn call_apple_pear_grape<S: wasmtime::AsContextMut>(
                         &self,
@@ -1001,17 +1039,20 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/conventions", function = "apple-pear-grape",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (),
-                            >::new_unchecked(self.apple_pear_grape)
-                        };
+                        let callee = self.func_apple_pear_grape();
                         let () = callee
                             .call_async(store.as_context_mut(), ())
                             .instrument(span.clone())
                             .await?;
                         Ok(())
+                    }
+                    pub fn func_a0(&self) -> wasmtime::component::TypedFunc<(), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (),
+                            >::new_unchecked(self.a0)
+                        }
                     }
                     pub async fn call_a0<S: wasmtime::AsContextMut>(
                         &self,
@@ -1025,17 +1066,20 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/conventions", function = "a0",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (),
-                            >::new_unchecked(self.a0)
-                        };
+                        let callee = self.func_a0();
                         let () = callee
                             .call_async(store.as_context_mut(), ())
                             .instrument(span.clone())
                             .await?;
                         Ok(())
+                    }
+                    pub fn func_is_xml(&self) -> wasmtime::component::TypedFunc<(), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (),
+                            >::new_unchecked(self.is_xml)
+                        }
                     }
                     /// Comment out identifiers that collide when mapped to snake_case, for now; see
                     ///  https://github.com/WebAssembly/component-model/issues/118
@@ -1054,17 +1098,22 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/conventions", function = "is-XML",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (),
-                            >::new_unchecked(self.is_xml)
-                        };
+                        let callee = self.func_is_xml();
                         let () = callee
                             .call_async(store.as_context_mut(), ())
                             .instrument(span.clone())
                             .await?;
                         Ok(())
+                    }
+                    pub fn func_explicit(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (),
+                            >::new_unchecked(self.explicit)
+                        }
                     }
                     pub async fn call_explicit<S: wasmtime::AsContextMut>(
                         &self,
@@ -1078,17 +1127,22 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/conventions", function = "explicit",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (),
-                            >::new_unchecked(self.explicit)
-                        };
+                        let callee = self.func_explicit();
                         let () = callee
                             .call_async(store.as_context_mut(), ())
                             .instrument(span.clone())
                             .await?;
                         Ok(())
+                    }
+                    pub fn func_explicit_kebab(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (),
+                            >::new_unchecked(self.explicit_kebab)
+                        }
                     }
                     pub async fn call_explicit_kebab<S: wasmtime::AsContextMut>(
                         &self,
@@ -1102,17 +1156,20 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/conventions", function = "explicit-kebab",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (),
-                            >::new_unchecked(self.explicit_kebab)
-                        };
+                        let callee = self.func_explicit_kebab();
                         let () = callee
                             .call_async(store.as_context_mut(), ())
                             .instrument(span.clone())
                             .await?;
                         Ok(())
+                    }
+                    pub fn func_bool(&self) -> wasmtime::component::TypedFunc<(), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (),
+                            >::new_unchecked(self.bool)
+                        }
                     }
                     /// Identifiers with the same name as keywords are quoted.
                     pub async fn call_bool<S: wasmtime::AsContextMut>(
@@ -1127,12 +1184,7 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/conventions", function = "bool",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (),
-                            >::new_unchecked(self.bool)
-                        };
+                        let callee = self.func_bool();
                         let () = callee
                             .call_async(store.as_context_mut(), ())
                             .instrument(span.clone())

--- a/crates/component-macro/tests/expanded/flags.rs
+++ b/crates/component-macro/tests/expanded/flags.rs
@@ -730,101 +730,136 @@ pub mod exports {
                     }
                 }
                 impl Guest {
+                    pub fn func_roundtrip_flag1(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(Flag1,), (Flag1,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (Flag1,),
+                                (Flag1,),
+                            >::new_unchecked(self.roundtrip_flag1)
+                        }
+                    }
                     pub fn call_roundtrip_flag1<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                         arg0: Flag1,
                     ) -> wasmtime::Result<Flag1> {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (Flag1,),
-                                (Flag1,),
-                            >::new_unchecked(self.roundtrip_flag1)
-                        };
+                        let callee = self.func_roundtrip_flag1();
                         let (ret0,) = callee.call(store.as_context_mut(), (arg0,))?;
                         Ok(ret0)
+                    }
+                    pub fn func_roundtrip_flag2(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(Flag2,), (Flag2,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (Flag2,),
+                                (Flag2,),
+                            >::new_unchecked(self.roundtrip_flag2)
+                        }
                     }
                     pub fn call_roundtrip_flag2<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                         arg0: Flag2,
                     ) -> wasmtime::Result<Flag2> {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (Flag2,),
-                                (Flag2,),
-                            >::new_unchecked(self.roundtrip_flag2)
-                        };
+                        let callee = self.func_roundtrip_flag2();
                         let (ret0,) = callee.call(store.as_context_mut(), (arg0,))?;
                         Ok(ret0)
+                    }
+                    pub fn func_roundtrip_flag4(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(Flag4,), (Flag4,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (Flag4,),
+                                (Flag4,),
+                            >::new_unchecked(self.roundtrip_flag4)
+                        }
                     }
                     pub fn call_roundtrip_flag4<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                         arg0: Flag4,
                     ) -> wasmtime::Result<Flag4> {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (Flag4,),
-                                (Flag4,),
-                            >::new_unchecked(self.roundtrip_flag4)
-                        };
+                        let callee = self.func_roundtrip_flag4();
                         let (ret0,) = callee.call(store.as_context_mut(), (arg0,))?;
                         Ok(ret0)
+                    }
+                    pub fn func_roundtrip_flag8(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(Flag8,), (Flag8,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (Flag8,),
+                                (Flag8,),
+                            >::new_unchecked(self.roundtrip_flag8)
+                        }
                     }
                     pub fn call_roundtrip_flag8<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                         arg0: Flag8,
                     ) -> wasmtime::Result<Flag8> {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (Flag8,),
-                                (Flag8,),
-                            >::new_unchecked(self.roundtrip_flag8)
-                        };
+                        let callee = self.func_roundtrip_flag8();
                         let (ret0,) = callee.call(store.as_context_mut(), (arg0,))?;
                         Ok(ret0)
+                    }
+                    pub fn func_roundtrip_flag16(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(Flag16,), (Flag16,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (Flag16,),
+                                (Flag16,),
+                            >::new_unchecked(self.roundtrip_flag16)
+                        }
                     }
                     pub fn call_roundtrip_flag16<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                         arg0: Flag16,
                     ) -> wasmtime::Result<Flag16> {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (Flag16,),
-                                (Flag16,),
-                            >::new_unchecked(self.roundtrip_flag16)
-                        };
+                        let callee = self.func_roundtrip_flag16();
                         let (ret0,) = callee.call(store.as_context_mut(), (arg0,))?;
                         Ok(ret0)
+                    }
+                    pub fn func_roundtrip_flag32(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(Flag32,), (Flag32,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (Flag32,),
+                                (Flag32,),
+                            >::new_unchecked(self.roundtrip_flag32)
+                        }
                     }
                     pub fn call_roundtrip_flag32<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                         arg0: Flag32,
                     ) -> wasmtime::Result<Flag32> {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (Flag32,),
-                                (Flag32,),
-                            >::new_unchecked(self.roundtrip_flag32)
-                        };
+                        let callee = self.func_roundtrip_flag32();
                         let (ret0,) = callee.call(store.as_context_mut(), (arg0,))?;
                         Ok(ret0)
+                    }
+                    pub fn func_roundtrip_flag64(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(Flag64,), (Flag64,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (Flag64,),
+                                (Flag64,),
+                            >::new_unchecked(self.roundtrip_flag64)
+                        }
                     }
                     pub fn call_roundtrip_flag64<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                         arg0: Flag64,
                     ) -> wasmtime::Result<Flag64> {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (Flag64,),
-                                (Flag64,),
-                            >::new_unchecked(self.roundtrip_flag64)
-                        };
+                        let callee = self.func_roundtrip_flag64();
                         let (ret0,) = callee.call(store.as_context_mut(), (arg0,))?;
                         Ok(ret0)
                     }

--- a/crates/component-macro/tests/expanded/flags_async.rs
+++ b/crates/component-macro/tests/expanded/flags_async.rs
@@ -786,6 +786,16 @@ pub mod exports {
                     }
                 }
                 impl Guest {
+                    pub fn func_roundtrip_flag1(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(Flag1,), (Flag1,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (Flag1,),
+                                (Flag1,),
+                            >::new_unchecked(self.roundtrip_flag1)
+                        }
+                    }
                     pub async fn call_roundtrip_flag1<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
@@ -794,16 +804,21 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (Flag1,),
-                                (Flag1,),
-                            >::new_unchecked(self.roundtrip_flag1)
-                        };
+                        let callee = self.func_roundtrip_flag1();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), (arg0,))
                             .await?;
                         Ok(ret0)
+                    }
+                    pub fn func_roundtrip_flag2(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(Flag2,), (Flag2,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (Flag2,),
+                                (Flag2,),
+                            >::new_unchecked(self.roundtrip_flag2)
+                        }
                     }
                     pub async fn call_roundtrip_flag2<S: wasmtime::AsContextMut>(
                         &self,
@@ -813,16 +828,21 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (Flag2,),
-                                (Flag2,),
-                            >::new_unchecked(self.roundtrip_flag2)
-                        };
+                        let callee = self.func_roundtrip_flag2();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), (arg0,))
                             .await?;
                         Ok(ret0)
+                    }
+                    pub fn func_roundtrip_flag4(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(Flag4,), (Flag4,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (Flag4,),
+                                (Flag4,),
+                            >::new_unchecked(self.roundtrip_flag4)
+                        }
                     }
                     pub async fn call_roundtrip_flag4<S: wasmtime::AsContextMut>(
                         &self,
@@ -832,16 +852,21 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (Flag4,),
-                                (Flag4,),
-                            >::new_unchecked(self.roundtrip_flag4)
-                        };
+                        let callee = self.func_roundtrip_flag4();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), (arg0,))
                             .await?;
                         Ok(ret0)
+                    }
+                    pub fn func_roundtrip_flag8(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(Flag8,), (Flag8,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (Flag8,),
+                                (Flag8,),
+                            >::new_unchecked(self.roundtrip_flag8)
+                        }
                     }
                     pub async fn call_roundtrip_flag8<S: wasmtime::AsContextMut>(
                         &self,
@@ -851,16 +876,21 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (Flag8,),
-                                (Flag8,),
-                            >::new_unchecked(self.roundtrip_flag8)
-                        };
+                        let callee = self.func_roundtrip_flag8();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), (arg0,))
                             .await?;
                         Ok(ret0)
+                    }
+                    pub fn func_roundtrip_flag16(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(Flag16,), (Flag16,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (Flag16,),
+                                (Flag16,),
+                            >::new_unchecked(self.roundtrip_flag16)
+                        }
                     }
                     pub async fn call_roundtrip_flag16<S: wasmtime::AsContextMut>(
                         &self,
@@ -870,16 +900,21 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (Flag16,),
-                                (Flag16,),
-                            >::new_unchecked(self.roundtrip_flag16)
-                        };
+                        let callee = self.func_roundtrip_flag16();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), (arg0,))
                             .await?;
                         Ok(ret0)
+                    }
+                    pub fn func_roundtrip_flag32(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(Flag32,), (Flag32,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (Flag32,),
+                                (Flag32,),
+                            >::new_unchecked(self.roundtrip_flag32)
+                        }
                     }
                     pub async fn call_roundtrip_flag32<S: wasmtime::AsContextMut>(
                         &self,
@@ -889,16 +924,21 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (Flag32,),
-                                (Flag32,),
-                            >::new_unchecked(self.roundtrip_flag32)
-                        };
+                        let callee = self.func_roundtrip_flag32();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), (arg0,))
                             .await?;
                         Ok(ret0)
+                    }
+                    pub fn func_roundtrip_flag64(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(Flag64,), (Flag64,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (Flag64,),
+                                (Flag64,),
+                            >::new_unchecked(self.roundtrip_flag64)
+                        }
                     }
                     pub async fn call_roundtrip_flag64<S: wasmtime::AsContextMut>(
                         &self,
@@ -908,12 +948,7 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (Flag64,),
-                                (Flag64,),
-                            >::new_unchecked(self.roundtrip_flag64)
-                        };
+                        let callee = self.func_roundtrip_flag64();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), (arg0,))
                             .await?;

--- a/crates/component-macro/tests/expanded/flags_concurrent.rs
+++ b/crates/component-macro/tests/expanded/flags_concurrent.rs
@@ -725,6 +725,16 @@ pub mod exports {
                     }
                 }
                 impl Guest {
+                    pub fn func_roundtrip_flag1(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(Flag1,), (Flag1,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (Flag1,),
+                                (Flag1,),
+                            >::new_unchecked(self.roundtrip_flag1)
+                        }
+                    }
                     pub async fn call_roundtrip_flag1<_T, _D>(
                         &self,
                         accessor: &wasmtime::component::Accessor<_T, _D>,
@@ -734,14 +744,19 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (Flag1,),
-                                (Flag1,),
-                            >::new_unchecked(self.roundtrip_flag1)
-                        };
+                        let callee = self.func_roundtrip_flag1();
                         let (ret0,) = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(ret0)
+                    }
+                    pub fn func_roundtrip_flag2(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(Flag2,), (Flag2,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (Flag2,),
+                                (Flag2,),
+                            >::new_unchecked(self.roundtrip_flag2)
+                        }
                     }
                     pub async fn call_roundtrip_flag2<_T, _D>(
                         &self,
@@ -752,14 +767,19 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (Flag2,),
-                                (Flag2,),
-                            >::new_unchecked(self.roundtrip_flag2)
-                        };
+                        let callee = self.func_roundtrip_flag2();
                         let (ret0,) = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(ret0)
+                    }
+                    pub fn func_roundtrip_flag4(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(Flag4,), (Flag4,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (Flag4,),
+                                (Flag4,),
+                            >::new_unchecked(self.roundtrip_flag4)
+                        }
                     }
                     pub async fn call_roundtrip_flag4<_T, _D>(
                         &self,
@@ -770,14 +790,19 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (Flag4,),
-                                (Flag4,),
-                            >::new_unchecked(self.roundtrip_flag4)
-                        };
+                        let callee = self.func_roundtrip_flag4();
                         let (ret0,) = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(ret0)
+                    }
+                    pub fn func_roundtrip_flag8(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(Flag8,), (Flag8,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (Flag8,),
+                                (Flag8,),
+                            >::new_unchecked(self.roundtrip_flag8)
+                        }
                     }
                     pub async fn call_roundtrip_flag8<_T, _D>(
                         &self,
@@ -788,14 +813,19 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (Flag8,),
-                                (Flag8,),
-                            >::new_unchecked(self.roundtrip_flag8)
-                        };
+                        let callee = self.func_roundtrip_flag8();
                         let (ret0,) = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(ret0)
+                    }
+                    pub fn func_roundtrip_flag16(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(Flag16,), (Flag16,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (Flag16,),
+                                (Flag16,),
+                            >::new_unchecked(self.roundtrip_flag16)
+                        }
                     }
                     pub async fn call_roundtrip_flag16<_T, _D>(
                         &self,
@@ -806,14 +836,19 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (Flag16,),
-                                (Flag16,),
-                            >::new_unchecked(self.roundtrip_flag16)
-                        };
+                        let callee = self.func_roundtrip_flag16();
                         let (ret0,) = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(ret0)
+                    }
+                    pub fn func_roundtrip_flag32(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(Flag32,), (Flag32,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (Flag32,),
+                                (Flag32,),
+                            >::new_unchecked(self.roundtrip_flag32)
+                        }
                     }
                     pub async fn call_roundtrip_flag32<_T, _D>(
                         &self,
@@ -824,14 +859,19 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (Flag32,),
-                                (Flag32,),
-                            >::new_unchecked(self.roundtrip_flag32)
-                        };
+                        let callee = self.func_roundtrip_flag32();
                         let (ret0,) = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(ret0)
+                    }
+                    pub fn func_roundtrip_flag64(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(Flag64,), (Flag64,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (Flag64,),
+                                (Flag64,),
+                            >::new_unchecked(self.roundtrip_flag64)
+                        }
                     }
                     pub async fn call_roundtrip_flag64<_T, _D>(
                         &self,
@@ -842,12 +882,7 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (Flag64,),
-                                (Flag64,),
-                            >::new_unchecked(self.roundtrip_flag64)
-                        };
+                        let callee = self.func_roundtrip_flag64();
                         let (ret0,) = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(ret0)
                     }

--- a/crates/component-macro/tests/expanded/flags_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/flags_tracing_async.rs
@@ -898,6 +898,16 @@ pub mod exports {
                     }
                 }
                 impl Guest {
+                    pub fn func_roundtrip_flag1(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(Flag1,), (Flag1,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (Flag1,),
+                                (Flag1,),
+                            >::new_unchecked(self.roundtrip_flag1)
+                        }
+                    }
                     pub async fn call_roundtrip_flag1<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
@@ -911,17 +921,22 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/flegs", function = "roundtrip-flag1",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (Flag1,),
-                                (Flag1,),
-                            >::new_unchecked(self.roundtrip_flag1)
-                        };
+                        let callee = self.func_roundtrip_flag1();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), (arg0,))
                             .instrument(span.clone())
                             .await?;
                         Ok(ret0)
+                    }
+                    pub fn func_roundtrip_flag2(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(Flag2,), (Flag2,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (Flag2,),
+                                (Flag2,),
+                            >::new_unchecked(self.roundtrip_flag2)
+                        }
                     }
                     pub async fn call_roundtrip_flag2<S: wasmtime::AsContextMut>(
                         &self,
@@ -936,17 +951,22 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/flegs", function = "roundtrip-flag2",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (Flag2,),
-                                (Flag2,),
-                            >::new_unchecked(self.roundtrip_flag2)
-                        };
+                        let callee = self.func_roundtrip_flag2();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), (arg0,))
                             .instrument(span.clone())
                             .await?;
                         Ok(ret0)
+                    }
+                    pub fn func_roundtrip_flag4(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(Flag4,), (Flag4,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (Flag4,),
+                                (Flag4,),
+                            >::new_unchecked(self.roundtrip_flag4)
+                        }
                     }
                     pub async fn call_roundtrip_flag4<S: wasmtime::AsContextMut>(
                         &self,
@@ -961,17 +981,22 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/flegs", function = "roundtrip-flag4",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (Flag4,),
-                                (Flag4,),
-                            >::new_unchecked(self.roundtrip_flag4)
-                        };
+                        let callee = self.func_roundtrip_flag4();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), (arg0,))
                             .instrument(span.clone())
                             .await?;
                         Ok(ret0)
+                    }
+                    pub fn func_roundtrip_flag8(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(Flag8,), (Flag8,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (Flag8,),
+                                (Flag8,),
+                            >::new_unchecked(self.roundtrip_flag8)
+                        }
                     }
                     pub async fn call_roundtrip_flag8<S: wasmtime::AsContextMut>(
                         &self,
@@ -986,17 +1011,22 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/flegs", function = "roundtrip-flag8",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (Flag8,),
-                                (Flag8,),
-                            >::new_unchecked(self.roundtrip_flag8)
-                        };
+                        let callee = self.func_roundtrip_flag8();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), (arg0,))
                             .instrument(span.clone())
                             .await?;
                         Ok(ret0)
+                    }
+                    pub fn func_roundtrip_flag16(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(Flag16,), (Flag16,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (Flag16,),
+                                (Flag16,),
+                            >::new_unchecked(self.roundtrip_flag16)
+                        }
                     }
                     pub async fn call_roundtrip_flag16<S: wasmtime::AsContextMut>(
                         &self,
@@ -1011,17 +1041,22 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/flegs", function = "roundtrip-flag16",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (Flag16,),
-                                (Flag16,),
-                            >::new_unchecked(self.roundtrip_flag16)
-                        };
+                        let callee = self.func_roundtrip_flag16();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), (arg0,))
                             .instrument(span.clone())
                             .await?;
                         Ok(ret0)
+                    }
+                    pub fn func_roundtrip_flag32(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(Flag32,), (Flag32,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (Flag32,),
+                                (Flag32,),
+                            >::new_unchecked(self.roundtrip_flag32)
+                        }
                     }
                     pub async fn call_roundtrip_flag32<S: wasmtime::AsContextMut>(
                         &self,
@@ -1036,17 +1071,22 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/flegs", function = "roundtrip-flag32",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (Flag32,),
-                                (Flag32,),
-                            >::new_unchecked(self.roundtrip_flag32)
-                        };
+                        let callee = self.func_roundtrip_flag32();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), (arg0,))
                             .instrument(span.clone())
                             .await?;
                         Ok(ret0)
+                    }
+                    pub fn func_roundtrip_flag64(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(Flag64,), (Flag64,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (Flag64,),
+                                (Flag64,),
+                            >::new_unchecked(self.roundtrip_flag64)
+                        }
                     }
                     pub async fn call_roundtrip_flag64<S: wasmtime::AsContextMut>(
                         &self,
@@ -1061,12 +1101,7 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/flegs", function = "roundtrip-flag64",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (Flag64,),
-                                (Flag64,),
-                            >::new_unchecked(self.roundtrip_flag64)
-                        };
+                        let callee = self.func_roundtrip_flag64();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), (arg0,))
                             .instrument(span.clone())

--- a/crates/component-macro/tests/expanded/floats.rs
+++ b/crates/component-macro/tests/expanded/floats.rs
@@ -367,57 +367,77 @@ pub mod exports {
                     }
                 }
                 impl Guest {
+                    pub fn func_f32_param(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(f32,), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (f32,),
+                                (),
+                            >::new_unchecked(self.f32_param)
+                        }
+                    }
                     pub fn call_f32_param<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                         arg0: f32,
                     ) -> wasmtime::Result<()> {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (f32,),
-                                (),
-                            >::new_unchecked(self.f32_param)
-                        };
+                        let callee = self.func_f32_param();
                         let () = callee.call(store.as_context_mut(), (arg0,))?;
                         Ok(())
+                    }
+                    pub fn func_f64_param(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(f64,), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (f64,),
+                                (),
+                            >::new_unchecked(self.f64_param)
+                        }
                     }
                     pub fn call_f64_param<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                         arg0: f64,
                     ) -> wasmtime::Result<()> {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (f64,),
-                                (),
-                            >::new_unchecked(self.f64_param)
-                        };
+                        let callee = self.func_f64_param();
                         let () = callee.call(store.as_context_mut(), (arg0,))?;
                         Ok(())
+                    }
+                    pub fn func_f32_result(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(), (f32,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (f32,),
+                            >::new_unchecked(self.f32_result)
+                        }
                     }
                     pub fn call_f32_result<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                     ) -> wasmtime::Result<f32> {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (f32,),
-                            >::new_unchecked(self.f32_result)
-                        };
+                        let callee = self.func_f32_result();
                         let (ret0,) = callee.call(store.as_context_mut(), ())?;
                         Ok(ret0)
+                    }
+                    pub fn func_f64_result(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(), (f64,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (f64,),
+                            >::new_unchecked(self.f64_result)
+                        }
                     }
                     pub fn call_f64_result<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                     ) -> wasmtime::Result<f64> {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (f64,),
-                            >::new_unchecked(self.f64_result)
-                        };
+                        let callee = self.func_f64_result();
                         let (ret0,) = callee.call(store.as_context_mut(), ())?;
                         Ok(ret0)
                     }

--- a/crates/component-macro/tests/expanded/floats_async.rs
+++ b/crates/component-macro/tests/expanded/floats_async.rs
@@ -395,6 +395,16 @@ pub mod exports {
                     }
                 }
                 impl Guest {
+                    pub fn func_f32_param(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(f32,), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (f32,),
+                                (),
+                            >::new_unchecked(self.f32_param)
+                        }
+                    }
                     pub async fn call_f32_param<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
@@ -403,16 +413,21 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (f32,),
-                                (),
-                            >::new_unchecked(self.f32_param)
-                        };
+                        let callee = self.func_f32_param();
                         let () = callee
                             .call_async(store.as_context_mut(), (arg0,))
                             .await?;
                         Ok(())
+                    }
+                    pub fn func_f64_param(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(f64,), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (f64,),
+                                (),
+                            >::new_unchecked(self.f64_param)
+                        }
                     }
                     pub async fn call_f64_param<S: wasmtime::AsContextMut>(
                         &self,
@@ -422,16 +437,21 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (f64,),
-                                (),
-                            >::new_unchecked(self.f64_param)
-                        };
+                        let callee = self.func_f64_param();
                         let () = callee
                             .call_async(store.as_context_mut(), (arg0,))
                             .await?;
                         Ok(())
+                    }
+                    pub fn func_f32_result(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(), (f32,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (f32,),
+                            >::new_unchecked(self.f32_result)
+                        }
                     }
                     pub async fn call_f32_result<S: wasmtime::AsContextMut>(
                         &self,
@@ -440,16 +460,21 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (f32,),
-                            >::new_unchecked(self.f32_result)
-                        };
+                        let callee = self.func_f32_result();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), ())
                             .await?;
                         Ok(ret0)
+                    }
+                    pub fn func_f64_result(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(), (f64,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (f64,),
+                            >::new_unchecked(self.f64_result)
+                        }
                     }
                     pub async fn call_f64_result<S: wasmtime::AsContextMut>(
                         &self,
@@ -458,12 +483,7 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (f64,),
-                            >::new_unchecked(self.f64_result)
-                        };
+                        let callee = self.func_f64_result();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), ())
                             .await?;

--- a/crates/component-macro/tests/expanded/floats_concurrent.rs
+++ b/crates/component-macro/tests/expanded/floats_concurrent.rs
@@ -368,6 +368,16 @@ pub mod exports {
                     }
                 }
                 impl Guest {
+                    pub fn func_f32_param(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(f32,), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (f32,),
+                                (),
+                            >::new_unchecked(self.f32_param)
+                        }
+                    }
                     pub async fn call_f32_param<_T, _D>(
                         &self,
                         accessor: &wasmtime::component::Accessor<_T, _D>,
@@ -377,14 +387,19 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (f32,),
-                                (),
-                            >::new_unchecked(self.f32_param)
-                        };
+                        let callee = self.func_f32_param();
                         let () = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(())
+                    }
+                    pub fn func_f64_param(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(f64,), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (f64,),
+                                (),
+                            >::new_unchecked(self.f64_param)
+                        }
                     }
                     pub async fn call_f64_param<_T, _D>(
                         &self,
@@ -395,14 +410,19 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (f64,),
-                                (),
-                            >::new_unchecked(self.f64_param)
-                        };
+                        let callee = self.func_f64_param();
                         let () = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(())
+                    }
+                    pub fn func_f32_result(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(), (f32,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (f32,),
+                            >::new_unchecked(self.f32_result)
+                        }
                     }
                     pub async fn call_f32_result<_T, _D>(
                         &self,
@@ -412,14 +432,19 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (f32,),
-                            >::new_unchecked(self.f32_result)
-                        };
+                        let callee = self.func_f32_result();
                         let (ret0,) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
+                    }
+                    pub fn func_f64_result(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(), (f64,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (f64,),
+                            >::new_unchecked(self.f64_result)
+                        }
                     }
                     pub async fn call_f64_result<_T, _D>(
                         &self,
@@ -429,12 +454,7 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (f64,),
-                            >::new_unchecked(self.f64_result)
-                        };
+                        let callee = self.func_f64_result();
                         let (ret0,) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
                     }

--- a/crates/component-macro/tests/expanded/floats_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/floats_tracing_async.rs
@@ -453,6 +453,16 @@ pub mod exports {
                     }
                 }
                 impl Guest {
+                    pub fn func_f32_param(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(f32,), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (f32,),
+                                (),
+                            >::new_unchecked(self.f32_param)
+                        }
+                    }
                     pub async fn call_f32_param<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
@@ -466,17 +476,22 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/floats", function = "f32-param",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (f32,),
-                                (),
-                            >::new_unchecked(self.f32_param)
-                        };
+                        let callee = self.func_f32_param();
                         let () = callee
                             .call_async(store.as_context_mut(), (arg0,))
                             .instrument(span.clone())
                             .await?;
                         Ok(())
+                    }
+                    pub fn func_f64_param(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(f64,), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (f64,),
+                                (),
+                            >::new_unchecked(self.f64_param)
+                        }
                     }
                     pub async fn call_f64_param<S: wasmtime::AsContextMut>(
                         &self,
@@ -491,17 +506,22 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/floats", function = "f64-param",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (f64,),
-                                (),
-                            >::new_unchecked(self.f64_param)
-                        };
+                        let callee = self.func_f64_param();
                         let () = callee
                             .call_async(store.as_context_mut(), (arg0,))
                             .instrument(span.clone())
                             .await?;
                         Ok(())
+                    }
+                    pub fn func_f32_result(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(), (f32,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (f32,),
+                            >::new_unchecked(self.f32_result)
+                        }
                     }
                     pub async fn call_f32_result<S: wasmtime::AsContextMut>(
                         &self,
@@ -515,17 +535,22 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/floats", function = "f32-result",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (f32,),
-                            >::new_unchecked(self.f32_result)
-                        };
+                        let callee = self.func_f32_result();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), ())
                             .instrument(span.clone())
                             .await?;
                         Ok(ret0)
+                    }
+                    pub fn func_f64_result(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(), (f64,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (f64,),
+                            >::new_unchecked(self.f64_result)
+                        }
                     }
                     pub async fn call_f64_result<S: wasmtime::AsContextMut>(
                         &self,
@@ -539,12 +564,7 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/floats", function = "f64-result",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (f64,),
-                            >::new_unchecked(self.f64_result)
-                        };
+                        let callee = self.func_f64_result();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), ())
                             .instrument(span.clone())

--- a/crates/component-macro/tests/expanded/function-new.rs
+++ b/crates/component-macro/tests/expanded/function-new.rs
@@ -180,13 +180,14 @@ const _: () = {
             let pre = linker.instantiate_pre(component)?;
             FooPre::new(pre)?.instantiate_async(store).await
         }
+        pub fn func_new(&self) -> wasmtime::component::TypedFunc<(), ()> {
+            unsafe { wasmtime::component::TypedFunc::<(), ()>::new_unchecked(self.new) }
+        }
         pub fn call_new<S: wasmtime::AsContextMut>(
             &self,
             mut store: S,
         ) -> wasmtime::Result<()> {
-            let callee = unsafe {
-                wasmtime::component::TypedFunc::<(), ()>::new_unchecked(self.new)
-            };
+            let callee = self.func_new();
             let () = callee.call(store.as_context_mut(), ())?;
             Ok(())
         }

--- a/crates/component-macro/tests/expanded/function-new_async.rs
+++ b/crates/component-macro/tests/expanded/function-new_async.rs
@@ -180,6 +180,9 @@ const _: () = {
             let pre = linker.instantiate_pre(component)?;
             FooPre::new(pre)?.instantiate_async(store).await
         }
+        pub fn func_new(&self) -> wasmtime::component::TypedFunc<(), ()> {
+            unsafe { wasmtime::component::TypedFunc::<(), ()>::new_unchecked(self.new) }
+        }
         pub async fn call_new<S: wasmtime::AsContextMut>(
             &self,
             mut store: S,
@@ -187,9 +190,7 @@ const _: () = {
         where
             <S as wasmtime::AsContext>::Data: Send,
         {
-            let callee = unsafe {
-                wasmtime::component::TypedFunc::<(), ()>::new_unchecked(self.new)
-            };
+            let callee = self.func_new();
             let () = callee.call_async(store.as_context_mut(), ()).await?;
             Ok(())
         }

--- a/crates/component-macro/tests/expanded/function-new_concurrent.rs
+++ b/crates/component-macro/tests/expanded/function-new_concurrent.rs
@@ -180,6 +180,9 @@ const _: () = {
             let pre = linker.instantiate_pre(component)?;
             FooPre::new(pre)?.instantiate_async(store).await
         }
+        pub fn func_new(&self) -> wasmtime::component::TypedFunc<(), ()> {
+            unsafe { wasmtime::component::TypedFunc::<(), ()>::new_unchecked(self.new) }
+        }
         pub async fn call_new<_T, _D>(
             &self,
             accessor: &wasmtime::component::Accessor<_T, _D>,
@@ -188,9 +191,7 @@ const _: () = {
             _T: Send,
             _D: wasmtime::component::HasData,
         {
-            let callee = unsafe {
-                wasmtime::component::TypedFunc::<(), ()>::new_unchecked(self.new)
-            };
+            let callee = self.func_new();
             let () = callee.call_concurrent(accessor, ()).await?;
             Ok(())
         }

--- a/crates/component-macro/tests/expanded/function-new_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/function-new_tracing_async.rs
@@ -180,6 +180,9 @@ const _: () = {
             let pre = linker.instantiate_pre(component)?;
             FooPre::new(pre)?.instantiate_async(store).await
         }
+        pub fn func_new(&self) -> wasmtime::component::TypedFunc<(), ()> {
+            unsafe { wasmtime::component::TypedFunc::<(), ()>::new_unchecked(self.new) }
+        }
         pub async fn call_new<S: wasmtime::AsContextMut>(
             &self,
             mut store: S,
@@ -192,9 +195,7 @@ const _: () = {
                 tracing::Level::TRACE, "wit-bindgen export", module = "default", function
                 = "new",
             );
-            let callee = unsafe {
-                wasmtime::component::TypedFunc::<(), ()>::new_unchecked(self.new)
-            };
+            let callee = self.func_new();
             let () = callee
                 .call_async(store.as_context_mut(), ())
                 .instrument(span.clone())

--- a/crates/component-macro/tests/expanded/integers.rs
+++ b/crates/component-macro/tests/expanded/integers.rs
@@ -695,117 +695,154 @@ pub mod exports {
                     }
                 }
                 impl Guest {
+                    pub fn func_a1(&self) -> wasmtime::component::TypedFunc<(u8,), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (u8,),
+                                (),
+                            >::new_unchecked(self.a1)
+                        }
+                    }
                     pub fn call_a1<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                         arg0: u8,
                     ) -> wasmtime::Result<()> {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (u8,),
-                                (),
-                            >::new_unchecked(self.a1)
-                        };
+                        let callee = self.func_a1();
                         let () = callee.call(store.as_context_mut(), (arg0,))?;
                         Ok(())
+                    }
+                    pub fn func_a2(&self) -> wasmtime::component::TypedFunc<(i8,), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (i8,),
+                                (),
+                            >::new_unchecked(self.a2)
+                        }
                     }
                     pub fn call_a2<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                         arg0: i8,
                     ) -> wasmtime::Result<()> {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (i8,),
-                                (),
-                            >::new_unchecked(self.a2)
-                        };
+                        let callee = self.func_a2();
                         let () = callee.call(store.as_context_mut(), (arg0,))?;
                         Ok(())
+                    }
+                    pub fn func_a3(&self) -> wasmtime::component::TypedFunc<(u16,), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (u16,),
+                                (),
+                            >::new_unchecked(self.a3)
+                        }
                     }
                     pub fn call_a3<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                         arg0: u16,
                     ) -> wasmtime::Result<()> {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (u16,),
-                                (),
-                            >::new_unchecked(self.a3)
-                        };
+                        let callee = self.func_a3();
                         let () = callee.call(store.as_context_mut(), (arg0,))?;
                         Ok(())
+                    }
+                    pub fn func_a4(&self) -> wasmtime::component::TypedFunc<(i16,), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (i16,),
+                                (),
+                            >::new_unchecked(self.a4)
+                        }
                     }
                     pub fn call_a4<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                         arg0: i16,
                     ) -> wasmtime::Result<()> {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (i16,),
-                                (),
-                            >::new_unchecked(self.a4)
-                        };
+                        let callee = self.func_a4();
                         let () = callee.call(store.as_context_mut(), (arg0,))?;
                         Ok(())
+                    }
+                    pub fn func_a5(&self) -> wasmtime::component::TypedFunc<(u32,), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (u32,),
+                                (),
+                            >::new_unchecked(self.a5)
+                        }
                     }
                     pub fn call_a5<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                         arg0: u32,
                     ) -> wasmtime::Result<()> {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (u32,),
-                                (),
-                            >::new_unchecked(self.a5)
-                        };
+                        let callee = self.func_a5();
                         let () = callee.call(store.as_context_mut(), (arg0,))?;
                         Ok(())
+                    }
+                    pub fn func_a6(&self) -> wasmtime::component::TypedFunc<(i32,), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (i32,),
+                                (),
+                            >::new_unchecked(self.a6)
+                        }
                     }
                     pub fn call_a6<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                         arg0: i32,
                     ) -> wasmtime::Result<()> {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (i32,),
-                                (),
-                            >::new_unchecked(self.a6)
-                        };
+                        let callee = self.func_a6();
                         let () = callee.call(store.as_context_mut(), (arg0,))?;
                         Ok(())
+                    }
+                    pub fn func_a7(&self) -> wasmtime::component::TypedFunc<(u64,), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (u64,),
+                                (),
+                            >::new_unchecked(self.a7)
+                        }
                     }
                     pub fn call_a7<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                         arg0: u64,
                     ) -> wasmtime::Result<()> {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (u64,),
-                                (),
-                            >::new_unchecked(self.a7)
-                        };
+                        let callee = self.func_a7();
                         let () = callee.call(store.as_context_mut(), (arg0,))?;
                         Ok(())
+                    }
+                    pub fn func_a8(&self) -> wasmtime::component::TypedFunc<(i64,), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (i64,),
+                                (),
+                            >::new_unchecked(self.a8)
+                        }
                     }
                     pub fn call_a8<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                         arg0: i64,
                     ) -> wasmtime::Result<()> {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (i64,),
-                                (),
-                            >::new_unchecked(self.a8)
-                        };
+                        let callee = self.func_a8();
                         let () = callee.call(store.as_context_mut(), (arg0,))?;
                         Ok(())
+                    }
+                    pub fn func_a9(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (u8, i8, u16, i16, u32, i32, u64, i64),
+                        (),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (u8, i8, u16, i16, u32, i32, u64, i64),
+                                (),
+                            >::new_unchecked(self.a9)
+                        }
                     }
                     pub fn call_a9<S: wasmtime::AsContextMut>(
                         &self,
@@ -819,12 +856,7 @@ pub mod exports {
                         arg6: u64,
                         arg7: i64,
                     ) -> wasmtime::Result<()> {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (u8, i8, u16, i16, u32, i32, u64, i64),
-                                (),
-                            >::new_unchecked(self.a9)
-                        };
+                        let callee = self.func_a9();
                         let () = callee
                             .call(
                                 store.as_context_mut(),
@@ -832,120 +864,149 @@ pub mod exports {
                             )?;
                         Ok(())
                     }
-                    pub fn call_r1<S: wasmtime::AsContextMut>(
-                        &self,
-                        mut store: S,
-                    ) -> wasmtime::Result<u8> {
-                        let callee = unsafe {
+                    pub fn func_r1(&self) -> wasmtime::component::TypedFunc<(), (u8,)> {
+                        unsafe {
                             wasmtime::component::TypedFunc::<
                                 (),
                                 (u8,),
                             >::new_unchecked(self.r1)
-                        };
+                        }
+                    }
+                    pub fn call_r1<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<u8> {
+                        let callee = self.func_r1();
                         let (ret0,) = callee.call(store.as_context_mut(), ())?;
                         Ok(ret0)
+                    }
+                    pub fn func_r2(&self) -> wasmtime::component::TypedFunc<(), (i8,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (i8,),
+                            >::new_unchecked(self.r2)
+                        }
                     }
                     pub fn call_r2<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                     ) -> wasmtime::Result<i8> {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (i8,),
-                            >::new_unchecked(self.r2)
-                        };
+                        let callee = self.func_r2();
                         let (ret0,) = callee.call(store.as_context_mut(), ())?;
                         Ok(ret0)
+                    }
+                    pub fn func_r3(&self) -> wasmtime::component::TypedFunc<(), (u16,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (u16,),
+                            >::new_unchecked(self.r3)
+                        }
                     }
                     pub fn call_r3<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                     ) -> wasmtime::Result<u16> {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (u16,),
-                            >::new_unchecked(self.r3)
-                        };
+                        let callee = self.func_r3();
                         let (ret0,) = callee.call(store.as_context_mut(), ())?;
                         Ok(ret0)
+                    }
+                    pub fn func_r4(&self) -> wasmtime::component::TypedFunc<(), (i16,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (i16,),
+                            >::new_unchecked(self.r4)
+                        }
                     }
                     pub fn call_r4<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                     ) -> wasmtime::Result<i16> {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (i16,),
-                            >::new_unchecked(self.r4)
-                        };
+                        let callee = self.func_r4();
                         let (ret0,) = callee.call(store.as_context_mut(), ())?;
                         Ok(ret0)
+                    }
+                    pub fn func_r5(&self) -> wasmtime::component::TypedFunc<(), (u32,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (u32,),
+                            >::new_unchecked(self.r5)
+                        }
                     }
                     pub fn call_r5<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                     ) -> wasmtime::Result<u32> {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (u32,),
-                            >::new_unchecked(self.r5)
-                        };
+                        let callee = self.func_r5();
                         let (ret0,) = callee.call(store.as_context_mut(), ())?;
                         Ok(ret0)
+                    }
+                    pub fn func_r6(&self) -> wasmtime::component::TypedFunc<(), (i32,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (i32,),
+                            >::new_unchecked(self.r6)
+                        }
                     }
                     pub fn call_r6<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                     ) -> wasmtime::Result<i32> {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (i32,),
-                            >::new_unchecked(self.r6)
-                        };
+                        let callee = self.func_r6();
                         let (ret0,) = callee.call(store.as_context_mut(), ())?;
                         Ok(ret0)
+                    }
+                    pub fn func_r7(&self) -> wasmtime::component::TypedFunc<(), (u64,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (u64,),
+                            >::new_unchecked(self.r7)
+                        }
                     }
                     pub fn call_r7<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                     ) -> wasmtime::Result<u64> {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (u64,),
-                            >::new_unchecked(self.r7)
-                        };
+                        let callee = self.func_r7();
                         let (ret0,) = callee.call(store.as_context_mut(), ())?;
                         Ok(ret0)
+                    }
+                    pub fn func_r8(&self) -> wasmtime::component::TypedFunc<(), (i64,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (i64,),
+                            >::new_unchecked(self.r8)
+                        }
                     }
                     pub fn call_r8<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                     ) -> wasmtime::Result<i64> {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (i64,),
-                            >::new_unchecked(self.r8)
-                        };
+                        let callee = self.func_r8();
                         let (ret0,) = callee.call(store.as_context_mut(), ())?;
                         Ok(ret0)
+                    }
+                    pub fn func_pair_ret(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(), ((i64, u8),)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                ((i64, u8),),
+                            >::new_unchecked(self.pair_ret)
+                        }
                     }
                     pub fn call_pair_ret<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                     ) -> wasmtime::Result<(i64, u8)> {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                ((i64, u8),),
-                            >::new_unchecked(self.pair_ret)
-                        };
+                        let callee = self.func_pair_ret();
                         let (ret0,) = callee.call(store.as_context_mut(), ())?;
                         Ok(ret0)
                     }

--- a/crates/component-macro/tests/expanded/integers_async.rs
+++ b/crates/component-macro/tests/expanded/integers_async.rs
@@ -784,6 +784,14 @@ pub mod exports {
                     }
                 }
                 impl Guest {
+                    pub fn func_a1(&self) -> wasmtime::component::TypedFunc<(u8,), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (u8,),
+                                (),
+                            >::new_unchecked(self.a1)
+                        }
+                    }
                     pub async fn call_a1<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
@@ -792,16 +800,19 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (u8,),
-                                (),
-                            >::new_unchecked(self.a1)
-                        };
+                        let callee = self.func_a1();
                         let () = callee
                             .call_async(store.as_context_mut(), (arg0,))
                             .await?;
                         Ok(())
+                    }
+                    pub fn func_a2(&self) -> wasmtime::component::TypedFunc<(i8,), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (i8,),
+                                (),
+                            >::new_unchecked(self.a2)
+                        }
                     }
                     pub async fn call_a2<S: wasmtime::AsContextMut>(
                         &self,
@@ -811,16 +822,19 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (i8,),
-                                (),
-                            >::new_unchecked(self.a2)
-                        };
+                        let callee = self.func_a2();
                         let () = callee
                             .call_async(store.as_context_mut(), (arg0,))
                             .await?;
                         Ok(())
+                    }
+                    pub fn func_a3(&self) -> wasmtime::component::TypedFunc<(u16,), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (u16,),
+                                (),
+                            >::new_unchecked(self.a3)
+                        }
                     }
                     pub async fn call_a3<S: wasmtime::AsContextMut>(
                         &self,
@@ -830,16 +844,19 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (u16,),
-                                (),
-                            >::new_unchecked(self.a3)
-                        };
+                        let callee = self.func_a3();
                         let () = callee
                             .call_async(store.as_context_mut(), (arg0,))
                             .await?;
                         Ok(())
+                    }
+                    pub fn func_a4(&self) -> wasmtime::component::TypedFunc<(i16,), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (i16,),
+                                (),
+                            >::new_unchecked(self.a4)
+                        }
                     }
                     pub async fn call_a4<S: wasmtime::AsContextMut>(
                         &self,
@@ -849,16 +866,19 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (i16,),
-                                (),
-                            >::new_unchecked(self.a4)
-                        };
+                        let callee = self.func_a4();
                         let () = callee
                             .call_async(store.as_context_mut(), (arg0,))
                             .await?;
                         Ok(())
+                    }
+                    pub fn func_a5(&self) -> wasmtime::component::TypedFunc<(u32,), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (u32,),
+                                (),
+                            >::new_unchecked(self.a5)
+                        }
                     }
                     pub async fn call_a5<S: wasmtime::AsContextMut>(
                         &self,
@@ -868,16 +888,19 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (u32,),
-                                (),
-                            >::new_unchecked(self.a5)
-                        };
+                        let callee = self.func_a5();
                         let () = callee
                             .call_async(store.as_context_mut(), (arg0,))
                             .await?;
                         Ok(())
+                    }
+                    pub fn func_a6(&self) -> wasmtime::component::TypedFunc<(i32,), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (i32,),
+                                (),
+                            >::new_unchecked(self.a6)
+                        }
                     }
                     pub async fn call_a6<S: wasmtime::AsContextMut>(
                         &self,
@@ -887,16 +910,19 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (i32,),
-                                (),
-                            >::new_unchecked(self.a6)
-                        };
+                        let callee = self.func_a6();
                         let () = callee
                             .call_async(store.as_context_mut(), (arg0,))
                             .await?;
                         Ok(())
+                    }
+                    pub fn func_a7(&self) -> wasmtime::component::TypedFunc<(u64,), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (u64,),
+                                (),
+                            >::new_unchecked(self.a7)
+                        }
                     }
                     pub async fn call_a7<S: wasmtime::AsContextMut>(
                         &self,
@@ -906,16 +932,19 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (u64,),
-                                (),
-                            >::new_unchecked(self.a7)
-                        };
+                        let callee = self.func_a7();
                         let () = callee
                             .call_async(store.as_context_mut(), (arg0,))
                             .await?;
                         Ok(())
+                    }
+                    pub fn func_a8(&self) -> wasmtime::component::TypedFunc<(i64,), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (i64,),
+                                (),
+                            >::new_unchecked(self.a8)
+                        }
                     }
                     pub async fn call_a8<S: wasmtime::AsContextMut>(
                         &self,
@@ -925,16 +954,24 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (i64,),
-                                (),
-                            >::new_unchecked(self.a8)
-                        };
+                        let callee = self.func_a8();
                         let () = callee
                             .call_async(store.as_context_mut(), (arg0,))
                             .await?;
                         Ok(())
+                    }
+                    pub fn func_a9(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (u8, i8, u16, i16, u32, i32, u64, i64),
+                        (),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (u8, i8, u16, i16, u32, i32, u64, i64),
+                                (),
+                            >::new_unchecked(self.a9)
+                        }
                     }
                     pub async fn call_a9<S: wasmtime::AsContextMut>(
                         &self,
@@ -951,12 +988,7 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (u8, i8, u16, i16, u32, i32, u64, i64),
-                                (),
-                            >::new_unchecked(self.a9)
-                        };
+                        let callee = self.func_a9();
                         let () = callee
                             .call_async(
                                 store.as_context_mut(),
@@ -965,6 +997,14 @@ pub mod exports {
                             .await?;
                         Ok(())
                     }
+                    pub fn func_r1(&self) -> wasmtime::component::TypedFunc<(), (u8,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (u8,),
+                            >::new_unchecked(self.r1)
+                        }
+                    }
                     pub async fn call_r1<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
@@ -972,16 +1012,19 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (u8,),
-                            >::new_unchecked(self.r1)
-                        };
+                        let callee = self.func_r1();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), ())
                             .await?;
                         Ok(ret0)
+                    }
+                    pub fn func_r2(&self) -> wasmtime::component::TypedFunc<(), (i8,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (i8,),
+                            >::new_unchecked(self.r2)
+                        }
                     }
                     pub async fn call_r2<S: wasmtime::AsContextMut>(
                         &self,
@@ -990,16 +1033,19 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (i8,),
-                            >::new_unchecked(self.r2)
-                        };
+                        let callee = self.func_r2();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), ())
                             .await?;
                         Ok(ret0)
+                    }
+                    pub fn func_r3(&self) -> wasmtime::component::TypedFunc<(), (u16,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (u16,),
+                            >::new_unchecked(self.r3)
+                        }
                     }
                     pub async fn call_r3<S: wasmtime::AsContextMut>(
                         &self,
@@ -1008,16 +1054,19 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (u16,),
-                            >::new_unchecked(self.r3)
-                        };
+                        let callee = self.func_r3();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), ())
                             .await?;
                         Ok(ret0)
+                    }
+                    pub fn func_r4(&self) -> wasmtime::component::TypedFunc<(), (i16,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (i16,),
+                            >::new_unchecked(self.r4)
+                        }
                     }
                     pub async fn call_r4<S: wasmtime::AsContextMut>(
                         &self,
@@ -1026,16 +1075,19 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (i16,),
-                            >::new_unchecked(self.r4)
-                        };
+                        let callee = self.func_r4();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), ())
                             .await?;
                         Ok(ret0)
+                    }
+                    pub fn func_r5(&self) -> wasmtime::component::TypedFunc<(), (u32,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (u32,),
+                            >::new_unchecked(self.r5)
+                        }
                     }
                     pub async fn call_r5<S: wasmtime::AsContextMut>(
                         &self,
@@ -1044,16 +1096,19 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (u32,),
-                            >::new_unchecked(self.r5)
-                        };
+                        let callee = self.func_r5();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), ())
                             .await?;
                         Ok(ret0)
+                    }
+                    pub fn func_r6(&self) -> wasmtime::component::TypedFunc<(), (i32,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (i32,),
+                            >::new_unchecked(self.r6)
+                        }
                     }
                     pub async fn call_r6<S: wasmtime::AsContextMut>(
                         &self,
@@ -1062,16 +1117,19 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (i32,),
-                            >::new_unchecked(self.r6)
-                        };
+                        let callee = self.func_r6();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), ())
                             .await?;
                         Ok(ret0)
+                    }
+                    pub fn func_r7(&self) -> wasmtime::component::TypedFunc<(), (u64,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (u64,),
+                            >::new_unchecked(self.r7)
+                        }
                     }
                     pub async fn call_r7<S: wasmtime::AsContextMut>(
                         &self,
@@ -1080,16 +1138,19 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (u64,),
-                            >::new_unchecked(self.r7)
-                        };
+                        let callee = self.func_r7();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), ())
                             .await?;
                         Ok(ret0)
+                    }
+                    pub fn func_r8(&self) -> wasmtime::component::TypedFunc<(), (i64,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (i64,),
+                            >::new_unchecked(self.r8)
+                        }
                     }
                     pub async fn call_r8<S: wasmtime::AsContextMut>(
                         &self,
@@ -1098,16 +1159,21 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (i64,),
-                            >::new_unchecked(self.r8)
-                        };
+                        let callee = self.func_r8();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), ())
                             .await?;
                         Ok(ret0)
+                    }
+                    pub fn func_pair_ret(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(), ((i64, u8),)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                ((i64, u8),),
+                            >::new_unchecked(self.pair_ret)
+                        }
                     }
                     pub async fn call_pair_ret<S: wasmtime::AsContextMut>(
                         &self,
@@ -1116,12 +1182,7 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                ((i64, u8),),
-                            >::new_unchecked(self.pair_ret)
-                        };
+                        let callee = self.func_pair_ret();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), ())
                             .await?;

--- a/crates/component-macro/tests/expanded/integers_concurrent.rs
+++ b/crates/component-macro/tests/expanded/integers_concurrent.rs
@@ -705,6 +705,14 @@ pub mod exports {
                     }
                 }
                 impl Guest {
+                    pub fn func_a1(&self) -> wasmtime::component::TypedFunc<(u8,), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (u8,),
+                                (),
+                            >::new_unchecked(self.a1)
+                        }
+                    }
                     pub async fn call_a1<_T, _D>(
                         &self,
                         accessor: &wasmtime::component::Accessor<_T, _D>,
@@ -714,14 +722,17 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (u8,),
-                                (),
-                            >::new_unchecked(self.a1)
-                        };
+                        let callee = self.func_a1();
                         let () = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(())
+                    }
+                    pub fn func_a2(&self) -> wasmtime::component::TypedFunc<(i8,), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (i8,),
+                                (),
+                            >::new_unchecked(self.a2)
+                        }
                     }
                     pub async fn call_a2<_T, _D>(
                         &self,
@@ -732,14 +743,17 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (i8,),
-                                (),
-                            >::new_unchecked(self.a2)
-                        };
+                        let callee = self.func_a2();
                         let () = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(())
+                    }
+                    pub fn func_a3(&self) -> wasmtime::component::TypedFunc<(u16,), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (u16,),
+                                (),
+                            >::new_unchecked(self.a3)
+                        }
                     }
                     pub async fn call_a3<_T, _D>(
                         &self,
@@ -750,14 +764,17 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (u16,),
-                                (),
-                            >::new_unchecked(self.a3)
-                        };
+                        let callee = self.func_a3();
                         let () = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(())
+                    }
+                    pub fn func_a4(&self) -> wasmtime::component::TypedFunc<(i16,), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (i16,),
+                                (),
+                            >::new_unchecked(self.a4)
+                        }
                     }
                     pub async fn call_a4<_T, _D>(
                         &self,
@@ -768,14 +785,17 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (i16,),
-                                (),
-                            >::new_unchecked(self.a4)
-                        };
+                        let callee = self.func_a4();
                         let () = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(())
+                    }
+                    pub fn func_a5(&self) -> wasmtime::component::TypedFunc<(u32,), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (u32,),
+                                (),
+                            >::new_unchecked(self.a5)
+                        }
                     }
                     pub async fn call_a5<_T, _D>(
                         &self,
@@ -786,14 +806,17 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (u32,),
-                                (),
-                            >::new_unchecked(self.a5)
-                        };
+                        let callee = self.func_a5();
                         let () = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(())
+                    }
+                    pub fn func_a6(&self) -> wasmtime::component::TypedFunc<(i32,), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (i32,),
+                                (),
+                            >::new_unchecked(self.a6)
+                        }
                     }
                     pub async fn call_a6<_T, _D>(
                         &self,
@@ -804,14 +827,17 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (i32,),
-                                (),
-                            >::new_unchecked(self.a6)
-                        };
+                        let callee = self.func_a6();
                         let () = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(())
+                    }
+                    pub fn func_a7(&self) -> wasmtime::component::TypedFunc<(u64,), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (u64,),
+                                (),
+                            >::new_unchecked(self.a7)
+                        }
                     }
                     pub async fn call_a7<_T, _D>(
                         &self,
@@ -822,14 +848,17 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (u64,),
-                                (),
-                            >::new_unchecked(self.a7)
-                        };
+                        let callee = self.func_a7();
                         let () = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(())
+                    }
+                    pub fn func_a8(&self) -> wasmtime::component::TypedFunc<(i64,), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (i64,),
+                                (),
+                            >::new_unchecked(self.a8)
+                        }
                     }
                     pub async fn call_a8<_T, _D>(
                         &self,
@@ -840,14 +869,22 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (i64,),
-                                (),
-                            >::new_unchecked(self.a8)
-                        };
+                        let callee = self.func_a8();
                         let () = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(())
+                    }
+                    pub fn func_a9(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (u8, i8, u16, i16, u32, i32, u64, i64),
+                        (),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (u8, i8, u16, i16, u32, i32, u64, i64),
+                                (),
+                            >::new_unchecked(self.a9)
+                        }
                     }
                     pub async fn call_a9<_T, _D>(
                         &self,
@@ -865,12 +902,7 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (u8, i8, u16, i16, u32, i32, u64, i64),
-                                (),
-                            >::new_unchecked(self.a9)
-                        };
+                        let callee = self.func_a9();
                         let () = callee
                             .call_concurrent(
                                 accessor,
@@ -878,6 +910,14 @@ pub mod exports {
                             )
                             .await?;
                         Ok(())
+                    }
+                    pub fn func_r1(&self) -> wasmtime::component::TypedFunc<(), (u8,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (u8,),
+                            >::new_unchecked(self.r1)
+                        }
                     }
                     pub async fn call_r1<_T, _D>(
                         &self,
@@ -887,14 +927,17 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (u8,),
-                            >::new_unchecked(self.r1)
-                        };
+                        let callee = self.func_r1();
                         let (ret0,) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
+                    }
+                    pub fn func_r2(&self) -> wasmtime::component::TypedFunc<(), (i8,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (i8,),
+                            >::new_unchecked(self.r2)
+                        }
                     }
                     pub async fn call_r2<_T, _D>(
                         &self,
@@ -904,14 +947,17 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (i8,),
-                            >::new_unchecked(self.r2)
-                        };
+                        let callee = self.func_r2();
                         let (ret0,) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
+                    }
+                    pub fn func_r3(&self) -> wasmtime::component::TypedFunc<(), (u16,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (u16,),
+                            >::new_unchecked(self.r3)
+                        }
                     }
                     pub async fn call_r3<_T, _D>(
                         &self,
@@ -921,14 +967,17 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (u16,),
-                            >::new_unchecked(self.r3)
-                        };
+                        let callee = self.func_r3();
                         let (ret0,) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
+                    }
+                    pub fn func_r4(&self) -> wasmtime::component::TypedFunc<(), (i16,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (i16,),
+                            >::new_unchecked(self.r4)
+                        }
                     }
                     pub async fn call_r4<_T, _D>(
                         &self,
@@ -938,14 +987,17 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (i16,),
-                            >::new_unchecked(self.r4)
-                        };
+                        let callee = self.func_r4();
                         let (ret0,) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
+                    }
+                    pub fn func_r5(&self) -> wasmtime::component::TypedFunc<(), (u32,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (u32,),
+                            >::new_unchecked(self.r5)
+                        }
                     }
                     pub async fn call_r5<_T, _D>(
                         &self,
@@ -955,14 +1007,17 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (u32,),
-                            >::new_unchecked(self.r5)
-                        };
+                        let callee = self.func_r5();
                         let (ret0,) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
+                    }
+                    pub fn func_r6(&self) -> wasmtime::component::TypedFunc<(), (i32,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (i32,),
+                            >::new_unchecked(self.r6)
+                        }
                     }
                     pub async fn call_r6<_T, _D>(
                         &self,
@@ -972,14 +1027,17 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (i32,),
-                            >::new_unchecked(self.r6)
-                        };
+                        let callee = self.func_r6();
                         let (ret0,) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
+                    }
+                    pub fn func_r7(&self) -> wasmtime::component::TypedFunc<(), (u64,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (u64,),
+                            >::new_unchecked(self.r7)
+                        }
                     }
                     pub async fn call_r7<_T, _D>(
                         &self,
@@ -989,14 +1047,17 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (u64,),
-                            >::new_unchecked(self.r7)
-                        };
+                        let callee = self.func_r7();
                         let (ret0,) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
+                    }
+                    pub fn func_r8(&self) -> wasmtime::component::TypedFunc<(), (i64,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (i64,),
+                            >::new_unchecked(self.r8)
+                        }
                     }
                     pub async fn call_r8<_T, _D>(
                         &self,
@@ -1006,14 +1067,19 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (i64,),
-                            >::new_unchecked(self.r8)
-                        };
+                        let callee = self.func_r8();
                         let (ret0,) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
+                    }
+                    pub fn func_pair_ret(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(), ((i64, u8),)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                ((i64, u8),),
+                            >::new_unchecked(self.pair_ret)
+                        }
                     }
                     pub async fn call_pair_ret<_T, _D>(
                         &self,
@@ -1023,12 +1089,7 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                ((i64, u8),),
-                            >::new_unchecked(self.pair_ret)
-                        };
+                        let callee = self.func_pair_ret();
                         let (ret0,) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
                     }

--- a/crates/component-macro/tests/expanded/integers_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/integers_tracing_async.rs
@@ -1049,6 +1049,14 @@ pub mod exports {
                     }
                 }
                 impl Guest {
+                    pub fn func_a1(&self) -> wasmtime::component::TypedFunc<(u8,), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (u8,),
+                                (),
+                            >::new_unchecked(self.a1)
+                        }
+                    }
                     pub async fn call_a1<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
@@ -1062,17 +1070,20 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/integers", function = "a1",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (u8,),
-                                (),
-                            >::new_unchecked(self.a1)
-                        };
+                        let callee = self.func_a1();
                         let () = callee
                             .call_async(store.as_context_mut(), (arg0,))
                             .instrument(span.clone())
                             .await?;
                         Ok(())
+                    }
+                    pub fn func_a2(&self) -> wasmtime::component::TypedFunc<(i8,), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (i8,),
+                                (),
+                            >::new_unchecked(self.a2)
+                        }
                     }
                     pub async fn call_a2<S: wasmtime::AsContextMut>(
                         &self,
@@ -1087,17 +1098,20 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/integers", function = "a2",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (i8,),
-                                (),
-                            >::new_unchecked(self.a2)
-                        };
+                        let callee = self.func_a2();
                         let () = callee
                             .call_async(store.as_context_mut(), (arg0,))
                             .instrument(span.clone())
                             .await?;
                         Ok(())
+                    }
+                    pub fn func_a3(&self) -> wasmtime::component::TypedFunc<(u16,), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (u16,),
+                                (),
+                            >::new_unchecked(self.a3)
+                        }
                     }
                     pub async fn call_a3<S: wasmtime::AsContextMut>(
                         &self,
@@ -1112,17 +1126,20 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/integers", function = "a3",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (u16,),
-                                (),
-                            >::new_unchecked(self.a3)
-                        };
+                        let callee = self.func_a3();
                         let () = callee
                             .call_async(store.as_context_mut(), (arg0,))
                             .instrument(span.clone())
                             .await?;
                         Ok(())
+                    }
+                    pub fn func_a4(&self) -> wasmtime::component::TypedFunc<(i16,), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (i16,),
+                                (),
+                            >::new_unchecked(self.a4)
+                        }
                     }
                     pub async fn call_a4<S: wasmtime::AsContextMut>(
                         &self,
@@ -1137,17 +1154,20 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/integers", function = "a4",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (i16,),
-                                (),
-                            >::new_unchecked(self.a4)
-                        };
+                        let callee = self.func_a4();
                         let () = callee
                             .call_async(store.as_context_mut(), (arg0,))
                             .instrument(span.clone())
                             .await?;
                         Ok(())
+                    }
+                    pub fn func_a5(&self) -> wasmtime::component::TypedFunc<(u32,), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (u32,),
+                                (),
+                            >::new_unchecked(self.a5)
+                        }
                     }
                     pub async fn call_a5<S: wasmtime::AsContextMut>(
                         &self,
@@ -1162,17 +1182,20 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/integers", function = "a5",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (u32,),
-                                (),
-                            >::new_unchecked(self.a5)
-                        };
+                        let callee = self.func_a5();
                         let () = callee
                             .call_async(store.as_context_mut(), (arg0,))
                             .instrument(span.clone())
                             .await?;
                         Ok(())
+                    }
+                    pub fn func_a6(&self) -> wasmtime::component::TypedFunc<(i32,), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (i32,),
+                                (),
+                            >::new_unchecked(self.a6)
+                        }
                     }
                     pub async fn call_a6<S: wasmtime::AsContextMut>(
                         &self,
@@ -1187,17 +1210,20 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/integers", function = "a6",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (i32,),
-                                (),
-                            >::new_unchecked(self.a6)
-                        };
+                        let callee = self.func_a6();
                         let () = callee
                             .call_async(store.as_context_mut(), (arg0,))
                             .instrument(span.clone())
                             .await?;
                         Ok(())
+                    }
+                    pub fn func_a7(&self) -> wasmtime::component::TypedFunc<(u64,), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (u64,),
+                                (),
+                            >::new_unchecked(self.a7)
+                        }
                     }
                     pub async fn call_a7<S: wasmtime::AsContextMut>(
                         &self,
@@ -1212,17 +1238,20 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/integers", function = "a7",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (u64,),
-                                (),
-                            >::new_unchecked(self.a7)
-                        };
+                        let callee = self.func_a7();
                         let () = callee
                             .call_async(store.as_context_mut(), (arg0,))
                             .instrument(span.clone())
                             .await?;
                         Ok(())
+                    }
+                    pub fn func_a8(&self) -> wasmtime::component::TypedFunc<(i64,), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (i64,),
+                                (),
+                            >::new_unchecked(self.a8)
+                        }
                     }
                     pub async fn call_a8<S: wasmtime::AsContextMut>(
                         &self,
@@ -1237,17 +1266,25 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/integers", function = "a8",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (i64,),
-                                (),
-                            >::new_unchecked(self.a8)
-                        };
+                        let callee = self.func_a8();
                         let () = callee
                             .call_async(store.as_context_mut(), (arg0,))
                             .instrument(span.clone())
                             .await?;
                         Ok(())
+                    }
+                    pub fn func_a9(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (u8, i8, u16, i16, u32, i32, u64, i64),
+                        (),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (u8, i8, u16, i16, u32, i32, u64, i64),
+                                (),
+                            >::new_unchecked(self.a9)
+                        }
                     }
                     pub async fn call_a9<S: wasmtime::AsContextMut>(
                         &self,
@@ -1269,12 +1306,7 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/integers", function = "a9",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (u8, i8, u16, i16, u32, i32, u64, i64),
-                                (),
-                            >::new_unchecked(self.a9)
-                        };
+                        let callee = self.func_a9();
                         let () = callee
                             .call_async(
                                 store.as_context_mut(),
@@ -1283,6 +1315,14 @@ pub mod exports {
                             .instrument(span.clone())
                             .await?;
                         Ok(())
+                    }
+                    pub fn func_r1(&self) -> wasmtime::component::TypedFunc<(), (u8,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (u8,),
+                            >::new_unchecked(self.r1)
+                        }
                     }
                     pub async fn call_r1<S: wasmtime::AsContextMut>(
                         &self,
@@ -1296,17 +1336,20 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/integers", function = "r1",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (u8,),
-                            >::new_unchecked(self.r1)
-                        };
+                        let callee = self.func_r1();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), ())
                             .instrument(span.clone())
                             .await?;
                         Ok(ret0)
+                    }
+                    pub fn func_r2(&self) -> wasmtime::component::TypedFunc<(), (i8,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (i8,),
+                            >::new_unchecked(self.r2)
+                        }
                     }
                     pub async fn call_r2<S: wasmtime::AsContextMut>(
                         &self,
@@ -1320,17 +1363,20 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/integers", function = "r2",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (i8,),
-                            >::new_unchecked(self.r2)
-                        };
+                        let callee = self.func_r2();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), ())
                             .instrument(span.clone())
                             .await?;
                         Ok(ret0)
+                    }
+                    pub fn func_r3(&self) -> wasmtime::component::TypedFunc<(), (u16,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (u16,),
+                            >::new_unchecked(self.r3)
+                        }
                     }
                     pub async fn call_r3<S: wasmtime::AsContextMut>(
                         &self,
@@ -1344,17 +1390,20 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/integers", function = "r3",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (u16,),
-                            >::new_unchecked(self.r3)
-                        };
+                        let callee = self.func_r3();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), ())
                             .instrument(span.clone())
                             .await?;
                         Ok(ret0)
+                    }
+                    pub fn func_r4(&self) -> wasmtime::component::TypedFunc<(), (i16,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (i16,),
+                            >::new_unchecked(self.r4)
+                        }
                     }
                     pub async fn call_r4<S: wasmtime::AsContextMut>(
                         &self,
@@ -1368,17 +1417,20 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/integers", function = "r4",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (i16,),
-                            >::new_unchecked(self.r4)
-                        };
+                        let callee = self.func_r4();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), ())
                             .instrument(span.clone())
                             .await?;
                         Ok(ret0)
+                    }
+                    pub fn func_r5(&self) -> wasmtime::component::TypedFunc<(), (u32,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (u32,),
+                            >::new_unchecked(self.r5)
+                        }
                     }
                     pub async fn call_r5<S: wasmtime::AsContextMut>(
                         &self,
@@ -1392,17 +1444,20 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/integers", function = "r5",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (u32,),
-                            >::new_unchecked(self.r5)
-                        };
+                        let callee = self.func_r5();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), ())
                             .instrument(span.clone())
                             .await?;
                         Ok(ret0)
+                    }
+                    pub fn func_r6(&self) -> wasmtime::component::TypedFunc<(), (i32,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (i32,),
+                            >::new_unchecked(self.r6)
+                        }
                     }
                     pub async fn call_r6<S: wasmtime::AsContextMut>(
                         &self,
@@ -1416,17 +1471,20 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/integers", function = "r6",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (i32,),
-                            >::new_unchecked(self.r6)
-                        };
+                        let callee = self.func_r6();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), ())
                             .instrument(span.clone())
                             .await?;
                         Ok(ret0)
+                    }
+                    pub fn func_r7(&self) -> wasmtime::component::TypedFunc<(), (u64,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (u64,),
+                            >::new_unchecked(self.r7)
+                        }
                     }
                     pub async fn call_r7<S: wasmtime::AsContextMut>(
                         &self,
@@ -1440,17 +1498,20 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/integers", function = "r7",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (u64,),
-                            >::new_unchecked(self.r7)
-                        };
+                        let callee = self.func_r7();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), ())
                             .instrument(span.clone())
                             .await?;
                         Ok(ret0)
+                    }
+                    pub fn func_r8(&self) -> wasmtime::component::TypedFunc<(), (i64,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (i64,),
+                            >::new_unchecked(self.r8)
+                        }
                     }
                     pub async fn call_r8<S: wasmtime::AsContextMut>(
                         &self,
@@ -1464,17 +1525,22 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/integers", function = "r8",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (i64,),
-                            >::new_unchecked(self.r8)
-                        };
+                        let callee = self.func_r8();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), ())
                             .instrument(span.clone())
                             .await?;
                         Ok(ret0)
+                    }
+                    pub fn func_pair_ret(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(), ((i64, u8),)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                ((i64, u8),),
+                            >::new_unchecked(self.pair_ret)
+                        }
                     }
                     pub async fn call_pair_ret<S: wasmtime::AsContextMut>(
                         &self,
@@ -1488,12 +1554,7 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/integers", function = "pair-ret",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                ((i64, u8),),
-                            >::new_unchecked(self.pair_ret)
-                        };
+                        let callee = self.func_pair_ret();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), ())
                             .instrument(span.clone())

--- a/crates/component-macro/tests/expanded/lists.rs
+++ b/crates/component-macro/tests/expanded/lists.rs
@@ -1552,275 +1552,418 @@ pub mod exports {
                     }
                 }
                 impl Guest {
+                    pub fn func_list_u8_param(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(&[u8],), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&[u8],),
+                                (),
+                            >::new_unchecked(self.list_u8_param)
+                        }
+                    }
                     pub fn call_list_u8_param<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                         arg0: &[u8],
                     ) -> wasmtime::Result<()> {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (&[u8],),
-                                (),
-                            >::new_unchecked(self.list_u8_param)
-                        };
+                        let callee = self.func_list_u8_param();
                         let () = callee.call(store.as_context_mut(), (arg0,))?;
                         Ok(())
+                    }
+                    pub fn func_list_u16_param(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(&[u16],), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&[u16],),
+                                (),
+                            >::new_unchecked(self.list_u16_param)
+                        }
                     }
                     pub fn call_list_u16_param<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                         arg0: &[u16],
                     ) -> wasmtime::Result<()> {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (&[u16],),
-                                (),
-                            >::new_unchecked(self.list_u16_param)
-                        };
+                        let callee = self.func_list_u16_param();
                         let () = callee.call(store.as_context_mut(), (arg0,))?;
                         Ok(())
+                    }
+                    pub fn func_list_u32_param(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(&[u32],), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&[u32],),
+                                (),
+                            >::new_unchecked(self.list_u32_param)
+                        }
                     }
                     pub fn call_list_u32_param<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                         arg0: &[u32],
                     ) -> wasmtime::Result<()> {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (&[u32],),
-                                (),
-                            >::new_unchecked(self.list_u32_param)
-                        };
+                        let callee = self.func_list_u32_param();
                         let () = callee.call(store.as_context_mut(), (arg0,))?;
                         Ok(())
+                    }
+                    pub fn func_list_u64_param(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(&[u64],), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&[u64],),
+                                (),
+                            >::new_unchecked(self.list_u64_param)
+                        }
                     }
                     pub fn call_list_u64_param<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                         arg0: &[u64],
                     ) -> wasmtime::Result<()> {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (&[u64],),
-                                (),
-                            >::new_unchecked(self.list_u64_param)
-                        };
+                        let callee = self.func_list_u64_param();
                         let () = callee.call(store.as_context_mut(), (arg0,))?;
                         Ok(())
+                    }
+                    pub fn func_list_s8_param(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(&[i8],), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&[i8],),
+                                (),
+                            >::new_unchecked(self.list_s8_param)
+                        }
                     }
                     pub fn call_list_s8_param<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                         arg0: &[i8],
                     ) -> wasmtime::Result<()> {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (&[i8],),
-                                (),
-                            >::new_unchecked(self.list_s8_param)
-                        };
+                        let callee = self.func_list_s8_param();
                         let () = callee.call(store.as_context_mut(), (arg0,))?;
                         Ok(())
+                    }
+                    pub fn func_list_s16_param(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(&[i16],), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&[i16],),
+                                (),
+                            >::new_unchecked(self.list_s16_param)
+                        }
                     }
                     pub fn call_list_s16_param<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                         arg0: &[i16],
                     ) -> wasmtime::Result<()> {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (&[i16],),
-                                (),
-                            >::new_unchecked(self.list_s16_param)
-                        };
+                        let callee = self.func_list_s16_param();
                         let () = callee.call(store.as_context_mut(), (arg0,))?;
                         Ok(())
+                    }
+                    pub fn func_list_s32_param(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(&[i32],), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&[i32],),
+                                (),
+                            >::new_unchecked(self.list_s32_param)
+                        }
                     }
                     pub fn call_list_s32_param<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                         arg0: &[i32],
                     ) -> wasmtime::Result<()> {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (&[i32],),
-                                (),
-                            >::new_unchecked(self.list_s32_param)
-                        };
+                        let callee = self.func_list_s32_param();
                         let () = callee.call(store.as_context_mut(), (arg0,))?;
                         Ok(())
+                    }
+                    pub fn func_list_s64_param(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(&[i64],), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&[i64],),
+                                (),
+                            >::new_unchecked(self.list_s64_param)
+                        }
                     }
                     pub fn call_list_s64_param<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                         arg0: &[i64],
                     ) -> wasmtime::Result<()> {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (&[i64],),
-                                (),
-                            >::new_unchecked(self.list_s64_param)
-                        };
+                        let callee = self.func_list_s64_param();
                         let () = callee.call(store.as_context_mut(), (arg0,))?;
                         Ok(())
+                    }
+                    pub fn func_list_f32_param(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(&[f32],), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&[f32],),
+                                (),
+                            >::new_unchecked(self.list_f32_param)
+                        }
                     }
                     pub fn call_list_f32_param<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                         arg0: &[f32],
                     ) -> wasmtime::Result<()> {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (&[f32],),
-                                (),
-                            >::new_unchecked(self.list_f32_param)
-                        };
+                        let callee = self.func_list_f32_param();
                         let () = callee.call(store.as_context_mut(), (arg0,))?;
                         Ok(())
+                    }
+                    pub fn func_list_f64_param(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(&[f64],), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&[f64],),
+                                (),
+                            >::new_unchecked(self.list_f64_param)
+                        }
                     }
                     pub fn call_list_f64_param<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                         arg0: &[f64],
                     ) -> wasmtime::Result<()> {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (&[f64],),
-                                (),
-                            >::new_unchecked(self.list_f64_param)
-                        };
+                        let callee = self.func_list_f64_param();
                         let () = callee.call(store.as_context_mut(), (arg0,))?;
                         Ok(())
+                    }
+                    pub fn func_list_u8_ret(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (),
+                        (wasmtime::component::__internal::Vec<u8>,),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (wasmtime::component::__internal::Vec<u8>,),
+                            >::new_unchecked(self.list_u8_ret)
+                        }
                     }
                     pub fn call_list_u8_ret<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                     ) -> wasmtime::Result<wasmtime::component::__internal::Vec<u8>> {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (wasmtime::component::__internal::Vec<u8>,),
-                            >::new_unchecked(self.list_u8_ret)
-                        };
+                        let callee = self.func_list_u8_ret();
                         let (ret0,) = callee.call(store.as_context_mut(), ())?;
                         Ok(ret0)
+                    }
+                    pub fn func_list_u16_ret(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (),
+                        (wasmtime::component::__internal::Vec<u16>,),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (wasmtime::component::__internal::Vec<u16>,),
+                            >::new_unchecked(self.list_u16_ret)
+                        }
                     }
                     pub fn call_list_u16_ret<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                     ) -> wasmtime::Result<wasmtime::component::__internal::Vec<u16>> {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (wasmtime::component::__internal::Vec<u16>,),
-                            >::new_unchecked(self.list_u16_ret)
-                        };
+                        let callee = self.func_list_u16_ret();
                         let (ret0,) = callee.call(store.as_context_mut(), ())?;
                         Ok(ret0)
+                    }
+                    pub fn func_list_u32_ret(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (),
+                        (wasmtime::component::__internal::Vec<u32>,),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (wasmtime::component::__internal::Vec<u32>,),
+                            >::new_unchecked(self.list_u32_ret)
+                        }
                     }
                     pub fn call_list_u32_ret<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                     ) -> wasmtime::Result<wasmtime::component::__internal::Vec<u32>> {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (wasmtime::component::__internal::Vec<u32>,),
-                            >::new_unchecked(self.list_u32_ret)
-                        };
+                        let callee = self.func_list_u32_ret();
                         let (ret0,) = callee.call(store.as_context_mut(), ())?;
                         Ok(ret0)
+                    }
+                    pub fn func_list_u64_ret(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (),
+                        (wasmtime::component::__internal::Vec<u64>,),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (wasmtime::component::__internal::Vec<u64>,),
+                            >::new_unchecked(self.list_u64_ret)
+                        }
                     }
                     pub fn call_list_u64_ret<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                     ) -> wasmtime::Result<wasmtime::component::__internal::Vec<u64>> {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (wasmtime::component::__internal::Vec<u64>,),
-                            >::new_unchecked(self.list_u64_ret)
-                        };
+                        let callee = self.func_list_u64_ret();
                         let (ret0,) = callee.call(store.as_context_mut(), ())?;
                         Ok(ret0)
+                    }
+                    pub fn func_list_s8_ret(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (),
+                        (wasmtime::component::__internal::Vec<i8>,),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (wasmtime::component::__internal::Vec<i8>,),
+                            >::new_unchecked(self.list_s8_ret)
+                        }
                     }
                     pub fn call_list_s8_ret<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                     ) -> wasmtime::Result<wasmtime::component::__internal::Vec<i8>> {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (wasmtime::component::__internal::Vec<i8>,),
-                            >::new_unchecked(self.list_s8_ret)
-                        };
+                        let callee = self.func_list_s8_ret();
                         let (ret0,) = callee.call(store.as_context_mut(), ())?;
                         Ok(ret0)
+                    }
+                    pub fn func_list_s16_ret(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (),
+                        (wasmtime::component::__internal::Vec<i16>,),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (wasmtime::component::__internal::Vec<i16>,),
+                            >::new_unchecked(self.list_s16_ret)
+                        }
                     }
                     pub fn call_list_s16_ret<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                     ) -> wasmtime::Result<wasmtime::component::__internal::Vec<i16>> {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (wasmtime::component::__internal::Vec<i16>,),
-                            >::new_unchecked(self.list_s16_ret)
-                        };
+                        let callee = self.func_list_s16_ret();
                         let (ret0,) = callee.call(store.as_context_mut(), ())?;
                         Ok(ret0)
+                    }
+                    pub fn func_list_s32_ret(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (),
+                        (wasmtime::component::__internal::Vec<i32>,),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (wasmtime::component::__internal::Vec<i32>,),
+                            >::new_unchecked(self.list_s32_ret)
+                        }
                     }
                     pub fn call_list_s32_ret<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                     ) -> wasmtime::Result<wasmtime::component::__internal::Vec<i32>> {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (wasmtime::component::__internal::Vec<i32>,),
-                            >::new_unchecked(self.list_s32_ret)
-                        };
+                        let callee = self.func_list_s32_ret();
                         let (ret0,) = callee.call(store.as_context_mut(), ())?;
                         Ok(ret0)
+                    }
+                    pub fn func_list_s64_ret(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (),
+                        (wasmtime::component::__internal::Vec<i64>,),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (wasmtime::component::__internal::Vec<i64>,),
+                            >::new_unchecked(self.list_s64_ret)
+                        }
                     }
                     pub fn call_list_s64_ret<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                     ) -> wasmtime::Result<wasmtime::component::__internal::Vec<i64>> {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (wasmtime::component::__internal::Vec<i64>,),
-                            >::new_unchecked(self.list_s64_ret)
-                        };
+                        let callee = self.func_list_s64_ret();
                         let (ret0,) = callee.call(store.as_context_mut(), ())?;
                         Ok(ret0)
+                    }
+                    pub fn func_list_f32_ret(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (),
+                        (wasmtime::component::__internal::Vec<f32>,),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (wasmtime::component::__internal::Vec<f32>,),
+                            >::new_unchecked(self.list_f32_ret)
+                        }
                     }
                     pub fn call_list_f32_ret<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                     ) -> wasmtime::Result<wasmtime::component::__internal::Vec<f32>> {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (wasmtime::component::__internal::Vec<f32>,),
-                            >::new_unchecked(self.list_f32_ret)
-                        };
+                        let callee = self.func_list_f32_ret();
                         let (ret0,) = callee.call(store.as_context_mut(), ())?;
                         Ok(ret0)
+                    }
+                    pub fn func_list_f64_ret(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (),
+                        (wasmtime::component::__internal::Vec<f64>,),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (wasmtime::component::__internal::Vec<f64>,),
+                            >::new_unchecked(self.list_f64_ret)
+                        }
                     }
                     pub fn call_list_f64_ret<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                     ) -> wasmtime::Result<wasmtime::component::__internal::Vec<f64>> {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (wasmtime::component::__internal::Vec<f64>,),
-                            >::new_unchecked(self.list_f64_ret)
-                        };
+                        let callee = self.func_list_f64_ret();
                         let (ret0,) = callee.call(store.as_context_mut(), ())?;
                         Ok(ret0)
+                    }
+                    pub fn func_tuple_list(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (&[(u8, i8)],),
+                        (wasmtime::component::__internal::Vec<(i64, u32)>,),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&[(u8, i8)],),
+                                (wasmtime::component::__internal::Vec<(i64, u32)>,),
+                            >::new_unchecked(self.tuple_list)
+                        }
                     }
                     pub fn call_tuple_list<S: wasmtime::AsContextMut>(
                         &self,
@@ -1829,28 +1972,52 @@ pub mod exports {
                     ) -> wasmtime::Result<
                         wasmtime::component::__internal::Vec<(i64, u32)>,
                     > {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (&[(u8, i8)],),
-                                (wasmtime::component::__internal::Vec<(i64, u32)>,),
-                            >::new_unchecked(self.tuple_list)
-                        };
+                        let callee = self.func_tuple_list();
                         let (ret0,) = callee.call(store.as_context_mut(), (arg0,))?;
                         Ok(ret0)
+                    }
+                    pub fn func_string_list_arg(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (&[wasmtime::component::__internal::String],),
+                        (),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&[wasmtime::component::__internal::String],),
+                                (),
+                            >::new_unchecked(self.string_list_arg)
+                        }
                     }
                     pub fn call_string_list_arg<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                         arg0: &[wasmtime::component::__internal::String],
                     ) -> wasmtime::Result<()> {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (&[wasmtime::component::__internal::String],),
-                                (),
-                            >::new_unchecked(self.string_list_arg)
-                        };
+                        let callee = self.func_string_list_arg();
                         let () = callee.call(store.as_context_mut(), (arg0,))?;
                         Ok(())
+                    }
+                    pub fn func_string_list_ret(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (),
+                        (
+                            wasmtime::component::__internal::Vec<
+                                wasmtime::component::__internal::String,
+                            >,
+                        ),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (
+                                    wasmtime::component::__internal::Vec<
+                                        wasmtime::component::__internal::String,
+                                    >,
+                                ),
+                            >::new_unchecked(self.string_list_ret)
+                        }
                     }
                     pub fn call_string_list_ret<S: wasmtime::AsContextMut>(
                         &self,
@@ -1860,18 +2027,30 @@ pub mod exports {
                             wasmtime::component::__internal::String,
                         >,
                     > {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (
-                                    wasmtime::component::__internal::Vec<
-                                        wasmtime::component::__internal::String,
-                                    >,
-                                ),
-                            >::new_unchecked(self.string_list_ret)
-                        };
+                        let callee = self.func_string_list_ret();
                         let (ret0,) = callee.call(store.as_context_mut(), ())?;
                         Ok(ret0)
+                    }
+                    pub fn func_tuple_string_list(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (&[(u8, wasmtime::component::__internal::String)],),
+                        (
+                            wasmtime::component::__internal::Vec<
+                                (wasmtime::component::__internal::String, u8),
+                            >,
+                        ),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&[(u8, wasmtime::component::__internal::String)],),
+                                (
+                                    wasmtime::component::__internal::Vec<
+                                        (wasmtime::component::__internal::String, u8),
+                                    >,
+                                ),
+                            >::new_unchecked(self.tuple_string_list)
+                        }
                     }
                     pub fn call_tuple_string_list<S: wasmtime::AsContextMut>(
                         &self,
@@ -1882,18 +2061,30 @@ pub mod exports {
                             (wasmtime::component::__internal::String, u8),
                         >,
                     > {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (&[(u8, wasmtime::component::__internal::String)],),
-                                (
-                                    wasmtime::component::__internal::Vec<
-                                        (wasmtime::component::__internal::String, u8),
-                                    >,
-                                ),
-                            >::new_unchecked(self.tuple_string_list)
-                        };
+                        let callee = self.func_tuple_string_list();
                         let (ret0,) = callee.call(store.as_context_mut(), (arg0,))?;
                         Ok(ret0)
+                    }
+                    pub fn func_string_list(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (&[wasmtime::component::__internal::String],),
+                        (
+                            wasmtime::component::__internal::Vec<
+                                wasmtime::component::__internal::String,
+                            >,
+                        ),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&[wasmtime::component::__internal::String],),
+                                (
+                                    wasmtime::component::__internal::Vec<
+                                        wasmtime::component::__internal::String,
+                                    >,
+                                ),
+                            >::new_unchecked(self.string_list)
+                        }
                     }
                     pub fn call_string_list<S: wasmtime::AsContextMut>(
                         &self,
@@ -1904,18 +2095,22 @@ pub mod exports {
                             wasmtime::component::__internal::String,
                         >,
                     > {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (&[wasmtime::component::__internal::String],),
-                                (
-                                    wasmtime::component::__internal::Vec<
-                                        wasmtime::component::__internal::String,
-                                    >,
-                                ),
-                            >::new_unchecked(self.string_list)
-                        };
+                        let callee = self.func_string_list();
                         let (ret0,) = callee.call(store.as_context_mut(), (arg0,))?;
                         Ok(ret0)
+                    }
+                    pub fn func_record_list(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (&[SomeRecord],),
+                        (wasmtime::component::__internal::Vec<OtherRecord>,),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&[SomeRecord],),
+                                (wasmtime::component::__internal::Vec<OtherRecord>,),
+                            >::new_unchecked(self.record_list)
+                        }
                     }
                     pub fn call_record_list<S: wasmtime::AsContextMut>(
                         &self,
@@ -1924,14 +2119,22 @@ pub mod exports {
                     ) -> wasmtime::Result<
                         wasmtime::component::__internal::Vec<OtherRecord>,
                     > {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (&[SomeRecord],),
-                                (wasmtime::component::__internal::Vec<OtherRecord>,),
-                            >::new_unchecked(self.record_list)
-                        };
+                        let callee = self.func_record_list();
                         let (ret0,) = callee.call(store.as_context_mut(), (arg0,))?;
                         Ok(ret0)
+                    }
+                    pub fn func_record_list_reverse(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (&[OtherRecord],),
+                        (wasmtime::component::__internal::Vec<SomeRecord>,),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&[OtherRecord],),
+                                (wasmtime::component::__internal::Vec<SomeRecord>,),
+                            >::new_unchecked(self.record_list_reverse)
+                        }
                     }
                     pub fn call_record_list_reverse<S: wasmtime::AsContextMut>(
                         &self,
@@ -1940,14 +2143,22 @@ pub mod exports {
                     ) -> wasmtime::Result<
                         wasmtime::component::__internal::Vec<SomeRecord>,
                     > {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (&[OtherRecord],),
-                                (wasmtime::component::__internal::Vec<SomeRecord>,),
-                            >::new_unchecked(self.record_list_reverse)
-                        };
+                        let callee = self.func_record_list_reverse();
                         let (ret0,) = callee.call(store.as_context_mut(), (arg0,))?;
                         Ok(ret0)
+                    }
+                    pub fn func_variant_list(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (&[SomeVariant],),
+                        (wasmtime::component::__internal::Vec<OtherVariant>,),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&[SomeVariant],),
+                                (wasmtime::component::__internal::Vec<OtherVariant>,),
+                            >::new_unchecked(self.variant_list)
+                        }
                     }
                     pub fn call_variant_list<S: wasmtime::AsContextMut>(
                         &self,
@@ -1956,26 +2167,29 @@ pub mod exports {
                     ) -> wasmtime::Result<
                         wasmtime::component::__internal::Vec<OtherVariant>,
                     > {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (&[SomeVariant],),
-                                (wasmtime::component::__internal::Vec<OtherVariant>,),
-                            >::new_unchecked(self.variant_list)
-                        };
+                        let callee = self.func_variant_list();
                         let (ret0,) = callee.call(store.as_context_mut(), (arg0,))?;
                         Ok(ret0)
+                    }
+                    pub fn func_load_store_everything(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (&LoadStoreAllSizes,),
+                        (LoadStoreAllSizes,),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&LoadStoreAllSizes,),
+                                (LoadStoreAllSizes,),
+                            >::new_unchecked(self.load_store_everything)
+                        }
                     }
                     pub fn call_load_store_everything<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                         arg0: &LoadStoreAllSizes,
                     ) -> wasmtime::Result<LoadStoreAllSizes> {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (&LoadStoreAllSizes,),
-                                (LoadStoreAllSizes,),
-                            >::new_unchecked(self.load_store_everything)
-                        };
+                        let callee = self.func_load_store_everything();
                         let (ret0,) = callee.call(store.as_context_mut(), (arg0,))?;
                         Ok(ret0)
                     }

--- a/crates/component-macro/tests/expanded/lists_async.rs
+++ b/crates/component-macro/tests/expanded/lists_async.rs
@@ -1718,6 +1718,16 @@ pub mod exports {
                     }
                 }
                 impl Guest {
+                    pub fn func_list_u8_param(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(&[u8],), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&[u8],),
+                                (),
+                            >::new_unchecked(self.list_u8_param)
+                        }
+                    }
                     pub async fn call_list_u8_param<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
@@ -1726,16 +1736,21 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (&[u8],),
-                                (),
-                            >::new_unchecked(self.list_u8_param)
-                        };
+                        let callee = self.func_list_u8_param();
                         let () = callee
                             .call_async(store.as_context_mut(), (arg0,))
                             .await?;
                         Ok(())
+                    }
+                    pub fn func_list_u16_param(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(&[u16],), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&[u16],),
+                                (),
+                            >::new_unchecked(self.list_u16_param)
+                        }
                     }
                     pub async fn call_list_u16_param<S: wasmtime::AsContextMut>(
                         &self,
@@ -1745,16 +1760,21 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (&[u16],),
-                                (),
-                            >::new_unchecked(self.list_u16_param)
-                        };
+                        let callee = self.func_list_u16_param();
                         let () = callee
                             .call_async(store.as_context_mut(), (arg0,))
                             .await?;
                         Ok(())
+                    }
+                    pub fn func_list_u32_param(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(&[u32],), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&[u32],),
+                                (),
+                            >::new_unchecked(self.list_u32_param)
+                        }
                     }
                     pub async fn call_list_u32_param<S: wasmtime::AsContextMut>(
                         &self,
@@ -1764,16 +1784,21 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (&[u32],),
-                                (),
-                            >::new_unchecked(self.list_u32_param)
-                        };
+                        let callee = self.func_list_u32_param();
                         let () = callee
                             .call_async(store.as_context_mut(), (arg0,))
                             .await?;
                         Ok(())
+                    }
+                    pub fn func_list_u64_param(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(&[u64],), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&[u64],),
+                                (),
+                            >::new_unchecked(self.list_u64_param)
+                        }
                     }
                     pub async fn call_list_u64_param<S: wasmtime::AsContextMut>(
                         &self,
@@ -1783,16 +1808,21 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (&[u64],),
-                                (),
-                            >::new_unchecked(self.list_u64_param)
-                        };
+                        let callee = self.func_list_u64_param();
                         let () = callee
                             .call_async(store.as_context_mut(), (arg0,))
                             .await?;
                         Ok(())
+                    }
+                    pub fn func_list_s8_param(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(&[i8],), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&[i8],),
+                                (),
+                            >::new_unchecked(self.list_s8_param)
+                        }
                     }
                     pub async fn call_list_s8_param<S: wasmtime::AsContextMut>(
                         &self,
@@ -1802,16 +1832,21 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (&[i8],),
-                                (),
-                            >::new_unchecked(self.list_s8_param)
-                        };
+                        let callee = self.func_list_s8_param();
                         let () = callee
                             .call_async(store.as_context_mut(), (arg0,))
                             .await?;
                         Ok(())
+                    }
+                    pub fn func_list_s16_param(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(&[i16],), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&[i16],),
+                                (),
+                            >::new_unchecked(self.list_s16_param)
+                        }
                     }
                     pub async fn call_list_s16_param<S: wasmtime::AsContextMut>(
                         &self,
@@ -1821,16 +1856,21 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (&[i16],),
-                                (),
-                            >::new_unchecked(self.list_s16_param)
-                        };
+                        let callee = self.func_list_s16_param();
                         let () = callee
                             .call_async(store.as_context_mut(), (arg0,))
                             .await?;
                         Ok(())
+                    }
+                    pub fn func_list_s32_param(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(&[i32],), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&[i32],),
+                                (),
+                            >::new_unchecked(self.list_s32_param)
+                        }
                     }
                     pub async fn call_list_s32_param<S: wasmtime::AsContextMut>(
                         &self,
@@ -1840,16 +1880,21 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (&[i32],),
-                                (),
-                            >::new_unchecked(self.list_s32_param)
-                        };
+                        let callee = self.func_list_s32_param();
                         let () = callee
                             .call_async(store.as_context_mut(), (arg0,))
                             .await?;
                         Ok(())
+                    }
+                    pub fn func_list_s64_param(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(&[i64],), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&[i64],),
+                                (),
+                            >::new_unchecked(self.list_s64_param)
+                        }
                     }
                     pub async fn call_list_s64_param<S: wasmtime::AsContextMut>(
                         &self,
@@ -1859,16 +1904,21 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (&[i64],),
-                                (),
-                            >::new_unchecked(self.list_s64_param)
-                        };
+                        let callee = self.func_list_s64_param();
                         let () = callee
                             .call_async(store.as_context_mut(), (arg0,))
                             .await?;
                         Ok(())
+                    }
+                    pub fn func_list_f32_param(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(&[f32],), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&[f32],),
+                                (),
+                            >::new_unchecked(self.list_f32_param)
+                        }
                     }
                     pub async fn call_list_f32_param<S: wasmtime::AsContextMut>(
                         &self,
@@ -1878,16 +1928,21 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (&[f32],),
-                                (),
-                            >::new_unchecked(self.list_f32_param)
-                        };
+                        let callee = self.func_list_f32_param();
                         let () = callee
                             .call_async(store.as_context_mut(), (arg0,))
                             .await?;
                         Ok(())
+                    }
+                    pub fn func_list_f64_param(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(&[f64],), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&[f64],),
+                                (),
+                            >::new_unchecked(self.list_f64_param)
+                        }
                     }
                     pub async fn call_list_f64_param<S: wasmtime::AsContextMut>(
                         &self,
@@ -1897,16 +1952,24 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (&[f64],),
-                                (),
-                            >::new_unchecked(self.list_f64_param)
-                        };
+                        let callee = self.func_list_f64_param();
                         let () = callee
                             .call_async(store.as_context_mut(), (arg0,))
                             .await?;
                         Ok(())
+                    }
+                    pub fn func_list_u8_ret(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (),
+                        (wasmtime::component::__internal::Vec<u8>,),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (wasmtime::component::__internal::Vec<u8>,),
+                            >::new_unchecked(self.list_u8_ret)
+                        }
                     }
                     pub async fn call_list_u8_ret<S: wasmtime::AsContextMut>(
                         &self,
@@ -1915,16 +1978,24 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (wasmtime::component::__internal::Vec<u8>,),
-                            >::new_unchecked(self.list_u8_ret)
-                        };
+                        let callee = self.func_list_u8_ret();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), ())
                             .await?;
                         Ok(ret0)
+                    }
+                    pub fn func_list_u16_ret(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (),
+                        (wasmtime::component::__internal::Vec<u16>,),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (wasmtime::component::__internal::Vec<u16>,),
+                            >::new_unchecked(self.list_u16_ret)
+                        }
                     }
                     pub async fn call_list_u16_ret<S: wasmtime::AsContextMut>(
                         &self,
@@ -1933,16 +2004,24 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (wasmtime::component::__internal::Vec<u16>,),
-                            >::new_unchecked(self.list_u16_ret)
-                        };
+                        let callee = self.func_list_u16_ret();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), ())
                             .await?;
                         Ok(ret0)
+                    }
+                    pub fn func_list_u32_ret(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (),
+                        (wasmtime::component::__internal::Vec<u32>,),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (wasmtime::component::__internal::Vec<u32>,),
+                            >::new_unchecked(self.list_u32_ret)
+                        }
                     }
                     pub async fn call_list_u32_ret<S: wasmtime::AsContextMut>(
                         &self,
@@ -1951,16 +2030,24 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (wasmtime::component::__internal::Vec<u32>,),
-                            >::new_unchecked(self.list_u32_ret)
-                        };
+                        let callee = self.func_list_u32_ret();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), ())
                             .await?;
                         Ok(ret0)
+                    }
+                    pub fn func_list_u64_ret(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (),
+                        (wasmtime::component::__internal::Vec<u64>,),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (wasmtime::component::__internal::Vec<u64>,),
+                            >::new_unchecked(self.list_u64_ret)
+                        }
                     }
                     pub async fn call_list_u64_ret<S: wasmtime::AsContextMut>(
                         &self,
@@ -1969,16 +2056,24 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (wasmtime::component::__internal::Vec<u64>,),
-                            >::new_unchecked(self.list_u64_ret)
-                        };
+                        let callee = self.func_list_u64_ret();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), ())
                             .await?;
                         Ok(ret0)
+                    }
+                    pub fn func_list_s8_ret(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (),
+                        (wasmtime::component::__internal::Vec<i8>,),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (wasmtime::component::__internal::Vec<i8>,),
+                            >::new_unchecked(self.list_s8_ret)
+                        }
                     }
                     pub async fn call_list_s8_ret<S: wasmtime::AsContextMut>(
                         &self,
@@ -1987,16 +2082,24 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (wasmtime::component::__internal::Vec<i8>,),
-                            >::new_unchecked(self.list_s8_ret)
-                        };
+                        let callee = self.func_list_s8_ret();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), ())
                             .await?;
                         Ok(ret0)
+                    }
+                    pub fn func_list_s16_ret(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (),
+                        (wasmtime::component::__internal::Vec<i16>,),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (wasmtime::component::__internal::Vec<i16>,),
+                            >::new_unchecked(self.list_s16_ret)
+                        }
                     }
                     pub async fn call_list_s16_ret<S: wasmtime::AsContextMut>(
                         &self,
@@ -2005,16 +2108,24 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (wasmtime::component::__internal::Vec<i16>,),
-                            >::new_unchecked(self.list_s16_ret)
-                        };
+                        let callee = self.func_list_s16_ret();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), ())
                             .await?;
                         Ok(ret0)
+                    }
+                    pub fn func_list_s32_ret(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (),
+                        (wasmtime::component::__internal::Vec<i32>,),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (wasmtime::component::__internal::Vec<i32>,),
+                            >::new_unchecked(self.list_s32_ret)
+                        }
                     }
                     pub async fn call_list_s32_ret<S: wasmtime::AsContextMut>(
                         &self,
@@ -2023,16 +2134,24 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (wasmtime::component::__internal::Vec<i32>,),
-                            >::new_unchecked(self.list_s32_ret)
-                        };
+                        let callee = self.func_list_s32_ret();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), ())
                             .await?;
                         Ok(ret0)
+                    }
+                    pub fn func_list_s64_ret(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (),
+                        (wasmtime::component::__internal::Vec<i64>,),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (wasmtime::component::__internal::Vec<i64>,),
+                            >::new_unchecked(self.list_s64_ret)
+                        }
                     }
                     pub async fn call_list_s64_ret<S: wasmtime::AsContextMut>(
                         &self,
@@ -2041,16 +2160,24 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (wasmtime::component::__internal::Vec<i64>,),
-                            >::new_unchecked(self.list_s64_ret)
-                        };
+                        let callee = self.func_list_s64_ret();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), ())
                             .await?;
                         Ok(ret0)
+                    }
+                    pub fn func_list_f32_ret(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (),
+                        (wasmtime::component::__internal::Vec<f32>,),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (wasmtime::component::__internal::Vec<f32>,),
+                            >::new_unchecked(self.list_f32_ret)
+                        }
                     }
                     pub async fn call_list_f32_ret<S: wasmtime::AsContextMut>(
                         &self,
@@ -2059,16 +2186,24 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (wasmtime::component::__internal::Vec<f32>,),
-                            >::new_unchecked(self.list_f32_ret)
-                        };
+                        let callee = self.func_list_f32_ret();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), ())
                             .await?;
                         Ok(ret0)
+                    }
+                    pub fn func_list_f64_ret(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (),
+                        (wasmtime::component::__internal::Vec<f64>,),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (wasmtime::component::__internal::Vec<f64>,),
+                            >::new_unchecked(self.list_f64_ret)
+                        }
                     }
                     pub async fn call_list_f64_ret<S: wasmtime::AsContextMut>(
                         &self,
@@ -2077,16 +2212,24 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (wasmtime::component::__internal::Vec<f64>,),
-                            >::new_unchecked(self.list_f64_ret)
-                        };
+                        let callee = self.func_list_f64_ret();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), ())
                             .await?;
                         Ok(ret0)
+                    }
+                    pub fn func_tuple_list(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (&[(u8, i8)],),
+                        (wasmtime::component::__internal::Vec<(i64, u32)>,),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&[(u8, i8)],),
+                                (wasmtime::component::__internal::Vec<(i64, u32)>,),
+                            >::new_unchecked(self.tuple_list)
+                        }
                     }
                     pub async fn call_tuple_list<S: wasmtime::AsContextMut>(
                         &self,
@@ -2098,16 +2241,24 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (&[(u8, i8)],),
-                                (wasmtime::component::__internal::Vec<(i64, u32)>,),
-                            >::new_unchecked(self.tuple_list)
-                        };
+                        let callee = self.func_tuple_list();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), (arg0,))
                             .await?;
                         Ok(ret0)
+                    }
+                    pub fn func_string_list_arg(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (&[wasmtime::component::__internal::String],),
+                        (),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&[wasmtime::component::__internal::String],),
+                                (),
+                            >::new_unchecked(self.string_list_arg)
+                        }
                     }
                     pub async fn call_string_list_arg<S: wasmtime::AsContextMut>(
                         &self,
@@ -2117,16 +2268,32 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (&[wasmtime::component::__internal::String],),
-                                (),
-                            >::new_unchecked(self.string_list_arg)
-                        };
+                        let callee = self.func_string_list_arg();
                         let () = callee
                             .call_async(store.as_context_mut(), (arg0,))
                             .await?;
                         Ok(())
+                    }
+                    pub fn func_string_list_ret(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (),
+                        (
+                            wasmtime::component::__internal::Vec<
+                                wasmtime::component::__internal::String,
+                            >,
+                        ),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (
+                                    wasmtime::component::__internal::Vec<
+                                        wasmtime::component::__internal::String,
+                                    >,
+                                ),
+                            >::new_unchecked(self.string_list_ret)
+                        }
                     }
                     pub async fn call_string_list_ret<S: wasmtime::AsContextMut>(
                         &self,
@@ -2139,20 +2306,32 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (
-                                    wasmtime::component::__internal::Vec<
-                                        wasmtime::component::__internal::String,
-                                    >,
-                                ),
-                            >::new_unchecked(self.string_list_ret)
-                        };
+                        let callee = self.func_string_list_ret();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), ())
                             .await?;
                         Ok(ret0)
+                    }
+                    pub fn func_tuple_string_list(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (&[(u8, wasmtime::component::__internal::String)],),
+                        (
+                            wasmtime::component::__internal::Vec<
+                                (wasmtime::component::__internal::String, u8),
+                            >,
+                        ),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&[(u8, wasmtime::component::__internal::String)],),
+                                (
+                                    wasmtime::component::__internal::Vec<
+                                        (wasmtime::component::__internal::String, u8),
+                                    >,
+                                ),
+                            >::new_unchecked(self.tuple_string_list)
+                        }
                     }
                     pub async fn call_tuple_string_list<S: wasmtime::AsContextMut>(
                         &self,
@@ -2166,20 +2345,32 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (&[(u8, wasmtime::component::__internal::String)],),
-                                (
-                                    wasmtime::component::__internal::Vec<
-                                        (wasmtime::component::__internal::String, u8),
-                                    >,
-                                ),
-                            >::new_unchecked(self.tuple_string_list)
-                        };
+                        let callee = self.func_tuple_string_list();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), (arg0,))
                             .await?;
                         Ok(ret0)
+                    }
+                    pub fn func_string_list(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (&[wasmtime::component::__internal::String],),
+                        (
+                            wasmtime::component::__internal::Vec<
+                                wasmtime::component::__internal::String,
+                            >,
+                        ),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&[wasmtime::component::__internal::String],),
+                                (
+                                    wasmtime::component::__internal::Vec<
+                                        wasmtime::component::__internal::String,
+                                    >,
+                                ),
+                            >::new_unchecked(self.string_list)
+                        }
                     }
                     pub async fn call_string_list<S: wasmtime::AsContextMut>(
                         &self,
@@ -2193,20 +2384,24 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (&[wasmtime::component::__internal::String],),
-                                (
-                                    wasmtime::component::__internal::Vec<
-                                        wasmtime::component::__internal::String,
-                                    >,
-                                ),
-                            >::new_unchecked(self.string_list)
-                        };
+                        let callee = self.func_string_list();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), (arg0,))
                             .await?;
                         Ok(ret0)
+                    }
+                    pub fn func_record_list(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (&[SomeRecord],),
+                        (wasmtime::component::__internal::Vec<OtherRecord>,),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&[SomeRecord],),
+                                (wasmtime::component::__internal::Vec<OtherRecord>,),
+                            >::new_unchecked(self.record_list)
+                        }
                     }
                     pub async fn call_record_list<S: wasmtime::AsContextMut>(
                         &self,
@@ -2218,16 +2413,24 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (&[SomeRecord],),
-                                (wasmtime::component::__internal::Vec<OtherRecord>,),
-                            >::new_unchecked(self.record_list)
-                        };
+                        let callee = self.func_record_list();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), (arg0,))
                             .await?;
                         Ok(ret0)
+                    }
+                    pub fn func_record_list_reverse(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (&[OtherRecord],),
+                        (wasmtime::component::__internal::Vec<SomeRecord>,),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&[OtherRecord],),
+                                (wasmtime::component::__internal::Vec<SomeRecord>,),
+                            >::new_unchecked(self.record_list_reverse)
+                        }
                     }
                     pub async fn call_record_list_reverse<S: wasmtime::AsContextMut>(
                         &self,
@@ -2239,16 +2442,24 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (&[OtherRecord],),
-                                (wasmtime::component::__internal::Vec<SomeRecord>,),
-                            >::new_unchecked(self.record_list_reverse)
-                        };
+                        let callee = self.func_record_list_reverse();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), (arg0,))
                             .await?;
                         Ok(ret0)
+                    }
+                    pub fn func_variant_list(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (&[SomeVariant],),
+                        (wasmtime::component::__internal::Vec<OtherVariant>,),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&[SomeVariant],),
+                                (wasmtime::component::__internal::Vec<OtherVariant>,),
+                            >::new_unchecked(self.variant_list)
+                        }
                     }
                     pub async fn call_variant_list<S: wasmtime::AsContextMut>(
                         &self,
@@ -2260,16 +2471,24 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (&[SomeVariant],),
-                                (wasmtime::component::__internal::Vec<OtherVariant>,),
-                            >::new_unchecked(self.variant_list)
-                        };
+                        let callee = self.func_variant_list();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), (arg0,))
                             .await?;
                         Ok(ret0)
+                    }
+                    pub fn func_load_store_everything(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (&LoadStoreAllSizes,),
+                        (LoadStoreAllSizes,),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&LoadStoreAllSizes,),
+                                (LoadStoreAllSizes,),
+                            >::new_unchecked(self.load_store_everything)
+                        }
                     }
                     pub async fn call_load_store_everything<S: wasmtime::AsContextMut>(
                         &self,
@@ -2279,12 +2498,7 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (&LoadStoreAllSizes,),
-                                (LoadStoreAllSizes,),
-                            >::new_unchecked(self.load_store_everything)
-                        };
+                        let callee = self.func_load_store_everything();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), (arg0,))
                             .await?;

--- a/crates/component-macro/tests/expanded/lists_concurrent.rs
+++ b/crates/component-macro/tests/expanded/lists_concurrent.rs
@@ -1521,6 +1521,19 @@ pub mod exports {
                     }
                 }
                 impl Guest {
+                    pub fn func_list_u8_param(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (wasmtime::component::__internal::Vec<u8>,),
+                        (),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (wasmtime::component::__internal::Vec<u8>,),
+                                (),
+                            >::new_unchecked(self.list_u8_param)
+                        }
+                    }
                     pub async fn call_list_u8_param<_T, _D>(
                         &self,
                         accessor: &wasmtime::component::Accessor<_T, _D>,
@@ -1530,14 +1543,22 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (wasmtime::component::__internal::Vec<u8>,),
-                                (),
-                            >::new_unchecked(self.list_u8_param)
-                        };
+                        let callee = self.func_list_u8_param();
                         let () = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(())
+                    }
+                    pub fn func_list_u16_param(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (wasmtime::component::__internal::Vec<u16>,),
+                        (),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (wasmtime::component::__internal::Vec<u16>,),
+                                (),
+                            >::new_unchecked(self.list_u16_param)
+                        }
                     }
                     pub async fn call_list_u16_param<_T, _D>(
                         &self,
@@ -1548,14 +1569,22 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (wasmtime::component::__internal::Vec<u16>,),
-                                (),
-                            >::new_unchecked(self.list_u16_param)
-                        };
+                        let callee = self.func_list_u16_param();
                         let () = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(())
+                    }
+                    pub fn func_list_u32_param(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (wasmtime::component::__internal::Vec<u32>,),
+                        (),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (wasmtime::component::__internal::Vec<u32>,),
+                                (),
+                            >::new_unchecked(self.list_u32_param)
+                        }
                     }
                     pub async fn call_list_u32_param<_T, _D>(
                         &self,
@@ -1566,14 +1595,22 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (wasmtime::component::__internal::Vec<u32>,),
-                                (),
-                            >::new_unchecked(self.list_u32_param)
-                        };
+                        let callee = self.func_list_u32_param();
                         let () = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(())
+                    }
+                    pub fn func_list_u64_param(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (wasmtime::component::__internal::Vec<u64>,),
+                        (),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (wasmtime::component::__internal::Vec<u64>,),
+                                (),
+                            >::new_unchecked(self.list_u64_param)
+                        }
                     }
                     pub async fn call_list_u64_param<_T, _D>(
                         &self,
@@ -1584,14 +1621,22 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (wasmtime::component::__internal::Vec<u64>,),
-                                (),
-                            >::new_unchecked(self.list_u64_param)
-                        };
+                        let callee = self.func_list_u64_param();
                         let () = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(())
+                    }
+                    pub fn func_list_s8_param(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (wasmtime::component::__internal::Vec<i8>,),
+                        (),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (wasmtime::component::__internal::Vec<i8>,),
+                                (),
+                            >::new_unchecked(self.list_s8_param)
+                        }
                     }
                     pub async fn call_list_s8_param<_T, _D>(
                         &self,
@@ -1602,14 +1647,22 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (wasmtime::component::__internal::Vec<i8>,),
-                                (),
-                            >::new_unchecked(self.list_s8_param)
-                        };
+                        let callee = self.func_list_s8_param();
                         let () = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(())
+                    }
+                    pub fn func_list_s16_param(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (wasmtime::component::__internal::Vec<i16>,),
+                        (),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (wasmtime::component::__internal::Vec<i16>,),
+                                (),
+                            >::new_unchecked(self.list_s16_param)
+                        }
                     }
                     pub async fn call_list_s16_param<_T, _D>(
                         &self,
@@ -1620,14 +1673,22 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (wasmtime::component::__internal::Vec<i16>,),
-                                (),
-                            >::new_unchecked(self.list_s16_param)
-                        };
+                        let callee = self.func_list_s16_param();
                         let () = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(())
+                    }
+                    pub fn func_list_s32_param(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (wasmtime::component::__internal::Vec<i32>,),
+                        (),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (wasmtime::component::__internal::Vec<i32>,),
+                                (),
+                            >::new_unchecked(self.list_s32_param)
+                        }
                     }
                     pub async fn call_list_s32_param<_T, _D>(
                         &self,
@@ -1638,14 +1699,22 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (wasmtime::component::__internal::Vec<i32>,),
-                                (),
-                            >::new_unchecked(self.list_s32_param)
-                        };
+                        let callee = self.func_list_s32_param();
                         let () = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(())
+                    }
+                    pub fn func_list_s64_param(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (wasmtime::component::__internal::Vec<i64>,),
+                        (),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (wasmtime::component::__internal::Vec<i64>,),
+                                (),
+                            >::new_unchecked(self.list_s64_param)
+                        }
                     }
                     pub async fn call_list_s64_param<_T, _D>(
                         &self,
@@ -1656,14 +1725,22 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (wasmtime::component::__internal::Vec<i64>,),
-                                (),
-                            >::new_unchecked(self.list_s64_param)
-                        };
+                        let callee = self.func_list_s64_param();
                         let () = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(())
+                    }
+                    pub fn func_list_f32_param(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (wasmtime::component::__internal::Vec<f32>,),
+                        (),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (wasmtime::component::__internal::Vec<f32>,),
+                                (),
+                            >::new_unchecked(self.list_f32_param)
+                        }
                     }
                     pub async fn call_list_f32_param<_T, _D>(
                         &self,
@@ -1674,14 +1751,22 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (wasmtime::component::__internal::Vec<f32>,),
-                                (),
-                            >::new_unchecked(self.list_f32_param)
-                        };
+                        let callee = self.func_list_f32_param();
                         let () = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(())
+                    }
+                    pub fn func_list_f64_param(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (wasmtime::component::__internal::Vec<f64>,),
+                        (),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (wasmtime::component::__internal::Vec<f64>,),
+                                (),
+                            >::new_unchecked(self.list_f64_param)
+                        }
                     }
                     pub async fn call_list_f64_param<_T, _D>(
                         &self,
@@ -1692,14 +1777,22 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (wasmtime::component::__internal::Vec<f64>,),
-                                (),
-                            >::new_unchecked(self.list_f64_param)
-                        };
+                        let callee = self.func_list_f64_param();
                         let () = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(())
+                    }
+                    pub fn func_list_u8_ret(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (),
+                        (wasmtime::component::__internal::Vec<u8>,),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (wasmtime::component::__internal::Vec<u8>,),
+                            >::new_unchecked(self.list_u8_ret)
+                        }
                     }
                     pub async fn call_list_u8_ret<_T, _D>(
                         &self,
@@ -1709,14 +1802,22 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (wasmtime::component::__internal::Vec<u8>,),
-                            >::new_unchecked(self.list_u8_ret)
-                        };
+                        let callee = self.func_list_u8_ret();
                         let (ret0,) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
+                    }
+                    pub fn func_list_u16_ret(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (),
+                        (wasmtime::component::__internal::Vec<u16>,),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (wasmtime::component::__internal::Vec<u16>,),
+                            >::new_unchecked(self.list_u16_ret)
+                        }
                     }
                     pub async fn call_list_u16_ret<_T, _D>(
                         &self,
@@ -1726,14 +1827,22 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (wasmtime::component::__internal::Vec<u16>,),
-                            >::new_unchecked(self.list_u16_ret)
-                        };
+                        let callee = self.func_list_u16_ret();
                         let (ret0,) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
+                    }
+                    pub fn func_list_u32_ret(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (),
+                        (wasmtime::component::__internal::Vec<u32>,),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (wasmtime::component::__internal::Vec<u32>,),
+                            >::new_unchecked(self.list_u32_ret)
+                        }
                     }
                     pub async fn call_list_u32_ret<_T, _D>(
                         &self,
@@ -1743,14 +1852,22 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (wasmtime::component::__internal::Vec<u32>,),
-                            >::new_unchecked(self.list_u32_ret)
-                        };
+                        let callee = self.func_list_u32_ret();
                         let (ret0,) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
+                    }
+                    pub fn func_list_u64_ret(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (),
+                        (wasmtime::component::__internal::Vec<u64>,),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (wasmtime::component::__internal::Vec<u64>,),
+                            >::new_unchecked(self.list_u64_ret)
+                        }
                     }
                     pub async fn call_list_u64_ret<_T, _D>(
                         &self,
@@ -1760,14 +1877,22 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (wasmtime::component::__internal::Vec<u64>,),
-                            >::new_unchecked(self.list_u64_ret)
-                        };
+                        let callee = self.func_list_u64_ret();
                         let (ret0,) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
+                    }
+                    pub fn func_list_s8_ret(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (),
+                        (wasmtime::component::__internal::Vec<i8>,),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (wasmtime::component::__internal::Vec<i8>,),
+                            >::new_unchecked(self.list_s8_ret)
+                        }
                     }
                     pub async fn call_list_s8_ret<_T, _D>(
                         &self,
@@ -1777,14 +1902,22 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (wasmtime::component::__internal::Vec<i8>,),
-                            >::new_unchecked(self.list_s8_ret)
-                        };
+                        let callee = self.func_list_s8_ret();
                         let (ret0,) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
+                    }
+                    pub fn func_list_s16_ret(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (),
+                        (wasmtime::component::__internal::Vec<i16>,),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (wasmtime::component::__internal::Vec<i16>,),
+                            >::new_unchecked(self.list_s16_ret)
+                        }
                     }
                     pub async fn call_list_s16_ret<_T, _D>(
                         &self,
@@ -1794,14 +1927,22 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (wasmtime::component::__internal::Vec<i16>,),
-                            >::new_unchecked(self.list_s16_ret)
-                        };
+                        let callee = self.func_list_s16_ret();
                         let (ret0,) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
+                    }
+                    pub fn func_list_s32_ret(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (),
+                        (wasmtime::component::__internal::Vec<i32>,),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (wasmtime::component::__internal::Vec<i32>,),
+                            >::new_unchecked(self.list_s32_ret)
+                        }
                     }
                     pub async fn call_list_s32_ret<_T, _D>(
                         &self,
@@ -1811,14 +1952,22 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (wasmtime::component::__internal::Vec<i32>,),
-                            >::new_unchecked(self.list_s32_ret)
-                        };
+                        let callee = self.func_list_s32_ret();
                         let (ret0,) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
+                    }
+                    pub fn func_list_s64_ret(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (),
+                        (wasmtime::component::__internal::Vec<i64>,),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (wasmtime::component::__internal::Vec<i64>,),
+                            >::new_unchecked(self.list_s64_ret)
+                        }
                     }
                     pub async fn call_list_s64_ret<_T, _D>(
                         &self,
@@ -1828,14 +1977,22 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (wasmtime::component::__internal::Vec<i64>,),
-                            >::new_unchecked(self.list_s64_ret)
-                        };
+                        let callee = self.func_list_s64_ret();
                         let (ret0,) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
+                    }
+                    pub fn func_list_f32_ret(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (),
+                        (wasmtime::component::__internal::Vec<f32>,),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (wasmtime::component::__internal::Vec<f32>,),
+                            >::new_unchecked(self.list_f32_ret)
+                        }
                     }
                     pub async fn call_list_f32_ret<_T, _D>(
                         &self,
@@ -1845,14 +2002,22 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (wasmtime::component::__internal::Vec<f32>,),
-                            >::new_unchecked(self.list_f32_ret)
-                        };
+                        let callee = self.func_list_f32_ret();
                         let (ret0,) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
+                    }
+                    pub fn func_list_f64_ret(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (),
+                        (wasmtime::component::__internal::Vec<f64>,),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (wasmtime::component::__internal::Vec<f64>,),
+                            >::new_unchecked(self.list_f64_ret)
+                        }
                     }
                     pub async fn call_list_f64_ret<_T, _D>(
                         &self,
@@ -1862,14 +2027,22 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (wasmtime::component::__internal::Vec<f64>,),
-                            >::new_unchecked(self.list_f64_ret)
-                        };
+                        let callee = self.func_list_f64_ret();
                         let (ret0,) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
+                    }
+                    pub fn func_tuple_list(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (wasmtime::component::__internal::Vec<(u8, i8)>,),
+                        (wasmtime::component::__internal::Vec<(i64, u32)>,),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (wasmtime::component::__internal::Vec<(u8, i8)>,),
+                                (wasmtime::component::__internal::Vec<(i64, u32)>,),
+                            >::new_unchecked(self.tuple_list)
+                        }
                     }
                     pub async fn call_tuple_list<_T, _D>(
                         &self,
@@ -1882,14 +2055,30 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (wasmtime::component::__internal::Vec<(u8, i8)>,),
-                                (wasmtime::component::__internal::Vec<(i64, u32)>,),
-                            >::new_unchecked(self.tuple_list)
-                        };
+                        let callee = self.func_tuple_list();
                         let (ret0,) = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(ret0)
+                    }
+                    pub fn func_string_list_arg(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (
+                            wasmtime::component::__internal::Vec<
+                                wasmtime::component::__internal::String,
+                            >,
+                        ),
+                        (),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (
+                                    wasmtime::component::__internal::Vec<
+                                        wasmtime::component::__internal::String,
+                                    >,
+                                ),
+                                (),
+                            >::new_unchecked(self.string_list_arg)
+                        }
                     }
                     pub async fn call_string_list_arg<_T, _D>(
                         &self,
@@ -1902,18 +2091,30 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
+                        let callee = self.func_string_list_arg();
+                        let () = callee.call_concurrent(accessor, (arg0,)).await?;
+                        Ok(())
+                    }
+                    pub fn func_string_list_ret(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (),
+                        (
+                            wasmtime::component::__internal::Vec<
+                                wasmtime::component::__internal::String,
+                            >,
+                        ),
+                    > {
+                        unsafe {
                             wasmtime::component::TypedFunc::<
+                                (),
                                 (
                                     wasmtime::component::__internal::Vec<
                                         wasmtime::component::__internal::String,
                                     >,
                                 ),
-                                (),
-                            >::new_unchecked(self.string_list_arg)
-                        };
-                        let () = callee.call_concurrent(accessor, (arg0,)).await?;
-                        Ok(())
+                            >::new_unchecked(self.string_list_ret)
+                        }
                     }
                     pub async fn call_string_list_ret<_T, _D>(
                         &self,
@@ -1927,18 +2128,38 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (
-                                    wasmtime::component::__internal::Vec<
-                                        wasmtime::component::__internal::String,
-                                    >,
-                                ),
-                            >::new_unchecked(self.string_list_ret)
-                        };
+                        let callee = self.func_string_list_ret();
                         let (ret0,) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
+                    }
+                    pub fn func_tuple_string_list(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (
+                            wasmtime::component::__internal::Vec<
+                                (u8, wasmtime::component::__internal::String),
+                            >,
+                        ),
+                        (
+                            wasmtime::component::__internal::Vec<
+                                (wasmtime::component::__internal::String, u8),
+                            >,
+                        ),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (
+                                    wasmtime::component::__internal::Vec<
+                                        (u8, wasmtime::component::__internal::String),
+                                    >,
+                                ),
+                                (
+                                    wasmtime::component::__internal::Vec<
+                                        (wasmtime::component::__internal::String, u8),
+                                    >,
+                                ),
+                            >::new_unchecked(self.tuple_string_list)
+                        }
                     }
                     pub async fn call_tuple_string_list<_T, _D>(
                         &self,
@@ -1955,22 +2176,38 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
+                        let callee = self.func_tuple_string_list();
+                        let (ret0,) = callee.call_concurrent(accessor, (arg0,)).await?;
+                        Ok(ret0)
+                    }
+                    pub fn func_string_list(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (
+                            wasmtime::component::__internal::Vec<
+                                wasmtime::component::__internal::String,
+                            >,
+                        ),
+                        (
+                            wasmtime::component::__internal::Vec<
+                                wasmtime::component::__internal::String,
+                            >,
+                        ),
+                    > {
+                        unsafe {
                             wasmtime::component::TypedFunc::<
                                 (
                                     wasmtime::component::__internal::Vec<
-                                        (u8, wasmtime::component::__internal::String),
+                                        wasmtime::component::__internal::String,
                                     >,
                                 ),
                                 (
                                     wasmtime::component::__internal::Vec<
-                                        (wasmtime::component::__internal::String, u8),
+                                        wasmtime::component::__internal::String,
                                     >,
                                 ),
-                            >::new_unchecked(self.tuple_string_list)
-                        };
-                        let (ret0,) = callee.call_concurrent(accessor, (arg0,)).await?;
-                        Ok(ret0)
+                            >::new_unchecked(self.string_list)
+                        }
                     }
                     pub async fn call_string_list<_T, _D>(
                         &self,
@@ -1987,22 +2224,22 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (
-                                    wasmtime::component::__internal::Vec<
-                                        wasmtime::component::__internal::String,
-                                    >,
-                                ),
-                                (
-                                    wasmtime::component::__internal::Vec<
-                                        wasmtime::component::__internal::String,
-                                    >,
-                                ),
-                            >::new_unchecked(self.string_list)
-                        };
+                        let callee = self.func_string_list();
                         let (ret0,) = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(ret0)
+                    }
+                    pub fn func_record_list(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (wasmtime::component::__internal::Vec<SomeRecord>,),
+                        (wasmtime::component::__internal::Vec<OtherRecord>,),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (wasmtime::component::__internal::Vec<SomeRecord>,),
+                                (wasmtime::component::__internal::Vec<OtherRecord>,),
+                            >::new_unchecked(self.record_list)
+                        }
                     }
                     pub async fn call_record_list<_T, _D>(
                         &self,
@@ -2015,14 +2252,22 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (wasmtime::component::__internal::Vec<SomeRecord>,),
-                                (wasmtime::component::__internal::Vec<OtherRecord>,),
-                            >::new_unchecked(self.record_list)
-                        };
+                        let callee = self.func_record_list();
                         let (ret0,) = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(ret0)
+                    }
+                    pub fn func_record_list_reverse(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (wasmtime::component::__internal::Vec<OtherRecord>,),
+                        (wasmtime::component::__internal::Vec<SomeRecord>,),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (wasmtime::component::__internal::Vec<OtherRecord>,),
+                                (wasmtime::component::__internal::Vec<SomeRecord>,),
+                            >::new_unchecked(self.record_list_reverse)
+                        }
                     }
                     pub async fn call_record_list_reverse<_T, _D>(
                         &self,
@@ -2035,14 +2280,22 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (wasmtime::component::__internal::Vec<OtherRecord>,),
-                                (wasmtime::component::__internal::Vec<SomeRecord>,),
-                            >::new_unchecked(self.record_list_reverse)
-                        };
+                        let callee = self.func_record_list_reverse();
                         let (ret0,) = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(ret0)
+                    }
+                    pub fn func_variant_list(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (wasmtime::component::__internal::Vec<SomeVariant>,),
+                        (wasmtime::component::__internal::Vec<OtherVariant>,),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (wasmtime::component::__internal::Vec<SomeVariant>,),
+                                (wasmtime::component::__internal::Vec<OtherVariant>,),
+                            >::new_unchecked(self.variant_list)
+                        }
                     }
                     pub async fn call_variant_list<_T, _D>(
                         &self,
@@ -2055,14 +2308,22 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (wasmtime::component::__internal::Vec<SomeVariant>,),
-                                (wasmtime::component::__internal::Vec<OtherVariant>,),
-                            >::new_unchecked(self.variant_list)
-                        };
+                        let callee = self.func_variant_list();
                         let (ret0,) = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(ret0)
+                    }
+                    pub fn func_load_store_everything(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (LoadStoreAllSizes,),
+                        (LoadStoreAllSizes,),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (LoadStoreAllSizes,),
+                                (LoadStoreAllSizes,),
+                            >::new_unchecked(self.load_store_everything)
+                        }
                     }
                     pub async fn call_load_store_everything<_T, _D>(
                         &self,
@@ -2073,12 +2334,7 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (LoadStoreAllSizes,),
-                                (LoadStoreAllSizes,),
-                            >::new_unchecked(self.load_store_everything)
-                        };
+                        let callee = self.func_load_store_everything();
                         let (ret0,) = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(ret0)
                     }

--- a/crates/component-macro/tests/expanded/lists_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/lists_tracing_async.rs
@@ -2149,6 +2149,16 @@ pub mod exports {
                     }
                 }
                 impl Guest {
+                    pub fn func_list_u8_param(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(&[u8],), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&[u8],),
+                                (),
+                            >::new_unchecked(self.list_u8_param)
+                        }
+                    }
                     pub async fn call_list_u8_param<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
@@ -2162,17 +2172,22 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/lists", function = "list-u8-param",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (&[u8],),
-                                (),
-                            >::new_unchecked(self.list_u8_param)
-                        };
+                        let callee = self.func_list_u8_param();
                         let () = callee
                             .call_async(store.as_context_mut(), (arg0,))
                             .instrument(span.clone())
                             .await?;
                         Ok(())
+                    }
+                    pub fn func_list_u16_param(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(&[u16],), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&[u16],),
+                                (),
+                            >::new_unchecked(self.list_u16_param)
+                        }
                     }
                     pub async fn call_list_u16_param<S: wasmtime::AsContextMut>(
                         &self,
@@ -2187,17 +2202,22 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/lists", function = "list-u16-param",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (&[u16],),
-                                (),
-                            >::new_unchecked(self.list_u16_param)
-                        };
+                        let callee = self.func_list_u16_param();
                         let () = callee
                             .call_async(store.as_context_mut(), (arg0,))
                             .instrument(span.clone())
                             .await?;
                         Ok(())
+                    }
+                    pub fn func_list_u32_param(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(&[u32],), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&[u32],),
+                                (),
+                            >::new_unchecked(self.list_u32_param)
+                        }
                     }
                     pub async fn call_list_u32_param<S: wasmtime::AsContextMut>(
                         &self,
@@ -2212,17 +2232,22 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/lists", function = "list-u32-param",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (&[u32],),
-                                (),
-                            >::new_unchecked(self.list_u32_param)
-                        };
+                        let callee = self.func_list_u32_param();
                         let () = callee
                             .call_async(store.as_context_mut(), (arg0,))
                             .instrument(span.clone())
                             .await?;
                         Ok(())
+                    }
+                    pub fn func_list_u64_param(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(&[u64],), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&[u64],),
+                                (),
+                            >::new_unchecked(self.list_u64_param)
+                        }
                     }
                     pub async fn call_list_u64_param<S: wasmtime::AsContextMut>(
                         &self,
@@ -2237,17 +2262,22 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/lists", function = "list-u64-param",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (&[u64],),
-                                (),
-                            >::new_unchecked(self.list_u64_param)
-                        };
+                        let callee = self.func_list_u64_param();
                         let () = callee
                             .call_async(store.as_context_mut(), (arg0,))
                             .instrument(span.clone())
                             .await?;
                         Ok(())
+                    }
+                    pub fn func_list_s8_param(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(&[i8],), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&[i8],),
+                                (),
+                            >::new_unchecked(self.list_s8_param)
+                        }
                     }
                     pub async fn call_list_s8_param<S: wasmtime::AsContextMut>(
                         &self,
@@ -2262,17 +2292,22 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/lists", function = "list-s8-param",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (&[i8],),
-                                (),
-                            >::new_unchecked(self.list_s8_param)
-                        };
+                        let callee = self.func_list_s8_param();
                         let () = callee
                             .call_async(store.as_context_mut(), (arg0,))
                             .instrument(span.clone())
                             .await?;
                         Ok(())
+                    }
+                    pub fn func_list_s16_param(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(&[i16],), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&[i16],),
+                                (),
+                            >::new_unchecked(self.list_s16_param)
+                        }
                     }
                     pub async fn call_list_s16_param<S: wasmtime::AsContextMut>(
                         &self,
@@ -2287,17 +2322,22 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/lists", function = "list-s16-param",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (&[i16],),
-                                (),
-                            >::new_unchecked(self.list_s16_param)
-                        };
+                        let callee = self.func_list_s16_param();
                         let () = callee
                             .call_async(store.as_context_mut(), (arg0,))
                             .instrument(span.clone())
                             .await?;
                         Ok(())
+                    }
+                    pub fn func_list_s32_param(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(&[i32],), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&[i32],),
+                                (),
+                            >::new_unchecked(self.list_s32_param)
+                        }
                     }
                     pub async fn call_list_s32_param<S: wasmtime::AsContextMut>(
                         &self,
@@ -2312,17 +2352,22 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/lists", function = "list-s32-param",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (&[i32],),
-                                (),
-                            >::new_unchecked(self.list_s32_param)
-                        };
+                        let callee = self.func_list_s32_param();
                         let () = callee
                             .call_async(store.as_context_mut(), (arg0,))
                             .instrument(span.clone())
                             .await?;
                         Ok(())
+                    }
+                    pub fn func_list_s64_param(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(&[i64],), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&[i64],),
+                                (),
+                            >::new_unchecked(self.list_s64_param)
+                        }
                     }
                     pub async fn call_list_s64_param<S: wasmtime::AsContextMut>(
                         &self,
@@ -2337,17 +2382,22 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/lists", function = "list-s64-param",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (&[i64],),
-                                (),
-                            >::new_unchecked(self.list_s64_param)
-                        };
+                        let callee = self.func_list_s64_param();
                         let () = callee
                             .call_async(store.as_context_mut(), (arg0,))
                             .instrument(span.clone())
                             .await?;
                         Ok(())
+                    }
+                    pub fn func_list_f32_param(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(&[f32],), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&[f32],),
+                                (),
+                            >::new_unchecked(self.list_f32_param)
+                        }
                     }
                     pub async fn call_list_f32_param<S: wasmtime::AsContextMut>(
                         &self,
@@ -2362,17 +2412,22 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/lists", function = "list-f32-param",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (&[f32],),
-                                (),
-                            >::new_unchecked(self.list_f32_param)
-                        };
+                        let callee = self.func_list_f32_param();
                         let () = callee
                             .call_async(store.as_context_mut(), (arg0,))
                             .instrument(span.clone())
                             .await?;
                         Ok(())
+                    }
+                    pub fn func_list_f64_param(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(&[f64],), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&[f64],),
+                                (),
+                            >::new_unchecked(self.list_f64_param)
+                        }
                     }
                     pub async fn call_list_f64_param<S: wasmtime::AsContextMut>(
                         &self,
@@ -2387,17 +2442,25 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/lists", function = "list-f64-param",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (&[f64],),
-                                (),
-                            >::new_unchecked(self.list_f64_param)
-                        };
+                        let callee = self.func_list_f64_param();
                         let () = callee
                             .call_async(store.as_context_mut(), (arg0,))
                             .instrument(span.clone())
                             .await?;
                         Ok(())
+                    }
+                    pub fn func_list_u8_ret(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (),
+                        (wasmtime::component::__internal::Vec<u8>,),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (wasmtime::component::__internal::Vec<u8>,),
+                            >::new_unchecked(self.list_u8_ret)
+                        }
                     }
                     pub async fn call_list_u8_ret<S: wasmtime::AsContextMut>(
                         &self,
@@ -2411,17 +2474,25 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/lists", function = "list-u8-ret",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (wasmtime::component::__internal::Vec<u8>,),
-                            >::new_unchecked(self.list_u8_ret)
-                        };
+                        let callee = self.func_list_u8_ret();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), ())
                             .instrument(span.clone())
                             .await?;
                         Ok(ret0)
+                    }
+                    pub fn func_list_u16_ret(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (),
+                        (wasmtime::component::__internal::Vec<u16>,),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (wasmtime::component::__internal::Vec<u16>,),
+                            >::new_unchecked(self.list_u16_ret)
+                        }
                     }
                     pub async fn call_list_u16_ret<S: wasmtime::AsContextMut>(
                         &self,
@@ -2435,17 +2506,25 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/lists", function = "list-u16-ret",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (wasmtime::component::__internal::Vec<u16>,),
-                            >::new_unchecked(self.list_u16_ret)
-                        };
+                        let callee = self.func_list_u16_ret();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), ())
                             .instrument(span.clone())
                             .await?;
                         Ok(ret0)
+                    }
+                    pub fn func_list_u32_ret(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (),
+                        (wasmtime::component::__internal::Vec<u32>,),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (wasmtime::component::__internal::Vec<u32>,),
+                            >::new_unchecked(self.list_u32_ret)
+                        }
                     }
                     pub async fn call_list_u32_ret<S: wasmtime::AsContextMut>(
                         &self,
@@ -2459,17 +2538,25 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/lists", function = "list-u32-ret",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (wasmtime::component::__internal::Vec<u32>,),
-                            >::new_unchecked(self.list_u32_ret)
-                        };
+                        let callee = self.func_list_u32_ret();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), ())
                             .instrument(span.clone())
                             .await?;
                         Ok(ret0)
+                    }
+                    pub fn func_list_u64_ret(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (),
+                        (wasmtime::component::__internal::Vec<u64>,),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (wasmtime::component::__internal::Vec<u64>,),
+                            >::new_unchecked(self.list_u64_ret)
+                        }
                     }
                     pub async fn call_list_u64_ret<S: wasmtime::AsContextMut>(
                         &self,
@@ -2483,17 +2570,25 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/lists", function = "list-u64-ret",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (wasmtime::component::__internal::Vec<u64>,),
-                            >::new_unchecked(self.list_u64_ret)
-                        };
+                        let callee = self.func_list_u64_ret();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), ())
                             .instrument(span.clone())
                             .await?;
                         Ok(ret0)
+                    }
+                    pub fn func_list_s8_ret(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (),
+                        (wasmtime::component::__internal::Vec<i8>,),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (wasmtime::component::__internal::Vec<i8>,),
+                            >::new_unchecked(self.list_s8_ret)
+                        }
                     }
                     pub async fn call_list_s8_ret<S: wasmtime::AsContextMut>(
                         &self,
@@ -2507,17 +2602,25 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/lists", function = "list-s8-ret",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (wasmtime::component::__internal::Vec<i8>,),
-                            >::new_unchecked(self.list_s8_ret)
-                        };
+                        let callee = self.func_list_s8_ret();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), ())
                             .instrument(span.clone())
                             .await?;
                         Ok(ret0)
+                    }
+                    pub fn func_list_s16_ret(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (),
+                        (wasmtime::component::__internal::Vec<i16>,),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (wasmtime::component::__internal::Vec<i16>,),
+                            >::new_unchecked(self.list_s16_ret)
+                        }
                     }
                     pub async fn call_list_s16_ret<S: wasmtime::AsContextMut>(
                         &self,
@@ -2531,17 +2634,25 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/lists", function = "list-s16-ret",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (wasmtime::component::__internal::Vec<i16>,),
-                            >::new_unchecked(self.list_s16_ret)
-                        };
+                        let callee = self.func_list_s16_ret();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), ())
                             .instrument(span.clone())
                             .await?;
                         Ok(ret0)
+                    }
+                    pub fn func_list_s32_ret(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (),
+                        (wasmtime::component::__internal::Vec<i32>,),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (wasmtime::component::__internal::Vec<i32>,),
+                            >::new_unchecked(self.list_s32_ret)
+                        }
                     }
                     pub async fn call_list_s32_ret<S: wasmtime::AsContextMut>(
                         &self,
@@ -2555,17 +2666,25 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/lists", function = "list-s32-ret",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (wasmtime::component::__internal::Vec<i32>,),
-                            >::new_unchecked(self.list_s32_ret)
-                        };
+                        let callee = self.func_list_s32_ret();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), ())
                             .instrument(span.clone())
                             .await?;
                         Ok(ret0)
+                    }
+                    pub fn func_list_s64_ret(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (),
+                        (wasmtime::component::__internal::Vec<i64>,),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (wasmtime::component::__internal::Vec<i64>,),
+                            >::new_unchecked(self.list_s64_ret)
+                        }
                     }
                     pub async fn call_list_s64_ret<S: wasmtime::AsContextMut>(
                         &self,
@@ -2579,17 +2698,25 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/lists", function = "list-s64-ret",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (wasmtime::component::__internal::Vec<i64>,),
-                            >::new_unchecked(self.list_s64_ret)
-                        };
+                        let callee = self.func_list_s64_ret();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), ())
                             .instrument(span.clone())
                             .await?;
                         Ok(ret0)
+                    }
+                    pub fn func_list_f32_ret(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (),
+                        (wasmtime::component::__internal::Vec<f32>,),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (wasmtime::component::__internal::Vec<f32>,),
+                            >::new_unchecked(self.list_f32_ret)
+                        }
                     }
                     pub async fn call_list_f32_ret<S: wasmtime::AsContextMut>(
                         &self,
@@ -2603,17 +2730,25 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/lists", function = "list-f32-ret",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (wasmtime::component::__internal::Vec<f32>,),
-                            >::new_unchecked(self.list_f32_ret)
-                        };
+                        let callee = self.func_list_f32_ret();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), ())
                             .instrument(span.clone())
                             .await?;
                         Ok(ret0)
+                    }
+                    pub fn func_list_f64_ret(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (),
+                        (wasmtime::component::__internal::Vec<f64>,),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (wasmtime::component::__internal::Vec<f64>,),
+                            >::new_unchecked(self.list_f64_ret)
+                        }
                     }
                     pub async fn call_list_f64_ret<S: wasmtime::AsContextMut>(
                         &self,
@@ -2627,17 +2762,25 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/lists", function = "list-f64-ret",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (wasmtime::component::__internal::Vec<f64>,),
-                            >::new_unchecked(self.list_f64_ret)
-                        };
+                        let callee = self.func_list_f64_ret();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), ())
                             .instrument(span.clone())
                             .await?;
                         Ok(ret0)
+                    }
+                    pub fn func_tuple_list(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (&[(u8, i8)],),
+                        (wasmtime::component::__internal::Vec<(i64, u32)>,),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&[(u8, i8)],),
+                                (wasmtime::component::__internal::Vec<(i64, u32)>,),
+                            >::new_unchecked(self.tuple_list)
+                        }
                     }
                     pub async fn call_tuple_list<S: wasmtime::AsContextMut>(
                         &self,
@@ -2654,17 +2797,25 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/lists", function = "tuple-list",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (&[(u8, i8)],),
-                                (wasmtime::component::__internal::Vec<(i64, u32)>,),
-                            >::new_unchecked(self.tuple_list)
-                        };
+                        let callee = self.func_tuple_list();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), (arg0,))
                             .instrument(span.clone())
                             .await?;
                         Ok(ret0)
+                    }
+                    pub fn func_string_list_arg(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (&[wasmtime::component::__internal::String],),
+                        (),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&[wasmtime::component::__internal::String],),
+                                (),
+                            >::new_unchecked(self.string_list_arg)
+                        }
                     }
                     pub async fn call_string_list_arg<S: wasmtime::AsContextMut>(
                         &self,
@@ -2679,17 +2830,33 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/lists", function = "string-list-arg",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (&[wasmtime::component::__internal::String],),
-                                (),
-                            >::new_unchecked(self.string_list_arg)
-                        };
+                        let callee = self.func_string_list_arg();
                         let () = callee
                             .call_async(store.as_context_mut(), (arg0,))
                             .instrument(span.clone())
                             .await?;
                         Ok(())
+                    }
+                    pub fn func_string_list_ret(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (),
+                        (
+                            wasmtime::component::__internal::Vec<
+                                wasmtime::component::__internal::String,
+                            >,
+                        ),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (
+                                    wasmtime::component::__internal::Vec<
+                                        wasmtime::component::__internal::String,
+                                    >,
+                                ),
+                            >::new_unchecked(self.string_list_ret)
+                        }
                     }
                     pub async fn call_string_list_ret<S: wasmtime::AsContextMut>(
                         &self,
@@ -2707,21 +2874,33 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/lists", function = "string-list-ret",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (
-                                    wasmtime::component::__internal::Vec<
-                                        wasmtime::component::__internal::String,
-                                    >,
-                                ),
-                            >::new_unchecked(self.string_list_ret)
-                        };
+                        let callee = self.func_string_list_ret();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), ())
                             .instrument(span.clone())
                             .await?;
                         Ok(ret0)
+                    }
+                    pub fn func_tuple_string_list(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (&[(u8, wasmtime::component::__internal::String)],),
+                        (
+                            wasmtime::component::__internal::Vec<
+                                (wasmtime::component::__internal::String, u8),
+                            >,
+                        ),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&[(u8, wasmtime::component::__internal::String)],),
+                                (
+                                    wasmtime::component::__internal::Vec<
+                                        (wasmtime::component::__internal::String, u8),
+                                    >,
+                                ),
+                            >::new_unchecked(self.tuple_string_list)
+                        }
                     }
                     pub async fn call_tuple_string_list<S: wasmtime::AsContextMut>(
                         &self,
@@ -2740,21 +2919,33 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/lists", function = "tuple-string-list",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (&[(u8, wasmtime::component::__internal::String)],),
-                                (
-                                    wasmtime::component::__internal::Vec<
-                                        (wasmtime::component::__internal::String, u8),
-                                    >,
-                                ),
-                            >::new_unchecked(self.tuple_string_list)
-                        };
+                        let callee = self.func_tuple_string_list();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), (arg0,))
                             .instrument(span.clone())
                             .await?;
                         Ok(ret0)
+                    }
+                    pub fn func_string_list(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (&[wasmtime::component::__internal::String],),
+                        (
+                            wasmtime::component::__internal::Vec<
+                                wasmtime::component::__internal::String,
+                            >,
+                        ),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&[wasmtime::component::__internal::String],),
+                                (
+                                    wasmtime::component::__internal::Vec<
+                                        wasmtime::component::__internal::String,
+                                    >,
+                                ),
+                            >::new_unchecked(self.string_list)
+                        }
                     }
                     pub async fn call_string_list<S: wasmtime::AsContextMut>(
                         &self,
@@ -2773,21 +2964,25 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/lists", function = "string-list",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (&[wasmtime::component::__internal::String],),
-                                (
-                                    wasmtime::component::__internal::Vec<
-                                        wasmtime::component::__internal::String,
-                                    >,
-                                ),
-                            >::new_unchecked(self.string_list)
-                        };
+                        let callee = self.func_string_list();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), (arg0,))
                             .instrument(span.clone())
                             .await?;
                         Ok(ret0)
+                    }
+                    pub fn func_record_list(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (&[SomeRecord],),
+                        (wasmtime::component::__internal::Vec<OtherRecord>,),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&[SomeRecord],),
+                                (wasmtime::component::__internal::Vec<OtherRecord>,),
+                            >::new_unchecked(self.record_list)
+                        }
                     }
                     pub async fn call_record_list<S: wasmtime::AsContextMut>(
                         &self,
@@ -2804,17 +2999,25 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/lists", function = "record-list",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (&[SomeRecord],),
-                                (wasmtime::component::__internal::Vec<OtherRecord>,),
-                            >::new_unchecked(self.record_list)
-                        };
+                        let callee = self.func_record_list();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), (arg0,))
                             .instrument(span.clone())
                             .await?;
                         Ok(ret0)
+                    }
+                    pub fn func_record_list_reverse(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (&[OtherRecord],),
+                        (wasmtime::component::__internal::Vec<SomeRecord>,),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&[OtherRecord],),
+                                (wasmtime::component::__internal::Vec<SomeRecord>,),
+                            >::new_unchecked(self.record_list_reverse)
+                        }
                     }
                     pub async fn call_record_list_reverse<S: wasmtime::AsContextMut>(
                         &self,
@@ -2831,17 +3034,25 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/lists", function = "record-list-reverse",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (&[OtherRecord],),
-                                (wasmtime::component::__internal::Vec<SomeRecord>,),
-                            >::new_unchecked(self.record_list_reverse)
-                        };
+                        let callee = self.func_record_list_reverse();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), (arg0,))
                             .instrument(span.clone())
                             .await?;
                         Ok(ret0)
+                    }
+                    pub fn func_variant_list(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (&[SomeVariant],),
+                        (wasmtime::component::__internal::Vec<OtherVariant>,),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&[SomeVariant],),
+                                (wasmtime::component::__internal::Vec<OtherVariant>,),
+                            >::new_unchecked(self.variant_list)
+                        }
                     }
                     pub async fn call_variant_list<S: wasmtime::AsContextMut>(
                         &self,
@@ -2858,17 +3069,25 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/lists", function = "variant-list",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (&[SomeVariant],),
-                                (wasmtime::component::__internal::Vec<OtherVariant>,),
-                            >::new_unchecked(self.variant_list)
-                        };
+                        let callee = self.func_variant_list();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), (arg0,))
                             .instrument(span.clone())
                             .await?;
                         Ok(ret0)
+                    }
+                    pub fn func_load_store_everything(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (&LoadStoreAllSizes,),
+                        (LoadStoreAllSizes,),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&LoadStoreAllSizes,),
+                                (LoadStoreAllSizes,),
+                            >::new_unchecked(self.load_store_everything)
+                        }
                     }
                     pub async fn call_load_store_everything<S: wasmtime::AsContextMut>(
                         &self,
@@ -2883,12 +3102,7 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/lists", function = "load-store-everything",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (&LoadStoreAllSizes,),
-                                (LoadStoreAllSizes,),
-                            >::new_unchecked(self.load_store_everything)
-                        };
+                        let callee = self.func_load_store_everything();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), (arg0,))
                             .instrument(span.clone())

--- a/crates/component-macro/tests/expanded/many-arguments.rs
+++ b/crates/component-macro/tests/expanded/many-arguments.rs
@@ -625,27 +625,30 @@ pub mod exports {
                     }
                 }
                 impl Guest {
-                    pub fn call_many_args<S: wasmtime::AsContextMut>(
+                    pub fn func_many_args(
                         &self,
-                        mut store: S,
-                        arg0: u64,
-                        arg1: u64,
-                        arg2: u64,
-                        arg3: u64,
-                        arg4: u64,
-                        arg5: u64,
-                        arg6: u64,
-                        arg7: u64,
-                        arg8: u64,
-                        arg9: u64,
-                        arg10: u64,
-                        arg11: u64,
-                        arg12: u64,
-                        arg13: u64,
-                        arg14: u64,
-                        arg15: u64,
-                    ) -> wasmtime::Result<()> {
-                        let callee = unsafe {
+                    ) -> wasmtime::component::TypedFunc<
+                        (
+                            u64,
+                            u64,
+                            u64,
+                            u64,
+                            u64,
+                            u64,
+                            u64,
+                            u64,
+                            u64,
+                            u64,
+                            u64,
+                            u64,
+                            u64,
+                            u64,
+                            u64,
+                            u64,
+                        ),
+                        (),
+                    > {
+                        unsafe {
                             wasmtime::component::TypedFunc::<
                                 (
                                     u64,
@@ -667,7 +670,29 @@ pub mod exports {
                                 ),
                                 (),
                             >::new_unchecked(self.many_args)
-                        };
+                        }
+                    }
+                    pub fn call_many_args<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: u64,
+                        arg1: u64,
+                        arg2: u64,
+                        arg3: u64,
+                        arg4: u64,
+                        arg5: u64,
+                        arg6: u64,
+                        arg7: u64,
+                        arg8: u64,
+                        arg9: u64,
+                        arg10: u64,
+                        arg11: u64,
+                        arg12: u64,
+                        arg13: u64,
+                        arg14: u64,
+                        arg15: u64,
+                    ) -> wasmtime::Result<()> {
+                        let callee = self.func_many_args();
                         let () = callee
                             .call(
                                 store.as_context_mut(),
@@ -692,17 +717,22 @@ pub mod exports {
                             )?;
                         Ok(())
                     }
+                    pub fn func_big_argument(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(&BigStruct,), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&BigStruct,),
+                                (),
+                            >::new_unchecked(self.big_argument)
+                        }
+                    }
                     pub fn call_big_argument<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                         arg0: &BigStruct,
                     ) -> wasmtime::Result<()> {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (&BigStruct,),
-                                (),
-                            >::new_unchecked(self.big_argument)
-                        };
+                        let callee = self.func_big_argument();
                         let () = callee.call(store.as_context_mut(), (arg0,))?;
                         Ok(())
                     }

--- a/crates/component-macro/tests/expanded/many-arguments_async.rs
+++ b/crates/component-macro/tests/expanded/many-arguments_async.rs
@@ -639,6 +639,53 @@ pub mod exports {
                     }
                 }
                 impl Guest {
+                    pub fn func_many_args(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (
+                            u64,
+                            u64,
+                            u64,
+                            u64,
+                            u64,
+                            u64,
+                            u64,
+                            u64,
+                            u64,
+                            u64,
+                            u64,
+                            u64,
+                            u64,
+                            u64,
+                            u64,
+                            u64,
+                        ),
+                        (),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (
+                                    u64,
+                                    u64,
+                                    u64,
+                                    u64,
+                                    u64,
+                                    u64,
+                                    u64,
+                                    u64,
+                                    u64,
+                                    u64,
+                                    u64,
+                                    u64,
+                                    u64,
+                                    u64,
+                                    u64,
+                                    u64,
+                                ),
+                                (),
+                            >::new_unchecked(self.many_args)
+                        }
+                    }
                     pub async fn call_many_args<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
@@ -662,29 +709,7 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (
-                                    u64,
-                                    u64,
-                                    u64,
-                                    u64,
-                                    u64,
-                                    u64,
-                                    u64,
-                                    u64,
-                                    u64,
-                                    u64,
-                                    u64,
-                                    u64,
-                                    u64,
-                                    u64,
-                                    u64,
-                                    u64,
-                                ),
-                                (),
-                            >::new_unchecked(self.many_args)
-                        };
+                        let callee = self.func_many_args();
                         let () = callee
                             .call_async(
                                 store.as_context_mut(),
@@ -710,6 +735,16 @@ pub mod exports {
                             .await?;
                         Ok(())
                     }
+                    pub fn func_big_argument(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(&BigStruct,), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&BigStruct,),
+                                (),
+                            >::new_unchecked(self.big_argument)
+                        }
+                    }
                     pub async fn call_big_argument<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
@@ -718,12 +753,7 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (&BigStruct,),
-                                (),
-                            >::new_unchecked(self.big_argument)
-                        };
+                        let callee = self.func_big_argument();
                         let () = callee
                             .call_async(store.as_context_mut(), (arg0,))
                             .await?;

--- a/crates/component-macro/tests/expanded/many-arguments_concurrent.rs
+++ b/crates/component-macro/tests/expanded/many-arguments_concurrent.rs
@@ -586,6 +586,53 @@ pub mod exports {
                     }
                 }
                 impl Guest {
+                    pub fn func_many_args(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (
+                            u64,
+                            u64,
+                            u64,
+                            u64,
+                            u64,
+                            u64,
+                            u64,
+                            u64,
+                            u64,
+                            u64,
+                            u64,
+                            u64,
+                            u64,
+                            u64,
+                            u64,
+                            u64,
+                        ),
+                        (),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (
+                                    u64,
+                                    u64,
+                                    u64,
+                                    u64,
+                                    u64,
+                                    u64,
+                                    u64,
+                                    u64,
+                                    u64,
+                                    u64,
+                                    u64,
+                                    u64,
+                                    u64,
+                                    u64,
+                                    u64,
+                                    u64,
+                                ),
+                                (),
+                            >::new_unchecked(self.many_args)
+                        }
+                    }
                     pub async fn call_many_args<_T, _D>(
                         &self,
                         accessor: &wasmtime::component::Accessor<_T, _D>,
@@ -610,29 +657,7 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (
-                                    u64,
-                                    u64,
-                                    u64,
-                                    u64,
-                                    u64,
-                                    u64,
-                                    u64,
-                                    u64,
-                                    u64,
-                                    u64,
-                                    u64,
-                                    u64,
-                                    u64,
-                                    u64,
-                                    u64,
-                                    u64,
-                                ),
-                                (),
-                            >::new_unchecked(self.many_args)
-                        };
+                        let callee = self.func_many_args();
                         let () = callee
                             .call_concurrent(
                                 accessor,
@@ -658,6 +683,16 @@ pub mod exports {
                             .await?;
                         Ok(())
                     }
+                    pub fn func_big_argument(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(BigStruct,), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (BigStruct,),
+                                (),
+                            >::new_unchecked(self.big_argument)
+                        }
+                    }
                     pub async fn call_big_argument<_T, _D>(
                         &self,
                         accessor: &wasmtime::component::Accessor<_T, _D>,
@@ -667,12 +702,7 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (BigStruct,),
-                                (),
-                            >::new_unchecked(self.big_argument)
-                        };
+                        let callee = self.func_big_argument();
                         let () = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(())
                     }

--- a/crates/component-macro/tests/expanded/many-arguments_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/many-arguments_tracing_async.rs
@@ -682,6 +682,53 @@ pub mod exports {
                     }
                 }
                 impl Guest {
+                    pub fn func_many_args(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (
+                            u64,
+                            u64,
+                            u64,
+                            u64,
+                            u64,
+                            u64,
+                            u64,
+                            u64,
+                            u64,
+                            u64,
+                            u64,
+                            u64,
+                            u64,
+                            u64,
+                            u64,
+                            u64,
+                        ),
+                        (),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (
+                                    u64,
+                                    u64,
+                                    u64,
+                                    u64,
+                                    u64,
+                                    u64,
+                                    u64,
+                                    u64,
+                                    u64,
+                                    u64,
+                                    u64,
+                                    u64,
+                                    u64,
+                                    u64,
+                                    u64,
+                                    u64,
+                                ),
+                                (),
+                            >::new_unchecked(self.many_args)
+                        }
+                    }
                     pub async fn call_many_args<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
@@ -710,29 +757,7 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/manyarg", function = "many-args",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (
-                                    u64,
-                                    u64,
-                                    u64,
-                                    u64,
-                                    u64,
-                                    u64,
-                                    u64,
-                                    u64,
-                                    u64,
-                                    u64,
-                                    u64,
-                                    u64,
-                                    u64,
-                                    u64,
-                                    u64,
-                                    u64,
-                                ),
-                                (),
-                            >::new_unchecked(self.many_args)
-                        };
+                        let callee = self.func_many_args();
                         let () = callee
                             .call_async(
                                 store.as_context_mut(),
@@ -759,6 +784,16 @@ pub mod exports {
                             .await?;
                         Ok(())
                     }
+                    pub fn func_big_argument(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(&BigStruct,), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&BigStruct,),
+                                (),
+                            >::new_unchecked(self.big_argument)
+                        }
+                    }
                     pub async fn call_big_argument<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
@@ -772,12 +807,7 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/manyarg", function = "big-argument",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (&BigStruct,),
-                                (),
-                            >::new_unchecked(self.big_argument)
-                        };
+                        let callee = self.func_big_argument();
                         let () = callee
                             .call_async(store.as_context_mut(), (arg0,))
                             .instrument(span.clone())

--- a/crates/component-macro/tests/expanded/multiversion.rs
+++ b/crates/component-macro/tests/expanded/multiversion.rs
@@ -363,16 +363,19 @@ pub mod exports {
                     }
                 }
                 impl Guest {
-                    pub fn call_x<S: wasmtime::AsContextMut>(
-                        &self,
-                        mut store: S,
-                    ) -> wasmtime::Result<()> {
-                        let callee = unsafe {
+                    pub fn func_x(&self) -> wasmtime::component::TypedFunc<(), ()> {
+                        unsafe {
                             wasmtime::component::TypedFunc::<
                                 (),
                                 (),
                             >::new_unchecked(self.x)
-                        };
+                        }
+                    }
+                    pub fn call_x<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<()> {
+                        let callee = self.func_x();
                         let () = callee.call(store.as_context_mut(), ())?;
                         Ok(())
                     }
@@ -442,16 +445,19 @@ pub mod exports {
                     }
                 }
                 impl Guest {
-                    pub fn call_x<S: wasmtime::AsContextMut>(
-                        &self,
-                        mut store: S,
-                    ) -> wasmtime::Result<()> {
-                        let callee = unsafe {
+                    pub fn func_x(&self) -> wasmtime::component::TypedFunc<(), ()> {
+                        unsafe {
                             wasmtime::component::TypedFunc::<
                                 (),
                                 (),
                             >::new_unchecked(self.x)
-                        };
+                        }
+                    }
+                    pub fn call_x<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<()> {
+                        let callee = self.func_x();
                         let () = callee.call(store.as_context_mut(), ())?;
                         Ok(())
                     }

--- a/crates/component-macro/tests/expanded/multiversion_async.rs
+++ b/crates/component-macro/tests/expanded/multiversion_async.rs
@@ -367,6 +367,14 @@ pub mod exports {
                     }
                 }
                 impl Guest {
+                    pub fn func_x(&self) -> wasmtime::component::TypedFunc<(), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (),
+                            >::new_unchecked(self.x)
+                        }
+                    }
                     pub async fn call_x<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
@@ -374,12 +382,7 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (),
-                            >::new_unchecked(self.x)
-                        };
+                        let callee = self.func_x();
                         let () = callee.call_async(store.as_context_mut(), ()).await?;
                         Ok(())
                     }
@@ -449,6 +452,14 @@ pub mod exports {
                     }
                 }
                 impl Guest {
+                    pub fn func_x(&self) -> wasmtime::component::TypedFunc<(), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (),
+                            >::new_unchecked(self.x)
+                        }
+                    }
                     pub async fn call_x<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
@@ -456,12 +467,7 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (),
-                            >::new_unchecked(self.x)
-                        };
+                        let callee = self.func_x();
                         let () = callee.call_async(store.as_context_mut(), ()).await?;
                         Ok(())
                     }

--- a/crates/component-macro/tests/expanded/multiversion_concurrent.rs
+++ b/crates/component-macro/tests/expanded/multiversion_concurrent.rs
@@ -355,6 +355,14 @@ pub mod exports {
                     }
                 }
                 impl Guest {
+                    pub fn func_x(&self) -> wasmtime::component::TypedFunc<(), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (),
+                            >::new_unchecked(self.x)
+                        }
+                    }
                     pub async fn call_x<_T, _D>(
                         &self,
                         accessor: &wasmtime::component::Accessor<_T, _D>,
@@ -363,12 +371,7 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (),
-                            >::new_unchecked(self.x)
-                        };
+                        let callee = self.func_x();
                         let () = callee.call_concurrent(accessor, ()).await?;
                         Ok(())
                     }
@@ -438,6 +441,14 @@ pub mod exports {
                     }
                 }
                 impl Guest {
+                    pub fn func_x(&self) -> wasmtime::component::TypedFunc<(), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (),
+                            >::new_unchecked(self.x)
+                        }
+                    }
                     pub async fn call_x<_T, _D>(
                         &self,
                         accessor: &wasmtime::component::Accessor<_T, _D>,
@@ -446,12 +457,7 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (),
-                            >::new_unchecked(self.x)
-                        };
+                        let callee = self.func_x();
                         let () = callee.call_concurrent(accessor, ()).await?;
                         Ok(())
                     }

--- a/crates/component-macro/tests/expanded/multiversion_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/multiversion_tracing_async.rs
@@ -393,6 +393,14 @@ pub mod exports {
                     }
                 }
                 impl Guest {
+                    pub fn func_x(&self) -> wasmtime::component::TypedFunc<(), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (),
+                            >::new_unchecked(self.x)
+                        }
+                    }
                     pub async fn call_x<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
@@ -405,12 +413,7 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "my:dep/a@0.1.0", function = "x",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (),
-                            >::new_unchecked(self.x)
-                        };
+                        let callee = self.func_x();
                         let () = callee
                             .call_async(store.as_context_mut(), ())
                             .instrument(span.clone())
@@ -483,6 +486,14 @@ pub mod exports {
                     }
                 }
                 impl Guest {
+                    pub fn func_x(&self) -> wasmtime::component::TypedFunc<(), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (),
+                            >::new_unchecked(self.x)
+                        }
+                    }
                     pub async fn call_x<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
@@ -495,12 +506,7 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "my:dep/a@0.2.0", function = "x",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (),
-                            >::new_unchecked(self.x)
-                        };
+                        let callee = self.func_x();
                         let () = callee
                             .call_async(store.as_context_mut(), ())
                             .instrument(span.clone())

--- a/crates/component-macro/tests/expanded/records.rs
+++ b/crates/component-macro/tests/expanded/records.rs
@@ -981,152 +981,207 @@ pub mod exports {
                     }
                 }
                 impl Guest {
+                    pub fn func_tuple_arg(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<((char, u32),), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                ((char, u32),),
+                                (),
+                            >::new_unchecked(self.tuple_arg)
+                        }
+                    }
                     pub fn call_tuple_arg<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                         arg0: (char, u32),
                     ) -> wasmtime::Result<()> {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                ((char, u32),),
-                                (),
-                            >::new_unchecked(self.tuple_arg)
-                        };
+                        let callee = self.func_tuple_arg();
                         let () = callee.call(store.as_context_mut(), (arg0,))?;
                         Ok(())
+                    }
+                    pub fn func_tuple_result(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(), ((char, u32),)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                ((char, u32),),
+                            >::new_unchecked(self.tuple_result)
+                        }
                     }
                     pub fn call_tuple_result<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                     ) -> wasmtime::Result<(char, u32)> {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                ((char, u32),),
-                            >::new_unchecked(self.tuple_result)
-                        };
+                        let callee = self.func_tuple_result();
                         let (ret0,) = callee.call(store.as_context_mut(), ())?;
                         Ok(ret0)
+                    }
+                    pub fn func_empty_arg(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(Empty,), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (Empty,),
+                                (),
+                            >::new_unchecked(self.empty_arg)
+                        }
                     }
                     pub fn call_empty_arg<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                         arg0: Empty,
                     ) -> wasmtime::Result<()> {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (Empty,),
-                                (),
-                            >::new_unchecked(self.empty_arg)
-                        };
+                        let callee = self.func_empty_arg();
                         let () = callee.call(store.as_context_mut(), (arg0,))?;
                         Ok(())
+                    }
+                    pub fn func_empty_result(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(), (Empty,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (Empty,),
+                            >::new_unchecked(self.empty_result)
+                        }
                     }
                     pub fn call_empty_result<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                     ) -> wasmtime::Result<Empty> {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (Empty,),
-                            >::new_unchecked(self.empty_result)
-                        };
+                        let callee = self.func_empty_result();
                         let (ret0,) = callee.call(store.as_context_mut(), ())?;
                         Ok(ret0)
+                    }
+                    pub fn func_scalar_arg(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(Scalars,), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (Scalars,),
+                                (),
+                            >::new_unchecked(self.scalar_arg)
+                        }
                     }
                     pub fn call_scalar_arg<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                         arg0: Scalars,
                     ) -> wasmtime::Result<()> {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (Scalars,),
-                                (),
-                            >::new_unchecked(self.scalar_arg)
-                        };
+                        let callee = self.func_scalar_arg();
                         let () = callee.call(store.as_context_mut(), (arg0,))?;
                         Ok(())
+                    }
+                    pub fn func_scalar_result(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(), (Scalars,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (Scalars,),
+                            >::new_unchecked(self.scalar_result)
+                        }
                     }
                     pub fn call_scalar_result<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                     ) -> wasmtime::Result<Scalars> {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (Scalars,),
-                            >::new_unchecked(self.scalar_result)
-                        };
+                        let callee = self.func_scalar_result();
                         let (ret0,) = callee.call(store.as_context_mut(), ())?;
                         Ok(ret0)
+                    }
+                    pub fn func_flags_arg(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(ReallyFlags,), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (ReallyFlags,),
+                                (),
+                            >::new_unchecked(self.flags_arg)
+                        }
                     }
                     pub fn call_flags_arg<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                         arg0: ReallyFlags,
                     ) -> wasmtime::Result<()> {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (ReallyFlags,),
-                                (),
-                            >::new_unchecked(self.flags_arg)
-                        };
+                        let callee = self.func_flags_arg();
                         let () = callee.call(store.as_context_mut(), (arg0,))?;
                         Ok(())
+                    }
+                    pub fn func_flags_result(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(), (ReallyFlags,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (ReallyFlags,),
+                            >::new_unchecked(self.flags_result)
+                        }
                     }
                     pub fn call_flags_result<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                     ) -> wasmtime::Result<ReallyFlags> {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (ReallyFlags,),
-                            >::new_unchecked(self.flags_result)
-                        };
+                        let callee = self.func_flags_result();
                         let (ret0,) = callee.call(store.as_context_mut(), ())?;
                         Ok(ret0)
+                    }
+                    pub fn func_aggregate_arg(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(&Aggregates,), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&Aggregates,),
+                                (),
+                            >::new_unchecked(self.aggregate_arg)
+                        }
                     }
                     pub fn call_aggregate_arg<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                         arg0: &Aggregates,
                     ) -> wasmtime::Result<()> {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (&Aggregates,),
-                                (),
-                            >::new_unchecked(self.aggregate_arg)
-                        };
+                        let callee = self.func_aggregate_arg();
                         let () = callee.call(store.as_context_mut(), (arg0,))?;
                         Ok(())
+                    }
+                    pub fn func_aggregate_result(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(), (Aggregates,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (Aggregates,),
+                            >::new_unchecked(self.aggregate_result)
+                        }
                     }
                     pub fn call_aggregate_result<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                     ) -> wasmtime::Result<Aggregates> {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (Aggregates,),
-                            >::new_unchecked(self.aggregate_result)
-                        };
+                        let callee = self.func_aggregate_result();
                         let (ret0,) = callee.call(store.as_context_mut(), ())?;
                         Ok(ret0)
+                    }
+                    pub fn func_typedef_inout(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(TupleTypedef2,), (i32,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (TupleTypedef2,),
+                                (i32,),
+                            >::new_unchecked(self.typedef_inout)
+                        }
                     }
                     pub fn call_typedef_inout<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                         arg0: TupleTypedef2,
                     ) -> wasmtime::Result<i32> {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (TupleTypedef2,),
-                                (i32,),
-                            >::new_unchecked(self.typedef_inout)
-                        };
+                        let callee = self.func_typedef_inout();
                         let (ret0,) = callee.call(store.as_context_mut(), (arg0,))?;
                         Ok(ret0)
                     }

--- a/crates/component-macro/tests/expanded/records_async.rs
+++ b/crates/component-macro/tests/expanded/records_async.rs
@@ -1059,6 +1059,16 @@ pub mod exports {
                     }
                 }
                 impl Guest {
+                    pub fn func_tuple_arg(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<((char, u32),), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                ((char, u32),),
+                                (),
+                            >::new_unchecked(self.tuple_arg)
+                        }
+                    }
                     pub async fn call_tuple_arg<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
@@ -1067,16 +1077,21 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                ((char, u32),),
-                                (),
-                            >::new_unchecked(self.tuple_arg)
-                        };
+                        let callee = self.func_tuple_arg();
                         let () = callee
                             .call_async(store.as_context_mut(), (arg0,))
                             .await?;
                         Ok(())
+                    }
+                    pub fn func_tuple_result(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(), ((char, u32),)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                ((char, u32),),
+                            >::new_unchecked(self.tuple_result)
+                        }
                     }
                     pub async fn call_tuple_result<S: wasmtime::AsContextMut>(
                         &self,
@@ -1085,16 +1100,21 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                ((char, u32),),
-                            >::new_unchecked(self.tuple_result)
-                        };
+                        let callee = self.func_tuple_result();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), ())
                             .await?;
                         Ok(ret0)
+                    }
+                    pub fn func_empty_arg(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(Empty,), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (Empty,),
+                                (),
+                            >::new_unchecked(self.empty_arg)
+                        }
                     }
                     pub async fn call_empty_arg<S: wasmtime::AsContextMut>(
                         &self,
@@ -1104,16 +1124,21 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (Empty,),
-                                (),
-                            >::new_unchecked(self.empty_arg)
-                        };
+                        let callee = self.func_empty_arg();
                         let () = callee
                             .call_async(store.as_context_mut(), (arg0,))
                             .await?;
                         Ok(())
+                    }
+                    pub fn func_empty_result(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(), (Empty,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (Empty,),
+                            >::new_unchecked(self.empty_result)
+                        }
                     }
                     pub async fn call_empty_result<S: wasmtime::AsContextMut>(
                         &self,
@@ -1122,16 +1147,21 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (Empty,),
-                            >::new_unchecked(self.empty_result)
-                        };
+                        let callee = self.func_empty_result();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), ())
                             .await?;
                         Ok(ret0)
+                    }
+                    pub fn func_scalar_arg(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(Scalars,), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (Scalars,),
+                                (),
+                            >::new_unchecked(self.scalar_arg)
+                        }
                     }
                     pub async fn call_scalar_arg<S: wasmtime::AsContextMut>(
                         &self,
@@ -1141,16 +1171,21 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (Scalars,),
-                                (),
-                            >::new_unchecked(self.scalar_arg)
-                        };
+                        let callee = self.func_scalar_arg();
                         let () = callee
                             .call_async(store.as_context_mut(), (arg0,))
                             .await?;
                         Ok(())
+                    }
+                    pub fn func_scalar_result(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(), (Scalars,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (Scalars,),
+                            >::new_unchecked(self.scalar_result)
+                        }
                     }
                     pub async fn call_scalar_result<S: wasmtime::AsContextMut>(
                         &self,
@@ -1159,16 +1194,21 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (Scalars,),
-                            >::new_unchecked(self.scalar_result)
-                        };
+                        let callee = self.func_scalar_result();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), ())
                             .await?;
                         Ok(ret0)
+                    }
+                    pub fn func_flags_arg(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(ReallyFlags,), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (ReallyFlags,),
+                                (),
+                            >::new_unchecked(self.flags_arg)
+                        }
                     }
                     pub async fn call_flags_arg<S: wasmtime::AsContextMut>(
                         &self,
@@ -1178,16 +1218,21 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (ReallyFlags,),
-                                (),
-                            >::new_unchecked(self.flags_arg)
-                        };
+                        let callee = self.func_flags_arg();
                         let () = callee
                             .call_async(store.as_context_mut(), (arg0,))
                             .await?;
                         Ok(())
+                    }
+                    pub fn func_flags_result(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(), (ReallyFlags,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (ReallyFlags,),
+                            >::new_unchecked(self.flags_result)
+                        }
                     }
                     pub async fn call_flags_result<S: wasmtime::AsContextMut>(
                         &self,
@@ -1196,16 +1241,21 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (ReallyFlags,),
-                            >::new_unchecked(self.flags_result)
-                        };
+                        let callee = self.func_flags_result();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), ())
                             .await?;
                         Ok(ret0)
+                    }
+                    pub fn func_aggregate_arg(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(&Aggregates,), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&Aggregates,),
+                                (),
+                            >::new_unchecked(self.aggregate_arg)
+                        }
                     }
                     pub async fn call_aggregate_arg<S: wasmtime::AsContextMut>(
                         &self,
@@ -1215,16 +1265,21 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (&Aggregates,),
-                                (),
-                            >::new_unchecked(self.aggregate_arg)
-                        };
+                        let callee = self.func_aggregate_arg();
                         let () = callee
                             .call_async(store.as_context_mut(), (arg0,))
                             .await?;
                         Ok(())
+                    }
+                    pub fn func_aggregate_result(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(), (Aggregates,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (Aggregates,),
+                            >::new_unchecked(self.aggregate_result)
+                        }
                     }
                     pub async fn call_aggregate_result<S: wasmtime::AsContextMut>(
                         &self,
@@ -1233,16 +1288,21 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (Aggregates,),
-                            >::new_unchecked(self.aggregate_result)
-                        };
+                        let callee = self.func_aggregate_result();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), ())
                             .await?;
                         Ok(ret0)
+                    }
+                    pub fn func_typedef_inout(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(TupleTypedef2,), (i32,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (TupleTypedef2,),
+                                (i32,),
+                            >::new_unchecked(self.typedef_inout)
+                        }
                     }
                     pub async fn call_typedef_inout<S: wasmtime::AsContextMut>(
                         &self,
@@ -1252,12 +1312,7 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (TupleTypedef2,),
-                                (i32,),
-                            >::new_unchecked(self.typedef_inout)
-                        };
+                        let callee = self.func_typedef_inout();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), (arg0,))
                             .await?;

--- a/crates/component-macro/tests/expanded/records_concurrent.rs
+++ b/crates/component-macro/tests/expanded/records_concurrent.rs
@@ -992,6 +992,16 @@ pub mod exports {
                     }
                 }
                 impl Guest {
+                    pub fn func_tuple_arg(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<((char, u32),), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                ((char, u32),),
+                                (),
+                            >::new_unchecked(self.tuple_arg)
+                        }
+                    }
                     pub async fn call_tuple_arg<_T, _D>(
                         &self,
                         accessor: &wasmtime::component::Accessor<_T, _D>,
@@ -1001,14 +1011,19 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                ((char, u32),),
-                                (),
-                            >::new_unchecked(self.tuple_arg)
-                        };
+                        let callee = self.func_tuple_arg();
                         let () = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(())
+                    }
+                    pub fn func_tuple_result(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(), ((char, u32),)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                ((char, u32),),
+                            >::new_unchecked(self.tuple_result)
+                        }
                     }
                     pub async fn call_tuple_result<_T, _D>(
                         &self,
@@ -1018,14 +1033,19 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                ((char, u32),),
-                            >::new_unchecked(self.tuple_result)
-                        };
+                        let callee = self.func_tuple_result();
                         let (ret0,) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
+                    }
+                    pub fn func_empty_arg(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(Empty,), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (Empty,),
+                                (),
+                            >::new_unchecked(self.empty_arg)
+                        }
                     }
                     pub async fn call_empty_arg<_T, _D>(
                         &self,
@@ -1036,14 +1056,19 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (Empty,),
-                                (),
-                            >::new_unchecked(self.empty_arg)
-                        };
+                        let callee = self.func_empty_arg();
                         let () = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(())
+                    }
+                    pub fn func_empty_result(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(), (Empty,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (Empty,),
+                            >::new_unchecked(self.empty_result)
+                        }
                     }
                     pub async fn call_empty_result<_T, _D>(
                         &self,
@@ -1053,14 +1078,19 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (Empty,),
-                            >::new_unchecked(self.empty_result)
-                        };
+                        let callee = self.func_empty_result();
                         let (ret0,) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
+                    }
+                    pub fn func_scalar_arg(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(Scalars,), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (Scalars,),
+                                (),
+                            >::new_unchecked(self.scalar_arg)
+                        }
                     }
                     pub async fn call_scalar_arg<_T, _D>(
                         &self,
@@ -1071,14 +1101,19 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (Scalars,),
-                                (),
-                            >::new_unchecked(self.scalar_arg)
-                        };
+                        let callee = self.func_scalar_arg();
                         let () = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(())
+                    }
+                    pub fn func_scalar_result(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(), (Scalars,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (Scalars,),
+                            >::new_unchecked(self.scalar_result)
+                        }
                     }
                     pub async fn call_scalar_result<_T, _D>(
                         &self,
@@ -1088,14 +1123,19 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (Scalars,),
-                            >::new_unchecked(self.scalar_result)
-                        };
+                        let callee = self.func_scalar_result();
                         let (ret0,) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
+                    }
+                    pub fn func_flags_arg(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(ReallyFlags,), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (ReallyFlags,),
+                                (),
+                            >::new_unchecked(self.flags_arg)
+                        }
                     }
                     pub async fn call_flags_arg<_T, _D>(
                         &self,
@@ -1106,14 +1146,19 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (ReallyFlags,),
-                                (),
-                            >::new_unchecked(self.flags_arg)
-                        };
+                        let callee = self.func_flags_arg();
                         let () = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(())
+                    }
+                    pub fn func_flags_result(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(), (ReallyFlags,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (ReallyFlags,),
+                            >::new_unchecked(self.flags_result)
+                        }
                     }
                     pub async fn call_flags_result<_T, _D>(
                         &self,
@@ -1123,14 +1168,19 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (ReallyFlags,),
-                            >::new_unchecked(self.flags_result)
-                        };
+                        let callee = self.func_flags_result();
                         let (ret0,) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
+                    }
+                    pub fn func_aggregate_arg(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(Aggregates,), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (Aggregates,),
+                                (),
+                            >::new_unchecked(self.aggregate_arg)
+                        }
                     }
                     pub async fn call_aggregate_arg<_T, _D>(
                         &self,
@@ -1141,14 +1191,19 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (Aggregates,),
-                                (),
-                            >::new_unchecked(self.aggregate_arg)
-                        };
+                        let callee = self.func_aggregate_arg();
                         let () = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(())
+                    }
+                    pub fn func_aggregate_result(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(), (Aggregates,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (Aggregates,),
+                            >::new_unchecked(self.aggregate_result)
+                        }
                     }
                     pub async fn call_aggregate_result<_T, _D>(
                         &self,
@@ -1158,14 +1213,19 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (Aggregates,),
-                            >::new_unchecked(self.aggregate_result)
-                        };
+                        let callee = self.func_aggregate_result();
                         let (ret0,) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
+                    }
+                    pub fn func_typedef_inout(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(TupleTypedef2,), (i32,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (TupleTypedef2,),
+                                (i32,),
+                            >::new_unchecked(self.typedef_inout)
+                        }
                     }
                     pub async fn call_typedef_inout<_T, _D>(
                         &self,
@@ -1176,12 +1236,7 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (TupleTypedef2,),
-                                (i32,),
-                            >::new_unchecked(self.typedef_inout)
-                        };
+                        let callee = self.func_typedef_inout();
                         let (ret0,) = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(ret0)
                     }

--- a/crates/component-macro/tests/expanded/records_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/records_tracing_async.rs
@@ -1220,6 +1220,16 @@ pub mod exports {
                     }
                 }
                 impl Guest {
+                    pub fn func_tuple_arg(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<((char, u32),), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                ((char, u32),),
+                                (),
+                            >::new_unchecked(self.tuple_arg)
+                        }
+                    }
                     pub async fn call_tuple_arg<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
@@ -1233,17 +1243,22 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/records", function = "tuple-arg",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                ((char, u32),),
-                                (),
-                            >::new_unchecked(self.tuple_arg)
-                        };
+                        let callee = self.func_tuple_arg();
                         let () = callee
                             .call_async(store.as_context_mut(), (arg0,))
                             .instrument(span.clone())
                             .await?;
                         Ok(())
+                    }
+                    pub fn func_tuple_result(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(), ((char, u32),)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                ((char, u32),),
+                            >::new_unchecked(self.tuple_result)
+                        }
                     }
                     pub async fn call_tuple_result<S: wasmtime::AsContextMut>(
                         &self,
@@ -1257,17 +1272,22 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/records", function = "tuple-result",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                ((char, u32),),
-                            >::new_unchecked(self.tuple_result)
-                        };
+                        let callee = self.func_tuple_result();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), ())
                             .instrument(span.clone())
                             .await?;
                         Ok(ret0)
+                    }
+                    pub fn func_empty_arg(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(Empty,), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (Empty,),
+                                (),
+                            >::new_unchecked(self.empty_arg)
+                        }
                     }
                     pub async fn call_empty_arg<S: wasmtime::AsContextMut>(
                         &self,
@@ -1282,17 +1302,22 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/records", function = "empty-arg",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (Empty,),
-                                (),
-                            >::new_unchecked(self.empty_arg)
-                        };
+                        let callee = self.func_empty_arg();
                         let () = callee
                             .call_async(store.as_context_mut(), (arg0,))
                             .instrument(span.clone())
                             .await?;
                         Ok(())
+                    }
+                    pub fn func_empty_result(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(), (Empty,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (Empty,),
+                            >::new_unchecked(self.empty_result)
+                        }
                     }
                     pub async fn call_empty_result<S: wasmtime::AsContextMut>(
                         &self,
@@ -1306,17 +1331,22 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/records", function = "empty-result",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (Empty,),
-                            >::new_unchecked(self.empty_result)
-                        };
+                        let callee = self.func_empty_result();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), ())
                             .instrument(span.clone())
                             .await?;
                         Ok(ret0)
+                    }
+                    pub fn func_scalar_arg(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(Scalars,), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (Scalars,),
+                                (),
+                            >::new_unchecked(self.scalar_arg)
+                        }
                     }
                     pub async fn call_scalar_arg<S: wasmtime::AsContextMut>(
                         &self,
@@ -1331,17 +1361,22 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/records", function = "scalar-arg",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (Scalars,),
-                                (),
-                            >::new_unchecked(self.scalar_arg)
-                        };
+                        let callee = self.func_scalar_arg();
                         let () = callee
                             .call_async(store.as_context_mut(), (arg0,))
                             .instrument(span.clone())
                             .await?;
                         Ok(())
+                    }
+                    pub fn func_scalar_result(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(), (Scalars,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (Scalars,),
+                            >::new_unchecked(self.scalar_result)
+                        }
                     }
                     pub async fn call_scalar_result<S: wasmtime::AsContextMut>(
                         &self,
@@ -1355,17 +1390,22 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/records", function = "scalar-result",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (Scalars,),
-                            >::new_unchecked(self.scalar_result)
-                        };
+                        let callee = self.func_scalar_result();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), ())
                             .instrument(span.clone())
                             .await?;
                         Ok(ret0)
+                    }
+                    pub fn func_flags_arg(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(ReallyFlags,), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (ReallyFlags,),
+                                (),
+                            >::new_unchecked(self.flags_arg)
+                        }
                     }
                     pub async fn call_flags_arg<S: wasmtime::AsContextMut>(
                         &self,
@@ -1380,17 +1420,22 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/records", function = "flags-arg",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (ReallyFlags,),
-                                (),
-                            >::new_unchecked(self.flags_arg)
-                        };
+                        let callee = self.func_flags_arg();
                         let () = callee
                             .call_async(store.as_context_mut(), (arg0,))
                             .instrument(span.clone())
                             .await?;
                         Ok(())
+                    }
+                    pub fn func_flags_result(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(), (ReallyFlags,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (ReallyFlags,),
+                            >::new_unchecked(self.flags_result)
+                        }
                     }
                     pub async fn call_flags_result<S: wasmtime::AsContextMut>(
                         &self,
@@ -1404,17 +1449,22 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/records", function = "flags-result",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (ReallyFlags,),
-                            >::new_unchecked(self.flags_result)
-                        };
+                        let callee = self.func_flags_result();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), ())
                             .instrument(span.clone())
                             .await?;
                         Ok(ret0)
+                    }
+                    pub fn func_aggregate_arg(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(&Aggregates,), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&Aggregates,),
+                                (),
+                            >::new_unchecked(self.aggregate_arg)
+                        }
                     }
                     pub async fn call_aggregate_arg<S: wasmtime::AsContextMut>(
                         &self,
@@ -1429,17 +1479,22 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/records", function = "aggregate-arg",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (&Aggregates,),
-                                (),
-                            >::new_unchecked(self.aggregate_arg)
-                        };
+                        let callee = self.func_aggregate_arg();
                         let () = callee
                             .call_async(store.as_context_mut(), (arg0,))
                             .instrument(span.clone())
                             .await?;
                         Ok(())
+                    }
+                    pub fn func_aggregate_result(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(), (Aggregates,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (Aggregates,),
+                            >::new_unchecked(self.aggregate_result)
+                        }
                     }
                     pub async fn call_aggregate_result<S: wasmtime::AsContextMut>(
                         &self,
@@ -1453,17 +1508,22 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/records", function = "aggregate-result",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (Aggregates,),
-                            >::new_unchecked(self.aggregate_result)
-                        };
+                        let callee = self.func_aggregate_result();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), ())
                             .instrument(span.clone())
                             .await?;
                         Ok(ret0)
+                    }
+                    pub fn func_typedef_inout(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(TupleTypedef2,), (i32,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (TupleTypedef2,),
+                                (i32,),
+                            >::new_unchecked(self.typedef_inout)
+                        }
                     }
                     pub async fn call_typedef_inout<S: wasmtime::AsContextMut>(
                         &self,
@@ -1478,12 +1538,7 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/records", function = "typedef-inout",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (TupleTypedef2,),
-                                (i32,),
-                            >::new_unchecked(self.typedef_inout)
-                        };
+                        let callee = self.func_typedef_inout();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), (arg0,))
                             .instrument(span.clone())

--- a/crates/component-macro/tests/expanded/resources-export.rs
+++ b/crates/component-macro/tests/expanded/resources-export.rs
@@ -400,43 +400,64 @@ pub mod exports {
                     }
                 }
                 impl GuestA<'_> {
-                    pub fn call_constructor<S: wasmtime::AsContextMut>(
+                    pub fn func_constructor(
                         &self,
-                        mut store: S,
-                    ) -> wasmtime::Result<wasmtime::component::ResourceAny> {
-                        let callee = unsafe {
+                    ) -> wasmtime::component::TypedFunc<
+                        (),
+                        (wasmtime::component::ResourceAny,),
+                    > {
+                        unsafe {
                             wasmtime::component::TypedFunc::<
                                 (),
                                 (wasmtime::component::ResourceAny,),
                             >::new_unchecked(self.funcs.constructor_a_constructor)
-                        };
+                        }
+                    }
+                    pub fn call_constructor<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<wasmtime::component::ResourceAny> {
+                        let callee = self.func_constructor();
                         let (ret0,) = callee.call(store.as_context_mut(), ())?;
                         Ok(ret0)
+                    }
+                    pub fn func_static_a(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(), (u32,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (u32,),
+                            >::new_unchecked(self.funcs.static_a_static_a)
+                        }
                     }
                     pub fn call_static_a<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                     ) -> wasmtime::Result<u32> {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (u32,),
-                            >::new_unchecked(self.funcs.static_a_static_a)
-                        };
+                        let callee = self.func_static_a();
                         let (ret0,) = callee.call(store.as_context_mut(), ())?;
                         Ok(ret0)
+                    }
+                    pub fn func_method_a(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (wasmtime::component::ResourceAny,),
+                        (u32,),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (wasmtime::component::ResourceAny,),
+                                (u32,),
+                            >::new_unchecked(self.funcs.method_a_method_a)
+                        }
                     }
                     pub fn call_method_a<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                         arg0: wasmtime::component::ResourceAny,
                     ) -> wasmtime::Result<u32> {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (wasmtime::component::ResourceAny,),
-                                (u32,),
-                            >::new_unchecked(self.funcs.method_a_method_a)
-                        };
+                        let callee = self.func_method_a();
                         let (ret0,) = callee.call(store.as_context_mut(), (arg0,))?;
                         Ok(ret0)
                     }
@@ -546,40 +567,59 @@ pub mod exports {
                     }
                 }
                 impl GuestA<'_> {
+                    pub fn func_constructor(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (wasmtime::component::Resource<Y>,),
+                        (wasmtime::component::ResourceAny,),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (wasmtime::component::Resource<Y>,),
+                                (wasmtime::component::ResourceAny,),
+                            >::new_unchecked(self.funcs.constructor_a_constructor)
+                        }
+                    }
                     pub fn call_constructor<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                         arg0: wasmtime::component::Resource<Y>,
                     ) -> wasmtime::Result<wasmtime::component::ResourceAny> {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (wasmtime::component::Resource<Y>,),
-                                (wasmtime::component::ResourceAny,),
-                            >::new_unchecked(self.funcs.constructor_a_constructor)
-                        };
+                        let callee = self.func_constructor();
                         let (ret0,) = callee.call(store.as_context_mut(), (arg0,))?;
                         Ok(ret0)
+                    }
+                    pub fn func_static_a(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (),
+                        (wasmtime::component::Resource<Y>,),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (wasmtime::component::Resource<Y>,),
+                            >::new_unchecked(self.funcs.static_a_static_a)
+                        }
                     }
                     pub fn call_static_a<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                     ) -> wasmtime::Result<wasmtime::component::Resource<Y>> {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (wasmtime::component::Resource<Y>,),
-                            >::new_unchecked(self.funcs.static_a_static_a)
-                        };
+                        let callee = self.func_static_a();
                         let (ret0,) = callee.call(store.as_context_mut(), ())?;
                         Ok(ret0)
                     }
-                    pub fn call_method_a<S: wasmtime::AsContextMut>(
+                    pub fn func_method_a(
                         &self,
-                        mut store: S,
-                        arg0: wasmtime::component::ResourceAny,
-                        arg1: wasmtime::component::Resource<Y>,
-                    ) -> wasmtime::Result<wasmtime::component::Resource<Y>> {
-                        let callee = unsafe {
+                    ) -> wasmtime::component::TypedFunc<
+                        (
+                            wasmtime::component::ResourceAny,
+                            wasmtime::component::Resource<Y>,
+                        ),
+                        (wasmtime::component::Resource<Y>,),
+                    > {
+                        unsafe {
                             wasmtime::component::TypedFunc::<
                                 (
                                     wasmtime::component::ResourceAny,
@@ -587,7 +627,15 @@ pub mod exports {
                                 ),
                                 (wasmtime::component::Resource<Y>,),
                             >::new_unchecked(self.funcs.method_a_method_a)
-                        };
+                        }
+                    }
+                    pub fn call_method_a<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: wasmtime::component::ResourceAny,
+                        arg1: wasmtime::component::Resource<Y>,
+                    ) -> wasmtime::Result<wasmtime::component::Resource<Y>> {
+                        let callee = self.func_method_a();
                         let (ret0,) = callee.call(store.as_context_mut(), (arg0, arg1))?;
                         Ok(ret0)
                     }
@@ -669,16 +717,24 @@ pub mod exports {
                     }
                 }
                 impl GuestA<'_> {
-                    pub fn call_constructor<S: wasmtime::AsContextMut>(
+                    pub fn func_constructor(
                         &self,
-                        mut store: S,
-                    ) -> wasmtime::Result<wasmtime::component::ResourceAny> {
-                        let callee = unsafe {
+                    ) -> wasmtime::component::TypedFunc<
+                        (),
+                        (wasmtime::component::ResourceAny,),
+                    > {
+                        unsafe {
                             wasmtime::component::TypedFunc::<
                                 (),
                                 (wasmtime::component::ResourceAny,),
                             >::new_unchecked(self.funcs.constructor_a_constructor)
-                        };
+                        }
+                    }
+                    pub fn call_constructor<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<wasmtime::component::ResourceAny> {
+                        let callee = self.func_constructor();
                         let (ret0,) = callee.call(store.as_context_mut(), ())?;
                         Ok(ret0)
                     }
@@ -761,17 +817,25 @@ pub mod exports {
                     }
                 }
                 impl GuestB<'_> {
+                    pub fn func_constructor(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (wasmtime::component::ResourceAny,),
+                        (wasmtime::component::ResourceAny,),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (wasmtime::component::ResourceAny,),
+                                (wasmtime::component::ResourceAny,),
+                            >::new_unchecked(self.funcs.constructor_b_constructor)
+                        }
+                    }
                     pub fn call_constructor<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                         arg0: wasmtime::component::ResourceAny,
                     ) -> wasmtime::Result<wasmtime::component::ResourceAny> {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (wasmtime::component::ResourceAny,),
-                                (wasmtime::component::ResourceAny,),
-                            >::new_unchecked(self.funcs.constructor_b_constructor)
-                        };
+                        let callee = self.func_constructor();
                         let (ret0,) = callee.call(store.as_context_mut(), (arg0,))?;
                         Ok(ret0)
                     }

--- a/crates/component-macro/tests/expanded/resources-export_async.rs
+++ b/crates/component-macro/tests/expanded/resources-export_async.rs
@@ -405,6 +405,19 @@ pub mod exports {
                     }
                 }
                 impl GuestA<'_> {
+                    pub fn func_constructor(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (),
+                        (wasmtime::component::ResourceAny,),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (wasmtime::component::ResourceAny,),
+                            >::new_unchecked(self.funcs.constructor_a_constructor)
+                        }
+                    }
                     pub async fn call_constructor<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
@@ -412,16 +425,21 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (wasmtime::component::ResourceAny,),
-                            >::new_unchecked(self.funcs.constructor_a_constructor)
-                        };
+                        let callee = self.func_constructor();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), ())
                             .await?;
                         Ok(ret0)
+                    }
+                    pub fn func_static_a(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(), (u32,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (u32,),
+                            >::new_unchecked(self.funcs.static_a_static_a)
+                        }
                     }
                     pub async fn call_static_a<S: wasmtime::AsContextMut>(
                         &self,
@@ -430,16 +448,24 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (u32,),
-                            >::new_unchecked(self.funcs.static_a_static_a)
-                        };
+                        let callee = self.func_static_a();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), ())
                             .await?;
                         Ok(ret0)
+                    }
+                    pub fn func_method_a(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (wasmtime::component::ResourceAny,),
+                        (u32,),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (wasmtime::component::ResourceAny,),
+                                (u32,),
+                            >::new_unchecked(self.funcs.method_a_method_a)
+                        }
                     }
                     pub async fn call_method_a<S: wasmtime::AsContextMut>(
                         &self,
@@ -449,12 +475,7 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (wasmtime::component::ResourceAny,),
-                                (u32,),
-                            >::new_unchecked(self.funcs.method_a_method_a)
-                        };
+                        let callee = self.func_method_a();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), (arg0,))
                             .await?;
@@ -566,6 +587,19 @@ pub mod exports {
                     }
                 }
                 impl GuestA<'_> {
+                    pub fn func_constructor(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (wasmtime::component::Resource<Y>,),
+                        (wasmtime::component::ResourceAny,),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (wasmtime::component::Resource<Y>,),
+                                (wasmtime::component::ResourceAny,),
+                            >::new_unchecked(self.funcs.constructor_a_constructor)
+                        }
+                    }
                     pub async fn call_constructor<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
@@ -574,16 +608,24 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (wasmtime::component::Resource<Y>,),
-                                (wasmtime::component::ResourceAny,),
-                            >::new_unchecked(self.funcs.constructor_a_constructor)
-                        };
+                        let callee = self.func_constructor();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), (arg0,))
                             .await?;
                         Ok(ret0)
+                    }
+                    pub fn func_static_a(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (),
+                        (wasmtime::component::Resource<Y>,),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (wasmtime::component::Resource<Y>,),
+                            >::new_unchecked(self.funcs.static_a_static_a)
+                        }
                     }
                     pub async fn call_static_a<S: wasmtime::AsContextMut>(
                         &self,
@@ -592,16 +634,30 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (wasmtime::component::Resource<Y>,),
-                            >::new_unchecked(self.funcs.static_a_static_a)
-                        };
+                        let callee = self.func_static_a();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), ())
                             .await?;
                         Ok(ret0)
+                    }
+                    pub fn func_method_a(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (
+                            wasmtime::component::ResourceAny,
+                            wasmtime::component::Resource<Y>,
+                        ),
+                        (wasmtime::component::Resource<Y>,),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (
+                                    wasmtime::component::ResourceAny,
+                                    wasmtime::component::Resource<Y>,
+                                ),
+                                (wasmtime::component::Resource<Y>,),
+                            >::new_unchecked(self.funcs.method_a_method_a)
+                        }
                     }
                     pub async fn call_method_a<S: wasmtime::AsContextMut>(
                         &self,
@@ -612,15 +668,7 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (
-                                    wasmtime::component::ResourceAny,
-                                    wasmtime::component::Resource<Y>,
-                                ),
-                                (wasmtime::component::Resource<Y>,),
-                            >::new_unchecked(self.funcs.method_a_method_a)
-                        };
+                        let callee = self.func_method_a();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), (arg0, arg1))
                             .await?;
@@ -704,6 +752,19 @@ pub mod exports {
                     }
                 }
                 impl GuestA<'_> {
+                    pub fn func_constructor(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (),
+                        (wasmtime::component::ResourceAny,),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (wasmtime::component::ResourceAny,),
+                            >::new_unchecked(self.funcs.constructor_a_constructor)
+                        }
+                    }
                     pub async fn call_constructor<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
@@ -711,12 +772,7 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (wasmtime::component::ResourceAny,),
-                            >::new_unchecked(self.funcs.constructor_a_constructor)
-                        };
+                        let callee = self.func_constructor();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), ())
                             .await?;
@@ -801,6 +857,19 @@ pub mod exports {
                     }
                 }
                 impl GuestB<'_> {
+                    pub fn func_constructor(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (wasmtime::component::ResourceAny,),
+                        (wasmtime::component::ResourceAny,),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (wasmtime::component::ResourceAny,),
+                                (wasmtime::component::ResourceAny,),
+                            >::new_unchecked(self.funcs.constructor_b_constructor)
+                        }
+                    }
                     pub async fn call_constructor<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
@@ -809,12 +878,7 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (wasmtime::component::ResourceAny,),
-                                (wasmtime::component::ResourceAny,),
-                            >::new_unchecked(self.funcs.constructor_b_constructor)
-                        };
+                        let callee = self.func_constructor();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), (arg0,))
                             .await?;

--- a/crates/component-macro/tests/expanded/resources-export_concurrent.rs
+++ b/crates/component-macro/tests/expanded/resources-export_concurrent.rs
@@ -397,6 +397,19 @@ pub mod exports {
                     }
                 }
                 impl GuestA<'_> {
+                    pub fn func_constructor(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (),
+                        (wasmtime::component::ResourceAny,),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (wasmtime::component::ResourceAny,),
+                            >::new_unchecked(self.funcs.constructor_a_constructor)
+                        }
+                    }
                     pub async fn call_constructor<_T, _D>(
                         &self,
                         accessor: &wasmtime::component::Accessor<_T, _D>,
@@ -405,14 +418,19 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (wasmtime::component::ResourceAny,),
-                            >::new_unchecked(self.funcs.constructor_a_constructor)
-                        };
+                        let callee = self.func_constructor();
                         let (ret0,) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
+                    }
+                    pub fn func_static_a(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(), (u32,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (u32,),
+                            >::new_unchecked(self.funcs.static_a_static_a)
+                        }
                     }
                     pub async fn call_static_a<_T, _D>(
                         &self,
@@ -422,14 +440,22 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (u32,),
-                            >::new_unchecked(self.funcs.static_a_static_a)
-                        };
+                        let callee = self.func_static_a();
                         let (ret0,) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
+                    }
+                    pub fn func_method_a(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (wasmtime::component::ResourceAny,),
+                        (u32,),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (wasmtime::component::ResourceAny,),
+                                (u32,),
+                            >::new_unchecked(self.funcs.method_a_method_a)
+                        }
                     }
                     pub async fn call_method_a<_T, _D>(
                         &self,
@@ -440,12 +466,7 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (wasmtime::component::ResourceAny,),
-                                (u32,),
-                            >::new_unchecked(self.funcs.method_a_method_a)
-                        };
+                        let callee = self.func_method_a();
                         let (ret0,) = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(ret0)
                     }
@@ -555,6 +576,19 @@ pub mod exports {
                     }
                 }
                 impl GuestA<'_> {
+                    pub fn func_constructor(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (wasmtime::component::Resource<Y>,),
+                        (wasmtime::component::ResourceAny,),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (wasmtime::component::Resource<Y>,),
+                                (wasmtime::component::ResourceAny,),
+                            >::new_unchecked(self.funcs.constructor_a_constructor)
+                        }
+                    }
                     pub async fn call_constructor<_T, _D>(
                         &self,
                         accessor: &wasmtime::component::Accessor<_T, _D>,
@@ -564,14 +598,22 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (wasmtime::component::Resource<Y>,),
-                                (wasmtime::component::ResourceAny,),
-                            >::new_unchecked(self.funcs.constructor_a_constructor)
-                        };
+                        let callee = self.func_constructor();
                         let (ret0,) = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(ret0)
+                    }
+                    pub fn func_static_a(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (),
+                        (wasmtime::component::Resource<Y>,),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (wasmtime::component::Resource<Y>,),
+                            >::new_unchecked(self.funcs.static_a_static_a)
+                        }
                     }
                     pub async fn call_static_a<_T, _D>(
                         &self,
@@ -581,14 +623,28 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (wasmtime::component::Resource<Y>,),
-                            >::new_unchecked(self.funcs.static_a_static_a)
-                        };
+                        let callee = self.func_static_a();
                         let (ret0,) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
+                    }
+                    pub fn func_method_a(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (
+                            wasmtime::component::ResourceAny,
+                            wasmtime::component::Resource<Y>,
+                        ),
+                        (wasmtime::component::Resource<Y>,),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (
+                                    wasmtime::component::ResourceAny,
+                                    wasmtime::component::Resource<Y>,
+                                ),
+                                (wasmtime::component::Resource<Y>,),
+                            >::new_unchecked(self.funcs.method_a_method_a)
+                        }
                     }
                     pub async fn call_method_a<_T, _D>(
                         &self,
@@ -600,15 +656,7 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (
-                                    wasmtime::component::ResourceAny,
-                                    wasmtime::component::Resource<Y>,
-                                ),
-                                (wasmtime::component::Resource<Y>,),
-                            >::new_unchecked(self.funcs.method_a_method_a)
-                        };
+                        let callee = self.func_method_a();
                         let (ret0,) = callee
                             .call_concurrent(accessor, (arg0, arg1))
                             .await?;
@@ -692,6 +740,19 @@ pub mod exports {
                     }
                 }
                 impl GuestA<'_> {
+                    pub fn func_constructor(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (),
+                        (wasmtime::component::ResourceAny,),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (wasmtime::component::ResourceAny,),
+                            >::new_unchecked(self.funcs.constructor_a_constructor)
+                        }
+                    }
                     pub async fn call_constructor<_T, _D>(
                         &self,
                         accessor: &wasmtime::component::Accessor<_T, _D>,
@@ -700,12 +761,7 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (wasmtime::component::ResourceAny,),
-                            >::new_unchecked(self.funcs.constructor_a_constructor)
-                        };
+                        let callee = self.func_constructor();
                         let (ret0,) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
                     }
@@ -788,6 +844,19 @@ pub mod exports {
                     }
                 }
                 impl GuestB<'_> {
+                    pub fn func_constructor(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (wasmtime::component::ResourceAny,),
+                        (wasmtime::component::ResourceAny,),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (wasmtime::component::ResourceAny,),
+                                (wasmtime::component::ResourceAny,),
+                            >::new_unchecked(self.funcs.constructor_b_constructor)
+                        }
+                    }
                     pub async fn call_constructor<_T, _D>(
                         &self,
                         accessor: &wasmtime::component::Accessor<_T, _D>,
@@ -797,12 +866,7 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (wasmtime::component::ResourceAny,),
-                                (wasmtime::component::ResourceAny,),
-                            >::new_unchecked(self.funcs.constructor_b_constructor)
-                        };
+                        let callee = self.func_constructor();
                         let (ret0,) = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(ret0)
                     }

--- a/crates/component-macro/tests/expanded/resources-export_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/resources-export_tracing_async.rs
@@ -405,6 +405,19 @@ pub mod exports {
                     }
                 }
                 impl GuestA<'_> {
+                    pub fn func_constructor(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (),
+                        (wasmtime::component::ResourceAny,),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (wasmtime::component::ResourceAny,),
+                            >::new_unchecked(self.funcs.constructor_a_constructor)
+                        }
+                    }
                     pub async fn call_constructor<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
@@ -417,17 +430,22 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/simple-export", function = "[constructor]a",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (wasmtime::component::ResourceAny,),
-                            >::new_unchecked(self.funcs.constructor_a_constructor)
-                        };
+                        let callee = self.func_constructor();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), ())
                             .instrument(span.clone())
                             .await?;
                         Ok(ret0)
+                    }
+                    pub fn func_static_a(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(), (u32,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (u32,),
+                            >::new_unchecked(self.funcs.static_a_static_a)
+                        }
                     }
                     pub async fn call_static_a<S: wasmtime::AsContextMut>(
                         &self,
@@ -441,17 +459,25 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/simple-export", function = "[static]a.static-a",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (u32,),
-                            >::new_unchecked(self.funcs.static_a_static_a)
-                        };
+                        let callee = self.func_static_a();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), ())
                             .instrument(span.clone())
                             .await?;
                         Ok(ret0)
+                    }
+                    pub fn func_method_a(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (wasmtime::component::ResourceAny,),
+                        (u32,),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (wasmtime::component::ResourceAny,),
+                                (u32,),
+                            >::new_unchecked(self.funcs.method_a_method_a)
+                        }
                     }
                     pub async fn call_method_a<S: wasmtime::AsContextMut>(
                         &self,
@@ -466,12 +492,7 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/simple-export", function = "[method]a.method-a",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (wasmtime::component::ResourceAny,),
-                                (u32,),
-                            >::new_unchecked(self.funcs.method_a_method_a)
-                        };
+                        let callee = self.func_method_a();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), (arg0,))
                             .instrument(span.clone())
@@ -584,6 +605,19 @@ pub mod exports {
                     }
                 }
                 impl GuestA<'_> {
+                    pub fn func_constructor(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (wasmtime::component::Resource<Y>,),
+                        (wasmtime::component::ResourceAny,),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (wasmtime::component::Resource<Y>,),
+                                (wasmtime::component::ResourceAny,),
+                            >::new_unchecked(self.funcs.constructor_a_constructor)
+                        }
+                    }
                     pub async fn call_constructor<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
@@ -597,17 +631,25 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/export-using-import", function = "[constructor]a",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (wasmtime::component::Resource<Y>,),
-                                (wasmtime::component::ResourceAny,),
-                            >::new_unchecked(self.funcs.constructor_a_constructor)
-                        };
+                        let callee = self.func_constructor();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), (arg0,))
                             .instrument(span.clone())
                             .await?;
                         Ok(ret0)
+                    }
+                    pub fn func_static_a(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (),
+                        (wasmtime::component::Resource<Y>,),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (wasmtime::component::Resource<Y>,),
+                            >::new_unchecked(self.funcs.static_a_static_a)
+                        }
                     }
                     pub async fn call_static_a<S: wasmtime::AsContextMut>(
                         &self,
@@ -622,17 +664,31 @@ pub mod exports {
                             "foo:foo/export-using-import", function =
                             "[static]a.static-a",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (wasmtime::component::Resource<Y>,),
-                            >::new_unchecked(self.funcs.static_a_static_a)
-                        };
+                        let callee = self.func_static_a();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), ())
                             .instrument(span.clone())
                             .await?;
                         Ok(ret0)
+                    }
+                    pub fn func_method_a(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (
+                            wasmtime::component::ResourceAny,
+                            wasmtime::component::Resource<Y>,
+                        ),
+                        (wasmtime::component::Resource<Y>,),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (
+                                    wasmtime::component::ResourceAny,
+                                    wasmtime::component::Resource<Y>,
+                                ),
+                                (wasmtime::component::Resource<Y>,),
+                            >::new_unchecked(self.funcs.method_a_method_a)
+                        }
                     }
                     pub async fn call_method_a<S: wasmtime::AsContextMut>(
                         &self,
@@ -649,15 +705,7 @@ pub mod exports {
                             "foo:foo/export-using-import", function =
                             "[method]a.method-a",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (
-                                    wasmtime::component::ResourceAny,
-                                    wasmtime::component::Resource<Y>,
-                                ),
-                                (wasmtime::component::Resource<Y>,),
-                            >::new_unchecked(self.funcs.method_a_method_a)
-                        };
+                        let callee = self.func_method_a();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), (arg0, arg1))
                             .instrument(span.clone())
@@ -742,6 +790,19 @@ pub mod exports {
                     }
                 }
                 impl GuestA<'_> {
+                    pub fn func_constructor(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (),
+                        (wasmtime::component::ResourceAny,),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (wasmtime::component::ResourceAny,),
+                            >::new_unchecked(self.funcs.constructor_a_constructor)
+                        }
+                    }
                     pub async fn call_constructor<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
@@ -754,12 +815,7 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/export-using-export1", function = "[constructor]a",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (wasmtime::component::ResourceAny,),
-                            >::new_unchecked(self.funcs.constructor_a_constructor)
-                        };
+                        let callee = self.func_constructor();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), ())
                             .instrument(span.clone())
@@ -845,6 +901,19 @@ pub mod exports {
                     }
                 }
                 impl GuestB<'_> {
+                    pub fn func_constructor(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (wasmtime::component::ResourceAny,),
+                        (wasmtime::component::ResourceAny,),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (wasmtime::component::ResourceAny,),
+                                (wasmtime::component::ResourceAny,),
+                            >::new_unchecked(self.funcs.constructor_b_constructor)
+                        }
+                    }
                     pub async fn call_constructor<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
@@ -858,12 +927,7 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/export-using-export2", function = "[constructor]b",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (wasmtime::component::ResourceAny,),
-                                (wasmtime::component::ResourceAny,),
-                            >::new_unchecked(self.funcs.constructor_b_constructor)
-                        };
+                        let callee = self.func_constructor();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), (arg0,))
                             .instrument(span.clone())

--- a/crates/component-macro/tests/expanded/resources-import.rs
+++ b/crates/component-macro/tests/expanded/resources-import.rs
@@ -351,16 +351,24 @@ const _: () = {
             >(linker, host_getter)?;
             Ok(())
         }
-        pub fn call_some_world_func2<S: wasmtime::AsContextMut>(
+        pub fn func_some_world_func2(
             &self,
-            mut store: S,
-        ) -> wasmtime::Result<wasmtime::component::Resource<WorldResource>> {
-            let callee = unsafe {
+        ) -> wasmtime::component::TypedFunc<
+            (),
+            (wasmtime::component::Resource<WorldResource>,),
+        > {
+            unsafe {
                 wasmtime::component::TypedFunc::<
                     (),
                     (wasmtime::component::Resource<WorldResource>,),
                 >::new_unchecked(self.some_world_func2)
-            };
+            }
+        }
+        pub fn call_some_world_func2<S: wasmtime::AsContextMut>(
+            &self,
+            mut store: S,
+        ) -> wasmtime::Result<wasmtime::component::Resource<WorldResource>> {
+            let callee = self.func_some_world_func2();
             let (ret0,) = callee.call(store.as_context_mut(), ())?;
             Ok(ret0)
         }
@@ -1274,17 +1282,25 @@ pub mod exports {
                     }
                 }
                 impl Guest {
+                    pub fn func_handle(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (wasmtime::component::Resource<Foo>,),
+                        (),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (wasmtime::component::Resource<Foo>,),
+                                (),
+                            >::new_unchecked(self.handle)
+                        }
+                    }
                     pub fn call_handle<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                         arg0: wasmtime::component::Resource<Foo>,
                     ) -> wasmtime::Result<()> {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (wasmtime::component::Resource<Foo>,),
-                                (),
-                            >::new_unchecked(self.handle)
-                        };
+                        let callee = self.func_handle();
                         let () = callee.call(store.as_context_mut(), (arg0,))?;
                         Ok(())
                     }

--- a/crates/component-macro/tests/expanded/resources-import_async.rs
+++ b/crates/component-macro/tests/expanded/resources-import_async.rs
@@ -384,6 +384,19 @@ const _: () = {
             >(linker, host_getter)?;
             Ok(())
         }
+        pub fn func_some_world_func2(
+            &self,
+        ) -> wasmtime::component::TypedFunc<
+            (),
+            (wasmtime::component::Resource<WorldResource>,),
+        > {
+            unsafe {
+                wasmtime::component::TypedFunc::<
+                    (),
+                    (wasmtime::component::Resource<WorldResource>,),
+                >::new_unchecked(self.some_world_func2)
+            }
+        }
         pub async fn call_some_world_func2<S: wasmtime::AsContextMut>(
             &self,
             mut store: S,
@@ -391,12 +404,7 @@ const _: () = {
         where
             <S as wasmtime::AsContext>::Data: Send,
         {
-            let callee = unsafe {
-                wasmtime::component::TypedFunc::<
-                    (),
-                    (wasmtime::component::Resource<WorldResource>,),
-                >::new_unchecked(self.some_world_func2)
-            };
+            let callee = self.func_some_world_func2();
             let (ret0,) = callee.call_async(store.as_context_mut(), ()).await?;
             Ok(ret0)
         }
@@ -1458,6 +1466,19 @@ pub mod exports {
                     }
                 }
                 impl Guest {
+                    pub fn func_handle(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (wasmtime::component::Resource<Foo>,),
+                        (),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (wasmtime::component::Resource<Foo>,),
+                                (),
+                            >::new_unchecked(self.handle)
+                        }
+                    }
                     pub async fn call_handle<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
@@ -1466,12 +1487,7 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (wasmtime::component::Resource<Foo>,),
-                                (),
-                            >::new_unchecked(self.handle)
-                        };
+                        let callee = self.func_handle();
                         let () = callee
                             .call_async(store.as_context_mut(), (arg0,))
                             .await?;

--- a/crates/component-macro/tests/expanded/resources-import_concurrent.rs
+++ b/crates/component-macro/tests/expanded/resources-import_concurrent.rs
@@ -355,6 +355,19 @@ const _: () = {
             >(linker, host_getter)?;
             Ok(())
         }
+        pub fn func_some_world_func2(
+            &self,
+        ) -> wasmtime::component::TypedFunc<
+            (),
+            (wasmtime::component::Resource<WorldResource>,),
+        > {
+            unsafe {
+                wasmtime::component::TypedFunc::<
+                    (),
+                    (wasmtime::component::Resource<WorldResource>,),
+                >::new_unchecked(self.some_world_func2)
+            }
+        }
         pub async fn call_some_world_func2<_T, _D>(
             &self,
             accessor: &wasmtime::component::Accessor<_T, _D>,
@@ -363,12 +376,7 @@ const _: () = {
             _T: Send,
             _D: wasmtime::component::HasData,
         {
-            let callee = unsafe {
-                wasmtime::component::TypedFunc::<
-                    (),
-                    (wasmtime::component::Resource<WorldResource>,),
-                >::new_unchecked(self.some_world_func2)
-            };
+            let callee = self.func_some_world_func2();
             let (ret0,) = callee.call_concurrent(accessor, ()).await?;
             Ok(ret0)
         }
@@ -1242,6 +1250,19 @@ pub mod exports {
                     }
                 }
                 impl Guest {
+                    pub fn func_handle(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (wasmtime::component::Resource<Foo>,),
+                        (),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (wasmtime::component::Resource<Foo>,),
+                                (),
+                            >::new_unchecked(self.handle)
+                        }
+                    }
                     pub async fn call_handle<_T, _D>(
                         &self,
                         accessor: &wasmtime::component::Accessor<_T, _D>,
@@ -1251,12 +1272,7 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (wasmtime::component::Resource<Foo>,),
-                                (),
-                            >::new_unchecked(self.handle)
-                        };
+                        let callee = self.func_handle();
                         let () = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(())
                     }

--- a/crates/component-macro/tests/expanded/resources-import_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/resources-import_tracing_async.rs
@@ -439,6 +439,19 @@ const _: () = {
             >(linker, host_getter)?;
             Ok(())
         }
+        pub fn func_some_world_func2(
+            &self,
+        ) -> wasmtime::component::TypedFunc<
+            (),
+            (wasmtime::component::Resource<WorldResource>,),
+        > {
+            unsafe {
+                wasmtime::component::TypedFunc::<
+                    (),
+                    (wasmtime::component::Resource<WorldResource>,),
+                >::new_unchecked(self.some_world_func2)
+            }
+        }
         pub async fn call_some_world_func2<S: wasmtime::AsContextMut>(
             &self,
             mut store: S,
@@ -451,12 +464,7 @@ const _: () = {
                 tracing::Level::TRACE, "wit-bindgen export", module = "default", function
                 = "some-world-func2",
             );
-            let callee = unsafe {
-                wasmtime::component::TypedFunc::<
-                    (),
-                    (wasmtime::component::Resource<WorldResource>,),
-                >::new_unchecked(self.some_world_func2)
-            };
+            let callee = self.func_some_world_func2();
             let (ret0,) = callee
                 .call_async(store.as_context_mut(), ())
                 .instrument(span.clone())
@@ -1875,6 +1883,19 @@ pub mod exports {
                     }
                 }
                 impl Guest {
+                    pub fn func_handle(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (wasmtime::component::Resource<Foo>,),
+                        (),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (wasmtime::component::Resource<Foo>,),
+                                (),
+                            >::new_unchecked(self.handle)
+                        }
+                    }
                     pub async fn call_handle<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
@@ -1888,12 +1909,7 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/uses-resource-transitively", function = "handle",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (wasmtime::component::Resource<Foo>,),
-                                (),
-                            >::new_unchecked(self.handle)
-                        };
+                        let callee = self.func_handle();
                         let () = callee
                             .call_async(store.as_context_mut(), (arg0,))
                             .instrument(span.clone())

--- a/crates/component-macro/tests/expanded/share-types.rs
+++ b/crates/component-macro/tests/expanded/share-types.rs
@@ -396,17 +396,22 @@ pub mod exports {
             }
         }
         impl Guest {
+            pub fn func_handle_request(
+                &self,
+            ) -> wasmtime::component::TypedFunc<(&Request,), (Response,)> {
+                unsafe {
+                    wasmtime::component::TypedFunc::<
+                        (&Request,),
+                        (Response,),
+                    >::new_unchecked(self.handle_request)
+                }
+            }
             pub fn call_handle_request<S: wasmtime::AsContextMut>(
                 &self,
                 mut store: S,
                 arg0: &Request,
             ) -> wasmtime::Result<Response> {
-                let callee = unsafe {
-                    wasmtime::component::TypedFunc::<
-                        (&Request,),
-                        (Response,),
-                    >::new_unchecked(self.handle_request)
-                };
+                let callee = self.func_handle_request();
                 let (ret0,) = callee.call(store.as_context_mut(), (arg0,))?;
                 Ok(ret0)
             }

--- a/crates/component-macro/tests/expanded/share-types_async.rs
+++ b/crates/component-macro/tests/expanded/share-types_async.rs
@@ -404,6 +404,16 @@ pub mod exports {
             }
         }
         impl Guest {
+            pub fn func_handle_request(
+                &self,
+            ) -> wasmtime::component::TypedFunc<(&Request,), (Response,)> {
+                unsafe {
+                    wasmtime::component::TypedFunc::<
+                        (&Request,),
+                        (Response,),
+                    >::new_unchecked(self.handle_request)
+                }
+            }
             pub async fn call_handle_request<S: wasmtime::AsContextMut>(
                 &self,
                 mut store: S,
@@ -412,12 +422,7 @@ pub mod exports {
             where
                 <S as wasmtime::AsContext>::Data: Send,
             {
-                let callee = unsafe {
-                    wasmtime::component::TypedFunc::<
-                        (&Request,),
-                        (Response,),
-                    >::new_unchecked(self.handle_request)
-                };
+                let callee = self.func_handle_request();
                 let (ret0,) = callee.call_async(store.as_context_mut(), (arg0,)).await?;
                 Ok(ret0)
             }

--- a/crates/component-macro/tests/expanded/share-types_concurrent.rs
+++ b/crates/component-macro/tests/expanded/share-types_concurrent.rs
@@ -393,6 +393,16 @@ pub mod exports {
             }
         }
         impl Guest {
+            pub fn func_handle_request(
+                &self,
+            ) -> wasmtime::component::TypedFunc<(Request,), (Response,)> {
+                unsafe {
+                    wasmtime::component::TypedFunc::<
+                        (Request,),
+                        (Response,),
+                    >::new_unchecked(self.handle_request)
+                }
+            }
             pub async fn call_handle_request<_T, _D>(
                 &self,
                 accessor: &wasmtime::component::Accessor<_T, _D>,
@@ -402,12 +412,7 @@ pub mod exports {
                 _T: Send,
                 _D: wasmtime::component::HasData,
             {
-                let callee = unsafe {
-                    wasmtime::component::TypedFunc::<
-                        (Request,),
-                        (Response,),
-                    >::new_unchecked(self.handle_request)
-                };
+                let callee = self.func_handle_request();
                 let (ret0,) = callee.call_concurrent(accessor, (arg0,)).await?;
                 Ok(ret0)
             }

--- a/crates/component-macro/tests/expanded/share-types_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/share-types_tracing_async.rs
@@ -420,6 +420,16 @@ pub mod exports {
             }
         }
         impl Guest {
+            pub fn func_handle_request(
+                &self,
+            ) -> wasmtime::component::TypedFunc<(&Request,), (Response,)> {
+                unsafe {
+                    wasmtime::component::TypedFunc::<
+                        (&Request,),
+                        (Response,),
+                    >::new_unchecked(self.handle_request)
+                }
+            }
             pub async fn call_handle_request<S: wasmtime::AsContextMut>(
                 &self,
                 mut store: S,
@@ -433,12 +443,7 @@ pub mod exports {
                     tracing::Level::TRACE, "wit-bindgen export", module = "http-handler",
                     function = "handle-request",
                 );
-                let callee = unsafe {
-                    wasmtime::component::TypedFunc::<
-                        (&Request,),
-                        (Response,),
-                    >::new_unchecked(self.handle_request)
-                };
+                let callee = self.func_handle_request();
                 let (ret0,) = callee
                     .call_async(store.as_context_mut(), (arg0,))
                     .instrument(span.clone())

--- a/crates/component-macro/tests/expanded/simple-functions.rs
+++ b/crates/component-macro/tests/expanded/simple-functions.rs
@@ -409,32 +409,48 @@ pub mod exports {
                     }
                 }
                 impl Guest {
-                    pub fn call_f1<S: wasmtime::AsContextMut>(
-                        &self,
-                        mut store: S,
-                    ) -> wasmtime::Result<()> {
-                        let callee = unsafe {
+                    pub fn func_f1(&self) -> wasmtime::component::TypedFunc<(), ()> {
+                        unsafe {
                             wasmtime::component::TypedFunc::<
                                 (),
                                 (),
                             >::new_unchecked(self.f1)
-                        };
+                        }
+                    }
+                    pub fn call_f1<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<()> {
+                        let callee = self.func_f1();
                         let () = callee.call(store.as_context_mut(), ())?;
                         Ok(())
+                    }
+                    pub fn func_f2(&self) -> wasmtime::component::TypedFunc<(u32,), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (u32,),
+                                (),
+                            >::new_unchecked(self.f2)
+                        }
                     }
                     pub fn call_f2<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                         arg0: u32,
                     ) -> wasmtime::Result<()> {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (u32,),
-                                (),
-                            >::new_unchecked(self.f2)
-                        };
+                        let callee = self.func_f2();
                         let () = callee.call(store.as_context_mut(), (arg0,))?;
                         Ok(())
+                    }
+                    pub fn func_f3(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(u32, u32), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (u32, u32),
+                                (),
+                            >::new_unchecked(self.f3)
+                        }
                     }
                     pub fn call_f3<S: wasmtime::AsContextMut>(
                         &self,
@@ -442,40 +458,56 @@ pub mod exports {
                         arg0: u32,
                         arg1: u32,
                     ) -> wasmtime::Result<()> {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (u32, u32),
-                                (),
-                            >::new_unchecked(self.f3)
-                        };
+                        let callee = self.func_f3();
                         let () = callee.call(store.as_context_mut(), (arg0, arg1))?;
                         Ok(())
+                    }
+                    pub fn func_f4(&self) -> wasmtime::component::TypedFunc<(), (u32,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (u32,),
+                            >::new_unchecked(self.f4)
+                        }
                     }
                     pub fn call_f4<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                     ) -> wasmtime::Result<u32> {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (u32,),
-                            >::new_unchecked(self.f4)
-                        };
+                        let callee = self.func_f4();
                         let (ret0,) = callee.call(store.as_context_mut(), ())?;
                         Ok(ret0)
+                    }
+                    pub fn func_f5(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(), ((u32, u32),)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                ((u32, u32),),
+                            >::new_unchecked(self.f5)
+                        }
                     }
                     pub fn call_f5<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                     ) -> wasmtime::Result<(u32, u32)> {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                ((u32, u32),),
-                            >::new_unchecked(self.f5)
-                        };
+                        let callee = self.func_f5();
                         let (ret0,) = callee.call(store.as_context_mut(), ())?;
                         Ok(ret0)
+                    }
+                    pub fn func_f6(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (u32, u32, u32),
+                        ((u32, u32, u32),),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (u32, u32, u32),
+                                ((u32, u32, u32),),
+                            >::new_unchecked(self.f6)
+                        }
                     }
                     pub fn call_f6<S: wasmtime::AsContextMut>(
                         &self,
@@ -484,12 +516,7 @@ pub mod exports {
                         arg1: u32,
                         arg2: u32,
                     ) -> wasmtime::Result<(u32, u32, u32)> {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (u32, u32, u32),
-                                ((u32, u32, u32),),
-                            >::new_unchecked(self.f6)
-                        };
+                        let callee = self.func_f6();
                         let (ret0,) = callee
                             .call(store.as_context_mut(), (arg0, arg1, arg2))?;
                         Ok(ret0)

--- a/crates/component-macro/tests/expanded/simple-functions_async.rs
+++ b/crates/component-macro/tests/expanded/simple-functions_async.rs
@@ -449,6 +449,14 @@ pub mod exports {
                     }
                 }
                 impl Guest {
+                    pub fn func_f1(&self) -> wasmtime::component::TypedFunc<(), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (),
+                            >::new_unchecked(self.f1)
+                        }
+                    }
                     pub async fn call_f1<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
@@ -456,14 +464,17 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (),
-                            >::new_unchecked(self.f1)
-                        };
+                        let callee = self.func_f1();
                         let () = callee.call_async(store.as_context_mut(), ()).await?;
                         Ok(())
+                    }
+                    pub fn func_f2(&self) -> wasmtime::component::TypedFunc<(u32,), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (u32,),
+                                (),
+                            >::new_unchecked(self.f2)
+                        }
                     }
                     pub async fn call_f2<S: wasmtime::AsContextMut>(
                         &self,
@@ -473,16 +484,21 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (u32,),
-                                (),
-                            >::new_unchecked(self.f2)
-                        };
+                        let callee = self.func_f2();
                         let () = callee
                             .call_async(store.as_context_mut(), (arg0,))
                             .await?;
                         Ok(())
+                    }
+                    pub fn func_f3(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(u32, u32), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (u32, u32),
+                                (),
+                            >::new_unchecked(self.f3)
+                        }
                     }
                     pub async fn call_f3<S: wasmtime::AsContextMut>(
                         &self,
@@ -493,16 +509,19 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (u32, u32),
-                                (),
-                            >::new_unchecked(self.f3)
-                        };
+                        let callee = self.func_f3();
                         let () = callee
                             .call_async(store.as_context_mut(), (arg0, arg1))
                             .await?;
                         Ok(())
+                    }
+                    pub fn func_f4(&self) -> wasmtime::component::TypedFunc<(), (u32,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (u32,),
+                            >::new_unchecked(self.f4)
+                        }
                     }
                     pub async fn call_f4<S: wasmtime::AsContextMut>(
                         &self,
@@ -511,16 +530,21 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (u32,),
-                            >::new_unchecked(self.f4)
-                        };
+                        let callee = self.func_f4();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), ())
                             .await?;
                         Ok(ret0)
+                    }
+                    pub fn func_f5(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(), ((u32, u32),)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                ((u32, u32),),
+                            >::new_unchecked(self.f5)
+                        }
                     }
                     pub async fn call_f5<S: wasmtime::AsContextMut>(
                         &self,
@@ -529,16 +553,24 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                ((u32, u32),),
-                            >::new_unchecked(self.f5)
-                        };
+                        let callee = self.func_f5();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), ())
                             .await?;
                         Ok(ret0)
+                    }
+                    pub fn func_f6(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (u32, u32, u32),
+                        ((u32, u32, u32),),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (u32, u32, u32),
+                                ((u32, u32, u32),),
+                            >::new_unchecked(self.f6)
+                        }
                     }
                     pub async fn call_f6<S: wasmtime::AsContextMut>(
                         &self,
@@ -550,12 +582,7 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (u32, u32, u32),
-                                ((u32, u32, u32),),
-                            >::new_unchecked(self.f6)
-                        };
+                        let callee = self.func_f6();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), (arg0, arg1, arg2))
                             .await?;

--- a/crates/component-macro/tests/expanded/simple-functions_concurrent.rs
+++ b/crates/component-macro/tests/expanded/simple-functions_concurrent.rs
@@ -417,6 +417,14 @@ pub mod exports {
                     }
                 }
                 impl Guest {
+                    pub fn func_f1(&self) -> wasmtime::component::TypedFunc<(), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (),
+                            >::new_unchecked(self.f1)
+                        }
+                    }
                     pub async fn call_f1<_T, _D>(
                         &self,
                         accessor: &wasmtime::component::Accessor<_T, _D>,
@@ -425,14 +433,17 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (),
-                            >::new_unchecked(self.f1)
-                        };
+                        let callee = self.func_f1();
                         let () = callee.call_concurrent(accessor, ()).await?;
                         Ok(())
+                    }
+                    pub fn func_f2(&self) -> wasmtime::component::TypedFunc<(u32,), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (u32,),
+                                (),
+                            >::new_unchecked(self.f2)
+                        }
                     }
                     pub async fn call_f2<_T, _D>(
                         &self,
@@ -443,14 +454,19 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (u32,),
-                                (),
-                            >::new_unchecked(self.f2)
-                        };
+                        let callee = self.func_f2();
                         let () = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(())
+                    }
+                    pub fn func_f3(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(u32, u32), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (u32, u32),
+                                (),
+                            >::new_unchecked(self.f3)
+                        }
                     }
                     pub async fn call_f3<_T, _D>(
                         &self,
@@ -462,14 +478,17 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (u32, u32),
-                                (),
-                            >::new_unchecked(self.f3)
-                        };
+                        let callee = self.func_f3();
                         let () = callee.call_concurrent(accessor, (arg0, arg1)).await?;
                         Ok(())
+                    }
+                    pub fn func_f4(&self) -> wasmtime::component::TypedFunc<(), (u32,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (u32,),
+                            >::new_unchecked(self.f4)
+                        }
                     }
                     pub async fn call_f4<_T, _D>(
                         &self,
@@ -479,14 +498,19 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (u32,),
-                            >::new_unchecked(self.f4)
-                        };
+                        let callee = self.func_f4();
                         let (ret0,) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
+                    }
+                    pub fn func_f5(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(), ((u32, u32),)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                ((u32, u32),),
+                            >::new_unchecked(self.f5)
+                        }
                     }
                     pub async fn call_f5<_T, _D>(
                         &self,
@@ -496,14 +520,22 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                ((u32, u32),),
-                            >::new_unchecked(self.f5)
-                        };
+                        let callee = self.func_f5();
                         let (ret0,) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
+                    }
+                    pub fn func_f6(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (u32, u32, u32),
+                        ((u32, u32, u32),),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (u32, u32, u32),
+                                ((u32, u32, u32),),
+                            >::new_unchecked(self.f6)
+                        }
                     }
                     pub async fn call_f6<_T, _D>(
                         &self,
@@ -516,12 +548,7 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (u32, u32, u32),
-                                ((u32, u32, u32),),
-                            >::new_unchecked(self.f6)
-                        };
+                        let callee = self.func_f6();
                         let (ret0,) = callee
                             .call_concurrent(accessor, (arg0, arg1, arg2))
                             .await?;

--- a/crates/component-macro/tests/expanded/simple-functions_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/simple-functions_tracing_async.rs
@@ -537,6 +537,14 @@ pub mod exports {
                     }
                 }
                 impl Guest {
+                    pub fn func_f1(&self) -> wasmtime::component::TypedFunc<(), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (),
+                            >::new_unchecked(self.f1)
+                        }
+                    }
                     pub async fn call_f1<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
@@ -549,17 +557,20 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/simple", function = "f1",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (),
-                            >::new_unchecked(self.f1)
-                        };
+                        let callee = self.func_f1();
                         let () = callee
                             .call_async(store.as_context_mut(), ())
                             .instrument(span.clone())
                             .await?;
                         Ok(())
+                    }
+                    pub fn func_f2(&self) -> wasmtime::component::TypedFunc<(u32,), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (u32,),
+                                (),
+                            >::new_unchecked(self.f2)
+                        }
                     }
                     pub async fn call_f2<S: wasmtime::AsContextMut>(
                         &self,
@@ -574,17 +585,22 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/simple", function = "f2",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (u32,),
-                                (),
-                            >::new_unchecked(self.f2)
-                        };
+                        let callee = self.func_f2();
                         let () = callee
                             .call_async(store.as_context_mut(), (arg0,))
                             .instrument(span.clone())
                             .await?;
                         Ok(())
+                    }
+                    pub fn func_f3(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(u32, u32), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (u32, u32),
+                                (),
+                            >::new_unchecked(self.f3)
+                        }
                     }
                     pub async fn call_f3<S: wasmtime::AsContextMut>(
                         &self,
@@ -600,17 +616,20 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/simple", function = "f3",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (u32, u32),
-                                (),
-                            >::new_unchecked(self.f3)
-                        };
+                        let callee = self.func_f3();
                         let () = callee
                             .call_async(store.as_context_mut(), (arg0, arg1))
                             .instrument(span.clone())
                             .await?;
                         Ok(())
+                    }
+                    pub fn func_f4(&self) -> wasmtime::component::TypedFunc<(), (u32,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (u32,),
+                            >::new_unchecked(self.f4)
+                        }
                     }
                     pub async fn call_f4<S: wasmtime::AsContextMut>(
                         &self,
@@ -624,17 +643,22 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/simple", function = "f4",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (u32,),
-                            >::new_unchecked(self.f4)
-                        };
+                        let callee = self.func_f4();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), ())
                             .instrument(span.clone())
                             .await?;
                         Ok(ret0)
+                    }
+                    pub fn func_f5(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(), ((u32, u32),)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                ((u32, u32),),
+                            >::new_unchecked(self.f5)
+                        }
                     }
                     pub async fn call_f5<S: wasmtime::AsContextMut>(
                         &self,
@@ -648,17 +672,25 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/simple", function = "f5",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                ((u32, u32),),
-                            >::new_unchecked(self.f5)
-                        };
+                        let callee = self.func_f5();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), ())
                             .instrument(span.clone())
                             .await?;
                         Ok(ret0)
+                    }
+                    pub fn func_f6(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (u32, u32, u32),
+                        ((u32, u32, u32),),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (u32, u32, u32),
+                                ((u32, u32, u32),),
+                            >::new_unchecked(self.f6)
+                        }
                     }
                     pub async fn call_f6<S: wasmtime::AsContextMut>(
                         &self,
@@ -675,12 +707,7 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/simple", function = "f6",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (u32, u32, u32),
-                                ((u32, u32, u32),),
-                            >::new_unchecked(self.f6)
-                        };
+                        let callee = self.func_f6();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), (arg0, arg1, arg2))
                             .instrument(span.clone())

--- a/crates/component-macro/tests/expanded/simple-lists.rs
+++ b/crates/component-macro/tests/expanded/simple-lists.rs
@@ -443,32 +443,68 @@ pub mod exports {
                     }
                 }
                 impl Guest {
+                    pub fn func_simple_list1(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(&[u32],), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&[u32],),
+                                (),
+                            >::new_unchecked(self.simple_list1)
+                        }
+                    }
                     pub fn call_simple_list1<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                         arg0: &[u32],
                     ) -> wasmtime::Result<()> {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (&[u32],),
-                                (),
-                            >::new_unchecked(self.simple_list1)
-                        };
+                        let callee = self.func_simple_list1();
                         let () = callee.call(store.as_context_mut(), (arg0,))?;
                         Ok(())
+                    }
+                    pub fn func_simple_list2(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (),
+                        (wasmtime::component::__internal::Vec<u32>,),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (wasmtime::component::__internal::Vec<u32>,),
+                            >::new_unchecked(self.simple_list2)
+                        }
                     }
                     pub fn call_simple_list2<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                     ) -> wasmtime::Result<wasmtime::component::__internal::Vec<u32>> {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (wasmtime::component::__internal::Vec<u32>,),
-                            >::new_unchecked(self.simple_list2)
-                        };
+                        let callee = self.func_simple_list2();
                         let (ret0,) = callee.call(store.as_context_mut(), ())?;
                         Ok(ret0)
+                    }
+                    pub fn func_simple_list3(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (&[u32], &[u32]),
+                        (
+                            (
+                                wasmtime::component::__internal::Vec<u32>,
+                                wasmtime::component::__internal::Vec<u32>,
+                            ),
+                        ),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&[u32], &[u32]),
+                                (
+                                    (
+                                        wasmtime::component::__internal::Vec<u32>,
+                                        wasmtime::component::__internal::Vec<u32>,
+                                    ),
+                                ),
+                            >::new_unchecked(self.simple_list3)
+                        }
                     }
                     pub fn call_simple_list3<S: wasmtime::AsContextMut>(
                         &self,
@@ -481,19 +517,30 @@ pub mod exports {
                             wasmtime::component::__internal::Vec<u32>,
                         ),
                     > {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (&[u32], &[u32]),
-                                (
-                                    (
-                                        wasmtime::component::__internal::Vec<u32>,
-                                        wasmtime::component::__internal::Vec<u32>,
-                                    ),
-                                ),
-                            >::new_unchecked(self.simple_list3)
-                        };
+                        let callee = self.func_simple_list3();
                         let (ret0,) = callee.call(store.as_context_mut(), (arg0, arg1))?;
                         Ok(ret0)
+                    }
+                    pub fn func_simple_list4(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (&[wasmtime::component::__internal::Vec<u32>],),
+                        (
+                            wasmtime::component::__internal::Vec<
+                                wasmtime::component::__internal::Vec<u32>,
+                            >,
+                        ),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&[wasmtime::component::__internal::Vec<u32>],),
+                                (
+                                    wasmtime::component::__internal::Vec<
+                                        wasmtime::component::__internal::Vec<u32>,
+                                    >,
+                                ),
+                            >::new_unchecked(self.simple_list4)
+                        }
                     }
                     pub fn call_simple_list4<S: wasmtime::AsContextMut>(
                         &self,
@@ -504,16 +551,7 @@ pub mod exports {
                             wasmtime::component::__internal::Vec<u32>,
                         >,
                     > {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (&[wasmtime::component::__internal::Vec<u32>],),
-                                (
-                                    wasmtime::component::__internal::Vec<
-                                        wasmtime::component::__internal::Vec<u32>,
-                                    >,
-                                ),
-                            >::new_unchecked(self.simple_list4)
-                        };
+                        let callee = self.func_simple_list4();
                         let (ret0,) = callee.call(store.as_context_mut(), (arg0,))?;
                         Ok(ret0)
                     }

--- a/crates/component-macro/tests/expanded/simple-lists_async.rs
+++ b/crates/component-macro/tests/expanded/simple-lists_async.rs
@@ -467,6 +467,16 @@ pub mod exports {
                     }
                 }
                 impl Guest {
+                    pub fn func_simple_list1(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(&[u32],), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&[u32],),
+                                (),
+                            >::new_unchecked(self.simple_list1)
+                        }
+                    }
                     pub async fn call_simple_list1<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
@@ -475,16 +485,24 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (&[u32],),
-                                (),
-                            >::new_unchecked(self.simple_list1)
-                        };
+                        let callee = self.func_simple_list1();
                         let () = callee
                             .call_async(store.as_context_mut(), (arg0,))
                             .await?;
                         Ok(())
+                    }
+                    pub fn func_simple_list2(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (),
+                        (wasmtime::component::__internal::Vec<u32>,),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (wasmtime::component::__internal::Vec<u32>,),
+                            >::new_unchecked(self.simple_list2)
+                        }
                     }
                     pub async fn call_simple_list2<S: wasmtime::AsContextMut>(
                         &self,
@@ -493,16 +511,34 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (wasmtime::component::__internal::Vec<u32>,),
-                            >::new_unchecked(self.simple_list2)
-                        };
+                        let callee = self.func_simple_list2();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), ())
                             .await?;
                         Ok(ret0)
+                    }
+                    pub fn func_simple_list3(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (&[u32], &[u32]),
+                        (
+                            (
+                                wasmtime::component::__internal::Vec<u32>,
+                                wasmtime::component::__internal::Vec<u32>,
+                            ),
+                        ),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&[u32], &[u32]),
+                                (
+                                    (
+                                        wasmtime::component::__internal::Vec<u32>,
+                                        wasmtime::component::__internal::Vec<u32>,
+                                    ),
+                                ),
+                            >::new_unchecked(self.simple_list3)
+                        }
                     }
                     pub async fn call_simple_list3<S: wasmtime::AsContextMut>(
                         &self,
@@ -518,21 +554,32 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (&[u32], &[u32]),
-                                (
-                                    (
-                                        wasmtime::component::__internal::Vec<u32>,
-                                        wasmtime::component::__internal::Vec<u32>,
-                                    ),
-                                ),
-                            >::new_unchecked(self.simple_list3)
-                        };
+                        let callee = self.func_simple_list3();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), (arg0, arg1))
                             .await?;
                         Ok(ret0)
+                    }
+                    pub fn func_simple_list4(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (&[wasmtime::component::__internal::Vec<u32>],),
+                        (
+                            wasmtime::component::__internal::Vec<
+                                wasmtime::component::__internal::Vec<u32>,
+                            >,
+                        ),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&[wasmtime::component::__internal::Vec<u32>],),
+                                (
+                                    wasmtime::component::__internal::Vec<
+                                        wasmtime::component::__internal::Vec<u32>,
+                                    >,
+                                ),
+                            >::new_unchecked(self.simple_list4)
+                        }
                     }
                     pub async fn call_simple_list4<S: wasmtime::AsContextMut>(
                         &self,
@@ -546,16 +593,7 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (&[wasmtime::component::__internal::Vec<u32>],),
-                                (
-                                    wasmtime::component::__internal::Vec<
-                                        wasmtime::component::__internal::Vec<u32>,
-                                    >,
-                                ),
-                            >::new_unchecked(self.simple_list4)
-                        };
+                        let callee = self.func_simple_list4();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), (arg0,))
                             .await?;

--- a/crates/component-macro/tests/expanded/simple-lists_concurrent.rs
+++ b/crates/component-macro/tests/expanded/simple-lists_concurrent.rs
@@ -426,6 +426,19 @@ pub mod exports {
                     }
                 }
                 impl Guest {
+                    pub fn func_simple_list1(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (wasmtime::component::__internal::Vec<u32>,),
+                        (),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (wasmtime::component::__internal::Vec<u32>,),
+                                (),
+                            >::new_unchecked(self.simple_list1)
+                        }
+                    }
                     pub async fn call_simple_list1<_T, _D>(
                         &self,
                         accessor: &wasmtime::component::Accessor<_T, _D>,
@@ -435,14 +448,22 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (wasmtime::component::__internal::Vec<u32>,),
-                                (),
-                            >::new_unchecked(self.simple_list1)
-                        };
+                        let callee = self.func_simple_list1();
                         let () = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(())
+                    }
+                    pub fn func_simple_list2(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (),
+                        (wasmtime::component::__internal::Vec<u32>,),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (wasmtime::component::__internal::Vec<u32>,),
+                            >::new_unchecked(self.simple_list2)
+                        }
                     }
                     pub async fn call_simple_list2<_T, _D>(
                         &self,
@@ -452,14 +473,38 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (wasmtime::component::__internal::Vec<u32>,),
-                            >::new_unchecked(self.simple_list2)
-                        };
+                        let callee = self.func_simple_list2();
                         let (ret0,) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
+                    }
+                    pub fn func_simple_list3(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (
+                            wasmtime::component::__internal::Vec<u32>,
+                            wasmtime::component::__internal::Vec<u32>,
+                        ),
+                        (
+                            (
+                                wasmtime::component::__internal::Vec<u32>,
+                                wasmtime::component::__internal::Vec<u32>,
+                            ),
+                        ),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (
+                                    wasmtime::component::__internal::Vec<u32>,
+                                    wasmtime::component::__internal::Vec<u32>,
+                                ),
+                                (
+                                    (
+                                        wasmtime::component::__internal::Vec<u32>,
+                                        wasmtime::component::__internal::Vec<u32>,
+                                    ),
+                                ),
+                            >::new_unchecked(self.simple_list3)
+                        }
                     }
                     pub async fn call_simple_list3<_T, _D>(
                         &self,
@@ -476,24 +521,40 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (
-                                    wasmtime::component::__internal::Vec<u32>,
-                                    wasmtime::component::__internal::Vec<u32>,
-                                ),
-                                (
-                                    (
-                                        wasmtime::component::__internal::Vec<u32>,
-                                        wasmtime::component::__internal::Vec<u32>,
-                                    ),
-                                ),
-                            >::new_unchecked(self.simple_list3)
-                        };
+                        let callee = self.func_simple_list3();
                         let (ret0,) = callee
                             .call_concurrent(accessor, (arg0, arg1))
                             .await?;
                         Ok(ret0)
+                    }
+                    pub fn func_simple_list4(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (
+                            wasmtime::component::__internal::Vec<
+                                wasmtime::component::__internal::Vec<u32>,
+                            >,
+                        ),
+                        (
+                            wasmtime::component::__internal::Vec<
+                                wasmtime::component::__internal::Vec<u32>,
+                            >,
+                        ),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (
+                                    wasmtime::component::__internal::Vec<
+                                        wasmtime::component::__internal::Vec<u32>,
+                                    >,
+                                ),
+                                (
+                                    wasmtime::component::__internal::Vec<
+                                        wasmtime::component::__internal::Vec<u32>,
+                                    >,
+                                ),
+                            >::new_unchecked(self.simple_list4)
+                        }
                     }
                     pub async fn call_simple_list4<_T, _D>(
                         &self,
@@ -510,20 +571,7 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (
-                                    wasmtime::component::__internal::Vec<
-                                        wasmtime::component::__internal::Vec<u32>,
-                                    >,
-                                ),
-                                (
-                                    wasmtime::component::__internal::Vec<
-                                        wasmtime::component::__internal::Vec<u32>,
-                                    >,
-                                ),
-                            >::new_unchecked(self.simple_list4)
-                        };
+                        let callee = self.func_simple_list4();
                         let (ret0,) = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(ret0)
                     }

--- a/crates/component-macro/tests/expanded/simple-lists_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/simple-lists_tracing_async.rs
@@ -528,6 +528,16 @@ pub mod exports {
                     }
                 }
                 impl Guest {
+                    pub fn func_simple_list1(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(&[u32],), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&[u32],),
+                                (),
+                            >::new_unchecked(self.simple_list1)
+                        }
+                    }
                     pub async fn call_simple_list1<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
@@ -541,17 +551,25 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/simple-lists", function = "simple-list1",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (&[u32],),
-                                (),
-                            >::new_unchecked(self.simple_list1)
-                        };
+                        let callee = self.func_simple_list1();
                         let () = callee
                             .call_async(store.as_context_mut(), (arg0,))
                             .instrument(span.clone())
                             .await?;
                         Ok(())
+                    }
+                    pub fn func_simple_list2(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (),
+                        (wasmtime::component::__internal::Vec<u32>,),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (wasmtime::component::__internal::Vec<u32>,),
+                            >::new_unchecked(self.simple_list2)
+                        }
                     }
                     pub async fn call_simple_list2<S: wasmtime::AsContextMut>(
                         &self,
@@ -565,17 +583,35 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/simple-lists", function = "simple-list2",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (wasmtime::component::__internal::Vec<u32>,),
-                            >::new_unchecked(self.simple_list2)
-                        };
+                        let callee = self.func_simple_list2();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), ())
                             .instrument(span.clone())
                             .await?;
                         Ok(ret0)
+                    }
+                    pub fn func_simple_list3(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (&[u32], &[u32]),
+                        (
+                            (
+                                wasmtime::component::__internal::Vec<u32>,
+                                wasmtime::component::__internal::Vec<u32>,
+                            ),
+                        ),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&[u32], &[u32]),
+                                (
+                                    (
+                                        wasmtime::component::__internal::Vec<u32>,
+                                        wasmtime::component::__internal::Vec<u32>,
+                                    ),
+                                ),
+                            >::new_unchecked(self.simple_list3)
+                        }
                     }
                     pub async fn call_simple_list3<S: wasmtime::AsContextMut>(
                         &self,
@@ -596,22 +632,33 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/simple-lists", function = "simple-list3",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (&[u32], &[u32]),
-                                (
-                                    (
-                                        wasmtime::component::__internal::Vec<u32>,
-                                        wasmtime::component::__internal::Vec<u32>,
-                                    ),
-                                ),
-                            >::new_unchecked(self.simple_list3)
-                        };
+                        let callee = self.func_simple_list3();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), (arg0, arg1))
                             .instrument(span.clone())
                             .await?;
                         Ok(ret0)
+                    }
+                    pub fn func_simple_list4(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (&[wasmtime::component::__internal::Vec<u32>],),
+                        (
+                            wasmtime::component::__internal::Vec<
+                                wasmtime::component::__internal::Vec<u32>,
+                            >,
+                        ),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&[wasmtime::component::__internal::Vec<u32>],),
+                                (
+                                    wasmtime::component::__internal::Vec<
+                                        wasmtime::component::__internal::Vec<u32>,
+                                    >,
+                                ),
+                            >::new_unchecked(self.simple_list4)
+                        }
                     }
                     pub async fn call_simple_list4<S: wasmtime::AsContextMut>(
                         &self,
@@ -630,16 +677,7 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/simple-lists", function = "simple-list4",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (&[wasmtime::component::__internal::Vec<u32>],),
-                                (
-                                    wasmtime::component::__internal::Vec<
-                                        wasmtime::component::__internal::Vec<u32>,
-                                    >,
-                                ),
-                            >::new_unchecked(self.simple_list4)
-                        };
+                        let callee = self.func_simple_list4();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), (arg0,))
                             .instrument(span.clone())

--- a/crates/component-macro/tests/expanded/small-anonymous.rs
+++ b/crates/component-macro/tests/expanded/small-anonymous.rs
@@ -413,13 +413,13 @@ pub mod exports {
                     }
                 }
                 impl Guest {
-                    pub fn call_option_test<S: wasmtime::AsContextMut>(
+                    pub fn func_option_test(
                         &self,
-                        mut store: S,
-                    ) -> wasmtime::Result<
-                        Result<Option<wasmtime::component::__internal::String>, Error>,
+                    ) -> wasmtime::component::TypedFunc<
+                        (),
+                        (Result<Option<wasmtime::component::__internal::String>, Error>,),
                     > {
-                        let callee = unsafe {
+                        unsafe {
                             wasmtime::component::TypedFunc::<
                                 (),
                                 (
@@ -429,7 +429,15 @@ pub mod exports {
                                     >,
                                 ),
                             >::new_unchecked(self.option_test)
-                        };
+                        }
+                    }
+                    pub fn call_option_test<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<
+                        Result<Option<wasmtime::component::__internal::String>, Error>,
+                    > {
+                        let callee = self.func_option_test();
                         let (ret0,) = callee.call(store.as_context_mut(), ())?;
                         Ok(ret0)
                     }

--- a/crates/component-macro/tests/expanded/small-anonymous_async.rs
+++ b/crates/component-macro/tests/expanded/small-anonymous_async.rs
@@ -425,16 +425,13 @@ pub mod exports {
                     }
                 }
                 impl Guest {
-                    pub async fn call_option_test<S: wasmtime::AsContextMut>(
+                    pub fn func_option_test(
                         &self,
-                        mut store: S,
-                    ) -> wasmtime::Result<
-                        Result<Option<wasmtime::component::__internal::String>, Error>,
-                    >
-                    where
-                        <S as wasmtime::AsContext>::Data: Send,
-                    {
-                        let callee = unsafe {
+                    ) -> wasmtime::component::TypedFunc<
+                        (),
+                        (Result<Option<wasmtime::component::__internal::String>, Error>,),
+                    > {
+                        unsafe {
                             wasmtime::component::TypedFunc::<
                                 (),
                                 (
@@ -444,7 +441,18 @@ pub mod exports {
                                     >,
                                 ),
                             >::new_unchecked(self.option_test)
-                        };
+                        }
+                    }
+                    pub async fn call_option_test<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<
+                        Result<Option<wasmtime::component::__internal::String>, Error>,
+                    >
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = self.func_option_test();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), ())
                             .await?;

--- a/crates/component-macro/tests/expanded/small-anonymous_concurrent.rs
+++ b/crates/component-macro/tests/expanded/small-anonymous_concurrent.rs
@@ -410,6 +410,24 @@ pub mod exports {
                     }
                 }
                 impl Guest {
+                    pub fn func_option_test(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (),
+                        (Result<Option<wasmtime::component::__internal::String>, Error>,),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (
+                                    Result<
+                                        Option<wasmtime::component::__internal::String>,
+                                        Error,
+                                    >,
+                                ),
+                            >::new_unchecked(self.option_test)
+                        }
+                    }
                     pub async fn call_option_test<_T, _D>(
                         &self,
                         accessor: &wasmtime::component::Accessor<_T, _D>,
@@ -420,17 +438,7 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (
-                                    Result<
-                                        Option<wasmtime::component::__internal::String>,
-                                        Error,
-                                    >,
-                                ),
-                            >::new_unchecked(self.option_test)
-                        };
+                        let callee = self.func_option_test();
                         let (ret0,) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
                     }

--- a/crates/component-macro/tests/expanded/small-anonymous_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/small-anonymous_tracing_async.rs
@@ -438,6 +438,24 @@ pub mod exports {
                     }
                 }
                 impl Guest {
+                    pub fn func_option_test(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (),
+                        (Result<Option<wasmtime::component::__internal::String>, Error>,),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (
+                                    Result<
+                                        Option<wasmtime::component::__internal::String>,
+                                        Error,
+                                    >,
+                                ),
+                            >::new_unchecked(self.option_test)
+                        }
+                    }
                     pub async fn call_option_test<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
@@ -452,17 +470,7 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/anon", function = "option-test",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (
-                                    Result<
-                                        Option<wasmtime::component::__internal::String>,
-                                        Error,
-                                    >,
-                                ),
-                            >::new_unchecked(self.option_test)
-                        };
+                        let callee = self.func_option_test();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), ())
                             .instrument(span.clone())

--- a/crates/component-macro/tests/expanded/smoke-default.rs
+++ b/crates/component-macro/tests/expanded/smoke-default.rs
@@ -180,13 +180,14 @@ const _: () = {
             let pre = linker.instantiate_pre(component)?;
             TheWorldPre::new(pre)?.instantiate_async(store).await
         }
+        pub fn func_y(&self) -> wasmtime::component::TypedFunc<(), ()> {
+            unsafe { wasmtime::component::TypedFunc::<(), ()>::new_unchecked(self.y) }
+        }
         pub fn call_y<S: wasmtime::AsContextMut>(
             &self,
             mut store: S,
         ) -> wasmtime::Result<()> {
-            let callee = unsafe {
-                wasmtime::component::TypedFunc::<(), ()>::new_unchecked(self.y)
-            };
+            let callee = self.func_y();
             let () = callee.call(store.as_context_mut(), ())?;
             Ok(())
         }

--- a/crates/component-macro/tests/expanded/smoke-default_async.rs
+++ b/crates/component-macro/tests/expanded/smoke-default_async.rs
@@ -180,6 +180,9 @@ const _: () = {
             let pre = linker.instantiate_pre(component)?;
             TheWorldPre::new(pre)?.instantiate_async(store).await
         }
+        pub fn func_y(&self) -> wasmtime::component::TypedFunc<(), ()> {
+            unsafe { wasmtime::component::TypedFunc::<(), ()>::new_unchecked(self.y) }
+        }
         pub async fn call_y<S: wasmtime::AsContextMut>(
             &self,
             mut store: S,
@@ -187,9 +190,7 @@ const _: () = {
         where
             <S as wasmtime::AsContext>::Data: Send,
         {
-            let callee = unsafe {
-                wasmtime::component::TypedFunc::<(), ()>::new_unchecked(self.y)
-            };
+            let callee = self.func_y();
             let () = callee.call_async(store.as_context_mut(), ()).await?;
             Ok(())
         }

--- a/crates/component-macro/tests/expanded/smoke-default_concurrent.rs
+++ b/crates/component-macro/tests/expanded/smoke-default_concurrent.rs
@@ -180,6 +180,9 @@ const _: () = {
             let pre = linker.instantiate_pre(component)?;
             TheWorldPre::new(pre)?.instantiate_async(store).await
         }
+        pub fn func_y(&self) -> wasmtime::component::TypedFunc<(), ()> {
+            unsafe { wasmtime::component::TypedFunc::<(), ()>::new_unchecked(self.y) }
+        }
         pub async fn call_y<_T, _D>(
             &self,
             accessor: &wasmtime::component::Accessor<_T, _D>,
@@ -188,9 +191,7 @@ const _: () = {
             _T: Send,
             _D: wasmtime::component::HasData,
         {
-            let callee = unsafe {
-                wasmtime::component::TypedFunc::<(), ()>::new_unchecked(self.y)
-            };
+            let callee = self.func_y();
             let () = callee.call_concurrent(accessor, ()).await?;
             Ok(())
         }

--- a/crates/component-macro/tests/expanded/smoke-default_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/smoke-default_tracing_async.rs
@@ -180,6 +180,9 @@ const _: () = {
             let pre = linker.instantiate_pre(component)?;
             TheWorldPre::new(pre)?.instantiate_async(store).await
         }
+        pub fn func_y(&self) -> wasmtime::component::TypedFunc<(), ()> {
+            unsafe { wasmtime::component::TypedFunc::<(), ()>::new_unchecked(self.y) }
+        }
         pub async fn call_y<S: wasmtime::AsContextMut>(
             &self,
             mut store: S,
@@ -192,9 +195,7 @@ const _: () = {
                 tracing::Level::TRACE, "wit-bindgen export", module = "default", function
                 = "y",
             );
-            let callee = unsafe {
-                wasmtime::component::TypedFunc::<(), ()>::new_unchecked(self.y)
-            };
+            let callee = self.func_y();
             let () = callee
                 .call_async(store.as_context_mut(), ())
                 .instrument(span.clone())

--- a/crates/component-macro/tests/expanded/smoke-export.rs
+++ b/crates/component-macro/tests/expanded/smoke-export.rs
@@ -230,13 +230,16 @@ pub mod exports {
             }
         }
         impl Guest {
+            pub fn func_y(&self) -> wasmtime::component::TypedFunc<(), ()> {
+                unsafe {
+                    wasmtime::component::TypedFunc::<(), ()>::new_unchecked(self.y)
+                }
+            }
             pub fn call_y<S: wasmtime::AsContextMut>(
                 &self,
                 mut store: S,
             ) -> wasmtime::Result<()> {
-                let callee = unsafe {
-                    wasmtime::component::TypedFunc::<(), ()>::new_unchecked(self.y)
-                };
+                let callee = self.func_y();
                 let () = callee.call(store.as_context_mut(), ())?;
                 Ok(())
             }

--- a/crates/component-macro/tests/expanded/smoke-export_async.rs
+++ b/crates/component-macro/tests/expanded/smoke-export_async.rs
@@ -230,6 +230,11 @@ pub mod exports {
             }
         }
         impl Guest {
+            pub fn func_y(&self) -> wasmtime::component::TypedFunc<(), ()> {
+                unsafe {
+                    wasmtime::component::TypedFunc::<(), ()>::new_unchecked(self.y)
+                }
+            }
             pub async fn call_y<S: wasmtime::AsContextMut>(
                 &self,
                 mut store: S,
@@ -237,9 +242,7 @@ pub mod exports {
             where
                 <S as wasmtime::AsContext>::Data: Send,
             {
-                let callee = unsafe {
-                    wasmtime::component::TypedFunc::<(), ()>::new_unchecked(self.y)
-                };
+                let callee = self.func_y();
                 let () = callee.call_async(store.as_context_mut(), ()).await?;
                 Ok(())
             }

--- a/crates/component-macro/tests/expanded/smoke-export_concurrent.rs
+++ b/crates/component-macro/tests/expanded/smoke-export_concurrent.rs
@@ -230,6 +230,11 @@ pub mod exports {
             }
         }
         impl Guest {
+            pub fn func_y(&self) -> wasmtime::component::TypedFunc<(), ()> {
+                unsafe {
+                    wasmtime::component::TypedFunc::<(), ()>::new_unchecked(self.y)
+                }
+            }
             pub async fn call_y<_T, _D>(
                 &self,
                 accessor: &wasmtime::component::Accessor<_T, _D>,
@@ -238,9 +243,7 @@ pub mod exports {
                 _T: Send,
                 _D: wasmtime::component::HasData,
             {
-                let callee = unsafe {
-                    wasmtime::component::TypedFunc::<(), ()>::new_unchecked(self.y)
-                };
+                let callee = self.func_y();
                 let () = callee.call_concurrent(accessor, ()).await?;
                 Ok(())
             }

--- a/crates/component-macro/tests/expanded/smoke-export_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/smoke-export_tracing_async.rs
@@ -230,6 +230,11 @@ pub mod exports {
             }
         }
         impl Guest {
+            pub fn func_y(&self) -> wasmtime::component::TypedFunc<(), ()> {
+                unsafe {
+                    wasmtime::component::TypedFunc::<(), ()>::new_unchecked(self.y)
+                }
+            }
             pub async fn call_y<S: wasmtime::AsContextMut>(
                 &self,
                 mut store: S,
@@ -242,9 +247,7 @@ pub mod exports {
                     tracing::Level::TRACE, "wit-bindgen export", module = "the-name",
                     function = "y",
                 );
-                let callee = unsafe {
-                    wasmtime::component::TypedFunc::<(), ()>::new_unchecked(self.y)
-                };
+                let callee = self.func_y();
                 let () = callee
                     .call_async(store.as_context_mut(), ())
                     .instrument(span.clone())

--- a/crates/component-macro/tests/expanded/strings.rs
+++ b/crates/component-macro/tests/expanded/strings.rs
@@ -365,32 +365,56 @@ pub mod exports {
                     }
                 }
                 impl Guest {
+                    pub fn func_a(&self) -> wasmtime::component::TypedFunc<(&str,), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&str,),
+                                (),
+                            >::new_unchecked(self.a)
+                        }
+                    }
                     pub fn call_a<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                         arg0: &str,
                     ) -> wasmtime::Result<()> {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (&str,),
-                                (),
-                            >::new_unchecked(self.a)
-                        };
+                        let callee = self.func_a();
                         let () = callee.call(store.as_context_mut(), (arg0,))?;
                         Ok(())
+                    }
+                    pub fn func_b(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (),
+                        (wasmtime::component::__internal::String,),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (wasmtime::component::__internal::String,),
+                            >::new_unchecked(self.b)
+                        }
                     }
                     pub fn call_b<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                     ) -> wasmtime::Result<wasmtime::component::__internal::String> {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (wasmtime::component::__internal::String,),
-                            >::new_unchecked(self.b)
-                        };
+                        let callee = self.func_b();
                         let (ret0,) = callee.call(store.as_context_mut(), ())?;
                         Ok(ret0)
+                    }
+                    pub fn func_c(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (&str, &str),
+                        (wasmtime::component::__internal::String,),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&str, &str),
+                                (wasmtime::component::__internal::String,),
+                            >::new_unchecked(self.c)
+                        }
                     }
                     pub fn call_c<S: wasmtime::AsContextMut>(
                         &self,
@@ -398,12 +422,7 @@ pub mod exports {
                         arg0: &str,
                         arg1: &str,
                     ) -> wasmtime::Result<wasmtime::component::__internal::String> {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (&str, &str),
-                                (wasmtime::component::__internal::String,),
-                            >::new_unchecked(self.c)
-                        };
+                        let callee = self.func_c();
                         let (ret0,) = callee.call(store.as_context_mut(), (arg0, arg1))?;
                         Ok(ret0)
                     }

--- a/crates/component-macro/tests/expanded/strings_async.rs
+++ b/crates/component-macro/tests/expanded/strings_async.rs
@@ -389,6 +389,14 @@ pub mod exports {
                     }
                 }
                 impl Guest {
+                    pub fn func_a(&self) -> wasmtime::component::TypedFunc<(&str,), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&str,),
+                                (),
+                            >::new_unchecked(self.a)
+                        }
+                    }
                     pub async fn call_a<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
@@ -397,16 +405,24 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (&str,),
-                                (),
-                            >::new_unchecked(self.a)
-                        };
+                        let callee = self.func_a();
                         let () = callee
                             .call_async(store.as_context_mut(), (arg0,))
                             .await?;
                         Ok(())
+                    }
+                    pub fn func_b(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (),
+                        (wasmtime::component::__internal::String,),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (wasmtime::component::__internal::String,),
+                            >::new_unchecked(self.b)
+                        }
                     }
                     pub async fn call_b<S: wasmtime::AsContextMut>(
                         &self,
@@ -415,16 +431,24 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (wasmtime::component::__internal::String,),
-                            >::new_unchecked(self.b)
-                        };
+                        let callee = self.func_b();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), ())
                             .await?;
                         Ok(ret0)
+                    }
+                    pub fn func_c(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (&str, &str),
+                        (wasmtime::component::__internal::String,),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&str, &str),
+                                (wasmtime::component::__internal::String,),
+                            >::new_unchecked(self.c)
+                        }
                     }
                     pub async fn call_c<S: wasmtime::AsContextMut>(
                         &self,
@@ -435,12 +459,7 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (&str, &str),
-                                (wasmtime::component::__internal::String,),
-                            >::new_unchecked(self.c)
-                        };
+                        let callee = self.func_c();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), (arg0, arg1))
                             .await?;

--- a/crates/component-macro/tests/expanded/strings_concurrent.rs
+++ b/crates/component-macro/tests/expanded/strings_concurrent.rs
@@ -362,6 +362,19 @@ pub mod exports {
                     }
                 }
                 impl Guest {
+                    pub fn func_a(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (wasmtime::component::__internal::String,),
+                        (),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (wasmtime::component::__internal::String,),
+                                (),
+                            >::new_unchecked(self.a)
+                        }
+                    }
                     pub async fn call_a<_T, _D>(
                         &self,
                         accessor: &wasmtime::component::Accessor<_T, _D>,
@@ -371,14 +384,22 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (wasmtime::component::__internal::String,),
-                                (),
-                            >::new_unchecked(self.a)
-                        };
+                        let callee = self.func_a();
                         let () = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(())
+                    }
+                    pub fn func_b(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (),
+                        (wasmtime::component::__internal::String,),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (wasmtime::component::__internal::String,),
+                            >::new_unchecked(self.b)
+                        }
                     }
                     pub async fn call_b<_T, _D>(
                         &self,
@@ -388,14 +409,28 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (wasmtime::component::__internal::String,),
-                            >::new_unchecked(self.b)
-                        };
+                        let callee = self.func_b();
                         let (ret0,) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
+                    }
+                    pub fn func_c(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (
+                            wasmtime::component::__internal::String,
+                            wasmtime::component::__internal::String,
+                        ),
+                        (wasmtime::component::__internal::String,),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (
+                                    wasmtime::component::__internal::String,
+                                    wasmtime::component::__internal::String,
+                                ),
+                                (wasmtime::component::__internal::String,),
+                            >::new_unchecked(self.c)
+                        }
                     }
                     pub async fn call_c<_T, _D>(
                         &self,
@@ -407,15 +442,7 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (
-                                    wasmtime::component::__internal::String,
-                                    wasmtime::component::__internal::String,
-                                ),
-                                (wasmtime::component::__internal::String,),
-                            >::new_unchecked(self.c)
-                        };
+                        let callee = self.func_c();
                         let (ret0,) = callee
                             .call_concurrent(accessor, (arg0, arg1))
                             .await?;

--- a/crates/component-macro/tests/expanded/strings_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/strings_tracing_async.rs
@@ -434,6 +434,14 @@ pub mod exports {
                     }
                 }
                 impl Guest {
+                    pub fn func_a(&self) -> wasmtime::component::TypedFunc<(&str,), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&str,),
+                                (),
+                            >::new_unchecked(self.a)
+                        }
+                    }
                     pub async fn call_a<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
@@ -447,17 +455,25 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/strings", function = "a",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (&str,),
-                                (),
-                            >::new_unchecked(self.a)
-                        };
+                        let callee = self.func_a();
                         let () = callee
                             .call_async(store.as_context_mut(), (arg0,))
                             .instrument(span.clone())
                             .await?;
                         Ok(())
+                    }
+                    pub fn func_b(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (),
+                        (wasmtime::component::__internal::String,),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (wasmtime::component::__internal::String,),
+                            >::new_unchecked(self.b)
+                        }
                     }
                     pub async fn call_b<S: wasmtime::AsContextMut>(
                         &self,
@@ -471,17 +487,25 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/strings", function = "b",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (wasmtime::component::__internal::String,),
-                            >::new_unchecked(self.b)
-                        };
+                        let callee = self.func_b();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), ())
                             .instrument(span.clone())
                             .await?;
                         Ok(ret0)
+                    }
+                    pub fn func_c(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (&str, &str),
+                        (wasmtime::component::__internal::String,),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&str, &str),
+                                (wasmtime::component::__internal::String,),
+                            >::new_unchecked(self.c)
+                        }
                     }
                     pub async fn call_c<S: wasmtime::AsContextMut>(
                         &self,
@@ -497,12 +521,7 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/strings", function = "c",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (&str, &str),
-                                (wasmtime::component::__internal::String,),
-                            >::new_unchecked(self.c)
-                        };
+                        let callee = self.func_c();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), (arg0, arg1))
                             .instrument(span.clone())

--- a/crates/component-macro/tests/expanded/variants.rs
+++ b/crates/component-macro/tests/expanded/variants.rs
@@ -1548,98 +1548,131 @@ pub mod exports {
                     }
                 }
                 impl Guest {
+                    pub fn func_e1_arg(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(E1,), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (E1,),
+                                (),
+                            >::new_unchecked(self.e1_arg)
+                        }
+                    }
                     pub fn call_e1_arg<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                         arg0: E1,
                     ) -> wasmtime::Result<()> {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (E1,),
-                                (),
-                            >::new_unchecked(self.e1_arg)
-                        };
+                        let callee = self.func_e1_arg();
                         let () = callee.call(store.as_context_mut(), (arg0,))?;
                         Ok(())
+                    }
+                    pub fn func_e1_result(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(), (E1,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (E1,),
+                            >::new_unchecked(self.e1_result)
+                        }
                     }
                     pub fn call_e1_result<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                     ) -> wasmtime::Result<E1> {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (E1,),
-                            >::new_unchecked(self.e1_result)
-                        };
+                        let callee = self.func_e1_result();
                         let (ret0,) = callee.call(store.as_context_mut(), ())?;
                         Ok(ret0)
+                    }
+                    pub fn func_v1_arg(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(&V1,), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&V1,),
+                                (),
+                            >::new_unchecked(self.v1_arg)
+                        }
                     }
                     pub fn call_v1_arg<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                         arg0: &V1,
                     ) -> wasmtime::Result<()> {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (&V1,),
-                                (),
-                            >::new_unchecked(self.v1_arg)
-                        };
+                        let callee = self.func_v1_arg();
                         let () = callee.call(store.as_context_mut(), (arg0,))?;
                         Ok(())
+                    }
+                    pub fn func_v1_result(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(), (V1,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (V1,),
+                            >::new_unchecked(self.v1_result)
+                        }
                     }
                     pub fn call_v1_result<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                     ) -> wasmtime::Result<V1> {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (V1,),
-                            >::new_unchecked(self.v1_result)
-                        };
+                        let callee = self.func_v1_result();
                         let (ret0,) = callee.call(store.as_context_mut(), ())?;
                         Ok(ret0)
+                    }
+                    pub fn func_bool_arg(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(bool,), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (bool,),
+                                (),
+                            >::new_unchecked(self.bool_arg)
+                        }
                     }
                     pub fn call_bool_arg<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                         arg0: bool,
                     ) -> wasmtime::Result<()> {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (bool,),
-                                (),
-                            >::new_unchecked(self.bool_arg)
-                        };
+                        let callee = self.func_bool_arg();
                         let () = callee.call(store.as_context_mut(), (arg0,))?;
                         Ok(())
+                    }
+                    pub fn func_bool_result(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(), (bool,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (bool,),
+                            >::new_unchecked(self.bool_result)
+                        }
                     }
                     pub fn call_bool_result<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                     ) -> wasmtime::Result<bool> {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (bool,),
-                            >::new_unchecked(self.bool_result)
-                        };
+                        let callee = self.func_bool_result();
                         let (ret0,) = callee.call(store.as_context_mut(), ())?;
                         Ok(ret0)
                     }
-                    pub fn call_option_arg<S: wasmtime::AsContextMut>(
+                    pub fn func_option_arg(
                         &self,
-                        mut store: S,
-                        arg0: Option<bool>,
-                        arg1: Option<()>,
-                        arg2: Option<u32>,
-                        arg3: Option<E1>,
-                        arg4: Option<f32>,
-                        arg5: Option<Option<bool>>,
-                    ) -> wasmtime::Result<()> {
-                        let callee = unsafe {
+                    ) -> wasmtime::component::TypedFunc<
+                        (
+                            Option<bool>,
+                            Option<()>,
+                            Option<u32>,
+                            Option<E1>,
+                            Option<f32>,
+                            Option<Option<bool>>,
+                        ),
+                        (),
+                    > {
+                        unsafe {
                             wasmtime::component::TypedFunc::<
                                 (
                                     Option<bool>,
@@ -1651,13 +1684,56 @@ pub mod exports {
                                 ),
                                 (),
                             >::new_unchecked(self.option_arg)
-                        };
+                        }
+                    }
+                    pub fn call_option_arg<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: Option<bool>,
+                        arg1: Option<()>,
+                        arg2: Option<u32>,
+                        arg3: Option<E1>,
+                        arg4: Option<f32>,
+                        arg5: Option<Option<bool>>,
+                    ) -> wasmtime::Result<()> {
+                        let callee = self.func_option_arg();
                         let () = callee
                             .call(
                                 store.as_context_mut(),
                                 (arg0, arg1, arg2, arg3, arg4, arg5),
                             )?;
                         Ok(())
+                    }
+                    pub fn func_option_result(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (),
+                        (
+                            (
+                                Option<bool>,
+                                Option<()>,
+                                Option<u32>,
+                                Option<E1>,
+                                Option<f32>,
+                                Option<Option<bool>>,
+                            ),
+                        ),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (
+                                    (
+                                        Option<bool>,
+                                        Option<()>,
+                                        Option<u32>,
+                                        Option<E1>,
+                                        Option<f32>,
+                                        Option<Option<bool>>,
+                                    ),
+                                ),
+                            >::new_unchecked(self.option_result)
+                        }
                     }
                     pub fn call_option_result<S: wasmtime::AsContextMut>(
                         &self,
@@ -1672,23 +1748,22 @@ pub mod exports {
                             Option<Option<bool>>,
                         ),
                     > {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (
-                                    (
-                                        Option<bool>,
-                                        Option<()>,
-                                        Option<u32>,
-                                        Option<E1>,
-                                        Option<f32>,
-                                        Option<Option<bool>>,
-                                    ),
-                                ),
-                            >::new_unchecked(self.option_result)
-                        };
+                        let callee = self.func_option_result();
                         let (ret0,) = callee.call(store.as_context_mut(), ())?;
                         Ok(ret0)
+                    }
+                    pub fn func_casts(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (Casts1, Casts2, Casts3, Casts4, Casts5, Casts6),
+                        ((Casts1, Casts2, Casts3, Casts4, Casts5, Casts6),),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (Casts1, Casts2, Casts3, Casts4, Casts5, Casts6),
+                                ((Casts1, Casts2, Casts3, Casts4, Casts5, Casts6),),
+                            >::new_unchecked(self.casts)
+                        }
                     }
                     pub fn call_casts<S: wasmtime::AsContextMut>(
                         &self,
@@ -1702,12 +1777,7 @@ pub mod exports {
                     ) -> wasmtime::Result<
                         (Casts1, Casts2, Casts3, Casts4, Casts5, Casts6),
                     > {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (Casts1, Casts2, Casts3, Casts4, Casts5, Casts6),
-                                ((Casts1, Casts2, Casts3, Casts4, Casts5, Casts6),),
-                            >::new_unchecked(self.casts)
-                        };
+                        let callee = self.func_casts();
                         let (ret0,) = callee
                             .call(
                                 store.as_context_mut(),
@@ -1715,17 +1785,20 @@ pub mod exports {
                             )?;
                         Ok(ret0)
                     }
-                    pub fn call_result_arg<S: wasmtime::AsContextMut>(
+                    pub fn func_result_arg(
                         &self,
-                        mut store: S,
-                        arg0: Result<(), ()>,
-                        arg1: Result<(), E1>,
-                        arg2: Result<E1, ()>,
-                        arg3: Result<(), ()>,
-                        arg4: Result<u32, &V1>,
-                        arg5: Result<&str, &[u8]>,
-                    ) -> wasmtime::Result<()> {
-                        let callee = unsafe {
+                    ) -> wasmtime::component::TypedFunc<
+                        (
+                            Result<(), ()>,
+                            Result<(), E1>,
+                            Result<E1, ()>,
+                            Result<(), ()>,
+                            Result<u32, &V1>,
+                            Result<&str, &[u8]>,
+                        ),
+                        (),
+                    > {
+                        unsafe {
                             wasmtime::component::TypedFunc::<
                                 (
                                     Result<(), ()>,
@@ -1737,13 +1810,62 @@ pub mod exports {
                                 ),
                                 (),
                             >::new_unchecked(self.result_arg)
-                        };
+                        }
+                    }
+                    pub fn call_result_arg<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: Result<(), ()>,
+                        arg1: Result<(), E1>,
+                        arg2: Result<E1, ()>,
+                        arg3: Result<(), ()>,
+                        arg4: Result<u32, &V1>,
+                        arg5: Result<&str, &[u8]>,
+                    ) -> wasmtime::Result<()> {
+                        let callee = self.func_result_arg();
                         let () = callee
                             .call(
                                 store.as_context_mut(),
                                 (arg0, arg1, arg2, arg3, arg4, arg5),
                             )?;
                         Ok(())
+                    }
+                    pub fn func_result_result(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (),
+                        (
+                            (
+                                Result<(), ()>,
+                                Result<(), E1>,
+                                Result<E1, ()>,
+                                Result<(), ()>,
+                                Result<u32, V1>,
+                                Result<
+                                    wasmtime::component::__internal::String,
+                                    wasmtime::component::__internal::Vec<u8>,
+                                >,
+                            ),
+                        ),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (
+                                    (
+                                        Result<(), ()>,
+                                        Result<(), E1>,
+                                        Result<E1, ()>,
+                                        Result<(), ()>,
+                                        Result<u32, V1>,
+                                        Result<
+                                            wasmtime::component::__internal::String,
+                                            wasmtime::component::__internal::Vec<u8>,
+                                        >,
+                                    ),
+                                ),
+                            >::new_unchecked(self.result_result)
+                        }
                     }
                     pub fn call_result_result<S: wasmtime::AsContextMut>(
                         &self,
@@ -1761,142 +1883,176 @@ pub mod exports {
                             >,
                         ),
                     > {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (
-                                    (
-                                        Result<(), ()>,
-                                        Result<(), E1>,
-                                        Result<E1, ()>,
-                                        Result<(), ()>,
-                                        Result<u32, V1>,
-                                        Result<
-                                            wasmtime::component::__internal::String,
-                                            wasmtime::component::__internal::Vec<u8>,
-                                        >,
-                                    ),
-                                ),
-                            >::new_unchecked(self.result_result)
-                        };
+                        let callee = self.func_result_result();
                         let (ret0,) = callee.call(store.as_context_mut(), ())?;
                         Ok(ret0)
+                    }
+                    pub fn func_return_result_sugar(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(), (Result<i32, MyErrno>,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (Result<i32, MyErrno>,),
+                            >::new_unchecked(self.return_result_sugar)
+                        }
                     }
                     pub fn call_return_result_sugar<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                     ) -> wasmtime::Result<Result<i32, MyErrno>> {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (Result<i32, MyErrno>,),
-                            >::new_unchecked(self.return_result_sugar)
-                        };
+                        let callee = self.func_return_result_sugar();
                         let (ret0,) = callee.call(store.as_context_mut(), ())?;
                         Ok(ret0)
+                    }
+                    pub fn func_return_result_sugar2(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(), (Result<(), MyErrno>,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (Result<(), MyErrno>,),
+                            >::new_unchecked(self.return_result_sugar2)
+                        }
                     }
                     pub fn call_return_result_sugar2<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                     ) -> wasmtime::Result<Result<(), MyErrno>> {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (Result<(), MyErrno>,),
-                            >::new_unchecked(self.return_result_sugar2)
-                        };
+                        let callee = self.func_return_result_sugar2();
                         let (ret0,) = callee.call(store.as_context_mut(), ())?;
                         Ok(ret0)
+                    }
+                    pub fn func_return_result_sugar3(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (),
+                        (Result<MyErrno, MyErrno>,),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (Result<MyErrno, MyErrno>,),
+                            >::new_unchecked(self.return_result_sugar3)
+                        }
                     }
                     pub fn call_return_result_sugar3<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                     ) -> wasmtime::Result<Result<MyErrno, MyErrno>> {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (Result<MyErrno, MyErrno>,),
-                            >::new_unchecked(self.return_result_sugar3)
-                        };
+                        let callee = self.func_return_result_sugar3();
                         let (ret0,) = callee.call(store.as_context_mut(), ())?;
                         Ok(ret0)
+                    }
+                    pub fn func_return_result_sugar4(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (),
+                        (Result<(i32, u32), MyErrno>,),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (Result<(i32, u32), MyErrno>,),
+                            >::new_unchecked(self.return_result_sugar4)
+                        }
                     }
                     pub fn call_return_result_sugar4<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                     ) -> wasmtime::Result<Result<(i32, u32), MyErrno>> {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (Result<(i32, u32), MyErrno>,),
-                            >::new_unchecked(self.return_result_sugar4)
-                        };
+                        let callee = self.func_return_result_sugar4();
                         let (ret0,) = callee.call(store.as_context_mut(), ())?;
                         Ok(ret0)
+                    }
+                    pub fn func_return_option_sugar(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(), (Option<i32>,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (Option<i32>,),
+                            >::new_unchecked(self.return_option_sugar)
+                        }
                     }
                     pub fn call_return_option_sugar<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                     ) -> wasmtime::Result<Option<i32>> {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (Option<i32>,),
-                            >::new_unchecked(self.return_option_sugar)
-                        };
+                        let callee = self.func_return_option_sugar();
                         let (ret0,) = callee.call(store.as_context_mut(), ())?;
                         Ok(ret0)
+                    }
+                    pub fn func_return_option_sugar2(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(), (Option<MyErrno>,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (Option<MyErrno>,),
+                            >::new_unchecked(self.return_option_sugar2)
+                        }
                     }
                     pub fn call_return_option_sugar2<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                     ) -> wasmtime::Result<Option<MyErrno>> {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (Option<MyErrno>,),
-                            >::new_unchecked(self.return_option_sugar2)
-                        };
+                        let callee = self.func_return_option_sugar2();
                         let (ret0,) = callee.call(store.as_context_mut(), ())?;
                         Ok(ret0)
+                    }
+                    pub fn func_result_simple(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(), (Result<u32, i32>,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (Result<u32, i32>,),
+                            >::new_unchecked(self.result_simple)
+                        }
                     }
                     pub fn call_result_simple<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                     ) -> wasmtime::Result<Result<u32, i32>> {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (Result<u32, i32>,),
-                            >::new_unchecked(self.result_simple)
-                        };
+                        let callee = self.func_result_simple();
                         let (ret0,) = callee.call(store.as_context_mut(), ())?;
                         Ok(ret0)
+                    }
+                    pub fn func_is_clone_arg(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(&IsClone,), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&IsClone,),
+                                (),
+                            >::new_unchecked(self.is_clone_arg)
+                        }
                     }
                     pub fn call_is_clone_arg<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                         arg0: &IsClone,
                     ) -> wasmtime::Result<()> {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (&IsClone,),
-                                (),
-                            >::new_unchecked(self.is_clone_arg)
-                        };
+                        let callee = self.func_is_clone_arg();
                         let () = callee.call(store.as_context_mut(), (arg0,))?;
                         Ok(())
+                    }
+                    pub fn func_is_clone_return(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(), (IsClone,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (IsClone,),
+                            >::new_unchecked(self.is_clone_return)
+                        }
                     }
                     pub fn call_is_clone_return<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                     ) -> wasmtime::Result<IsClone> {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (IsClone,),
-                            >::new_unchecked(self.is_clone_return)
-                        };
+                        let callee = self.func_is_clone_return();
                         let (ret0,) = callee.call(store.as_context_mut(), ())?;
                         Ok(ret0)
                     }

--- a/crates/component-macro/tests/expanded/variants_async.rs
+++ b/crates/component-macro/tests/expanded/variants_async.rs
@@ -1679,6 +1679,16 @@ pub mod exports {
                     }
                 }
                 impl Guest {
+                    pub fn func_e1_arg(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(E1,), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (E1,),
+                                (),
+                            >::new_unchecked(self.e1_arg)
+                        }
+                    }
                     pub async fn call_e1_arg<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
@@ -1687,16 +1697,21 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (E1,),
-                                (),
-                            >::new_unchecked(self.e1_arg)
-                        };
+                        let callee = self.func_e1_arg();
                         let () = callee
                             .call_async(store.as_context_mut(), (arg0,))
                             .await?;
                         Ok(())
+                    }
+                    pub fn func_e1_result(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(), (E1,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (E1,),
+                            >::new_unchecked(self.e1_result)
+                        }
                     }
                     pub async fn call_e1_result<S: wasmtime::AsContextMut>(
                         &self,
@@ -1705,16 +1720,21 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (E1,),
-                            >::new_unchecked(self.e1_result)
-                        };
+                        let callee = self.func_e1_result();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), ())
                             .await?;
                         Ok(ret0)
+                    }
+                    pub fn func_v1_arg(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(&V1,), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&V1,),
+                                (),
+                            >::new_unchecked(self.v1_arg)
+                        }
                     }
                     pub async fn call_v1_arg<S: wasmtime::AsContextMut>(
                         &self,
@@ -1724,16 +1744,21 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (&V1,),
-                                (),
-                            >::new_unchecked(self.v1_arg)
-                        };
+                        let callee = self.func_v1_arg();
                         let () = callee
                             .call_async(store.as_context_mut(), (arg0,))
                             .await?;
                         Ok(())
+                    }
+                    pub fn func_v1_result(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(), (V1,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (V1,),
+                            >::new_unchecked(self.v1_result)
+                        }
                     }
                     pub async fn call_v1_result<S: wasmtime::AsContextMut>(
                         &self,
@@ -1742,16 +1767,21 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (V1,),
-                            >::new_unchecked(self.v1_result)
-                        };
+                        let callee = self.func_v1_result();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), ())
                             .await?;
                         Ok(ret0)
+                    }
+                    pub fn func_bool_arg(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(bool,), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (bool,),
+                                (),
+                            >::new_unchecked(self.bool_arg)
+                        }
                     }
                     pub async fn call_bool_arg<S: wasmtime::AsContextMut>(
                         &self,
@@ -1761,16 +1791,21 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (bool,),
-                                (),
-                            >::new_unchecked(self.bool_arg)
-                        };
+                        let callee = self.func_bool_arg();
                         let () = callee
                             .call_async(store.as_context_mut(), (arg0,))
                             .await?;
                         Ok(())
+                    }
+                    pub fn func_bool_result(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(), (bool,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (bool,),
+                            >::new_unchecked(self.bool_result)
+                        }
                     }
                     pub async fn call_bool_result<S: wasmtime::AsContextMut>(
                         &self,
@@ -1779,16 +1814,38 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (bool,),
-                            >::new_unchecked(self.bool_result)
-                        };
+                        let callee = self.func_bool_result();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), ())
                             .await?;
                         Ok(ret0)
+                    }
+                    pub fn func_option_arg(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (
+                            Option<bool>,
+                            Option<()>,
+                            Option<u32>,
+                            Option<E1>,
+                            Option<f32>,
+                            Option<Option<bool>>,
+                        ),
+                        (),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (
+                                    Option<bool>,
+                                    Option<()>,
+                                    Option<u32>,
+                                    Option<E1>,
+                                    Option<f32>,
+                                    Option<Option<bool>>,
+                                ),
+                                (),
+                            >::new_unchecked(self.option_arg)
+                        }
                     }
                     pub async fn call_option_arg<S: wasmtime::AsContextMut>(
                         &self,
@@ -1803,19 +1860,7 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (
-                                    Option<bool>,
-                                    Option<()>,
-                                    Option<u32>,
-                                    Option<E1>,
-                                    Option<f32>,
-                                    Option<Option<bool>>,
-                                ),
-                                (),
-                            >::new_unchecked(self.option_arg)
-                        };
+                        let callee = self.func_option_arg();
                         let () = callee
                             .call_async(
                                 store.as_context_mut(),
@@ -1823,6 +1868,37 @@ pub mod exports {
                             )
                             .await?;
                         Ok(())
+                    }
+                    pub fn func_option_result(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (),
+                        (
+                            (
+                                Option<bool>,
+                                Option<()>,
+                                Option<u32>,
+                                Option<E1>,
+                                Option<f32>,
+                                Option<Option<bool>>,
+                            ),
+                        ),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (
+                                    (
+                                        Option<bool>,
+                                        Option<()>,
+                                        Option<u32>,
+                                        Option<E1>,
+                                        Option<f32>,
+                                        Option<Option<bool>>,
+                                    ),
+                                ),
+                            >::new_unchecked(self.option_result)
+                        }
                     }
                     pub async fn call_option_result<S: wasmtime::AsContextMut>(
                         &self,
@@ -1840,25 +1916,24 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (
-                                    (
-                                        Option<bool>,
-                                        Option<()>,
-                                        Option<u32>,
-                                        Option<E1>,
-                                        Option<f32>,
-                                        Option<Option<bool>>,
-                                    ),
-                                ),
-                            >::new_unchecked(self.option_result)
-                        };
+                        let callee = self.func_option_result();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), ())
                             .await?;
                         Ok(ret0)
+                    }
+                    pub fn func_casts(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (Casts1, Casts2, Casts3, Casts4, Casts5, Casts6),
+                        ((Casts1, Casts2, Casts3, Casts4, Casts5, Casts6),),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (Casts1, Casts2, Casts3, Casts4, Casts5, Casts6),
+                                ((Casts1, Casts2, Casts3, Casts4, Casts5, Casts6),),
+                            >::new_unchecked(self.casts)
+                        }
                     }
                     pub async fn call_casts<S: wasmtime::AsContextMut>(
                         &self,
@@ -1875,12 +1950,7 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (Casts1, Casts2, Casts3, Casts4, Casts5, Casts6),
-                                ((Casts1, Casts2, Casts3, Casts4, Casts5, Casts6),),
-                            >::new_unchecked(self.casts)
-                        };
+                        let callee = self.func_casts();
                         let (ret0,) = callee
                             .call_async(
                                 store.as_context_mut(),
@@ -1888,6 +1958,33 @@ pub mod exports {
                             )
                             .await?;
                         Ok(ret0)
+                    }
+                    pub fn func_result_arg(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (
+                            Result<(), ()>,
+                            Result<(), E1>,
+                            Result<E1, ()>,
+                            Result<(), ()>,
+                            Result<u32, &V1>,
+                            Result<&str, &[u8]>,
+                        ),
+                        (),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (
+                                    Result<(), ()>,
+                                    Result<(), E1>,
+                                    Result<E1, ()>,
+                                    Result<(), ()>,
+                                    Result<u32, &V1>,
+                                    Result<&str, &[u8]>,
+                                ),
+                                (),
+                            >::new_unchecked(self.result_arg)
+                        }
                     }
                     pub async fn call_result_arg<S: wasmtime::AsContextMut>(
                         &self,
@@ -1902,19 +1999,7 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (
-                                    Result<(), ()>,
-                                    Result<(), E1>,
-                                    Result<E1, ()>,
-                                    Result<(), ()>,
-                                    Result<u32, &V1>,
-                                    Result<&str, &[u8]>,
-                                ),
-                                (),
-                            >::new_unchecked(self.result_arg)
-                        };
+                        let callee = self.func_result_arg();
                         let () = callee
                             .call_async(
                                 store.as_context_mut(),
@@ -1922,6 +2007,43 @@ pub mod exports {
                             )
                             .await?;
                         Ok(())
+                    }
+                    pub fn func_result_result(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (),
+                        (
+                            (
+                                Result<(), ()>,
+                                Result<(), E1>,
+                                Result<E1, ()>,
+                                Result<(), ()>,
+                                Result<u32, V1>,
+                                Result<
+                                    wasmtime::component::__internal::String,
+                                    wasmtime::component::__internal::Vec<u8>,
+                                >,
+                            ),
+                        ),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (
+                                    (
+                                        Result<(), ()>,
+                                        Result<(), E1>,
+                                        Result<E1, ()>,
+                                        Result<(), ()>,
+                                        Result<u32, V1>,
+                                        Result<
+                                            wasmtime::component::__internal::String,
+                                            wasmtime::component::__internal::Vec<u8>,
+                                        >,
+                                    ),
+                                ),
+                            >::new_unchecked(self.result_result)
+                        }
                     }
                     pub async fn call_result_result<S: wasmtime::AsContextMut>(
                         &self,
@@ -1942,28 +2064,21 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (
-                                    (
-                                        Result<(), ()>,
-                                        Result<(), E1>,
-                                        Result<E1, ()>,
-                                        Result<(), ()>,
-                                        Result<u32, V1>,
-                                        Result<
-                                            wasmtime::component::__internal::String,
-                                            wasmtime::component::__internal::Vec<u8>,
-                                        >,
-                                    ),
-                                ),
-                            >::new_unchecked(self.result_result)
-                        };
+                        let callee = self.func_result_result();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), ())
                             .await?;
                         Ok(ret0)
+                    }
+                    pub fn func_return_result_sugar(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(), (Result<i32, MyErrno>,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (Result<i32, MyErrno>,),
+                            >::new_unchecked(self.return_result_sugar)
+                        }
                     }
                     pub async fn call_return_result_sugar<S: wasmtime::AsContextMut>(
                         &self,
@@ -1972,16 +2087,21 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (Result<i32, MyErrno>,),
-                            >::new_unchecked(self.return_result_sugar)
-                        };
+                        let callee = self.func_return_result_sugar();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), ())
                             .await?;
                         Ok(ret0)
+                    }
+                    pub fn func_return_result_sugar2(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(), (Result<(), MyErrno>,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (Result<(), MyErrno>,),
+                            >::new_unchecked(self.return_result_sugar2)
+                        }
                     }
                     pub async fn call_return_result_sugar2<S: wasmtime::AsContextMut>(
                         &self,
@@ -1990,16 +2110,24 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (Result<(), MyErrno>,),
-                            >::new_unchecked(self.return_result_sugar2)
-                        };
+                        let callee = self.func_return_result_sugar2();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), ())
                             .await?;
                         Ok(ret0)
+                    }
+                    pub fn func_return_result_sugar3(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (),
+                        (Result<MyErrno, MyErrno>,),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (Result<MyErrno, MyErrno>,),
+                            >::new_unchecked(self.return_result_sugar3)
+                        }
                     }
                     pub async fn call_return_result_sugar3<S: wasmtime::AsContextMut>(
                         &self,
@@ -2008,16 +2136,24 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (Result<MyErrno, MyErrno>,),
-                            >::new_unchecked(self.return_result_sugar3)
-                        };
+                        let callee = self.func_return_result_sugar3();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), ())
                             .await?;
                         Ok(ret0)
+                    }
+                    pub fn func_return_result_sugar4(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (),
+                        (Result<(i32, u32), MyErrno>,),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (Result<(i32, u32), MyErrno>,),
+                            >::new_unchecked(self.return_result_sugar4)
+                        }
                     }
                     pub async fn call_return_result_sugar4<S: wasmtime::AsContextMut>(
                         &self,
@@ -2026,16 +2162,21 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (Result<(i32, u32), MyErrno>,),
-                            >::new_unchecked(self.return_result_sugar4)
-                        };
+                        let callee = self.func_return_result_sugar4();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), ())
                             .await?;
                         Ok(ret0)
+                    }
+                    pub fn func_return_option_sugar(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(), (Option<i32>,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (Option<i32>,),
+                            >::new_unchecked(self.return_option_sugar)
+                        }
                     }
                     pub async fn call_return_option_sugar<S: wasmtime::AsContextMut>(
                         &self,
@@ -2044,16 +2185,21 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (Option<i32>,),
-                            >::new_unchecked(self.return_option_sugar)
-                        };
+                        let callee = self.func_return_option_sugar();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), ())
                             .await?;
                         Ok(ret0)
+                    }
+                    pub fn func_return_option_sugar2(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(), (Option<MyErrno>,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (Option<MyErrno>,),
+                            >::new_unchecked(self.return_option_sugar2)
+                        }
                     }
                     pub async fn call_return_option_sugar2<S: wasmtime::AsContextMut>(
                         &self,
@@ -2062,16 +2208,21 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (Option<MyErrno>,),
-                            >::new_unchecked(self.return_option_sugar2)
-                        };
+                        let callee = self.func_return_option_sugar2();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), ())
                             .await?;
                         Ok(ret0)
+                    }
+                    pub fn func_result_simple(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(), (Result<u32, i32>,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (Result<u32, i32>,),
+                            >::new_unchecked(self.result_simple)
+                        }
                     }
                     pub async fn call_result_simple<S: wasmtime::AsContextMut>(
                         &self,
@@ -2080,16 +2231,21 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (Result<u32, i32>,),
-                            >::new_unchecked(self.result_simple)
-                        };
+                        let callee = self.func_result_simple();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), ())
                             .await?;
                         Ok(ret0)
+                    }
+                    pub fn func_is_clone_arg(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(&IsClone,), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&IsClone,),
+                                (),
+                            >::new_unchecked(self.is_clone_arg)
+                        }
                     }
                     pub async fn call_is_clone_arg<S: wasmtime::AsContextMut>(
                         &self,
@@ -2099,16 +2255,21 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (&IsClone,),
-                                (),
-                            >::new_unchecked(self.is_clone_arg)
-                        };
+                        let callee = self.func_is_clone_arg();
                         let () = callee
                             .call_async(store.as_context_mut(), (arg0,))
                             .await?;
                         Ok(())
+                    }
+                    pub fn func_is_clone_return(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(), (IsClone,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (IsClone,),
+                            >::new_unchecked(self.is_clone_return)
+                        }
                     }
                     pub async fn call_is_clone_return<S: wasmtime::AsContextMut>(
                         &self,
@@ -2117,12 +2278,7 @@ pub mod exports {
                     where
                         <S as wasmtime::AsContext>::Data: Send,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (IsClone,),
-                            >::new_unchecked(self.is_clone_return)
-                        };
+                        let callee = self.func_is_clone_return();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), ())
                             .await?;

--- a/crates/component-macro/tests/expanded/variants_concurrent.rs
+++ b/crates/component-macro/tests/expanded/variants_concurrent.rs
@@ -1533,6 +1533,16 @@ pub mod exports {
                     }
                 }
                 impl Guest {
+                    pub fn func_e1_arg(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(E1,), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (E1,),
+                                (),
+                            >::new_unchecked(self.e1_arg)
+                        }
+                    }
                     pub async fn call_e1_arg<_T, _D>(
                         &self,
                         accessor: &wasmtime::component::Accessor<_T, _D>,
@@ -1542,14 +1552,19 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (E1,),
-                                (),
-                            >::new_unchecked(self.e1_arg)
-                        };
+                        let callee = self.func_e1_arg();
                         let () = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(())
+                    }
+                    pub fn func_e1_result(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(), (E1,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (E1,),
+                            >::new_unchecked(self.e1_result)
+                        }
                     }
                     pub async fn call_e1_result<_T, _D>(
                         &self,
@@ -1559,14 +1574,19 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (E1,),
-                            >::new_unchecked(self.e1_result)
-                        };
+                        let callee = self.func_e1_result();
                         let (ret0,) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
+                    }
+                    pub fn func_v1_arg(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(V1,), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (V1,),
+                                (),
+                            >::new_unchecked(self.v1_arg)
+                        }
                     }
                     pub async fn call_v1_arg<_T, _D>(
                         &self,
@@ -1577,14 +1597,19 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (V1,),
-                                (),
-                            >::new_unchecked(self.v1_arg)
-                        };
+                        let callee = self.func_v1_arg();
                         let () = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(())
+                    }
+                    pub fn func_v1_result(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(), (V1,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (V1,),
+                            >::new_unchecked(self.v1_result)
+                        }
                     }
                     pub async fn call_v1_result<_T, _D>(
                         &self,
@@ -1594,14 +1619,19 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (V1,),
-                            >::new_unchecked(self.v1_result)
-                        };
+                        let callee = self.func_v1_result();
                         let (ret0,) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
+                    }
+                    pub fn func_bool_arg(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(bool,), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (bool,),
+                                (),
+                            >::new_unchecked(self.bool_arg)
+                        }
                     }
                     pub async fn call_bool_arg<_T, _D>(
                         &self,
@@ -1612,14 +1642,19 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (bool,),
-                                (),
-                            >::new_unchecked(self.bool_arg)
-                        };
+                        let callee = self.func_bool_arg();
                         let () = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(())
+                    }
+                    pub fn func_bool_result(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(), (bool,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (bool,),
+                            >::new_unchecked(self.bool_result)
+                        }
                     }
                     pub async fn call_bool_result<_T, _D>(
                         &self,
@@ -1629,14 +1664,36 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (bool,),
-                            >::new_unchecked(self.bool_result)
-                        };
+                        let callee = self.func_bool_result();
                         let (ret0,) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
+                    }
+                    pub fn func_option_arg(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (
+                            Option<bool>,
+                            Option<()>,
+                            Option<u32>,
+                            Option<E1>,
+                            Option<f32>,
+                            Option<Option<bool>>,
+                        ),
+                        (),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (
+                                    Option<bool>,
+                                    Option<()>,
+                                    Option<u32>,
+                                    Option<E1>,
+                                    Option<f32>,
+                                    Option<Option<bool>>,
+                                ),
+                                (),
+                            >::new_unchecked(self.option_arg)
+                        }
                     }
                     pub async fn call_option_arg<_T, _D>(
                         &self,
@@ -1652,19 +1709,7 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (
-                                    Option<bool>,
-                                    Option<()>,
-                                    Option<u32>,
-                                    Option<E1>,
-                                    Option<f32>,
-                                    Option<Option<bool>>,
-                                ),
-                                (),
-                            >::new_unchecked(self.option_arg)
-                        };
+                        let callee = self.func_option_arg();
                         let () = callee
                             .call_concurrent(
                                 accessor,
@@ -1672,6 +1717,37 @@ pub mod exports {
                             )
                             .await?;
                         Ok(())
+                    }
+                    pub fn func_option_result(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (),
+                        (
+                            (
+                                Option<bool>,
+                                Option<()>,
+                                Option<u32>,
+                                Option<E1>,
+                                Option<f32>,
+                                Option<Option<bool>>,
+                            ),
+                        ),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (
+                                    (
+                                        Option<bool>,
+                                        Option<()>,
+                                        Option<u32>,
+                                        Option<E1>,
+                                        Option<f32>,
+                                        Option<Option<bool>>,
+                                    ),
+                                ),
+                            >::new_unchecked(self.option_result)
+                        }
                     }
                     pub async fn call_option_result<_T, _D>(
                         &self,
@@ -1690,23 +1766,22 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (
-                                    (
-                                        Option<bool>,
-                                        Option<()>,
-                                        Option<u32>,
-                                        Option<E1>,
-                                        Option<f32>,
-                                        Option<Option<bool>>,
-                                    ),
-                                ),
-                            >::new_unchecked(self.option_result)
-                        };
+                        let callee = self.func_option_result();
                         let (ret0,) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
+                    }
+                    pub fn func_casts(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (Casts1, Casts2, Casts3, Casts4, Casts5, Casts6),
+                        ((Casts1, Casts2, Casts3, Casts4, Casts5, Casts6),),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (Casts1, Casts2, Casts3, Casts4, Casts5, Casts6),
+                                ((Casts1, Casts2, Casts3, Casts4, Casts5, Casts6),),
+                            >::new_unchecked(self.casts)
+                        }
                     }
                     pub async fn call_casts<_T, _D>(
                         &self,
@@ -1724,12 +1799,7 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (Casts1, Casts2, Casts3, Casts4, Casts5, Casts6),
-                                ((Casts1, Casts2, Casts3, Casts4, Casts5, Casts6),),
-                            >::new_unchecked(self.casts)
-                        };
+                        let callee = self.func_casts();
                         let (ret0,) = callee
                             .call_concurrent(
                                 accessor,
@@ -1737,6 +1807,39 @@ pub mod exports {
                             )
                             .await?;
                         Ok(ret0)
+                    }
+                    pub fn func_result_arg(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (
+                            Result<(), ()>,
+                            Result<(), E1>,
+                            Result<E1, ()>,
+                            Result<(), ()>,
+                            Result<u32, V1>,
+                            Result<
+                                wasmtime::component::__internal::String,
+                                wasmtime::component::__internal::Vec<u8>,
+                            >,
+                        ),
+                        (),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (
+                                    Result<(), ()>,
+                                    Result<(), E1>,
+                                    Result<E1, ()>,
+                                    Result<(), ()>,
+                                    Result<u32, V1>,
+                                    Result<
+                                        wasmtime::component::__internal::String,
+                                        wasmtime::component::__internal::Vec<u8>,
+                                    >,
+                                ),
+                                (),
+                            >::new_unchecked(self.result_arg)
+                        }
                     }
                     pub async fn call_result_arg<_T, _D>(
                         &self,
@@ -1755,22 +1858,7 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (
-                                    Result<(), ()>,
-                                    Result<(), E1>,
-                                    Result<E1, ()>,
-                                    Result<(), ()>,
-                                    Result<u32, V1>,
-                                    Result<
-                                        wasmtime::component::__internal::String,
-                                        wasmtime::component::__internal::Vec<u8>,
-                                    >,
-                                ),
-                                (),
-                            >::new_unchecked(self.result_arg)
-                        };
+                        let callee = self.func_result_arg();
                         let () = callee
                             .call_concurrent(
                                 accessor,
@@ -1778,6 +1866,43 @@ pub mod exports {
                             )
                             .await?;
                         Ok(())
+                    }
+                    pub fn func_result_result(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (),
+                        (
+                            (
+                                Result<(), ()>,
+                                Result<(), E1>,
+                                Result<E1, ()>,
+                                Result<(), ()>,
+                                Result<u32, V1>,
+                                Result<
+                                    wasmtime::component::__internal::String,
+                                    wasmtime::component::__internal::Vec<u8>,
+                                >,
+                            ),
+                        ),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (
+                                    (
+                                        Result<(), ()>,
+                                        Result<(), E1>,
+                                        Result<E1, ()>,
+                                        Result<(), ()>,
+                                        Result<u32, V1>,
+                                        Result<
+                                            wasmtime::component::__internal::String,
+                                            wasmtime::component::__internal::Vec<u8>,
+                                        >,
+                                    ),
+                                ),
+                            >::new_unchecked(self.result_result)
+                        }
                     }
                     pub async fn call_result_result<_T, _D>(
                         &self,
@@ -1799,26 +1924,19 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (
-                                    (
-                                        Result<(), ()>,
-                                        Result<(), E1>,
-                                        Result<E1, ()>,
-                                        Result<(), ()>,
-                                        Result<u32, V1>,
-                                        Result<
-                                            wasmtime::component::__internal::String,
-                                            wasmtime::component::__internal::Vec<u8>,
-                                        >,
-                                    ),
-                                ),
-                            >::new_unchecked(self.result_result)
-                        };
+                        let callee = self.func_result_result();
                         let (ret0,) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
+                    }
+                    pub fn func_return_result_sugar(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(), (Result<i32, MyErrno>,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (Result<i32, MyErrno>,),
+                            >::new_unchecked(self.return_result_sugar)
+                        }
                     }
                     pub async fn call_return_result_sugar<_T, _D>(
                         &self,
@@ -1828,14 +1946,19 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (Result<i32, MyErrno>,),
-                            >::new_unchecked(self.return_result_sugar)
-                        };
+                        let callee = self.func_return_result_sugar();
                         let (ret0,) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
+                    }
+                    pub fn func_return_result_sugar2(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(), (Result<(), MyErrno>,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (Result<(), MyErrno>,),
+                            >::new_unchecked(self.return_result_sugar2)
+                        }
                     }
                     pub async fn call_return_result_sugar2<_T, _D>(
                         &self,
@@ -1845,14 +1968,22 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (Result<(), MyErrno>,),
-                            >::new_unchecked(self.return_result_sugar2)
-                        };
+                        let callee = self.func_return_result_sugar2();
                         let (ret0,) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
+                    }
+                    pub fn func_return_result_sugar3(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (),
+                        (Result<MyErrno, MyErrno>,),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (Result<MyErrno, MyErrno>,),
+                            >::new_unchecked(self.return_result_sugar3)
+                        }
                     }
                     pub async fn call_return_result_sugar3<_T, _D>(
                         &self,
@@ -1862,14 +1993,22 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (Result<MyErrno, MyErrno>,),
-                            >::new_unchecked(self.return_result_sugar3)
-                        };
+                        let callee = self.func_return_result_sugar3();
                         let (ret0,) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
+                    }
+                    pub fn func_return_result_sugar4(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (),
+                        (Result<(i32, u32), MyErrno>,),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (Result<(i32, u32), MyErrno>,),
+                            >::new_unchecked(self.return_result_sugar4)
+                        }
                     }
                     pub async fn call_return_result_sugar4<_T, _D>(
                         &self,
@@ -1879,14 +2018,19 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (Result<(i32, u32), MyErrno>,),
-                            >::new_unchecked(self.return_result_sugar4)
-                        };
+                        let callee = self.func_return_result_sugar4();
                         let (ret0,) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
+                    }
+                    pub fn func_return_option_sugar(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(), (Option<i32>,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (Option<i32>,),
+                            >::new_unchecked(self.return_option_sugar)
+                        }
                     }
                     pub async fn call_return_option_sugar<_T, _D>(
                         &self,
@@ -1896,14 +2040,19 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (Option<i32>,),
-                            >::new_unchecked(self.return_option_sugar)
-                        };
+                        let callee = self.func_return_option_sugar();
                         let (ret0,) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
+                    }
+                    pub fn func_return_option_sugar2(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(), (Option<MyErrno>,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (Option<MyErrno>,),
+                            >::new_unchecked(self.return_option_sugar2)
+                        }
                     }
                     pub async fn call_return_option_sugar2<_T, _D>(
                         &self,
@@ -1913,14 +2062,19 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (Option<MyErrno>,),
-                            >::new_unchecked(self.return_option_sugar2)
-                        };
+                        let callee = self.func_return_option_sugar2();
                         let (ret0,) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
+                    }
+                    pub fn func_result_simple(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(), (Result<u32, i32>,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (Result<u32, i32>,),
+                            >::new_unchecked(self.result_simple)
+                        }
                     }
                     pub async fn call_result_simple<_T, _D>(
                         &self,
@@ -1930,14 +2084,19 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (Result<u32, i32>,),
-                            >::new_unchecked(self.result_simple)
-                        };
+                        let callee = self.func_result_simple();
                         let (ret0,) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
+                    }
+                    pub fn func_is_clone_arg(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(IsClone,), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (IsClone,),
+                                (),
+                            >::new_unchecked(self.is_clone_arg)
+                        }
                     }
                     pub async fn call_is_clone_arg<_T, _D>(
                         &self,
@@ -1948,14 +2107,19 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (IsClone,),
-                                (),
-                            >::new_unchecked(self.is_clone_arg)
-                        };
+                        let callee = self.func_is_clone_arg();
                         let () = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(())
+                    }
+                    pub fn func_is_clone_return(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(), (IsClone,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (IsClone,),
+                            >::new_unchecked(self.is_clone_return)
+                        }
                     }
                     pub async fn call_is_clone_return<_T, _D>(
                         &self,
@@ -1965,12 +2129,7 @@ pub mod exports {
                         _T: Send,
                         _D: wasmtime::component::HasData,
                     {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (IsClone,),
-                            >::new_unchecked(self.is_clone_return)
-                        };
+                        let callee = self.func_is_clone_return();
                         let (ret0,) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
                     }

--- a/crates/component-macro/tests/expanded/variants_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/variants_tracing_async.rs
@@ -1977,6 +1977,16 @@ pub mod exports {
                     }
                 }
                 impl Guest {
+                    pub fn func_e1_arg(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(E1,), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (E1,),
+                                (),
+                            >::new_unchecked(self.e1_arg)
+                        }
+                    }
                     pub async fn call_e1_arg<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
@@ -1990,17 +2000,22 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/variants", function = "e1-arg",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (E1,),
-                                (),
-                            >::new_unchecked(self.e1_arg)
-                        };
+                        let callee = self.func_e1_arg();
                         let () = callee
                             .call_async(store.as_context_mut(), (arg0,))
                             .instrument(span.clone())
                             .await?;
                         Ok(())
+                    }
+                    pub fn func_e1_result(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(), (E1,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (E1,),
+                            >::new_unchecked(self.e1_result)
+                        }
                     }
                     pub async fn call_e1_result<S: wasmtime::AsContextMut>(
                         &self,
@@ -2014,17 +2029,22 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/variants", function = "e1-result",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (E1,),
-                            >::new_unchecked(self.e1_result)
-                        };
+                        let callee = self.func_e1_result();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), ())
                             .instrument(span.clone())
                             .await?;
                         Ok(ret0)
+                    }
+                    pub fn func_v1_arg(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(&V1,), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&V1,),
+                                (),
+                            >::new_unchecked(self.v1_arg)
+                        }
                     }
                     pub async fn call_v1_arg<S: wasmtime::AsContextMut>(
                         &self,
@@ -2039,17 +2059,22 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/variants", function = "v1-arg",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (&V1,),
-                                (),
-                            >::new_unchecked(self.v1_arg)
-                        };
+                        let callee = self.func_v1_arg();
                         let () = callee
                             .call_async(store.as_context_mut(), (arg0,))
                             .instrument(span.clone())
                             .await?;
                         Ok(())
+                    }
+                    pub fn func_v1_result(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(), (V1,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (V1,),
+                            >::new_unchecked(self.v1_result)
+                        }
                     }
                     pub async fn call_v1_result<S: wasmtime::AsContextMut>(
                         &self,
@@ -2063,17 +2088,22 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/variants", function = "v1-result",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (V1,),
-                            >::new_unchecked(self.v1_result)
-                        };
+                        let callee = self.func_v1_result();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), ())
                             .instrument(span.clone())
                             .await?;
                         Ok(ret0)
+                    }
+                    pub fn func_bool_arg(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(bool,), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (bool,),
+                                (),
+                            >::new_unchecked(self.bool_arg)
+                        }
                     }
                     pub async fn call_bool_arg<S: wasmtime::AsContextMut>(
                         &self,
@@ -2088,17 +2118,22 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/variants", function = "bool-arg",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (bool,),
-                                (),
-                            >::new_unchecked(self.bool_arg)
-                        };
+                        let callee = self.func_bool_arg();
                         let () = callee
                             .call_async(store.as_context_mut(), (arg0,))
                             .instrument(span.clone())
                             .await?;
                         Ok(())
+                    }
+                    pub fn func_bool_result(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(), (bool,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (bool,),
+                            >::new_unchecked(self.bool_result)
+                        }
                     }
                     pub async fn call_bool_result<S: wasmtime::AsContextMut>(
                         &self,
@@ -2112,17 +2147,39 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/variants", function = "bool-result",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (bool,),
-                            >::new_unchecked(self.bool_result)
-                        };
+                        let callee = self.func_bool_result();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), ())
                             .instrument(span.clone())
                             .await?;
                         Ok(ret0)
+                    }
+                    pub fn func_option_arg(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (
+                            Option<bool>,
+                            Option<()>,
+                            Option<u32>,
+                            Option<E1>,
+                            Option<f32>,
+                            Option<Option<bool>>,
+                        ),
+                        (),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (
+                                    Option<bool>,
+                                    Option<()>,
+                                    Option<u32>,
+                                    Option<E1>,
+                                    Option<f32>,
+                                    Option<Option<bool>>,
+                                ),
+                                (),
+                            >::new_unchecked(self.option_arg)
+                        }
                     }
                     pub async fn call_option_arg<S: wasmtime::AsContextMut>(
                         &self,
@@ -2142,19 +2199,7 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/variants", function = "option-arg",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (
-                                    Option<bool>,
-                                    Option<()>,
-                                    Option<u32>,
-                                    Option<E1>,
-                                    Option<f32>,
-                                    Option<Option<bool>>,
-                                ),
-                                (),
-                            >::new_unchecked(self.option_arg)
-                        };
+                        let callee = self.func_option_arg();
                         let () = callee
                             .call_async(
                                 store.as_context_mut(),
@@ -2163,6 +2208,37 @@ pub mod exports {
                             .instrument(span.clone())
                             .await?;
                         Ok(())
+                    }
+                    pub fn func_option_result(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (),
+                        (
+                            (
+                                Option<bool>,
+                                Option<()>,
+                                Option<u32>,
+                                Option<E1>,
+                                Option<f32>,
+                                Option<Option<bool>>,
+                            ),
+                        ),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (
+                                    (
+                                        Option<bool>,
+                                        Option<()>,
+                                        Option<u32>,
+                                        Option<E1>,
+                                        Option<f32>,
+                                        Option<Option<bool>>,
+                                    ),
+                                ),
+                            >::new_unchecked(self.option_result)
+                        }
                     }
                     pub async fn call_option_result<S: wasmtime::AsContextMut>(
                         &self,
@@ -2185,26 +2261,25 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/variants", function = "option-result",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (
-                                    (
-                                        Option<bool>,
-                                        Option<()>,
-                                        Option<u32>,
-                                        Option<E1>,
-                                        Option<f32>,
-                                        Option<Option<bool>>,
-                                    ),
-                                ),
-                            >::new_unchecked(self.option_result)
-                        };
+                        let callee = self.func_option_result();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), ())
                             .instrument(span.clone())
                             .await?;
                         Ok(ret0)
+                    }
+                    pub fn func_casts(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (Casts1, Casts2, Casts3, Casts4, Casts5, Casts6),
+                        ((Casts1, Casts2, Casts3, Casts4, Casts5, Casts6),),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (Casts1, Casts2, Casts3, Casts4, Casts5, Casts6),
+                                ((Casts1, Casts2, Casts3, Casts4, Casts5, Casts6),),
+                            >::new_unchecked(self.casts)
+                        }
                     }
                     pub async fn call_casts<S: wasmtime::AsContextMut>(
                         &self,
@@ -2226,12 +2301,7 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/variants", function = "casts",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (Casts1, Casts2, Casts3, Casts4, Casts5, Casts6),
-                                ((Casts1, Casts2, Casts3, Casts4, Casts5, Casts6),),
-                            >::new_unchecked(self.casts)
-                        };
+                        let callee = self.func_casts();
                         let (ret0,) = callee
                             .call_async(
                                 store.as_context_mut(),
@@ -2240,6 +2310,33 @@ pub mod exports {
                             .instrument(span.clone())
                             .await?;
                         Ok(ret0)
+                    }
+                    pub fn func_result_arg(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (
+                            Result<(), ()>,
+                            Result<(), E1>,
+                            Result<E1, ()>,
+                            Result<(), ()>,
+                            Result<u32, &V1>,
+                            Result<&str, &[u8]>,
+                        ),
+                        (),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (
+                                    Result<(), ()>,
+                                    Result<(), E1>,
+                                    Result<E1, ()>,
+                                    Result<(), ()>,
+                                    Result<u32, &V1>,
+                                    Result<&str, &[u8]>,
+                                ),
+                                (),
+                            >::new_unchecked(self.result_arg)
+                        }
                     }
                     pub async fn call_result_arg<S: wasmtime::AsContextMut>(
                         &self,
@@ -2259,19 +2356,7 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/variants", function = "result-arg",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (
-                                    Result<(), ()>,
-                                    Result<(), E1>,
-                                    Result<E1, ()>,
-                                    Result<(), ()>,
-                                    Result<u32, &V1>,
-                                    Result<&str, &[u8]>,
-                                ),
-                                (),
-                            >::new_unchecked(self.result_arg)
-                        };
+                        let callee = self.func_result_arg();
                         let () = callee
                             .call_async(
                                 store.as_context_mut(),
@@ -2280,6 +2365,43 @@ pub mod exports {
                             .instrument(span.clone())
                             .await?;
                         Ok(())
+                    }
+                    pub fn func_result_result(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (),
+                        (
+                            (
+                                Result<(), ()>,
+                                Result<(), E1>,
+                                Result<E1, ()>,
+                                Result<(), ()>,
+                                Result<u32, V1>,
+                                Result<
+                                    wasmtime::component::__internal::String,
+                                    wasmtime::component::__internal::Vec<u8>,
+                                >,
+                            ),
+                        ),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (
+                                    (
+                                        Result<(), ()>,
+                                        Result<(), E1>,
+                                        Result<E1, ()>,
+                                        Result<(), ()>,
+                                        Result<u32, V1>,
+                                        Result<
+                                            wasmtime::component::__internal::String,
+                                            wasmtime::component::__internal::Vec<u8>,
+                                        >,
+                                    ),
+                                ),
+                            >::new_unchecked(self.result_result)
+                        }
                     }
                     pub async fn call_result_result<S: wasmtime::AsContextMut>(
                         &self,
@@ -2305,29 +2427,22 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/variants", function = "result-result",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (
-                                    (
-                                        Result<(), ()>,
-                                        Result<(), E1>,
-                                        Result<E1, ()>,
-                                        Result<(), ()>,
-                                        Result<u32, V1>,
-                                        Result<
-                                            wasmtime::component::__internal::String,
-                                            wasmtime::component::__internal::Vec<u8>,
-                                        >,
-                                    ),
-                                ),
-                            >::new_unchecked(self.result_result)
-                        };
+                        let callee = self.func_result_result();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), ())
                             .instrument(span.clone())
                             .await?;
                         Ok(ret0)
+                    }
+                    pub fn func_return_result_sugar(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(), (Result<i32, MyErrno>,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (Result<i32, MyErrno>,),
+                            >::new_unchecked(self.return_result_sugar)
+                        }
                     }
                     pub async fn call_return_result_sugar<S: wasmtime::AsContextMut>(
                         &self,
@@ -2341,17 +2456,22 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/variants", function = "return-result-sugar",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (Result<i32, MyErrno>,),
-                            >::new_unchecked(self.return_result_sugar)
-                        };
+                        let callee = self.func_return_result_sugar();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), ())
                             .instrument(span.clone())
                             .await?;
                         Ok(ret0)
+                    }
+                    pub fn func_return_result_sugar2(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(), (Result<(), MyErrno>,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (Result<(), MyErrno>,),
+                            >::new_unchecked(self.return_result_sugar2)
+                        }
                     }
                     pub async fn call_return_result_sugar2<S: wasmtime::AsContextMut>(
                         &self,
@@ -2365,17 +2485,25 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/variants", function = "return-result-sugar2",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (Result<(), MyErrno>,),
-                            >::new_unchecked(self.return_result_sugar2)
-                        };
+                        let callee = self.func_return_result_sugar2();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), ())
                             .instrument(span.clone())
                             .await?;
                         Ok(ret0)
+                    }
+                    pub fn func_return_result_sugar3(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (),
+                        (Result<MyErrno, MyErrno>,),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (Result<MyErrno, MyErrno>,),
+                            >::new_unchecked(self.return_result_sugar3)
+                        }
                     }
                     pub async fn call_return_result_sugar3<S: wasmtime::AsContextMut>(
                         &self,
@@ -2389,17 +2517,25 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/variants", function = "return-result-sugar3",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (Result<MyErrno, MyErrno>,),
-                            >::new_unchecked(self.return_result_sugar3)
-                        };
+                        let callee = self.func_return_result_sugar3();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), ())
                             .instrument(span.clone())
                             .await?;
                         Ok(ret0)
+                    }
+                    pub fn func_return_result_sugar4(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<
+                        (),
+                        (Result<(i32, u32), MyErrno>,),
+                    > {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (Result<(i32, u32), MyErrno>,),
+                            >::new_unchecked(self.return_result_sugar4)
+                        }
                     }
                     pub async fn call_return_result_sugar4<S: wasmtime::AsContextMut>(
                         &self,
@@ -2413,17 +2549,22 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/variants", function = "return-result-sugar4",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (Result<(i32, u32), MyErrno>,),
-                            >::new_unchecked(self.return_result_sugar4)
-                        };
+                        let callee = self.func_return_result_sugar4();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), ())
                             .instrument(span.clone())
                             .await?;
                         Ok(ret0)
+                    }
+                    pub fn func_return_option_sugar(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(), (Option<i32>,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (Option<i32>,),
+                            >::new_unchecked(self.return_option_sugar)
+                        }
                     }
                     pub async fn call_return_option_sugar<S: wasmtime::AsContextMut>(
                         &self,
@@ -2437,17 +2578,22 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/variants", function = "return-option-sugar",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (Option<i32>,),
-                            >::new_unchecked(self.return_option_sugar)
-                        };
+                        let callee = self.func_return_option_sugar();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), ())
                             .instrument(span.clone())
                             .await?;
                         Ok(ret0)
+                    }
+                    pub fn func_return_option_sugar2(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(), (Option<MyErrno>,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (Option<MyErrno>,),
+                            >::new_unchecked(self.return_option_sugar2)
+                        }
                     }
                     pub async fn call_return_option_sugar2<S: wasmtime::AsContextMut>(
                         &self,
@@ -2461,17 +2607,22 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/variants", function = "return-option-sugar2",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (Option<MyErrno>,),
-                            >::new_unchecked(self.return_option_sugar2)
-                        };
+                        let callee = self.func_return_option_sugar2();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), ())
                             .instrument(span.clone())
                             .await?;
                         Ok(ret0)
+                    }
+                    pub fn func_result_simple(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(), (Result<u32, i32>,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (Result<u32, i32>,),
+                            >::new_unchecked(self.result_simple)
+                        }
                     }
                     pub async fn call_result_simple<S: wasmtime::AsContextMut>(
                         &self,
@@ -2485,17 +2636,22 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/variants", function = "result-simple",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (Result<u32, i32>,),
-                            >::new_unchecked(self.result_simple)
-                        };
+                        let callee = self.func_result_simple();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), ())
                             .instrument(span.clone())
                             .await?;
                         Ok(ret0)
+                    }
+                    pub fn func_is_clone_arg(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(&IsClone,), ()> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&IsClone,),
+                                (),
+                            >::new_unchecked(self.is_clone_arg)
+                        }
                     }
                     pub async fn call_is_clone_arg<S: wasmtime::AsContextMut>(
                         &self,
@@ -2510,17 +2666,22 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/variants", function = "is-clone-arg",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (&IsClone,),
-                                (),
-                            >::new_unchecked(self.is_clone_arg)
-                        };
+                        let callee = self.func_is_clone_arg();
                         let () = callee
                             .call_async(store.as_context_mut(), (arg0,))
                             .instrument(span.clone())
                             .await?;
                         Ok(())
+                    }
+                    pub fn func_is_clone_return(
+                        &self,
+                    ) -> wasmtime::component::TypedFunc<(), (IsClone,)> {
+                        unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (IsClone,),
+                            >::new_unchecked(self.is_clone_return)
+                        }
                     }
                     pub async fn call_is_clone_return<S: wasmtime::AsContextMut>(
                         &self,
@@ -2534,12 +2695,7 @@ pub mod exports {
                             tracing::Level::TRACE, "wit-bindgen export", module =
                             "foo:foo/variants", function = "is-clone-return",
                         );
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (),
-                                (IsClone,),
-                            >::new_unchecked(self.is_clone_return)
-                        };
+                        let callee = self.func_is_clone_return();
                         let (ret0,) = callee
                             .call_async(store.as_context_mut(), ())
                             .instrument(span.clone())

--- a/crates/component-macro/tests/expanded/worlds-with-types.rs
+++ b/crates/component-macro/tests/expanded/worlds-with-types.rs
@@ -219,13 +219,16 @@ const _: () = {
             foo::foo::i::add_to_linker::<T, D>(linker, host_getter)?;
             Ok(())
         }
+        pub fn func_f(&self) -> wasmtime::component::TypedFunc<(), ((T, U, R),)> {
+            unsafe {
+                wasmtime::component::TypedFunc::<(), ((T, U, R),)>::new_unchecked(self.f)
+            }
+        }
         pub fn call_f<S: wasmtime::AsContextMut>(
             &self,
             mut store: S,
         ) -> wasmtime::Result<(T, U, R)> {
-            let callee = unsafe {
-                wasmtime::component::TypedFunc::<(), ((T, U, R),)>::new_unchecked(self.f)
-            };
+            let callee = self.func_f();
             let (ret0,) = callee.call(store.as_context_mut(), ())?;
             Ok(ret0)
         }

--- a/crates/component-macro/tests/expanded/worlds-with-types_async.rs
+++ b/crates/component-macro/tests/expanded/worlds-with-types_async.rs
@@ -219,6 +219,11 @@ const _: () = {
             foo::foo::i::add_to_linker::<T, D>(linker, host_getter)?;
             Ok(())
         }
+        pub fn func_f(&self) -> wasmtime::component::TypedFunc<(), ((T, U, R),)> {
+            unsafe {
+                wasmtime::component::TypedFunc::<(), ((T, U, R),)>::new_unchecked(self.f)
+            }
+        }
         pub async fn call_f<S: wasmtime::AsContextMut>(
             &self,
             mut store: S,
@@ -226,9 +231,7 @@ const _: () = {
         where
             <S as wasmtime::AsContext>::Data: Send,
         {
-            let callee = unsafe {
-                wasmtime::component::TypedFunc::<(), ((T, U, R),)>::new_unchecked(self.f)
-            };
+            let callee = self.func_f();
             let (ret0,) = callee.call_async(store.as_context_mut(), ()).await?;
             Ok(ret0)
         }

--- a/crates/component-macro/tests/expanded/worlds-with-types_concurrent.rs
+++ b/crates/component-macro/tests/expanded/worlds-with-types_concurrent.rs
@@ -219,6 +219,11 @@ const _: () = {
             foo::foo::i::add_to_linker::<T, D>(linker, host_getter)?;
             Ok(())
         }
+        pub fn func_f(&self) -> wasmtime::component::TypedFunc<(), ((T, U, R),)> {
+            unsafe {
+                wasmtime::component::TypedFunc::<(), ((T, U, R),)>::new_unchecked(self.f)
+            }
+        }
         pub async fn call_f<_T, _D>(
             &self,
             accessor: &wasmtime::component::Accessor<_T, _D>,
@@ -227,9 +232,7 @@ const _: () = {
             _T: Send,
             _D: wasmtime::component::HasData,
         {
-            let callee = unsafe {
-                wasmtime::component::TypedFunc::<(), ((T, U, R),)>::new_unchecked(self.f)
-            };
+            let callee = self.func_f();
             let (ret0,) = callee.call_concurrent(accessor, ()).await?;
             Ok(ret0)
         }

--- a/crates/component-macro/tests/expanded/worlds-with-types_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/worlds-with-types_tracing_async.rs
@@ -219,6 +219,11 @@ const _: () = {
             foo::foo::i::add_to_linker::<T, D>(linker, host_getter)?;
             Ok(())
         }
+        pub fn func_f(&self) -> wasmtime::component::TypedFunc<(), ((T, U, R),)> {
+            unsafe {
+                wasmtime::component::TypedFunc::<(), ((T, U, R),)>::new_unchecked(self.f)
+            }
+        }
         pub async fn call_f<S: wasmtime::AsContextMut>(
             &self,
             mut store: S,
@@ -231,9 +236,7 @@ const _: () = {
                 tracing::Level::TRACE, "wit-bindgen export", module = "default", function
                 = "f",
             );
-            let callee = unsafe {
-                wasmtime::component::TypedFunc::<(), ((T, U, R),)>::new_unchecked(self.f)
-            };
+            let callee = self.func_f();
             let (ret0,) = callee
                 .call_async(store.as_context_mut(), ())
                 .instrument(span.clone())

--- a/crates/wasi-http/src/handler.rs
+++ b/crates/wasi-http/src/handler.rs
@@ -2,6 +2,8 @@
 //! `wasi:http/handler` guest instances.
 
 #[cfg(feature = "p2")]
+use crate::p2;
+#[cfg(feature = "p2")]
 use crate::p2::bindings::http::types as p2_types;
 #[cfg(feature = "p3")]
 use crate::p3;
@@ -29,10 +31,10 @@ use std::sync::{
 use std::task::{Context, Poll};
 use std::time::Instant;
 use tokio::sync::Notify;
-use wasmtime::component::Accessor;
+use wasmtime::component::{Accessor, GuestTaskId, Resource, TypedFuncCallConcurrent};
 #[cfg(feature = "p2")]
 use wasmtime::error::Context as _;
-use wasmtime::{AsContextMut, Result, Store, format_err};
+use wasmtime::{AsContextMut, Result, Store, StoreContextMut, format_err};
 
 /// Represents either a `wasi:http/types@0.2.x` or `wasi:http/types@0.3.x` `error-code`.
 pub enum ErrorCode {
@@ -287,30 +289,6 @@ pub type Request = http::Request<UnsyncBoxBody<Bytes, ErrorCode>>;
 /// A Response returned by `ProxyHandler::handle`.
 pub type Response = http::Response<UnsyncBoxBody<Bytes, wasmtime::Error>>;
 
-/// Alternative p2 bindings generated with `exports: { default: async | store }`
-/// so we can use `TypedFunc::call_concurrent` with both p2 and p3 instances.
-#[cfg(feature = "p2")]
-pub mod p2 {
-    #[expect(missing_docs, reason = "bindgen-generated code")]
-    pub mod bindings {
-        wasmtime::component::bindgen!({
-            path: "wit",
-            world: "wasi:http/proxy",
-            imports: { default: tracing },
-            exports: { default: async | store },
-            require_store_data_send: true,
-            with: {
-                // http is in this crate
-                "wasi:http": crate::p2::bindings::http,
-                // Upstream package dependencies
-                "wasi:io": wasmtime_wasi::p2::bindings::io,
-            }
-        });
-
-        pub use wasi::*;
-    }
-}
-
 /// Represents either a `wasi:http/incoming-handler@0.2.x` or
 /// `wasi:http/handler@0.3.x` pre-instance.
 pub enum ProxyPre<T: 'static> {
@@ -442,12 +420,21 @@ pub trait WorkerState: 'static + Send + Sync {
     /// The type of the associated data for [`Store`] belonging to this worker.
     type StoreData: Send;
 
+    /// An opaque unique identifier that hosts can assigned to requests which is
+    /// threaded from [`ProxyHandler::handle`] into
+    /// [`WorkerState::on_request_start`]
+    type RequestId: Send + Sync;
+
     /// Indicate whether the worker should accept another request given the
     /// current number it is already handling concurrently and the total it has
     /// handled so far.
     fn should_accept_request(&self, concurrent_count: usize, total_count: usize) -> ShouldAccept;
 
     /// Notification that a request has been accepted by the worker.
+    ///
+    /// This method can be used to record anything within `store`, if necessary.
+    /// The `task` corresponding to the component-model-level async task about
+    /// to be created is additionally passed here.
     ///
     /// If the future returned by this function resolves before the guest has
     /// produced a response, the request will be considered "expired" and the
@@ -477,7 +464,9 @@ pub trait WorkerState: 'static + Send + Sync {
     /// defence" will no longer be necessary.
     fn on_request_start(
         &self,
-        request: &Request,
+        store: StoreContextMut<'_, Self::StoreData>,
+        id: Self::RequestId,
+        task: GuestTaskId,
     ) -> Pin<Box<dyn Future<Output = ()> + 'static + Send + Sync>>;
 
     /// Dispose of the store belonging to the now-exited worker.
@@ -542,7 +531,7 @@ pub trait HandlerState: 'static + Sync + Send + Sized {
 
 struct ProxyHandlerInner<S: HandlerState> {
     state: S,
-    request_queue: Queue<(Request, oneshot::Sender<Result<Response, wasmtime::Error>>)>,
+    request_queue: Queue<WorkerRequest<S>>,
     worker_count: AtomicUsize,
 }
 
@@ -577,6 +566,12 @@ impl StartTimes {
         self.0.last_key_value().map(|(&k, _)| k)
     }
 }
+
+type WorkerRequest<S> = (
+    <<S as HandlerState>::WorkerState as WorkerState>::RequestId,
+    Request,
+    oneshot::Sender<Result<Response, wasmtime::Error>>,
+);
 
 struct Worker<S>
 where
@@ -615,10 +610,7 @@ where
         }
     }
 
-    async fn run(
-        self,
-        request: Option<(Request, oneshot::Sender<Result<Response, wasmtime::Error>>)>,
-    ) {
+    async fn run(self, request: Option<WorkerRequest<S>>) {
         match self.handler.0.state.instantiate().await {
             Ok(Instance {
                 store,
@@ -633,8 +625,9 @@ where
 
             Err(error) => {
                 let error = Arc::new(error);
-                if let Some((request, tx)) = request {
+                if let Some((request_id, request, tx)) = request {
                     _ = tx.send(Err(InstantiationError {
+                        request_id,
                         request: Mutex::new(request),
                         error,
                     }
@@ -643,7 +636,7 @@ where
                     // In this case, the worker was spawned to handle any queued
                     // requests.  Since we can't handle those requests, we send
                     // them all an instantiation error.
-                    for (request, tx) in mem::take(
+                    for (request_id, request, tx) in mem::take(
                         self.handler
                             .0
                             .request_queue
@@ -653,6 +646,7 @@ where
                             .deref_mut(),
                     ) {
                         _ = tx.send(Err(InstantiationError {
+                            request_id,
                             request: Mutex::new(request),
                             error: error.clone(),
                         }
@@ -670,7 +664,7 @@ where
         view: ViewFn<S::StoreData>,
         expiration: S::WorkerExpiration,
         state: S::WorkerState,
-        request: Option<(Request, oneshot::Sender<Result<Response, wasmtime::Error>>)>,
+        request: Option<WorkerRequest<S>>,
     ) {
         // NB: The code the follows is rather subtle in that it is structured
         // carefully to give the `HandlerState` implementation full control over
@@ -733,8 +727,7 @@ where
             let mut futures = FuturesUnordered::new();
             let mut start_times = StartTimes::default();
 
-            let accept_request = |request: Request,
-                                  tx: oneshot::Sender<Result<Response, wasmtime::Error>>,
+            let accept_request = |(request_id, request, tx): WorkerRequest<S>,
                                   futures: &mut FuturesUnordered<_>,
                                   start_times: &mut StartTimes,
                                   reuse_count: &mut usize| {
@@ -750,34 +743,41 @@ where
                 accept_concurrent.store(false, Relaxed);
                 *reuse_count += 1;
 
-                // Notify the `HandlerState` that we're starting to handle a
-                // request and retrieve the deadline by which it must produce a
-                // response.
-                //
-                // If it fails to produce a response by the deadline, we'll stop
-                // accepting new requests and eventually exit the worker.
-                let expiration = dropper.state.on_request_start(&request);
+                let prepared = accessor.with(|mut store| {
+                    let prepared = Prepared::new(store.as_context_mut(), proxy, request, view, tx);
+                    match prepared {
+                        Ok(prepared) => {
+                            // Notify the `HandlerState` that we're starting to
+                            // handle a request and retrieve the deadline by
+                            // which it must produce a response.
+                            //
+                            // If it fails to produce a response by the
+                            // deadline, we'll stop accepting new requests and
+                            // eventually exit the worker.
+                            let expiration = dropper.state.on_request_start(
+                                store.as_context_mut(),
+                                request_id,
+                                prepared.task(),
+                            );
+                            Ok((prepared, expiration))
+                        }
+                        Err(e) => Err(e),
+                    }
+                });
 
                 let start_time = Instant::now();
                 start_times.add(start_time);
                 *status.try_lock().unwrap() = (WorkerStatus::Requests, start_time);
 
                 futures.push(async move {
-                    Ok::<_, wasmtime::Error>((
-                        handle(accessor, proxy, request, view, tx, expiration).await?,
-                        start_time,
-                    ))
+                    let (prepared, expiration) = prepared?;
+                    let sent = prepared.run(accessor, expiration).await?;
+                    wasmtime::error::Ok((sent, start_time))
                 });
             };
 
-            if let Some((request, tx)) = request {
-                accept_request(
-                    request,
-                    tx,
-                    &mut futures,
-                    &mut start_times,
-                    &mut reuse_count,
-                );
+            if let Some(req) = request {
+                accept_request(req, &mut futures, &mut start_times, &mut reuse_count);
             }
 
             // This is the main driver loop for this worker. This is modeled as
@@ -870,16 +870,9 @@ where
                     // successful then push it into `futures` and turn this loop
                     // again to see where we're at next time around.
                     if self.available
-                        && let Poll::Ready(Some((request, tx))) =
-                            incoming_requests.as_mut().poll_next(cx)
+                        && let Poll::Ready(Some(req)) = incoming_requests.as_mut().poll_next(cx)
                     {
-                        accept_request(
-                            request,
-                            tx,
-                            &mut futures,
-                            &mut start_times,
-                            &mut reuse_count,
-                        );
+                        accept_request(req, &mut futures, &mut start_times, &mut reuse_count);
                         continue;
                     }
 
@@ -1018,7 +1011,9 @@ impl<S: HandlerState> Clone for ProxyHandler<S> {
 /// case, the caller may be able to recover and retry (e.g. after waiting for
 /// existing instances to be dropped and/or freeing memory used by caches,
 /// etc.).  Otherwise, it will probably need to return an HTTP 500 error.
-pub struct InstantiationError {
+pub struct InstantiationError<T> {
+    /// The ID of the request which was originally configured,
+    pub request_id: T,
     /// The original request passed to `ProxyHandler::handle`.
     ///
     /// This is wrapped in a `Mutex` to satisfy the `Send + Sync` bounds
@@ -1031,19 +1026,19 @@ pub struct InstantiationError {
     pub error: Arc<wasmtime::Error>,
 }
 
-impl fmt::Display for InstantiationError {
+impl<T> fmt::Display for InstantiationError<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         write!(f, "instantiation error: {}", self.error)
     }
 }
 
-impl fmt::Debug for InstantiationError {
+impl<T> fmt::Debug for InstantiationError<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         write!(f, "instantiation error: {:?}", self.error)
     }
 }
 
-impl error::Error for InstantiationError {}
+impl<T> error::Error for InstantiationError<T> {}
 
 /// Returned when the guest failed to produce a response before the expiration
 /// returned by `HandlerState::on_request_start` elapsed.
@@ -1114,18 +1109,22 @@ where
     /// In other failure cases (e.g. `wasi:http/types#error-code` return values
     /// and/or traps when executing synchronous WASIp2 handler functions), the
     /// original error returned by the handler will be returned.
-    pub async fn handle(&self, request: Request) -> Result<Response, wasmtime::Error> {
+    pub async fn handle(
+        &self,
+        id: <S::WorkerState as WorkerState>::RequestId,
+        request: Request,
+    ) -> Result<Response, wasmtime::Error> {
         let (tx, rx) = oneshot::channel();
-
+        let req = (id, request, tx);
         if self.0.worker_count.load(Relaxed) == 0 {
             // There are no available workers; skip the queue and pass
             // the request directly to the worker, which improves
             // performance as measured by `wasmtime-server-rps.sh` by
             // about 15%.
-            self.start_worker(Some((request, tx)));
+            self.start_worker(Some(req));
         } else {
             let mut queue = self.0.request_queue.queue.lock().unwrap();
-            queue.push_back((request, tx));
+            queue.push_back(req);
 
             // Start a new worker to handle the request if the last worker just
             // went unavailable.  See also `Worker::set_available` for what
@@ -1146,9 +1145,9 @@ where
             // instantiation error, we'll give the request back to the caller in
             // an `Err(_)`, allowing the application to decide what to do next.
             if self.0.worker_count.load(Relaxed) == 0 {
-                let (request, tx) = queue.pop_back().unwrap();
+                let req = queue.pop_back().unwrap();
                 drop(queue);
-                self.start_worker(Some((request, tx)));
+                self.start_worker(Some(req));
             } else {
                 drop(queue);
                 self.0.request_queue.notify_push.notify_one();
@@ -1163,10 +1162,7 @@ where
         &self.0.state
     }
 
-    fn start_worker(
-        &self,
-        request: Option<(Request, oneshot::Sender<Result<Response, wasmtime::Error>>)>,
-    ) {
+    fn start_worker(&self, request: Option<WorkerRequest<S>>) {
         tokio::spawn(
             Worker {
                 handler: self.clone(),
@@ -1177,133 +1173,213 @@ where
     }
 }
 
-async fn handle<T: Send>(
-    accessor: &Accessor<T>,
-    proxy: &Proxy,
-    request: Request,
-    view: ViewFn<T>,
-    tx: oneshot::Sender<Result<Response, wasmtime::Error>>,
-    expiration: impl Future<Output = ()>,
-) -> Result<bool> {
-    let expiration = pin!(expiration);
+/// Representation of a "prepared" call for a guest, used to extract the
+/// `GuestTaskId` before actually executing any handlers.
+///
+/// Right now this is a bit gross since it has to type out a bunch of types by
+/// hand.
+enum Prepared<'a, T: 'static> {
+    #[cfg(feature = "p2")]
+    P2 {
+        guest: &'a p2::bindings::Proxy,
+        call: TypedFuncCallConcurrent<
+            T,
+            (
+                Resource<p2_types::IncomingRequest>,
+                Resource<p2_types::ResponseOutparam>,
+            ),
+            (),
+        >,
+        tx: Arc<Mutex<Option<oneshot::Sender<Result<Response, wasmtime::Error>>>>>,
+    },
+    #[cfg(feature = "p3")]
+    P3 {
+        guest: &'a p3::bindings::Service,
+        call: TypedFuncCallConcurrent<
+            T,
+            (Resource<p3_types::Request>,),
+            (Result<Resource<p3_types::Response>, p3_types::ErrorCode>,),
+        >,
+        tx: oneshot::Sender<Result<Response, wasmtime::Error>>,
+        request_io_result: Pin<Box<dyn Future<Output = Result<(), p3_types::ErrorCode>> + Send>>,
+        view: fn(&mut T) -> p3::WasiHttpCtxView,
+    },
+}
 
-    match (proxy, view) {
-        #[cfg(feature = "p3")]
-        (Proxy::P3(guest), ViewFn::P3(view)) => {
-            let (request, body) = request.into_parts();
-            let body = body.map_err(p3_types::ErrorCode::from);
-            let request = http::Request::from_parts(request, body);
-            let (request, request_io_result) = p3::Request::from_http(request);
+impl<'a, T: Send> Prepared<'a, T> {
+    fn new(
+        mut store: StoreContextMut<'_, T>,
+        proxy: &'a Proxy,
+        request: Request,
+        view: ViewFn<T>,
+        tx: oneshot::Sender<Result<Response, wasmtime::Error>>,
+    ) -> Result<Prepared<'a, T>> {
+        match (proxy, view) {
+            #[cfg(feature = "p3")]
+            (Proxy::P3(guest), ViewFn::P3(view)) => {
+                let (request, body) = request.into_parts();
+                let body = body.map_err(p3_types::ErrorCode::from);
+                let request = http::Request::from_parts(request, body);
+                let (request, request_io_result) = p3::Request::from_http(request);
+                let request = view(store.data_mut()).table.push(request)?;
 
-            let request = accessor.with(|mut store| {
-                Ok::<_, wasmtime::Error>(view(store.data_mut()).table.push(request)?)
-            })?;
+                Ok(Prepared::P3 {
+                    tx,
+                    request_io_result: Box::pin(request_io_result),
+                    guest,
+                    view,
+                    call: guest
+                        .wasi_http_handler()
+                        .func_handle()
+                        .start_call_concurrent(store, (request,))?,
+                })
+            }
+            #[cfg(feature = "p2")]
+            (Proxy::P2(guest), ViewFn::P2(view)) => {
+                // Here we wrap the sender in an `Arc<Mutex<Option<_>>>`, with one
+                // clone used in the `response-outparam` and the other used to send
+                // an error if the request expires or the handler returns without
+                // producing a response.
+                let tx = Arc::new(Mutex::new(Some(tx)));
 
-            let handle = pin!(async move {
-                let response = guest
-                    .wasi_http_handler()
-                    .call_handle(accessor, request)
-                    .await?;
+                let request =
+                    view(store.data_mut()).new_incoming_request(p2_types::Scheme::Http, request)?;
 
-                let response = accessor.with(|mut store| {
-                    let response = view(store.get()).table.delete(response?)?;
-                    Ok::<_, wasmtime::Error>(response.into_http_with_getter(
-                        &mut store,
-                        request_io_result,
-                        view,
-                    )?)
+                let out = view(store.data_mut()).new_response_outparam_from_callback({
+                    let tx = tx.clone();
+                    move |value| {
+                        if let Some(tx) = tx.lock().unwrap().take() {
+                            _ = tx.send(
+                                value
+                                    .map(|v| {
+                                        v.map(move |body| {
+                                            body.map_err(wasmtime::Error::from).boxed_unsync()
+                                        })
+                                    })
+                                    .map_err(wasmtime::Error::from),
+                            );
+                        }
+                    }
                 })?;
 
-                Ok(response.map(move |body| body.map_err(wasmtime::Error::from).boxed_unsync()))
-            });
-
-            // TODO: We should also use `oneshot::Sender::poll_close` to be
-            // notified when the receiver is dropped, in which case we should
-            // expire the request since the response is no longer of interest to
-            // the original `ProxyHandler::handle` caller.
-            let (result, sent) = match futures::future::select(handle, expiration).await {
-                Either::Left((result, _)) => (result, true),
-                // TODO: We should also send a cancel request to the expired
-                // task to give it a chance to shut down gracefully, but as of
-                // this writing Wasmtime does not yet provide an API for doing
-                // that.  See issue #11833.  Instead, we let it continue running
-                // as a background task until it either returns a response
-                // (which we'll ignore) or the instance itself has expired.
-                Either::Right(((), _)) => (Err(ExpirationError.into()), false),
-            };
-
-            _ = tx.send(result);
-
-            Ok(sent)
+                Ok(Prepared::P2 {
+                    guest,
+                    tx,
+                    call: guest
+                        .wasi_http_incoming_handler()
+                        .func_handle()
+                        .start_call_concurrent(store, (request, out))?,
+                })
+            }
+            #[cfg(all(feature = "p2", feature = "p3"))]
+            _ => unreachable!(),
         }
-        #[cfg(feature = "p2")]
-        (Proxy::P2(guest), ViewFn::P2(view)) => {
-            // Here we wrap the sender in an `Arc<Mutex<Option<_>>>`, with one
-            // clone used in the `response-outparam` and the other used to send
-            // an error if the request expires or the handler returns without
-            // producing a response.
-            let tx = Arc::new(Mutex::new(Some(tx)));
+    }
 
-            let (request, out) = accessor.with({
-                let tx = tx.clone();
-                move |mut access| {
-                    let request = view(access.data_mut())
-                        .new_incoming_request(p2_types::Scheme::Http, request)?;
+    fn task(&self) -> GuestTaskId {
+        match self {
+            #[cfg(feature = "p3")]
+            Prepared::P3 { call, .. } => call.task(),
+            #[cfg(feature = "p2")]
+            Prepared::P2 { call, .. } => call.task(),
+        }
+    }
 
-                    let out = view(access.data_mut()).new_response_outparam_from_callback(
-                        move |value| {
-                            if let Some(tx) = tx.lock().unwrap().take() {
-                                _ = tx.send(
-                                    value
-                                        .map(|v| {
-                                            v.map(move |body| {
-                                                body.map_err(wasmtime::Error::from).boxed_unsync()
-                                            })
-                                        })
-                                        .map_err(wasmtime::Error::from),
-                                );
-                            }
-                        },
-                    )?;
+    async fn run(
+        self,
+        accessor: &Accessor<T>,
+        expiration: impl Future<Output = ()>,
+    ) -> Result<bool> {
+        let expiration = pin!(expiration);
 
-                    wasmtime::error::Ok((request, out))
-                }
-            })?;
+        match self {
+            #[cfg(feature = "p3")]
+            Prepared::P3 {
+                guest,
+                call,
+                tx,
+                request_io_result,
+                view,
+            } => {
+                let handle =
+                    pin!(async move {
+                        let response = guest
+                            .wasi_http_handler()
+                            .func_handle()
+                            .finish_call_concurrent(accessor, call)
+                            .await?
+                            .0?;
 
-            let handle = pin!(
-                guest
-                    .wasi_http_incoming_handler()
-                    .call_handle(accessor, request, out)
-            );
+                        let response = accessor.with(|mut store| {
+                            let response = view(store.get()).table.delete(response)?;
+                            Ok::<_, wasmtime::Error>(response.into_http_with_getter(
+                                &mut store,
+                                request_io_result,
+                                view,
+                            )?)
+                        })?;
 
-            const MESSAGE: &str = "guest never invoked `response-outparam::set` method";
+                        Ok(response
+                            .map(move |body| body.map_err(wasmtime::Error::from).boxed_unsync()))
+                    });
 
-            struct Dropper(Arc<Mutex<Option<oneshot::Sender<Result<Response, wasmtime::Error>>>>>);
+                // TODO: We should also use `oneshot::Sender::poll_close` to be
+                // notified when the receiver is dropped, in which case we should
+                // expire the request since the response is no longer of interest to
+                // the original `ProxyHandler::handle` caller.
+                let (result, sent) = match futures::future::select(handle, expiration).await {
+                    Either::Left((result, _)) => (result, true),
+                    // TODO: We should also send a cancel request to the expired
+                    // task to give it a chance to shut down gracefully, but as of
+                    // this writing Wasmtime does not yet provide an API for doing
+                    // that.  See issue #11833.  Instead, we let it continue running
+                    // as a background task until it either returns a response
+                    // (which we'll ignore) or the instance itself has expired.
+                    Either::Right(((), _)) => (Err(ExpirationError.into()), false),
+                };
 
-            impl Drop for Dropper {
-                fn drop(&mut self) {
-                    if let Some(tx) = self.0.lock().unwrap().take() {
-                        _ = tx.send(Err(format_err!("{MESSAGE}")));
+                _ = tx.send(result);
+
+                Ok(sent)
+            }
+            #[cfg(feature = "p2")]
+            Prepared::P2 { guest, call, tx } => {
+                let handle = pin!(
+                    guest
+                        .wasi_http_incoming_handler()
+                        .func_handle()
+                        .finish_call_concurrent(accessor, call)
+                );
+
+                const MESSAGE: &str = "guest never invoked `response-outparam::set` method";
+
+                struct Dropper(
+                    Arc<Mutex<Option<oneshot::Sender<Result<Response, wasmtime::Error>>>>>,
+                );
+
+                impl Drop for Dropper {
+                    fn drop(&mut self) {
+                        if let Some(tx) = self.0.lock().unwrap().take() {
+                            _ = tx.send(Err(format_err!("{MESSAGE}")));
+                        }
                     }
                 }
-            }
 
-            let tx = Dropper(tx);
+                let tx = Dropper(tx);
 
-            // See corresponding TODO comment for the p3 case above.
-            let (result, sent) = match futures::future::select(handle, expiration).await {
-                Either::Left((result, _)) => (result.context(MESSAGE), true),
                 // See corresponding TODO comment for the p3 case above.
-                Either::Right(((), _)) => (Err(ExpirationError.into()), false),
-            };
+                let (result, sent) = match futures::future::select(handle, expiration).await {
+                    Either::Left((result, _)) => (result.context(MESSAGE), true),
+                    // See corresponding TODO comment for the p3 case above.
+                    Either::Right(((), _)) => (Err(ExpirationError.into()), false),
+                };
 
-            if let Some(tx) = tx.0.lock().unwrap().take() {
-                _ = tx.send(result.and_then(|()| Err(format_err!("{MESSAGE}"))));
+                if let Some(tx) = tx.0.lock().unwrap().take() {
+                    _ = tx.send(result.and_then(|()| Err(format_err!("{MESSAGE}"))));
+                }
+
+                Ok(sent)
             }
-
-            Ok(sent)
         }
-        #[cfg(all(feature = "p2", feature = "p3"))]
-        _ => unreachable!(),
     }
 }

--- a/crates/wasmtime/src/runtime/component/concurrent.rs
+++ b/crates/wasmtime/src/runtime/component/concurrent.rs
@@ -52,7 +52,7 @@
 
 use self::error_contexts::GlobalErrorContextRefCount;
 use crate::bail_bug;
-use crate::component::func::{self, Func, call_post_return};
+use crate::component::func::{Func, call_post_return};
 use crate::component::{
     HasData, HasSelf, Instance, Resource, ResourceTable, ResourceTableError, RuntimeInstance,
 };
@@ -70,6 +70,7 @@ use alloc::collections::{BTreeMap, BTreeSet, VecDeque};
 use core::any::Any;
 use core::cell::UnsafeCell;
 use core::fmt;
+use core::future;
 use core::future::Future;
 use core::marker::PhantomData;
 use core::mem::{self, ManuallyDrop, MaybeUninit};
@@ -78,7 +79,6 @@ use core::pin::{Pin, pin};
 use core::ptr::{self, NonNull};
 use core::task::{Context, Poll, Waker};
 use futures::channel::oneshot;
-use futures::future::{self, FutureExt};
 use futures::stream::{FuturesUnordered, StreamExt};
 use futures_and_streams::{FlatAbi, ReturnCode, TransmitHandle, TransmitIndex};
 use table::{TableDebug, TableId};
@@ -93,6 +93,7 @@ use wasmtime_environ::packed_option::ReservedValue;
 use wasmtime_environ::{NUM_COMPONENT_CONTEXT_SLOTS, Trap};
 
 pub use abort::JoinHandle;
+pub use func::{FuncCallConcurrent, TypedFuncCallConcurrent};
 pub use future_stream_any::{FutureAny, StreamAny};
 pub use futures_and_streams::{
     Destination, DirectDestination, DirectSource, ErrorContext, FutureConsumer, FutureProducer,
@@ -103,6 +104,7 @@ pub(crate) use futures_and_streams::{ResourcePair, lower_error_context_to_index}
 
 mod abort;
 mod error_contexts;
+mod func;
 mod future_stream_any;
 mod futures_and_streams;
 pub(crate) mod table;
@@ -1526,6 +1528,30 @@ impl<T> StoreContextMut<'_, T> {
             closure(&mut accessor).await
         }
     }
+
+    /// Returns an iterator over the current async call stack defined by the
+    /// component model.
+    ///
+    /// This can be used, for example to correlate a host import call with which
+    /// root export task originally called it.
+    ///
+    /// Tasks are yielded "youngest first" where the first item in the iterator
+    /// is the current task, and the last item in the iterator is the original
+    /// call.
+    pub fn async_call_stack(&mut self) -> impl Iterator<Item = GuestTaskId> {
+        let state = self.0.concurrent_state_mut();
+        let mut cur = Some(state.current_thread);
+        core::iter::from_fn(move || {
+            while let Some(t) = cur {
+                cur = state.parent(t);
+                if let Some(thread) = t.guest() {
+                    return Some(GuestTaskId(thread.task));
+                }
+            }
+
+            None
+        })
+    }
 }
 
 impl StoreOpaque {
@@ -1683,32 +1709,23 @@ impl StoreOpaque {
             return Ok(true);
         }
         let state = self.concurrent_state_mut();
-        let mut cur = state.current_thread;
-        loop {
-            match cur {
-                CurrentThread::None => break Ok(true),
-                CurrentThread::Guest(thread) => {
-                    let task = state.get_mut(thread.task)?;
-
-                    // Note that we only compare top-level instance IDs here.
-                    // The idea is that the host is not allowed to recursively
-                    // enter a top-level instance even if the specific leaf
-                    // instance is not on the stack. This the behavior defined
-                    // in the spec, and it allows us to elide runtime checks in
-                    // guest-to-guest adapters.
-                    if task.instance.instance == instance.instance {
-                        break Ok(false);
-                    }
-                    cur = match task.caller {
-                        Caller::Host { caller, .. } => caller,
-                        Caller::Guest { thread } => thread.into(),
-                    };
-                }
-                CurrentThread::Host(id) => {
-                    cur = state.get_mut(id)?.caller.into();
+        let mut cur = Some(state.current_thread);
+        while let Some(t) = cur {
+            if let Some(thread) = t.guest() {
+                let task = state.get_mut(thread.task)?;
+                // Note that we only compare top-level instance IDs here.
+                // The idea is that the host is not allowed to recursively
+                // enter a top-level instance even if the specific leaf
+                // instance is not on the stack. This the behavior defined
+                // in the spec, and it allows us to elide runtime checks in
+                // guest-to-guest adapters.
+                if task.instance.instance == instance.instance {
+                    return Ok(false);
                 }
             }
+            cur = state.parent(t);
         }
+        Ok(true)
     }
 
     /// Helper function to retrieve the `InstanceState` for the
@@ -3711,7 +3728,7 @@ impl Instance {
             }
         };
         let memory = self.options_memory_mut(store, params.options);
-        let ptr = func::validate_inbounds_dynamic(
+        let ptr = crate::component::func::validate_inbounds_dynamic(
             &CanonicalAbiInfo::POINTER_PAIR,
             memory,
             &ValRaw::u32(params.payload),
@@ -5350,6 +5367,21 @@ impl ConcurrentState {
     pub(crate) fn table(&mut self) -> &mut ResourceTable {
         self.table.get_mut()
     }
+
+    /// Returns the parent thread, if any, of `cur`.
+    fn parent(&mut self, cur: CurrentThread) -> Option<CurrentThread> {
+        match cur {
+            CurrentThread::Guest(thread) => {
+                let task = self.get_mut(thread.task).ok()?;
+                Some(match task.caller {
+                    Caller::Host { caller, .. } => caller,
+                    Caller::Guest { thread } => thread.into(),
+                })
+            }
+            CurrentThread::Host(id) => Some(self.get_mut(id).ok()?.caller.into()),
+            CurrentThread::None => None,
+        }
+    }
 }
 
 /// Provide a type hint to compiler about the shape of a parameter lower
@@ -5371,37 +5403,23 @@ fn for_any_lift<
     fun
 }
 
-/// Wrap the specified future in a `poll_fn` which asserts that the future is
-/// only polled from the event loop of the specified `Store`.
-///
-/// See `StoreContextMut::run_concurrent` for details.
-fn checked<F: Future + Send + 'static>(
-    id: StoreId,
-    fut: F,
-) -> impl Future<Output = F::Output> + Send + 'static {
-    async move {
-        let mut fut = pin!(fut);
-        future::poll_fn(move |cx| {
-            let message = "\
-                `Future`s which depend on asynchronous component tasks, streams, or \
-                futures to complete may only be polled from the event loop of the \
-                store to which they belong.  Please use \
-                `StoreContextMut::{run_concurrent,spawn}` to poll or await them.\
-            ";
-            tls::try_get(|store| {
-                let matched = match store {
-                    tls::TryGet::Some(store) => store.id() == id,
-                    tls::TryGet::Taken | tls::TryGet::None => false,
-                };
+fn check_ambient_store(id: StoreId) {
+    let message = "\
+        `Future`s which depend on asynchronous component tasks, streams, or \
+        futures to complete may only be polled from the event loop of the \
+        store to which they belong.  Please use \
+        `StoreContextMut::{run_concurrent,spawn}` to poll or await them.\
+    ";
+    tls::try_get(|store| {
+        let matched = match store {
+            tls::TryGet::Some(store) => store.id() == id,
+            tls::TryGet::Taken | tls::TryGet::None => false,
+        };
 
-                if !matched {
-                    panic!("{message}")
-                }
-            });
-            fut.as_mut().poll(cx)
-        })
-        .await
-    }
+        if !matched {
+            panic!("{message}")
+        }
+    });
 }
 
 /// Assert that `StoreContextMut::run_concurrent` has not been called from
@@ -5433,6 +5451,15 @@ enum WaitableCheck {
     Wait,
     Poll,
 }
+
+/// An identifier representing a guest task within a component.
+///
+/// This can be acquired by calling [`Func::start_call_concurrent`] or
+/// [`TypedFunc::start_call_concurrent`] and then using the
+/// [`FuncCallConcurrent::task`] accessor, for example. This can then be
+/// reflected on with [`StoreContextMut::async_call_stack`].
+#[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
+pub struct GuestTaskId(TableId<GuestTask>);
 
 /// Represents a guest task called from the host, prepared using `prepare_call`.
 pub(crate) struct PreparedCall<R> {
@@ -5577,36 +5604,63 @@ pub(crate) fn prepare_call<T, R>(
     })
 }
 
-/// Queue a call previously prepared using `prepare_call` to be run as part of
-/// the associated `ComponentInstance`'s event loop.
-///
-/// The returned future will resolve to the result once it is available, but
-/// must only be polled via the instance's event loop. See
-/// `StoreContextMut::run_concurrent` for details.
-pub(crate) fn queue_call<T: 'static, R: Send + 'static>(
-    mut store: StoreContextMut<T>,
-    prepared: PreparedCall<R>,
-) -> Result<impl Future<Output = Result<R>> + Send + 'static + use<T, R>> {
-    let PreparedCall {
-        handle,
-        thread,
-        param_count,
-        rx,
-        ..
-    } = prepared;
+pub(crate) struct QueuedCall<R> {
+    store: StoreId,
+    task: TableId<GuestTask>,
+    rx: oneshot::Receiver<LiftedResult>,
+    _marker: PhantomData<fn() -> R>,
+}
 
-    queue_call0(store.as_context_mut(), handle, thread, param_count)?;
+impl<R> QueuedCall<R> {
+    /// Queue a call previously prepared using `prepare_call` to be run as part of
+    /// the associated `ComponentInstance`'s event loop.
+    ///
+    /// The returned future will resolve to the result once it is available, but
+    /// must only be polled via the instance's event loop. See
+    /// `StoreContextMut::run_concurrent` for details.
+    pub(crate) fn new<T: 'static>(
+        mut store: StoreContextMut<T>,
+        prepared: PreparedCall<R>,
+    ) -> Result<QueuedCall<R>> {
+        let PreparedCall {
+            handle,
+            thread,
+            param_count,
+            rx,
+            ..
+        } = prepared;
 
-    Ok(checked(
-        store.0.id(),
-        rx.map(move |result| match result {
+        queue_call0(store.as_context_mut(), handle, thread, param_count)?;
+
+        Ok(QueuedCall {
+            store: store.0.id(),
+            task: thread.task,
+            rx,
+            _marker: PhantomData,
+        })
+    }
+
+    fn task(&self) -> GuestTaskId {
+        GuestTaskId(self.task)
+    }
+}
+
+impl<R> Future for QueuedCall<R>
+where
+    R: 'static,
+{
+    type Output = Result<R>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        check_ambient_store(self.store);
+        Pin::new(&mut self.rx).poll(cx).map(|result| match result {
             Ok(r) => match r.downcast() {
                 Ok(r) => Ok(*r),
                 Err(_) => bail_bug!("wrong type of value produced"),
             },
             Err(oneshot::Canceled) => bail_bug!("channel erroneously dropped"),
-        }),
-    ))
+        })
+    }
 }
 
 /// Queue a call previously prepared using `prepare_call` to be run as part of

--- a/crates/wasmtime/src/runtime/component/concurrent.rs
+++ b/crates/wasmtime/src/runtime/component/concurrent.rs
@@ -5458,6 +5458,8 @@ enum WaitableCheck {
 /// [`TypedFunc::start_call_concurrent`] and then using the
 /// [`FuncCallConcurrent::task`] accessor, for example. This can then be
 /// reflected on with [`StoreContextMut::async_call_stack`].
+///
+/// [`TypedFunc::start_call_concurrent`]: crate::component::TypedFunc::start_call_concurrent
 #[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
 pub struct GuestTaskId(TableId<GuestTask>);
 

--- a/crates/wasmtime/src/runtime/component/concurrent/func.rs
+++ b/crates/wasmtime/src/runtime/component/concurrent/func.rs
@@ -1,0 +1,489 @@
+use crate::component::concurrent::TaskId;
+use crate::component::concurrent::{self, GuestTaskId, PreparedCall};
+use crate::component::func::LowerContext;
+use crate::component::{AsAccessor, ComponentNamedList, Func, Lift, Lower, TypedFunc, Val};
+use crate::prelude::*;
+use crate::runtime::vm::SendSyncPtr;
+use crate::{AsContextMut, StoreContextMut, ValRaw};
+use core::marker;
+use core::mem::MaybeUninit;
+use core::ptr::NonNull;
+use wasmtime_environ::component::{InterfaceType, MAX_FLAT_PARAMS, MAX_FLAT_RESULTS};
+
+/// Returned from [`Func::start_call_concurrent`] to represent a
+/// pending-but-not-yet-resolved call into wasm.
+pub struct FuncCallConcurrent<'a, T> {
+    call: concurrent::QueuedCall<Vec<Val>>,
+    results: &'a mut [Val],
+    _marker: marker::PhantomData<fn(T)>,
+}
+
+impl Func {
+    /// Start a concurrent call to this function.
+    ///
+    /// Concurrency is achieved by relying on the [`Accessor`] argument, which
+    /// can be obtained by calling [`StoreContextMut::run_concurrent`].
+    ///
+    /// Unlike [`Self::call`] and [`Self::call_async`] (both of which require
+    /// exclusive access to the store until the completion of the call), calls
+    /// made using this method may run concurrently with other calls to the same
+    /// instance.  In addition, the runtime will call the `post-return` function
+    /// (if any) automatically when the guest task completes.
+    ///
+    /// # Progress
+    ///
+    /// For the wasm task being created in `call_concurrent` to make progress it
+    /// must be run within the scope of [`run_concurrent`]. If there are no
+    /// active calls to [`run_concurrent`] then the wasm task will appear as
+    /// stalled. This is typically not a concern as an [`Accessor`] is bound
+    /// by default to a scope of [`run_concurrent`].
+    ///
+    /// One situation in which this can arise, for example, is that if a
+    /// [`run_concurrent`] computation finishes its async closure before all
+    /// wasm tasks have completed, then there will be no scope of
+    /// [`run_concurrent`] anywhere. In this situation the wasm tasks that have
+    /// not yet completed will not make progress until [`run_concurrent`] is
+    /// called again.
+    ///
+    /// Embedders will need to ensure that this future is `await`'d within the
+    /// scope of [`run_concurrent`] to ensure that the value can be produced
+    /// during the `await` call.
+    ///
+    /// # Cancellation
+    ///
+    /// Cancelling an async task created via `call_concurrent`, at this time, is
+    /// only possible by dropping the store that the computation runs within.
+    /// With [#11833] implemented then it will be possible to request
+    /// cancellation of a task, but that is not yet implemented. Hard-cancelling
+    /// a task will only ever be possible by dropping the entire store and it is
+    /// not possible to remove just one task from a store.
+    ///
+    /// This async function behaves more like a "spawn" than a normal Rust async
+    /// function. When this function is invoked then metadata for the function
+    /// call is recorded in the store connected to the `accessor` argument and
+    /// the wasm invocation is from then on connected to the store. If the
+    /// future created by this function is dropped it does not cancel the
+    /// in-progress execution of the wasm task. Dropping the future
+    /// relinquishes the host's ability to learn about the result of the task
+    /// but the task will still progress and invoke callbacks and such until
+    /// completion.
+    ///
+    /// This function will return an error if [`Config::concurrency_support`] is
+    /// disabled.
+    ///
+    /// [`Config::concurrency_support`]: crate::Config::concurrency_support
+    /// [`run_concurrent`]: crate::Store::run_concurrent
+    /// [#11833]: https://github.com/bytecodealliance/wasmtime/issues/11833
+    /// [`Accessor`]: crate::component::Accessor
+    ///
+    /// # Panics
+    ///
+    /// Panics if the store that the [`Accessor`] is derived from does not own
+    /// this function.
+    ///
+    /// # Example
+    ///
+    /// Using [`StoreContextMut::run_concurrent`] to get an [`Accessor`]:
+    ///
+    /// ```
+    /// # use {
+    /// #   wasmtime::{
+    /// #     error::{Result},
+    /// #     component::{Component, Linker, ResourceTable},
+    /// #     Config, Engine, Store
+    /// #   },
+    /// # };
+    /// #
+    /// # struct Ctx { table: ResourceTable }
+    /// #
+    /// # async fn foo() -> Result<()> {
+    /// # let mut config = Config::new();
+    /// # let engine = Engine::new(&config)?;
+    /// # let mut store = Store::new(&engine, Ctx { table: ResourceTable::new() });
+    /// # let mut linker = Linker::new(&engine);
+    /// # let component = Component::new(&engine, "")?;
+    /// # let instance = linker.instantiate_async(&mut store, &component).await?;
+    /// let my_func = instance.get_func(&mut store, "my_func").unwrap();
+    /// store.run_concurrent(async |accessor| -> wasmtime::Result<_> {
+    ///    my_func.call_concurrent(accessor, &[], &mut Vec::new()).await?;
+    ///    Ok(())
+    /// }).await??;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn call_concurrent(
+        self,
+        accessor: impl AsAccessor<Data: Send>,
+        params: &[Val],
+        results: &mut [Val],
+    ) -> Result<()> {
+        let accessor = accessor.as_accessor();
+        let call = accessor.with(|store| self.start_call_concurrent(store, params, results))?;
+        self.finish_call_concurrent(accessor, call).await
+    }
+
+    /// Performs preparatory work for invoking this function with `params`,
+    /// returning a [`FuncCallConcurrent`]
+    /// which can be passed to [`Func::finish_call_concurrent`] to resolve
+    /// the call.
+    ///
+    /// For more information see [`Func::call_concurrent`].
+    pub fn start_call_concurrent<'a, T: Send + 'static>(
+        self,
+        mut store: impl AsContextMut<Data = T>,
+        params: &'a [Val],
+        results: &'a mut [Val],
+    ) -> Result<FuncCallConcurrent<'a, T>> {
+        self.check_params_results(store.as_context_mut(), params, results)?;
+        let prepared = self.prepare_call_dynamic(store.as_context_mut(), params.to_vec())?;
+        let call = concurrent::QueuedCall::new(store.as_context_mut(), prepared)?;
+        Ok(FuncCallConcurrent {
+            call,
+            results,
+            _marker: marker::PhantomData,
+        })
+    }
+
+    /// Completes a call that was initiated via
+    /// [`Func::start_call_concurrent`].
+    pub async fn finish_call_concurrent<T: Send>(
+        self,
+        accessor: impl AsAccessor<Data = T>,
+        call: FuncCallConcurrent<'_, T>,
+    ) -> Result<()> {
+        // Intentionally not used today, but left here for future API
+        // compatibility with using this.
+        let _ = accessor;
+        let FuncCallConcurrent { call, results, .. } = call;
+        let run_results = call.await?;
+        assert_eq!(run_results.len(), results.len());
+        for (result, slot) in run_results.into_iter().zip(results) {
+            *slot = result;
+        }
+        Ok(())
+    }
+
+    /// Calls `concurrent::prepare_call` with monomorphized functions for
+    /// lowering the parameters and lifting the result.
+    fn prepare_call_dynamic<'a, T: Send + 'static>(
+        self,
+        mut store: StoreContextMut<'a, T>,
+        params: Vec<Val>,
+    ) -> Result<PreparedCall<Vec<Val>>> {
+        let store = store.as_context_mut();
+
+        concurrent::prepare_call(
+            store,
+            self,
+            MAX_FLAT_PARAMS,
+            false,
+            move |func, store, params_out| {
+                func.with_lower_context(store, |cx, ty| {
+                    Self::lower_args(cx, &params, ty, params_out)
+                })
+            },
+            move |func, store, results| {
+                let max_flat = if func.abi_async(store) {
+                    MAX_FLAT_PARAMS
+                } else {
+                    MAX_FLAT_RESULTS
+                };
+                let results = func.with_lift_context(store, |cx, ty| {
+                    Self::lift_results(cx, ty, results, max_flat)?.collect::<Result<Vec<_>>>()
+                })?;
+                Ok(Box::new(results))
+            },
+        )
+    }
+}
+
+impl<T> FuncCallConcurrent<'_, T> {
+    /// Returns the task that this invocation corresponds to.
+    ///
+    /// This can be later correlated with [`StoreContextMut::async_call_stack`]
+    /// for example.
+    pub fn task(&self) -> GuestTaskId {
+        self.call.task()
+    }
+}
+
+/// Returned from [`TypedFunc::start_call_concurrent`] to represent a
+/// pending-but-not-yet-resolved call into wasm.
+pub struct TypedFuncCallConcurrent<T, P, R> {
+    call: concurrent::QueuedCall<R>,
+    _marker: marker::PhantomData<fn(T, P)>,
+}
+
+impl<Params, Return> TypedFunc<Params, Return>
+where
+    Params: ComponentNamedList + Lower,
+    Return: ComponentNamedList + Lift,
+{
+    pub(crate) async fn call_async_concurrent(
+        &self,
+        mut store: impl AsContextMut<Data: Send>,
+        params: Params,
+    ) -> Result<Return>
+    where
+        Return: 'static,
+    {
+        let mut store = store.as_context_mut();
+        let ptr = SendSyncPtr::from(NonNull::from(&params).cast::<u8>());
+        let prepared = self.prepare_call(store.as_context_mut(), true, move |cx, ty, dst| {
+            // SAFETY: The goal here is to get `Params`, a non-`'static`
+            // value, to live long enough to the lowering of the
+            // parameters. We're guaranteed that `Params` lives in the
+            // future of the outer function (we're in an `async fn`) so it'll
+            // stay alive as long as the future itself. That is distinct,
+            // for example, from the signature of `call_concurrent` below.
+            //
+            // Here a pointer to `Params` is smuggled to this location
+            // through a `SendSyncPtr<u8>` to thwart the `'static` check
+            // of rustc and the signature of `prepare_call`.
+            //
+            // Note the use of `SignalOnDrop` in the code that follows
+            // this closure, which ensures that the task will be removed
+            // from the concurrent state to which it belongs when the
+            // containing `Future` is dropped, so long as the parameters
+            // have not yet been lowered. Since this closure is removed from
+            // the task after the parameters are lowered, it will never be called
+            // after the containing `Future` is dropped.
+            let params = unsafe { ptr.cast::<Params>().as_ref() };
+            Self::lower_args(cx, ty, dst, params)
+        })?;
+
+        struct SignalOnDrop<'a, T: 'static> {
+            store: StoreContextMut<'a, T>,
+            task: TaskId,
+        }
+
+        impl<'a, T> Drop for SignalOnDrop<'a, T> {
+            fn drop(&mut self) {
+                self.task.host_future_dropped(self.store.0).unwrap();
+            }
+        }
+
+        let mut wrapper = SignalOnDrop {
+            store,
+            task: prepared.task_id(),
+        };
+
+        let result = concurrent::QueuedCall::new(wrapper.store.as_context_mut(), prepared)?;
+        wrapper
+            .store
+            .as_context_mut()
+            .run_concurrent_trap_on_idle(async |_| Ok(result.await?))
+            .await?
+    }
+
+    /// Start a concurrent call to this function.
+    ///
+    /// Concurrency is achieved by relying on the [`Accessor`] argument, which
+    /// can be obtained by calling [`StoreContextMut::run_concurrent`].
+    ///
+    /// Unlike [`Self::call`] and [`Self::call_async`] (both of which require
+    /// exclusive access to the store until the completion of the call), calls
+    /// made using this method may run concurrently with other calls to the same
+    /// instance.  In addition, the runtime will call the `post-return` function
+    /// (if any) automatically when the guest task completes.
+    ///
+    /// This function will return an error if [`Config::concurrency_support`] is
+    /// disabled.
+    ///
+    /// [`Config::concurrency_support`]: crate::Config::concurrency_support
+    ///
+    /// # Progress and Cancellation
+    ///
+    /// For more information about how to make progress on the wasm task or how
+    /// to cancel the wasm task see the documentation for
+    /// [`Func::call_concurrent`].
+    ///
+    /// [`Func::call_concurrent`]: crate::component::Func::call_concurrent
+    ///
+    /// # Panics
+    ///
+    /// Panics if the store that the [`Accessor`] is derived from does not own
+    /// this function.
+    ///
+    /// [`Accessor`]: crate::component::Accessor
+    ///
+    /// # Example
+    ///
+    /// Using [`StoreContextMut::run_concurrent`] to get an [`Accessor`]:
+    ///
+    /// ```
+    /// # use {
+    /// #   wasmtime::{
+    /// #     error::{Result},
+    /// #     component::{Component, Linker, ResourceTable},
+    /// #     Config, Engine, Store
+    /// #   },
+    /// # };
+    /// #
+    /// # struct Ctx { table: ResourceTable }
+    /// #
+    /// # async fn foo() -> Result<()> {
+    /// # let mut config = Config::new();
+    /// # let engine = Engine::new(&config)?;
+    /// # let mut store = Store::new(&engine, Ctx { table: ResourceTable::new() });
+    /// # let mut linker = Linker::new(&engine);
+    /// # let component = Component::new(&engine, "")?;
+    /// # let instance = linker.instantiate_async(&mut store, &component).await?;
+    /// let my_typed_func = instance.get_typed_func::<(), ()>(&mut store, "my_typed_func")?;
+    /// store.run_concurrent(async |accessor| -> wasmtime::Result<_> {
+    ///    my_typed_func.call_concurrent(accessor, ()).await?;
+    ///    Ok(())
+    /// }).await??;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn call_concurrent(
+        self,
+        accessor: impl AsAccessor<Data: Send>,
+        params: Params,
+    ) -> Result<Return>
+    where
+        Params: 'static,
+        Return: 'static,
+    {
+        let call = accessor
+            .as_accessor()
+            .with(|store| self.start_call_concurrent(store, params))?;
+        self.finish_call_concurrent(accessor, call).await
+    }
+
+    /// Performs preparatory work for invoking this function with `params`,
+    /// returning a [`TypedFuncCallConcurrent`]
+    /// which can be passed to [`TypedFunc::finish_call_concurrent`] to resolve
+    /// the call.
+    ///
+    /// For more information see [`TypedFunc::call_concurrent`].
+    pub fn start_call_concurrent<T>(
+        self,
+        mut store: impl AsContextMut<Data = T>,
+        params: Params,
+    ) -> Result<TypedFuncCallConcurrent<T, Params, Return>>
+    where
+        T: Send + 'static,
+        Params: 'static,
+        Return: 'static,
+    {
+        let mut store = store.as_context_mut();
+        let mut store = store.as_context_mut();
+        ensure!(
+            store.0.concurrency_support(),
+            "cannot use `call_concurrent` Config::concurrency_support disabled",
+        );
+
+        let prepared = self.prepare_call(store.as_context_mut(), false, move |cx, ty, dst| {
+            Self::lower_args(cx, ty, dst, &params)
+        })?;
+        let call = concurrent::QueuedCall::new(store, prepared)?;
+        Ok(TypedFuncCallConcurrent {
+            call,
+            _marker: marker::PhantomData,
+        })
+    }
+
+    /// Completes a call that was initiated via
+    /// [`TypedFunc::start_call_concurrent`].
+    pub async fn finish_call_concurrent<T>(
+        self,
+        accessor: impl AsAccessor<Data = T>,
+        call: TypedFuncCallConcurrent<T, Params, Return>,
+    ) -> Result<Return>
+    where
+        T: Send + 'static,
+        Params: 'static,
+        Return: 'static,
+    {
+        // This is intentionally part of the public API but not used yet.
+        // This'll likely want to be used in future refactorings.
+        let _ = accessor;
+        call.call.await
+    }
+
+    /// Calls `concurrent::prepare_call` with monomorphized functions for
+    /// lowering the parameters and lifting the result according to the number
+    /// of core Wasm parameters and results in the signature of the function to
+    /// be called.
+    fn prepare_call<T>(
+        self,
+        store: StoreContextMut<'_, T>,
+        host_future_present: bool,
+        lower: impl FnOnce(
+            &mut LowerContext<T>,
+            InterfaceType,
+            &mut [MaybeUninit<ValRaw>],
+        ) -> Result<()>
+        + Send
+        + Sync
+        + 'static,
+    ) -> Result<PreparedCall<Return>>
+    where
+        Return: 'static,
+    {
+        use crate::component::storage::slice_to_storage;
+        debug_assert!(store.0.concurrency_support());
+
+        let param_count = if Params::flatten_count() <= MAX_FLAT_PARAMS {
+            Params::flatten_count()
+        } else {
+            1
+        };
+        let max_results = if self.func().abi_async(store.0) {
+            MAX_FLAT_PARAMS
+        } else {
+            MAX_FLAT_RESULTS
+        };
+        concurrent::prepare_call(
+            store,
+            *self.func(),
+            param_count,
+            host_future_present,
+            move |func, store, params_out| {
+                func.with_lower_context(store, |cx, ty| lower(cx, ty, params_out))
+            },
+            move |func, store, results| {
+                let result = if Return::flatten_count() <= max_results {
+                    func.with_lift_context(store, |cx, ty| {
+                        // SAFETY: Per the safety requiments documented for the
+                        // `ComponentType` trait, `Return::Lower` must be
+                        // compatible at the binary level with a `[ValRaw; N]`,
+                        // where `N` is `mem::size_of::<Return::Lower>() /
+                        // mem::size_of::<ValRaw>()`.  And since this function
+                        // is only used when `Return::flatten_count() <=
+                        // MAX_FLAT_RESULTS` and `MAX_FLAT_RESULTS == 1`, `N`
+                        // can only either be 0 or 1.
+                        //
+                        // See `ComponentInstance::exit_call` for where we use
+                        // the result count passed from
+                        // `wasmtime_environ::fact::trampoline`-generated code
+                        // to ensure the slice has the correct length, and also
+                        // `concurrent::start_call` for where we conservatively
+                        // use a slice length of 1 unconditionally.  Also note
+                        // that, as of this writing `slice_to_storage`
+                        // double-checks the slice length is sufficient.
+                        let results: &Return::Lower = unsafe { slice_to_storage(results) };
+                        Self::lift_stack_result(cx, ty, results)
+                    })?
+                } else {
+                    func.with_lift_context(store, |cx, ty| {
+                        Self::lift_heap_result(cx, ty, &results[0])
+                    })?
+                };
+                Ok(Box::new(result))
+            },
+        )
+    }
+}
+
+impl<T, P, R> TypedFuncCallConcurrent<T, P, R> {
+    /// Returns the task that this invocation corresponds to.
+    ///
+    /// This can be later correlated with [`StoreContextMut::async_call_stack`]
+    /// for example.
+    pub fn task(&self) -> GuestTaskId {
+        self.call.task()
+    }
+}

--- a/crates/wasmtime/src/runtime/component/concurrent/func.rs
+++ b/crates/wasmtime/src/runtime/component/concurrent/func.rs
@@ -447,7 +447,7 @@ where
             move |func, store, results| {
                 let result = if Return::flatten_count() <= max_results {
                     func.with_lift_context(store, |cx, ty| {
-                        // SAFETY: Per the safety requiments documented for the
+                        // SAFETY: Per the safety requirements documented for the
                         // `ComponentType` trait, `Return::Lower` must be
                         // compatible at the binary level with a `[ValRaw; N]`,
                         // where `N` is `mem::size_of::<Return::Lower>() /

--- a/crates/wasmtime/src/runtime/component/func.rs
+++ b/crates/wasmtime/src/runtime/component/func.rs
@@ -15,9 +15,6 @@ use wasmtime_environ::component::{
     TypeFuncIndex, TypeTuple,
 };
 
-#[cfg(feature = "component-model-async")]
-use crate::component::concurrent::{self, AsAccessor, PreparedCall};
-
 mod host;
 mod options;
 mod typed;
@@ -263,26 +260,24 @@ impl Func {
         params: &[Val],
         results: &mut [Val],
     ) -> Result<()> {
-        let store = store.as_context_mut();
+        let mut store = store.as_context_mut();
 
         #[cfg(feature = "component-model-async")]
         if store.0.concurrency_support() {
+            let call = self.start_call_concurrent(&mut store, params, results)?;
             return store
                 .run_concurrent_trap_on_idle(async |store| {
-                    self.call_concurrent_dynamic(store, params, results)
-                        .await
-                        .map(drop)
+                    self.finish_call_concurrent(store, call).await
                 })
                 .await?;
         }
 
-        let mut store = store;
         store
             .on_fiber(|store| self.call_impl(store, params, results))
             .await?
     }
 
-    fn check_params_results<T>(
+    pub(crate) fn check_params_results<T>(
         &self,
         store: StoreContextMut<T>,
         params: &[Val],
@@ -306,165 +301,6 @@ impl Func {
         }
 
         Ok(())
-    }
-
-    /// Start a concurrent call to this function.
-    ///
-    /// Concurrency is achieved by relying on the [`Accessor`] argument, which
-    /// can be obtained by calling [`StoreContextMut::run_concurrent`].
-    ///
-    /// Unlike [`Self::call`] and [`Self::call_async`] (both of which require
-    /// exclusive access to the store until the completion of the call), calls
-    /// made using this method may run concurrently with other calls to the same
-    /// instance.  In addition, the runtime will call the `post-return` function
-    /// (if any) automatically when the guest task completes.
-    ///
-    /// # Progress
-    ///
-    /// For the wasm task being created in `call_concurrent` to make progress it
-    /// must be run within the scope of [`run_concurrent`]. If there are no
-    /// active calls to [`run_concurrent`] then the wasm task will appear as
-    /// stalled. This is typically not a concern as an [`Accessor`] is bound
-    /// by default to a scope of [`run_concurrent`].
-    ///
-    /// One situation in which this can arise, for example, is that if a
-    /// [`run_concurrent`] computation finishes its async closure before all
-    /// wasm tasks have completed, then there will be no scope of
-    /// [`run_concurrent`] anywhere. In this situation the wasm tasks that have
-    /// not yet completed will not make progress until [`run_concurrent`] is
-    /// called again.
-    ///
-    /// Embedders will need to ensure that this future is `await`'d within the
-    /// scope of [`run_concurrent`] to ensure that the value can be produced
-    /// during the `await` call.
-    ///
-    /// # Cancellation
-    ///
-    /// Cancelling an async task created via `call_concurrent`, at this time, is
-    /// only possible by dropping the store that the computation runs within.
-    /// With [#11833] implemented then it will be possible to request
-    /// cancellation of a task, but that is not yet implemented. Hard-cancelling
-    /// a task will only ever be possible by dropping the entire store and it is
-    /// not possible to remove just one task from a store.
-    ///
-    /// This async function behaves more like a "spawn" than a normal Rust async
-    /// function. When this function is invoked then metadata for the function
-    /// call is recorded in the store connected to the `accessor` argument and
-    /// the wasm invocation is from then on connected to the store. If the
-    /// future created by this function is dropped it does not cancel the
-    /// in-progress execution of the wasm task. Dropping the future
-    /// relinquishes the host's ability to learn about the result of the task
-    /// but the task will still progress and invoke callbacks and such until
-    /// completion.
-    ///
-    /// This function will return an error if [`Config::concurrency_support`] is
-    /// disabled.
-    ///
-    /// [`Config::concurrency_support`]: crate::Config::concurrency_support
-    /// [`run_concurrent`]: crate::Store::run_concurrent
-    /// [#11833]: https://github.com/bytecodealliance/wasmtime/issues/11833
-    /// [`Accessor`]: crate::component::Accessor
-    ///
-    /// # Panics
-    ///
-    /// Panics if the store that the [`Accessor`] is derived from does not own
-    /// this function.
-    ///
-    /// # Example
-    ///
-    /// Using [`StoreContextMut::run_concurrent`] to get an [`Accessor`]:
-    ///
-    /// ```
-    /// # use {
-    /// #   wasmtime::{
-    /// #     error::{Result},
-    /// #     component::{Component, Linker, ResourceTable},
-    /// #     Config, Engine, Store
-    /// #   },
-    /// # };
-    /// #
-    /// # struct Ctx { table: ResourceTable }
-    /// #
-    /// # async fn foo() -> Result<()> {
-    /// # let mut config = Config::new();
-    /// # let engine = Engine::new(&config)?;
-    /// # let mut store = Store::new(&engine, Ctx { table: ResourceTable::new() });
-    /// # let mut linker = Linker::new(&engine);
-    /// # let component = Component::new(&engine, "")?;
-    /// # let instance = linker.instantiate_async(&mut store, &component).await?;
-    /// let my_func = instance.get_func(&mut store, "my_func").unwrap();
-    /// store.run_concurrent(async |accessor| -> wasmtime::Result<_> {
-    ///    my_func.call_concurrent(accessor, &[], &mut Vec::new()).await?;
-    ///    Ok(())
-    /// }).await??;
-    /// # Ok(())
-    /// # }
-    /// ```
-    #[cfg(feature = "component-model-async")]
-    pub async fn call_concurrent(
-        self,
-        accessor: impl AsAccessor<Data: Send>,
-        params: &[Val],
-        results: &mut [Val],
-    ) -> Result<()> {
-        self.call_concurrent_dynamic(accessor, params, results)
-            .await
-    }
-
-    /// Internal helper function for `call_async` and `call_concurrent`.
-    #[cfg(feature = "component-model-async")]
-    async fn call_concurrent_dynamic(
-        self,
-        accessor: impl AsAccessor<Data: Send>,
-        params: &[Val],
-        results: &mut [Val],
-    ) -> Result<()> {
-        let result = accessor.as_accessor().with(|mut store| {
-            self.check_params_results(store.as_context_mut(), params, results)?;
-            let prepared = self.prepare_call_dynamic(store.as_context_mut(), params.to_vec())?;
-            concurrent::queue_call(store.as_context_mut(), prepared)
-        })?;
-
-        let run_results = result.await?;
-        assert_eq!(run_results.len(), results.len());
-        for (result, slot) in run_results.into_iter().zip(results) {
-            *slot = result;
-        }
-        Ok(())
-    }
-
-    /// Calls `concurrent::prepare_call` with monomorphized functions for
-    /// lowering the parameters and lifting the result.
-    #[cfg(feature = "component-model-async")]
-    fn prepare_call_dynamic<'a, T: Send + 'static>(
-        self,
-        mut store: StoreContextMut<'a, T>,
-        params: Vec<Val>,
-    ) -> Result<PreparedCall<Vec<Val>>> {
-        let store = store.as_context_mut();
-
-        concurrent::prepare_call(
-            store,
-            self,
-            MAX_FLAT_PARAMS,
-            false,
-            move |func, store, params_out| {
-                func.with_lower_context(store, |cx, ty| {
-                    Self::lower_args(cx, &params, ty, params_out)
-                })
-            },
-            move |func, store, results| {
-                let max_flat = if func.abi_async(store) {
-                    MAX_FLAT_PARAMS
-                } else {
-                    MAX_FLAT_RESULTS
-                };
-                let results = func.with_lift_context(store, |cx, ty| {
-                    Self::lift_results(cx, ty, results, max_flat)?.collect::<Result<Vec<_>>>()
-                })?;
-                Ok(Box::new(results))
-            },
-        )
     }
 
     fn call_impl(
@@ -728,7 +564,7 @@ impl Func {
         Ok(())
     }
 
-    fn lower_args<T>(
+    pub(crate) fn lower_args<T>(
         cx: &mut LowerContext<'_, T>,
         params: &[Val],
         params_ty: InterfaceType,
@@ -769,7 +605,7 @@ impl Func {
         Ok(())
     }
 
-    fn lift_results<'a, 'b>(
+    pub(crate) fn lift_results<'a, 'b>(
         cx: &'a mut LiftContext<'b>,
         results_ty: InterfaceType,
         src: &'a [ValRaw],
@@ -829,7 +665,7 @@ impl Func {
     /// The `lower` closure provided should perform the actual lowering and
     /// return the result of the lowering operation which is then returned from
     /// this function as well.
-    fn with_lower_context<T>(
+    pub(crate) fn with_lower_context<T>(
         self,
         mut store: StoreContextMut<T>,
         lower: impl FnOnce(&mut LowerContext<T>, InterfaceType) -> Result<()>,
@@ -854,7 +690,7 @@ impl Func {
     ///
     /// The closure `lift` provided should actually perform the lift itself and
     /// the result of that closure is returned from this function call as well.
-    fn with_lift_context<R>(
+    pub(crate) fn with_lift_context<R>(
         self,
         store: &mut StoreOpaque,
         lift: impl FnOnce(&mut LiftContext, InterfaceType) -> Result<R>,

--- a/crates/wasmtime/src/runtime/component/func/typed.rs
+++ b/crates/wasmtime/src/runtime/component/func/typed.rs
@@ -17,9 +17,6 @@ use wasmtime_environ::component::{
     OptionsIndex, StringEncoding, TypeMap, VariantInfo,
 };
 
-#[cfg(feature = "component-model-async")]
-use crate::component::concurrent::{self, AsAccessor, PreparedCall};
-
 /// A statically-typed version of [`Func`] which takes `Params` as input and
 /// returns `Return`.
 ///
@@ -178,57 +175,7 @@ where
 
         #[cfg(feature = "component-model-async")]
         if store.0.concurrency_support() {
-            use crate::component::concurrent::TaskId;
-            use crate::runtime::vm::SendSyncPtr;
-            use core::ptr::NonNull;
-
-            let ptr = SendSyncPtr::from(NonNull::from(&params).cast::<u8>());
-            let prepared =
-                self.prepare_call(store.as_context_mut(), true, move |cx, ty, dst| {
-                    // SAFETY: The goal here is to get `Params`, a non-`'static`
-                    // value, to live long enough to the lowering of the
-                    // parameters. We're guaranteed that `Params` lives in the
-                    // future of the outer function (we're in an `async fn`) so it'll
-                    // stay alive as long as the future itself. That is distinct,
-                    // for example, from the signature of `call_concurrent` below.
-                    //
-                    // Here a pointer to `Params` is smuggled to this location
-                    // through a `SendSyncPtr<u8>` to thwart the `'static` check
-                    // of rustc and the signature of `prepare_call`.
-                    //
-                    // Note the use of `SignalOnDrop` in the code that follows
-                    // this closure, which ensures that the task will be removed
-                    // from the concurrent state to which it belongs when the
-                    // containing `Future` is dropped, so long as the parameters
-                    // have not yet been lowered. Since this closure is removed from
-                    // the task after the parameters are lowered, it will never be called
-                    // after the containing `Future` is dropped.
-                    let params = unsafe { ptr.cast::<Params>().as_ref() };
-                    Self::lower_args(cx, ty, dst, params)
-                })?;
-
-            struct SignalOnDrop<'a, T: 'static> {
-                store: StoreContextMut<'a, T>,
-                task: TaskId,
-            }
-
-            impl<'a, T> Drop for SignalOnDrop<'a, T> {
-                fn drop(&mut self) {
-                    self.task.host_future_dropped(self.store.0).unwrap();
-                }
-            }
-
-            let mut wrapper = SignalOnDrop {
-                store,
-                task: prepared.task_id(),
-            };
-
-            let result = concurrent::queue_call(wrapper.store.as_context_mut(), prepared)?;
-            return wrapper
-                .store
-                .as_context_mut()
-                .run_concurrent_trap_on_idle(async |_| Ok(result.await?))
-                .await?;
+            return self.call_async_concurrent(store, params).await;
         }
 
         store
@@ -236,94 +183,7 @@ where
             .await?
     }
 
-    /// Start a concurrent call to this function.
-    ///
-    /// Concurrency is achieved by relying on the [`Accessor`] argument, which
-    /// can be obtained by calling [`StoreContextMut::run_concurrent`].
-    ///
-    /// Unlike [`Self::call`] and [`Self::call_async`] (both of which require
-    /// exclusive access to the store until the completion of the call), calls
-    /// made using this method may run concurrently with other calls to the same
-    /// instance.  In addition, the runtime will call the `post-return` function
-    /// (if any) automatically when the guest task completes.
-    ///
-    /// This function will return an error if [`Config::concurrency_support`] is
-    /// disabled.
-    ///
-    /// [`Config::concurrency_support`]: crate::Config::concurrency_support
-    ///
-    /// # Progress and Cancellation
-    ///
-    /// For more information about how to make progress on the wasm task or how
-    /// to cancel the wasm task see the documentation for
-    /// [`Func::call_concurrent`].
-    ///
-    /// [`Func::call_concurrent`]: crate::component::Func::call_concurrent
-    ///
-    /// # Panics
-    ///
-    /// Panics if the store that the [`Accessor`] is derived from does not own
-    /// this function.
-    ///
-    /// [`Accessor`]: crate::component::Accessor
-    ///
-    /// # Example
-    ///
-    /// Using [`StoreContextMut::run_concurrent`] to get an [`Accessor`]:
-    ///
-    /// ```
-    /// # use {
-    /// #   wasmtime::{
-    /// #     error::{Result},
-    /// #     component::{Component, Linker, ResourceTable},
-    /// #     Config, Engine, Store
-    /// #   },
-    /// # };
-    /// #
-    /// # struct Ctx { table: ResourceTable }
-    /// #
-    /// # async fn foo() -> Result<()> {
-    /// # let mut config = Config::new();
-    /// # let engine = Engine::new(&config)?;
-    /// # let mut store = Store::new(&engine, Ctx { table: ResourceTable::new() });
-    /// # let mut linker = Linker::new(&engine);
-    /// # let component = Component::new(&engine, "")?;
-    /// # let instance = linker.instantiate_async(&mut store, &component).await?;
-    /// let my_typed_func = instance.get_typed_func::<(), ()>(&mut store, "my_typed_func")?;
-    /// store.run_concurrent(async |accessor| -> wasmtime::Result<_> {
-    ///    my_typed_func.call_concurrent(accessor, ()).await?;
-    ///    Ok(())
-    /// }).await??;
-    /// # Ok(())
-    /// # }
-    /// ```
-    #[cfg(feature = "component-model-async")]
-    pub async fn call_concurrent(
-        self,
-        accessor: impl AsAccessor<Data: Send>,
-        params: Params,
-    ) -> Result<Return>
-    where
-        Params: 'static,
-        Return: 'static,
-    {
-        let result = accessor.as_accessor().with(|mut store| {
-            let mut store = store.as_context_mut();
-            ensure!(
-                store.0.concurrency_support(),
-                "cannot use `call_concurrent` Config::concurrency_support disabled",
-            );
-
-            let prepared =
-                self.prepare_call(store.as_context_mut(), false, move |cx, ty, dst| {
-                    Self::lower_args(cx, ty, dst, &params)
-                })?;
-            concurrent::queue_call(store, prepared)
-        });
-        Ok(result?.await?)
-    }
-
-    fn lower_args<T>(
+    pub(crate) fn lower_args<T>(
         cx: &mut LowerContext<T>,
         ty: InterfaceType,
         dst: &mut [MaybeUninit<ValRaw>],
@@ -341,81 +201,6 @@ where
         } else {
             Self::lower_heap_args(cx, &params, ty, &mut dst[0])
         }
-    }
-
-    /// Calls `concurrent::prepare_call` with monomorphized functions for
-    /// lowering the parameters and lifting the result according to the number
-    /// of core Wasm parameters and results in the signature of the function to
-    /// be called.
-    #[cfg(feature = "component-model-async")]
-    fn prepare_call<T>(
-        self,
-        store: StoreContextMut<'_, T>,
-        host_future_present: bool,
-        lower: impl FnOnce(
-            &mut LowerContext<T>,
-            InterfaceType,
-            &mut [MaybeUninit<ValRaw>],
-        ) -> Result<()>
-        + Send
-        + Sync
-        + 'static,
-    ) -> Result<PreparedCall<Return>>
-    where
-        Return: 'static,
-    {
-        use crate::component::storage::slice_to_storage;
-        debug_assert!(store.0.concurrency_support());
-
-        let param_count = if Params::flatten_count() <= MAX_FLAT_PARAMS {
-            Params::flatten_count()
-        } else {
-            1
-        };
-        let max_results = if self.func.abi_async(store.0) {
-            MAX_FLAT_PARAMS
-        } else {
-            MAX_FLAT_RESULTS
-        };
-        concurrent::prepare_call(
-            store,
-            self.func,
-            param_count,
-            host_future_present,
-            move |func, store, params_out| {
-                func.with_lower_context(store, |cx, ty| lower(cx, ty, params_out))
-            },
-            move |func, store, results| {
-                let result = if Return::flatten_count() <= max_results {
-                    func.with_lift_context(store, |cx, ty| {
-                        // SAFETY: Per the safety requiments documented for the
-                        // `ComponentType` trait, `Return::Lower` must be
-                        // compatible at the binary level with a `[ValRaw; N]`,
-                        // where `N` is `mem::size_of::<Return::Lower>() /
-                        // mem::size_of::<ValRaw>()`.  And since this function
-                        // is only used when `Return::flatten_count() <=
-                        // MAX_FLAT_RESULTS` and `MAX_FLAT_RESULTS == 1`, `N`
-                        // can only either be 0 or 1.
-                        //
-                        // See `ComponentInstance::exit_call` for where we use
-                        // the result count passed from
-                        // `wasmtime_environ::fact::trampoline`-generated code
-                        // to ensure the slice has the correct length, and also
-                        // `concurrent::start_call` for where we conservatively
-                        // use a slice length of 1 unconditionally.  Also note
-                        // that, as of this writing `slice_to_storage`
-                        // double-checks the slice length is sufficient.
-                        let results: &Return::Lower = unsafe { slice_to_storage(results) };
-                        Self::lift_stack_result(cx, ty, results)
-                    })?
-                } else {
-                    func.with_lift_context(store, |cx, ty| {
-                        Self::lift_heap_result(cx, ty, &results[0])
-                    })?
-                };
-                Ok(Box::new(result))
-            },
-        )
     }
 
     fn call_impl(&self, mut store: impl AsContextMut, params: Params) -> Result<Return> {
@@ -539,7 +324,7 @@ where
     ///
     /// This is only used when the result fits in the maximum number of stack
     /// slots.
-    fn lift_stack_result(
+    pub(crate) fn lift_stack_result(
         cx: &mut LiftContext<'_>,
         ty: InterfaceType,
         dst: &Return::Lower,
@@ -549,7 +334,7 @@ where
 
     /// Lift the result of a function where the result is stored indirectly on
     /// the heap.
-    fn lift_heap_result(
+    pub(crate) fn lift_heap_result(
         cx: &mut LiftContext<'_>,
         ty: InterfaceType,
         dst: &ValRaw,

--- a/crates/wasmtime/src/runtime/component/mod.rs
+++ b/crates/wasmtime/src/runtime/component/mod.rs
@@ -120,9 +120,10 @@ pub use self::component::{Component, ComponentExportIndex, ExportLookup};
 #[cfg(feature = "component-model-async")]
 pub use self::concurrent::{
     Access, Accessor, AccessorTask, AsAccessor, Destination, DirectDestination, DirectSource,
-    ErrorContext, FutureAny, FutureConsumer, FutureProducer, FutureReader, GuardedFutureReader,
-    GuardedStreamReader, JoinHandle, ReadBuffer, Source, StreamAny, StreamConsumer, StreamProducer,
-    StreamReader, StreamResult, VMComponentAsyncStore, VecBuffer, WriteBuffer,
+    ErrorContext, FuncCallConcurrent, FutureAny, FutureConsumer, FutureProducer, FutureReader,
+    GuardedFutureReader, GuardedStreamReader, GuestTaskId, JoinHandle, ReadBuffer, Source,
+    StreamAny, StreamConsumer, StreamProducer, StreamReader, StreamResult, TypedFuncCallConcurrent,
+    VMComponentAsyncStore, VecBuffer, WriteBuffer,
 };
 pub use self::func::{
     ComponentNamedList, ComponentType, Func, Lift, Lower, TypedFunc, WasmList, WasmStr,

--- a/crates/wit-bindgen/src/lib.rs
+++ b/crates/wit-bindgen/src/lib.rs
@@ -2797,10 +2797,42 @@ impl<'a> InterfaceGenerator<'a> {
         } else {
             ("", "", "")
         };
-
-        self.rustdoc(&func.docs);
+        let param_mode = if flags.contains(FunctionFlags::ASYNC | FunctionFlags::STORE) {
+            TypeMode::Owned
+        } else {
+            TypeMode::AllBorrowed("'_")
+        };
         let wt = self.generator.wasmtime_path();
 
+        // First generate an accessor to get the raw `TypedFunc` itself.
+        uwrite!(
+            self.src,
+            "pub fn func_{}(&self) -> {wt}::component::TypedFunc<{}> {{\n",
+            func.item_name().to_snake_case(),
+            self.typedfunc_sig(func, param_mode)
+        );
+
+        self.src.push_str("unsafe {\n");
+        uwrite!(
+            self.src,
+            "{wt}::component::TypedFunc::<{}>",
+            self.typedfunc_sig(func, param_mode)
+        );
+        let projection_to_func = if func.kind.resource().is_some() {
+            ".funcs"
+        } else {
+            ""
+        };
+        uwriteln!(
+            self.src,
+            "::new_unchecked(self{projection_to_func}.{})",
+            func_field_name(self.resolve, func),
+        );
+        self.src.push_str("}\n");
+        self.src.push_str("}\n");
+
+        // Next generate the actual function itself.
+        self.rustdoc(&func.docs);
         uwrite!(
             self.src,
             "pub {async_} fn call_{}",
@@ -2814,12 +2846,6 @@ impl<'a> InterfaceGenerator<'a> {
         } else {
             uwrite!(self.src, "<S: {wt}::AsContextMut>(&self, mut store: S, ",);
         }
-
-        let param_mode = if flags.contains(FunctionFlags::ASYNC | FunctionFlags::STORE) {
-            TypeMode::Owned
-        } else {
-            TypeMode::AllBorrowed("'_")
-        };
 
         for (i, param) in func.params.iter().enumerate() {
             uwrite!(self.src, "arg{}: ", i);
@@ -2868,23 +2894,11 @@ impl<'a> InterfaceGenerator<'a> {
             }
         }
 
-        self.src.push_str("let callee = unsafe {\n");
-        uwrite!(
-            self.src,
-            "{wt}::component::TypedFunc::<{}>",
-            self.typedfunc_sig(func, param_mode)
-        );
-        let projection_to_func = if func.kind.resource().is_some() {
-            ".funcs"
-        } else {
-            ""
-        };
         uwriteln!(
             self.src,
-            "::new_unchecked(self{projection_to_func}.{})",
-            func_field_name(self.resolve, func),
+            "let callee = self.func_{}();",
+            func.item_name().to_snake_case(),
         );
-        self.src.push_str("};\n");
 
         self.src.push_str("let (");
         if func.result.is_some() {

--- a/src/commands/serve.rs
+++ b/src/commands/serve.rs
@@ -20,7 +20,7 @@ use std::{
 };
 use tokio::io::{self, AsyncWrite};
 use tokio::sync::Notify;
-use wasmtime::component::{Component, Linker};
+use wasmtime::component::{Component, GuestTaskId, Linker};
 use wasmtime::error::Context as _;
 use wasmtime::{
     AsContextMut as _, Engine, Result, Store, StoreContextMut, StoreLimits, UpdateDeadline, bail,
@@ -28,8 +28,6 @@ use wasmtime::{
 use wasmtime_cli_flags::opt::WasmtimeOptionValue;
 use wasmtime_wasi::p2::{StreamError, StreamResult};
 use wasmtime_wasi::{WasiCtx, WasiCtxBuilder, WasiCtxView, WasiView};
-#[cfg(feature = "component-model-async")]
-use wasmtime_wasi_http::handler::p2::bindings as p2;
 use wasmtime_wasi_http::handler::{
     self, HandlerState, Instance, ProxyHandler, ProxyPre, ShouldAccept, ViewFn, WorkerExpiration,
     WorkerState, WorkerStatus,
@@ -609,10 +607,10 @@ impl ServeCommand {
         #[cfg(feature = "component-model-async")]
         let instance = match wasmtime_wasi_http::p3::bindings::ServicePre::new(instance.clone()) {
             Ok(pre) => ProxyPre::P3(pre),
-            Err(_) => ProxyPre::P2(p2::ProxyPre::new(instance)?),
+            Err(_) => ProxyPre::P2(wasmtime_wasi_http::p2::bindings::ProxyPre::new(instance)?),
         };
         #[cfg(not(feature = "component-model-async"))]
-        let instance = ProxyPre::P2(p2::ProxyPre::new(instance)?);
+        let instance = ProxyPre::P2(wasmtime_wasi_http::p2::bindings::ProxyPre::new(instance)?);
 
         // Spawn background task(s) waiting for graceful shutdown signals. This
         // always listens for ctrl-c but additionally can listen for a TCP
@@ -691,6 +689,7 @@ impl ServeCommand {
             max_instance_concurrent_reuse_count,
             instance,
             next_instance_id: AtomicU64::default(),
+            next_request_id: AtomicU64::default(),
             // Give one shutdown guard to this handler which will track the
             // full lifetime of any instances spawned.
             _shutdown_guard: Box::new(shutdown.clone().increment()),
@@ -835,6 +834,7 @@ struct HostWorkerState {
 
 impl WorkerState for HostWorkerState {
     type StoreData = Host;
+    type RequestId = u64;
 
     fn should_accept_request(&self, concurrent_count: usize, total_count: usize) -> ShouldAccept {
         if total_count >= self.max_instance_reuse_count {
@@ -848,13 +848,13 @@ impl WorkerState for HostWorkerState {
 
     fn on_request_start(
         &self,
-        req: &handler::Request,
+        _store: StoreContextMut<Host>,
+        request_id: u64,
+        _task_id: GuestTaskId,
     ) -> Pin<Box<dyn Future<Output = ()> + 'static + Send + Sync>> {
         log::info!(
-            "Instance {} handling request {} {}",
+            "Instance {} handling request {request_id}",
             self.instance_id,
-            req.method(),
-            req.uri()
         );
 
         Box::pin(tokio::time::sleep(self.request_timeout))
@@ -882,6 +882,7 @@ struct HostHandlerState {
     max_instance_concurrent_reuse_count: usize,
     instance: ProxyPre<Host>,
     next_instance_id: AtomicU64,
+    next_request_id: AtomicU64,
     _shutdown_guard: Box<dyn std::any::Any + Send + Sync>,
 }
 
@@ -1257,12 +1258,24 @@ async fn handle_request(
 
     handler.state().request_headers.apply(req.headers_mut());
 
+    let request_id = handler
+        .state()
+        .next_request_id
+        .fetch_add(1, Ordering::Relaxed);
+    log::info!(
+        "Received request {request_id}: {} {}",
+        req.method(),
+        req.uri()
+    );
     handler
-        .handle(req.map(|body| {
-            body.map_err(ErrorCode::from_hyper_request_error)
-                .map_err(handler::ErrorCode::from)
-                .boxed_unsync()
-        }))
+        .handle(
+            request_id,
+            req.map(|body| {
+                body.map_err(ErrorCode::from_hyper_request_error)
+                    .map_err(handler::ErrorCode::from)
+                    .boxed_unsync()
+            }),
+        )
         .await
 }
 

--- a/tests/all/component_model/async.rs
+++ b/tests/all/component_model/async.rs
@@ -970,3 +970,95 @@ async fn bytes_stream_producer() -> Result<()> {
 
     Ok(())
 }
+
+#[tokio::test]
+#[cfg_attr(miri, ignore)]
+async fn async_call_stack() -> Result<()> {
+    let mut config = Config::new();
+    config.wasm_component_model_async(true);
+    let engine = Engine::new(&config)?;
+
+    let component = Component::new(
+        &engine,
+        r#"
+        (component
+            (import "a" (func $a))
+            (core func $a (canon lower (func $a)))
+
+            (core module $a
+                (import "" "a" (func $a))
+                (func (export "a") call $a)
+            )
+            (core instance $a (instantiate $a
+                (with "" (instance (export "a" (func $a))))
+            ))
+            (func (export "a") async (canon lift (core func $a "a")))
+        )
+    "#,
+    )?;
+
+    let mut linker = Linker::new(&engine);
+    linker.root().func_wrap(
+        "a",
+        |mut store: StoreContextMut<Option<GuestTaskId>>, (): ()| {
+            let stack = store.async_call_stack().collect::<Vec<_>>();
+            assert_eq!(stack, [store.data().unwrap()]);
+            Ok(())
+        },
+    )?;
+    let mut store = Store::new(&engine, None);
+    let instance = linker.instantiate_async(&mut store, &component).await?;
+    let func = instance.get_typed_func::<(), ()>(&mut store, "a")?;
+
+    let call = func.start_call_concurrent(&mut store, ())?;
+    *store.data_mut() = Some(call.task());
+    store
+        .run_concurrent(async |store| func.finish_call_concurrent(store, call).await)
+        .await??;
+
+    let component = Component::new(
+        &engine,
+        r#"
+        (component
+            (import "a" (func $a))
+            (component $a
+                (import "a" (func $a))
+                (core func $a (canon lower (func $a)))
+
+                (core module $a
+                    (import "" "a" (func $a))
+                    (func (export "a") call $a)
+                )
+                (core instance $a (instantiate $a
+                    (with "" (instance (export "a" (func $a))))
+                ))
+                (func (export "a") (canon lift (core func $a "a")))
+            )
+
+            (instance $a (instantiate $a (with "a" (func $a))))
+            (instance $b (instantiate $a (with "a" (func $a "a"))))
+            (export "a" (func $b "a"))
+        )
+    "#,
+    )?;
+
+    let mut linker = Linker::new(&engine);
+    linker.root().func_wrap(
+        "a",
+        |mut store: StoreContextMut<Option<GuestTaskId>>, (): ()| {
+            let stack = store.async_call_stack().collect::<Vec<_>>();
+            assert_eq!(stack.len(), 2);
+            assert_eq!(stack.last(), store.data().as_ref());
+            Ok(())
+        },
+    )?;
+    let instance = linker.instantiate_async(&mut store, &component).await?;
+    let func = instance.get_typed_func::<(), ()>(&mut store, "a")?;
+
+    let call = func.start_call_concurrent(&mut store, ())?;
+    *store.data_mut() = Some(call.task());
+    store
+        .run_concurrent(async |store| func.finish_call_concurrent(store, call).await)
+        .await??;
+    Ok(())
+}


### PR DESCRIPTION
This PR is intended to be the Wasmtime-specific resolution of WebAssembly/WASI#918, WebAssembly/WASI#919, and WebAssembly/WASI#920. Two commits are included here, both of which have more details as to what they're doing. At a high level though the first commit is providing the primitives in the `wasmtime` crate's API to reflect on the async call stack as defined by the component model. The second commit then refactors our `wasmtime serve` handling to thread this through and provide the host with a strong guarantee of "this request is being served on this store with this task", which is intended to then enable the store to do whatever it likes in terms of handling.