### PR TITLE
winch: Fix bugs in `table.init` translation

### DIFF
--- a/tests/disas/winch/x64/table/init_copy_drop.wat
+++ b/tests/disas/winch/x64/table/init_copy_drop.wat
@@ -131,20 +131,20 @@
 ;;       movq    0x18(%r11), %r11
 ;;       addq    $0x40, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0xa2b
+;;       ja      0xa31
 ;;  15c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
 ;;       movq    %rsi, (%rsp)
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
-;;       callq   0x10af
+;;       callq   0x10bf
 ;;       movq    8(%rsp), %r14
 ;;       pushq   %rax
 ;;       subq    $8, %rsp
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
-;;       callq   0x10da
+;;       callq   0x10ea
 ;;       addq    $8, %rsp
 ;;       movq    0x10(%rsp), %r14
 ;;       movq    %r14, %r11
@@ -156,95 +156,97 @@
 ;;       movl    %ebx, %ebx
 ;;       movl    %esi, %r8d
 ;;       addl    %ebx, %r8d
-;;       jb      0xa2d
+;;       jb      0xa33
 ;;  1ca: cmpl    %edx, %r8d
-;;       ja      0xa2f
+;;       ja      0xa35
 ;;  1d3: movl    %edi, %r8d
 ;;       addl    %ebx, %r8d
-;;       jb      0xa31
-;;  1df: cmpl    %edx, %r8d
-;;       ja      0xa33
+;;       jb      0xa37
+;;  1df: cmpl    %ecx, %r8d
+;;       ja      0xa39
 ;;  1e8: movl    %esi, %esi
 ;;       imulq   $0x10, %rsi, %rsi
 ;;       addq    %rsi, %rax
 ;;       cmpq    $0, %rbx
-;;       je      0x24f
-;;  1fe: movq    (%rax), %rax
+;;       je      0x256
+;;  1fe: movq    (%rax), %rcx
 ;;       addq    $0x10, %rax
-;;       movl    %edi, %ecx
-;;       movq    %r14, %rdx
-;;       movq    0xd8(%rdx), %r8
-;;       cmpq    %r8, %rcx
-;;       jae     0xa35
-;;  21c: movq    %rcx, %r11
+;;       movl    %edi, %edx
+;;       movq    %r14, %rsi
+;;       movq    0xd8(%rsi), %r8
+;;       cmpq    %r8, %rdx
+;;       jae     0xa3b
+;;  21c: movq    %rdx, %r11
 ;;       imulq   $8, %r11, %r11
-;;       movq    0xd0(%rdx), %rdx
-;;       movq    %rdx, %r9
-;;       addq    %r11, %rdx
-;;       cmpq    %r8, %rcx
-;;       cmovaeq %r9, %rdx
+;;       movq    0xd0(%rsi), %rsi
+;;       movq    %rsi, %r9
+;;       addq    %r11, %rsi
+;;       cmpq    %r8, %rdx
+;;       cmovaeq %r9, %rsi
 ;;       orq     $1, %rcx
-;;       movq    %rcx, (%rdx)
+;;       movq    %rcx, (%rsi)
 ;;       addl    $1, %edi
+;;       subq    $1, %rbx
 ;;       jmp     0x1f4
-;;  24f: movq    %r14, %rdi
+;;  256: movq    %r14, %rdi
 ;;       movl    $0, %esi
-;;       callq   0x1105
+;;       callq   0x1115
 ;;       movq    8(%rsp), %r14
 ;;       movq    %r14, %rdi
 ;;       movl    $1, %esi
-;;       callq   0x10af
+;;       callq   0x10bf
 ;;       movq    8(%rsp), %r14
 ;;       pushq   %rax
 ;;       subq    $8, %rsp
 ;;       movq    %r14, %rdi
 ;;       movl    $1, %esi
-;;       callq   0x10da
+;;       callq   0x10ea
 ;;       addq    $8, %rsp
 ;;       movq    0x10(%rsp), %r14
 ;;       movq    %r14, %r11
 ;;       movq    0xd8(%r11), %rcx
 ;;       popq    %rdx
 ;;       movl    $3, %ebx
-;;       movl    $1, %edi
-;;       movl    $0xf, %r8d
-;;       movl    %ebx, %ebx
-;;       movl    %edi, %r9d
-;;       addl    %ebx, %r9d
-;;       jb      0xa37
-;;  2bd: cmpl    %edx, %r9d
-;;       ja      0xa39
-;;  2c6: movl    %r8d, %r9d
-;;       addl    %ebx, %r9d
-;;       jb      0xa3b
-;;  2d2: cmpl    %edx, %r9d
-;;       ja      0xa3d
-;;  2db: movl    %edi, %edi
-;;       imulq   $0x10, %rdi, %rdi
-;;       addq    %rdi, %rax
-;;       cmpq    $0, %rbx
-;;       je      0x344
-;;  2f1: movq    (%rax), %rax
-;;       addq    $0x10, %rax
-;;       movl    %r8d, %ecx
-;;       movq    %r14, %rdx
-;;       movq    0xd8(%rdx), %r9
-;;       cmpq    %r9, %rcx
-;;       jae     0xa3f
-;;  310: movq    %rcx, %r11
-;;       imulq   $8, %r11, %r11
-;;       movq    0xd0(%rdx), %rdx
-;;       movq    %rdx, %r10
-;;       addq    %r11, %rdx
-;;       cmpq    %r9, %rcx
-;;       cmovaeq %r10, %rdx
-;;       orq     $1, %rcx
-;;       movq    %rcx, (%rdx)
-;;       addl    $1, %r8d
-;;       jmp     0x2e7
-;;  344: movq    %r14, %rdi
 ;;       movl    $1, %esi
