### PR TITLE
wasmtime: Use fine-grained alias regions for memory, globals, tables, vmctx, and GC heap

### DIFF
--- a/crates/cranelift/src/alias_region_key.rs
+++ b/crates/cranelift/src/alias_region_key.rs
@@ -64,9 +64,9 @@ pub(crate) enum AliasRegionKey {
     },
 
     /// A GC heap access.
-    #[cfg_attr(
-        not(any(feature = "gc-drc", feature = "gc-copying")),
-        expect(dead_code, reason = "easier not to cfg off")
+    #[allow(
+        dead_code,
+        reason = "easier not to cfg off; exact feature set is wonky in workspace"
     )]
     GcHeap,
 }

--- a/crates/cranelift/src/alias_region_key.rs
+++ b/crates/cranelift/src/alias_region_key.rs
@@ -12,7 +12,6 @@ use wasmtime_environ::{
 /// The key encodes into a single `u32` with the following layout:
 /// `[ kind: 4 bits | data: 28 bits ]`
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
-#[allow(dead_code)]
 pub(crate) enum AliasRegionKey {
     /// A `VMContext` field access.
     VMContext {
@@ -22,6 +21,10 @@ pub(crate) enum AliasRegionKey {
     },
 
     /// A `VMStoreContext` field access.
+    #[cfg_attr(
+        not(feature = "component-model"),
+        expect(dead_code, reason = "easier not to cfg off")
+    )]
     VMStoreContext {
         /// The offset of the `VMStoreContext` field being accessed.
         offset: u32,
@@ -61,6 +64,10 @@ pub(crate) enum AliasRegionKey {
     },
 
     /// A GC heap access.
+    #[cfg_attr(
+        not(any(feature = "gc-drc", feature = "gc-copying")),
+        expect(dead_code, reason = "easier not to cfg off")
+    )]
     GcHeap,
 }
 

--- a/crates/cranelift/src/alias_region_key.rs
+++ b/crates/cranelift/src/alias_region_key.rs
@@ -1,0 +1,172 @@
+use core::fmt;
+use cranelift_codegen::ir;
+use wasmtime_environ::{
+    DefinedGlobalIndex, DefinedMemoryIndex, DefinedTableIndex, StaticModuleIndex,
+};
+
+/// A key that uniquely identifies an alias region across an entire compilation.
+///
+/// This is used to assign stable `user_id`s to `AliasRegionData` entries so
+/// that alias regions can be deduplicated during inlining.
+///
+/// The key encodes into a single `u32` with the following layout:
+/// `[ kind: 4 bits | data: 28 bits ]`
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+#[allow(dead_code)]
+pub(crate) enum AliasRegionKey {
+    /// A `VMContext` field access.
+    VMContext {
+        /// The offset of the `VMContext` field being accessed (or the base
+        /// of the array for `VMContext` array fields).
+        offset: u32,
+    },
+
+    /// A `VMStoreContext` field access.
+    VMStoreContext {
+        /// The offset of the `VMStoreContext` field being accessed.
+        offset: u32,
+    },
+
+    /// An imported memory access (shared across all imported memories).
+    ImportedMemory,
+
+    /// A defined memory access.
+    DefinedMemory {
+        /// The static module index.
+        module: StaticModuleIndex,
+        /// The defined memory index within the module.
+        index: DefinedMemoryIndex,
+    },
+
+    /// An imported table access (shared across all imported tables).
+    ImportedTable,
+
+    /// A defined table access.
+    DefinedTable {
+        /// The static module index.
+        module: StaticModuleIndex,
+        /// The defined table index within the module.
+        index: DefinedTableIndex,
+    },
+
+    /// An imported global access (shared across all imported globals).
+    ImportedGlobal,
+
+    /// A defined global access.
+    DefinedGlobal {
+        /// The static module index.
+        module: StaticModuleIndex,
+        /// The defined global index within the module.
+        index: DefinedGlobalIndex,
+    },
+
+    /// A GC heap access.
+    GcHeap,
+}
+
+impl AliasRegionKey {
+    const KIND_BITS: u32 = 4;
+    const KIND_OFFSET: u32 = 32 - Self::KIND_BITS;
+    const KIND_MASK: u32 = ((1 << Self::KIND_BITS) - 1) << Self::KIND_OFFSET;
+
+    const OFFSET_MASK: u32 = !Self::KIND_MASK;
+
+    const MODULE_BITS: u32 = 8;
+    const MODULE_OFFSET: u32 = Self::KIND_OFFSET - Self::MODULE_BITS;
+    const MODULE_MASK: u32 = ((1 << Self::MODULE_BITS) - 1) << Self::MODULE_OFFSET;
+
+    const INDEX_MASK: u32 = !Self::KIND_MASK & !Self::MODULE_MASK;
+
+    const fn new_kind(kind: u32) -> u32 {
+        assert!(kind < (1 << Self::KIND_BITS));
+        kind << Self::KIND_OFFSET
+    }
+
+    const VM_CONTEXT_KIND: u32 = Self::new_kind(0b0000);
+    const VM_STORE_CONTEXT_KIND: u32 = Self::new_kind(0b0001);
+    const IMPORTED_MEMORY_KIND: u32 = Self::new_kind(0b0010);
+    const DEFINED_MEMORY_KIND: u32 = Self::new_kind(0b0011);
+    const IMPORTED_TABLE_KIND: u32 = Self::new_kind(0b0100);
+    const DEFINED_TABLE_KIND: u32 = Self::new_kind(0b0101);
+    const IMPORTED_GLOBAL_KIND: u32 = Self::new_kind(0b0110);
+    const DEFINED_GLOBAL_KIND: u32 = Self::new_kind(0b0111);
+    const GC_HEAP_KIND: u32 = Self::new_kind(0b1000);
+
+    /// Encode this key into a raw `u32` suitable for use as an
+    /// `AliasRegionData::user_id`.
+    pub(crate) fn into_raw(self) -> u32 {
+        match self {
+            AliasRegionKey::VMContext { offset } => {
+                debug_assert_eq!(offset & Self::KIND_MASK, 0);
+                Self::VM_CONTEXT_KIND | (offset & Self::OFFSET_MASK)
+            }
+            AliasRegionKey::VMStoreContext { offset } => {
+                debug_assert_eq!(offset & Self::KIND_MASK, 0);
+                Self::VM_STORE_CONTEXT_KIND | (offset & Self::OFFSET_MASK)
+            }
+            AliasRegionKey::ImportedMemory => Self::IMPORTED_MEMORY_KIND,
+            AliasRegionKey::DefinedMemory { module, index } => {
+                debug_assert_eq!(
+                    module.as_u32() & !Self::MODULE_MASK >> Self::MODULE_OFFSET,
+                    0
+                );
+                debug_assert_eq!(index.as_u32() & !Self::INDEX_MASK, 0);
+                Self::DEFINED_MEMORY_KIND
+                    | (module.as_u32() << Self::MODULE_OFFSET)
+                    | index.as_u32()
+            }
+            AliasRegionKey::ImportedTable => Self::IMPORTED_TABLE_KIND,
+            AliasRegionKey::DefinedTable { module, index } => {
+                debug_assert_eq!(
+                    module.as_u32() & !Self::MODULE_MASK >> Self::MODULE_OFFSET,
+                    0
+                );
+                debug_assert_eq!(index.as_u32() & !Self::INDEX_MASK, 0);
+                Self::DEFINED_TABLE_KIND | (module.as_u32() << Self::MODULE_OFFSET) | index.as_u32()
+            }
+            AliasRegionKey::ImportedGlobal => Self::IMPORTED_GLOBAL_KIND,
+            AliasRegionKey::DefinedGlobal { module, index } => {
+                debug_assert_eq!(
+                    module.as_u32() & !Self::MODULE_MASK >> Self::MODULE_OFFSET,
+                    0
+                );
+                debug_assert_eq!(index.as_u32() & !Self::INDEX_MASK, 0);
+                Self::DEFINED_GLOBAL_KIND
+                    | (module.as_u32() << Self::MODULE_OFFSET)
+                    | index.as_u32()
+            }
+            AliasRegionKey::GcHeap => Self::GC_HEAP_KIND,
+        }
+    }
+}
+
+impl fmt::Debug for AliasRegionKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            AliasRegionKey::VMContext { offset } => write!(f, "VMContext+{offset:#x}"),
+            AliasRegionKey::VMStoreContext { offset } => write!(f, "VMStoreContext+{offset:#x}"),
+            AliasRegionKey::ImportedMemory => write!(f, "ImportedMemory"),
+            AliasRegionKey::DefinedMemory { module, index } => {
+                write!(f, "DefinedMemory({module:?}, {index:?})")
+            }
+            AliasRegionKey::ImportedTable => write!(f, "ImportedTable"),
+            AliasRegionKey::DefinedTable { module, index } => {
+                write!(f, "DefinedTable({module:?}, {index:?})")
+            }
+            AliasRegionKey::ImportedGlobal => write!(f, "ImportedGlobal"),
+            AliasRegionKey::DefinedGlobal { module, index } => {
+                write!(f, "DefinedGlobal({module:?}, {index:?})")
+            }
+            AliasRegionKey::GcHeap => write!(f, "GcHeap"),
+        }
+    }
+}
+
+impl From<AliasRegionKey> for ir::AliasRegionData {
+    fn from(key: AliasRegionKey) -> ir::AliasRegionData {
+        ir::AliasRegionData {
+            user_id: key.into_raw(),
+            description: format!("{key:?}").into(),
+        }
+    }
+}

--- a/crates/cranelift/src/compiler/component.rs
+++ b/crates/cranelift/src/compiler/component.rs
@@ -1,5 +1,6 @@
 //! Compilation support for the component model.
 
+use crate::alias_region_key::AliasRegionKey;
 use crate::func_environ::BuiltinFunctions;
 use crate::trap::TranslateTrap;
 use crate::{TRAP_CANNOT_LEAVE_COMPONENT, TRAP_INTERNAL_ASSERT, compiler::Compiler};
@@ -1724,15 +1725,18 @@ impl ComponentCompiler for Compiler {
                 let pointer_type = self.isa.pointer_type();
 
                 // Load the `*mut VMStoreContext` out of our vmctx.
-                let vmctx_region = c
-                    .builder
-                    .func
-                    .dfg
-                    .alias_regions
-                    .insert(ir::AliasRegionData {
-                        user_id: 2,
-                        description: "vmctx".into(),
-                    });
+                let vmctx_region = c.builder.func.dfg.alias_regions.insert(
+                    AliasRegionKey::VMContext {
+                        offset: c.offsets.vm_store_context(),
+                    }
+                    .into(),
+                );
+                let store_ctx_region = c.builder.func.dfg.alias_regions.insert(
+                    AliasRegionKey::VMStoreContext {
+                        offset: u32::from(c.offsets.ptr.vmstore_context_store_data()),
+                    }
+                    .into(),
+                );
                 let store_ctx = c.builder.ins().load(
                     pointer_type,
                     ir::MemFlagsData::trusted()
@@ -1748,7 +1752,7 @@ impl ComponentCompiler for Compiler {
                     pointer_type,
                     ir::MemFlagsData::trusted()
                         .with_readonly()
-                        .with_alias_region(Some(vmctx_region))
+                        .with_alias_region(Some(store_ctx_region))
                         .with_can_move(),
                     store_ctx,
                     i32::from(c.offsets.ptr.vmstore_context_store_data()),

--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -420,8 +420,8 @@ impl<'module_environment> FuncEnvironment<'module_environment> {
     }
 
     #[cfg_attr(
-        not(feature = "gc"),
-        allow(dead_code, reason = "used in upcoming commits")
+        not(any(feature = "gc-copying", feature = "gc-drc", feature = "gc-null")),
+        expect(dead_code, reason = "easier not to cfg off; used in upcoming commits")
     )]
     pub(crate) fn vmctx_alias_region(
         &mut self,

--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -1,6 +1,7 @@
 mod gc;
 pub(crate) mod stack_switching;
 
+use crate::alias_region_key::AliasRegionKey;
 use crate::compiler::Compiler;
 use crate::translate::{
     FuncTranslationStacks, GlobalVariable, Heap, HeapData, MemoryKind, StructFieldsVec, TableData,
@@ -246,13 +247,7 @@ pub struct FuncEnvironment<'module_environment> {
     func_body_offset: usize,
 
     /// Cached alias regions for alias analysis.
-    heap_alias_region: Option<ir::AliasRegion>,
-    table_alias_region: Option<ir::AliasRegion>,
-    #[allow(
-        dead_code,
-        reason = "included for completeness, will be used in follow up commits"
-    )]
-    vmctx_alias_region: Option<ir::AliasRegion>,
+    alias_regions: std::collections::HashMap<AliasRegionKey, ir::AliasRegion>,
 }
 
 impl<'module_environment> FuncEnvironment<'module_environment> {
@@ -326,9 +321,8 @@ impl<'module_environment> FuncEnvironment<'module_environment> {
 
             branch_hints,
             func_body_offset,
-            heap_alias_region: None,
-            table_alias_region: None,
-            vmctx_alias_region: None,
+
+            alias_regions: std::collections::HashMap::new(),
         }
     }
 
@@ -369,35 +363,72 @@ impl<'module_environment> FuncEnvironment<'module_environment> {
         })
     }
 
-    pub(crate) fn get_heap_alias_region(&mut self, func: &mut Function) -> ir::AliasRegion {
-        *self.heap_alias_region.get_or_insert_with(|| {
-            func.dfg.alias_regions.insert(ir::AliasRegionData {
-                user_id: 0,
-                description: "heap".into(),
-            })
-        })
+    pub(crate) fn alias_region(
+        &mut self,
+        func: &mut Function,
+        key: AliasRegionKey,
+    ) -> ir::AliasRegion {
+        *self
+            .alias_regions
+            .entry(key)
+            .or_insert_with(|| func.dfg.alias_regions.insert(key.into()))
     }
 
-    pub(crate) fn get_table_alias_region(&mut self, func: &mut Function) -> ir::AliasRegion {
-        *self.table_alias_region.get_or_insert_with(|| {
-            func.dfg.alias_regions.insert(ir::AliasRegionData {
-                user_id: 1,
-                description: "table".into(),
-            })
-        })
+    pub(crate) fn memory_alias_region(
+        &mut self,
+        func: &mut Function,
+        memory: MemoryIndex,
+    ) -> ir::AliasRegion {
+        let key = match self.module.defined_memory_index(memory) {
+            Some(def) => AliasRegionKey::DefinedMemory {
+                module: self.translation.module_index(),
+                index: def,
+            },
+            None => AliasRegionKey::ImportedMemory,
+        };
+        self.alias_region(func, key)
     }
 
-    #[allow(
-        dead_code,
-        reason = "included for completeness, will be used in follow up commits"
+    pub(crate) fn table_alias_region(
+        &mut self,
+        func: &mut Function,
+        table: TableIndex,
+    ) -> ir::AliasRegion {
+        let key = match self.module.defined_table_index(table) {
+            Some(def) => AliasRegionKey::DefinedTable {
+                module: self.translation.module_index(),
+                index: def,
+            },
+            None => AliasRegionKey::ImportedTable,
+        };
+        self.alias_region(func, key)
+    }
+
+    pub(crate) fn global_alias_region(
+        &mut self,
+        func: &mut Function,
+        global: GlobalIndex,
+    ) -> ir::AliasRegion {
+        let key = match self.module.defined_global_index(global) {
+            Some(def) => AliasRegionKey::DefinedGlobal {
+                module: self.translation.module_index(),
+                index: def,
+            },
+            None => AliasRegionKey::ImportedGlobal,
+        };
+        self.alias_region(func, key)
+    }
+
+    #[cfg_attr(
+        not(feature = "gc"),
+        allow(dead_code, reason = "used in upcoming commits")
     )]
