### PR TITLE
fix: resolve #13200 — Cranelift: JITMemoryProvider cannot be implemented because JITMemoryKind is private

### DIFF
--- a/cranelift/jit/src/lib.rs
+++ b/cranelift/jit/src/lib.rs
@@ -12,7 +12,7 @@ mod memory;
 
 pub use crate::backend::{JITBuilder, JITModule};
 pub use crate::memory::{
-    ArenaMemoryProvider, BranchProtection, JITMemoryProvider, SystemMemoryProvider,
+    ArenaMemoryProvider, BranchProtection, JITMemoryKind, JITMemoryProvider, SystemMemoryProvider,
 };
 
 /// Version number of this crate.


### PR DESCRIPTION
## Summary

Making `JITMemoryKind` public in `memory.rs` is not sufficient if it is not re-exported from the crate root alongside `JITMemoryProvider` and the other memory-related public items. Downstream users import these symbols from `cranelift_jit::...`, so the type needs to be reachable through the same path used for `JITMemoryProvider`

Fixes #13200

## Changes

- `cranelift/jit/src/lib.rs`

## Why

`cranelift/jit/src/lib.rs`: Making `JITMemoryKind` public in `memory.rs` is not sufficient if it is not re-exported from the crate root alongside `JITMemoryProvider` and the other memory-related public items. Downstream users import these symbols from `cranelift_jit::...`, so the type needs to be reachable through the same path used for `JITMemoryProvider`.