-;;       callq   0x1105
+;;       movl    $0xf, %edi
+;;       movl    %ebx, %ebx
+;;       movl    %esi, %r8d
+;;       addl    %ebx, %r8d
+;;       jb      0xa3d
+;;  2c3: cmpl    %edx, %r8d
+;;       ja      0xa3f
+;;  2cc: movl    %edi, %r8d
+;;       addl    %ebx, %r8d
+;;       jb      0xa41
+;;  2d8: cmpl    %ecx, %r8d
+;;       ja      0xa43
+;;  2e1: movl    %esi, %esi
+;;       imulq   $0x10, %rsi, %rsi
+;;       addq    %rsi, %rax
+;;       cmpq    $0, %rbx
+;;       je      0x34f
+;;  2f7: movq    (%rax), %rcx
+;;       addq    $0x10, %rax
+;;       movl    %edi, %edx
+;;       movq    %r14, %rsi
+;;       movq    0xd8(%rsi), %r8
+;;       cmpq    %r8, %rdx
+;;       jae     0xa45
+;;  315: movq    %rdx, %r11
+;;       imulq   $8, %r11, %r11
+;;       movq    0xd0(%rsi), %rsi
+;;       movq    %rsi, %r9
+;;       addq    %r11, %rsi
+;;       cmpq    %r8, %rdx
+;;       cmovaeq %r9, %rsi
+;;       orq     $1, %rcx
+;;       movq    %rcx, (%rsi)
+;;       addl    $1, %edi
+;;       subq    $1, %rbx
+;;       jmp     0x2ed
+;;  34f: movq    %r14, %rdi
+;;       movl    $1, %esi
+;;       callq   0x1115
 ;;       movq    8(%rsp), %r14
 ;;       movl    $5, %eax
 ;;       movl    $0xf, %ecx
@@ -254,84 +256,84 @@
 ;;       movl    %edx, %edx
 ;;       movq    %r14, %r11
 ;;       movq    0xd8(%r11), %rbx
-;;       movq    %rcx, %r8
-;;       addq    %rax, %r8
-;;       jb      0xa41
-;;  381: cmpq    %rbx, %r8
-;;       ja      0xa43
-;;  38a: movq    %r14, %r11
+;;       movq    %rcx, %rsi
+;;       addq    %rax, %rsi
+;;       jb      0xa47
+;;  38c: cmpq    %rbx, %rsi
+;;       ja      0xa49
+;;  395: movq    %r14, %r11
 ;;       movq    0xd8(%r11), %rbx
-;;       movq    %rdx, %r8
-;;       addq    %rax, %r8
-;;       jb      0xa45
-;;  3a0: cmpq    %rbx, %r8
-;;       ja      0xa47
-;;  3a9: cmpq    %rcx, %rdx
-;;       jbe     0x3d2
-;;  3b2: movq    $18446744073709551615, %rbx
+;;       movq    %rdx, %rsi
+;;       addq    %rax, %rsi
+;;       jb      0xa4b
+;;  3ab: cmpq    %rbx, %rsi
+;;       ja      0xa4d
+;;  3b4: cmpq    %rcx, %rdx
+;;       jbe     0x3dd
+;;  3bd: movq    $18446744073709551615, %rbx
 ;;       addq    %rax, %rcx
 ;;       subq    $1, %rcx
 ;;       addq    %rax, %rdx
 ;;       subq    $1, %rdx
-;;       jmp     0x3d7
-;;  3d2: movl    $1, %ebx
+;;       jmp     0x3e2
+;;  3dd: movl    $1, %ebx
 ;;       cmpq    $0, %rax
-;;       je      0x4b2
-;;  3e1: movq    %rcx, %r8
+;;       je      0x4bc
+;;  3ec: movq    %rcx, %rsi
 ;;       pushq   %rbx
 ;;       pushq   %rax
 ;;       pushq   %rdx
 ;;       pushq   %rcx
-;;       pushq   %r8
+;;       pushq   %rsi
 ;;       popq    %rcx
 ;;       movq    %r14, %rdx
 ;;       movq    0xd8(%rdx), %rbx
 ;;       cmpq    %rbx, %rcx
-;;       jae     0xa49
-;;  3fe: movq    %rcx, %r11
+;;       jae     0xa4f
+;;  408: movq    %rcx, %r11
 ;;       imulq   $8, %r11, %r11
 ;;       movq    0xd0(%rdx), %rdx