-    pub(crate) fn get_vmctx_alias_region(&mut self, func: &mut Function) -> ir::AliasRegion {
-        *self.vmctx_alias_region.get_or_insert_with(|| {
-            func.dfg.alias_regions.insert(ir::AliasRegionData {
-                user_id: 2,
-                description: "vmctx".into(),
-            })
-        })
+    pub(crate) fn vmctx_alias_region(
+        &mut self,
+        func: &mut Function,
+        offset: u32,
+    ) -> ir::AliasRegion {
+        self.alias_region(func, AliasRegionKey::VMContext { offset })
     }
 
     #[cfg(feature = "threads")]
@@ -970,7 +1001,8 @@ impl<'module_environment> FuncEnvironment<'module_environment> {
         // contents, we check for a null entry here, and
         // if null, we take a slow-path that invokes a
         // libcall.
-        let (table_entry_addr, flags) = table_data.prepare_table_addr(self, builder, index);
+        let (table_entry_addr, flags) =
+            table_data.prepare_table_addr(self, builder, index, table_index);
         let value = builder.ins().load(pointer_type, flags, table_entry_addr, 0);
 
         if !self.tunables.table_lazy_init {
@@ -2635,7 +2667,7 @@ impl FuncEnvironment<'_> {
         match heap_ty.top() {
             // GC-managed types.
             WasmHeapTopType::Any | WasmHeapTopType::Extern | WasmHeapTopType::Exn => {
-                let (src, flags) = table_data.prepare_table_addr(self, builder, index);
+                let (src, flags) = table_data.prepare_table_addr(self, builder, index, table_index);
                 gc::gc_compiler(self)?.translate_read_gc_reference(
                     self,
                     builder,
@@ -2650,7 +2682,8 @@ impl FuncEnvironment<'_> {
 
             // Continuation types.
             WasmHeapTopType::Cont => {
-                let (elem_addr, flags) = table_data.prepare_table_addr(self, builder, index);
+                let (elem_addr, flags) =
+                    table_data.prepare_table_addr(self, builder, index, table_index);
                 Ok(builder.ins().load(
                     stack_switching::fatpointer::fatpointer_type(self),
                     flags,
@@ -2669,7 +2702,7 @@ impl FuncEnvironment<'_> {
         index: ir::Value,
     ) -> WasmResult<()> {
         let table_data = self.get_or_create_table(builder.func, table_index);
-        let (dst, flags) = table_data.prepare_table_addr(self, builder, index);
+        let (dst, flags) = table_data.prepare_table_addr(self, builder, index, table_index);
         self.emit_table_set(builder, table_index, dst, flags, value, true)
     }
 
@@ -3201,8 +3234,7 @@ impl FuncEnvironment<'_> {
                 if ty.is_vector() {
                     flags.set_endianness(ir::Endianness::Little);
                 }
-                // Put globals in the "table" abstract heap category as well.
-                let region = self.get_table_alias_region(builder.func);
+                let region = self.global_alias_region(builder.func, global_index);
                 flags.set_alias_region(Some(region));
                 Ok(builder.ins().load(ty, flags, addr, offset))
             }
@@ -3265,8 +3297,7 @@ impl FuncEnvironment<'_> {
                 if ty.is_vector() {
                     flags.set_endianness(ir::Endianness::Little);
                 }
-                // Put globals in the "table" abstract heap category as well.
-                let region = self.get_table_alias_region(builder.func);
+                let region = self.global_alias_region(builder.func, global_index);
                 flags.set_alias_region(Some(region));
                 debug_assert_eq!(ty, builder.func.dfg.value_type(val));
                 builder.ins().store(flags, val, addr, offset);

--- a/crates/cranelift/src/func_environ/gc/enabled.rs
+++ b/crates/cranelift/src/func_environ/gc/enabled.rs
@@ -1,5 +1,6 @@
 use super::GcCompiler;
 use crate::TRAP_ARRAY_OUT_OF_BOUNDS;
+use crate::alias_region_key::AliasRegionKey;
 use crate::bounds_checks::BoundsCheck;
 use crate::func_environ::{CheckedEntity, Extension, FuncEnvironment};
 use crate::translate::{Heap, HeapData, MemoryKind, StructFieldsVec, TargetEnvironment};
@@ -27,15 +28,6 @@ mod null;
 
 #[cfg(feature = "gc-copying")]
 mod copying;
-
-/// Flags to use for general-purpose GC loads/stores.
-///
-/// This is used for accesses to the GC heap which aren't expected to trap, but
-/// retain internal assertion metadata to report if such a trap happens. This
-/// is here to ensure that in the face of heap corruption that there's no
-/// possible UB within Cranelift and/or the runtime.
-const GC_MEMFLAGS: ir::MemFlagsData =
-    ir::MemFlagsData::new().with_trap_code(Some(crate::TRAP_GC_HEAP_CORRUPT));
 
 /// Get the default GC compiler.
 pub fn gc_compiler(func_env: &mut FuncEnvironment<'_>) -> WasmResult<Box<dyn GcCompiler>> {
@@ -172,9 +164,8 @@ fn emit_gc_kind_assert(
             object_size: wasmtime_environ::VM_GC_HEADER_SIZE,
         },
     );
-    let kind_and_reserved_bits = builder
-        .ins()
-        .load(ir::types::I32, GC_MEMFLAGS, kind_addr, 0);
+    let flags = func_env.gc_memflags(&mut builder.func).with_readonly();
+    let kind_and_reserved_bits = builder.ins().load(ir::types::I32, flags, kind_addr, 0);
     let kind_mask = builder
         .ins()
         .iconst(ir::types::I32, i64::from(VMGcKind::MASK));
@@ -210,7 +201,9 @@ pub fn read_field_at_addr(
     );
 
     // Data inside GC objects is always little endian.
-    let flags = GC_MEMFLAGS.with_endianness(ir::Endianness::Little);
+    let flags = func_env
+        .gc_memflags(&mut builder.func)
+        .with_endianness(ir::Endianness::Little);
 
     let value = match ty {
         WasmStorageType::I8 => builder.ins().load(ir::types::I8, flags, addr, 0),
@@ -350,7 +343,9 @@ pub fn write_field_at_addr(
     new_val: ir::Value,
 ) -> WasmResult<()> {
     // Data inside GC objects is always little endian.
-    let flags = GC_MEMFLAGS.with_endianness(ir::Endianness::Little);
+    let flags = func_env
+        .gc_memflags(&mut builder.func)
+        .with_endianness(ir::Endianness::Little);
 
     match field_ty {
         WasmStorageType::I8 => {
@@ -754,9 +749,8 @@ pub fn translate_array_len(
             access_size: u8::try_from(ir::types::I32.bytes()).unwrap(),
         },
     );
-    let result = builder
-        .ins()
-        .load(ir::types::I32, GC_MEMFLAGS.with_readonly(), len_field, 0);
+    let flags = func_env.gc_memflags(&mut builder.func).with_readonly();
+    let result = builder.ins().load(ir::types::I32, flags, len_field, 0);
     log::trace!("translate_array_len(..) -> {result:?}");
     Ok(result)
 }
@@ -1067,10 +1061,11 @@ pub fn translate_ref_test(
                 object_size: wasmtime_environ::VM_GC_HEADER_SIZE,
             },
         );
+        let gc_memflags = func_env.gc_memflags(&mut builder.func);
         let actual_kind =
             builder
                 .ins()
-                .load(ir::types::I32, GC_MEMFLAGS.with_readonly(), kind_addr, 0);
+                .load(ir::types::I32, gc_memflags.with_readonly(), kind_addr, 0);
         let expected_kind = builder
             .ins()
             .iconst(ir::types::I32, i64::from(expected_kind.as_u32()));
@@ -1122,10 +1117,11 @@ pub fn translate_ref_test(
                     access_size: func_env.offsets.size_of_vmshared_type_index(),
                 },
             );
+            let gc_memflags = func_env.gc_memflags(&mut builder.func);
             let actual_shared_ty =
                 builder
                     .ins()
-                    .load(ir::types::I32, GC_MEMFLAGS.with_readonly(), ty_addr, 0);
+                    .load(ir::types::I32, gc_memflags.with_readonly(), ty_addr, 0);
 
             func_env.is_subtype(builder, actual_shared_ty, expected_shared_ty)
         }
@@ -1138,9 +1134,10 @@ pub fn translate_ref_test(
             let expected_shared_ty =
                 func_env.module_interned_to_shared_ty(&mut builder.cursor(), expected_interned_ty);
 
+            let gc_memflags = func_env.gc_memflags(&mut builder.func);
             let actual_shared_ty = func_env.load_funcref_type_index(
                 &mut builder.cursor(),
-                GC_MEMFLAGS.with_readonly(),
+                gc_memflags.with_readonly(),
                 val,
             );
 
@@ -1268,6 +1265,23 @@ fn initialize_struct_fields(
 }
 
 impl FuncEnvironment<'_> {
+    pub(crate) fn gc_heap_alias_region(&mut self, func: &mut ir::Function) -> ir::AliasRegion {
+        self.alias_region(func, AliasRegionKey::GcHeap)
+    }
+
+    /// Flags to use for general-purpose GC loads/stores.
+    ///
+    /// This is used for accesses to the GC heap which aren't expected to trap, but
+    /// retain internal assertion metadata to report if such a trap happens. This
+    /// is here to ensure that in the face of heap corruption that there's no
+    /// possible UB within Cranelift and/or the runtime.
+    fn gc_memflags(&mut self, func: &mut ir::Function) -> ir::MemFlagsData {
+        let region = self.gc_heap_alias_region(func);
+        ir::MemFlagsData::new()
+            .with_trap_code(Some(crate::TRAP_GC_HEAP_CORRUPT))
+            .with_alias_region(Some(region))
+    }
+
     fn gc_layout(&mut self, type_index: ModuleInternedTypeIndex) -> &GcLayout {
         // Lazily compute and cache the layout.
         if !self.ty_to_gc_layout.contains_key(&type_index) {

--- a/crates/cranelift/src/func_environ/gc/enabled/copying.rs
+++ b/crates/cranelift/src/func_environ/gc/enabled/copying.rs
@@ -154,7 +154,8 @@ impl CopyingCompiler {
 
             // Update the bump pointer.
             let end_of_object = builder.ins().ireduce(ir::types::I32, end_64);
-            let vmctx_region = func_env.get_vmctx_alias_region(&mut builder.func);
+            let gc_heap_data_offset = u32::from(func_env.offsets.ptr.vmctx_gc_heap_data());
+            let vmctx_region = func_env.vmctx_alias_region(&mut builder.func, gc_heap_data_offset);
             builder.ins().store(
                 ir::MemFlagsData::trusted().with_alias_region(Some(vmctx_region)),
                 end_of_object,
@@ -248,7 +249,8 @@ impl GcCompiler for CopyingCompiler {
             reserved_bits,
         )?;
         let len_addr = builder.ins().iadd_imm(object_addr, i64::from(len_offset));
-        builder.ins().store(GC_MEMFLAGS, len, len_addr, 0);
+        let flags = func_env.gc_memflags(&mut builder.func);
+        builder.ins().store(flags, len, len_addr, 0);
 
         Ok(array_ref)
     }
@@ -422,7 +424,9 @@ impl GcCompiler for CopyingCompiler {
         val: ir::Value,
     ) -> WasmResult<()> {
         // Data inside GC objects is always little endian.
-        let flags = GC_MEMFLAGS.with_endianness(ir::Endianness::Little);
+        let flags = func_env
+            .gc_memflags(&mut builder.func)
+            .with_endianness(ir::Endianness::Little);
 
         match ty {
             WasmStorageType::Val(WasmValType::Ref(r)) => match r.heap_type.top() {

--- a/crates/cranelift/src/func_environ/gc/enabled/drc.rs
+++ b/crates/cranelift/src/func_environ/gc/enabled/drc.rs
@@ -31,13 +31,18 @@ impl DrcCompiler {
         builder: &mut FunctionBuilder,
     ) -> ir::Value {
         let ptr_ty = func_env.pointer_type();
+        let gc_heap_data_offset = u32::from(func_env.offsets.ptr.vmctx_gc_heap_data());
+        let vmctx_region = func_env.vmctx_alias_region(&mut builder.func, gc_heap_data_offset);
         let vmctx = func_env.vmctx(&mut builder.func);
         let vmctx = builder.ins().global_value(ptr_ty, vmctx);
         builder.ins().load(
             ptr_ty,
-            ir::MemFlagsData::trusted().with_readonly().with_can_move(),
+            ir::MemFlagsData::trusted()
+                .with_readonly()
+                .with_can_move()
+                .with_alias_region(Some(vmctx_region)),
             vmctx,
-            i32::from(func_env.offsets.ptr.vmctx_gc_heap_data()),
+            i32::try_from(gc_heap_data_offset).unwrap(),
         )
     }
 
@@ -59,7 +64,8 @@ impl DrcCompiler {
                 access_size: u8::try_from(ir::types::I64.bytes()).unwrap(),
             },
         );
-        builder.ins().load(ir::types::I64, GC_MEMFLAGS, pointer, 0)
+        let flags = func_env.gc_memflags(&mut builder.func);
+        builder.ins().load(ir::types::I64, flags, pointer, 0)
     }
 
     /// Generate code to update the given GC reference's ref count to the new
@@ -82,7 +88,8 @@ impl DrcCompiler {
                 access_size: u8::try_from(ir::types::I64.bytes()).unwrap(),
             },
         );
-        builder.ins().store(GC_MEMFLAGS, new_ref_count, pointer, 0);
+        let flags = func_env.gc_memflags(&mut builder.func);
+        builder.ins().store(flags, new_ref_count, pointer, 0);
     }
 
     /// Generate code to increment or decrement the given GC reference's ref
@@ -122,9 +129,11 @@ impl DrcCompiler {
 
         let head = self.load_over_approximated_stack_roots_head(func_env, builder);
 
+        let flags = func_env.gc_memflags(&mut builder.func);
+
         // Load the current first list element, which will be our new next list
         // element.
-        let next = builder.ins().load(ir::types::I32, GC_MEMFLAGS, head, 0);
+        let next = builder.ins().load(ir::types::I32, flags, head, 0);
 
         // Update our object's header to point to `next` and consider itself part of the list.
         self.set_next_over_approximated_stack_root(func_env, builder, gc_ref, next);
@@ -134,7 +143,7 @@ impl DrcCompiler {
         self.mutate_ref_count(func_env, builder, gc_ref, 1);
 
         // Commit this object as the new head of the list.
-        builder.ins().store(GC_MEMFLAGS, gc_ref, head, 0);
+        builder.ins().store(flags, gc_ref, head, 0);
 
         // Increment the list's length.
         //
@@ -292,7 +301,8 @@ impl DrcCompiler {
                 access_size: u8::try_from(ir::types::I32.bytes()).unwrap(),
             },
         );
-        builder.ins().store(GC_MEMFLAGS, next, ptr, 0);
+        let flags = func_env.gc_memflags(&mut builder.func);
+        builder.ins().store(flags, next, ptr, 0);
     }
 
     /// Set the in-over-approximated-stack-roots list bit in a `VMDrcHeader`'s
@@ -328,7 +338,8 @@ impl DrcCompiler {
                 access_size: u8::try_from(ir::types::I32.bytes()).unwrap(),
             },
         );
-        builder.ins().store(GC_MEMFLAGS, new_reserved, ptr, 0);
+        let flags = func_env.gc_memflags(&mut builder.func);
+        builder.ins().store(flags, new_reserved, ptr, 0);
     }
 }
 
@@ -380,7 +391,8 @@ impl GcCompiler for DrcCompiler {
             uextend_i32_to_pointer_type(builder, func_env.pointer_type(), array_ref);
         let object_addr = builder.ins().iadd(base, extended_array_ref);
         let len_addr = builder.ins().iadd_imm(object_addr, i64::from(len_offset));
-        builder.ins().store(GC_MEMFLAGS, len, len_addr, 0);
+        let flags = func_env.gc_memflags(&mut builder.func);
+        builder.ins().store(flags, len, len_addr, 0);
         Ok(array_ref)
     }
 
@@ -629,7 +641,8 @@ impl GcCompiler for DrcCompiler {
                 access_size: u8::try_from(ir::types::I32.bytes()).unwrap(),
             },
         );
-        let reserved = builder.ins().load(ir::types::I32, GC_MEMFLAGS, ptr, 0);
+        let flags = func_env.gc_memflags(&mut builder.func);
+        let reserved = builder.ins().load(ir::types::I32, flags, ptr, 0);
         let in_set_bit = builder.ins().iconst(
             ir::types::I32,
             i64::from(wasmtime_environ::drc::HEADER_IN_OVER_APPROX_LIST_BIT),
@@ -972,7 +985,9 @@ impl GcCompiler for DrcCompiler {
             && r.is_vmgcref_type_and_not_i31()
         {
             // Data inside GC objects is always little endian.
-            let flags = GC_MEMFLAGS.with_endianness(ir::Endianness::Little);
+            let flags = func_env
+                .gc_memflags(&mut builder.func)
+                .with_endianness(ir::Endianness::Little);
             return self.translate_init_gc_reference(func_env, builder, r, field_addr, val, flags);
         }
 

--- a/crates/cranelift/src/func_environ/gc/enabled/null.rs
+++ b/crates/cranelift/src/func_environ/gc/enabled/null.rs
@@ -70,16 +70,19 @@ impl NullCompiler {
         // Load the bump "pointer" (it is actually an index into the GC heap,
         // not a raw pointer).
         let pointer_type = func_env.pointer_type();
+        let gc_heap_data_offset = u32::from(func_env.offsets.ptr.vmctx_gc_heap_data());
+        let vmctx_region = func_env.vmctx_alias_region(&mut builder.func, gc_heap_data_offset);
         let vmctx = func_env.vmctx_val(&mut builder.cursor());
         let ptr_to_next = builder.ins().load(
             pointer_type,
-            ir::MemFlagsData::trusted().with_readonly(),
+            ir::MemFlagsData::trusted()
+                .with_readonly()
+                .with_alias_region(Some(vmctx_region)),
             vmctx,
-            i32::from(func_env.offsets.ptr.vmctx_gc_heap_data()),
+            i32::try_from(gc_heap_data_offset).unwrap(),
         );
-        let next = builder
-            .ins()
-            .load(ir::types::I32, GC_MEMFLAGS, ptr_to_next, 0);
+        let flags = func_env.gc_memflags(&mut builder.func);
+        let next = builder.ins().load(ir::types::I32, flags, ptr_to_next, 0);
 
         // Increment the bump "pointer" to the requested alignment:
         //
@@ -156,21 +159,20 @@ impl NullCompiler {
                 i64::from(VMSharedTypeIndex::reserved_value().as_bits()),
             ),
         };
+        let flags = func_env.gc_memflags(&mut builder.func);
         builder.ins().store(
-            GC_MEMFLAGS,
+            flags,
             kind_and_size,
             ptr_to_object,
             i32::try_from(wasmtime_environ::VM_GC_HEADER_KIND_OFFSET).unwrap(),
         );
         builder.ins().store(
-            GC_MEMFLAGS,
+            flags,
             ty,
             ptr_to_object,
             i32::try_from(wasmtime_environ::VM_GC_HEADER_TYPE_INDEX_OFFSET).unwrap(),
         );
-        builder
-            .ins()
-            .store(GC_MEMFLAGS, end_of_object, ptr_to_next, 0);
+        builder.ins().store(flags, end_of_object, ptr_to_next, 0);
 
         log::trace!("emit_inline_alloc(..) -> ({aligned}, {ptr_to_object})");
         Ok((aligned, ptr_to_object))
@@ -222,7 +224,8 @@ impl GcCompiler for NullCompiler {
         // the result of the inline allocation is trusted and we aren't reading
         // any pointers or offsets out from the (untrusted) GC heap.
         let len_addr = builder.ins().iadd_imm(ptr_to_object, i64::from(len_offset));
-        builder.ins().store(GC_MEMFLAGS, len, len_addr, 0);
+        let flags = func_env.gc_memflags(&mut builder.func);
+        builder.ins().store(flags, len, len_addr, 0);
 
         Ok(gc_ref)
     }

--- a/crates/cranelift/src/lib.rs
+++ b/crates/cranelift/src/lib.rs
@@ -37,6 +37,7 @@ pub use obj::*;
 mod compiled_function;
 pub use compiled_function::*;
 
+mod alias_region_key;
 mod bounds_checks;
 mod builder;
 mod compiler;

--- a/crates/cranelift/src/translate/code_translator.rs
+++ b/crates/cranelift/src/translate/code_translator.rs
@@ -3666,11 +3666,11 @@ fn prepare_addr(
     let mut flags = MemFlagsData::new();
     flags.set_endianness(ir::Endianness::Little);
 
-    // The access occurs to the `heap` disjoint category of abstract
+    // The access occurs to a per-memory disjoint category of abstract
     // state. This may allow alias analysis to merge redundant loads,
     // etc. when heap accesses occur interleaved with other (table,
     // vmctx, stack) accesses.
-    let region = environ.get_heap_alias_region(builder.func);
+    let region = environ.memory_alias_region(builder.func, memory_index);
     flags.set_alias_region(Some(region));
 
     Ok(Reachability::Reachable((flags, index, addr)))

--- a/crates/cranelift/src/translate/table.rs
+++ b/crates/cranelift/src/translate/table.rs
@@ -4,6 +4,7 @@ use cranelift_codegen::cursor::FuncCursor;
 use cranelift_codegen::ir::{self, InstBuilder, condcodes::IntCC, immediates::Imm64};
 use cranelift_codegen::isa::TargetIsa;
 use cranelift_frontend::FunctionBuilder;
+use wasmtime_environ::TableIndex;
 
 /// Size of a WebAssembly table, in elements.
 #[derive(Clone)]
@@ -63,6 +64,7 @@ impl TableData {
         env: &mut FuncEnvironment<'_>,
         pos: &mut FunctionBuilder,
         mut index: ir::Value,
+        table_index: TableIndex,
     ) -> (ir::Value, ir::MemFlagsData) {
         let index_ty = pos.func.dfg.value_type(index);
         let addr_ty = env.pointer_type();
@@ -104,7 +106,7 @@ impl TableData {
 
         let element_addr = pos.ins().iadd(base, offset);
 
-        let region = env.get_table_alias_region(pos.func);
+        let region = env.table_alias_region(pos.func, table_index);
         let base_flags = ir::MemFlagsData::new()
             .with_aligned()
             .with_alias_region(Some(region));

--- a/tests/disas/alias-region-globals.wat
+++ b/tests/disas/alias-region-globals.wat
@@ -1,0 +1,35 @@
+;;! target = "x86_64"
+;;! test = "optimize"
+
+(module
+  (import "env" "g" (global $imported (mut i32)))
+  (global $defined (mut i32) (i32.const 0))
+
+  (func (export "test") (param i32) (result i32)
+    ;; Set imported global
+    (global.set $imported (local.get 0))
+    ;; Set defined global
+    (global.set $defined (local.get 0))
+    ;; Get imported global (should alias with first set)
+    (global.get $imported)
+  )
+)
+;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
+;;     region0 = 1610612736 "ImportedGlobal"
+;;     region1 = 1879048192 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(0))"
+;;     gv0 = vmctx
+;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv3 = vmctx
+;;     gv4 = load.i64 notrap aligned readonly can_move gv3+48
+;;     stack_limit = gv2
+;;
+;;                                 block0(v0: i64, v1: i64, v2: i32):
+;; @0039                               v4 = load.i64 notrap aligned readonly can_move v0+48
+;; @0039                               store notrap aligned region0 v2, v4
+;; @003d                               store notrap aligned region1 v2, v0+80
+;; @0041                               jump block1
+;;
+;;                                 block1:
+;; @0041                               return v2
+;; }

--- a/tests/disas/alias-region-memories.wat
+++ b/tests/disas/alias-region-memories.wat
@@ -1,0 +1,44 @@
+;;! target = "x86_64"
+;;! test = "optimize"
+
+(module
+  (import "env" "mem" (memory $imported 1))
+  (memory $defined 1)
+
+  (func (export "test") (param i32 i32) (result i32)
+    ;; Store to imported memory
+    (i32.store $imported (local.get 0) (local.get 1))
+    ;; Store to defined memory
+    (i32.store $defined (local.get 0) (local.get 1))
+    ;; Load from imported memory (should alias with first store)
+    (i32.load $imported (local.get 0))
+  )
+)
+;; function u0:0(i64 vmctx, i64, i32, i32) -> i32 tail {
+;;     region0 = 536870912 "ImportedMemory"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     gv0 = vmctx
+;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv3 = vmctx
+;;     gv4 = load.i64 notrap aligned readonly can_move gv3+48
+;;     gv5 = load.i64 notrap aligned gv4+8
+;;     gv6 = load.i64 notrap aligned readonly can_move gv4
+;;     gv7 = load.i64 notrap aligned gv3+88
+;;     gv8 = load.i64 notrap aligned readonly can_move gv3+80
+;;     stack_limit = gv2
+;;
+;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
+;; @003b                               v18 = load.i64 notrap aligned readonly can_move v0+48
+;; @003b                               v6 = load.i64 notrap aligned readonly can_move v18
+;; @003b                               v5 = uextend.i64 v2
+;; @003b                               v7 = iadd v6, v5
+;; @003b                               store little region0 v3, v7
+;; @0042                               v9 = load.i64 notrap aligned readonly can_move v0+80
+;; @0042                               v10 = iadd v9, v5
+;; @0042                               store little region1 v3, v10
+;; @004b                               jump block1
+;;
+;;                                 block1:
+;; @004b                               return v3
+;; }

--- a/tests/disas/alias-region-tables.wat
+++ b/tests/disas/alias-region-tables.wat
@@ -1,0 +1,79 @@
+;;! target = "x86_64"
+;;! test = "optimize"
+
+(module
+  (type $ft (func (result i32)))
+  (import "env" "table" (table $imported 10 funcref))
+  (table $defined 10 funcref)
+
+  (func (export "test") (param i32 funcref) (result i32)
+    ;; Set in imported table
+    (table.set $imported (local.get 0) (local.get 1))
+    ;; Set in defined table
+    (table.set $defined (local.get 0) (local.get 1))
+    ;; Indirect call through imported table
+    (call_indirect $imported (type $ft) (local.get 0))
+  )
+)
+;; function u0:0(i64 vmctx, i64, i32, i64) -> i32 tail {
+;;     region0 = 1073741824 "ImportedTable"
+;;     region1 = 1342177280 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
+;;     gv0 = vmctx
+;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv3 = vmctx
+;;     gv4 = load.i64 notrap aligned readonly can_move gv3+48
+;;     gv5 = load.i64 notrap aligned gv4
+;;     gv6 = load.i64 notrap aligned gv4+8
+;;     gv7 = load.i64 notrap aligned gv3+72
+;;     gv8 = load.i64 notrap aligned gv3+80
+;;     sig0 = (i64 vmctx, i64) -> i32 tail
+;;     sig1 = (i64 vmctx, i32, i64) -> i64 tail
+;;     fn0 = colocated u805306368:7 sig1
+;;     stack_limit = gv2
+;;
+;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i64):
+;; @0043                               v63 = load.i64 notrap aligned readonly can_move v0+48
+;; @0043                               v5 = load.i64 notrap aligned v63+8
+;; @0043                               v9 = load.i64 notrap aligned v63
+;;                                     v59 = iconst.i64 1
+;; @0043                               v14 = bor v3, v59  ; v59 = 1
+;; @0043                               v6 = ireduce.i32 v5
+;; @0043                               v7 = icmp uge v2, v6
+;; @0043                               v12 = iconst.i64 0
+;; @0043                               v8 = uextend.i64 v2
+;;                                     v60 = iconst.i64 3
+;; @0043                               v10 = ishl v8, v60  ; v60 = 3
+;; @0043                               v11 = iadd v9, v10
+;; @0043                               v13 = select_spectre_guard v7, v12, v11  ; v12 = 0
+;; @0043                               store user6 aligned region0 v14, v13
+;; @0049                               v15 = load.i64 notrap aligned v0+80
+;; @0049                               v19 = load.i64 notrap aligned v0+72
+;; @0049                               v16 = ireduce.i32 v15
+;; @0049                               v17 = icmp uge v2, v16
+;; @0049                               v21 = iadd v19, v10
+;; @0049                               v23 = select_spectre_guard v17, v12, v21  ; v12 = 0
+;; @0049                               store user6 aligned region1 v14, v23
+;;                                     v49 = iconst.i64 -2
+;; @004d                               v35 = band v14, v49  ; v49 = -2
+;; @004d                               brif v14, block3(v35), block2
+;;
+;;                                 block2 cold:
+;; @004d                               v37 = iconst.i32 0
+;; @004d                               v40 = call fn0(v0, v37, v8)  ; v37 = 0
+;; @004d                               jump block3(v40)
+;;
+;;                                 block3(v36: i64):
+;; @004d                               v44 = load.i32 user7 aligned readonly v36+16
+;; @004d                               v42 = load.i64 notrap aligned readonly can_move v0+40
+;; @004d                               v43 = load.i32 notrap aligned readonly can_move v42
+;; @004d                               v45 = icmp eq v44, v43
+;; @004d                               trapz v45, user8
+;; @004d                               v46 = load.i64 notrap aligned readonly v36+8
+;; @004d                               v47 = load.i64 notrap aligned readonly v36+24
+;; @004d                               v48 = call_indirect sig0, v46(v47, v0)
+;; @0050                               jump block1
+;;
+;;                                 block1:
+;; @0050                               return v48
+;; }

--- a/tests/disas/array-copy-anyref.wat
+++ b/tests/disas/array-copy-anyref.wat
@@ -10,6 +10,7 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32, i32, i32, i32) tail {
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -27,7 +28,7 @@
 ;; @002b                               v9 = iadd v8, v7
 ;; @002b                               v10 = iconst.i64 16
 ;; @002b                               v11 = iadd v9, v10  ; v10 = 16
-;; @002b                               v12 = load.i32 user2 readonly v11
+;; @002b                               v12 = load.i32 user2 readonly region0 v11
 ;; @002b                               v14 = uextend.i64 v3
 ;; @002b                               v15 = uextend.i64 v6
 ;; @002b                               v17 = iadd v14, v15
@@ -38,7 +39,7 @@
 ;; @002b                               v26 = uextend.i64 v4
 ;; @002b                               v28 = iadd v8, v26
 ;; @002b                               v30 = iadd v28, v10  ; v10 = 16
-;; @002b                               v31 = load.i32 user2 readonly v30
+;; @002b                               v31 = load.i32 user2 readonly region0 v30
 ;; @002b                               v33 = uextend.i64 v5
 ;; @002b                               v36 = iadd v33, v15
 ;; @002b                               v32 = uextend.i64 v31
@@ -73,8 +74,8 @@
 ;; @002b                               brif v58, block3(v25, v44, v5), block4(v61, v62, v64)
 ;;
 ;;                                 block3(v65: i64, v66: i64, v67: i32):
-;; @002b                               v70 = load.i32 user2 little v66
-;; @002b                               store user2 little v70, v65
+;; @002b                               v70 = load.i32 user2 little region0 v66
+;; @002b                               store user2 little region0 v70, v65
 ;;                                     v131 = iconst.i64 4
 ;;                                     v132 = iadd v66, v131  ; v131 = 4
 ;; @002b                               v74 = icmp eq v132, v62
@@ -86,9 +87,9 @@
 ;;                                 block4(v75: i64, v76: i64, v77: i32):
 ;;                                     v126 = iconst.i64 4
 ;;                                     v127 = isub v76, v126  ; v126 = 4
-;; @002b                               v86 = load.i32 user2 little v127
+;; @002b                               v86 = load.i32 user2 little region0 v127
 ;;                                     v128 = isub v75, v126  ; v126 = 4
-;; @002b                               store user2 little v86, v128
+;; @002b                               store user2 little region0 v86, v128
 ;; @002b                               v87 = icmp eq v127, v44
 ;;                                     v129 = iconst.i32 1
 ;;                                     v130 = isub v77, v129  ; v129 = 1

--- a/tests/disas/array-copy-i64.wat
+++ b/tests/disas/array-copy-i64.wat
@@ -10,6 +10,7 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32, i32, i32, i32) tail {
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -29,7 +30,7 @@
 ;; @002b                               v9 = iadd v8, v7
 ;; @002b                               v10 = iconst.i64 16
 ;; @002b                               v11 = iadd v9, v10  ; v10 = 16
-;; @002b                               v12 = load.i32 user2 readonly v11
+;; @002b                               v12 = load.i32 user2 readonly region0 v11
 ;; @002b                               v14 = uextend.i64 v3
 ;; @002b                               v15 = uextend.i64 v6
 ;; @002b                               v17 = iadd v14, v15
@@ -40,7 +41,7 @@
 ;; @002b                               v26 = uextend.i64 v4
 ;; @002b                               v28 = iadd v8, v26
 ;; @002b                               v30 = iadd v28, v10  ; v10 = 16
-;; @002b                               v31 = load.i32 user2 readonly v30
+;; @002b                               v31 = load.i32 user2 readonly region0 v30
 ;; @002b                               v33 = uextend.i64 v5
 ;; @002b                               v36 = iadd v33, v15
 ;; @002b                               v32 = uextend.i64 v31

--- a/tests/disas/array-copy-i8.wat
+++ b/tests/disas/array-copy-i8.wat
@@ -10,6 +10,7 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32, i32, i32, i32) tail {
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -29,7 +30,7 @@
 ;; @002b                               v9 = iadd v8, v7
 ;; @002b                               v10 = iconst.i64 16
 ;; @002b                               v11 = iadd v9, v10  ; v10 = 16
-;; @002b                               v12 = load.i32 user2 readonly v11
+;; @002b                               v12 = load.i32 user2 readonly region0 v11
 ;; @002b                               v14 = uextend.i64 v3
 ;; @002b                               v15 = uextend.i64 v6
 ;; @002b                               v17 = iadd v14, v15
@@ -40,7 +41,7 @@
 ;; @002b                               v26 = uextend.i64 v4
 ;; @002b                               v28 = iadd v8, v26
 ;; @002b                               v30 = iadd v28, v10  ; v10 = 16
-;; @002b                               v31 = load.i32 user2 readonly v30
+;; @002b                               v31 = load.i32 user2 readonly region0 v30
 ;; @002b                               v33 = uextend.i64 v5
 ;; @002b                               v36 = iadd v33, v15
 ;; @002b                               v32 = uextend.i64 v31

--- a/tests/disas/array-copy-inline.wat
+++ b/tests/disas/array-copy-inline.wat
@@ -16,6 +16,7 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32, i32, i32) tail {
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -33,7 +34,7 @@
 ;; @002a                               v9 = iadd v8, v7
 ;; @002a                               v10 = iconst.i64 16
 ;; @002a                               v11 = iadd v9, v10  ; v10 = 16
-;; @002a                               v12 = load.i32 user2 readonly v11
+;; @002a                               v12 = load.i32 user2 readonly region0 v11
 ;; @002a                               v14 = uextend.i64 v3
 ;;                                     v85 = iconst.i64 7
 ;; @002a                               v17 = iadd v14, v85  ; v85 = 7
@@ -44,7 +45,7 @@
 ;; @002a                               v26 = uextend.i64 v4
 ;; @002a                               v28 = iadd v8, v26
 ;; @002a                               v30 = iadd v28, v10  ; v10 = 16
-;; @002a                               v31 = load.i32 user2 readonly v30
+;; @002a                               v31 = load.i32 user2 readonly region0 v30
 ;; @002a                               v33 = uextend.i64 v5
 ;; @002a                               v36 = iadd v33, v85  ; v85 = 7
 ;; @002a                               v32 = uextend.i64 v31

--- a/tests/disas/array-fill-anyref.wat
+++ b/tests/disas/array-fill-anyref.wat
@@ -18,6 +18,7 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32, i32, i32) tail {
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -35,7 +36,7 @@
 ;; @0030                               v8 = iadd v7, v6
 ;; @0030                               v9 = iconst.i64 16
 ;; @0030                               v10 = iadd v8, v9  ; v9 = 16
-;; @0030                               v11 = load.i32 user2 readonly v10
+;; @0030                               v11 = load.i32 user2 readonly region0 v10
 ;; @0030                               v13 = uextend.i64 v3
 ;; @0030                               v14 = uextend.i64 v5
 ;; @0030                               v16 = iadd v13, v14
@@ -60,7 +61,7 @@
 ;; @0030                               brif v33, block3, block2(v24)
 ;;
 ;;                                 block2(v34: i64):
-;; @0030                               store.i32 user2 little v4, v34
+;; @0030                               store.i32 user2 little region0 v4, v34
 ;;                                     v58 = iconst.i64 4
 ;;                                     v59 = iadd v34, v58  ; v58 = 4
 ;; @0030                               v36 = icmp eq v59, v32
@@ -74,6 +75,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32, i32, i32) tail {
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -91,7 +93,7 @@
 ;; @003e                               v8 = iadd v7, v6
 ;; @003e                               v9 = iconst.i64 16
 ;; @003e                               v10 = iadd v8, v9  ; v9 = 16
-;; @003e                               v11 = load.i32 user2 readonly v10
+;; @003e                               v11 = load.i32 user2 readonly region0 v10
 ;; @003e                               v13 = uextend.i64 v3
 ;; @003e                               v14 = uextend.i64 v4
 ;; @003e                               v16 = iadd v13, v14
@@ -118,7 +120,7 @@
 ;;
 ;;                                 block2(v34: i64):
 ;;                                     v58 = iconst.i32 0
-;; @003e                               store user2 little v58, v34  ; v58 = 0
+;; @003e                               store user2 little region0 v58, v34  ; v58 = 0
 ;;                                     v59 = iconst.i64 4
 ;;                                     v60 = iadd v34, v59  ; v59 = 4
 ;; @003e                               v36 = icmp eq v60, v32
@@ -132,6 +134,7 @@
 ;; }
 ;;
 ;; function u0:2(i64 vmctx, i64, i32, i32, i32) tail {
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -149,7 +152,7 @@
 ;; @004e                               v10 = iadd v9, v8
 ;; @004e                               v11 = iconst.i64 16
 ;; @004e                               v12 = iadd v10, v11  ; v11 = 16
-;; @004e                               v13 = load.i32 user2 readonly v12
+;; @004e                               v13 = load.i32 user2 readonly region0 v12
 ;; @004e                               v15 = uextend.i64 v3
 ;; @004e                               v16 = uextend.i64 v4
 ;; @004e                               v18 = iadd v15, v16
@@ -176,7 +179,7 @@
 ;;
 ;;                                 block2(v36: i64):
 ;;                                     v68 = iconst.i32 -1
-;; @004e                               store user2 little v68, v36  ; v68 = -1
+;; @004e                               store user2 little region0 v68, v36  ; v68 = -1
 ;;                                     v69 = iconst.i64 4
 ;;                                     v70 = iadd v36, v69  ; v69 = 4
 ;; @004e                               v38 = icmp eq v70, v34

--- a/tests/disas/array-fill-externref.wat
+++ b/tests/disas/array-fill-externref.wat
@@ -14,6 +14,7 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32, i32, i32) tail {
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -31,7 +32,7 @@
 ;; @002f                               v8 = iadd v7, v6
 ;; @002f                               v9 = iconst.i64 16
 ;; @002f                               v10 = iadd v8, v9  ; v9 = 16
-;; @002f                               v11 = load.i32 user2 readonly v10
+;; @002f                               v11 = load.i32 user2 readonly region0 v10
 ;; @002f                               v13 = uextend.i64 v3
 ;; @002f                               v14 = uextend.i64 v5
 ;; @002f                               v16 = iadd v13, v14
@@ -56,7 +57,7 @@
 ;; @002f                               brif v33, block3, block2(v24)
 ;;
 ;;                                 block2(v34: i64):
-;; @002f                               store.i32 user2 little v4, v34
+;; @002f                               store.i32 user2 little region0 v4, v34
 ;;                                     v58 = iconst.i64 4
 ;;                                     v59 = iadd v34, v58  ; v58 = 4
 ;; @002f                               v36 = icmp eq v59, v32
@@ -70,6 +71,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32, i32, i32) tail {
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -87,7 +89,7 @@
 ;; @003d                               v8 = iadd v7, v6
 ;; @003d                               v9 = iconst.i64 16
 ;; @003d                               v10 = iadd v8, v9  ; v9 = 16
-;; @003d                               v11 = load.i32 user2 readonly v10
+;; @003d                               v11 = load.i32 user2 readonly region0 v10
 ;; @003d                               v13 = uextend.i64 v3
 ;; @003d                               v14 = uextend.i64 v4
 ;; @003d                               v16 = iadd v13, v14
@@ -114,7 +116,7 @@
 ;;
 ;;                                 block2(v34: i64):
 ;;                                     v58 = iconst.i32 0
-;; @003d                               store user2 little v58, v34  ; v58 = 0
+;; @003d                               store user2 little region0 v58, v34  ; v58 = 0
 ;;                                     v59 = iconst.i64 4
 ;;                                     v60 = iadd v34, v59  ; v59 = 4
 ;; @003d                               v36 = icmp eq v60, v32

--- a/tests/disas/array-fill-f32.wat
+++ b/tests/disas/array-fill-f32.wat
@@ -18,6 +18,7 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32, f32, i32) tail {
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -35,7 +36,7 @@
 ;; @0030                               v8 = iadd v7, v6
 ;; @0030                               v9 = iconst.i64 16
 ;; @0030                               v10 = iadd v8, v9  ; v9 = 16
-;; @0030                               v11 = load.i32 user2 readonly v10
+;; @0030                               v11 = load.i32 user2 readonly region0 v10
 ;; @0030                               v13 = uextend.i64 v3
 ;; @0030                               v14 = uextend.i64 v5
 ;; @0030                               v16 = iadd v13, v14
@@ -60,7 +61,7 @@
 ;; @0030                               brif v33, block3, block2(v24)
 ;;
 ;;                                 block2(v34: i64):
-;; @0030                               store.f32 user2 little v4, v34
+;; @0030                               store.f32 user2 little region0 v4, v34
 ;;                                     v58 = iconst.i64 4
 ;;                                     v59 = iadd v34, v58  ; v58 = 4
 ;; @0030                               v36 = icmp eq v59, v32
@@ -74,6 +75,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32, i32, i32) tail {
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -93,7 +95,7 @@
 ;; @0041                               v8 = iadd v7, v6
 ;; @0041                               v9 = iconst.i64 16
 ;; @0041                               v10 = iadd v8, v9  ; v9 = 16
-;; @0041                               v11 = load.i32 user2 readonly v10
+;; @0041                               v11 = load.i32 user2 readonly region0 v10
 ;; @0041                               v13 = uextend.i64 v3
 ;; @0041                               v14 = uextend.i64 v4
 ;; @0041                               v16 = iadd v13, v14
@@ -120,6 +122,7 @@
 ;; }
 ;;
 ;; function u0:2(i64 vmctx, i64, i32, i32, i32) tail {
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -137,7 +140,7 @@
 ;; @0052                               v8 = iadd v7, v6
 ;; @0052                               v9 = iconst.i64 16
 ;; @0052                               v10 = iadd v8, v9  ; v9 = 16
-;; @0052                               v11 = load.i32 user2 readonly v10
+;; @0052                               v11 = load.i32 user2 readonly region0 v10
 ;; @0052                               v13 = uextend.i64 v3
 ;; @0052                               v14 = uextend.i64 v4
 ;; @0052                               v16 = iadd v13, v14
@@ -164,7 +167,7 @@
 ;;
 ;;                                 block2(v34: i64):
 ;;                                     v58 = f32const 0x1.000000p0
-;; @0052                               store user2 little v58, v34  ; v58 = 0x1.000000p0
+;; @0052                               store user2 little region0 v58, v34  ; v58 = 0x1.000000p0
 ;;                                     v59 = iconst.i64 4
 ;;                                     v60 = iadd v34, v59  ; v59 = 4
 ;; @0052                               v36 = icmp eq v60, v32

--- a/tests/disas/array-fill-f64.wat
+++ b/tests/disas/array-fill-f64.wat
@@ -18,6 +18,7 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32, f64, i32) tail {
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -35,7 +36,7 @@
 ;; @0030                               v8 = iadd v7, v6
 ;; @0030                               v9 = iconst.i64 16
 ;; @0030                               v10 = iadd v8, v9  ; v9 = 16
-;; @0030                               v11 = load.i32 user2 readonly v10
+;; @0030                               v11 = load.i32 user2 readonly region0 v10
 ;; @0030                               v13 = uextend.i64 v3
 ;; @0030                               v14 = uextend.i64 v5
 ;; @0030                               v16 = iadd v13, v14
@@ -60,7 +61,7 @@
 ;; @0030                               brif v33, block3, block2(v24)
 ;;
 ;;                                 block2(v34: i64):
-;; @0030                               store.f64 user2 little v4, v34
+;; @0030                               store.f64 user2 little region0 v4, v34
 ;;                                     v58 = iconst.i64 8
 ;;                                     v59 = iadd v34, v58  ; v58 = 8
 ;; @0030                               v36 = icmp eq v59, v32
@@ -74,6 +75,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32, i32, i32) tail {
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -93,7 +95,7 @@
 ;; @0045                               v8 = iadd v7, v6
 ;; @0045                               v9 = iconst.i64 16
 ;; @0045                               v10 = iadd v8, v9  ; v9 = 16
-;; @0045                               v11 = load.i32 user2 readonly v10
+;; @0045                               v11 = load.i32 user2 readonly region0 v10
 ;; @0045                               v13 = uextend.i64 v3
 ;; @0045                               v14 = uextend.i64 v4
 ;; @0045                               v16 = iadd v13, v14
@@ -120,6 +122,7 @@
 ;; }
 ;;
 ;; function u0:2(i64 vmctx, i64, i32, i32, i32) tail {
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -137,7 +140,7 @@
 ;; @005a                               v8 = iadd v7, v6
 ;; @005a                               v9 = iconst.i64 16
 ;; @005a                               v10 = iadd v8, v9  ; v9 = 16
-;; @005a                               v11 = load.i32 user2 readonly v10
+;; @005a                               v11 = load.i32 user2 readonly region0 v10
 ;; @005a                               v13 = uextend.i64 v3
 ;; @005a                               v14 = uextend.i64 v4
 ;; @005a                               v16 = iadd v13, v14
@@ -164,7 +167,7 @@
 ;;
 ;;                                 block2(v34: i64):
 ;;                                     v58 = f64const 0x1.0000000000000p0
-;; @005a                               store user2 little v58, v34  ; v58 = 0x1.0000000000000p0
+;; @005a                               store user2 little region0 v58, v34  ; v58 = 0x1.0000000000000p0
 ;;                                     v59 = iconst.i64 8
 ;;                                     v60 = iadd v34, v59  ; v59 = 8
 ;; @005a                               v36 = icmp eq v60, v32

--- a/tests/disas/array-fill-funcref.wat
+++ b/tests/disas/array-fill-funcref.wat
@@ -21,6 +21,7 @@
   (elem declare func $hi)
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32, i64, i32) tail {
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -40,7 +41,7 @@
 ;; @003b                               v8 = iadd v7, v6
 ;; @003b                               v9 = iconst.i64 16
 ;; @003b                               v10 = iadd v8, v9  ; v9 = 16
-;; @003b                               v11 = load.i32 user2 readonly v10
+;; @003b                               v11 = load.i32 user2 readonly region0 v10
 ;; @003b                               v13 = uextend.i64 v3
 ;; @003b                               v14 = uextend.i64 v5
 ;; @003b                               v16 = iadd v13, v14
@@ -81,6 +82,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32, i32, i32) tail {
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -100,7 +102,7 @@
 ;; @0049                               v8 = iadd v7, v6
 ;; @0049                               v9 = iconst.i64 16
 ;; @0049                               v10 = iadd v8, v9  ; v9 = 16
-;; @0049                               v11 = load.i32 user2 readonly v10
+;; @0049                               v11 = load.i32 user2 readonly region0 v10
 ;; @0049                               v13 = uextend.i64 v3
 ;; @0049                               v14 = uextend.i64 v4
 ;; @0049                               v16 = iadd v13, v14
@@ -142,6 +144,7 @@
 ;;
 ;; function u0:2(i64 vmctx, i64, i32, i32, i32) tail {
 ;;     ss0 = explicit_slot 4, align = 4
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -168,7 +171,7 @@
 ;; @0057                               v10 = iadd v9, v8
 ;; @0057                               v11 = iconst.i64 16
 ;; @0057                               v12 = iadd v10, v11  ; v11 = 16
-;; @0057                               v13 = load.i32 user2 readonly v12
+;; @0057                               v13 = load.i32 user2 readonly region0 v12
 ;; @0057                               v15 = uextend.i64 v3
 ;; @0057                               v16 = uextend.i64 v4
 ;; @0057                               v18 = iadd v15, v16

--- a/tests/disas/array-fill-i16.wat
+++ b/tests/disas/array-fill-i16.wat
@@ -22,6 +22,7 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32, i32, i32) tail {
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -39,7 +40,7 @@
 ;; @0031                               v8 = iadd v7, v6
 ;; @0031                               v9 = iconst.i64 16
 ;; @0031                               v10 = iadd v8, v9  ; v9 = 16
-;; @0031                               v11 = load.i32 user2 readonly v10
+;; @0031                               v11 = load.i32 user2 readonly region0 v10
 ;; @0031                               v13 = uextend.i64 v3
 ;; @0031                               v14 = uextend.i64 v5
 ;; @0031                               v16 = iadd v13, v14
@@ -64,7 +65,7 @@
 ;; @0031                               brif v33, block3, block2(v24)
 ;;
 ;;                                 block2(v34: i64):
-;; @0031                               istore16.i32 user2 little v4, v34
+;; @0031                               istore16.i32 user2 little region0 v4, v34
 ;;                                     v61 = iconst.i64 2
 ;;                                     v62 = iadd v34, v61  ; v61 = 2
 ;; @0031                               v36 = icmp eq v62, v32
@@ -78,6 +79,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32, i32, i32) tail {
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -97,7 +99,7 @@
 ;; @003f                               v8 = iadd v7, v6
 ;; @003f                               v9 = iconst.i64 16
 ;; @003f                               v10 = iadd v8, v9  ; v9 = 16
-;; @003f                               v11 = load.i32 user2 readonly v10
+;; @003f                               v11 = load.i32 user2 readonly region0 v10
 ;; @003f                               v13 = uextend.i64 v3
 ;; @003f                               v14 = uextend.i64 v4
 ;; @003f                               v16 = iadd v13, v14
@@ -124,6 +126,7 @@
 ;; }
 ;;
 ;; function u0:2(i64 vmctx, i64, i32, i32, i32) tail {
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -143,7 +146,7 @@
 ;; @004d                               v8 = iadd v7, v6
 ;; @004d                               v9 = iconst.i64 16
 ;; @004d                               v10 = iadd v8, v9  ; v9 = 16
-;; @004d                               v11 = load.i32 user2 readonly v10
+;; @004d                               v11 = load.i32 user2 readonly region0 v10
 ;; @004d                               v13 = uextend.i64 v3
 ;; @004d                               v14 = uextend.i64 v4
 ;; @004d                               v16 = iadd v13, v14
@@ -170,6 +173,7 @@
 ;; }
 ;;
 ;; function u0:3(i64 vmctx, i64, i32, i32, i32) tail {
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -187,7 +191,7 @@
 ;; @005d                               v8 = iadd v7, v6
 ;; @005d                               v9 = iconst.i64 16
 ;; @005d                               v10 = iadd v8, v9  ; v9 = 16
-;; @005d                               v11 = load.i32 user2 readonly v10
+;; @005d                               v11 = load.i32 user2 readonly region0 v10
 ;; @005d                               v13 = uextend.i64 v3
 ;; @005d                               v14 = uextend.i64 v4
 ;; @005d                               v16 = iadd v13, v14
@@ -214,7 +218,7 @@
 ;;
 ;;                                 block2(v34: i64):
 ;;                                     v61 = iconst.i32 0xdead
-;; @005d                               istore16 user2 little v61, v34  ; v61 = 0xdead
+;; @005d                               istore16 user2 little region0 v61, v34  ; v61 = 0xdead
 ;;                                     v62 = iconst.i64 2
 ;;                                     v63 = iadd v34, v62  ; v62 = 2
 ;; @005d                               v36 = icmp eq v63, v32

--- a/tests/disas/array-fill-i31ref.wat
+++ b/tests/disas/array-fill-i31ref.wat
@@ -18,6 +18,7 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32, i32, i32) tail {
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -35,7 +36,7 @@
 ;; @0030                               v8 = iadd v7, v6
 ;; @0030                               v9 = iconst.i64 16
 ;; @0030                               v10 = iadd v8, v9  ; v9 = 16
-;; @0030                               v11 = load.i32 user2 readonly v10
+;; @0030                               v11 = load.i32 user2 readonly region0 v10
 ;; @0030                               v13 = uextend.i64 v3
 ;; @0030                               v14 = uextend.i64 v5
 ;; @0030                               v16 = iadd v13, v14
@@ -60,7 +61,7 @@
 ;; @0030                               brif v33, block3, block2(v24)
 ;;
 ;;                                 block2(v34: i64):
-;; @0030                               store.i32 user2 little v4, v34
+;; @0030                               store.i32 user2 little region0 v4, v34
 ;;                                     v58 = iconst.i64 4
 ;;                                     v59 = iadd v34, v58  ; v58 = 4
 ;; @0030                               v36 = icmp eq v59, v32
@@ -74,6 +75,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32, i32, i32) tail {
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -91,7 +93,7 @@
 ;; @003e                               v8 = iadd v7, v6
 ;; @003e                               v9 = iconst.i64 16
 ;; @003e                               v10 = iadd v8, v9  ; v9 = 16
-;; @003e                               v11 = load.i32 user2 readonly v10
+;; @003e                               v11 = load.i32 user2 readonly region0 v10
 ;; @003e                               v13 = uextend.i64 v3
 ;; @003e                               v14 = uextend.i64 v4
 ;; @003e                               v16 = iadd v13, v14
@@ -118,7 +120,7 @@
 ;;
 ;;                                 block2(v34: i64):
 ;;                                     v58 = iconst.i32 0
-;; @003e                               store user2 little v58, v34  ; v58 = 0
+;; @003e                               store user2 little region0 v58, v34  ; v58 = 0
 ;;                                     v59 = iconst.i64 4
 ;;                                     v60 = iadd v34, v59  ; v59 = 4
 ;; @003e                               v36 = icmp eq v60, v32
@@ -132,6 +134,7 @@
 ;; }
 ;;
 ;; function u0:2(i64 vmctx, i64, i32, i32, i32) tail {
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -149,7 +152,7 @@
 ;; @004e                               v10 = iadd v9, v8
 ;; @004e                               v11 = iconst.i64 16
 ;; @004e                               v12 = iadd v10, v11  ; v11 = 16
-;; @004e                               v13 = load.i32 user2 readonly v12
+;; @004e                               v13 = load.i32 user2 readonly region0 v12
 ;; @004e                               v15 = uextend.i64 v3
 ;; @004e                               v16 = uextend.i64 v4
 ;; @004e                               v18 = iadd v15, v16
@@ -176,7 +179,7 @@
 ;;
 ;;                                 block2(v36: i64):
 ;;                                     v68 = iconst.i32 -1
-;; @004e                               store user2 little v68, v36  ; v68 = -1
+;; @004e                               store user2 little region0 v68, v36  ; v68 = -1
 ;;                                     v69 = iconst.i64 4
 ;;                                     v70 = iadd v36, v69  ; v69 = 4
 ;; @004e                               v38 = icmp eq v70, v34

--- a/tests/disas/array-fill-i32.wat
+++ b/tests/disas/array-fill-i32.wat
@@ -22,6 +22,7 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32, i32, i32) tail {
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -39,7 +40,7 @@
 ;; @0031                               v8 = iadd v7, v6
 ;; @0031                               v9 = iconst.i64 16
 ;; @0031                               v10 = iadd v8, v9  ; v9 = 16
-;; @0031                               v11 = load.i32 user2 readonly v10
+;; @0031                               v11 = load.i32 user2 readonly region0 v10
 ;; @0031                               v13 = uextend.i64 v3
 ;; @0031                               v14 = uextend.i64 v5
 ;; @0031                               v16 = iadd v13, v14
@@ -64,7 +65,7 @@
 ;; @0031                               brif v33, block3, block2(v24)
 ;;
 ;;                                 block2(v34: i64):
-;; @0031                               store.i32 user2 little v4, v34
+;; @0031                               store.i32 user2 little region0 v4, v34
 ;;                                     v58 = iconst.i64 4
 ;;                                     v59 = iadd v34, v58  ; v58 = 4
 ;; @0031                               v36 = icmp eq v59, v32
@@ -78,6 +79,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32, i32, i32) tail {
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -97,7 +99,7 @@
 ;; @003f                               v8 = iadd v7, v6
 ;; @003f                               v9 = iconst.i64 16
 ;; @003f                               v10 = iadd v8, v9  ; v9 = 16
-;; @003f                               v11 = load.i32 user2 readonly v10
+;; @003f                               v11 = load.i32 user2 readonly region0 v10
 ;; @003f                               v13 = uextend.i64 v3
 ;; @003f                               v14 = uextend.i64 v4
 ;; @003f                               v16 = iadd v13, v14
@@ -124,6 +126,7 @@
 ;; }
 ;;
 ;; function u0:2(i64 vmctx, i64, i32, i32, i32) tail {
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -143,7 +146,7 @@
 ;; @004d                               v8 = iadd v7, v6
 ;; @004d                               v9 = iconst.i64 16
 ;; @004d                               v10 = iadd v8, v9  ; v9 = 16
-;; @004d                               v11 = load.i32 user2 readonly v10
+;; @004d                               v11 = load.i32 user2 readonly region0 v10
 ;; @004d                               v13 = uextend.i64 v3
 ;; @004d                               v14 = uextend.i64 v4
 ;; @004d                               v16 = iadd v13, v14
@@ -170,6 +173,7 @@
 ;; }
 ;;
 ;; function u0:3(i64 vmctx, i64, i32, i32, i32) tail {
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -187,7 +191,7 @@
 ;; @005d                               v8 = iadd v7, v6
 ;; @005d                               v9 = iconst.i64 16
 ;; @005d                               v10 = iadd v8, v9  ; v9 = 16
-;; @005d                               v11 = load.i32 user2 readonly v10
+;; @005d                               v11 = load.i32 user2 readonly region0 v10
 ;; @005d                               v13 = uextend.i64 v3
 ;; @005d                               v14 = uextend.i64 v4
 ;; @005d                               v16 = iadd v13, v14
@@ -214,7 +218,7 @@
 ;;
 ;;                                 block2(v34: i64):
 ;;                                     v58 = iconst.i32 0xdead
-;; @005d                               store user2 little v58, v34  ; v58 = 0xdead
+;; @005d                               store user2 little region0 v58, v34  ; v58 = 0xdead
 ;;                                     v59 = iconst.i64 4
 ;;                                     v60 = iadd v34, v59  ; v59 = 4
 ;; @005d                               v36 = icmp eq v60, v32

--- a/tests/disas/array-fill-i64.wat
+++ b/tests/disas/array-fill-i64.wat
@@ -22,6 +22,7 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32, i64, i32) tail {
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -39,7 +40,7 @@
 ;; @0031                               v8 = iadd v7, v6
 ;; @0031                               v9 = iconst.i64 16
 ;; @0031                               v10 = iadd v8, v9  ; v9 = 16
-;; @0031                               v11 = load.i32 user2 readonly v10
+;; @0031                               v11 = load.i32 user2 readonly region0 v10
 ;; @0031                               v13 = uextend.i64 v3
 ;; @0031                               v14 = uextend.i64 v5
 ;; @0031                               v16 = iadd v13, v14
@@ -64,7 +65,7 @@
 ;; @0031                               brif v33, block3, block2(v24)
 ;;
 ;;                                 block2(v34: i64):
-;; @0031                               store.i64 user2 little v4, v34
+;; @0031                               store.i64 user2 little region0 v4, v34
 ;;                                     v58 = iconst.i64 8
 ;;                                     v59 = iadd v34, v58  ; v58 = 8
 ;; @0031                               v36 = icmp eq v59, v32
@@ -78,6 +79,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32, i32, i32) tail {
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -97,7 +99,7 @@
 ;; @003f                               v8 = iadd v7, v6
 ;; @003f                               v9 = iconst.i64 16
 ;; @003f                               v10 = iadd v8, v9  ; v9 = 16
-;; @003f                               v11 = load.i32 user2 readonly v10
+;; @003f                               v11 = load.i32 user2 readonly region0 v10
 ;; @003f                               v13 = uextend.i64 v3
 ;; @003f                               v14 = uextend.i64 v4
 ;; @003f                               v16 = iadd v13, v14
@@ -124,6 +126,7 @@
 ;; }
 ;;
 ;; function u0:2(i64 vmctx, i64, i32, i32, i32) tail {
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -143,7 +146,7 @@
 ;; @004d                               v8 = iadd v7, v6
 ;; @004d                               v9 = iconst.i64 16
 ;; @004d                               v10 = iadd v8, v9  ; v9 = 16
-;; @004d                               v11 = load.i32 user2 readonly v10
+;; @004d                               v11 = load.i32 user2 readonly region0 v10
 ;; @004d                               v13 = uextend.i64 v3
 ;; @004d                               v14 = uextend.i64 v4
 ;; @004d                               v16 = iadd v13, v14
@@ -170,6 +173,7 @@
 ;; }
 ;;
 ;; function u0:3(i64 vmctx, i64, i32, i32, i32) tail {
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -187,7 +191,7 @@
 ;; @005b                               v8 = iadd v7, v6
 ;; @005b                               v9 = iconst.i64 16
 ;; @005b                               v10 = iadd v8, v9  ; v9 = 16
-;; @005b                               v11 = load.i32 user2 readonly v10
+;; @005b                               v11 = load.i32 user2 readonly region0 v10
 ;; @005b                               v13 = uextend.i64 v3
 ;; @005b                               v14 = uextend.i64 v4
 ;; @005b                               v16 = iadd v13, v14
@@ -214,7 +218,7 @@
 ;;
 ;;                                 block2(v34: i64):
 ;;                                     v58 = iconst.i64 1
-;; @005b                               store user2 little v58, v34  ; v58 = 1
+;; @005b                               store user2 little region0 v58, v34  ; v58 = 1
 ;;                                     v59 = iconst.i64 8
 ;;                                     v60 = iadd v34, v59  ; v59 = 8
 ;; @005b                               v36 = icmp eq v60, v32

--- a/tests/disas/basic-wat-test.wat
+++ b/tests/disas/basic-wat-test.wat
@@ -10,7 +10,7 @@
     i32.add))
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) -> i32 tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/bounds-check.wat
+++ b/tests/disas/bounds-check.wat
@@ -25,7 +25,7 @@
   (export "store" (func $store))
 )
 ;; function u0:0(i64 vmctx, i64, i32) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/branch-hinting.wat
+++ b/tests/disas/branch-hinting.wat
@@ -163,7 +163,7 @@
 ;; }
 ;;
 ;; function u0:4(i64 vmctx, i64, i32) tail {
-;;     region0 = 1 "table"
+;;     region0 = 1879048192 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/call-indirect.wat
+++ b/tests/disas/call-indirect.wat
@@ -8,7 +8,7 @@
 )
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) -> i32 tail {
-;;     region0 = 1 "table"
+;;     region0 = 1342177280 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/component-model/direct-adapter-calls-inlining.wat
+++ b/tests/disas/component-model/direct-adapter-calls-inlining.wat
@@ -55,7 +55,7 @@
 )
 
 ;; function u1:0(i64 vmctx, i64) -> i32 tail {
-;;     region0 = 1 "table"
+;;     region0 = 1610612736 "ImportedGlobal"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/component-model/direct-adapter-calls.wat
+++ b/tests/disas/component-model/direct-adapter-calls.wat
@@ -92,7 +92,7 @@
 ;; }
 ;;
 ;; function u2:0(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 1 "table"
+;;     region0 = 1610612736 "ImportedGlobal"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/component-model/unsafe-intrinsics-used.wat
+++ b/tests/disas/component-model/unsafe-intrinsics-used.wat
@@ -35,11 +35,12 @@
 )
 
 ;; function u0:0(i64 vmctx, i64) -> i64 tail {
-;;     region0 = 2 "vmctx"
+;;     region0 = 16 "VMContext+0x10"
+;;     region1 = 268435560 "VMStoreContext+0x68"
 ;;
 ;; block0(v0: i64, v1: i64):
 ;;     v2 = load.i64 notrap aligned readonly can_move region0 v0+16
-;;     v3 = load.i64 notrap aligned readonly can_move region0 v2+104
+;;     v3 = load.i64 notrap aligned readonly can_move region1 v2+104
 ;;     return v3
 ;; }
 ;;

--- a/tests/disas/duplicate-function-types.wat
+++ b/tests/disas/duplicate-function-types.wat
@@ -17,7 +17,7 @@
 )
 
 ;; function u0:0(i64 vmctx, i64, i32) -> i32, i32 tail {
-;;     region0 = 1 "table"
+;;     region0 = 1073741824 "ImportedTable"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/duplicate-loads-dynamic-memory.wat
+++ b/tests/disas/duplicate-loads-dynamic-memory.wat
@@ -23,7 +23,7 @@
 )
 
 ;; function u0:0(i64 vmctx, i64, i32) -> i32, i32 tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -48,7 +48,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32, i32 tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/duplicate-loads-static-memory.wat
+++ b/tests/disas/duplicate-loads-static-memory.wat
@@ -18,7 +18,7 @@
 )
 
 ;; function u0:0(i64 vmctx, i64, i32) -> i32, i32 tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -39,7 +39,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32, i32 tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/dynamic-memory-no-spectre-access-same-index-different-offsets.wat
