### PR TITLE
Optimize `Table::new` slightly with null initializers

### DIFF
--- a/crates/wasmtime/src/runtime/externals/table.rs
+++ b/crates/wasmtime/src/runtime/externals/table.rs
@@ -126,7 +126,18 @@ impl Table {
         ty: TableType,
         init: Ref,
     ) -> Result<Table> {
+        init.ensure_matches_ty(store, ty.element())
+            .context("type mismatch: value does not match table element type")?;
         let table = generate_table_export(store, limiter, &ty).await?;
+        // Tables are always allocated as all zeroes, so skip the fill below if
+        // the value being inserted is all zeros.
+        if init.is_zero_pattern() {
+            if cfg!(debug_assertions) {
+                let (table, _) = table.wasmtime_table(store, None);
+                table.debug_assert_all_zero();
+            }
+            return Ok(table);
+        }
         table._fill(store, 0, init, ty.minimum())?;
         Ok(table)
     }
@@ -604,6 +615,15 @@ impl Ref {
             },
 
             _ => unreachable!("checked that the value matches the type above"),
+        }
+    }
+
+    fn is_zero_pattern(&self) -> bool {
+        match self {
+            Ref::Extern(None) | Ref::Any(None) | Ref::Exn(None) | Ref::Func(None) => true,
+            Ref::Extern(Some(_)) | Ref::Any(Some(_)) | Ref::Exn(Some(_)) | Ref::Func(Some(_)) => {
+                false
+            }
         }
     }
 }

--- a/crates/wasmtime/src/runtime/externals/table.rs
+++ b/crates/wasmtime/src/runtime/externals/table.rs
@@ -129,8 +129,17 @@ impl Table {
         init.ensure_matches_ty(store, ty.element())
             .context("type mismatch: value does not match table element type")?;
         let table = generate_table_export(store, limiter, &ty).await?;
+
         // Tables are always allocated as all zeroes, so skip the fill below if
         // the value being inserted is all zeros.
+        //
+        // Note that this is applicable for funcref tables when
+        // `tunables.table_lazy_init` is enabled as well. In that situation the
+        // null image means "go check the instance" and the instance created by
+        // `generate_table_export` says everything is null.
+        //
+        // In all cases a zero-initialized table will reflect all-null elements
+        // at runtime.
         if init.is_zero_pattern() {
             if cfg!(debug_assertions) {
                 let (table, _) = table.wasmtime_table(store, None);

--- a/crates/wasmtime/src/runtime/trampoline/table.rs
+++ b/crates/wasmtime/src/runtime/trampoline/table.rs
@@ -22,6 +22,7 @@ pub async fn create_table(
     );
 
     let table_id = module.tables.push(wasmtime_table)?;
+    module.table_initialization.push(Default::default())?;
 
     // TODO: can this `exports.insert` get removed?
     let name = module.strings.insert("")?;

--- a/crates/wasmtime/src/runtime/vm/table.rs
+++ b/crates/wasmtime/src/runtime/vm/table.rs
@@ -946,6 +946,21 @@ impl Table {
             }
         }
     }
+
+    pub fn debug_assert_all_zero(&self) {
+        match self.element_type() {
+            TableElementType::Func => {
+                let (funcrefs, _lazy_init) = self.funcrefs();
+                debug_assert!(funcrefs.iter().all(|f| f.0.is_none()));
+            }
+            TableElementType::GcRef => {
+                debug_assert!(self.gc_refs().iter().all(|r| r.is_none()));
+            }
+            TableElementType::Cont => {
+                debug_assert!(self.contrefs().iter().all(|c| c.is_none()));
+            }
+        }
+    }
 }
 
 // The default table representation is an empty funcref table that cannot grow.


### PR DESCRIPTION
Trying to fix some timeouts on OSS-Fuzz where the per-element fill is slow enough to time out. By skipping initialization entirely it should be possibly to bypass those timeouts in theory.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