-;;       movq    %rdx, %r8
+;;       movq    %rdx, %rsi
 ;;       addq    %r11, %rdx
 ;;       cmpq    %rbx, %rcx
-;;       cmovaeq %r8, %rdx
+;;       cmovaeq %rsi, %rdx
 ;;       movq    (%rdx), %rax
 ;;       testq   %rax, %rax
-;;       jne     0x45a
-;;  428: pushq   %rcx
+;;       jne     0x464
+;;  432: pushq   %rcx
 ;;       subq    $8, %rsp
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
 ;;       movq    8(%rsp), %rdx
-;;       callq   0x1178
+;;       callq   0x1188
 ;;       addq    $8, %rsp
 ;;       addq    $8, %rsp
 ;;       movq    0x28(%rsp), %r14
-;;       jmp     0x460
-;;  45a: andq    $0xfffffffffffffffe, %rax
+;;       jmp     0x46a
+;;  464: andq    $0xfffffffffffffffe, %rax
 ;;       popq    %rcx
 ;;       popq    %rdx
 ;;       movq    %rdx, %rbx
-;;       movq    %r14, %r8
-;;       movq    0xd8(%r8), %r9
-;;       cmpq    %r9, %rbx
-;;       jae     0xa4b
-;;  478: movq    %rbx, %r11
+;;       movq    %r14, %rsi
+;;       movq    0xd8(%rsi), %rdi
+;;       cmpq    %rdi, %rbx
+;;       jae     0xa51
+;;  482: movq    %rbx, %r11
 ;;       imulq   $8, %r11, %r11
-;;       movq    0xd0(%r8), %r8
-;;       movq    %r8, %r10
-;;       addq    %r11, %r8
-;;       cmpq    %r9, %rbx
-;;       cmovaeq %r10, %r8
+;;       movq    0xd0(%rsi), %rsi
+;;       movq    %rsi, %r8
+;;       addq    %r11, %rsi
+;;       cmpq    %rdi, %rbx
+;;       cmovaeq %r8, %rsi
 ;;       orq     $1, %rax
-;;       movq    %rax, (%r8)
+;;       movq    %rax, (%rsi)
 ;;       popq    %rax
 ;;       popq    %rbx
 ;;       addq    %rbx, %rdx
 ;;       addq    %rbx, %rcx
 ;;       subq    $1, %rax
-;;       jmp     0x3d7
-;;  4b2: movl    $1, %eax
+;;       jmp     0x3e2
+;;  4bc: movl    $1, %eax
 ;;       movl    $0x1d, %ecx
 ;;       movl    $0x15, %edx
 ;;       movl    %eax, %eax
@@ -339,84 +341,84 @@
 ;;       movl    %edx, %edx
 ;;       movq    %r14, %r11
 ;;       movq    0xd8(%r11), %rbx
-;;       movq    %rcx, %r8
-;;       addq    %rax, %r8
-;;       jb      0xa4d
-;;  4dd: cmpq    %rbx, %r8
-;;       ja      0xa4f
-;;  4e6: movq    %r14, %r11
+;;       movq    %rcx, %rsi
+;;       addq    %rax, %rsi
+;;       jb      0xa53
+;;  4e7: cmpq    %rbx, %rsi
+;;       ja      0xa55
+;;  4f0: movq    %r14, %r11
 ;;       movq    0xd8(%r11), %rbx
-;;       movq    %rdx, %r8
-;;       addq    %rax, %r8
-;;       jb      0xa51
-;;  4fc: cmpq    %rbx, %r8
-;;       ja      0xa53
-;;  505: cmpq    %rcx, %rdx
-;;       jbe     0x52e
-;;  50e: movq    $18446744073709551615, %rbx
+;;       movq    %rdx, %rsi
+;;       addq    %rax, %rsi
+;;       jb      0xa57
+;;  506: cmpq    %rbx, %rsi
+;;       ja      0xa59
+;;  50f: cmpq    %rcx, %rdx
+;;       jbe     0x538
+;;  518: movq    $18446744073709551615, %rbx
 ;;       addq    %rax, %rcx
 ;;       subq    $1, %rcx
 ;;       addq    %rax, %rdx
 ;;       subq    $1, %rdx
-;;       jmp     0x533
-;;  52e: movl    $1, %ebx
+;;       jmp     0x53d
+;;  538: movl    $1, %ebx
 ;;       cmpq    $0, %rax
-;;       je      0x60e
-;;  53d: movq    %rcx, %r8
+;;       je      0x617
+;;  547: movq    %rcx, %rsi
 ;;       pushq   %rbx
 ;;       pushq   %rax
 ;;       pushq   %rdx
 ;;       pushq   %rcx
-;;       pushq   %r8
+;;       pushq   %rsi
 ;;       popq    %rcx
 ;;       movq    %r14, %rdx
 ;;       movq    0xd8(%rdx), %rbx
 ;;       cmpq    %rbx, %rcx