+++ b/tests/disas/dynamic-memory-no-spectre-access-same-index-different-offsets.wat
@@ -36,7 +36,7 @@
 )
 
 ;; function u0:0(i64 vmctx, i64, i32) -> i32, i32, i32 tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -70,7 +70,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32, i32, i32, i32) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/dynamic-memory-yes-spectre-access-same-index-different-offsets.wat
+++ b/tests/disas/dynamic-memory-yes-spectre-access-same-index-different-offsets.wat
@@ -32,7 +32,7 @@
 )
 
 ;; function u0:0(i64 vmctx, i64, i32) -> i32, i32, i32 tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -68,7 +68,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32, i32, i32, i32) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/f32-load.wat
+++ b/tests/disas/f32-load.wat
@@ -7,7 +7,7 @@
     f32.load))
 
 ;; function u0:0(i64 vmctx, i64, i32) -> f32 tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/f32-store.wat
+++ b/tests/disas/f32-store.wat
@@ -10,7 +10,7 @@
     f32.store))
 
 ;; function u0:0(i64 vmctx, i64, i32, f32) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/f64-load.wat
+++ b/tests/disas/f64-load.wat
@@ -9,7 +9,7 @@
     f64.load))
 
 ;; function u0:0(i64 vmctx, i64, i32) -> f64 tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/f64-store.wat
+++ b/tests/disas/f64-store.wat
@@ -10,7 +10,7 @@
     f64.store))
 
 ;; function u0:0(i64 vmctx, i64, i32, f64) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/fibonacci.wat
+++ b/tests/disas/fibonacci.wat
@@ -24,7 +24,7 @@
 )
 
 ;; function u0:0(i64 vmctx, i64) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/fixed-size-memory.wat
+++ b/tests/disas/fixed-size-memory.wat
@@ -21,7 +21,7 @@
     i32.load8_u offset=0))
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -45,7 +45,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/foo.wat
+++ b/tests/disas/foo.wat
@@ -1,0 +1,101 @@
+;;! target = "x86_64"
+;;! test = "optimize"
+
+
+(module
+  (import "" "" (table 1 funcref))
+  (memory 1)
+  (func (export "i32.load") (param i32 i32) (result i32 i32)
+    local.get 0
+    (i32.load (local.get 1))
+    call_indirect (param i32) (result i32)
+    local.get 0
+    (i32.load (local.get 1))
+    call_indirect (param i32) (result i32)
+  )
+)
+;; function u0:0(i64 vmctx, i64, i32, i32) -> i32, i32 tail {
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 1073741824 "ImportedTable"
+;;     gv0 = vmctx
+;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv3 = vmctx
+;;     gv4 = load.i64 notrap aligned gv3+64
+;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
+;;     gv6 = load.i64 notrap aligned readonly can_move gv3+72
+;;     gv7 = load.i64 notrap aligned gv6
+;;     gv8 = load.i64 notrap aligned gv6+8
+;;     sig0 = (i64 vmctx, i64, i32) -> i32 tail
+;;     sig1 = (i64 vmctx, i32, i64) -> i64 tail
+;;     fn0 = colocated u805306368:7 sig1
+;;     stack_limit = gv2
+;;
+;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
+;; @0040                               v7 = load.i64 notrap aligned readonly can_move v0+56
+;; @0040                               v6 = uextend.i64 v3
+;; @0040                               v8 = iadd v7, v6
+;; @0040                               v9 = load.i32 little region0 v8
+;; @0043                               v75 = load.i64 notrap aligned readonly can_move v0+72
+;; @0043                               v10 = load.i64 notrap aligned v75+8
+;; @0043                               v14 = load.i64 notrap aligned v75
+;; @0043                               v11 = ireduce.i32 v10
+;; @0043                               v12 = icmp uge v9, v11
+;; @0043                               v17 = iconst.i64 0
+;; @0043                               v13 = uextend.i64 v9
+;;                                     v72 = iconst.i64 3
+;; @0043                               v15 = ishl v13, v72  ; v72 = 3
+;; @0043                               v16 = iadd v14, v15
+;; @0043                               v18 = select_spectre_guard v12, v17, v16  ; v17 = 0
+;; @0043                               v19 = load.i64 user6 aligned region1 v18
+;;                                     v71 = iconst.i64 -2
+;; @0043                               v20 = band v19, v71  ; v71 = -2
+;; @0043                               brif v19, block3(v20), block2
+;;
+;;                                 block2 cold:
+;; @0043                               v22 = iconst.i32 0
+;; @0043                               v25 = call fn0(v0, v22, v13)  ; v22 = 0
+;; @0043                               jump block3(v25)
+;;
+;;                                 block3(v21: i64):
+;; @0043                               v29 = load.i32 user7 aligned readonly v21+16
+;; @0043                               v27 = load.i64 notrap aligned readonly can_move v0+40
+;; @0043                               v28 = load.i32 notrap aligned readonly can_move v27+4
+;; @0043                               v30 = icmp eq v29, v28
+;; @0043                               trapz v30, user8
+;; @0043                               v31 = load.i64 notrap aligned readonly v21+8
+;; @0043                               v32 = load.i64 notrap aligned readonly v21+24
+;; @0043                               v33 = call_indirect sig0, v31(v32, v0, v2)
+;; @004a                               v39 = load.i32 little region0 v8
+;; @004d                               v40 = load.i64 notrap aligned v75+8
+;; @004d                               v44 = load.i64 notrap aligned v75
+;; @004d                               v41 = ireduce.i32 v40
+;; @004d                               v42 = icmp uge v39, v41
+;; @004d                               v43 = uextend.i64 v39
+;;                                     v78 = iconst.i64 3
+;;                                     v79 = ishl v43, v78  ; v78 = 3
+;; @004d                               v46 = iadd v44, v79
+;;                                     v80 = iconst.i64 0
+;;                                     v81 = select_spectre_guard v42, v80, v46  ; v80 = 0
+;; @004d                               v49 = load.i64 user6 aligned region1 v81
+;;                                     v82 = iconst.i64 -2
+;;                                     v83 = band v49, v82  ; v82 = -2
+;; @004d                               brif v49, block5(v83), block4
+;;
+;;                                 block4 cold:
+;;                                     v84 = iconst.i32 0
+;; @004d                               v55 = call fn0(v0, v84, v43)  ; v84 = 0
+;; @004d                               jump block5(v55)
+;;
+;;                                 block5(v51: i64):
+;; @004d                               v59 = load.i32 user7 aligned readonly v51+16
+;; @004d                               v60 = icmp eq v59, v28
+;; @004d                               trapz v60, user8
+;; @004d                               v61 = load.i64 notrap aligned readonly v51+8
+;; @004d                               v62 = load.i64 notrap aligned readonly v51+24
+;; @004d                               v63 = call_indirect sig0, v61(v62, v0, v2)
+;; @0050                               jump block1
+;;
+;;                                 block1:
+;; @0050                               return v33, v63
+;; }