-;;       jae     0xa55
-;;  55a: movq    %rcx, %r11
+;;       jae     0xa5b
+;;  563: movq    %rcx, %r11
 ;;       imulq   $8, %r11, %r11
 ;;       movq    0xd0(%rdx), %rdx
-;;       movq    %rdx, %r8
+;;       movq    %rdx, %rsi
 ;;       addq    %r11, %rdx
 ;;       cmpq    %rbx, %rcx
-;;       cmovaeq %r8, %rdx
+;;       cmovaeq %rsi, %rdx
 ;;       movq    (%rdx), %rax
 ;;       testq   %rax, %rax
-;;       jne     0x5b6
-;;  584: pushq   %rcx
+;;       jne     0x5bf
+;;  58d: pushq   %rcx
 ;;       subq    $8, %rsp
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
 ;;       movq    8(%rsp), %rdx
-;;       callq   0x1178
+;;       callq   0x1188
 ;;       addq    $8, %rsp
 ;;       addq    $8, %rsp
 ;;       movq    0x28(%rsp), %r14
-;;       jmp     0x5bc
-;;  5b6: andq    $0xfffffffffffffffe, %rax
+;;       jmp     0x5c5
+;;  5bf: andq    $0xfffffffffffffffe, %rax
 ;;       popq    %rcx
 ;;       popq    %rdx
 ;;       movq    %rdx, %rbx
-;;       movq    %r14, %r8
-;;       movq    0xd8(%r8), %r9
-;;       cmpq    %r9, %rbx
-;;       jae     0xa57
-;;  5d4: movq    %rbx, %r11
+;;       movq    %r14, %rsi
+;;       movq    0xd8(%rsi), %rdi
+;;       cmpq    %rdi, %rbx
+;;       jae     0xa5d
+;;  5dd: movq    %rbx, %r11
 ;;       imulq   $8, %r11, %r11
-;;       movq    0xd0(%r8), %r8
-;;       movq    %r8, %r10
-;;       addq    %r11, %r8
-;;       cmpq    %r9, %rbx
-;;       cmovaeq %r10, %r8
+;;       movq    0xd0(%rsi), %rsi
+;;       movq    %rsi, %r8
+;;       addq    %r11, %rsi
+;;       cmpq    %rdi, %rbx
+;;       cmovaeq %r8, %rsi
 ;;       orq     $1, %rax
-;;       movq    %rax, (%r8)
+;;       movq    %rax, (%rsi)
 ;;       popq    %rax
 ;;       popq    %rbx
 ;;       addq    %rbx, %rdx
 ;;       addq    %rbx, %rcx
 ;;       subq    $1, %rax
-;;       jmp     0x533
-;;  60e: movl    $1, %eax
+;;       jmp     0x53d
+;;  617: movl    $1, %eax
 ;;       movl    $0xa, %ecx
 ;;       movl    $0x18, %edx
 ;;       movl    %eax, %eax
@@ -424,84 +426,84 @@
 ;;       movl    %edx, %edx
 ;;       movq    %r14, %r11
 ;;       movq    0xd8(%r11), %rbx
-;;       movq    %rcx, %r8
-;;       addq    %rax, %r8
-;;       jb      0xa59
-;;  639: cmpq    %rbx, %r8
-;;       ja      0xa5b
-;;  642: movq    %r14, %r11
+;;       movq    %rcx, %rsi
+;;       addq    %rax, %rsi
+;;       jb      0xa5f
+;;  642: cmpq    %rbx, %rsi
+;;       ja      0xa61
+;;  64b: movq    %r14, %r11
 ;;       movq    0xd8(%r11), %rbx
-;;       movq    %rdx, %r8
-;;       addq    %rax, %r8
-;;       jb      0xa5d
-;;  658: cmpq    %rbx, %r8
-;;       ja      0xa5f
-;;  661: cmpq    %rcx, %rdx
-;;       jbe     0x68a
-;;  66a: movq    $18446744073709551615, %rbx
+;;       movq    %rdx, %rsi
+;;       addq    %rax, %rsi
+;;       jb      0xa63
+;;  661: cmpq    %rbx, %rsi
+;;       ja      0xa65
+;;  66a: cmpq    %rcx, %rdx
+;;       jbe     0x693
+;;  673: movq    $18446744073709551615, %rbx
 ;;       addq    %rax, %rcx
 ;;       subq    $1, %rcx
 ;;       addq    %rax, %rdx
 ;;       subq    $1, %rdx
-;;       jmp     0x68f
-;;  68a: movl    $1, %ebx
+;;       jmp     0x698
+;;  693: movl    $1, %ebx
 ;;       cmpq    $0, %rax
-;;       je      0x76a
-;;  699: movq    %rcx, %r8
+;;       je      0x772
+;;  6a2: movq    %rcx, %rsi
 ;;       pushq   %rbx
 ;;       pushq   %rax
 ;;       pushq   %rdx
 ;;       pushq   %rcx
-;;       pushq   %r8
+;;       pushq   %rsi
 ;;       popq    %rcx
 ;;       movq    %r14, %rdx
 ;;       movq    0xd8(%rdx), %rbx
 ;;       cmpq    %rbx, %rcx
-;;       jae     0xa61
-;;  6b6: movq    %rcx, %r11
+;;       jae     0xa67
+;;  6be: movq    %rcx, %r11
 ;;       imulq   $8, %r11, %r11
 ;;       movq    0xd0(%rdx), %rdx
-;;       movq    %rdx, %r8
+;;       movq    %rdx, %rsi
 ;;       addq    %r11, %rdx
 ;;       cmpq    %rbx, %rcx
-;;       cmovaeq %r8, %rdx
+;;       cmovaeq %rsi, %rdx
 ;;       movq    (%rdx), %rax
 ;;       testq   %rax, %rax
-;;       jne     0x712
-;;  6e0: pushq   %rcx
+;;       jne     0x71a
+;;  6e8: pushq   %rcx
 ;;       subq    $8, %rsp
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
 ;;       movq    8(%rsp), %rdx
-;;       callq   0x1178
+;;       callq   0x1188
 ;;       addq    $8, %rsp
 ;;       addq    $8, %rsp
 ;;       movq    0x28(%rsp), %r14
-;;       jmp     0x718
-;;  712: andq    $0xfffffffffffffffe, %rax
+;;       jmp     0x720
+;;  71a: andq    $0xfffffffffffffffe, %rax
 ;;       popq    %rcx
 ;;       popq    %rdx
 ;;       movq    %rdx, %rbx
-;;       movq    %r14, %r8
-;;       movq    0xd8(%r8), %r9
-;;       cmpq    %r9, %rbx
-;;       jae     0xa63
-;;  730: movq    %rbx, %r11
+;;       movq    %r14, %rsi
+;;       movq    0xd8(%rsi), %rdi
+;;       cmpq    %rdi, %rbx
+;;       jae     0xa69
+;;  738: movq    %rbx, %r11
 ;;       imulq   $8, %r11, %r11
-;;       movq    0xd0(%r8), %r8
-;;       movq    %r8, %r10
-;;       addq    %r11, %r8
-;;       cmpq    %r9, %rbx
-;;       cmovaeq %r10, %r8
+;;       movq    0xd0(%rsi), %rsi
+;;       movq    %rsi, %r8
+;;       addq    %r11, %rsi
+;;       cmpq    %rdi, %rbx
+;;       cmovaeq %r8, %rsi
 ;;       orq     $1, %rax
-;;       movq    %rax, (%r8)
+;;       movq    %rax, (%rsi)
 ;;       popq    %rax
 ;;       popq    %rbx
 ;;       addq    %rbx, %rdx
 ;;       addq    %rbx, %rcx
 ;;       subq    $1, %rax
-;;       jmp     0x68f
-;;  76a: movl    $4, %eax
+;;       jmp     0x698
+;;  772: movl    $4, %eax
 ;;       movl    $0xb, %ecx
 ;;       movl    $0xd, %edx
 ;;       movl    %eax, %eax
@@ -509,84 +511,84 @@
 ;;       movl    %edx, %edx
 ;;       movq    %r14, %r11
 ;;       movq    0xd8(%r11), %rbx
-;;       movq    %rcx, %r8
-;;       addq    %rax, %r8
-;;       jb      0xa65
-;;  795: cmpq    %rbx, %r8
-;;       ja      0xa67
-;;  79e: movq    %r14, %r11
+;;       movq    %rcx, %rsi
+;;       addq    %rax, %rsi
+;;       jb      0xa6b
+;;  79d: cmpq    %rbx, %rsi
+;;       ja      0xa6d
+;;  7a6: movq    %r14, %r11
 ;;       movq    0xd8(%r11), %rbx
-;;       movq    %rdx, %r8
-;;       addq    %rax, %r8
-;;       jb      0xa69
-;;  7b4: cmpq    %rbx, %r8
-;;       ja      0xa6b
-;;  7bd: cmpq    %rcx, %rdx
-;;       jbe     0x7e6
-;;  7c6: movq    $18446744073709551615, %rbx
+;;       movq    %rdx, %rsi
+;;       addq    %rax, %rsi
+;;       jb      0xa6f
+;;  7bc: cmpq    %rbx, %rsi
+;;       ja      0xa71
+;;  7c5: cmpq    %rcx, %rdx
+;;       jbe     0x7ee
+;;  7ce: movq    $18446744073709551615, %rbx
 ;;       addq    %rax, %rcx
 ;;       subq    $1, %rcx
 ;;       addq    %rax, %rdx
 ;;       subq    $1, %rdx
-;;       jmp     0x7eb
-;;  7e6: movl    $1, %ebx
+;;       jmp     0x7f3
+;;  7ee: movl    $1, %ebx
 ;;       cmpq    $0, %rax
-;;       je      0x8c6
-;;  7f5: movq    %rcx, %r8
+;;       je      0x8cd
+;;  7fd: movq    %rcx, %rsi
 ;;       pushq   %rbx
 ;;       pushq   %rax
 ;;       pushq   %rdx
 ;;       pushq   %rcx