--- a/tests/disas/gc/array-copy-with-fuel.wat
+++ b/tests/disas/gc/array-copy-with-fuel.wat
@@ -12,6 +12,7 @@
 ;; function u0:0(i64 vmctx, i64, i32, i32, i32, i32, i32) tail {
 ;;     ss0 = explicit_slot 4, align = 4
 ;;     ss1 = explicit_slot 4, align = 4
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -51,7 +52,7 @@
 ;; @002b                               v24 = iadd v23, v22
 ;; @002b                               v25 = iconst.i64 16
 ;; @002b                               v26 = iadd v24, v25  ; v25 = 16
-;; @002b                               v27 = load.i32 user2 readonly v26
+;; @002b                               v27 = load.i32 user2 readonly region0 v26
 ;; @002b                               v29 = uextend.i64 v3
 ;; @002b                               v30 = uextend.i64 v6
 ;; @002b                               v32 = iadd v29, v30
@@ -63,7 +64,7 @@
 ;; @002b                               v41 = uextend.i64 v137
 ;; @002b                               v43 = iadd v23, v41
 ;; @002b                               v45 = iadd v43, v25  ; v25 = 16
-;; @002b                               v46 = load.i32 user2 readonly v45
+;; @002b                               v46 = load.i32 user2 readonly region0 v45
 ;; @002b                               v48 = uextend.i64 v5
 ;; @002b                               v51 = iadd v48, v30
 ;; @002b                               v47 = uextend.i64 v46
@@ -130,8 +131,8 @@
 ;; @002b                               jump block9(v95)
 ;;
 ;;                                 block9(v123: i64):
-;; @002b                               v96 = load.i32 user2 little v83
-;; @002b                               store user2 little v96, v82
+;; @002b                               v96 = load.i32 user2 little region0 v83
+;; @002b                               store user2 little region0 v96, v82
 ;;                                     v127 = load.i32 notrap v201
 ;;                                     v128 = load.i32 notrap v200
 ;;                                     v225 = iconst.i64 4
@@ -151,9 +152,9 @@
 ;;                                 block11(v124: i64):
 ;;                                     v216 = iconst.i64 4
 ;;                                     v217 = isub.i64 v102, v216  ; v216 = 4
-;; @002b                               v121 = load.i32 user2 little v217
+;; @002b                               v121 = load.i32 user2 little region0 v217
 ;;                                     v218 = isub.i64 v101, v216  ; v216 = 4
-;; @002b                               store user2 little v121, v218
+;; @002b                               store user2 little region0 v121, v218
 ;;                                     v129 = load.i32 notrap v200
 ;;                                     v130 = load.i32 notrap v201
 ;; @002b                               v122 = icmp eq v217, v59

--- a/tests/disas/gc/array-fill-i8.wat
+++ b/tests/disas/gc/array-fill-i8.wat
@@ -10,6 +10,7 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32, i32, i32) tail {
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -29,7 +30,7 @@
 ;; @0027                               v8 = iadd v7, v6
 ;; @0027                               v9 = iconst.i64 16
 ;; @0027                               v10 = iadd v8, v9  ; v9 = 16
-;; @0027                               v11 = load.i32 user2 readonly v10
+;; @0027                               v11 = load.i32 user2 readonly region0 v10
 ;; @0027                               v13 = uextend.i64 v3
 ;; @0027                               v14 = uextend.i64 v5
 ;; @0027                               v16 = iadd v13, v14

--- a/tests/disas/gc/array-init-data.wat
+++ b/tests/disas/gc/array-init-data.wat
@@ -14,6 +14,7 @@
     array.init_data $a $passive)
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32, i32, i32) tail {
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -33,7 +34,7 @@
 ;; @002a                               v8 = iadd v7, v6
 ;; @002a                               v9 = iconst.i64 16
 ;; @002a                               v10 = iadd v8, v9  ; v9 = 16
-;; @002a                               v11 = load.i32 user2 readonly v10
+;; @002a                               v11 = load.i32 user2 readonly region0 v10
 ;; @002a                               v13 = uextend.i64 v3
 ;; @002a                               v14 = uextend.i64 v5
 ;; @002a                               v16 = iadd v13, v14

--- a/tests/disas/gc/array-new-data.wat
+++ b/tests/disas/gc/array-new-data.wat
@@ -77,7 +77,8 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) -> i32 tail {
 ;;     ss0 = explicit_slot 4, align = 4
-;;     region0 = 2 "vmctx"
+;;     region0 = 32 "VMContext+0x20"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -155,15 +156,14 @@
 ;;                                     store notrap v54, v121
 ;;                                     v120 = iconst.i64 16
 ;; @0025                               v56 = iadd v55, v120  ; v120 = 16
-;; @0025                               store.i32 user2 v3, v56
-;;                                     v101 = load.i32 notrap v121
-;; @0025                               trapz v101, user16
+;; @0025                               store.i32 user2 region1 v3, v56
+;; @0025                               trapz v54, user16
 ;;                                     v163 = load.i64 notrap aligned readonly can_move v0+8
 ;;                                     v164 = load.i64 notrap aligned readonly can_move v163+32
-;; @0025                               v58 = uextend.i64 v101
+;; @0025                               v58 = uextend.i64 v54
 ;; @0025                               v60 = iadd v164, v58
 ;; @0025                               v62 = iadd v60, v120  ; v120 = 16
-;; @0025                               v63 = load.i32 user2 readonly v62
+;; @0025                               v63 = load.i32 user2 readonly region1 v62
 ;; @0025                               v64 = uextend.i64 v63
 ;; @0025                               v69 = icmp.i64 ugt v9, v64
 ;; @0025                               trapnz v69, user17

--- a/tests/disas/gc/array-new-default-anyref.wat
+++ b/tests/disas/gc/array-new-default-anyref.wat
@@ -10,7 +10,8 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 2 "vmctx"
+;;     region0 = 32 "VMContext+0x20"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -81,14 +82,14 @@
 ;;                                 block4(v41: i32, v42: i64):
 ;;                                     v91 = iconst.i64 16
 ;; @001f                               v43 = iadd v42, v91  ; v91 = 16
-;; @001f                               store.i32 user2 v2, v43
+;; @001f                               store.i32 user2 region1 v2, v43
 ;; @001f                               trapz v41, user16
 ;;                                     v143 = load.i64 notrap aligned readonly can_move v0+8
 ;;                                     v144 = load.i64 notrap aligned readonly can_move v143+32
 ;; @001f                               v46 = uextend.i64 v41
 ;; @001f                               v48 = iadd v144, v46
 ;; @001f                               v50 = iadd v48, v91  ; v91 = 16
-;; @001f                               v51 = load.i32 user2 readonly v50
+;; @001f                               v51 = load.i32 user2 readonly region1 v50
 ;; @001f                               v52 = uextend.i64 v51
 ;; @001f                               v57 = icmp.i64 ugt v5, v52
 ;; @001f                               trapnz v57, user17
@@ -108,7 +109,7 @@
 ;;
 ;;                                 block5(v74: i64):
 ;;                                     v145 = iconst.i32 0
-;; @001f                               store user2 little v145, v74  ; v145 = 0
+;; @001f                               store user2 little region1 v145, v74  ; v145 = 0
 ;;                                     v146 = iconst.i64 4
 ;;                                     v147 = iadd v74, v146  ; v146 = 4
 ;; @001f                               v76 = icmp eq v147, v72

--- a/tests/disas/gc/array-new-default-exnref.wat
+++ b/tests/disas/gc/array-new-default-exnref.wat
@@ -10,7 +10,8 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 2 "vmctx"
+;;     region0 = 32 "VMContext+0x20"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -81,14 +82,14 @@
 ;;                                 block4(v41: i32, v42: i64):
 ;;                                     v91 = iconst.i64 16
 ;; @001f                               v43 = iadd v42, v91  ; v91 = 16
-;; @001f                               store.i32 user2 v2, v43
+;; @001f                               store.i32 user2 region1 v2, v43
 ;; @001f                               trapz v41, user16
 ;;                                     v143 = load.i64 notrap aligned readonly can_move v0+8
 ;;                                     v144 = load.i64 notrap aligned readonly can_move v143+32
 ;; @001f                               v46 = uextend.i64 v41
 ;; @001f                               v48 = iadd v144, v46
 ;; @001f                               v50 = iadd v48, v91  ; v91 = 16
-;; @001f                               v51 = load.i32 user2 readonly v50
+;; @001f                               v51 = load.i32 user2 readonly region1 v50
 ;; @001f                               v52 = uextend.i64 v51
 ;; @001f                               v57 = icmp.i64 ugt v5, v52
 ;; @001f                               trapnz v57, user17
@@ -108,7 +109,7 @@
 ;;
 ;;                                 block5(v74: i64):
 ;;                                     v145 = iconst.i32 0
-;; @001f                               store user2 little v145, v74  ; v145 = 0
+;; @001f                               store user2 little region1 v145, v74  ; v145 = 0
 ;;                                     v146 = iconst.i64 4
 ;;                                     v147 = iadd v74, v146  ; v146 = 4
 ;; @001f                               v76 = icmp eq v147, v72

--- a/tests/disas/gc/array-new-default-externref.wat
+++ b/tests/disas/gc/array-new-default-externref.wat
@@ -10,7 +10,8 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 2 "vmctx"
+;;     region0 = 32 "VMContext+0x20"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -81,14 +82,14 @@
 ;;                                 block4(v41: i32, v42: i64):
 ;;                                     v91 = iconst.i64 16
 ;; @001f                               v43 = iadd v42, v91  ; v91 = 16
-;; @001f                               store.i32 user2 v2, v43
+;; @001f                               store.i32 user2 region1 v2, v43
 ;; @001f                               trapz v41, user16
 ;;                                     v143 = load.i64 notrap aligned readonly can_move v0+8
 ;;                                     v144 = load.i64 notrap aligned readonly can_move v143+32
 ;; @001f                               v46 = uextend.i64 v41
 ;; @001f                               v48 = iadd v144, v46
 ;; @001f                               v50 = iadd v48, v91  ; v91 = 16
-;; @001f                               v51 = load.i32 user2 readonly v50
+;; @001f                               v51 = load.i32 user2 readonly region1 v50
 ;; @001f                               v52 = uextend.i64 v51
 ;; @001f                               v57 = icmp.i64 ugt v5, v52
 ;; @001f                               trapnz v57, user17
@@ -108,7 +109,7 @@
 ;;
 ;;                                 block5(v74: i64):
 ;;                                     v145 = iconst.i32 0
-;; @001f                               store user2 little v145, v74  ; v145 = 0
+;; @001f                               store user2 little region1 v145, v74  ; v145 = 0
 ;;                                     v146 = iconst.i64 4
 ;;                                     v147 = iadd v74, v146  ; v146 = 4
 ;; @001f                               v76 = icmp eq v147, v72

--- a/tests/disas/gc/array-new-default-f32.wat
+++ b/tests/disas/gc/array-new-default-f32.wat
@@ -11,7 +11,8 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     ss0 = explicit_slot 4, align = 4
-;;     region0 = 2 "vmctx"
+;;     region0 = 32 "VMContext+0x20"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -86,15 +87,14 @@
 ;;                                     store notrap v41, v95
 ;;                                     v94 = iconst.i64 16
 ;; @001f                               v43 = iadd v42, v94  ; v94 = 16
-;; @001f                               store.i32 user2 v2, v43
-;;                                     v77 = load.i32 notrap v95
-;; @001f                               trapz v77, user16
+;; @001f                               store.i32 user2 region1 v2, v43
+;; @001f                               trapz v41, user16
 ;;                                     v147 = load.i64 notrap aligned readonly can_move v0+8
 ;;                                     v148 = load.i64 notrap aligned readonly can_move v147+32
-;; @001f                               v46 = uextend.i64 v77
+;; @001f                               v46 = uextend.i64 v41
 ;; @001f                               v48 = iadd v148, v46
 ;; @001f                               v50 = iadd v48, v94  ; v94 = 16
-;; @001f                               v51 = load.i32 user2 readonly v50
+;; @001f                               v51 = load.i32 user2 readonly region1 v50
 ;; @001f                               v52 = uextend.i64 v51
 ;; @001f                               v57 = icmp.i64 ugt v5, v52
 ;; @001f                               trapnz v57, user17

--- a/tests/disas/gc/array-new-default-f64.wat
+++ b/tests/disas/gc/array-new-default-f64.wat
@@ -11,7 +11,8 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     ss0 = explicit_slot 4, align = 4
-;;     region0 = 2 "vmctx"
+;;     region0 = 32 "VMContext+0x20"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -86,15 +87,14 @@
 ;;                                     store notrap v41, v95
 ;;                                     v94 = iconst.i64 16
 ;; @001f                               v43 = iadd v42, v94  ; v94 = 16
-;; @001f                               store.i32 user2 v2, v43
-;;                                     v77 = load.i32 notrap v95
-;; @001f                               trapz v77, user16
+;; @001f                               store.i32 user2 region1 v2, v43
+;; @001f                               trapz v41, user16
 ;;                                     v147 = load.i64 notrap aligned readonly can_move v0+8
 ;;                                     v148 = load.i64 notrap aligned readonly can_move v147+32
-;; @001f                               v46 = uextend.i64 v77
+;; @001f                               v46 = uextend.i64 v41
 ;; @001f                               v48 = iadd v148, v46
 ;; @001f                               v50 = iadd v48, v94  ; v94 = 16
-;; @001f                               v51 = load.i32 user2 readonly v50
+;; @001f                               v51 = load.i32 user2 readonly region1 v50
 ;; @001f                               v52 = uextend.i64 v51
 ;; @001f                               v57 = icmp.i64 ugt v5, v52
 ;; @001f                               trapnz v57, user17

--- a/tests/disas/gc/array-new-default-funcref.wat
+++ b/tests/disas/gc/array-new-default-funcref.wat
@@ -11,7 +11,8 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     ss0 = explicit_slot 4, align = 4
-;;     region0 = 2 "vmctx"
+;;     region0 = 32 "VMContext+0x20"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -86,15 +87,14 @@
 ;;                                     store notrap v41, v103
 ;;                                     v102 = iconst.i64 16
 ;; @001f                               v43 = iadd v42, v102  ; v102 = 16
-;; @001f                               store.i32 user2 v2, v43
-;;                                     v83 = load.i32 notrap v103
-;; @001f                               trapz v83, user16
+;; @001f                               store.i32 user2 region1 v2, v43
+;; @001f                               trapz v41, user16
 ;;                                     v154 = load.i64 notrap aligned readonly can_move v0+8
 ;;                                     v155 = load.i64 notrap aligned readonly can_move v154+32
-;; @001f                               v46 = uextend.i64 v83
+;; @001f                               v46 = uextend.i64 v41
 ;; @001f                               v48 = iadd v155, v46
 ;; @001f                               v50 = iadd v48, v102  ; v102 = 16
-;; @001f                               v51 = load.i32 user2 readonly v50
+;; @001f                               v51 = load.i32 user2 readonly region1 v50
 ;; @001f                               v52 = uextend.i64 v51
 ;; @001f                               v57 = icmp.i64 ugt v5, v52
 ;; @001f                               trapnz v57, user17

--- a/tests/disas/gc/array-new-default-i16.wat
+++ b/tests/disas/gc/array-new-default-i16.wat
@@ -11,7 +11,8 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     ss0 = explicit_slot 4, align = 4
-;;     region0 = 2 "vmctx"
+;;     region0 = 32 "VMContext+0x20"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -85,15 +86,14 @@
 ;;                                     store notrap v41, v95
 ;;                                     v94 = iconst.i64 16
 ;; @001f                               v43 = iadd v42, v94  ; v94 = 16
-;; @001f                               store.i32 user2 v2, v43
-;;                                     v77 = load.i32 notrap v95
-;; @001f                               trapz v77, user16
+;; @001f                               store.i32 user2 region1 v2, v43
+;; @001f                               trapz v41, user16
 ;;                                     v157 = load.i64 notrap aligned readonly can_move v0+8
 ;;                                     v158 = load.i64 notrap aligned readonly can_move v157+32
-;; @001f                               v46 = uextend.i64 v77
+;; @001f                               v46 = uextend.i64 v41
 ;; @001f                               v48 = iadd v158, v46
 ;; @001f                               v50 = iadd v48, v94  ; v94 = 16
-;; @001f                               v51 = load.i32 user2 readonly v50
+;; @001f                               v51 = load.i32 user2 readonly region1 v50
 ;; @001f                               v52 = uextend.i64 v51
 ;; @001f                               v57 = icmp.i64 ugt v5, v52
 ;; @001f                               trapnz v57, user17

--- a/tests/disas/gc/array-new-default-i32.wat
+++ b/tests/disas/gc/array-new-default-i32.wat
@@ -11,7 +11,8 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     ss0 = explicit_slot 4, align = 4
-;;     region0 = 2 "vmctx"
+;;     region0 = 32 "VMContext+0x20"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -86,15 +87,14 @@
 ;;                                     store notrap v41, v95
 ;;                                     v94 = iconst.i64 16
 ;; @001f                               v43 = iadd v42, v94  ; v94 = 16
-;; @001f                               store.i32 user2 v2, v43
-;;                                     v77 = load.i32 notrap v95
-;; @001f                               trapz v77, user16
+;; @001f                               store.i32 user2 region1 v2, v43
+;; @001f                               trapz v41, user16
 ;;                                     v147 = load.i64 notrap aligned readonly can_move v0+8
 ;;                                     v148 = load.i64 notrap aligned readonly can_move v147+32
-;; @001f                               v46 = uextend.i64 v77
+;; @001f                               v46 = uextend.i64 v41
 ;; @001f                               v48 = iadd v148, v46
 ;; @001f                               v50 = iadd v48, v94  ; v94 = 16
-;; @001f                               v51 = load.i32 user2 readonly v50
+;; @001f                               v51 = load.i32 user2 readonly region1 v50
 ;; @001f                               v52 = uextend.i64 v51
 ;; @001f                               v57 = icmp.i64 ugt v5, v52
 ;; @001f                               trapnz v57, user17

--- a/tests/disas/gc/array-new-default-i64.wat
+++ b/tests/disas/gc/array-new-default-i64.wat
@@ -11,7 +11,8 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     ss0 = explicit_slot 4, align = 4
-;;     region0 = 2 "vmctx"
+;;     region0 = 32 "VMContext+0x20"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -86,15 +87,14 @@
 ;;                                     store notrap v41, v95
 ;;                                     v94 = iconst.i64 16
 ;; @001f                               v43 = iadd v42, v94  ; v94 = 16
-;; @001f                               store.i32 user2 v2, v43
-;;                                     v77 = load.i32 notrap v95
-;; @001f                               trapz v77, user16
+;; @001f                               store.i32 user2 region1 v2, v43
+;; @001f                               trapz v41, user16
 ;;                                     v146 = load.i64 notrap aligned readonly can_move v0+8
 ;;                                     v147 = load.i64 notrap aligned readonly can_move v146+32
-;; @001f                               v46 = uextend.i64 v77
+;; @001f                               v46 = uextend.i64 v41
 ;; @001f                               v48 = iadd v147, v46
 ;; @001f                               v50 = iadd v48, v94  ; v94 = 16
-;; @001f                               v51 = load.i32 user2 readonly v50
+;; @001f                               v51 = load.i32 user2 readonly region1 v50
 ;; @001f                               v52 = uextend.i64 v51
 ;; @001f                               v57 = icmp.i64 ugt v5, v52
 ;; @001f                               trapnz v57, user17

--- a/tests/disas/gc/array-new-default-i8.wat
+++ b/tests/disas/gc/array-new-default-i8.wat
@@ -11,7 +11,8 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     ss0 = explicit_slot 4, align = 4
-;;     region0 = 2 "vmctx"
+;;     region0 = 32 "VMContext+0x20"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -82,15 +83,14 @@
 ;;                                     store notrap v41, v94
 ;;                                     v93 = iconst.i64 16
 ;; @001f                               v43 = iadd v42, v93  ; v93 = 16
-;; @001f                               store.i32 user2 v2, v43
-;;                                     v76 = load.i32 notrap v94
-;; @001f                               trapz v76, user16
+;; @001f                               store.i32 user2 region1 v2, v43
+;; @001f                               trapz v41, user16
 ;;                                     v135 = load.i64 notrap aligned readonly can_move v0+8
 ;;                                     v136 = load.i64 notrap aligned readonly can_move v135+32
-;; @001f                               v46 = uextend.i64 v76
+;; @001f                               v46 = uextend.i64 v41
 ;; @001f                               v48 = iadd v136, v46
 ;; @001f                               v50 = iadd v48, v93  ; v93 = 16
-;; @001f                               v51 = load.i32 user2 readonly v50
+;; @001f                               v51 = load.i32 user2 readonly region1 v50
 ;; @001f                               v52 = uextend.i64 v51
 ;; @001f                               v57 = icmp.i64 ugt v5, v52
 ;; @001f                               trapnz v57, user17

--- a/tests/disas/gc/copying/array-fill.wat
+++ b/tests/disas/gc/copying/array-fill.wat
@@ -9,6 +9,7 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32, i64, i32) tail {
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -26,7 +27,7 @@
 ;; @0027                               v8 = iadd v7, v6
 ;; @0027                               v9 = iconst.i64 16
 ;; @0027                               v10 = iadd v8, v9  ; v9 = 16
-;; @0027                               v11 = load.i32 user2 readonly v10
+;; @0027                               v11 = load.i32 user2 readonly region0 v10
 ;; @0027                               v13 = uextend.i64 v3
 ;; @0027                               v14 = uextend.i64 v5
 ;; @0027                               v16 = iadd v13, v14
@@ -51,7 +52,7 @@
 ;; @0027                               brif v33, block3, block2(v24)
 ;;
 ;;                                 block2(v34: i64):
-;; @0027                               store.i64 user2 little v4, v34
+;; @0027                               store.i64 user2 little region0 v4, v34
 ;;                                     v58 = iconst.i64 8
 ;;                                     v59 = iadd v34, v58  ; v58 = 8
 ;; @0027                               v36 = icmp eq v59, v32

--- a/tests/disas/gc/copying/array-get-s.wat
+++ b/tests/disas/gc/copying/array-get-s.wat
@@ -9,6 +9,7 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32) -> i32 tail {
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -26,7 +27,7 @@
 ;; @0022                               v7 = iadd v6, v5
 ;; @0022                               v8 = iconst.i64 16
 ;; @0022                               v9 = iadd v7, v8  ; v8 = 16
-;; @0022                               v10 = load.i32 user2 readonly v9
+;; @0022                               v10 = load.i32 user2 readonly region0 v9
 ;; @0022                               v11 = icmp ult v3, v10
 ;; @0022                               trapz v11, user17
 ;; @0022                               v13 = uextend.i64 v10
@@ -42,7 +43,7 @@
 ;; @0022                               v26 = isub v18, v21
 ;; @0022                               v27 = uextend.i64 v26
 ;; @0022                               v28 = isub v25, v27
-;; @0022                               v29 = load.i8 user2 little v28
+;; @0022                               v29 = load.i8 user2 little region0 v28
 ;; @0025                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/copying/array-get-u.wat
+++ b/tests/disas/gc/copying/array-get-u.wat
@@ -9,6 +9,7 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32) -> i32 tail {
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -26,7 +27,7 @@
 ;; @0022                               v7 = iadd v6, v5
 ;; @0022                               v8 = iconst.i64 16
 ;; @0022                               v9 = iadd v7, v8  ; v8 = 16
-;; @0022                               v10 = load.i32 user2 readonly v9
+;; @0022                               v10 = load.i32 user2 readonly region0 v9
 ;; @0022                               v11 = icmp ult v3, v10
 ;; @0022                               trapz v11, user17
 ;; @0022                               v13 = uextend.i64 v10
@@ -42,7 +43,7 @@
 ;; @0022                               v26 = isub v18, v21
 ;; @0022                               v27 = uextend.i64 v26
 ;; @0022                               v28 = isub v25, v27
-;; @0022                               v29 = load.i8 user2 little v28
+;; @0022                               v29 = load.i8 user2 little region0 v28
 ;; @0025                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/copying/array-get.wat
+++ b/tests/disas/gc/copying/array-get.wat
@@ -9,6 +9,7 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32) -> i64 tail {
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -26,7 +27,7 @@
 ;; @0022                               v7 = iadd v6, v5
 ;; @0022                               v8 = iconst.i64 16
 ;; @0022                               v9 = iadd v7, v8  ; v8 = 16
-;; @0022                               v10 = load.i32 user2 readonly v9
+;; @0022                               v10 = load.i32 user2 readonly region0 v9
 ;; @0022                               v11 = icmp ult v3, v10
 ;; @0022                               trapz v11, user17
 ;; @0022                               v13 = uextend.i64 v10
@@ -47,7 +48,7 @@
 ;; @0022                               v26 = isub v18, v21
 ;; @0022                               v27 = uextend.i64 v26
 ;; @0022                               v28 = isub v25, v27
-;; @0022                               v29 = load.i64 user2 little v28
+;; @0022                               v29 = load.i64 user2 little region0 v28
 ;; @0025                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/copying/array-len.wat
+++ b/tests/disas/gc/copying/array-len.wat
@@ -9,6 +9,7 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -26,7 +27,7 @@
 ;; @001f                               v6 = iadd v5, v4
 ;; @001f                               v7 = iconst.i64 16
 ;; @001f                               v8 = iadd v6, v7  ; v7 = 16
-;; @001f                               v9 = load.i32 user2 readonly v8
+;; @001f                               v9 = load.i32 user2 readonly region0 v8
 ;; @0021                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/copying/array-new-fixed-of-gc-refs.wat
+++ b/tests/disas/gc/copying/array-new-fixed-of-gc-refs.wat
@@ -12,7 +12,8 @@
 ;;     ss0 = explicit_slot 4, align = 4
 ;;     ss1 = explicit_slot 4, align = 4
 ;;     ss2 = explicit_slot 4, align = 4
-;;     region0 = 2 "vmctx"
+;;     region0 = 32 "VMContext+0x20"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -74,14 +75,14 @@
 ;; @0025                               v6 = iconst.i32 3
 ;;                                     v143 = iconst.i64 16
 ;; @0025                               v46 = iadd v45, v143  ; v143 = 16
-;; @0025                               store user2 v6, v46  ; v6 = 3
+;; @0025                               store user2 region1 v6, v46  ; v6 = 3
 ;; @0025                               trapz v44, user16
 ;;                                     v279 = load.i64 notrap aligned readonly can_move v0+8
 ;;                                     v280 = load.i64 notrap aligned readonly can_move v279+32
 ;; @0025                               v48 = uextend.i64 v44
 ;; @0025                               v50 = iadd v280, v48
 ;; @0025                               v52 = iadd v50, v143  ; v143 = 16
-;; @0025                               v53 = load.i32 user2 readonly v52
+;; @0025                               v53 = load.i32 user2 readonly region1 v52
 ;; @0025                               v47 = iconst.i32 0
 ;;                                     v181 = icmp ne v53, v47  ; v47 = 0
 ;; @0025                               trapz v181, user17
@@ -102,8 +103,8 @@
 ;; @0025                               v69 = isub v61, v7  ; v7 = 20
 ;; @0025                               v70 = uextend.i64 v69
 ;; @0025                               v71 = isub v68, v70
-;; @0025                               store user2 little v124, v71
-;; @0025                               v78 = load.i32 user2 readonly v52
+;; @0025                               store user2 little region1 v124, v71
+;; @0025                               v78 = load.i32 user2 readonly region1 v52
 ;; @0025                               v72 = iconst.i32 1
 ;;                                     v211 = icmp ugt v78, v72  ; v72 = 1
 ;; @0025                               trapz v211, user17
@@ -121,8 +122,8 @@
 ;; @0025                               v94 = isub v86, v233  ; v233 = 24
 ;; @0025                               v95 = uextend.i64 v94
 ;; @0025                               v96 = isub v93, v95
-;; @0025                               store user2 little v123, v96
-;; @0025                               v103 = load.i32 user2 readonly v52
+;; @0025                               store user2 little region1 v123, v96
+;; @0025                               v103 = load.i32 user2 readonly region1 v52
 ;;                                     v239 = icmp ugt v103, v193  ; v193 = 2
 ;; @0025                               trapz v239, user17
 ;; @0025                               v106 = uextend.i64 v103
@@ -139,7 +140,7 @@
 ;; @0025                               v119 = isub v111, v266  ; v266 = 28
 ;; @0025                               v120 = uextend.i64 v119
 ;; @0025                               v121 = isub v118, v120
-;; @0025                               store user2 little v122, v121
+;; @0025                               store user2 little region1 v122, v121
 ;; @0029                               jump block1(v44)
 ;;
 ;;                                 block1(v5: i32):

--- a/tests/disas/gc/copying/array-new-fixed.wat
+++ b/tests/disas/gc/copying/array-new-fixed.wat
@@ -9,7 +9,8 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i64, i64, i64) -> i32 tail {
-;;     region0 = 2 "vmctx"
+;;     region0 = 32 "VMContext+0x20"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -65,14 +66,14 @@
 ;; @0025                               v6 = iconst.i32 3
 ;;                                     v137 = iconst.i64 16
 ;; @0025                               v46 = iadd v45, v137  ; v137 = 16
-;; @0025                               store user2 v6, v46  ; v6 = 3
+;; @0025                               store user2 region1 v6, v46  ; v6 = 3
 ;; @0025                               trapz v44, user16
 ;;                                     v267 = load.i64 notrap aligned readonly can_move v0+8
 ;;                                     v268 = load.i64 notrap aligned readonly can_move v267+32
 ;; @0025                               v48 = uextend.i64 v44
 ;; @0025                               v50 = iadd v268, v48
 ;; @0025                               v52 = iadd v50, v137  ; v137 = 16
-;; @0025                               v53 = load.i32 user2 readonly v52
+;; @0025                               v53 = load.i32 user2 readonly region1 v52
 ;; @0025                               v47 = iconst.i32 0
 ;;                                     v171 = icmp ne v53, v47  ; v47 = 0
 ;; @0025                               trapz v171, user17
@@ -91,8 +92,8 @@
 ;; @0025                               v69 = isub v61, v7  ; v7 = 24
 ;; @0025                               v70 = uextend.i64 v69
 ;; @0025                               v71 = isub v68, v70
-;; @0025                               store.i64 user2 little v2, v71
-;; @0025                               v78 = load.i32 user2 readonly v52
+;; @0025                               store.i64 user2 little region1 v2, v71
+;; @0025                               v78 = load.i32 user2 readonly region1 v52
 ;; @0025                               v72 = iconst.i32 1
 ;;                                     v200 = icmp ugt v78, v72  ; v72 = 1
 ;; @0025                               trapz v200, user17
@@ -109,8 +110,8 @@
 ;; @0025                               v94 = isub v86, v222  ; v222 = 32
 ;; @0025                               v95 = uextend.i64 v94
 ;; @0025                               v96 = isub v93, v95
-;; @0025                               store.i64 user2 little v3, v96
-;; @0025                               v103 = load.i32 user2 readonly v52
+;; @0025                               store.i64 user2 little region1 v3, v96
+;; @0025                               v103 = load.i32 user2 readonly region1 v52
 ;; @0025                               v97 = iconst.i32 2
 ;;                                     v228 = icmp ugt v103, v97  ; v97 = 2
 ;; @0025                               trapz v228, user17
@@ -127,7 +128,7 @@
 ;; @0025                               v119 = isub v111, v254  ; v254 = 40
 ;; @0025                               v120 = uextend.i64 v119
 ;; @0025                               v121 = isub v118, v120
-;; @0025                               store.i64 user2 little v4, v121
+;; @0025                               store.i64 user2 little region1 v4, v121
 ;; @0029                               jump block1(v44)
 ;;
 ;;                                 block1(v5: i32):

--- a/tests/disas/gc/copying/array-new.wat
+++ b/tests/disas/gc/copying/array-new.wat
@@ -9,7 +9,8 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i64, i32) -> i32 tail {
-;;     region0 = 2 "vmctx"
+;;     region0 = 32 "VMContext+0x20"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -80,14 +81,14 @@
 ;;                                 block4(v42: i32, v43: i64):
 ;;                                     v91 = iconst.i64 16
 ;; @0022                               v44 = iadd v43, v91  ; v91 = 16
-;; @0022                               store.i32 user2 v3, v44
+;; @0022                               store.i32 user2 region1 v3, v44
 ;; @0022                               trapz v42, user16
 ;;                                     v143 = load.i64 notrap aligned readonly can_move v0+8
 ;;                                     v144 = load.i64 notrap aligned readonly can_move v143+32
 ;; @0022                               v46 = uextend.i64 v42
 ;; @0022                               v48 = iadd v144, v46
 ;; @0022                               v50 = iadd v48, v91  ; v91 = 16
-;; @0022                               v51 = load.i32 user2 readonly v50
+;; @0022                               v51 = load.i32 user2 readonly region1 v50
 ;; @0022                               v52 = uextend.i64 v51
 ;; @0022                               v57 = icmp.i64 ugt v6, v52
 ;; @0022                               trapnz v57, user17
@@ -105,7 +106,7 @@
 ;; @0022                               brif v73, block6, block5(v61)
 ;;
 ;;                                 block5(v74: i64):
-;; @0022                               store.i64 user2 little v2, v74
+;; @0022                               store.i64 user2 little region1 v2, v74
 ;;                                     v145 = iconst.i64 8
 ;;                                     v146 = iadd v74, v145  ; v145 = 8
 ;; @0022                               v76 = icmp eq v146, v72

--- a/tests/disas/gc/copying/array-set.wat
+++ b/tests/disas/gc/copying/array-set.wat
@@ -9,6 +9,7 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32, i64) tail {
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -26,7 +27,7 @@
 ;; @0024                               v7 = iadd v6, v5
 ;; @0024                               v8 = iconst.i64 16
 ;; @0024                               v9 = iadd v7, v8  ; v8 = 16
-;; @0024                               v10 = load.i32 user2 readonly v9
+;; @0024                               v10 = load.i32 user2 readonly region0 v9
 ;; @0024                               v11 = icmp ult v3, v10
 ;; @0024                               trapz v11, user17
 ;; @0024                               v13 = uextend.i64 v10
@@ -47,7 +48,7 @@
 ;; @0024                               v26 = isub v18, v21
 ;; @0024                               v27 = uextend.i64 v26
 ;; @0024                               v28 = isub v25, v27
-;; @0024                               store user2 little v4, v28
+;; @0024                               store user2 little region0 v4, v28
 ;; @0027                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/copying/br-on-cast-fail.wat
+++ b/tests/disas/gc/copying/br-on-cast-fail.wat
@@ -17,6 +17,7 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) tail {
 ;;     ss0 = explicit_slot 4, align = 4
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -50,7 +51,7 @@
 ;; @002e                               v15 = iadd v14, v13
 ;; @002e                               v16 = iconst.i64 4
 ;; @002e                               v17 = iadd v15, v16  ; v16 = 4
-;; @002e                               v18 = load.i32 user2 readonly v17
+;; @002e                               v18 = load.i32 user2 readonly region0 v17
 ;; @002e                               v11 = load.i64 notrap aligned readonly can_move v0+40
 ;; @002e                               v12 = load.i32 notrap aligned readonly can_move v11
 ;; @002e                               v19 = icmp eq v18, v12

--- a/tests/disas/gc/copying/br-on-cast.wat
+++ b/tests/disas/gc/copying/br-on-cast.wat
@@ -17,6 +17,7 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) tail {
 ;;     ss0 = explicit_slot 4, align = 4
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -50,7 +51,7 @@
 ;; @002f                               v15 = iadd v14, v13
 ;; @002f                               v16 = iconst.i64 4
 ;; @002f                               v17 = iadd v15, v16  ; v16 = 4
-;; @002f                               v18 = load.i32 user2 readonly v17
+;; @002f                               v18 = load.i32 user2 readonly region0 v17
 ;; @002f                               v11 = load.i64 notrap aligned readonly can_move v0+40
 ;; @002f                               v12 = load.i32 notrap aligned readonly can_move v11
 ;; @002f                               v19 = icmp eq v18, v12

--- a/tests/disas/gc/copying/call-indirect-and-subtyping.wat
+++ b/tests/disas/gc/copying/call-indirect-and-subtyping.wat
@@ -16,7 +16,7 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32) tail {
-;;     region0 = 1 "table"
+;;     region0 = 1342177280 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/gc/copying/funcref-in-gc-heap-get.wat
+++ b/tests/disas/gc/copying/funcref-in-gc-heap-get.wat
@@ -9,6 +9,7 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i64 tail {
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -28,7 +29,7 @@
 ;; @0020                               v6 = iadd v5, v4
 ;; @0020                               v7 = iconst.i64 16
 ;; @0020                               v8 = iadd v6, v7  ; v7 = 16
-;; @0020                               v11 = load.i32 user2 little v8
+;; @0020                               v11 = load.i32 user2 little region0 v8
 ;; @0020                               v9 = iconst.i32 -1
 ;; @0020                               v12 = call fn0(v0, v11, v9)  ; v9 = -1
 ;; @0024                               jump block1

--- a/tests/disas/gc/copying/funcref-in-gc-heap-new.wat
+++ b/tests/disas/gc/copying/funcref-in-gc-heap-new.wat
@@ -10,7 +10,8 @@
 )
 ;; function u0:0(i64 vmctx, i64, i64) -> i32 tail {
 ;;     ss0 = explicit_slot 4, align = 4
-;;     region0 = 2 "vmctx"
+;;     region0 = 32 "VMContext+0x20"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -70,7 +71,7 @@
 ;; @0020                               v41 = ireduce.i32 v40
 ;;                                     v44 = iconst.i64 16
 ;; @0020                               v38 = iadd v37, v44  ; v44 = 16
-;; @0020                               store user2 little v41, v38
+;; @0020                               store user2 little region1 v41, v38
 ;;                                     v42 = load.i32 notrap v45
 ;; @0023                               jump block1
 ;;

--- a/tests/disas/gc/copying/funcref-in-gc-heap-set.wat
+++ b/tests/disas/gc/copying/funcref-in-gc-heap-set.wat
@@ -9,6 +9,7 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32, i64) tail {
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -30,7 +31,7 @@
 ;; @0022                               v6 = iadd v5, v4
 ;; @0022                               v7 = iconst.i64 16
 ;; @0022                               v8 = iadd v6, v7  ; v7 = 16
-;; @0022                               store user2 little v11, v8
+;; @0022                               store user2 little region0 v11, v8
 ;; @0026                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/copying/multiple-array-get.wat
+++ b/tests/disas/gc/copying/multiple-array-get.wat
@@ -10,6 +10,7 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32, i32) -> i64, i64 tail {
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -27,7 +28,7 @@
 ;; @0024                               v9 = iadd v8, v7
 ;; @0024                               v10 = iconst.i64 16
 ;; @0024                               v11 = iadd v9, v10  ; v10 = 16
-;; @0024                               v12 = load.i32 user2 readonly v11
+;; @0024                               v12 = load.i32 user2 readonly region0 v11
 ;; @0024                               v13 = icmp ult v3, v12
 ;; @0024                               trapz v13, user17
 ;; @0024                               v15 = uextend.i64 v12
@@ -48,7 +49,7 @@
 ;; @0024                               v28 = isub v20, v23
 ;; @0024                               v29 = uextend.i64 v28
 ;; @0024                               v30 = isub v27, v29
-;; @0024                               v31 = load.i64 user2 little v30
+;; @0024                               v31 = load.i64 user2 little region0 v30
 ;; @002b                               v38 = icmp ult v4, v12
 ;; @002b                               trapz v38, user17
 ;;                                     v86 = ishl v4, v77  ; v77 = 3
@@ -56,7 +57,7 @@
 ;; @002b                               v53 = isub v20, v48
 ;; @002b                               v54 = uextend.i64 v53
 ;; @002b                               v55 = isub v27, v54
-;; @002b                               v56 = load.i64 user2 little v55
+;; @002b                               v56 = load.i64 user2 little region0 v55
 ;; @002e                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/copying/multiple-struct-get.wat
+++ b/tests/disas/gc/copying/multiple-struct-get.wat
@@ -11,6 +11,7 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> f32, i32 tail {
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -28,10 +29,10 @@
 ;; @0023                               v7 = iadd v6, v5
 ;; @0023                               v8 = iconst.i64 16
 ;; @0023                               v9 = iadd v7, v8  ; v8 = 16
-;; @0023                               v10 = load.f32 user2 little v9
+;; @0023                               v10 = load.f32 user2 little region0 v9
 ;; @0029                               v14 = iconst.i64 20
 ;; @0029                               v15 = iadd v7, v14  ; v14 = 20
-;; @0029                               v16 = load.i8 user2 little v15
+;; @0029                               v16 = load.i8 user2 little region0 v15
 ;; @002d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/copying/ref-cast.wat
+++ b/tests/disas/gc/copying/ref-cast.wat
@@ -9,6 +9,7 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     ss0 = explicit_slot 4, align = 4
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -41,7 +42,7 @@
 ;; @001e                               v15 = iadd v14, v13
 ;; @001e                               v16 = iconst.i64 4
 ;; @001e                               v17 = iadd v15, v16  ; v16 = 4
-;; @001e                               v18 = load.i32 user2 readonly v17
+;; @001e                               v18 = load.i32 user2 readonly region0 v17
 ;; @001e                               v11 = load.i64 notrap aligned readonly can_move v0+40
 ;; @001e                               v12 = load.i32 notrap aligned readonly can_move v11
 ;; @001e                               v19 = icmp eq v18, v12

--- a/tests/disas/gc/copying/ref-test-array.wat
+++ b/tests/disas/gc/copying/ref-test-array.wat
@@ -7,6 +7,7 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -33,7 +34,7 @@
 ;; @001b                               v11 = load.i64 notrap aligned readonly can_move v21+32
 ;; @001b                               v10 = uextend.i64 v2
 ;; @001b                               v12 = iadd v11, v10
-;; @001b                               v15 = load.i32 user2 readonly v12
+;; @001b                               v15 = load.i32 user2 readonly region0 v12
 ;; @001b                               v16 = iconst.i32 -1476395008
 ;; @001b                               v17 = band v15, v16  ; v16 = -1476395008
 ;; @001b                               v18 = icmp eq v17, v16  ; v16 = -1476395008

--- a/tests/disas/gc/copying/ref-test-concrete-func-type.wat
+++ b/tests/disas/gc/copying/ref-test-concrete-func-type.wat
@@ -8,6 +8,7 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i64) -> i32 tail {
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -27,7 +28,7 @@
 ;; @0020                               jump block3
 ;;
 ;;                                 block3:
-;; @0020                               v10 = load.i32 user2 readonly v2+16
+;; @0020                               v10 = load.i32 user2 readonly region0 v2+16
 ;; @0020                               v8 = load.i64 notrap aligned readonly can_move v0+40
 ;; @0020                               v9 = load.i32 notrap aligned readonly can_move v8
 ;; @0020                               v11 = icmp eq v10, v9

--- a/tests/disas/gc/copying/ref-test-concrete-type.wat
+++ b/tests/disas/gc/copying/ref-test-concrete-type.wat
@@ -8,6 +8,7 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -38,7 +39,7 @@
 ;; @001d                               v15 = iadd v14, v13
 ;; @001d                               v16 = iconst.i64 4
 ;; @001d                               v17 = iadd v15, v16  ; v16 = 4
-;; @001d                               v18 = load.i32 user2 readonly v17
+;; @001d                               v18 = load.i32 user2 readonly region0 v17
 ;; @001d                               v11 = load.i64 notrap aligned readonly can_move v0+40
 ;; @001d                               v12 = load.i32 notrap aligned readonly can_move v11
 ;; @001d                               v19 = icmp eq v18, v12

--- a/tests/disas/gc/copying/ref-test-eq.wat
+++ b/tests/disas/gc/copying/ref-test-eq.wat
@@ -7,6 +7,7 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -32,7 +33,7 @@
 ;; @001b                               v11 = load.i64 notrap aligned readonly can_move v21+32
 ;; @001b                               v10 = uextend.i64 v2
 ;; @001b                               v12 = iadd v11, v10
-;; @001b                               v15 = load.i32 user2 readonly v12
+;; @001b                               v15 = load.i32 user2 readonly region0 v12
 ;; @001b                               v16 = iconst.i32 -1610612736
 ;; @001b                               v17 = band v15, v16  ; v16 = -1610612736
 ;; @001b                               v18 = icmp eq v17, v16  ; v16 = -1610612736

--- a/tests/disas/gc/copying/ref-test-struct.wat
+++ b/tests/disas/gc/copying/ref-test-struct.wat
@@ -7,6 +7,7 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -33,7 +34,7 @@
 ;; @001b                               v11 = load.i64 notrap aligned readonly can_move v21+32
 ;; @001b                               v10 = uextend.i64 v2
 ;; @001b                               v12 = iadd v11, v10
-;; @001b                               v15 = load.i32 user2 readonly v12
+;; @001b                               v15 = load.i32 user2 readonly region0 v12
 ;; @001b                               v16 = iconst.i32 -1342177280
 ;; @001b                               v17 = band v15, v16  ; v16 = -1342177280
 ;; @001b                               v18 = icmp eq v17, v16  ; v16 = -1342177280

--- a/tests/disas/gc/copying/struct-get.wat
+++ b/tests/disas/gc/copying/struct-get.wat
@@ -23,6 +23,7 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> f32 tail {
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -40,7 +41,7 @@
 ;; @0033                               v6 = iadd v5, v4
 ;; @0033                               v7 = iconst.i64 16
 ;; @0033                               v8 = iadd v6, v7  ; v7 = 16
-;; @0033                               v9 = load.f32 user2 little v8
+;; @0033                               v9 = load.f32 user2 little region0 v8
 ;; @0037                               jump block1
 ;;
 ;;                                 block1:
@@ -48,6 +49,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -65,7 +67,7 @@
 ;; @003c                               v6 = iadd v5, v4
 ;; @003c                               v7 = iconst.i64 20
 ;; @003c                               v8 = iadd v6, v7  ; v7 = 20
-;; @003c                               v9 = load.i8 user2 little v8
+;; @003c                               v9 = load.i8 user2 little region0 v8
 ;; @0040                               jump block1
 ;;
 ;;                                 block1:
@@ -74,6 +76,7 @@
 ;; }
 ;;
 ;; function u0:2(i64 vmctx, i64, i32) -> i32 tail {
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -91,7 +94,7 @@
 ;; @0045                               v6 = iadd v5, v4
 ;; @0045                               v7 = iconst.i64 20
 ;; @0045                               v8 = iadd v6, v7  ; v7 = 20
-;; @0045                               v9 = load.i8 user2 little v8
+;; @0045                               v9 = load.i8 user2 little region0 v8
 ;; @0049                               jump block1
 ;;
 ;;                                 block1:
@@ -100,6 +103,7 @@
 ;; }
 ;;
 ;; function u0:3(i64 vmctx, i64, i32) -> i32 tail {
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -117,7 +121,7 @@
 ;; @004e                               v6 = iadd v5, v4
 ;; @004e                               v7 = iconst.i64 24
 ;; @004e                               v8 = iadd v6, v7  ; v7 = 24
-;; @004e                               v9 = load.i32 user2 little v8
+;; @004e                               v9 = load.i32 user2 little region0 v8
 ;; @0052                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/copying/struct-new-default.wat
+++ b/tests/disas/gc/copying/struct-new-default.wat
@@ -11,7 +11,8 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64) -> i32 tail {
-;;     region0 = 2 "vmctx"
+;;     region0 = 32 "VMContext+0x20"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -66,14 +67,14 @@
 ;; @0021                               v3 = f32const 0.0
 ;;                                     v45 = iconst.i64 16
 ;; @0021                               v40 = iadd v39, v45  ; v45 = 16
-;; @0021                               store user2 little v3, v40  ; v3 = 0.0
+;; @0021                               store user2 little region1 v3, v40  ; v3 = 0.0
 ;; @0021                               v4 = iconst.i32 0
 ;;                                     v44 = iconst.i64 20
 ;; @0021                               v41 = iadd v39, v44  ; v44 = 20
-;; @0021                               istore8 user2 little v4, v41  ; v4 = 0
+;; @0021                               istore8 user2 little region1 v4, v41  ; v4 = 0
 ;;                                     v43 = iconst.i64 24
 ;; @0021                               v42 = iadd v39, v43  ; v43 = 24
-;; @0021                               store user2 little v4, v42  ; v4 = 0
+;; @0021                               store user2 little region1 v4, v42  ; v4 = 0
 ;; @0024                               jump block1(v38)
 ;;
 ;;                                 block1(v2: i32):

--- a/tests/disas/gc/copying/struct-new.wat
+++ b/tests/disas/gc/copying/struct-new.wat
@@ -12,7 +12,8 @@
 )
 ;; function u0:0(i64 vmctx, i64, f32, i32, i32) -> i32 tail {
 ;;     ss0 = explicit_slot 4, align = 4
-;;     region0 = 2 "vmctx"
+;;     region0 = 32 "VMContext+0x20"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -68,14 +69,14 @@
 ;;                                 block4(v38: i32, v39: i64):
 ;;                                     v47 = iconst.i64 16
 ;; @002a                               v40 = iadd v39, v47  ; v47 = 16
-;; @002a                               store.f32 user2 little v2, v40
+;; @002a                               store.f32 user2 little region1 v2, v40
 ;;                                     v46 = iconst.i64 20
 ;; @002a                               v41 = iadd v39, v46  ; v46 = 20
-;; @002a                               istore8.i32 user2 little v3, v41
+;; @002a                               istore8.i32 user2 little region1 v3, v41
 ;;                                     v43 = load.i32 notrap v52
 ;;                                     v45 = iconst.i64 24
 ;; @002a                               v42 = iadd v39, v45  ; v45 = 24
-;; @002a                               store user2 little v43, v42
+;; @002a                               store user2 little region1 v43, v42
 ;; @002d                               jump block1(v38)
 ;;
 ;;                                 block1(v5: i32):

--- a/tests/disas/gc/copying/struct-set.wat
+++ b/tests/disas/gc/copying/struct-set.wat
@@ -19,6 +19,7 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32, f32) tail {
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -36,7 +37,7 @@
 ;; @0034                               v6 = iadd v5, v4
 ;; @0034                               v7 = iconst.i64 16
 ;; @0034                               v8 = iadd v6, v7  ; v7 = 16
-;; @0034                               store user2 little v3, v8
+;; @0034                               store user2 little region0 v3, v8
 ;; @0038                               jump block1
 ;;
 ;;                                 block1:
@@ -44,6 +45,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32, i32) tail {
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -61,7 +63,7 @@
 ;; @003f                               v6 = iadd v5, v4
 ;; @003f                               v7 = iconst.i64 20
 ;; @003f                               v8 = iadd v6, v7  ; v7 = 20
-;; @003f                               istore8 user2 little v3, v8
+;; @003f                               istore8 user2 little region0 v3, v8
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -69,6 +71,7 @@
 ;; }
 ;;
 ;; function u0:2(i64 vmctx, i64, i32, i32) tail {
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -86,7 +89,7 @@
 ;; @004a                               v6 = iadd v5, v4
 ;; @004a                               v7 = iconst.i64 24
 ;; @004a                               v8 = iadd v6, v7  ; v7 = 24
-;; @004a                               store user2 little v3, v8
+;; @004a                               store user2 little region0 v3, v8
 ;; @004e                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/copying/v128-fields.wat
+++ b/tests/disas/gc/copying/v128-fields.wat
@@ -11,6 +11,7 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i8x16 tail {
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -28,7 +29,7 @@
 ;; @0022                               v6 = iadd v5, v4
 ;; @0022                               v7 = iconst.i64 16
 ;; @0022                               v8 = iadd v6, v7  ; v7 = 16
-;; @0022                               v9 = load.i8x16 user2 little v8
+;; @0022                               v9 = load.i8x16 user2 little region0 v8
 ;; @002e                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/drc/array-fill.wat
+++ b/tests/disas/gc/drc/array-fill.wat
@@ -10,6 +10,7 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32, i64, i32) tail {
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -27,7 +28,7 @@
 ;; @0027                               v8 = iadd v7, v6
 ;; @0027                               v9 = iconst.i64 24
 ;; @0027                               v10 = iadd v8, v9  ; v9 = 24
-;; @0027                               v11 = load.i32 user2 readonly v10
+;; @0027                               v11 = load.i32 user2 readonly region0 v10
 ;; @0027                               v13 = uextend.i64 v3
 ;; @0027                               v14 = uextend.i64 v5
 ;; @0027                               v16 = iadd v13, v14
@@ -52,7 +53,7 @@
 ;; @0027                               brif v33, block3, block2(v24)
 ;;
 ;;                                 block2(v34: i64):
-;; @0027                               store.i64 user2 little v4, v34
+;; @0027                               store.i64 user2 little region0 v4, v34
 ;;                                     v58 = iconst.i64 8
 ;;                                     v59 = iadd v34, v58  ; v58 = 8
 ;; @0027                               v36 = icmp eq v59, v32

--- a/tests/disas/gc/drc/array-get-s.wat
+++ b/tests/disas/gc/drc/array-get-s.wat
@@ -10,6 +10,7 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32) -> i32 tail {
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -27,7 +28,7 @@
 ;; @0022                               v7 = iadd v6, v5
 ;; @0022                               v8 = iconst.i64 24
 ;; @0022                               v9 = iadd v7, v8  ; v8 = 24
-;; @0022                               v10 = load.i32 user2 readonly v9
+;; @0022                               v10 = load.i32 user2 readonly region0 v9
 ;; @0022                               v11 = icmp ult v3, v10
 ;; @0022                               trapz v11, user17
 ;; @0022                               v13 = uextend.i64 v10
@@ -43,7 +44,7 @@
 ;; @0022                               v26 = isub v18, v21
 ;; @0022                               v27 = uextend.i64 v26
 ;; @0022                               v28 = isub v25, v27
-;; @0022                               v29 = load.i8 user2 little v28
+;; @0022                               v29 = load.i8 user2 little region0 v28
 ;; @0025                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/drc/array-get-u.wat
+++ b/tests/disas/gc/drc/array-get-u.wat
@@ -10,6 +10,7 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32) -> i32 tail {
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -27,7 +28,7 @@
 ;; @0022                               v7 = iadd v6, v5
 ;; @0022                               v8 = iconst.i64 24
 ;; @0022                               v9 = iadd v7, v8  ; v8 = 24
-;; @0022                               v10 = load.i32 user2 readonly v9
+;; @0022                               v10 = load.i32 user2 readonly region0 v9
 ;; @0022                               v11 = icmp ult v3, v10
 ;; @0022                               trapz v11, user17
 ;; @0022                               v13 = uextend.i64 v10
@@ -43,7 +44,7 @@
 ;; @0022                               v26 = isub v18, v21
 ;; @0022                               v27 = uextend.i64 v26
 ;; @0022                               v28 = isub v25, v27
-;; @0022                               v29 = load.i8 user2 little v28
+;; @0022                               v29 = load.i8 user2 little region0 v28
 ;; @0025                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/drc/array-get.wat
+++ b/tests/disas/gc/drc/array-get.wat
@@ -10,6 +10,7 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32) -> i64 tail {
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -27,7 +28,7 @@
 ;; @0022                               v7 = iadd v6, v5
 ;; @0022                               v8 = iconst.i64 24
 ;; @0022                               v9 = iadd v7, v8  ; v8 = 24
-;; @0022                               v10 = load.i32 user2 readonly v9
+;; @0022                               v10 = load.i32 user2 readonly region0 v9
 ;; @0022                               v11 = icmp ult v3, v10
 ;; @0022                               trapz v11, user17
 ;; @0022                               v13 = uextend.i64 v10
@@ -48,7 +49,7 @@
 ;; @0022                               v26 = isub v18, v21
 ;; @0022                               v27 = uextend.i64 v26
 ;; @0022                               v28 = isub v25, v27
-;; @0022                               v29 = load.i64 user2 little v28
+;; @0022                               v29 = load.i64 user2 little region0 v28
 ;; @0025                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/drc/array-len.wat
+++ b/tests/disas/gc/drc/array-len.wat
@@ -10,6 +10,7 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -27,7 +28,7 @@
 ;; @001f                               v6 = iadd v5, v4
 ;; @001f                               v7 = iconst.i64 24
 ;; @001f                               v8 = iadd v6, v7  ; v7 = 24
-;; @001f                               v9 = load.i32 user2 readonly v8
+;; @001f                               v9 = load.i32 user2 readonly region0 v8
 ;; @0021                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/drc/array-new-fixed-of-gc-refs.wat
+++ b/tests/disas/gc/drc/array-new-fixed-of-gc-refs.wat
@@ -13,6 +13,7 @@
 ;;     ss0 = explicit_slot 4, align = 4
 ;;     ss1 = explicit_slot 4, align = 4
 ;;     ss2 = explicit_slot 4, align = 4
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -44,7 +45,7 @@
 ;; @0025                               v22 = iadd v20, v21
 ;;                                     v213 = iconst.i64 24
 ;; @0025                               v23 = iadd v22, v213  ; v213 = 24
-;; @0025                               store user2 v6, v23  ; v6 = 3
+;; @0025                               store user2 region0 v6, v23  ; v6 = 3
 ;; @0025                               trapz v19, user16
 ;; @0025                               v42 = uadd_overflow_trap v19, v232, user2  ; v232 = 40
 ;;                                     v161 = load.i32 notrap v220
@@ -62,10 +63,10 @@
 ;; @0025                               v55 = iadd.i64 v20, v53
 ;; @0025                               v56 = iconst.i64 8
 ;; @0025                               v57 = iadd v55, v56  ; v56 = 8
-;; @0025                               v58 = load.i64 user2 v57
+;; @0025                               v58 = load.i64 user2 region0 v57
 ;;                                     v200 = iconst.i64 1
 ;; @0025                               v59 = iadd v58, v200  ; v200 = 1
-;; @0025                               store user2 v59, v57
+;; @0025                               store user2 region0 v59, v57
 ;; @0025                               jump block3
 ;;
 ;;                                 block3:
@@ -74,9 +75,9 @@
 ;; @0025                               v45 = iadd.i64 v20, v43
 ;;                                     v222 = iconst.i64 12
 ;; @0025                               v48 = isub v45, v222  ; v222 = 12
-;; @0025                               store user2 little v157, v48
+;; @0025                               store user2 little region0 v157, v48
 ;;                                     v325 = iadd.i64 v22, v213  ; v213 = 24
-;; @0025                               v71 = load.i32 user2 readonly v325
+;; @0025                               v71 = load.i32 user2 readonly region0 v325
 ;;                                     v326 = iconst.i32 1
 ;;                                     v327 = icmp ugt v71, v326  ; v326 = 1
 ;; @0025                               trapz v327, user17
@@ -105,10 +106,10 @@
 ;; @0025                               v96 = iadd.i64 v20, v94
 ;;                                     v331 = iconst.i64 8
 ;; @0025                               v98 = iadd v96, v331  ; v331 = 8
-;; @0025                               v99 = load.i64 user2 v98
+;; @0025                               v99 = load.i64 user2 region0 v98
 ;;                                     v332 = iconst.i64 1
 ;; @0025                               v100 = iadd v99, v332  ; v332 = 1
-;; @0025                               store user2 v100, v98
+;; @0025                               store user2 region0 v100, v98
 ;; @0025                               jump block5
 ;;
 ;;                                 block5:
@@ -119,9 +120,9 @@
 ;; @0025                               v87 = isub.i32 v79, v287  ; v287 = 32
 ;; @0025                               v88 = uextend.i64 v87
 ;; @0025                               v89 = isub v86, v88
-;; @0025                               store user2 little v152, v89
+;; @0025                               store user2 little region0 v152, v89
 ;;                                     v333 = iadd.i64 v22, v213  ; v213 = 24
-;; @0025                               v112 = load.i32 user2 readonly v333
+;; @0025                               v112 = load.i32 user2 readonly region0 v333
 ;;                                     v334 = iconst.i32 2
 ;;                                     v335 = icmp ugt v112, v334  ; v334 = 2
 ;; @0025                               trapz v335, user17
@@ -150,10 +151,10 @@
 ;; @0025                               v137 = iadd.i64 v20, v135
 ;;                                     v346 = iconst.i64 8
 ;; @0025                               v139 = iadd v137, v346  ; v346 = 8
-;; @0025                               v140 = load.i64 user2 v139
+;; @0025                               v140 = load.i64 user2 region0 v139
 ;;                                     v347 = iconst.i64 1
 ;; @0025                               v141 = iadd v140, v347  ; v347 = 1
-;; @0025                               store user2 v141, v139
+;; @0025                               store user2 region0 v141, v139
 ;; @0025                               jump block7
 ;;
 ;;                                 block7:
@@ -164,7 +165,7 @@
 ;; @0025                               v128 = isub.i32 v120, v319  ; v319 = 36
 ;; @0025                               v129 = uextend.i64 v128
 ;; @0025                               v130 = isub v127, v129
-;; @0025                               store user2 little v147, v130
+;; @0025                               store user2 little region0 v147, v130
 ;; @0029                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/drc/array-new-fixed.wat
+++ b/tests/disas/gc/drc/array-new-fixed.wat
@@ -10,6 +10,7 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i64, i64, i64) -> i32 tail {
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -35,14 +36,14 @@
 ;; @0025                               v22 = iadd v20, v21
 ;;                                     v120 = iconst.i64 24
 ;; @0025                               v23 = iadd v22, v120  ; v120 = 24
-;; @0025                               store user2 v6, v23  ; v6 = 3
+;; @0025                               store user2 region0 v6, v23  ; v6 = 3
 ;; @0025                               trapz v19, user16
 ;; @0025                               v42 = uadd_overflow_trap v19, v129, user2  ; v129 = 56
 ;; @0025                               v43 = uextend.i64 v42
 ;; @0025                               v45 = iadd v20, v43
 ;; @0025                               v48 = isub v45, v120  ; v120 = 24
-;; @0025                               store user2 little v2, v48
-;; @0025                               v55 = load.i32 user2 readonly v23
+;; @0025                               store user2 little region0 v2, v48
+;; @0025                               v55 = load.i32 user2 readonly region0 v23
 ;; @0025                               v49 = iconst.i32 1
 ;;                                     v160 = icmp ugt v55, v49  ; v49 = 1
 ;; @0025                               trapz v160, user17
@@ -62,8 +63,8 @@
 ;; @0025                               v71 = isub v63, v182  ; v182 = 40
 ;; @0025                               v72 = uextend.i64 v71
 ;; @0025                               v73 = isub v70, v72
-;; @0025                               store user2 little v3, v73
-;; @0025                               v80 = load.i32 user2 readonly v23
+;; @0025                               store user2 little region0 v3, v73
+;; @0025                               v80 = load.i32 user2 readonly region0 v23
 ;; @0025                               v74 = iconst.i32 2
 ;;                                     v188 = icmp ugt v80, v74  ; v74 = 2
 ;; @0025                               trapz v188, user17
@@ -80,7 +81,7 @@
 ;; @0025                               v96 = isub v88, v215  ; v215 = 48
 ;; @0025                               v97 = uextend.i64 v96
 ;; @0025                               v98 = isub v95, v97
-;; @0025                               store user2 little v4, v98
+;; @0025                               store user2 little region0 v4, v98
 ;; @0029                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/drc/array-new.wat
+++ b/tests/disas/gc/drc/array-new.wat
@@ -10,6 +10,7 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i64, i32) -> i32 tail {
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -43,7 +44,7 @@
 ;; @0022                               v20 = iadd v18, v19
 ;;                                     v68 = iconst.i64 24
 ;; @0022                               v21 = iadd v20, v68  ; v68 = 24
-;; @0022                               store user2 v3, v21
+;; @0022                               store user2 region0 v3, v21
 ;; @0022                               trapz v17, user16
 ;; @0022                               v45 = load.i64 notrap aligned v69+40
 ;; @0022                               v38 = iadd v20, v71  ; v71 = 32
@@ -58,7 +59,7 @@
 ;; @0022                               brif v50, block3, block2(v38)
 ;;
 ;;                                 block2(v51: i64):
-;; @0022                               store.i64 user2 little v2, v51
+;; @0022                               store.i64 user2 little region0 v2, v51
 ;;                                     v99 = iconst.i64 8
 ;;                                     v100 = iadd v51, v99  ; v99 = 8
 ;; @0022                               v53 = icmp eq v100, v49

--- a/tests/disas/gc/drc/array-set.wat
+++ b/tests/disas/gc/drc/array-set.wat
@@ -10,6 +10,7 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32, i64) tail {
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -27,7 +28,7 @@
 ;; @0024                               v7 = iadd v6, v5
 ;; @0024                               v8 = iconst.i64 24
 ;; @0024                               v9 = iadd v7, v8  ; v8 = 24
-;; @0024                               v10 = load.i32 user2 readonly v9
+;; @0024                               v10 = load.i32 user2 readonly region0 v9
 ;; @0024                               v11 = icmp ult v3, v10
 ;; @0024                               trapz v11, user17
 ;; @0024                               v13 = uextend.i64 v10
@@ -48,7 +49,7 @@
 ;; @0024                               v26 = isub v18, v21
 ;; @0024                               v27 = uextend.i64 v26
 ;; @0024                               v28 = isub v25, v27
-;; @0024                               store user2 little v4, v28
+;; @0024                               store user2 little region0 v4, v28
 ;; @0027                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/drc/br-on-cast-fail.wat
+++ b/tests/disas/gc/drc/br-on-cast-fail.wat
@@ -18,6 +18,7 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) tail {
 ;;     ss0 = explicit_slot 4, align = 4
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -51,7 +52,7 @@
 ;; @002e                               v15 = iadd v14, v13
 ;; @002e                               v16 = iconst.i64 4
 ;; @002e                               v17 = iadd v15, v16  ; v16 = 4
-;; @002e                               v18 = load.i32 user2 readonly v17
+;; @002e                               v18 = load.i32 user2 readonly region0 v17
 ;; @002e                               v11 = load.i64 notrap aligned readonly can_move v0+40
 ;; @002e                               v12 = load.i32 notrap aligned readonly can_move v11
 ;; @002e                               v19 = icmp eq v18, v12

--- a/tests/disas/gc/drc/br-on-cast.wat
+++ b/tests/disas/gc/drc/br-on-cast.wat
@@ -18,6 +18,7 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) tail {
 ;;     ss0 = explicit_slot 4, align = 4
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -51,7 +52,7 @@
 ;; @002f                               v15 = iadd v14, v13
 ;; @002f                               v16 = iconst.i64 4
 ;; @002f                               v17 = iadd v15, v16  ; v16 = 4
-;; @002f                               v18 = load.i32 user2 readonly v17
+;; @002f                               v18 = load.i32 user2 readonly region0 v17
 ;; @002f                               v11 = load.i64 notrap aligned readonly can_move v0+40
 ;; @002f                               v12 = load.i32 notrap aligned readonly can_move v11
 ;; @002f                               v19 = icmp eq v18, v12

--- a/tests/disas/gc/drc/call-indirect-and-subtyping.wat
+++ b/tests/disas/gc/drc/call-indirect-and-subtyping.wat
@@ -17,7 +17,7 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32) tail {
-;;     region0 = 1 "table"
+;;     region0 = 1342177280 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/gc/drc/externref-globals.wat
+++ b/tests/disas/gc/drc/externref-globals.wat
@@ -14,6 +14,8 @@
 
 ;; function u0:0(i64 vmctx, i64) -> i32 tail {
 ;;     ss0 = explicit_slot 4, align = 4
+;;     region0 = 2147483648 "GcHeap"
+;;     region1 = 32 "VMContext+0x20"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -44,34 +46,27 @@
 ;; @0034                               v11 = load.i64 notrap aligned readonly can_move v84+32
 ;; @0034                               v10 = uextend.i64 v5
 ;; @0034                               v12 = iadd v11, v10
-;; @0034                               v13 = load.i32 user2 v12
+;; @0034                               v13 = load.i32 user2 region0 v12
 ;; @0034                               v14 = iconst.i32 2
 ;; @0034                               v15 = band v13, v14  ; v14 = 2
 ;; @0034                               brif v15, block4, block3
 ;;
 ;;                                 block3:
-;; @0034                               v17 = load.i64 notrap aligned readonly can_move v0+32
-;; @0034                               v18 = load.i32 user2 v17
+;; @0034                               v17 = load.i64 notrap aligned readonly can_move region1 v0+32
+;; @0034                               v18 = load.i32 user2 region0 v17
 ;; @0034                               v22 = iconst.i64 16
 ;; @0034                               v23 = iadd.i64 v12, v22  ; v22 = 16
-;; @0034                               store user2 v18, v23
-;;                                     v63 = load.i32 notrap v91
+;; @0034                               store user2 region0 v18, v23
 ;;                                     v93 = iconst.i32 2
 ;;                                     v94 = bor.i32 v13, v93  ; v93 = 2
-;; @0034                               v26 = uextend.i64 v63
-;; @0034                               v28 = iadd.i64 v11, v26
-;; @0034                               store user2 v94, v28
-;;                                     v62 = load.i32 notrap v91
-;; @0034                               v29 = uextend.i64 v62
-;; @0034                               v31 = iadd.i64 v11, v29
+;; @0034                               store user2 region0 v94, v12
 ;; @0034                               v32 = iconst.i64 8
-;; @0034                               v33 = iadd v31, v32  ; v32 = 8
-;; @0034                               v34 = load.i64 user2 v33
+;; @0034                               v33 = iadd.i64 v12, v32  ; v32 = 8
+;; @0034                               v34 = load.i64 user2 region0 v33
 ;;                                     v74 = iconst.i64 1
 ;; @0034                               v35 = iadd v34, v74  ; v74 = 1
-;; @0034                               store user2 v35, v33
-;;                                     v60 = load.i32 notrap v91
-;; @0034                               store user2 v60, v17
+;; @0034                               store user2 region0 v35, v33
+;; @0034                               store.i32 user2 region0 v5, v17
 ;; @0034                               v43 = load.i32 notrap aligned v17+4
 ;;                                     v95 = iconst.i32 1
 ;;                                     v96 = iadd v43, v95  ; v95 = 1
@@ -99,6 +94,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) tail {
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -129,10 +125,10 @@
 ;; @003b                               v12 = iadd v11, v10
 ;; @003b                               v13 = iconst.i64 8
 ;; @003b                               v14 = iadd v12, v13  ; v13 = 8
-;; @003b                               v15 = load.i64 user2 v14
+;; @003b                               v15 = load.i64 user2 region0 v14
 ;;                                     v50 = iconst.i64 1
 ;; @003b                               v16 = iadd v15, v50  ; v50 = 1
-;; @003b                               store user2 v16, v14
+;; @003b                               store user2 region0 v16, v14
 ;; @003b                               jump block3
 ;;
 ;;                                 block3:
@@ -153,7 +149,7 @@
 ;; @003b                               v28 = iadd v74, v26
 ;;                                     v75 = iconst.i64 8
 ;; @003b                               v30 = iadd v28, v75  ; v75 = 8
-;; @003b                               v31 = load.i64 user2 v30
+;; @003b                               v31 = load.i64 user2 region0 v30
 ;;                                     v76 = iconst.i64 1
 ;;                                     v66 = icmp eq v31, v76  ; v76 = 1
 ;; @003b                               brif v66, block5, block6
@@ -166,7 +162,7 @@
 ;;                                     v43 = iconst.i64 -1
 ;; @003b                               v32 = iadd.i64 v31, v43  ; v43 = -1
 ;;                                     v77 = iadd.i64 v28, v75  ; v75 = 8
-;; @003b                               store user2 v32, v77
+;; @003b                               store user2 region0 v32, v77
 ;; @003b                               jump block7
 ;;
 ;;                                 block7:

--- a/tests/disas/gc/drc/funcref-in-gc-heap-get.wat
+++ b/tests/disas/gc/drc/funcref-in-gc-heap-get.wat
@@ -10,6 +10,7 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i64 tail {
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -29,7 +30,7 @@
 ;; @0020                               v6 = iadd v5, v4
 ;; @0020                               v7 = iconst.i64 24
 ;; @0020                               v8 = iadd v6, v7  ; v7 = 24
-;; @0020                               v11 = load.i32 user2 little v8
+;; @0020                               v11 = load.i32 user2 little region0 v8
 ;; @0020                               v9 = iconst.i32 -1
 ;; @0020                               v12 = call fn0(v0, v11, v9)  ; v9 = -1
 ;; @0024                               jump block1

--- a/tests/disas/gc/drc/funcref-in-gc-heap-new.wat
+++ b/tests/disas/gc/drc/funcref-in-gc-heap-new.wat
@@ -11,6 +11,7 @@
 )
 ;; function u0:0(i64 vmctx, i64, i64) -> i32 tail {
 ;;     ss0 = explicit_slot 4, align = 4
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -40,7 +41,7 @@
 ;; @0020                               v14 = iadd v12, v13
 ;;                                     v22 = iconst.i64 24
 ;; @0020                               v15 = iadd v14, v22  ; v22 = 24
-;; @0020                               store user2 little v18, v15
+;; @0020                               store user2 little region0 v18, v15
 ;;                                     v19 = load.i32 notrap v26
 ;; @0023                               jump block1
 ;;

--- a/tests/disas/gc/drc/funcref-in-gc-heap-set.wat
+++ b/tests/disas/gc/drc/funcref-in-gc-heap-set.wat
@@ -10,6 +10,7 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32, i64) tail {
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -31,7 +32,7 @@
 ;; @0022                               v6 = iadd v5, v4
 ;; @0022                               v7 = iconst.i64 24
 ;; @0022                               v8 = iadd v6, v7  ; v7 = 24
-;; @0022                               store user2 little v11, v8
+;; @0022                               store user2 little region0 v11, v8
 ;; @0026                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/drc/multiple-array-get.wat
+++ b/tests/disas/gc/drc/multiple-array-get.wat
@@ -11,6 +11,7 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32, i32) -> i64, i64 tail {
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -28,7 +29,7 @@
 ;; @0024                               v9 = iadd v8, v7
 ;; @0024                               v10 = iconst.i64 24
 ;; @0024                               v11 = iadd v9, v10  ; v10 = 24
-;; @0024                               v12 = load.i32 user2 readonly v11
+;; @0024                               v12 = load.i32 user2 readonly region0 v11
 ;; @0024                               v13 = icmp ult v3, v12
 ;; @0024                               trapz v13, user17
 ;; @0024                               v15 = uextend.i64 v12
@@ -49,7 +50,7 @@
 ;; @0024                               v28 = isub v20, v23
 ;; @0024                               v29 = uextend.i64 v28
 ;; @0024                               v30 = isub v27, v29
-;; @0024                               v31 = load.i64 user2 little v30
+;; @0024                               v31 = load.i64 user2 little region0 v30
 ;; @002b                               v38 = icmp ult v4, v12
 ;; @002b                               trapz v38, user17
 ;;                                     v86 = ishl v4, v77  ; v77 = 3
@@ -57,7 +58,7 @@
 ;; @002b                               v53 = isub v20, v48
 ;; @002b                               v54 = uextend.i64 v53
 ;; @002b                               v55 = isub v27, v54
-;; @002b                               v56 = load.i64 user2 little v55
+;; @002b                               v56 = load.i64 user2 little region0 v55
 ;; @002e                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/drc/multiple-struct-get.wat
+++ b/tests/disas/gc/drc/multiple-struct-get.wat
@@ -12,6 +12,7 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> f32, i32 tail {
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -29,10 +30,10 @@
 ;; @0023                               v7 = iadd v6, v5
 ;; @0023                               v8 = iconst.i64 24
 ;; @0023                               v9 = iadd v7, v8  ; v8 = 24
-;; @0023                               v10 = load.f32 user2 little v9
+;; @0023                               v10 = load.f32 user2 little region0 v9
 ;; @0029                               v14 = iconst.i64 28
 ;; @0029                               v15 = iadd v7, v14  ; v14 = 28
-;; @0029                               v16 = load.i8 user2 little v15
+;; @0029                               v16 = load.i8 user2 little region0 v15
 ;; @002d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/drc/ref-cast.wat
+++ b/tests/disas/gc/drc/ref-cast.wat
@@ -10,6 +10,7 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     ss0 = explicit_slot 4, align = 4
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -42,7 +43,7 @@
 ;; @001e                               v15 = iadd v14, v13
 ;; @001e                               v16 = iconst.i64 4
 ;; @001e                               v17 = iadd v15, v16  ; v16 = 4
-;; @001e                               v18 = load.i32 user2 readonly v17
+;; @001e                               v18 = load.i32 user2 readonly region0 v17
 ;; @001e                               v11 = load.i64 notrap aligned readonly can_move v0+40
 ;; @001e                               v12 = load.i32 notrap aligned readonly can_move v11
 ;; @001e                               v19 = icmp eq v18, v12

--- a/tests/disas/gc/drc/ref-test-array.wat
+++ b/tests/disas/gc/drc/ref-test-array.wat
@@ -8,6 +8,7 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -34,7 +35,7 @@
 ;; @001b                               v11 = load.i64 notrap aligned readonly can_move v21+32
 ;; @001b                               v10 = uextend.i64 v2
 ;; @001b                               v12 = iadd v11, v10
-;; @001b                               v15 = load.i32 user2 readonly v12
+;; @001b                               v15 = load.i32 user2 readonly region0 v12
 ;; @001b                               v16 = iconst.i32 -1476395008
 ;; @001b                               v17 = band v15, v16  ; v16 = -1476395008
 ;; @001b                               v18 = icmp eq v17, v16  ; v16 = -1476395008

--- a/tests/disas/gc/drc/ref-test-concrete-func-type.wat
+++ b/tests/disas/gc/drc/ref-test-concrete-func-type.wat
@@ -9,6 +9,7 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i64) -> i32 tail {
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -28,7 +29,7 @@
 ;; @0020                               jump block3
 ;;
 ;;                                 block3:
-;; @0020                               v10 = load.i32 user2 readonly v2+16
+;; @0020                               v10 = load.i32 user2 readonly region0 v2+16
 ;; @0020                               v8 = load.i64 notrap aligned readonly can_move v0+40
 ;; @0020                               v9 = load.i32 notrap aligned readonly can_move v8
 ;; @0020                               v11 = icmp eq v10, v9

--- a/tests/disas/gc/drc/ref-test-concrete-type.wat
+++ b/tests/disas/gc/drc/ref-test-concrete-type.wat
@@ -9,6 +9,7 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -39,7 +40,7 @@
 ;; @001d                               v15 = iadd v14, v13
 ;; @001d                               v16 = iconst.i64 4
 ;; @001d                               v17 = iadd v15, v16  ; v16 = 4
-;; @001d                               v18 = load.i32 user2 readonly v17
+;; @001d                               v18 = load.i32 user2 readonly region0 v17
 ;; @001d                               v11 = load.i64 notrap aligned readonly can_move v0+40
 ;; @001d                               v12 = load.i32 notrap aligned readonly can_move v11
 ;; @001d                               v19 = icmp eq v18, v12

--- a/tests/disas/gc/drc/ref-test-eq.wat
+++ b/tests/disas/gc/drc/ref-test-eq.wat
@@ -8,6 +8,7 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -33,7 +34,7 @@
 ;; @001b                               v11 = load.i64 notrap aligned readonly can_move v21+32
 ;; @001b                               v10 = uextend.i64 v2
 ;; @001b                               v12 = iadd v11, v10
-;; @001b                               v15 = load.i32 user2 readonly v12
+;; @001b                               v15 = load.i32 user2 readonly region0 v12
 ;; @001b                               v16 = iconst.i32 -1610612736
 ;; @001b                               v17 = band v15, v16  ; v16 = -1610612736
 ;; @001b                               v18 = icmp eq v17, v16  ; v16 = -1610612736

--- a/tests/disas/gc/drc/ref-test-struct.wat
+++ b/tests/disas/gc/drc/ref-test-struct.wat
@@ -8,6 +8,7 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -34,7 +35,7 @@
 ;; @001b                               v11 = load.i64 notrap aligned readonly can_move v21+32
 ;; @001b                               v10 = uextend.i64 v2
 ;; @001b                               v12 = iadd v11, v10
-;; @001b                               v15 = load.i32 user2 readonly v12
+;; @001b                               v15 = load.i32 user2 readonly region0 v12
 ;; @001b                               v16 = iconst.i32 -1342177280
 ;; @001b                               v17 = band v15, v16  ; v16 = -1342177280
 ;; @001b                               v18 = icmp eq v17, v16  ; v16 = -1342177280

--- a/tests/disas/gc/drc/struct-get.wat
+++ b/tests/disas/gc/drc/struct-get.wat
@@ -24,6 +24,7 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> f32 tail {
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -41,7 +42,7 @@
 ;; @0033                               v6 = iadd v5, v4
 ;; @0033                               v7 = iconst.i64 24
 ;; @0033                               v8 = iadd v6, v7  ; v7 = 24
-;; @0033                               v9 = load.f32 user2 little v8
+;; @0033                               v9 = load.f32 user2 little region0 v8
 ;; @0037                               jump block1
 ;;
 ;;                                 block1:
@@ -49,6 +50,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -66,7 +68,7 @@
 ;; @003c                               v6 = iadd v5, v4
 ;; @003c                               v7 = iconst.i64 28
 ;; @003c                               v8 = iadd v6, v7  ; v7 = 28
-;; @003c                               v9 = load.i8 user2 little v8
+;; @003c                               v9 = load.i8 user2 little region0 v8
 ;; @0040                               jump block1
 ;;
 ;;                                 block1:
@@ -75,6 +77,7 @@
 ;; }
 ;;
 ;; function u0:2(i64 vmctx, i64, i32) -> i32 tail {
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -92,7 +95,7 @@
 ;; @0045                               v6 = iadd v5, v4
 ;; @0045                               v7 = iconst.i64 28
 ;; @0045                               v8 = iadd v6, v7  ; v7 = 28
-;; @0045                               v9 = load.i8 user2 little v8
+;; @0045                               v9 = load.i8 user2 little region0 v8
 ;; @0049                               jump block1
 ;;
 ;;                                 block1:
@@ -102,6 +105,8 @@
 ;;
 ;; function u0:3(i64 vmctx, i64, i32) -> i32 tail {
 ;;     ss0 = explicit_slot 4, align = 4
+;;     region0 = 2147483648 "GcHeap"
+;;     region1 = 32 "VMContext+0x20"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -121,7 +126,7 @@
 ;; @004e                               v6 = iadd v5, v4
 ;; @004e                               v7 = iconst.i64 32
 ;; @004e                               v8 = iadd v6, v7  ; v7 = 32
-;; @004e                               v9 = load.i32 user2 little v8
+;; @004e                               v9 = load.i32 user2 little region0 v8
 ;;                                     v95 = stack_addr.i64 ss0
 ;;                                     store notrap v9, v95
 ;;                                     v93 = iconst.i32 1
@@ -135,34 +140,27 @@
 ;;                                 block2:
 ;; @004e                               v14 = uextend.i64 v9
 ;; @004e                               v16 = iadd.i64 v5, v14
-;; @004e                               v17 = load.i32 user2 v16
+;; @004e                               v17 = load.i32 user2 region0 v16
 ;; @004e                               v18 = iconst.i32 2
 ;; @004e                               v19 = band v17, v18  ; v18 = 2
 ;; @004e                               brif v19, block4, block3
 ;;
 ;;                                 block3:
-;; @004e                               v21 = load.i64 notrap aligned readonly can_move v0+32
-;; @004e                               v22 = load.i32 user2 v21
+;; @004e                               v21 = load.i64 notrap aligned readonly can_move region1 v0+32
+;; @004e                               v22 = load.i32 user2 region0 v21
 ;; @004e                               v26 = iconst.i64 16
 ;; @004e                               v27 = iadd.i64 v16, v26  ; v26 = 16
-;; @004e                               store user2 v22, v27
-;;                                     v67 = load.i32 notrap v95
+;; @004e                               store user2 region0 v22, v27
 ;;                                     v98 = iconst.i32 2
 ;;                                     v99 = bor.i32 v17, v98  ; v98 = 2
-;; @004e                               v30 = uextend.i64 v67
-;; @004e                               v32 = iadd.i64 v5, v30
-;; @004e                               store user2 v99, v32
-;;                                     v66 = load.i32 notrap v95
-;; @004e                               v33 = uextend.i64 v66
-;; @004e                               v35 = iadd.i64 v5, v33
+;; @004e                               store user2 region0 v99, v16
 ;; @004e                               v36 = iconst.i64 8
-;; @004e                               v37 = iadd v35, v36  ; v36 = 8
-;; @004e                               v38 = load.i64 user2 v37
+;; @004e                               v37 = iadd.i64 v16, v36  ; v36 = 8
+;; @004e                               v38 = load.i64 user2 region0 v37
 ;;                                     v78 = iconst.i64 1
 ;; @004e                               v39 = iadd v38, v78  ; v78 = 1
-;; @004e                               store user2 v39, v37
-;;                                     v64 = load.i32 notrap v95
-;; @004e                               store user2 v64, v21
+;; @004e                               store user2 region0 v39, v37
+;; @004e                               store.i32 user2 region0 v9, v21
 ;; @004e                               v47 = load.i32 notrap aligned v21+4
 ;;                                     v100 = iconst.i32 1
 ;;                                     v101 = iadd v47, v100  ; v100 = 1

--- a/tests/disas/gc/drc/struct-new-default.wat
+++ b/tests/disas/gc/drc/struct-new-default.wat
@@ -12,6 +12,7 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64) -> i32 tail {
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -37,18 +38,18 @@
 ;; @0021                               v16 = iadd v14, v15
 ;;                                     v45 = iconst.i64 24
 ;; @0021                               v17 = iadd v16, v45  ; v45 = 24
-;; @0021                               store user2 little v3, v17  ; v3 = 0.0
+;; @0021                               store user2 little region0 v3, v17  ; v3 = 0.0
 ;; @0021                               v4 = iconst.i32 0
 ;;                                     v44 = iconst.i64 28
 ;; @0021                               v18 = iadd v16, v44  ; v44 = 28
-;; @0021                               istore8 user2 little v4, v18  ; v4 = 0
+;; @0021                               istore8 user2 little region0 v4, v18  ; v4 = 0
 ;;                                     jump block3
 ;;
 ;;                                 block3:
 ;;                                     v65 = iconst.i32 0
 ;;                                     v43 = iconst.i64 32
 ;; @0021                               v19 = iadd.i64 v16, v43  ; v43 = 32
-;; @0021                               store user2 little v65, v19  ; v65 = 0
+;; @0021                               store user2 little region0 v65, v19  ; v65 = 0
 ;; @0024                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/drc/struct-new.wat
+++ b/tests/disas/gc/drc/struct-new.wat
@@ -13,6 +13,7 @@
 )
 ;; function u0:0(i64 vmctx, i64, f32, i32, i32) -> i32 tail {
 ;;     ss0 = explicit_slot 4, align = 4
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -39,10 +40,10 @@
 ;; @002a                               v16 = iadd v14, v15
 ;;                                     v55 = iconst.i64 24
 ;; @002a                               v17 = iadd v16, v55  ; v55 = 24
-;; @002a                               store user2 little v2, v17
+;; @002a                               store user2 little region0 v2, v17
 ;;                                     v54 = iconst.i64 28
 ;; @002a                               v18 = iadd v16, v54  ; v54 = 28
-;; @002a                               istore8 user2 little v3, v18
+;; @002a                               istore8 user2 little region0 v3, v18
 ;;                                     v40 = load.i32 notrap v58
 ;;                                     v51 = iconst.i32 1
 ;; @002a                               v20 = band v40, v51  ; v51 = 1
@@ -57,17 +58,16 @@
 ;; @002a                               v26 = iadd.i64 v14, v24
 ;; @002a                               v27 = iconst.i64 8
 ;; @002a                               v28 = iadd v26, v27  ; v27 = 8
-;; @002a                               v29 = load.i64 user2 v28
+;; @002a                               v29 = load.i64 user2 region0 v28
 ;;                                     v45 = iconst.i64 1
 ;; @002a                               v30 = iadd v29, v45  ; v45 = 1
-;; @002a                               store user2 v30, v28
+;; @002a                               store user2 region0 v30, v28
 ;; @002a                               jump block3
 ;;
 ;;                                 block3:
-;;                                     v36 = load.i32 notrap v58
 ;;                                     v53 = iconst.i64 32
 ;; @002a                               v19 = iadd.i64 v16, v53  ; v53 = 32
-;; @002a                               store user2 little v36, v19
+;; @002a                               store.i32 user2 little region0 v40, v19
 ;; @002d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/drc/struct-set.wat
+++ b/tests/disas/gc/drc/struct-set.wat
@@ -20,6 +20,7 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32, f32) tail {
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -37,7 +38,7 @@
 ;; @0034                               v6 = iadd v5, v4
 ;; @0034                               v7 = iconst.i64 24
 ;; @0034                               v8 = iadd v6, v7  ; v7 = 24
-;; @0034                               store user2 little v3, v8
+;; @0034                               store user2 little region0 v3, v8
 ;; @0038                               jump block1
 ;;
 ;;                                 block1:
@@ -45,6 +46,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32, i32) tail {
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -62,7 +64,7 @@
 ;; @003f                               v6 = iadd v5, v4
 ;; @003f                               v7 = iconst.i64 28
 ;; @003f                               v8 = iadd v6, v7  ; v7 = 28
-;; @003f                               istore8 user2 little v3, v8
+;; @003f                               istore8 user2 little region0 v3, v8
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -70,6 +72,7 @@
 ;; }
 ;;
 ;; function u0:2(i64 vmctx, i64, i32, i32) tail {
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -89,7 +92,7 @@
 ;; @004a                               v6 = iadd v5, v4
 ;; @004a                               v7 = iconst.i64 32
 ;; @004a                               v8 = iadd v6, v7  ; v7 = 32
-;; @004a                               v9 = load.i32 user2 little v8
+;; @004a                               v9 = load.i32 user2 little region0 v8
 ;;                                     v58 = iconst.i32 1
 ;; @004a                               v10 = band v3, v58  ; v58 = 1
 ;;                                     v57 = iconst.i32 0
@@ -103,15 +106,15 @@
 ;; @004a                               v16 = iadd.i64 v5, v14
 ;; @004a                               v17 = iconst.i64 8
 ;; @004a                               v18 = iadd v16, v17  ; v17 = 8
-;; @004a                               v19 = load.i64 user2 v18
+;; @004a                               v19 = load.i64 user2 region0 v18
 ;;                                     v54 = iconst.i64 1
 ;; @004a                               v20 = iadd v19, v54  ; v54 = 1
-;; @004a                               store user2 v20, v18
+;; @004a                               store user2 region0 v20, v18
 ;; @004a                               jump block3
 ;;
 ;;                                 block3:
 ;;                                     v73 = iadd.i64 v6, v7  ; v7 = 32
-;; @004a                               store.i32 user2 little v3, v73
+;; @004a                               store.i32 user2 little region0 v3, v73
 ;;                                     v74 = iconst.i32 1
 ;;                                     v75 = band.i32 v9, v74  ; v74 = 1
 ;;                                     v76 = iconst.i32 0
@@ -125,7 +128,7 @@
 ;; @004a                               v32 = iadd.i64 v5, v30
 ;;                                     v78 = iconst.i64 8
 ;; @004a                               v34 = iadd v32, v78  ; v78 = 8
-;; @004a                               v35 = load.i64 user2 v34
+;; @004a                               v35 = load.i64 user2 region0 v34
 ;;                                     v79 = iconst.i64 1
 ;;                                     v71 = icmp eq v35, v79  ; v79 = 1
 ;; @004a                               brif v71, block5, block6
@@ -138,7 +141,7 @@
 ;;                                     v47 = iconst.i64 -1
 ;; @004a                               v36 = iadd.i64 v35, v47  ; v47 = -1
 ;;                                     v80 = iadd.i64 v32, v78  ; v78 = 8
-;; @004a                               store user2 v36, v80
+;; @004a                               store user2 region0 v36, v80
 ;; @004a                               jump block7
 ;;
 ;;                                 block7:

--- a/tests/disas/gc/null/array-fill.wat
+++ b/tests/disas/gc/null/array-fill.wat
@@ -10,6 +10,7 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32, i64, i32) tail {
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -27,7 +28,7 @@
 ;; @0027                               v8 = iadd v7, v6
 ;; @0027                               v9 = iconst.i64 8
 ;; @0027                               v10 = iadd v8, v9  ; v9 = 8
-;; @0027                               v11 = load.i32 user2 readonly v10
+;; @0027                               v11 = load.i32 user2 readonly region0 v10
 ;; @0027                               v13 = uextend.i64 v3
 ;; @0027                               v14 = uextend.i64 v5
 ;; @0027                               v16 = iadd v13, v14
@@ -51,7 +52,7 @@
 ;; @0027                               brif v33, block3, block2(v24)
 ;;
 ;;                                 block2(v34: i64):
-;; @0027                               store.i64 user2 little v4, v34
+;; @0027                               store.i64 user2 little region0 v4, v34
 ;;                                     v58 = iconst.i64 8
 ;;                                     v59 = iadd v34, v58  ; v58 = 8
 ;; @0027                               v36 = icmp eq v59, v32

--- a/tests/disas/gc/null/array-get-s.wat
+++ b/tests/disas/gc/null/array-get-s.wat
@@ -10,6 +10,7 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32) -> i32 tail {
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -27,7 +28,7 @@
 ;; @0022                               v7 = iadd v6, v5
 ;; @0022                               v8 = iconst.i64 8
 ;; @0022                               v9 = iadd v7, v8  ; v8 = 8
-;; @0022                               v10 = load.i32 user2 readonly v9
+;; @0022                               v10 = load.i32 user2 readonly region0 v9
 ;; @0022                               v11 = icmp ult v3, v10
 ;; @0022                               trapz v11, user17
 ;; @0022                               v13 = uextend.i64 v10
@@ -43,7 +44,7 @@
 ;; @0022                               v26 = isub v18, v21
 ;; @0022                               v27 = uextend.i64 v26
 ;; @0022                               v28 = isub v25, v27
-;; @0022                               v29 = load.i8 user2 little v28
+;; @0022                               v29 = load.i8 user2 little region0 v28
 ;; @0025                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/null/array-get-u.wat
+++ b/tests/disas/gc/null/array-get-u.wat
@@ -10,6 +10,7 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32) -> i32 tail {
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -27,7 +28,7 @@
 ;; @0022                               v7 = iadd v6, v5
 ;; @0022                               v8 = iconst.i64 8
 ;; @0022                               v9 = iadd v7, v8  ; v8 = 8
-;; @0022                               v10 = load.i32 user2 readonly v9
+;; @0022                               v10 = load.i32 user2 readonly region0 v9
 ;; @0022                               v11 = icmp ult v3, v10
 ;; @0022                               trapz v11, user17
 ;; @0022                               v13 = uextend.i64 v10
@@ -43,7 +44,7 @@
 ;; @0022                               v26 = isub v18, v21
 ;; @0022                               v27 = uextend.i64 v26
 ;; @0022                               v28 = isub v25, v27
-;; @0022                               v29 = load.i8 user2 little v28
+;; @0022                               v29 = load.i8 user2 little region0 v28
 ;; @0025                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/null/array-get.wat
+++ b/tests/disas/gc/null/array-get.wat
@@ -10,6 +10,7 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32) -> i64 tail {
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -27,7 +28,7 @@
 ;; @0022                               v7 = iadd v6, v5
 ;; @0022                               v8 = iconst.i64 8
 ;; @0022                               v9 = iadd v7, v8  ; v8 = 8
-;; @0022                               v10 = load.i32 user2 readonly v9
+;; @0022                               v10 = load.i32 user2 readonly region0 v9
 ;; @0022                               v11 = icmp ult v3, v10
 ;; @0022                               trapz v11, user17
 ;; @0022                               v13 = uextend.i64 v10
@@ -48,7 +49,7 @@
 ;; @0022                               v26 = isub v18, v21
 ;; @0022                               v27 = uextend.i64 v26
 ;; @0022                               v28 = isub v25, v27
-;; @0022                               v29 = load.i64 user2 little v28
+;; @0022                               v29 = load.i64 user2 little region0 v28
 ;; @0025                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/null/array-len.wat
+++ b/tests/disas/gc/null/array-len.wat
@@ -10,6 +10,7 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -27,7 +28,7 @@
 ;; @001f                               v6 = iadd v5, v4
 ;; @001f                               v7 = iconst.i64 8
 ;; @001f                               v8 = iadd v6, v7  ; v7 = 8
-;; @001f                               v9 = load.i32 user2 readonly v8
+;; @001f                               v9 = load.i32 user2 readonly region0 v8
 ;; @0021                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/null/array-new-fixed-of-gc-refs.wat
+++ b/tests/disas/gc/null/array-new-fixed-of-gc-refs.wat
@@ -13,6 +13,8 @@
 ;;     ss0 = explicit_slot 4, align = 4
 ;;     ss1 = explicit_slot 4, align = 4
 ;;     ss2 = explicit_slot 4, align = 4
+;;     region0 = 32 "VMContext+0x20"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -31,8 +33,8 @@
 ;;                                     store notrap v3, v144
 ;;                                     v143 = stack_addr.i64 ss0
 ;;                                     store notrap v4, v143
-;; @0025                               v17 = load.i64 notrap aligned readonly v0+32
-;; @0025                               v18 = load.i32 user2 v17
+;; @0025                               v17 = load.i64 notrap aligned readonly region0 v0+32
+;; @0025                               v18 = load.i32 user2 region1 v17
 ;;                                     v163 = iconst.i32 7
 ;; @0025                               v21 = uadd_overflow_trap v18, v163, user18  ; v163 = 7
 ;;                                     v169 = iconst.i32 -8
@@ -51,15 +53,15 @@
 ;;                                     v268 = band.i32 v21, v169  ; v169 = -8
 ;;                                     v269 = uextend.i64 v268
 ;; @0025                               v33 = iadd v31, v269
-;; @0025                               store user2 v170, v33  ; v170 = -1476394984
+;; @0025                               store user2 region1 v170, v33  ; v170 = -1476394984
 ;; @0025                               v37 = load.i64 notrap aligned readonly can_move v0+40
 ;; @0025                               v38 = load.i32 notrap aligned readonly can_move v37
-;; @0025                               store user2 v38, v33+4
-;; @0025                               store.i32 user2 v24, v17
+;; @0025                               store user2 region1 v38, v33+4
+;; @0025                               store.i32 user2 region1 v24, v17
 ;; @0025                               v6 = iconst.i32 3
 ;;                                     v136 = iconst.i64 8
 ;; @0025                               v39 = iadd v33, v136  ; v136 = 8
-;; @0025                               store user2 v6, v39  ; v6 = 3
+;; @0025                               store user2 region1 v6, v39  ; v6 = 3
 ;; @0025                               trapz v268, user16
 ;;                                     v270 = iconst.i32 24
 ;; @0025                               v58 = uadd_overflow_trap v268, v270, user2  ; v270 = 24
@@ -68,8 +70,8 @@
 ;; @0025                               v61 = iadd v31, v59
 ;;                                     v147 = iconst.i64 12
 ;; @0025                               v64 = isub v61, v147  ; v147 = 12
-;; @0025                               store user2 little v117, v64
-;; @0025                               v71 = load.i32 user2 readonly v39
+;; @0025                               store user2 little region1 v117, v64
+;; @0025                               v71 = load.i32 user2 readonly region1 v39
 ;; @0025                               v65 = iconst.i32 1
 ;;                                     v208 = icmp ugt v71, v65  ; v65 = 1
 ;; @0025                               trapz v208, user17
@@ -91,8 +93,8 @@
 ;; @0025                               v87 = isub v79, v230  ; v230 = 16
 ;; @0025                               v88 = uextend.i64 v87
 ;; @0025                               v89 = isub v86, v88
-;; @0025                               store user2 little v116, v89
-;; @0025                               v96 = load.i32 user2 readonly v39
+;; @0025                               store user2 little region1 v116, v89
+;; @0025                               v96 = load.i32 user2 readonly region1 v39
 ;;                                     v236 = icmp ugt v96, v187  ; v187 = 2
 ;; @0025                               trapz v236, user17
 ;; @0025                               v99 = uextend.i64 v96
@@ -109,7 +111,7 @@
 ;; @0025                               v112 = isub v104, v262  ; v262 = 20
 ;; @0025                               v113 = uextend.i64 v112
 ;; @0025                               v114 = isub v111, v113
-;; @0025                               store user2 little v115, v114
+;; @0025                               store user2 little region1 v115, v114
 ;; @0029                               jump block1
 ;;
 ;;                                 block3 cold:

--- a/tests/disas/gc/null/array-new-fixed.wat
+++ b/tests/disas/gc/null/array-new-fixed.wat
@@ -10,6 +10,8 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i64, i64, i64) -> i32 tail {
+;;     region0 = 32 "VMContext+0x20"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -22,8 +24,8 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i64, v4: i64):
-;; @0025                               v17 = load.i64 notrap aligned readonly v0+32
-;; @0025                               v18 = load.i32 user2 v17
+;; @0025                               v17 = load.i64 notrap aligned readonly region0 v0+32
+;; @0025                               v18 = load.i32 user2 region1 v17
 ;;                                     v154 = iconst.i32 7
 ;; @0025                               v21 = uadd_overflow_trap v18, v154, user18  ; v154 = 7
 ;;                                     v160 = iconst.i32 -8
@@ -42,15 +44,15 @@
 ;;                                     v256 = band.i32 v21, v160  ; v160 = -8
 ;;                                     v257 = uextend.i64 v256
 ;; @0025                               v33 = iadd v31, v257
-;; @0025                               store user2 v161, v33  ; v161 = -1476394968
+;; @0025                               store user2 region1 v161, v33  ; v161 = -1476394968
 ;; @0025                               v37 = load.i64 notrap aligned readonly can_move v0+40
 ;; @0025                               v38 = load.i32 notrap aligned readonly can_move v37
-;; @0025                               store user2 v38, v33+4
-;; @0025                               store.i32 user2 v24, v17
+;; @0025                               store user2 region1 v38, v33+4
+;; @0025                               store.i32 user2 region1 v24, v17
 ;; @0025                               v6 = iconst.i32 3
 ;;                                     v136 = iconst.i64 8
 ;; @0025                               v39 = iadd v33, v136  ; v136 = 8
-;; @0025                               store user2 v6, v39  ; v6 = 3
+;; @0025                               store user2 region1 v6, v39  ; v6 = 3
 ;; @0025                               trapz v256, user16
 ;;                                     v258 = iconst.i32 40
 ;; @0025                               v58 = uadd_overflow_trap v256, v258, user2  ; v258 = 40
@@ -58,8 +60,8 @@
 ;; @0025                               v61 = iadd v31, v59
 ;;                                     v138 = iconst.i64 24
 ;; @0025                               v64 = isub v61, v138  ; v138 = 24
-;; @0025                               store.i64 user2 little v2, v64
-;; @0025                               v71 = load.i32 user2 readonly v39
+;; @0025                               store.i64 user2 little region1 v2, v64
+;; @0025                               v71 = load.i32 user2 readonly region1 v39
 ;; @0025                               v65 = iconst.i32 1
 ;;                                     v197 = icmp ugt v71, v65  ; v65 = 1
 ;; @0025                               trapz v197, user17
@@ -79,8 +81,8 @@
 ;; @0025                               v87 = isub v79, v146  ; v146 = 24
 ;; @0025                               v88 = uextend.i64 v87
 ;; @0025                               v89 = isub v86, v88
-;; @0025                               store.i64 user2 little v3, v89
-;; @0025                               v96 = load.i32 user2 readonly v39
+;; @0025                               store.i64 user2 little region1 v3, v89
+;; @0025                               v96 = load.i32 user2 readonly region1 v39
 ;; @0025                               v90 = iconst.i32 2
 ;;                                     v224 = icmp ugt v96, v90  ; v90 = 2
 ;; @0025                               trapz v224, user17
@@ -97,7 +99,7 @@
 ;; @0025                               v112 = isub v104, v250  ; v250 = 32
 ;; @0025                               v113 = uextend.i64 v112
 ;; @0025                               v114 = isub v111, v113
-;; @0025                               store.i64 user2 little v4, v114
+;; @0025                               store.i64 user2 little region1 v4, v114
 ;; @0029                               jump block1
 ;;
 ;;                                 block3 cold:

--- a/tests/disas/gc/null/array-new.wat
+++ b/tests/disas/gc/null/array-new.wat
@@ -10,6 +10,8 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i64, i32) -> i32 tail {
+;;     region0 = 32 "VMContext+0x20"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -35,8 +37,8 @@
 ;; @0022                               v12 = iconst.i32 -67108864
 ;; @0022                               v13 = band v10, v12  ; v12 = -67108864
 ;; @0022                               trapnz v13, user18
-;; @0022                               v15 = load.i64 notrap aligned readonly v0+32
-;; @0022                               v16 = load.i32 user2 v15
+;; @0022                               v15 = load.i64 notrap aligned readonly region0 v0+32
+;; @0022                               v16 = load.i32 user2 region1 v15
 ;;                                     v102 = iconst.i32 7
 ;; @0022                               v19 = uadd_overflow_trap v16, v102, user18  ; v102 = 7
 ;;                                     v108 = iconst.i32 -8
@@ -55,14 +57,14 @@
 ;;                                     v126 = band.i32 v19, v108  ; v108 = -8
 ;;                                     v127 = uextend.i64 v126
 ;; @0022                               v31 = iadd v29, v127
-;; @0022                               store user2 v109, v31
+;; @0022                               store user2 region1 v109, v31
 ;; @0022                               v35 = load.i64 notrap aligned readonly can_move v0+40
 ;; @0022                               v36 = load.i32 notrap aligned readonly can_move v35
-;; @0022                               store user2 v36, v31+4
-;; @0022                               store.i32 user2 v22, v15
+;; @0022                               store user2 region1 v36, v31+4
+;; @0022                               store.i32 user2 region1 v22, v15
 ;;                                     v90 = iconst.i64 8
 ;; @0022                               v37 = iadd v31, v90  ; v90 = 8
-;; @0022                               store.i32 user2 v3, v37
+;; @0022                               store.i32 user2 region1 v3, v37
 ;; @0022                               trapz v126, user16
 ;; @0022                               v61 = load.i64 notrap aligned v87+40
 ;;                                     v78 = iconst.i64 16
@@ -77,7 +79,7 @@
 ;; @0022                               brif v66, block5, block4(v54)
 ;;
 ;;                                 block4(v67: i64):
-;; @0022                               store.i64 user2 little v2, v67
+;; @0022                               store.i64 user2 little region1 v2, v67
 ;;                                     v128 = iconst.i64 8
 ;;                                     v129 = iadd v67, v128  ; v128 = 8
 ;; @0022                               v69 = icmp eq v129, v65

--- a/tests/disas/gc/null/array-set.wat
+++ b/tests/disas/gc/null/array-set.wat
@@ -10,6 +10,7 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32, i64) tail {
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -27,7 +28,7 @@
 ;; @0024                               v7 = iadd v6, v5
 ;; @0024                               v8 = iconst.i64 8
 ;; @0024                               v9 = iadd v7, v8  ; v8 = 8
-;; @0024                               v10 = load.i32 user2 readonly v9
+;; @0024                               v10 = load.i32 user2 readonly region0 v9
 ;; @0024                               v11 = icmp ult v3, v10
 ;; @0024                               trapz v11, user17
 ;; @0024                               v13 = uextend.i64 v10
@@ -48,7 +49,7 @@
 ;; @0024                               v26 = isub v18, v21
 ;; @0024                               v27 = uextend.i64 v26
 ;; @0024                               v28 = isub v25, v27
-;; @0024                               store user2 little v4, v28
+;; @0024                               store user2 little region0 v4, v28
 ;; @0027                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/null/br-on-cast-fail.wat
+++ b/tests/disas/gc/null/br-on-cast-fail.wat
@@ -18,6 +18,7 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) tail {
 ;;     ss0 = explicit_slot 4, align = 4
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -51,7 +52,7 @@
 ;; @002e                               v15 = iadd v14, v13
 ;; @002e                               v16 = iconst.i64 4
 ;; @002e                               v17 = iadd v15, v16  ; v16 = 4
-;; @002e                               v18 = load.i32 user2 readonly v17
+;; @002e                               v18 = load.i32 user2 readonly region0 v17
 ;; @002e                               v11 = load.i64 notrap aligned readonly can_move v0+40
 ;; @002e                               v12 = load.i32 notrap aligned readonly can_move v11
 ;; @002e                               v19 = icmp eq v18, v12

--- a/tests/disas/gc/null/br-on-cast.wat
+++ b/tests/disas/gc/null/br-on-cast.wat
@@ -18,6 +18,7 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) tail {
 ;;     ss0 = explicit_slot 4, align = 4
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -51,7 +52,7 @@
 ;; @002f                               v15 = iadd v14, v13
 ;; @002f                               v16 = iconst.i64 4
 ;; @002f                               v17 = iadd v15, v16  ; v16 = 4
-;; @002f                               v18 = load.i32 user2 readonly v17
+;; @002f                               v18 = load.i32 user2 readonly region0 v17
 ;; @002f                               v11 = load.i64 notrap aligned readonly can_move v0+40
 ;; @002f                               v12 = load.i32 notrap aligned readonly can_move v11
 ;; @002f                               v19 = icmp eq v18, v12

--- a/tests/disas/gc/null/call-indirect-and-subtyping.wat
+++ b/tests/disas/gc/null/call-indirect-and-subtyping.wat
@@ -17,7 +17,7 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32) tail {
-;;     region0 = 1 "table"
+;;     region0 = 1342177280 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/gc/null/funcref-in-gc-heap-get.wat
+++ b/tests/disas/gc/null/funcref-in-gc-heap-get.wat
@@ -10,6 +10,7 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i64 tail {
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -29,7 +30,7 @@
 ;; @0020                               v6 = iadd v5, v4
 ;; @0020                               v7 = iconst.i64 8
 ;; @0020                               v8 = iadd v6, v7  ; v7 = 8
-;; @0020                               v11 = load.i32 user2 little v8
+;; @0020                               v11 = load.i32 user2 little region0 v8
 ;; @0020                               v9 = iconst.i32 -1
 ;; @0020                               v12 = call fn0(v0, v11, v9)  ; v9 = -1
 ;; @0024                               jump block1

--- a/tests/disas/gc/null/funcref-in-gc-heap-new.wat
+++ b/tests/disas/gc/null/funcref-in-gc-heap-new.wat
@@ -10,6 +10,8 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i64) -> i32 tail {
+;;     region0 = 32 "VMContext+0x20"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -24,8 +26,8 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0020                               v9 = load.i64 notrap aligned readonly v0+32
-;; @0020                               v10 = load.i32 user2 v9
+;; @0020                               v9 = load.i64 notrap aligned readonly region0 v0+32
+;; @0020                               v10 = load.i32 user2 region1 v9
 ;;                                     v46 = iconst.i32 7
 ;; @0020                               v13 = uadd_overflow_trap v10, v46, user18  ; v46 = 7
 ;;                                     v52 = iconst.i32 -8
@@ -44,16 +46,16 @@
 ;;                                     v59 = band.i32 v13, v52  ; v52 = -8
 ;;                                     v60 = uextend.i64 v59
 ;; @0020                               v25 = iadd v23, v60
-;; @0020                               store user2 v53, v25  ; v53 = -1342177264
+;; @0020                               store user2 region1 v53, v25  ; v53 = -1342177264
 ;; @0020                               v29 = load.i64 notrap aligned readonly can_move v0+40
 ;; @0020                               v30 = load.i32 notrap aligned readonly can_move v29
-;; @0020                               store user2 v30, v25+4
-;; @0020                               store.i32 user2 v16, v9
+;; @0020                               store user2 region1 v30, v25+4
+;; @0020                               store.i32 user2 region1 v16, v9
 ;; @0020                               v33 = call fn1(v0, v2)
 ;; @0020                               v34 = ireduce.i32 v33
 ;;                                     v35 = iconst.i64 8
 ;; @0020                               v31 = iadd v25, v35  ; v35 = 8
-;; @0020                               store user2 little v34, v31
+;; @0020                               store user2 little region1 v34, v31
 ;; @0023                               jump block1
 ;;
 ;;                                 block3 cold:

--- a/tests/disas/gc/null/funcref-in-gc-heap-set.wat
+++ b/tests/disas/gc/null/funcref-in-gc-heap-set.wat
@@ -10,6 +10,7 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32, i64) tail {
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -31,7 +32,7 @@
 ;; @0022                               v6 = iadd v5, v4
 ;; @0022                               v7 = iconst.i64 8
 ;; @0022                               v8 = iadd v6, v7  ; v7 = 8
-;; @0022                               store user2 little v11, v8
+;; @0022                               store user2 little region0 v11, v8
 ;; @0026                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/null/multiple-array-get.wat
+++ b/tests/disas/gc/null/multiple-array-get.wat
@@ -11,6 +11,7 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32, i32) -> i64, i64 tail {
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -28,7 +29,7 @@
 ;; @0024                               v9 = iadd v8, v7
 ;; @0024                               v10 = iconst.i64 8
 ;; @0024                               v11 = iadd v9, v10  ; v10 = 8
-;; @0024                               v12 = load.i32 user2 readonly v11
+;; @0024                               v12 = load.i32 user2 readonly region0 v11
 ;; @0024                               v13 = icmp ult v3, v12
 ;; @0024                               trapz v13, user17
 ;; @0024                               v15 = uextend.i64 v12
@@ -49,7 +50,7 @@
 ;; @0024                               v28 = isub v20, v23
 ;; @0024                               v29 = uextend.i64 v28
 ;; @0024                               v30 = isub v27, v29
-;; @0024                               v31 = load.i64 user2 little v30
+;; @0024                               v31 = load.i64 user2 little region0 v30
 ;; @002b                               v38 = icmp ult v4, v12
 ;; @002b                               trapz v38, user17
 ;;                                     v86 = ishl v4, v77  ; v77 = 3
@@ -57,7 +58,7 @@
 ;; @002b                               v53 = isub v20, v48
 ;; @002b                               v54 = uextend.i64 v53
 ;; @002b                               v55 = isub v27, v54
-;; @002b                               v56 = load.i64 user2 little v55
+;; @002b                               v56 = load.i64 user2 little region0 v55
 ;; @002e                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/null/multiple-struct-get.wat
+++ b/tests/disas/gc/null/multiple-struct-get.wat
@@ -12,6 +12,7 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> f32, i32 tail {
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -29,10 +30,10 @@
 ;; @0023                               v7 = iadd v6, v5
 ;; @0023                               v8 = iconst.i64 8
 ;; @0023                               v9 = iadd v7, v8  ; v8 = 8
-;; @0023                               v10 = load.f32 user2 little v9
+;; @0023                               v10 = load.f32 user2 little region0 v9
 ;; @0029                               v14 = iconst.i64 12
 ;; @0029                               v15 = iadd v7, v14  ; v14 = 12
-;; @0029                               v16 = load.i8 user2 little v15
+;; @0029                               v16 = load.i8 user2 little region0 v15
 ;; @002d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/null/ref-cast.wat
+++ b/tests/disas/gc/null/ref-cast.wat
@@ -10,6 +10,7 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     ss0 = explicit_slot 4, align = 4
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -42,7 +43,7 @@
 ;; @001e                               v15 = iadd v14, v13
 ;; @001e                               v16 = iconst.i64 4
 ;; @001e                               v17 = iadd v15, v16  ; v16 = 4
-;; @001e                               v18 = load.i32 user2 readonly v17
+;; @001e                               v18 = load.i32 user2 readonly region0 v17
 ;; @001e                               v11 = load.i64 notrap aligned readonly can_move v0+40
 ;; @001e                               v12 = load.i32 notrap aligned readonly can_move v11
 ;; @001e                               v19 = icmp eq v18, v12

--- a/tests/disas/gc/null/ref-test-array.wat
+++ b/tests/disas/gc/null/ref-test-array.wat
@@ -8,6 +8,7 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -34,7 +35,7 @@
 ;; @001b                               v11 = load.i64 notrap aligned readonly can_move v21+32
 ;; @001b                               v10 = uextend.i64 v2
 ;; @001b                               v12 = iadd v11, v10
-;; @001b                               v15 = load.i32 user2 readonly v12
+;; @001b                               v15 = load.i32 user2 readonly region0 v12
 ;; @001b                               v16 = iconst.i32 -1476395008
 ;; @001b                               v17 = band v15, v16  ; v16 = -1476395008
 ;; @001b                               v18 = icmp eq v17, v16  ; v16 = -1476395008

--- a/tests/disas/gc/null/ref-test-concrete-func-type.wat
+++ b/tests/disas/gc/null/ref-test-concrete-func-type.wat
@@ -9,6 +9,7 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i64) -> i32 tail {
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -28,7 +29,7 @@
 ;; @0020                               jump block3
 ;;
 ;;                                 block3:
-;; @0020                               v10 = load.i32 user2 readonly v2+16
+;; @0020                               v10 = load.i32 user2 readonly region0 v2+16
 ;; @0020                               v8 = load.i64 notrap aligned readonly can_move v0+40
 ;; @0020                               v9 = load.i32 notrap aligned readonly can_move v8
 ;; @0020                               v11 = icmp eq v10, v9

--- a/tests/disas/gc/null/ref-test-concrete-type.wat
+++ b/tests/disas/gc/null/ref-test-concrete-type.wat
@@ -9,6 +9,7 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -39,7 +40,7 @@
 ;; @001d                               v15 = iadd v14, v13
 ;; @001d                               v16 = iconst.i64 4
 ;; @001d                               v17 = iadd v15, v16  ; v16 = 4
-;; @001d                               v18 = load.i32 user2 readonly v17
+;; @001d                               v18 = load.i32 user2 readonly region0 v17
 ;; @001d                               v11 = load.i64 notrap aligned readonly can_move v0+40
 ;; @001d                               v12 = load.i32 notrap aligned readonly can_move v11
 ;; @001d                               v19 = icmp eq v18, v12

--- a/tests/disas/gc/null/ref-test-eq.wat
+++ b/tests/disas/gc/null/ref-test-eq.wat
@@ -8,6 +8,7 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -33,7 +34,7 @@
 ;; @001b                               v11 = load.i64 notrap aligned readonly can_move v21+32
 ;; @001b                               v10 = uextend.i64 v2
 ;; @001b                               v12 = iadd v11, v10
-;; @001b                               v15 = load.i32 user2 readonly v12
+;; @001b                               v15 = load.i32 user2 readonly region0 v12
 ;; @001b                               v16 = iconst.i32 -1610612736
 ;; @001b                               v17 = band v15, v16  ; v16 = -1610612736
 ;; @001b                               v18 = icmp eq v17, v16  ; v16 = -1610612736

--- a/tests/disas/gc/null/ref-test-struct.wat
+++ b/tests/disas/gc/null/ref-test-struct.wat
@@ -8,6 +8,7 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -34,7 +35,7 @@
 ;; @001b                               v11 = load.i64 notrap aligned readonly can_move v21+32
 ;; @001b                               v10 = uextend.i64 v2
 ;; @001b                               v12 = iadd v11, v10
-;; @001b                               v15 = load.i32 user2 readonly v12
+;; @001b                               v15 = load.i32 user2 readonly region0 v12
 ;; @001b                               v16 = iconst.i32 -1342177280
 ;; @001b                               v17 = band v15, v16  ; v16 = -1342177280
 ;; @001b                               v18 = icmp eq v17, v16  ; v16 = -1342177280

--- a/tests/disas/gc/null/struct-get-guard-pages.wat
+++ b/tests/disas/gc/null/struct-get-guard-pages.wat
@@ -24,6 +24,7 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> f32 tail {
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -41,7 +42,7 @@
 ;; @0033                               v6 = iadd v5, v4
 ;; @0033                               v7 = iconst.i64 8
 ;; @0033                               v8 = iadd v6, v7  ; v7 = 8
-;; @0033                               v9 = load.f32 user2 little v8
+;; @0033                               v9 = load.f32 user2 little region0 v8
 ;; @0037                               jump block1
 ;;
 ;;                                 block1:
@@ -49,6 +50,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -66,7 +68,7 @@
 ;; @003c                               v6 = iadd v5, v4
 ;; @003c                               v7 = iconst.i64 12
 ;; @003c                               v8 = iadd v6, v7  ; v7 = 12
-;; @003c                               v9 = load.i8 user2 little v8
+;; @003c                               v9 = load.i8 user2 little region0 v8
 ;; @0040                               jump block1
 ;;
 ;;                                 block1:
@@ -75,6 +77,7 @@
 ;; }
 ;;
 ;; function u0:2(i64 vmctx, i64, i32) -> i32 tail {
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -92,7 +95,7 @@
 ;; @0045                               v6 = iadd v5, v4
 ;; @0045                               v7 = iconst.i64 12
 ;; @0045                               v8 = iadd v6, v7  ; v7 = 12
-;; @0045                               v9 = load.i8 user2 little v8
+;; @0045                               v9 = load.i8 user2 little region0 v8
 ;; @0049                               jump block1
 ;;
 ;;                                 block1:
@@ -101,6 +104,7 @@
 ;; }
 ;;
 ;; function u0:3(i64 vmctx, i64, i32) -> i32 tail {
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -118,7 +122,7 @@
 ;; @004e                               v6 = iadd v5, v4
 ;; @004e                               v7 = iconst.i64 16
 ;; @004e                               v8 = iadd v6, v7  ; v7 = 16
-;; @004e                               v9 = load.i32 user2 little v8
+;; @004e                               v9 = load.i32 user2 little region0 v8
 ;; @0052                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/null/struct-get-no-guard-pages.wat
+++ b/tests/disas/gc/null/struct-get-no-guard-pages.wat
@@ -24,6 +24,7 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> f32 tail {
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -47,7 +48,7 @@
 ;; @0033                               v12 = select_spectre_guard v8, v11, v10  ; v11 = 0
 ;; @0033                               v13 = iconst.i64 8
 ;; @0033                               v14 = iadd v12, v13  ; v13 = 8
-;; @0033                               v15 = load.f32 user2 little v14
+;; @0033                               v15 = load.f32 user2 little region0 v14
 ;; @0037                               jump block1
 ;;
 ;;                                 block1:
@@ -55,6 +56,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -78,7 +80,7 @@
 ;; @003c                               v12 = select_spectre_guard v8, v11, v10  ; v11 = 0
 ;; @003c                               v13 = iconst.i64 12
 ;; @003c                               v14 = iadd v12, v13  ; v13 = 12
-;; @003c                               v15 = load.i8 user2 little v14
+;; @003c                               v15 = load.i8 user2 little region0 v14
 ;; @0040                               jump block1
 ;;
 ;;                                 block1:
@@ -87,6 +89,7 @@
 ;; }
 ;;
 ;; function u0:2(i64 vmctx, i64, i32) -> i32 tail {
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -110,7 +113,7 @@
 ;; @0045                               v12 = select_spectre_guard v8, v11, v10  ; v11 = 0
 ;; @0045                               v13 = iconst.i64 12
 ;; @0045                               v14 = iadd v12, v13  ; v13 = 12
-;; @0045                               v15 = load.i8 user2 little v14
+;; @0045                               v15 = load.i8 user2 little region0 v14
 ;; @0049                               jump block1
 ;;
 ;;                                 block1:
@@ -119,6 +122,7 @@
 ;; }
 ;;
 ;; function u0:3(i64 vmctx, i64, i32) -> i32 tail {
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -142,7 +146,7 @@
 ;; @004e                               v12 = select_spectre_guard v8, v11, v10  ; v11 = 0
 ;; @004e                               v13 = iconst.i64 16
 ;; @004e                               v14 = iadd v12, v13  ; v13 = 16
-;; @004e                               v15 = load.i32 user2 little v14
+;; @004e                               v15 = load.i32 user2 little region0 v14
 ;; @0052                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/null/struct-get.wat
+++ b/tests/disas/gc/null/struct-get.wat
@@ -24,6 +24,7 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> f32 tail {
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -41,7 +42,7 @@
 ;; @0033                               v6 = iadd v5, v4
 ;; @0033                               v7 = iconst.i64 8
 ;; @0033                               v8 = iadd v6, v7  ; v7 = 8
-;; @0033                               v9 = load.f32 user2 little v8
+;; @0033                               v9 = load.f32 user2 little region0 v8
 ;; @0037                               jump block1
 ;;
 ;;                                 block1:
@@ -49,6 +50,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -66,7 +68,7 @@
 ;; @003c                               v6 = iadd v5, v4
 ;; @003c                               v7 = iconst.i64 12
 ;; @003c                               v8 = iadd v6, v7  ; v7 = 12
-;; @003c                               v9 = load.i8 user2 little v8
+;; @003c                               v9 = load.i8 user2 little region0 v8
 ;; @0040                               jump block1
 ;;
 ;;                                 block1:
@@ -75,6 +77,7 @@
 ;; }
 ;;
 ;; function u0:2(i64 vmctx, i64, i32) -> i32 tail {
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -92,7 +95,7 @@
 ;; @0045                               v6 = iadd v5, v4
 ;; @0045                               v7 = iconst.i64 12
 ;; @0045                               v8 = iadd v6, v7  ; v7 = 12
-;; @0045                               v9 = load.i8 user2 little v8
+;; @0045                               v9 = load.i8 user2 little region0 v8
 ;; @0049                               jump block1
 ;;
 ;;                                 block1:
@@ -101,6 +104,7 @@
 ;; }
 ;;
 ;; function u0:3(i64 vmctx, i64, i32) -> i32 tail {
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -118,7 +122,7 @@
 ;; @004e                               v6 = iadd v5, v4
 ;; @004e                               v7 = iconst.i64 16
 ;; @004e                               v8 = iadd v6, v7  ; v7 = 16
-;; @004e                               v9 = load.i32 user2 little v8
+;; @004e                               v9 = load.i32 user2 little region0 v8
 ;; @0052                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/null/struct-new-default.wat
+++ b/tests/disas/gc/null/struct-new-default.wat
@@ -12,6 +12,8 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64) -> i32 tail {
+;;     region0 = 32 "VMContext+0x20"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -24,8 +26,8 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @0021                               v11 = load.i64 notrap aligned readonly v0+32
-;; @0021                               v12 = load.i32 user2 v11
+;; @0021                               v11 = load.i64 notrap aligned readonly region0 v0+32
+;; @0021                               v12 = load.i32 user2 region1 v11
 ;;                                     v48 = iconst.i32 7
 ;; @0021                               v15 = uadd_overflow_trap v12, v48, user18  ; v48 = 7
 ;;                                     v54 = iconst.i32 -8
@@ -44,22 +46,22 @@
 ;;                                     v61 = band.i32 v15, v54  ; v54 = -8
 ;;                                     v62 = uextend.i64 v61
 ;; @0021                               v27 = iadd v25, v62
-;; @0021                               store user2 v55, v27  ; v55 = -1342177256
+;; @0021                               store user2 region1 v55, v27  ; v55 = -1342177256
 ;; @0021                               v31 = load.i64 notrap aligned readonly can_move v0+40
 ;; @0021                               v32 = load.i32 notrap aligned readonly can_move v31
-;; @0021                               store user2 v32, v27+4
-;; @0021                               store.i32 user2 v18, v11
+;; @0021                               store user2 region1 v32, v27+4
+;; @0021                               store.i32 user2 region1 v18, v11
 ;; @0021                               v3 = f32const 0.0
 ;;                                     v38 = iconst.i64 8
 ;; @0021                               v33 = iadd v27, v38  ; v38 = 8
-;; @0021                               store user2 little v3, v33  ; v3 = 0.0
+;; @0021                               store user2 little region1 v3, v33  ; v3 = 0.0
 ;; @0021                               v4 = iconst.i32 0
 ;;                                     v37 = iconst.i64 12
 ;; @0021                               v34 = iadd v27, v37  ; v37 = 12
-;; @0021                               istore8 user2 little v4, v34  ; v4 = 0
+;; @0021                               istore8 user2 little region1 v4, v34  ; v4 = 0
 ;;                                     v36 = iconst.i64 16
 ;; @0021                               v35 = iadd v27, v36  ; v36 = 16
-;; @0021                               store user2 little v4, v35  ; v4 = 0
+;; @0021                               store user2 little region1 v4, v35  ; v4 = 0
 ;; @0024                               jump block1
 ;;
 ;;                                 block3 cold:

--- a/tests/disas/gc/null/struct-new.wat
+++ b/tests/disas/gc/null/struct-new.wat
@@ -13,6 +13,8 @@
 )
 ;; function u0:0(i64 vmctx, i64, f32, i32, i32) -> i32 tail {
 ;;     ss0 = explicit_slot 4, align = 4
+;;     region0 = 32 "VMContext+0x20"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -27,8 +29,8 @@
 ;;                                 block0(v0: i64, v1: i64, v2: f32, v3: i32, v4: i32):
 ;;                                     v45 = stack_addr.i64 ss0
 ;;                                     store notrap v4, v45
-;; @002a                               v11 = load.i64 notrap aligned readonly v0+32
-;; @002a                               v12 = load.i32 user2 v11
+;; @002a                               v11 = load.i64 notrap aligned readonly region0 v0+32
+;; @002a                               v12 = load.i32 user2 region1 v11
 ;;                                     v52 = iconst.i32 7
 ;; @002a                               v15 = uadd_overflow_trap v12, v52, user18  ; v52 = 7
 ;;                                     v58 = iconst.i32 -8
@@ -47,21 +49,21 @@
 ;;                                     v65 = band.i32 v15, v58  ; v58 = -8
 ;;                                     v66 = uextend.i64 v65
 ;; @002a                               v27 = iadd v25, v66
-;; @002a                               store user2 v59, v27  ; v59 = -1342177256
+;; @002a                               store user2 region1 v59, v27  ; v59 = -1342177256
 ;; @002a                               v31 = load.i64 notrap aligned readonly can_move v0+40
 ;; @002a                               v32 = load.i32 notrap aligned readonly can_move v31
-;; @002a                               store user2 v32, v27+4
-;; @002a                               store.i32 user2 v18, v11
+;; @002a                               store user2 region1 v32, v27+4
+;; @002a                               store.i32 user2 region1 v18, v11
 ;;                                     v40 = iconst.i64 8
 ;; @002a                               v33 = iadd v27, v40  ; v40 = 8
-;; @002a                               store.f32 user2 little v2, v33
+;; @002a                               store.f32 user2 little region1 v2, v33
 ;;                                     v39 = iconst.i64 12
 ;; @002a                               v34 = iadd v27, v39  ; v39 = 12
-;; @002a                               istore8.i32 user2 little v3, v34
+;; @002a                               istore8.i32 user2 little region1 v3, v34
 ;;                                     v36 = load.i32 notrap v45
 ;;                                     v38 = iconst.i64 16
 ;; @002a                               v35 = iadd v27, v38  ; v38 = 16
-;; @002a                               store user2 little v36, v35
+;; @002a                               store user2 little region1 v36, v35
 ;; @002d                               jump block1
 ;;
 ;;                                 block3 cold:

--- a/tests/disas/gc/null/struct-set.wat
+++ b/tests/disas/gc/null/struct-set.wat
@@ -20,6 +20,7 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32, f32) tail {
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -37,7 +38,7 @@
 ;; @0034                               v6 = iadd v5, v4
 ;; @0034                               v7 = iconst.i64 8
 ;; @0034                               v8 = iadd v6, v7  ; v7 = 8
-;; @0034                               store user2 little v3, v8
+;; @0034                               store user2 little region0 v3, v8
 ;; @0038                               jump block1
 ;;
 ;;                                 block1:
@@ -45,6 +46,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32, i32) tail {
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -62,7 +64,7 @@
 ;; @003f                               v6 = iadd v5, v4
 ;; @003f                               v7 = iconst.i64 12
 ;; @003f                               v8 = iadd v6, v7  ; v7 = 12
-;; @003f                               istore8 user2 little v3, v8
+;; @003f                               istore8 user2 little region0 v3, v8
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -70,6 +72,7 @@
 ;; }
 ;;
 ;; function u0:2(i64 vmctx, i64, i32, i32) tail {
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -87,7 +90,7 @@
 ;; @004a                               v6 = iadd v5, v4
 ;; @004a                               v7 = iconst.i64 16
 ;; @004a                               v8 = iadd v6, v7  ; v7 = 16
-;; @004a                               store user2 little v3, v8
+;; @004a                               store user2 little region0 v3, v8
 ;; @004e                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/null/v128-fields.wat
+++ b/tests/disas/gc/null/v128-fields.wat
@@ -12,6 +12,7 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i8x16 tail {
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -29,7 +30,7 @@
 ;; @0022                               v6 = iadd v5, v4
 ;; @0022                               v7 = iconst.i64 16
 ;; @0022                               v8 = iadd v6, v7  ; v7 = 16
-;; @0022                               v9 = load.i8x16 user2 little v8
+;; @0022                               v9 = load.i8x16 user2 little region0 v8
 ;; @002e                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/struct-new-default.wat
+++ b/tests/disas/gc/struct-new-default.wat
@@ -13,7 +13,8 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64) -> i32 tail {
-;;     region0 = 2 "vmctx"
+;;     region0 = 32 "VMContext+0x20"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -69,18 +70,18 @@
 ;; @0023                               v3 = f32const 0.0
 ;;                                     v48 = iconst.i64 16
 ;; @0023                               v41 = iadd v40, v48  ; v48 = 16
-;; @0023                               store user2 little v3, v41  ; v3 = 0.0
+;; @0023                               store user2 little region1 v3, v41  ; v3 = 0.0
 ;; @0023                               v4 = iconst.i32 0
 ;;                                     v47 = iconst.i64 20
 ;; @0023                               v42 = iadd v40, v47  ; v47 = 20
-;; @0023                               istore8 user2 little v4, v42  ; v4 = 0
+;; @0023                               istore8 user2 little region1 v4, v42  ; v4 = 0
 ;;                                     v46 = iconst.i64 24
 ;; @0023                               v43 = iadd v40, v46  ; v46 = 24
-;; @0023                               store user2 little v4, v43  ; v4 = 0
+;; @0023                               store user2 little region1 v4, v43  ; v4 = 0
 ;; @0023                               v6 = vconst.i8x16 const0
 ;;                                     v45 = iconst.i64 32
 ;; @0023                               v44 = iadd v40, v45  ; v45 = 32
-;; @0023                               store user2 little v6, v44  ; v6 = const0
+;; @0023                               store user2 little region1 v6, v44  ; v6 = const0
 ;; @0026                               jump block1(v39)
 ;;
 ;;                                 block1(v2: i32):

--- a/tests/disas/gc/struct-new.wat
+++ b/tests/disas/gc/struct-new.wat
@@ -13,7 +13,8 @@
 )
 ;; function u0:0(i64 vmctx, i64, f32, i32, i32) -> i32 tail {
 ;;     ss0 = explicit_slot 4, align = 4
-;;     region0 = 2 "vmctx"
+;;     region0 = 32 "VMContext+0x20"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -69,14 +70,14 @@
 ;;                                 block4(v38: i32, v39: i64):
 ;;                                     v47 = iconst.i64 16
 ;; @002a                               v40 = iadd v39, v47  ; v47 = 16
-;; @002a                               store.f32 user2 little v2, v40
+;; @002a                               store.f32 user2 little region1 v2, v40
 ;;                                     v46 = iconst.i64 20
 ;; @002a                               v41 = iadd v39, v46  ; v46 = 20
-;; @002a                               istore8.i32 user2 little v3, v41
+;; @002a                               istore8.i32 user2 little region1 v3, v41
 ;;                                     v43 = load.i32 notrap v52
 ;;                                     v45 = iconst.i64 24
 ;; @002a                               v42 = iadd v39, v45  ; v45 = 24
-;; @002a                               store user2 little v43, v42
+;; @002a                               store user2 little region1 v43, v42
 ;; @002d                               jump block1(v38)
 ;;
 ;;                                 block1(v5: i32):

--- a/tests/disas/global-get.wat
+++ b/tests/disas/global-get.wat
@@ -31,7 +31,7 @@
 )
 
 ;; function u0:0(i64 vmctx, i64) -> i32 tail {
-;;     region0 = 1 "table"
+;;     region0 = 1610612736 "ImportedGlobal"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -49,7 +49,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64) -> i32 tail {
-;;     region0 = 1 "table"
+;;     region0 = 1610612736 "ImportedGlobal"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -81,7 +81,7 @@
 ;; }
 ;;
 ;; function u0:3(i64 vmctx, i64) -> i32 tail {
-;;     region0 = 1 "table"
+;;     region0 = 1879048193 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(1))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/globals.wat
+++ b/tests/disas/globals.wat
@@ -10,8 +10,8 @@
 )
 
 ;; function u0:0(i64 vmctx, i64) tail {
-;;     region0 = 1 "table"
-;;     region1 = 0 "heap"
+;;     region0 = 1879048192 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(0))"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/i32-load.wat
+++ b/tests/disas/i32-load.wat
@@ -9,7 +9,7 @@
     i32.load))
 
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/i32-load16-s.wat
+++ b/tests/disas/i32-load16-s.wat
@@ -9,7 +9,7 @@
     i32.load16_s))
 
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/i32-load16-u.wat
+++ b/tests/disas/i32-load16-u.wat
@@ -9,7 +9,7 @@
     i32.load16_u))
 
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/i32-load8-s.wat
+++ b/tests/disas/i32-load8-s.wat
@@ -9,7 +9,7 @@
     i32.load8_s))
 
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/i32-load8-u.wat
+++ b/tests/disas/i32-load8-u.wat
@@ -9,7 +9,7 @@
     i32.load8_u))
 
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/i32-store.wat
+++ b/tests/disas/i32-store.wat
@@ -10,7 +10,7 @@
     i32.store))
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/i32-store16.wat
+++ b/tests/disas/i32-store16.wat
@@ -10,7 +10,7 @@
     i32.store16))
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/i32-store8.wat
+++ b/tests/disas/i32-store8.wat
@@ -10,7 +10,7 @@
     i32.store8))
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/i64-load.wat
+++ b/tests/disas/i64-load.wat
@@ -9,7 +9,7 @@
     i64.load))
 
 ;; function u0:0(i64 vmctx, i64, i32) -> i64 tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/i64-load16-s.wat