-;;       pushq   %r8
+;;       pushq   %rsi
 ;;       popq    %rcx
 ;;       movq    %r14, %rdx
 ;;       movq    0xd8(%rdx), %rbx
 ;;       cmpq    %rbx, %rcx
-;;       jae     0xa6d
-;;  812: movq    %rcx, %r11
+;;       jae     0xa73
+;;  819: movq    %rcx, %r11
 ;;       imulq   $8, %r11, %r11
 ;;       movq    0xd0(%rdx), %rdx
-;;       movq    %rdx, %r8
+;;       movq    %rdx, %rsi
 ;;       addq    %r11, %rdx
 ;;       cmpq    %rbx, %rcx
-;;       cmovaeq %r8, %rdx
+;;       cmovaeq %rsi, %rdx
 ;;       movq    (%rdx), %rax
 ;;       testq   %rax, %rax
-;;       jne     0x86e
-;;  83c: pushq   %rcx
+;;       jne     0x875
+;;  843: pushq   %rcx
 ;;       subq    $8, %rsp
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
 ;;       movq    8(%rsp), %rdx
-;;       callq   0x1178
+;;       callq   0x1188
 ;;       addq    $8, %rsp
 ;;       addq    $8, %rsp
 ;;       movq    0x28(%rsp), %r14
-;;       jmp     0x874
-;;  86e: andq    $0xfffffffffffffffe, %rax
+;;       jmp     0x87b
+;;  875: andq    $0xfffffffffffffffe, %rax
 ;;       popq    %rcx
 ;;       popq    %rdx
 ;;       movq    %rdx, %rbx
-;;       movq    %r14, %r8
-;;       movq    0xd8(%r8), %r9
-;;       cmpq    %r9, %rbx
-;;       jae     0xa6f
-;;  88c: movq    %rbx, %r11
+;;       movq    %r14, %rsi
+;;       movq    0xd8(%rsi), %rdi
+;;       cmpq    %rdi, %rbx
+;;       jae     0xa75
+;;  893: movq    %rbx, %r11
 ;;       imulq   $8, %r11, %r11
-;;       movq    0xd0(%r8), %r8
-;;       movq    %r8, %r10
-;;       addq    %r11, %r8
-;;       cmpq    %r9, %rbx
-;;       cmovaeq %r10, %r8
+;;       movq    0xd0(%rsi), %rsi
+;;       movq    %rsi, %r8
+;;       addq    %r11, %rsi
+;;       cmpq    %rdi, %rbx
+;;       cmovaeq %r8, %rsi
 ;;       orq     $1, %rax
-;;       movq    %rax, (%r8)
+;;       movq    %rax, (%rsi)
 ;;       popq    %rax
 ;;       popq    %rbx
 ;;       addq    %rbx, %rdx
 ;;       addq    %rbx, %rcx
 ;;       subq    $1, %rax
-;;       jmp     0x7eb
-;;  8c6: movl    $5, %eax
+;;       jmp     0x7f3
+;;  8cd: movl    $5, %eax
 ;;       movl    $0x14, %ecx
 ;;       movl    $0x13, %edx
 ;;       movl    %eax, %eax
@@ -594,89 +596,86 @@
 ;;       movl    %edx, %edx
 ;;       movq    %r14, %r11
 ;;       movq    0xd8(%r11), %rbx
-;;       movq    %rcx, %r8
-;;       addq    %rax, %r8
-;;       jb      0xa71
-;;  8f1: cmpq    %rbx, %r8
-;;       ja      0xa73
-;;  8fa: movq    %r14, %r11
+;;       movq    %rcx, %rsi
+;;       addq    %rax, %rsi
+;;       jb      0xa77
+;;  8f8: cmpq    %rbx, %rsi
+;;       ja      0xa79
+;;  901: movq    %r14, %r11
 ;;       movq    0xd8(%r11), %rbx
-;;       movq    %rdx, %r8
-;;       addq    %rax, %r8
-;;       jb      0xa75
-;;  910: cmpq    %rbx, %r8
-;;       ja      0xa77
-;;  919: cmpq    %rcx, %rdx
-;;       jbe     0x942
-;;  922: movq    $18446744073709551615, %rbx
+;;       movq    %rdx, %rsi
+;;       addq    %rax, %rsi
+;;       jb      0xa7b
+;;  917: cmpq    %rbx, %rsi
+;;       ja      0xa7d
+;;  920: cmpq    %rcx, %rdx
+;;       jbe     0x949
+;;  929: movq    $18446744073709551615, %rbx
 ;;       addq    %rax, %rcx
 ;;       subq    $1, %rcx
 ;;       addq    %rax, %rdx
 ;;       subq    $1, %rdx
-;;       jmp     0x947
-;;  942: movl    $1, %ebx
+;;       jmp     0x94e
+;;  949: movl    $1, %ebx
 ;;       cmpq    $0, %rax
-;;       je      0xa22
-;;  951: movq    %rcx, %r8
+;;       je      0xa28
+;;  958: movq    %rcx, %rsi
 ;;       pushq   %rbx
 ;;       pushq   %rax
 ;;       pushq   %rdx
 ;;       pushq   %rcx
-;;       pushq   %r8
+;;       pushq   %rsi
 ;;       popq    %rcx
 ;;       movq    %r14, %rdx
 ;;       movq    0xd8(%rdx), %rbx
 ;;       cmpq    %rbx, %rcx
-;;       jae     0xa79
-;;  96e: movq    %rcx, %r11
+;;       jae     0xa7f
+;;  974: movq    %rcx, %r11
 ;;       imulq   $8, %r11, %r11
 ;;       movq    0xd0(%rdx), %rdx
-;;       movq    %rdx, %r8
+;;       movq    %rdx, %rsi
 ;;       addq    %r11, %rdx
 ;;       cmpq    %rbx, %rcx
-;;       cmovaeq %r8, %rdx
+;;       cmovaeq %rsi, %rdx
 ;;       movq    (%rdx), %rax
 ;;       testq   %rax, %rax
-;;       jne     0x9ca
-;;  998: pushq   %rcx
+;;       jne     0x9d0
+;;  99e: pushq   %rcx
 ;;       subq    $8, %rsp
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
 ;;       movq    8(%rsp), %rdx
-;;       callq   0x1178
+;;       callq   0x1188
 ;;       addq    $8, %rsp
 ;;       addq    $8, %rsp
 ;;       movq    0x28(%rsp), %r14
-;;       jmp     0x9d0
-;;  9ca: andq    $0xfffffffffffffffe, %rax
+;;       jmp     0x9d6
+;;  9d0: andq    $0xfffffffffffffffe, %rax
 ;;       popq    %rcx
 ;;       popq    %rdx
 ;;       movq    %rdx, %rbx
-;;       movq    %r14, %r8
-;;       movq    0xd8(%r8), %r9
-;;       cmpq    %r9, %rbx
-;;       jae     0xa7b
-;;  9e8: movq    %rbx, %r11
+;;       movq    %r14, %rsi
+;;       movq    0xd8(%rsi), %rdi
+;;       cmpq    %rdi, %rbx
+;;       jae     0xa81
+;;  9ee: movq    %rbx, %r11
 ;;       imulq   $8, %r11, %r11
-;;       movq    0xd0(%r8), %r8
-;;       movq    %r8, %r10
-;;       addq    %r11, %r8
-;;       cmpq    %r9, %rbx
-;;       cmovaeq %r10, %r8
+;;       movq    0xd0(%rsi), %rsi
+;;       movq    %rsi, %r8
+;;       addq    %r11, %rsi
+;;       cmpq    %rdi, %rbx
+;;       cmovaeq %r8, %rsi
 ;;       orq     $1, %rax
-;;       movq    %rax, (%r8)
+;;       movq    %rax, (%rsi)
 ;;       popq    %rax
 ;;       popq    %rbx
 ;;       addq    %rbx, %rdx
 ;;       addq    %rbx, %rcx
 ;;       subq    $1, %rax
-;;       jmp     0x947
-;;  a22: addq    $0x10, %rsp
+;;       jmp     0x94e
+;;  a28: addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;  a2b: ud2
-;;  a2d: ud2
-;;  a2f: ud2
 ;;  a31: ud2
 ;;  a33: ud2
 ;;  a35: ud2
@@ -715,6 +714,9 @@
 ;;  a77: ud2
 ;;  a79: ud2
 ;;  a7b: ud2
+;;  a7d: ud2
+;;  a7f: ud2
+;;  a81: ud2
 ;;
 ;; wasm[0]::function[11]:
 ;;       pushq   %rbp
@@ -723,8 +725,8 @@
 ;;       movq    0x18(%r11), %r11
 ;;       addq    $0x30, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0xb86
-;;  a9c: movq    %rdi, %r14
+;;       ja      0xb96
+;;  aac: movq    %rdi, %r14
 ;;       subq    $0x20, %rsp
 ;;       movq    %rdi, 0x18(%rsp)
 ;;       movq    %rsi, 0x10(%rsp)
@@ -737,8 +739,8 @@
 ;;       movq    %r14, %rdx
 ;;       movq    0xd8(%rdx), %rbx
 ;;       cmpq    %rbx, %rcx
-;;       jae     0xb88
-;;  ae1: movq    %rcx, %r11
+;;       jae     0xb98
+;;  af1: movq    %rcx, %r11
 ;;       imulq   $8, %r11, %r11
 ;;       movq    0xd0(%rdx), %rdx
 ;;       movq    %rdx, %rsi
@@ -747,27 +749,27 @@
 ;;       cmovaeq %rsi, %rdx
 ;;       movq    (%rdx), %rax
 ;;       testq   %rax, %rax
-;;       jne     0xb45
-;;  b0b: subq    $4, %rsp
+;;       jne     0xb55
+;;  b1b: subq    $4, %rsp
 ;;       movl    %ecx, (%rsp)
 ;;       subq    $0xc, %rsp
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
 ;;       movl    0xc(%rsp), %edx