+++ b/tests/disas/i64-load16-s.wat
@@ -9,7 +9,7 @@
     i64.load16_s))
 
 ;; function u0:0(i64 vmctx, i64, i32) -> i64 tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/i64-load16-u.wat
+++ b/tests/disas/i64-load16-u.wat
@@ -9,7 +9,7 @@
     i64.load16_u))
 
 ;; function u0:0(i64 vmctx, i64, i32) -> i64 tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/i64-load8-s.wat
+++ b/tests/disas/i64-load8-s.wat
@@ -9,7 +9,7 @@
     i64.load8_s))
 
 ;; function u0:0(i64 vmctx, i64, i32) -> i64 tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/i64-load8-u.wat
+++ b/tests/disas/i64-load8-u.wat
@@ -9,7 +9,7 @@
     i64.load8_u))
 
 ;; function u0:0(i64 vmctx, i64, i32) -> i64 tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/i64-store.wat
+++ b/tests/disas/i64-store.wat
@@ -10,7 +10,7 @@
     i64.store))
 
 ;; function u0:0(i64 vmctx, i64, i32, i64) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/i64-store16.wat
+++ b/tests/disas/i64-store16.wat
@@ -10,7 +10,7 @@
     i64.store16))
 
 ;; function u0:0(i64 vmctx, i64, i32, i64) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/i64-store32.wat
+++ b/tests/disas/i64-store32.wat
@@ -10,7 +10,7 @@
     i64.store32))
 
 ;; function u0:0(i64 vmctx, i64, i32, i64) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/i64-store8.wat
+++ b/tests/disas/i64-store8.wat
@@ -10,7 +10,7 @@
     i64.store8))
 
 ;; function u0:0(i64 vmctx, i64, i32, i64) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/icall-loop.wat
+++ b/tests/disas/icall-loop.wat
@@ -23,7 +23,7 @@
 )
 
 ;; function u0:0(i64 vmctx, i64, i32) tail {
-;;     region0 = 1 "table"
+;;     region0 = 1342177280 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -72,7 +72,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64) tail {
-;;     region0 = 1 "table"
+;;     region0 = 1342177280 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/icall-simd.wat
+++ b/tests/disas/icall-simd.wat
@@ -9,7 +9,7 @@
 )
 
 ;; function u0:0(i64 vmctx, i64, i32, i8x16) -> i8x16 tail {
-;;     region0 = 1 "table"
+;;     region0 = 1342177280 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/icall.wat
+++ b/tests/disas/icall.wat
@@ -9,7 +9,7 @@
 )
 
 ;; function u0:0(i64 vmctx, i64, i32, f32) -> i32 tail {
-;;     region0 = 1 "table"
+;;     region0 = 1342177280 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/idempotent-store.wat
+++ b/tests/disas/idempotent-store.wat
@@ -15,7 +15,7 @@
 )
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/if-unreachable-else-params-2.wat
+++ b/tests/disas/if-unreachable-else-params-2.wat
@@ -20,7 +20,7 @@
   (export "memory" (memory 0)))
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) -> f64 tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/if-unreachable-else-params.wat
+++ b/tests/disas/if-unreachable-else-params.wat
@@ -43,7 +43,7 @@
   (export "memory" (memory 0)))
 
 ;; function u0:0(i64 vmctx, i64, i32) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/indirect-call-no-caching.wat