-;;       callq   0x1178
+;;       callq   0x1188
 ;;       addq    $0xc, %rsp
 ;;       addq    $4, %rsp
 ;;       movq    0x18(%rsp), %r14
-;;       jmp     0xb4b
-;;  b45: andq    $0xfffffffffffffffe, %rax
+;;       jmp     0xb5b
+;;  b55: andq    $0xfffffffffffffffe, %rax
 ;;       testq   %rax, %rax
-;;       je      0xb8a
-;;  b54: movq    0x28(%r14), %r11
+;;       je      0xb9a
+;;  b64: movq    0x28(%r14), %r11
 ;;       movl    (%r11), %ecx
 ;;       movl    0x10(%rax), %edx
 ;;       cmpl    %edx, %ecx
-;;       jne     0xb8c
-;;  b66: pushq   %rax
+;;       jne     0xb9c
+;;  b76: pushq   %rax
 ;;       popq    %rcx
 ;;       movq    0x18(%rcx), %rbx
 ;;       movq    8(%rcx), %rdx
@@ -778,7 +780,7 @@
 ;;       addq    $0x20, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;  b86: ud2
-;;  b88: ud2
-;;  b8a: ud2
-;;  b8c: ud2
+;;  b96: ud2
+;;  b98: ud2
+;;  b9a: ud2
+;;  b9c: ud2

--- a/tests/misc_testsuite/winch/table-init-fuzz-bug.wast
+++ b/tests/misc_testsuite/winch/table-init-fuzz-bug.wast
@@ -1,0 +1,19 @@
+;;! bulk_memory = true
+
+(module
+  (table 0 funcref)
+  (elem (i32.const 0) func)
+
+  (func (result i64)
+    (local i32)
+    i32.const 1
+    i32.const 0
+    i32.const 1
+
+    local.get 0
+    if unreachable end
+
+    table.init 0
+    unreachable
+  )
+)

--- a/winch/codegen/src/codegen/mod.rs
+++ b/winch/codegen/src/codegen/mod.rs
@@ -1916,7 +1916,7 @@ where
                 idx_size,
                 TRAP_TABLE_OUT_OF_BOUNDS,
             )?;
-            self.masm.cmp(tmp, segment_len.reg.into(), idx_size)?;
+            self.masm.cmp(tmp, table_size.reg.into(), idx_size)?;
             self.masm
                 .trapif(IntCmpKind::GtU, TRAP_TABLE_OUT_OF_BOUNDS)?;
             self.context.free_reg(table_size);
@@ -1942,7 +1942,7 @@ where
                 segment_off.reg.into(),
                 OperandSize::S64,
             )?;
-            self.context.free_reg(segment_base);
+            self.context.free_reg(segment_off);
         }
 
         // Now run `table.set` in a loop with the values read from the element
@@ -1962,10 +1962,10 @@ where
 
             // Read `*mut VMFuncRef` from `ValRaw`, and then increment the
             // `segment_base` pointer.
-            let tmp = self.context.any_gpr(self.masm)?;
+            let funcref = self.context.any_gpr(self.masm)?;
             self.masm.load_ptr(
                 self.masm.address_at_reg(segment_base.reg, 0)?,
-                writable!(tmp),
+                writable!(funcref),
             )?;
             self.masm.add(
                 writable!(segment_base.reg),
@@ -1979,19 +1979,19 @@ where
             // `table.set` and the other persists across the loop.
             self.context.stack.push(segment_base.into());
             self.context.stack.push(len.into());
-            let tmp = self.context.any_gpr(self.masm)?;
+            let table_off_copy = self.context.any_gpr(self.masm)?;
             self.masm.mov(
-                writable!(tmp),
+                writable!(table_off_copy),
                 table_off.reg.into(),
                 table_off.ty.try_into()?,
             )?;
             self.context.stack.push(table_off.into());
             self.context
                 .stack
-                .push(TypedReg::new(table_off.ty, tmp).into());
+                .push(TypedReg::new(table_off.ty, table_off_copy).into());
             self.context
                 .stack
-                .push(TypedReg::new(WasmValType::FUNCREF, tmp).into());
+                .push(TypedReg::new(WasmValType::FUNCREF, funcref).into());
             self.emit_table_set(table_index)?;
 
             // Pop loop variables into their original registers for the loop.
@@ -2005,6 +2005,15 @@ where
                 table_off.reg,
                 RegImm::i64(1),
                 table_off.ty.try_into()?,
+            )?;
+
+            // Decrement the number of remaining elements to copy, used as the
+            // loop's exit condition above.
+            self.masm.sub(
+                writable!(len.reg),
+                len.reg,
+                RegImm::i64(1),
+                OperandSize::S64,
             )?;
         }
         self.masm.jmp(header)?;


### PR DESCRIPTION
Turns out #13444 had a very buggy translation of `table.init` within Winch. This was surfaced with a compilation error in a fuzz bug but further digging revealed that there were a number of typo and copy/paste issues as well.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