+++ b/tests/disas/indirect-call-no-caching.wat
@@ -63,7 +63,7 @@
 ;; }
 ;;
 ;; function u0:3(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 1 "table"
+;;     region0 = 1342177280 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0_offset.wat
@@ -19,7 +19,7 @@
     i32.load offset=0))
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -45,7 +45,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -19,7 +19,7 @@
     i32.load offset=0x1000))
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -47,7 +47,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -19,7 +19,7 @@
     i32.load offset=0xffff0000))
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -47,7 +47,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0_offset.wat
@@ -19,7 +19,7 @@
     i32.load8_u offset=0))
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -43,7 +43,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -19,7 +19,7 @@
     i32.load8_u offset=0x1000))
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -47,7 +47,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -19,7 +19,7 @@
     i32.load8_u offset=0xffff0000))
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -47,7 +47,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0_offset.wat
@@ -19,7 +19,7 @@
     i32.load offset=0))
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -46,7 +46,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -19,7 +19,7 @@
     i32.load offset=0x1000))
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -48,7 +48,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -19,7 +19,7 @@
     i32.load offset=0xffff0000))
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -48,7 +48,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0_offset.wat
@@ -19,7 +19,7 @@
     i32.load8_u offset=0))
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -44,7 +44,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -19,7 +19,7 @@
     i32.load8_u offset=0x1000))
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -48,7 +48,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -19,7 +19,7 @@
     i32.load8_u offset=0xffff0000))
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -48,7 +48,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
@@ -19,7 +19,7 @@
     i32.load offset=0))
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -43,7 +43,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -19,7 +19,7 @@
     i32.load offset=0x1000))
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -45,7 +45,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -19,7 +19,7 @@
     i32.load offset=0xffff0000))
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -45,7 +45,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
@@ -19,7 +19,7 @@
     i32.load8_u offset=0))
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -43,7 +43,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -19,7 +19,7 @@
     i32.load8_u offset=0x1000))
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -45,7 +45,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -19,7 +19,7 @@
     i32.load8_u offset=0xffff0000))
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -45,7 +45,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
@@ -19,7 +19,7 @@
     i32.load offset=0))
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -44,7 +44,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -19,7 +19,7 @@
     i32.load offset=0x1000))
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -46,7 +46,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -19,7 +19,7 @@
     i32.load offset=0xffff0000))
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -46,7 +46,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
@@ -19,7 +19,7 @@
     i32.load8_u offset=0))
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -44,7 +44,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -19,7 +19,7 @@
     i32.load8_u offset=0x1000))
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -46,7 +46,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -19,7 +19,7 @@
     i32.load8_u offset=0xffff0000))
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -46,7 +46,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0_offset.wat
@@ -19,7 +19,7 @@
     i32.load offset=0))
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -44,7 +44,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -19,7 +19,7 @@
     i32.load offset=0x1000))
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -46,7 +46,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -19,7 +19,7 @@
     i32.load offset=0xffff0000))
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -46,7 +46,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0_offset.wat
@@ -19,7 +19,7 @@
     i32.load8_u offset=0))
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -42,7 +42,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -19,7 +19,7 @@
     i32.load8_u offset=0x1000))
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -46,7 +46,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -19,7 +19,7 @@
     i32.load8_u offset=0xffff0000))
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -46,7 +46,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0_offset.wat
@@ -19,7 +19,7 @@
     i32.load offset=0))
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -45,7 +45,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -19,7 +19,7 @@
     i32.load offset=0x1000))
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -47,7 +47,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -19,7 +19,7 @@
     i32.load offset=0xffff0000))
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -47,7 +47,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0_offset.wat
@@ -19,7 +19,7 @@
     i32.load8_u offset=0))
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -43,7 +43,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -19,7 +19,7 @@
     i32.load8_u offset=0x1000))
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -47,7 +47,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -19,7 +19,7 @@
     i32.load8_u offset=0xffff0000))
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -47,7 +47,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
@@ -19,7 +19,7 @@
     i32.load offset=0))
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -42,7 +42,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -19,7 +19,7 @@
     i32.load offset=0x1000))
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -44,7 +44,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -19,7 +19,7 @@
     i32.load offset=0xffff0000))
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -44,7 +44,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
@@ -19,7 +19,7 @@
     i32.load8_u offset=0))
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -42,7 +42,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -19,7 +19,7 @@
     i32.load8_u offset=0x1000))
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -44,7 +44,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -19,7 +19,7 @@
     i32.load8_u offset=0xffff0000))
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -44,7 +44,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
@@ -19,7 +19,7 @@
     i32.load offset=0))
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -43,7 +43,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -19,7 +19,7 @@
     i32.load offset=0x1000))
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -45,7 +45,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -19,7 +19,7 @@
     i32.load offset=0xffff0000))
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -45,7 +45,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
@@ -19,7 +19,7 @@
     i32.load8_u offset=0))
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -43,7 +43,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -19,7 +19,7 @@
     i32.load8_u offset=0x1000))
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -45,7 +45,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -19,7 +19,7 @@
     i32.load8_u offset=0xffff0000))
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -45,7 +45,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0_offset.wat
@@ -19,7 +19,7 @@
     i32.load offset=0))
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -43,7 +43,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -19,7 +19,7 @@
     i32.load offset=0x1000))
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -45,7 +45,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -19,7 +19,7 @@
     i32.load offset=0xffff0000))
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -45,7 +45,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0_offset.wat
@@ -19,7 +19,7 @@
     i32.load8_u offset=0))
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -40,7 +40,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -19,7 +19,7 @@
     i32.load8_u offset=0x1000))
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -45,7 +45,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -19,7 +19,7 @@
     i32.load8_u offset=0xffff0000))
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -45,7 +45,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0_offset.wat
@@ -19,7 +19,7 @@
     i32.load offset=0))
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -44,7 +44,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -19,7 +19,7 @@
     i32.load offset=0x1000))
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -46,7 +46,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -19,7 +19,7 @@
     i32.load offset=0xffff0000))
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -46,7 +46,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i8_access_0_offset.wat
@@ -19,7 +19,7 @@
     i32.load8_u offset=0))
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -40,7 +40,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -19,7 +19,7 @@
     i32.load8_u offset=0x1000))
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -46,7 +46,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -19,7 +19,7 @@
     i32.load8_u offset=0xffff0000))
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -46,7 +46,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
@@ -19,7 +19,7 @@
     i32.load offset=0))
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -40,7 +40,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -19,7 +19,7 @@
     i32.load offset=0x1000))
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -42,7 +42,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -19,7 +19,7 @@
     i32.load offset=0xffff0000))
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -42,7 +42,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
@@ -19,7 +19,7 @@
     i32.load8_u offset=0))
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -40,7 +40,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -19,7 +19,7 @@
     i32.load8_u offset=0x1000))
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -42,7 +42,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -19,7 +19,7 @@
     i32.load8_u offset=0xffff0000))
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -42,7 +42,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
@@ -19,7 +19,7 @@
     i32.load offset=0))
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -40,7 +40,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -19,7 +19,7 @@
     i32.load offset=0x1000))
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -42,7 +42,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -19,7 +19,7 @@
     i32.load offset=0xffff0000))
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -42,7 +42,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
@@ -19,7 +19,7 @@
     i32.load8_u offset=0))
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -40,7 +40,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -19,7 +19,7 @@
     i32.load8_u offset=0x1000))
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -42,7 +42,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -19,7 +19,7 @@
     i32.load8_u offset=0xffff0000))
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -42,7 +42,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0_offset.wat
@@ -19,7 +19,7 @@
     i32.load offset=0))
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -42,7 +42,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -19,7 +19,7 @@
     i32.load offset=0x1000))
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -44,7 +44,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -19,7 +19,7 @@
     i32.load offset=0xffff0000))
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -44,7 +44,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0_offset.wat
@@ -19,7 +19,7 @@
     i32.load8_u offset=0))
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -42,7 +42,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -19,7 +19,7 @@
     i32.load8_u offset=0x1000))
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -44,7 +44,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -19,7 +19,7 @@
     i32.load8_u offset=0xffff0000))
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -44,7 +44,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0_offset.wat
@@ -19,7 +19,7 @@
     i32.load offset=0))
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -43,7 +43,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -19,7 +19,7 @@
     i32.load offset=0x1000))
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -45,7 +45,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -19,7 +19,7 @@
     i32.load offset=0xffff0000))
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -45,7 +45,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0_offset.wat
@@ -19,7 +19,7 @@
     i32.load8_u offset=0))
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -43,7 +43,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -19,7 +19,7 @@
     i32.load8_u offset=0x1000))
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -45,7 +45,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -19,7 +19,7 @@
     i32.load8_u offset=0xffff0000))
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -45,7 +45,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
@@ -19,7 +19,7 @@
     i32.load offset=0))
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -42,7 +42,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -19,7 +19,7 @@
     i32.load offset=0x1000))
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -44,7 +44,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -19,7 +19,7 @@
     i32.load offset=0xffff0000))
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -44,7 +44,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
@@ -19,7 +19,7 @@
     i32.load8_u offset=0))
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -42,7 +42,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -19,7 +19,7 @@
     i32.load8_u offset=0x1000))
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -44,7 +44,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -19,7 +19,7 @@
     i32.load8_u offset=0xffff0000))
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -44,7 +44,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
@@ -19,7 +19,7 @@
     i32.load offset=0))
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -43,7 +43,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -19,7 +19,7 @@
     i32.load offset=0x1000))
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -45,7 +45,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -19,7 +19,7 @@
     i32.load offset=0xffff0000))
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -45,7 +45,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
@@ -19,7 +19,7 @@
     i32.load8_u offset=0))
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -43,7 +43,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -19,7 +19,7 @@
     i32.load8_u offset=0x1000))
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -45,7 +45,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -19,7 +19,7 @@
     i32.load8_u offset=0xffff0000))
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -45,7 +45,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/memory-min-max-same.wat
+++ b/tests/disas/memory-min-max-same.wat
@@ -34,7 +34,7 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/memory.wat
+++ b/tests/disas/memory.wat
@@ -13,7 +13,7 @@
 )
 
 ;; function u0:0(i64 vmctx, i64) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/non-fixed-size-memory.wat
+++ b/tests/disas/non-fixed-size-memory.wat
@@ -21,7 +21,7 @@
     i32.load8_u offset=0))
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -45,7 +45,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/pic.wat
+++ b/tests/disas/pic.wat
@@ -1,0 +1,110 @@
+;;! target = "x86_64"
+;;! test = "optimize"
+
+(module $test.wasm
+  (type (;0;) (func (param i32)))
+  (type (;1;) (func (result i32)))
+  (type (;2;) (func (param i32) (result i32)))
+  (type (;3;) (func))
+  (import "env" "force_frame" (func $force_frame (;0;) (type 0)))
+  (table (;0;) 1 1 funcref)
+  (memory (;0;) 17)
+  (global $__stack_pointer (;0;) (mut i32) i32.const 1048576)
+  (global $GOT.data.internal.__memory_base (;1;) i32 i32.const 0)
+  (func $get_var (;1;) (type 1) (result i32)
+    global.get $GOT.data.internal.__memory_base
+    i32.const 1048576
+    i32.add
+    i32.load
+  )
+  (func $set_var (;2;) (type 2) (param i32) (result i32)
+    (local i32 i32)
+    global.get $__stack_pointer
+    i32.const 16
+    i32.sub
+    local.tee 1
+    global.set $__stack_pointer
+    local.get 1
+    local.get 0
+    i32.load
+    local.tee 0
+    i32.store offset=12
+    global.get $GOT.data.internal.__memory_base
+    local.set 2
+    local.get 1
+    i32.const 12
+    i32.add
+    call $force_frame
+    local.get 2
+    i32.const 1048576
+    i32.add
+    local.get 0
+    i32.store
+    local.get 1
+    i32.const 16
+    i32.add
+    global.set $__stack_pointer
+    local.get 0
+  )
+)
+;; function u0:0(i64 vmctx, i64) -> i32 tail {
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     gv0 = vmctx
+;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv3 = vmctx
+;;     gv4 = load.i64 notrap aligned gv3+64
+;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
+;;     stack_limit = gv2
+;;
+;;                                 block0(v0: i64, v1: i64):
+;; @005e                               v7 = load.i64 notrap aligned readonly can_move v0+56
+;;                                     v16 = iconst.i64 0x0010_0000
+;; @005e                               v8 = iadd v7, v16  ; v16 = 0x0010_0000
+;; @005e                               v9 = load.i32 little region0 v8
+;; @0061                               jump block1
+;;
+;;                                 block1:
+;; @0061                               return v9
+;; }
+;;
+;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
+;;     region0 = 1879048192 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(0))"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     gv0 = vmctx
+;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv3 = vmctx
+;;     gv4 = load.i64 notrap aligned gv3+64
+;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
+;;     sig0 = (i64 vmctx, i64, i32) tail
+;;     stack_limit = gv2
+;;
+;;                                 block0(v0: i64, v1: i64, v2: i32):
+;; @0066                               v6 = load.i32 notrap aligned region0 v0+128
+;; @0068                               v7 = iconst.i32 16
+;; @006a                               v8 = isub v6, v7  ; v7 = 16
+;; @006d                               store notrap aligned region0 v8, v0+128
+;; @0073                               v11 = load.i64 notrap aligned readonly can_move v0+56
+;; @0073                               v10 = uextend.i64 v2
+;; @0073                               v12 = iadd v11, v10
+;; @0073                               v13 = load.i32 little region1 v12
+;; @0078                               v14 = uextend.i64 v8
+;; @0078                               v16 = iadd v11, v14
+;; @0078                               v17 = iconst.i64 12
+;; @0078                               v18 = iadd v16, v17  ; v17 = 12
+;; @0078                               store little region1 v13, v18
+;; @0084                               v24 = load.i64 notrap aligned readonly can_move v0+80
+;; @0084                               v23 = load.i64 notrap aligned readonly can_move v0+96
+;;                                     v36 = iconst.i32 -4
+;;                                     v37 = iadd v6, v36  ; v36 = -4
+;; @0084                               call_indirect sig0, v24(v23, v0, v37)
+;;                                     v44 = iconst.i64 0x0010_0000
+;; @0090                               v29 = iadd v11, v44  ; v44 = 0x0010_0000
+;; @0090                               store little region1 v13, v29
+;; @0098                               store notrap aligned region0 v6, v0+128
+;; @009c                               jump block1
+;;
+;;                                 block1:
+;; @009c                               return v13
+;; }

--- a/tests/disas/pr2303.wat
+++ b/tests/disas/pr2303.wat
@@ -17,7 +17,7 @@
 )
 
 ;; function u0:0(i64 vmctx, i64, i32) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/readonly-funcrefs.wat
+++ b/tests/disas/readonly-funcrefs.wat
@@ -32,7 +32,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) tail {
-;;     region0 = 1 "table"
+;;     region0 = 1342177280 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/readonly-heap-base-pointer1.wat
+++ b/tests/disas/readonly-heap-base-pointer1.wat
@@ -8,7 +8,7 @@
     (i32.load (local.get 0)))
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/readonly-heap-base-pointer2.wat
+++ b/tests/disas/readonly-heap-base-pointer2.wat
@@ -8,7 +8,7 @@
     (i32.load (local.get 0)))
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/readonly-heap-base-pointer3.wat
+++ b/tests/disas/readonly-heap-base-pointer3.wat
@@ -8,7 +8,7 @@
     (i32.load (local.get 0)))
 )
 ;; function u0:0(i64 vmctx, i64, i64) -> i32 tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/ref-func-0.wat
+++ b/tests/disas/ref-func-0.wat
@@ -14,7 +14,8 @@
   (global (export "funcref-local") funcref (ref.func $local)))
 
 ;; function u0:0(i64 vmctx, i64) -> i32, i32, i64, i64 tail {
-;;     region0 = 1 "table"
+;;     region0 = 1879048194 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(2))"
+;;     region1 = 1879048195 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(3))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -29,7 +30,7 @@
 ;; @0091                               v10 = iadd v0, v16  ; v16 = 96
 ;; @0091                               v11 = load.i32 notrap aligned v10
 ;; @0093                               v13 = load.i64 notrap aligned region0 v0+112
-;; @0095                               v15 = load.i64 notrap aligned region0 v0+128
+;; @0095                               v15 = load.i64 notrap aligned region1 v0+128
 ;; @0097                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/simd-store.wat
+++ b/tests/disas/simd-store.wat
@@ -85,7 +85,7 @@
 )
 
 ;; function u0:0(i64 vmctx, i64, i8x16) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -108,7 +108,7 @@
 ;; }
 ;;
 ;; function u0:10(i64 vmctx, i64, i8x16) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -133,7 +133,7 @@
 ;; }
 ;;
 ;; function u0:11(i64 vmctx, i64, i8x16) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -158,7 +158,7 @@
 ;; }
 ;;
 ;; function u0:12(i64 vmctx, i64, i8x16) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -181,7 +181,7 @@
 ;; }
 ;;
 ;; function u0:13(i64 vmctx, i64, i8x16) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -206,7 +206,7 @@
 ;; }
 ;;
 ;; function u0:14(i64 vmctx, i64, i8x16) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -231,7 +231,7 @@
 ;; }
 ;;
 ;; function u0:15(i64 vmctx, i64, i8x16) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -254,7 +254,7 @@
 ;; }
 ;;
 ;; function u0:16(i64 vmctx, i64, i8x16) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -279,7 +279,7 @@
 ;; }
 ;;
 ;; function u0:17(i64 vmctx, i64, i8x16) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -304,7 +304,7 @@
 ;; }
 ;;
 ;; function u0:18(i64 vmctx, i64, i8x16) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -329,7 +329,7 @@
 ;; }
 ;;
 ;; function u0:19(i64 vmctx, i64, i8x16) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -352,7 +352,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i8x16) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -377,7 +377,7 @@
 ;; }
 ;;
 ;; function u0:20(i64 vmctx, i64, i8x16) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -402,7 +402,7 @@
 ;; }
 ;;
 ;; function u0:21(i64 vmctx, i64, i8x16) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -427,7 +427,7 @@
 ;; }
 ;;
 ;; function u0:22(i64 vmctx, i64, i8x16) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -452,7 +452,7 @@
 ;; }
 ;;
 ;; function u0:23(i64 vmctx, i64, i8x16) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -477,7 +477,7 @@
 ;; }
 ;;
 ;; function u0:24(i64 vmctx, i64, i8x16) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -502,7 +502,7 @@
 ;; }
 ;;
 ;; function u0:25(i64 vmctx, i64, i8x16) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -527,7 +527,7 @@
 ;; }
 ;;
 ;; function u0:26(i64 vmctx, i64, i8x16) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -552,7 +552,7 @@
 ;; }
 ;;
 ;; function u0:27(i64 vmctx, i64, i8x16) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -577,7 +577,7 @@
 ;; }
 ;;
 ;; function u0:28(i64 vmctx, i64, i8x16) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -602,7 +602,7 @@
 ;; }
 ;;
 ;; function u0:29(i64 vmctx, i64, i8x16) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -627,7 +627,7 @@
 ;; }
 ;;
 ;; function u0:2(i64 vmctx, i64, i8x16) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -652,7 +652,7 @@
 ;; }
 ;;
 ;; function u0:30(i64 vmctx, i64, i8x16) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -677,7 +677,7 @@
 ;; }
 ;;
 ;; function u0:31(i64 vmctx, i64, i8x16) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -702,7 +702,7 @@
 ;; }
 ;;
 ;; function u0:32(i64 vmctx, i64, i8x16) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -727,7 +727,7 @@
 ;; }
 ;;
 ;; function u0:33(i64 vmctx, i64, i8x16) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -752,7 +752,7 @@
 ;; }
 ;;
 ;; function u0:3(i64 vmctx, i64, i8x16) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -777,7 +777,7 @@
 ;; }
 ;;
 ;; function u0:4(i64 vmctx, i64, i8x16) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -800,7 +800,7 @@
 ;; }
 ;;
 ;; function u0:5(i64 vmctx, i64, i8x16) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -825,7 +825,7 @@
 ;; }
 ;;
 ;; function u0:6(i64 vmctx, i64, i8x16) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -850,7 +850,7 @@
 ;; }
 ;;
 ;; function u0:7(i64 vmctx, i64, i8x16) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -875,7 +875,7 @@
 ;; }
 ;;
 ;; function u0:8(i64 vmctx, i64, i8x16) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -898,7 +898,7 @@
 ;; }
 ;;
 ;; function u0:9(i64 vmctx, i64, i8x16) tail {
-;;     region0 = 0 "heap"
+;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/startup-elem-active.wat
+++ b/tests/disas/startup-elem-active.wat
@@ -39,7 +39,7 @@
 ;; }
 ;;
 ;; function u2415919104:0(i64 vmctx, i64) tail {
-;;     region0 = 1 "table"
+;;     region0 = 1342177280 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned gv0+48
 ;;     gv2 = load.i64 notrap aligned gv0+56

--- a/tests/disas/startup-global.wat
+++ b/tests/disas/startup-global.wat
@@ -32,7 +32,7 @@
 ;; }
 ;;
 ;; function u2415919104:0(i64 vmctx, i64) tail {
-;;     region0 = 1 "table"
+;;     region0 = 1879048192 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(0))"
 ;;     gv0 = vmctx
 ;;
 ;; block0(v0: i64, v1: i64):

--- a/tests/disas/startup-passive-segment.wat
+++ b/tests/disas/startup-passive-segment.wat
@@ -33,6 +33,7 @@
 ;; }
 ;;
 ;; function u2415919104:0(i64 vmctx, i64) tail {
+;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     sig0 = (i64 vmctx, i32) -> i64 tail
 ;;     fn0 = colocated u805306368:4 sig0
@@ -41,10 +42,10 @@
 ;;     v3 = iconst.i32 0
 ;;     v4 = call fn0(v0, v3)  ; v3 = 0
 ;;     v18 = iconst.i32 1
-;;     store user2 little v18, v4  ; v18 = 1
+;;     store user2 little region0 v18, v4  ; v18 = 1
 ;;     v25 = iconst.i32 3
 ;;     v13 = iconst.i64 16
 ;;     v12 = iadd v4, v13  ; v13 = 16
-;;     store user2 little v25, v12  ; v25 = 3
+;;     store user2 little region0 v25, v12  ; v25 = 3
 ;;     return
 ;; }

--- a/tests/disas/sub-global.wat
+++ b/tests/disas/sub-global.wat
@@ -13,7 +13,7 @@
 )
 
 ;; function u0:0(i64 vmctx, i64) tail {
-;;     region0 = 1 "table"
+;;     region0 = 1879048192 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/table-copy.wat
+++ b/tests/disas/table-copy.wat
@@ -63,7 +63,7 @@
 ;; }
 ;;
 ;; function u0:3(i64 vmctx, i64, i32, i32, i32, i32) -> i32 tail {
-;;     region0 = 1 "table"
+;;     region0 = 1342177280 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -203,7 +203,7 @@
 ;; }
 ;;
 ;; function u0:4(i64 vmctx, i64, i32, i32, i32, i32) -> i32 tail {
-;;     region0 = 1 "table"
+;;     region0 = 1073741824 "ImportedTable"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/table-get-fixed-size.wat
+++ b/tests/disas/table-get-fixed-size.wat
@@ -16,7 +16,7 @@
     table.get 0))
 
 ;; function u0:0(i64 vmctx, i64) -> i32 tail {
-;;     region0 = 1 "table"
+;;     region0 = 1342177280 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -43,7 +43,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 1 "table"
+;;     region0 = 1342177280 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/table-get.wat
+++ b/tests/disas/table-get.wat
@@ -15,7 +15,7 @@
     table.get 0))
 
 ;; function u0:0(i64 vmctx, i64) -> i32 tail {
-;;     region0 = 1 "table"
+;;     region0 = 1342177280 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -44,7 +44,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 1 "table"
+;;     region0 = 1342177280 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/table-set-fixed-size.wat
+++ b/tests/disas/table-set-fixed-size.wat
@@ -17,7 +17,7 @@
     local.get 1
     table.set 0))
 ;; function u0:0(i64 vmctx, i64, i32) tail {
-;;     region0 = 1 "table"
+;;     region0 = 1342177280 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -44,7 +44,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32, i32) tail {
-;;     region0 = 1 "table"
+;;     region0 = 1342177280 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/table-set.wat
+++ b/tests/disas/table-set.wat
@@ -17,7 +17,7 @@
     table.set 0))
 
 ;; function u0:0(i64 vmctx, i64, i32) tail {
-;;     region0 = 1 "table"
+;;     region0 = 1342177280 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -46,7 +46,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32, i32) tail {
-;;     region0 = 1 "table"
+;;     region0 = 1342177280 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/typed-funcrefs-eager-init.wat
+++ b/tests/disas/typed-funcrefs-eager-init.wat
@@ -127,7 +127,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32, i32, i32, i32) -> i32 tail {
-;;     region0 = 1 "table"
+;;     region0 = 1342177280 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -158,7 +158,7 @@
 ;; }
 ;;
 ;; function u0:2(i64 vmctx, i64, i32, i32, i32, i32) -> i32 tail {
-;;     region0 = 1 "table"
+;;     region0 = 1342177280 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -189,7 +189,8 @@
 ;; }
 ;;
 ;; function u0:3(i64 vmctx, i64, i32, i32, i32, i32) -> i32 tail {
-;;     region0 = 1 "table"
+;;     region0 = 1879048192 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(0))"
+;;     region1 = 1879048193 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(1))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -202,7 +203,7 @@
 ;; @00a0                               v10 = load.i64 user16 aligned readonly v9+8
 ;; @00a0                               v11 = load.i64 notrap aligned readonly v9+24
 ;; @00a0                               v12 = call_indirect sig0, v10(v11, v0, v2, v3, v4, v5)
-;; @00af                               v15 = load.i64 notrap aligned region0 v0+80
+;; @00af                               v15 = load.i64 notrap aligned region1 v0+80
 ;; @00b1                               v16 = load.i64 user16 aligned readonly v15+8
 ;; @00b1                               v17 = load.i64 notrap aligned readonly v15+24
 ;; @00b1                               v18 = call_indirect sig0, v16(v17, v0, v2, v3, v4, v5)

--- a/tests/disas/typed-funcrefs.wat
+++ b/tests/disas/typed-funcrefs.wat
@@ -127,7 +127,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32, i32, i32, i32) -> i32 tail {
-;;     region0 = 1 "table"
+;;     region0 = 1342177280 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -182,7 +182,7 @@
 ;; }
 ;;
 ;; function u0:2(i64 vmctx, i64, i32, i32, i32, i32) -> i32 tail {
-;;     region0 = 1 "table"
+;;     region0 = 1342177280 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -237,7 +237,8 @@
 ;; }
 ;;
 ;; function u0:3(i64 vmctx, i64, i32, i32, i32, i32) -> i32 tail {
-;;     region0 = 1 "table"
+;;     region0 = 1879048192 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(0))"
+;;     region1 = 1879048193 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(1))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -250,7 +251,7 @@
 ;; @00a0                               v10 = load.i64 user16 aligned readonly v9+8
 ;; @00a0                               v11 = load.i64 notrap aligned readonly v9+24
 ;; @00a0                               v12 = call_indirect sig0, v10(v11, v0, v2, v3, v4, v5)
-;; @00af                               v15 = load.i64 notrap aligned region0 v0+80
+;; @00af                               v15 = load.i64 notrap aligned region1 v0+80
 ;; @00b1                               v16 = load.i64 user16 aligned readonly v15+8
 ;; @00b1                               v17 = load.i64 notrap aligned readonly v15+24
 ;; @00b1                               v18 = call_indirect sig0, v16(v17, v0, v2, v3, v4, v5)

--- a/tests/misc_testsuite/alias-region-imported-globals.wast
+++ b/tests/misc_testsuite/alias-region-imported-globals.wast
@@ -1,0 +1,19 @@
+;; Test that two imports of the same global correctly alias.
+;; The alias region system should ensure that global.set through one import
+;; is visible through global.get on the other import.
+
+(module $M
+  (global (export "a") (export "b") (mut i32) (i32.const 0))
+)
+(register "M")
+
+(module
+  (import "M" "a" (global $a (mut i32)))
+  (import "M" "b" (global $b (mut i32)))
+  (func (export "test") (param i32) (result i32)
+    (global.set $a (local.get 0))
+    (global.get $b)
+  )
+)
+(assert_return (invoke "test" (i32.const 42)) (i32.const 42))
+(assert_return (invoke "test" (i32.const 0xdeadbeef)) (i32.const 0xdeadbeef))

--- a/tests/misc_testsuite/alias-region-imported-memories.wast
+++ b/tests/misc_testsuite/alias-region-imported-memories.wast
@@ -1,0 +1,21 @@
+;;! multi_memory = true
+;; Test that two imports of the same memory correctly alias.
+;; The alias region system should ensure that stores through one import
+;; are visible through loads from the other import.
+
+(module $M
+  (memory (export "a") (export "b") 1)
+)
+(register "M")
+
+(module
+  (import "M" "a" (memory $a 1))
+  (import "M" "b" (memory $b 1))
+  (func (export "test") (param i32) (result i32)
+    (i32.store $a (i32.const 0) (local.get 0))
+    (i32.load $b (i32.const 0))
+  )
+)
+(assert_return (invoke "test" (i32.const 42)) (i32.const 42))
+(assert_return (invoke "test" (i32.const 0xdeadbeef)) (i32.const 0xdeadbeef))
+

--- a/tests/misc_testsuite/alias-region-imported-tables.wast
+++ b/tests/misc_testsuite/alias-region-imported-tables.wast
@@ -1,0 +1,31 @@
+;;! reference_types = true
+;;! bulk_memory = true
+;; Test that two imports of the same table correctly alias.
+;; The alias region system should ensure that table.set through one import
+;; is visible through call_indirect on the other import.
+
+(module $M
+  (type $ft (func (result i32)))
+  (func $f99 (type $ft) (i32.const 99))
+  (func $f42 (type $ft) (i32.const 42))
+  (table (export "a") (export "b") 10 funcref)
+  (elem declare func $f99 $f42)
+  (func (export "get_f99") (result funcref) (ref.func $f99))
+  (func (export "get_f42") (result funcref) (ref.func $f42))
+)
+(register "M")
+
+(module
+  (type $ft (func (result i32)))
+  (import "M" "a" (table $a 10 funcref))
+  (import "M" "b" (table $b 10 funcref))
+  (import "M" "get_f99" (func $get_f99 (result funcref)))
+  (import "M" "get_f42" (func $get_f42 (result funcref)))
+  (func (export "test") (result i32)
+    ;; Set element 0 of table $a
+    (table.set $a (i32.const 0) (call $get_f99))
+    ;; Call through table $b at index 0 -- should see what we set via $a
+    (call_indirect $b (type $ft) (i32.const 0))
+  )
+)
+(assert_return (invoke "test") (i32.const 99))


### PR DESCRIPTION
Defines an `AliasRegionKey` that gets turned into a Cranelift `ir::AliasRegionData` and yields a different region per defined memory/global/table vs GC heap vs vmctx structures, etc...

Relatively small diff in reality, only a few hundred lines, but the disas test expectations all got updated.