### PR TITLE
Cranelift: remove the `iadd_imm` instruction

### DIFF
--- a/cranelift/codegen/meta/src/shared/instructions.rs
+++ b/cranelift/codegen/meta/src/shared/instructions.rs
@@ -1782,7 +1782,8 @@ pub(crate) fn define(
             &formats.binary,
         )
         .operands_in(vec![Operand::new("x", Int), Operand::new("y", Int)])
-        .operands_out(vec![Operand::new("a", Int)]),
+        .operands_out(vec![Operand::new("a", Int)])
+        .inst_builder_imm_method(true),
     );
 
     ig.push(
@@ -1977,23 +1978,6 @@ pub(crate) fn define(
         .operands_out(vec![Operand::new("a", iB)])
         .can_trap()
         .side_effects_idempotent(),
-    );
-
-    ig.push(
-        Inst::new(
-            "iadd_imm",
-            r#"
-        Add immediate integer.
-
-        Same as `iadd`, but one operand is a sign extended 64 bit immediate constant.
-
-        Polymorphic over all scalar integer types, but does not support vector
-        types.
-        "#,
-            &formats.binary_imm64,
-        )
-        .operands_in(vec![Operand::new("x", iB), Operand::new("Y", &imm.imm64)])
-        .operands_out(vec![Operand::new("a", iB)]),
     );
 
     ig.push(

--- a/cranelift/codegen/src/ir/instructions.rs
+++ b/cranelift/codegen/src/ir/instructions.rs
@@ -1184,12 +1184,12 @@ mod tests {
         assert_eq!(x, y);
         assert_eq!(x.format(), InstructionFormat::Binary);
 
-        assert_eq!(format!("{:?}", Opcode::IaddImm), "IaddImm");
-        assert_eq!(Opcode::IaddImm.to_string(), "iadd_imm");
+        assert_eq!(format!("{:?}", Opcode::BandNot), "BandNot");
+        assert_eq!(Opcode::BandNot.to_string(), "band_not");
 
         // Check the matcher.
         assert_eq!("iadd".parse::<Opcode>(), Ok(Opcode::Iadd));
-        assert_eq!("iadd_imm".parse::<Opcode>(), Ok(Opcode::IaddImm));
+        assert_eq!("band_not".parse::<Opcode>(), Ok(Opcode::BandNot));
         assert_eq!("iadd\0".parse::<Opcode>(), Err("Unknown opcode"));
         assert_eq!("".parse::<Opcode>(), Err("Unknown opcode"));
         assert_eq!("\0".parse::<Opcode>(), Err("Unknown opcode"));

--- a/cranelift/codegen/src/legalizer/mod.rs
+++ b/cranelift/codegen/src/legalizer/mod.rs
@@ -204,11 +204,9 @@ fn expand_binary_imm64(
     pos.goto_inst(inst);
 
     let is_signed = match opcode {
-        ir::Opcode::IaddImm
-        | ir::Opcode::IrsubImm
-        | ir::Opcode::ImulImm
-        | ir::Opcode::SdivImm
-        | ir::Opcode::SremImm => true,
+        ir::Opcode::IrsubImm | ir::Opcode::ImulImm | ir::Opcode::SdivImm | ir::Opcode::SremImm => {
+            true
+        }
         _ => false,
     };
 
@@ -243,9 +241,6 @@ fn expand_binary_imm64(
             replace.ushr(arg, imm);
         }
         // math
-        ir::Opcode::IaddImm => {
-            replace.iadd(arg, imm);
-        }
         ir::Opcode::IrsubImm => {
             // note: arg order reversed
             replace.isub(imm, arg);

--- a/cranelift/codegen/src/souper_harvest.rs
+++ b/cranelift/codegen/src/souper_harvest.rs
@@ -95,7 +95,6 @@ fn harvest_candidate_lhs(
     let should_trace = |val| match func.dfg.value_def(val) {
         ir::ValueDef::Result(inst, 0) => match func.dfg.insts[inst].opcode() {
                 ir::Opcode::Iadd
-                | ir::Opcode::IaddImm
                 | ir::Opcode::IrsubImm
                 | ir::Opcode::Imul
                 | ir::Opcode::ImulImm
@@ -183,17 +182,6 @@ fn harvest_candidate_lhs(
                     (ir::Opcode::Iadd, _) => {
                         let a = arg(allocs, 0);
                         let b = arg(allocs, 1);
-                        ast::Instruction::Add { a, b }.into()
-                    }
-                    (ir::Opcode::IaddImm, ir::InstructionData::BinaryImm64 { imm, .. }) => {
-                        let a = arg(allocs, 0);
-                        let value: i64 = (*imm).into();
-                        let value: i128 = value.into();
-                        let b = ast::Constant {
-                            value,
-                            r#type: souper_type_of(&func.dfg, val),
-                        }
-                        .into();
                         ast::Instruction::Add { a, b }.into()
                     }
                     (ir::Opcode::IrsubImm, ir::InstructionData::BinaryImm64 { imm, .. }) => {

--- a/cranelift/filetests/filetests/cfg/loop.clif
+++ b/cranelift/filetests/filetests/cfg/loop.clif
@@ -36,7 +36,8 @@ block1(v5: i32):
     v9 = f32const 0.0
     v10 = f32const 0.0
     v11 = fadd v9, v10
-    v12 = iadd_imm v5, 1
+    v101 = iconst.i32 1
+    v12 = iadd v5, v101
     v13 = icmp ult v12, v2
     brif v13, block1(v12), block4 ; unordered: block1:$BRIF1 -> block1
                                   ; unordered: block1:$BRIF1 -> block4

--- a/cranelift/filetests/filetests/egraph/licm.clif
+++ b/cranelift/filetests/filetests/egraph/licm.clif
@@ -125,7 +125,8 @@ block2(v11: i64):
     store.f64 v10, v15
 
     ;; loop breakout condition
-    v17 = iadd_imm v11, 1
+    v21 = iconst.i64 1
+    v17 = iadd v11, v21
     v20 = iconst.i64 100
     v19 = icmp ne v17, v20
     brif v19, block2(v17), block1

--- a/cranelift/filetests/filetests/isa/aarch64/amodes.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/amodes.clif
@@ -451,7 +451,8 @@ block0(v0: i64):
 
 function %i128_add_offset(i64) -> i128 {
 block0(v0: i64):
-  v1 = iadd_imm v0, 32
+  v3 = iconst.i64 32
+  v1 = iadd v0, v3
   v2 = load.i128 v1
   store.i128 v2, v1
   return v2
@@ -497,7 +498,8 @@ function %i128_32bit_sextend(i64, i32) -> i128 {
 block0(v0: i64, v1: i32):
   v2 = sextend.i64 v1
   v3 = iadd.i64 v0, v2
-  v4 = iadd_imm.i64 v3, 24
+  v6 = iconst.i64 24
+  v4 = iadd v3, v6
   v5 = load.i128 v4
   store.i128 v5, v4
   return v5

--- a/cranelift/filetests/filetests/isa/aarch64/big-endian.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/big-endian.clif
@@ -201,7 +201,8 @@ function %f(i64) -> i64 {
 function %f(i64) {
     block0(v0: i64):
         v1 = load.i32 big v0+8
-        v2 = iadd_imm v0, 1
+        v3 = iconst.i64 1
+        v2 = iadd v0, v3
         store v2, v0
         return
 }

--- a/cranelift/filetests/filetests/isa/aarch64/exceptions.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/exceptions.clif
@@ -15,7 +15,8 @@ function %f0(i32) -> i32, f32, f64 {
 
     block2(v6: i64):
         v7 = ireduce.i32 v6
-        v8 = iadd_imm.i32 v7, 1
+        v10 = iconst.i32 1
+        v8 = iadd v7, v10
         v9 = f32const 0x0.0        
         return v8, v9, v2
 }
@@ -136,7 +137,8 @@ function %f2(i32) -> i32, f32, f64 {
 
     block2(v6: i64):
         v7 = ireduce.i32 v6
-        v8 = iadd_imm.i32 v7, 1
+        v11 = iconst.i32 1
+        v8 = iadd v7, v11
         v9 = f32const 0x0.0        
         return v8, v9, v2
 }
@@ -261,7 +263,8 @@ function %f4(i64, i32) -> i32, f32, f64 {
 
     block2(v6: i64):
         v7 = ireduce.i32 v6
-        v8 = iadd_imm.i32 v7, 1
+        v10 = iconst.i32 1
+        v8 = iadd v7, v10
         v9 = f32const 0x0.0        
         return v8, v9, v2
 

--- a/cranelift/filetests/filetests/isa/aarch64/pinned-reg.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/pinned-reg.clif
@@ -5,7 +5,8 @@ target aarch64
 function %f0() {
 block0:
     v1 = get_pinned_reg.i64
-    v2 = iadd_imm v1, 1
+    v3 = iconst.i64 1
+    v2 = iadd v1, v3
     set_pinned_reg v2
     return
 }

--- a/cranelift/filetests/filetests/isa/aarch64/return-call-indirect.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/return-call-indirect.clif
@@ -6,7 +6,8 @@ target aarch64
 
 function %callee_i64(i64) -> i64 tail {
 block0(v0: i64):
-    v1 = iadd_imm.i64 v0, 10
+    v2 = iconst.i64 10
+    v1 = iadd v0, v2
     return v1
 }
 

--- a/cranelift/filetests/filetests/isa/aarch64/return-call.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/return-call.clif
@@ -6,7 +6,8 @@ target aarch64
 
 function %callee_i64(i64) -> i64 tail {
 block0(v0: i64):
-    v1 = iadd_imm.i64 v0, 10
+    v2 = iconst.i64 10
+    v1 = iadd v0, v2
     return v1
 }
 

--- a/cranelift/filetests/filetests/isa/pulley32/exceptions.clif
+++ b/cranelift/filetests/filetests/isa/pulley32/exceptions.clif
@@ -14,7 +14,8 @@ function %f0(i32) -> i32, f32, f64 {
         return v5, v3, v4
 
     block2(v6: i32):
-        v8 = iadd_imm.i32 v6, 1
+        v10 = iconst.i32 1
+        v8 = iadd v6, v10
         v9 = f32const 0x0.0
         return v8, v9, v2
 }
@@ -65,7 +66,8 @@ function %f2(i32, i32) -> i32, f32, f64 {
         return v5, v3, v4
 
     block2(v7: i32):
-        v8 = iadd_imm.i32 v7, 1
+        v11 = iconst.i32 1
+        v8 = iadd v7, v11
         v9 = f32const 0x0.0
         return v8, v9, v2
 }
@@ -116,7 +118,8 @@ function %f4(i32, i32) -> i32, f32, f64 {
         return v5, v3, v4
 
     block2(v6: i32):
-        v8 = iadd_imm.i32 v6, 1
+        v10 = iconst.i32 1
+        v8 = iadd v6, v10
         v9 = f32const 0x0.0
         return v8, v9, v2
 

--- a/cranelift/filetests/filetests/isa/pulley32/iadd.clif
+++ b/cranelift/filetests/filetests/isa/pulley32/iadd.clif
@@ -63,7 +63,8 @@ block0(v0: i64, v1: i64):
 
 function %i8_imm(i8) -> i8 {
 block0(v0: i8):
-    v2 = iadd_imm v0, 10
+    v3 = iconst.i8 10
+    v2 = iadd v0, v3
     return v2
 }
 
@@ -78,7 +79,8 @@ block0(v0: i8):
 
 function %i16_imm(i16) -> i16 {
 block0(v0: i16):
-    v2 = iadd_imm v0, 10
+    v3 = iconst.i16 10
+    v2 = iadd v0, v3
     return v2
 }
 
@@ -93,7 +95,8 @@ block0(v0: i16):
 
 function %i32_imm(i32) -> i32 {
 block0(v0: i32):
-    v2 = iadd_imm v0, 10
+    v3 = iconst.i32 10
+    v2 = iadd v0, v3
     return v2
 }
 
@@ -108,7 +111,8 @@ block0(v0: i32):
 
 function %i64_imm(i64) -> i64 {
 block0(v0: i64):
-    v2 = iadd_imm v0, 10
+    v3 = iconst.i64 10
+    v2 = iadd v0, v3
     return v2
 }
 
@@ -123,7 +127,8 @@ block0(v0: i64):
 
 function %i32_imm_big(i32) -> i32 {
 block0(v0: i32):
-    v2 = iadd_imm v0, 65536
+    v3 = iconst.i32 65536
+    v2 = iadd v0, v3
     return v2
 }
 
@@ -138,7 +143,8 @@ block0(v0: i32):
 
 function %i64_imm_big(i64) -> i64 {
 block0(v0: i64):
-    v2 = iadd_imm v0, 65536
+    v3 = iconst.i64 65536
+    v2 = iadd v0, v3
     return v2
 }
 
@@ -153,7 +159,8 @@ block0(v0: i64):
 
 function %i64_imm_super_big(i64) -> i64 {
 block0(v0: i64):
-    v2 = iadd_imm v0, 0x1_1111_1111
+    v3 = iconst.i64 0x1_1111_1111
+    v2 = iadd v0, v3
     return v2
 }
 
@@ -170,7 +177,8 @@ block0(v0: i64):
 
 function %i8_negative_imm(i8) -> i8 {
 block0(v0: i8):
-    v2 = iadd_imm v0, -10
+    v3 = iconst.i8 -10
+    v2 = iadd v0, v3
     return v2
 }
 
@@ -185,7 +193,8 @@ block0(v0: i8):
 
 function %i16_negative_imm(i16) -> i16 {
 block0(v0: i16):
-    v2 = iadd_imm v0, -10
+    v3 = iconst.i16 -10
+    v2 = iadd v0, v3
     return v2
 }
 
@@ -200,7 +209,8 @@ block0(v0: i16):
 
 function %i32_negative_imm(i32) -> i32 {
 block0(v0: i32):
-    v2 = iadd_imm v0, -10
+    v3 = iconst.i32 -10
+    v2 = iadd v0, v3
     return v2
 }
 
@@ -215,7 +225,8 @@ block0(v0: i32):
 
 function %i64_negative_imm(i64) -> i64 {
 block0(v0: i64):
-    v2 = iadd_imm v0, -10
+    v3 = iconst.i64 -10
+    v2 = iadd v0, v3
     return v2
 }
 
@@ -230,7 +241,8 @@ block0(v0: i64):
 
 function %i32_negative_imm_big(i32) -> i32 {
 block0(v0: i32):
-    v2 = iadd_imm v0, -65536
+    v3 = iconst.i32 -65536
+    v2 = iadd v0, v3
     return v2
 }
 
@@ -245,7 +257,8 @@ block0(v0: i32):
 
 function %i64_negative_imm_big(i64) -> i64 {
 block0(v0: i64):
-    v2 = iadd_imm v0, -65536
+    v3 = iconst.i64 -65536
+    v2 = iadd v0, v3
     return v2
 }
 
@@ -260,7 +273,8 @@ block0(v0: i64):
 
 function %i32_negative_i32_min(i32) -> i32 {
 block0(v0: i32):
-    v2 = iadd_imm v0, 0x8000_0000
+    v3 = iconst.i32 -2147483648
+    v2 = iadd v0, v3
     return v2
 }
 

--- a/cranelift/filetests/filetests/isa/pulley64/exceptions.clif
+++ b/cranelift/filetests/filetests/isa/pulley64/exceptions.clif
@@ -15,7 +15,8 @@ function %f0(i32) -> i32, f32, f64 {
 
     block2(v6: i64):
         v7 = ireduce.i32 v6
-        v8 = iadd_imm.i32 v7, 1
+        v10 = iconst.i32 1
+        v8 = iadd v7, v10
         v9 = f32const 0x0.0
         return v8, v9, v2
 }
@@ -67,7 +68,8 @@ function %f2(i32, i64) -> i32, f32, f64 {
 
     block2(v6: i64):
         v7 = ireduce.i32 v6
-        v8 = iadd_imm.i32 v7, 1
+        v11 = iconst.i32 1
+        v8 = iadd v7, v11
         v9 = f32const 0x0.0
         return v8, v9, v2
 }
@@ -119,7 +121,8 @@ function %f4(i64, i32) -> i32, f32, f64 {
 
     block2(v6: i64):
         v7 = ireduce.i32 v6
-        v8 = iadd_imm.i32 v7, 1
+        v10 = iconst.i32 1
+        v8 = iadd v7, v10
         v9 = f32const 0x0.0
         return v8, v9, v2
 

--- a/cranelift/filetests/filetests/isa/pulley64/load.clif
+++ b/cranelift/filetests/filetests/isa/pulley64/load.clif
@@ -465,7 +465,8 @@ block0(v0: i64):
 
 function %load_i64_with_add_and_offset(i64) -> i64 {
 block0(v0: i64):
-    v1 = iadd_imm v0, 10
+    v3 = iconst.i64 10
+    v1 = iadd v0, v3
     v2 = load.i64 v1+8
     return v2
 }
@@ -481,7 +482,8 @@ block0(v0: i64):
 
 function %load_i8_be_custom_trap(i64) -> i8 {
 block0(v0: i64):
-    v1 = iadd_imm v0, 10
+    v3 = iconst.i64 10
+    v1 = iadd v0, v3
     v2 = load.i8 big user12 v1+8
     return v2
 }
@@ -497,7 +499,8 @@ block0(v0: i64):
 
 function %load_i16_be_custom_trap(i64) -> i16 {
 block0(v0: i64):
-    v1 = iadd_imm v0, 10
+    v3 = iconst.i64 10
+    v1 = iadd v0, v3
     v2 = load.i16 big user12 v1+8
     return v2
 }
@@ -513,7 +516,8 @@ block0(v0: i64):
 
 function %load_i32_be_custom_trap(i64) -> i32 {
 block0(v0: i64):
-    v1 = iadd_imm v0, 10
+    v3 = iconst.i64 10
+    v1 = iadd v0, v3
     v2 = load.i32 big user12 v1+8
     return v2
 }
@@ -529,7 +533,8 @@ block0(v0: i64):
 
 function %load_i64_be_custom_trap(i64) -> i64 {
 block0(v0: i64):
-    v1 = iadd_imm v0, 10
+    v3 = iconst.i64 10
+    v1 = iadd v0, v3
     v2 = load.i64 big user12 v1+8
     return v2
 }
@@ -545,7 +550,8 @@ block0(v0: i64):
 
 function %load_f32_be_custom_trap(i64) -> f32 {
 block0(v0: i64):
-    v1 = iadd_imm v0, 10
+    v3 = iconst.i64 10
+    v1 = iadd v0, v3
     v2 = load.f32 big user12 v1+8
     return v2
 }
@@ -561,7 +567,8 @@ block0(v0: i64):
 
 function %load_f64_be_custom_trap(i64) -> f64 {
 block0(v0: i64):
-    v1 = iadd_imm v0, 10
+    v3 = iconst.i64 10
+    v1 = iadd v0, v3
     v2 = load.f64 big user12 v1+8
     return v2
 }
@@ -577,7 +584,8 @@ block0(v0: i64):
 
 function %load_i64x2_be_custom_trap(i64) -> i64x2 {
 block0(v0: i64):
-    v1 = iadd_imm v0, 10
+    v3 = iconst.i64 10
+    v1 = iadd v0, v3
     v2 = load.i64x2 big user12 v1+8
     return v2
 }

--- a/cranelift/filetests/filetests/isa/riscv64/amodes.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/amodes.clif
@@ -479,7 +479,8 @@ block0(v0: i64):
 
 function %i128_add_offset(i64) -> i128 {
 block0(v0: i64):
-  v1 = iadd_imm v0, 32
+  v3 = iconst.i64 32
+  v1 = iadd v0, v3
   v2 = load.i128 v1
   store.i128 v2, v1
   return v2
@@ -535,7 +536,8 @@ function %i128_32bit_sextend(i64, i32) -> i128 {
 block0(v0: i64, v1: i32):
   v2 = sextend.i64 v1
   v3 = iadd.i64 v0, v2
-  v4 = iadd_imm.i64 v3, 24
+  v6 = iconst.i64 24
+  v4 = iadd v3, v6
   v5 = load.i128 v4
   store.i128 v5, v4
   return v5

--- a/cranelift/filetests/filetests/isa/riscv64/big-endian.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/big-endian.clif
@@ -201,7 +201,8 @@ function %f(i64) -> i64 {
 function %f(i64) {
     block0(v0: i64):
         v1 = load.i32 big v0+8
-        v2 = iadd_imm v0, 1
+        v3 = iconst.i64 1
+        v2 = iadd v0, v3
         store v2, v0
         return
 }

--- a/cranelift/filetests/filetests/isa/riscv64/exceptions.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/exceptions.clif
@@ -15,7 +15,8 @@ function %f0(i32) -> i32, f32, f64 {
 
     block2(v6: i64):
         v7 = ireduce.i32 v6
-        v8 = iadd_imm.i32 v7, 1
+        v10 = iconst.i32 1
+        v8 = iadd v7, v10
         v9 = f32const 0x0.0        
         return v8, v9, v2
 }
@@ -235,7 +236,8 @@ function %f2(i32) -> i32, f32, f64 {
 
     block2(v6: i64):
         v7 = ireduce.i32 v6
-        v8 = iadd_imm.i32 v7, 1
+        v11 = iconst.i32 1
+        v8 = iadd v7, v11
         v9 = f32const 0x0.0        
         return v8, v9, v2
 }
@@ -459,7 +461,8 @@ function %f4(i64, i32) -> i32, f32, f64 {
 
     block2(v6: i64):
         v7 = ireduce.i32 v6
-        v8 = iadd_imm.i32 v7, 1
+        v10 = iconst.i32 1
+        v8 = iadd v7, v10
         v9 = f32const 0x0.0        
         return v8, v9, v2
 

--- a/cranelift/filetests/filetests/isa/riscv64/issue-6954.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/issue-6954.clif
@@ -79,7 +79,8 @@ block0(v0: i16, v1: f32, v2: f64x2, v3: i32, v4: i8, v5: i64x2, v6: i8, v7: f32x
     v38 = ishl v32, v32
     v39 = select v30, v36, v36
     v40 = stack_addr.i64 ss0+3
-    v41 = iadd_imm v40, 0
+    v87 = iconst.i64 0
+    v41 = iadd v40, v87
     v42 = atomic_rmw.i8 and v41, v10
     v43 = select v30, v39, v39
     v44 = select v30, v43, v43

--- a/cranelift/filetests/filetests/isa/riscv64/issue8847.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/issue8847.clif
@@ -197,7 +197,8 @@ block10:
     brif v70, block12, block11
 
 block12:
-    v71 = iadd_imm.i16 v3, 0xffff_ffff_ffff_0087  ; v3 = 0xffef
+    v216 = iconst.i16 135
+    v71 = iadd v3, v216 ; v3 = 0xffef
     v72 = uextend.i32 v71
     br_table v72, block1, [block1, block1, block1, block1, block1, block1]
 
@@ -207,7 +208,8 @@ block11:
     brif v73, block13, block1
 
 block13:
-    v74 = iadd_imm.i16 v3, 0xffff_ffff_ffff_00de  ; v3 = 0xffef
+    v217 = iconst.i16 222
+    v74 = iadd v3, v217 ; v3 = 0xffef
     v75 = uextend.i32 v74
     br_table v75, block1, [block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1]
 
@@ -222,7 +224,8 @@ block14:
     brif v77, block15, block1
 
 block15:
-    v78 = iadd_imm.i16 v3, 0xffff_ffff_ffff_0901  ; v3 = 0xffef
+    v218 = iconst.i16 2305
+    v78 = iadd v3, v218 ; v3 = 0xffef
     v79 = uextend.i32 v78
     br_table v79, block1, [block1, block1, block1, block1, block1, block1, block1]
 
@@ -242,7 +245,8 @@ block18:
     brif v82, block20, block19
 
 block20:
-    v83 = iadd_imm.i16 v3, 0xffff_ffff_ffff_1001  ; v3 = 0xffef
+    v219 = iconst.i16 4097
+    v83 = iadd v3, v219 ; v3 = 0xffef
     v84 = uextend.i32 v83
     br_table v84, block1, [block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1]
 
@@ -252,7 +256,8 @@ block19:
     brif v85, block21, block1
 
 block21:
-    v86 = iadd_imm.i16 v3, 0xffff_ffff_ffff_10d6  ; v3 = 0xffef
+    v220 = iconst.i16 4310
+    v86 = iadd v3, v220 ; v3 = 0xffef
     v87 = uextend.i32 v86
     br_table v87, block1, [block1, block1, block1, block1, block1, block1, block1, block1, block1]
 
@@ -267,7 +272,8 @@ block22:
     brif v89, block23, block1
 
 block23:
-    v90 = iadd_imm.i16 v3, 0xffff_ffff_ffff_2a29  ; v3 = 0xffef
+    v221 = iconst.i16 10793
+    v90 = iadd v3, v221 ; v3 = 0xffef
     v91 = uextend.i32 v90
     br_table v91, block1, [block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1]
 
@@ -287,7 +293,8 @@ block27:
     brif v94, block29, block28
 
 block29:
-    v95 = iadd_imm.i16 v3, 0xffff_ffff_ffff_40bf  ; v3 = 0xffef
+    v222 = iconst.i16 16575
+    v95 = iadd v3, v222 ; v3 = 0xffef
     v96 = uextend.i32 v95
     br_table v96, block1, [block1, block1, block1, block1, block1, block1, block1, block1, block1]
 
@@ -307,7 +314,8 @@ block26:
     brif v99, block32, block31
 
 block32:
-    v100 = iadd_imm.i16 v3, 0xffff_ffff_ffff_6cff  ; v3 = 0xffef
+    v223 = iconst.i16 27903
+    v100 = iadd v3, v223 ; v3 = 0xffef
     v101 = uextend.i32 v100
     br_table v101, block1, [block1, block1, block1, block1, block1, block1, block1]
 
@@ -317,7 +325,8 @@ block31:
     brif v102, block33, block1
 
 block33:
-    v103 = iadd_imm.i16 v3, 0xffff_ffff_ffff_8c9d  ; v3 = 0xffef
+    v224 = iconst.i16 -29539
+    v103 = iadd v3, v224 ; v3 = 0xffef
     v104 = uextend.i32 v103
     br_table v104, block1, [block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1]
 
@@ -347,7 +356,8 @@ block37:
     brif v109, block38, block1
 
 block38:
-    v110 = iadd_imm.i16 v3, 0xffff_ffff_ffff_aedd  ; v3 = 0xffef
+    v225 = iconst.i16 -20771
+    v110 = iadd v3, v225 ; v3 = 0xffef
     v111 = uextend.i32 v110
     br_table v111, block1, [block1, block1, block1, block1, block1, block1, block1]
 
@@ -372,7 +382,8 @@ block44:
     brif v115, block46, block45
 
 block46:
-    v116 = iadd_imm.i16 v3, 0xffff_ffff_ffff_afb3  ; v3 = 0xffef
+    v226 = iconst.i16 -20557
+    v116 = iadd v3, v226 ; v3 = 0xffef
     v117 = uextend.i32 v116
     br_table v117, block1, [block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1]
 
@@ -392,7 +403,8 @@ block43:
     brif v120, block49, block48
 
 block49:
-    v121 = iadd_imm.i16 v3, 0xffff_ffff_ffff_d0d6  ; v3 = 0xffef
+    v227 = iconst.i16 -12074
+    v121 = iadd v3, v227 ; v3 = 0xffef
     v122 = uextend.i32 v121
     br_table v122, block1, [block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1]
 
@@ -412,7 +424,8 @@ block51:
     brif v125, block53, block52
 
 block53:
-    v126 = iadd_imm.i16 v3, 0xffff_ffff_ffff_d522  ; v3 = 0xffef
+    v228 = iconst.i16 -10974
+    v126 = iadd v3, v228 ; v3 = 0xffef
     v127 = uextend.i32 v126
     br_table v127, block1, [block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1]
 
@@ -427,7 +440,8 @@ block54:
     brif v129, block55, block1
 
 block55:
-    v130 = iadd_imm.i16 v3, 0xffff_ffff_ffff_d599  ; v3 = 0xffef
+    v229 = iconst.i16 -10855
+    v130 = iadd v3, v229 ; v3 = 0xffef
     v131 = uextend.i32 v130
     br_table v131, block1, [block1, block1, block1, block1, block1, block1]
 
@@ -462,7 +476,8 @@ block61:
     brif v137, block63, block62
 
 block63:
-    v138 = iadd_imm.i16 v3, -8738  ; v3 = 0xffef
+    v230 = iconst.i16 -8738
+    v138 = iadd v3, v230 ; v3 = 0xffef
     v139 = uextend.i32 v138
     br_table v139, block1, [block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1]
 
@@ -472,7 +487,8 @@ block62:
     brif v140, block64, block1
 
 block64:
-    v141 = iadd_imm.i16 v3, -8241  ; v3 = 0xffef
+    v231 = iconst.i16 -8241
+    v141 = iadd v3, v231 ; v3 = 0xffef
     v142 = uextend.i32 v141
     br_table v142, block1, [block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1]
 
@@ -487,7 +503,8 @@ block65:
     brif v144, block66, block1
 
 block66:
-    v145 = iadd_imm.i16 v3, -512  ; v3 = 0xffef
+    v232 = iconst.i16 -512
+    v145 = iadd v3, v232 ; v3 = 0xffef
     v146 = uextend.i32 v145
     br_table v146, block1, [block1, block1, block1]
 
@@ -502,7 +519,8 @@ block68:
     brif v148, block70, block69
 
 block70:
-    v149 = iadd_imm.i16 v3, -341  ; v3 = 0xffef
+    v233 = iconst.i16 -341
+    v149 = iadd v3, v233 ; v3 = 0xffef
     v150 = uextend.i32 v149
     br_table v150, block1, [block1, block1]
 
@@ -512,7 +530,8 @@ block69:
     brif v151, block71, block1
 
 block71:
-    v152 = iadd_imm.i16 v3, -212  ; v3 = 0xffef
+    v234 = iconst.i16 -212
+    v152 = iadd v3, v234 ; v3 = 0xffef
     v153 = uextend.i32 v152
     br_table v153, block1, [block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1]
 
@@ -522,7 +541,8 @@ block67:
     brif v154, block73, block72
 
 block73:
-    v155 = iadd_imm.i16 v3, -128  ; v3 = 0xffef
+    v235 = iconst.i16 -128
+    v155 = iadd v3, v235 ; v3 = 0xffef
     v156 = uextend.i32 v155
     br_table v156, block1, [block1, block1]
 

--- a/cranelift/filetests/filetests/isa/riscv64/issue8866.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/issue8866.clif
@@ -197,7 +197,8 @@ block10:
     brif v70, block12, block11
 
 block12:
-    v71 = iadd_imm.i16 v3, 0xffff_ffff_ffff_0087  ; v3 = 0xffef
+    v220 = iconst.i16 135
+    v71 = iadd v3, v220 ; v3 = 0xffef
     v72 = uextend.i32 v71
     br_table v72, block1, [block1, block1, block1, block1, block1, block1]
 
@@ -207,7 +208,8 @@ block11:
     brif v73, block13, block1
 
 block13:
-    v74 = iadd_imm.i16 v3, 0xffff_ffff_ffff_00de  ; v3 = 0xffef
+    v221 = iconst.i16 222
+    v74 = iadd v3, v221 ; v3 = 0xffef
     v75 = uextend.i32 v74
     br_table v75, block1, [block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1]
 
@@ -222,7 +224,8 @@ block14:
     brif v77, block15, block1
 
 block15:
-    v78 = iadd_imm.i16 v3, 0xffff_ffff_ffff_0901  ; v3 = 0xffef
+    v222 = iconst.i16 2305
+    v78 = iadd v3, v222 ; v3 = 0xffef
     v79 = uextend.i32 v78
     br_table v79, block1, [block1, block1, block1, block1, block1, block1, block1]
 
@@ -242,7 +245,8 @@ block18:
     brif v82, block20, block19
 
 block20:
-    v83 = iadd_imm.i16 v3, 0xffff_ffff_ffff_1001  ; v3 = 0xffef
+    v223 = iconst.i16 4097
+    v83 = iadd v3, v223 ; v3 = 0xffef
     v84 = uextend.i32 v83
     br_table v84, block1, [block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1]
 
@@ -252,7 +256,8 @@ block19:
     brif v85, block21, block1
 
 block21:
-    v86 = iadd_imm.i16 v3, 0xffff_ffff_ffff_10d6  ; v3 = 0xffef
+    v224 = iconst.i16 4310
+    v86 = iadd v3, v224 ; v3 = 0xffef
     v87 = uextend.i32 v86
     br_table v87, block1, [block1, block1, block1, block1, block1, block1, block1, block1, block1]
 
@@ -267,7 +272,8 @@ block22:
     brif v89, block23, block1
 
 block23:
-    v90 = iadd_imm.i16 v3, 0xffff_ffff_ffff_2a29  ; v3 = 0xffef
+    v225 = iconst.i16 10793
+    v90 = iadd v3, v225 ; v3 = 0xffef
     v91 = uextend.i32 v90
     br_table v91, block1, [block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1]
 
@@ -287,7 +293,8 @@ block27:
     brif v94, block29, block28
 
 block29:
-    v95 = iadd_imm.i16 v3, 0xffff_ffff_ffff_40bf  ; v3 = 0xffef
+    v226 = iconst.i16 16575
+    v95 = iadd v3, v226 ; v3 = 0xffef
     v96 = uextend.i32 v95
     br_table v96, block1, [block1, block1, block1, block1, block1, block1, block1, block1, block1]
 
@@ -307,7 +314,8 @@ block26:
     brif v99, block32, block31
 
 block32:
-    v100 = iadd_imm.i16 v3, 0xffff_ffff_ffff_6cff  ; v3 = 0xffef
+    v227 = iconst.i16 27903
+    v100 = iadd v3, v227 ; v3 = 0xffef
     v101 = uextend.i32 v100
     br_table v101, block1, [block1, block1, block1, block1, block1, block1, block1]
 
@@ -317,7 +325,8 @@ block31:
     brif v102, block33, block1
 
 block33:
-    v103 = iadd_imm.i16 v3, 0xffff_ffff_ffff_8c9d  ; v3 = 0xffef
+    v228 = iconst.i16 -29539
+    v103 = iadd v3, v228 ; v3 = 0xffef
     v104 = uextend.i32 v103
     br_table v104, block1, [block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1]
 
@@ -347,7 +356,8 @@ block34:
     brif v109, block39, block38
 
 block39:
-    v110 = iadd_imm.i16 v3, 0xffff_ffff_ffff_aedd  ; v3 = 0xffef
+    v229 = iconst.i16 -20771
+    v110 = iadd v3, v229 ; v3 = 0xffef
     v111 = uextend.i32 v110
     br_table v111, block1, [block1, block1, block1, block1, block1, block1, block1]
 
@@ -357,7 +367,8 @@ block38:
     brif v112, block40, block1
 
 block40:
-    v113 = iadd_imm.i16 v3, 0xffff_ffff_ffff_afb3  ; v3 = 0xffef
+    v230 = iconst.i16 -20557
+    v113 = iadd v3, v230 ; v3 = 0xffef
     v114 = uextend.i32 v113
     br_table v114, block1, [block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1]
 
@@ -392,7 +403,8 @@ block48:
     brif v120, block49, block1
 
 block49:
-    v121 = iadd_imm.i16 v3, 0xffff_ffff_ffff_d0d6  ; v3 = 0xffef
+    v231 = iconst.i16 -12074
+    v121 = iadd v3, v231 ; v3 = 0xffef
     v122 = uextend.i32 v121
     br_table v122, block1, [block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1]
 
@@ -407,7 +419,8 @@ block50:
     brif v124, block51, block1
 
 block51:
-    v125 = iadd_imm.i16 v3, 0xffff_ffff_ffff_d522  ; v3 = 0xffef
+    v232 = iconst.i16 -10974
+    v125 = iadd v3, v232 ; v3 = 0xffef
     v126 = uextend.i32 v125
     br_table v126, block1, [block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1]
 
@@ -427,7 +440,8 @@ block54:
     brif v129, block56, block55
 
 block56:
-    v130 = iadd_imm.i16 v3, 0xffff_ffff_ffff_d599  ; v3 = 0xffef
+    v233 = iconst.i16 -10855
+    v130 = iadd v3, v233 ; v3 = 0xffef
     v131 = uextend.i32 v130
     br_table v131, block1, [block1, block1, block1, block1, block1, block1]
 
@@ -462,7 +476,8 @@ block61:
     brif v137, block63, block62
 
 block63:
-    v138 = iadd_imm.i16 v3, -8738  ; v3 = 0xffef
+    v234 = iconst.i16 -8738
+    v138 = iadd v3, v234 ; v3 = 0xffef
     v139 = uextend.i32 v138
     br_table v139, block1, [block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1]
 
@@ -472,7 +487,8 @@ block62:
     brif v140, block65, block64
 
 block65:
-    v141 = iadd_imm.i16 v3, -8241  ; v3 = 0xffef
+    v235 = iconst.i16 -8241
+    v141 = iadd v3, v235 ; v3 = 0xffef
     v142 = uextend.i32 v141
     br_table v142, block1, [block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1]
 
@@ -487,7 +503,8 @@ block60:
     brif v144, block67, block66
 
 block67:
-    v145 = iadd_imm.i16 v3, -512  ; v3 = 0xffef
+    v236 = iconst.i16 -512
+    v145 = iadd v3, v236 ; v3 = 0xffef
     v146 = uextend.i32 v145
     br_table v146, block1, [block1, block1, block1]
 
@@ -497,7 +514,8 @@ block66:
     brif v147, block68, block1
 
 block68:
-    v148 = iadd_imm.i16 v3, -341  ; v3 = 0xffef
+    v237 = iconst.i16 -341
+    v148 = iadd v3, v237 ; v3 = 0xffef
     v149 = uextend.i32 v148
     br_table v149, block1, [block1, block1]
 
@@ -512,7 +530,8 @@ block70:
     brif v151, block72, block71
 
 block72:
-    v152 = iadd_imm.i16 v3, -212  ; v3 = 0xffef
+    v238 = iconst.i16 -212
+    v152 = iadd v3, v238 ; v3 = 0xffef
     v153 = uextend.i32 v152
     br_table v153, block1, [block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1]
 
@@ -522,7 +541,8 @@ block71:
     brif v154, block73, block1
 
 block73:
-    v155 = iadd_imm.i16 v3, -148  ; v3 = 0xffef
+    v239 = iconst.i16 -148
+    v155 = iadd v3, v239 ; v3 = 0xffef
     v156 = uextend.i32 v155
     br_table v156, block1, [block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1, block1]
 
@@ -532,7 +552,8 @@ block69:
     brif v157, block75, block74
 
 block75:
-    v158 = iadd_imm.i16 v3, -128  ; v3 = 0xffef
+    v240 = iconst.i16 -128
+    v158 = iadd v3, v240 ; v3 = 0xffef
     v159 = uextend.i32 v158
     br_table v159, block1, [block1, block1]
 

--- a/cranelift/filetests/filetests/isa/riscv64/return-call-indirect.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/return-call-indirect.clif
@@ -6,7 +6,8 @@ target riscv64
 
 function %callee_i64(i64) -> i64 tail {
 block0(v0: i64):
-    v1 = iadd_imm.i64 v0, 10
+    v2 = iconst.i64 10
+    v1 = iadd v0, v2
     return v1
 }
 

--- a/cranelift/filetests/filetests/isa/riscv64/return-call.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/return-call.clif
@@ -6,7 +6,8 @@ target riscv64
 
 function %callee_i64(i64) -> i64 tail {
 block0(v0: i64):
-    v1 = iadd_imm.i64 v0, 10
+    v2 = iconst.i64 10
+    v1 = iadd v0, v2
     return v1
 }
 

--- a/cranelift/filetests/filetests/isa/riscv64/zca.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/zca.clif
@@ -283,7 +283,8 @@ block0:
 
 function %c_addi_max(i64) -> i64 {
 block0(v0: i64):
-  v2 = iadd_imm.i64 v0, 31
+  v3 = iconst.i64 31
+  v2 = iadd v0, v3
   return v2
 }
 
@@ -299,7 +300,8 @@ block0(v0: i64):
 
 function %c_addi_min(i64) -> i64 {
 block0(v0: i64):
-  v2 = iadd_imm.i64 v0, -32
+  v3 = iconst.i64 -32
+  v2 = iadd v0, v3
   return v2
 }
 
@@ -331,7 +333,8 @@ block0(v0: i32):
 
 function %c_addiw(i32) -> i64 {
 block0(v0: i32):
-  v1 = iadd_imm.i32 v0, -32
+  v3 = iconst.i32 -32
+  v1 = iadd v0, v3
   v2 = sextend.i64 v1
   return v2
 }

--- a/cranelift/filetests/filetests/isa/s390x/exceptions.clif
+++ b/cranelift/filetests/filetests/isa/s390x/exceptions.clif
@@ -15,7 +15,8 @@ function %f0(i32) -> i32, f32, f64 {
 
     block2(v6: i64):
         v7 = ireduce.i32 v6
-        v8 = iadd_imm.i32 v7, 1
+        v10 = iconst.i32 1
+        v8 = iadd v7, v10
         v9 = f32const 0x0.0        
         return v8, v9, v2
 }
@@ -132,7 +133,8 @@ function %f2(i32) -> i32, f32, f64 {
 
     block2(v6: i64):
         v7 = ireduce.i32 v6
-        v8 = iadd_imm.i32 v7, 1
+        v11 = iconst.i32 1
+        v8 = iadd v7, v11
         v9 = f32const 0x0.0        
         return v8, v9, v2
 }
@@ -256,7 +258,8 @@ function %f4(i64, i32) -> i32, f32, f64 {
 
     block2(v6: i64):
         v7 = ireduce.i32 v6
-        v8 = iadd_imm.i32 v7, 1
+        v10 = iconst.i32 1
+        v8 = iadd v7, v10
         v9 = f32const 0x0.0        
         return v8, v9, v2
 

--- a/cranelift/filetests/filetests/isa/s390x/return-call-indirect.clif
+++ b/cranelift/filetests/filetests/isa/s390x/return-call-indirect.clif
@@ -6,7 +6,8 @@ target s390x
 
 function %callee_i64(i64) -> i64 tail {
 block0(v0: i64):
-    v1 = iadd_imm.i64 v0, 10
+    v2 = iconst.i64 10
+    v1 = iadd v0, v2
     return v1
 }
 

--- a/cranelift/filetests/filetests/isa/s390x/return-call.clif
+++ b/cranelift/filetests/filetests/isa/s390x/return-call.clif
@@ -7,7 +7,8 @@ target s390x
 
 function %callee_i64(i64) -> i64 tail {
 block0(v0: i64):
-    v1 = iadd_imm.i64 v0, 10
+    v2 = iconst.i64 10
+    v1 = iadd v0, v2
     return v1
 }
 

--- a/cranelift/filetests/filetests/isa/x64/big-endian.clif
+++ b/cranelift/filetests/filetests/isa/x64/big-endian.clif
@@ -201,7 +201,8 @@ function %f(i64) -> i64 {
 function %f(i64) {
     block0(v0: i64):
         v1 = load.i32 big v0+8
-        v2 = iadd_imm v0, 1
+        v3 = iconst.i64 1
+        v2 = iadd v0, v3
         store v2, v0
         return
 }

--- a/cranelift/filetests/filetests/isa/x64/crit-edge.clif
+++ b/cranelift/filetests/filetests/isa/x64/crit-edge.clif
@@ -3,7 +3,8 @@ target x86_64
 
 function %f(i32) -> i32 {
     block0(v0: i32):
-        v1 = iadd_imm.i32 v0, 1
+        v6 = iconst.i32 1
+        v1 = iadd v0, v6
         brif v0, block1(v0), block2(v1)
 
     block1(v2: i32):

--- a/cranelift/filetests/filetests/isa/x64/exceptions.clif
+++ b/cranelift/filetests/filetests/isa/x64/exceptions.clif
@@ -15,7 +15,8 @@ function %f0(i32) -> i32, f32, f64 {
 
     block2(v6: i64):
         v7 = ireduce.i32 v6
-        v8 = iadd_imm.i32 v7, 1
+        v10 = iconst.i32 1
+        v8 = iadd v7, v10
         v9 = f32const 0x0.0        
         return v8, v9, v2
 }
@@ -127,7 +128,8 @@ function %f1(i32) -> i32, f32, f64 {
 
     block4(v9: i64):
         v10 = ireduce.i32 v9
-        v11 = iadd_imm.i32 v10, 1
+        v14 = iconst.i32 1
+        v11 = iadd v10, v14
         v12 = f32const 0x0.0
         v13 = bitcast.f64 v9
         return v11, v12, v13
@@ -275,7 +277,8 @@ function %f2(i32) -> i32, f32, f64 {
 
     block2(v6: i64):
         v7 = ireduce.i32 v6
-        v8 = iadd_imm.i32 v7, 1
+        v11 = iconst.i32 1
+        v8 = iadd v7, v11
         v9 = f32const 0x0.0        
         return v8, v9, v2
 }
@@ -415,7 +418,8 @@ function %f4(i64, i32) -> i32, f32, f64 {
 
     block2(v6: i64):
         v7 = ireduce.i32 v6
-        v8 = iadd_imm.i32 v7, 1
+        v10 = iconst.i32 1
+        v8 = iadd v7, v10
         v9 = f32const 0x0.0        
         return v8, v9, v2
 

--- a/cranelift/filetests/filetests/isa/x64/pinned-reg.clif
+++ b/cranelift/filetests/filetests/isa/x64/pinned-reg.clif
@@ -5,7 +5,8 @@ target x86_64
 function %f0() {
 block0:
     v1 = get_pinned_reg.i64
-    v2 = iadd_imm v1, 1
+    v3 = iconst.i64 1
+    v2 = iadd v1, v3
     set_pinned_reg v2
     return
 }
@@ -36,7 +37,8 @@ block0:
 function %f1() windows_fastcall {
 block0:
     v1 = get_pinned_reg.i64
-    v2 = iadd_imm v1, 1
+    v3 = iconst.i64 1
+    v2 = iadd v1, v3
     set_pinned_reg v2
     return
 }

--- a/cranelift/filetests/filetests/isa/x64/return-call-indirect.clif
+++ b/cranelift/filetests/filetests/isa/x64/return-call-indirect.clif
@@ -6,7 +6,8 @@ target x86_64
 
 function %callee_i64(i64) -> i64 tail {
 block0(v0: i64):
-    v1 = iadd_imm.i64 v0, 10
+    v2 = iconst.i64 10
+    v1 = iadd v0, v2
     return v1
 }
 

--- a/cranelift/filetests/filetests/isa/x64/return-call.clif
+++ b/cranelift/filetests/filetests/isa/x64/return-call.clif
@@ -6,7 +6,8 @@ target x86_64
 
 function %callee_i64(i64) -> i64 tail {
 block0(v0: i64):
-    v1 = iadd_imm.i64 v0, 10
+    v2 = iconst.i64 10
+    v1 = iadd v0, v2
     return v1
 }
 

--- a/cranelift/filetests/filetests/parser/rewrite.clif
+++ b/cranelift/filetests/filetests/parser/rewrite.clif
@@ -19,13 +19,15 @@ block100(v20: i32):
 ; Using values.
 function %use_value() {
 block100(v20: i32):
-    v1000 = iadd_imm v20, 5
+    v1001 = iconst.i32 5
+    v1000 = iadd v20, v1001
     v200 = iadd v20, v1000
     jump block100(v1000)
 }
 ; sameln: function %use_value() fast {
 ; nextln: block100(v20: i32):
-; nextln:     v1000 = iadd_imm v20, 5
+; nextln:     v1001 = iconst.i32 5
+; nextln:     v1000 = iadd v20, v1001  ; v1001 = 5
 ; nextln:     v200 = iadd v20, v1000
 ; nextln:     jump block100(v1000)
 ; nextln: }

--- a/cranelift/filetests/filetests/runtests/call.clif
+++ b/cranelift/filetests/filetests/runtests/call.clif
@@ -11,7 +11,8 @@ target riscv64 has_c has_zcb
 
 function %callee_i64(i64) -> i64 {
 block0(v0: i64):
-    v1 = iadd_imm.i64 v0, 10
+    v2 = iconst.i64 10
+    v1 = iadd v0, v2
     return v1
 }
 
@@ -77,7 +78,8 @@ block0(v0: i8):
 
 function %callee_wasm_i64(i64) -> i64 windows_fastcall {
 block0(v0: i64):
-    v1 = iadd_imm.i64 v0, 10
+    v2 = iconst.i64 10
+    v1 = iadd v0, v2
     return v1
 }
 

--- a/cranelift/filetests/filetests/runtests/call_indirect.clif
+++ b/cranelift/filetests/filetests/runtests/call_indirect.clif
@@ -15,7 +15,8 @@ target pulley64be
 
 function %callee_indirect(i64) -> i64 {
 block0(v0: i64):
-    v1 = iadd_imm.i64 v0, 10
+    v2 = iconst.i64 10
+    v1 = iadd v0, v2
     return v1
 }
 

--- a/cranelift/filetests/filetests/runtests/fibonacci.clif
+++ b/cranelift/filetests/filetests/runtests/fibonacci.clif
@@ -19,12 +19,14 @@ block0(v0: i32):
 
 block1(v4: i32, v5:i32):
     v6 = iconst.i32 1
-    v7 = iadd_imm v4, -2
+    v23 = iconst.i32 -2
+    v7 = iadd v4, v23
     jump block2(v7, v5, v6)
 
 block2(v10: i32, v11: i32, v12: i32): ; params: n, fib(n-1), fib(n-2)
     v13 = iadd v11, v12
-    v14 = iadd_imm v10, -1
+    v24 = iconst.i32 -1
+    v14 = iadd v10, v24
     v22 = iconst.i32 0
     v15 = icmp eq v14, v22
     brif v15, block3(v13), block2(v14, v13, v11)
@@ -52,9 +54,11 @@ block0(v0: i32):
     brif v1, block2, block1(v0)
 
 block1(v10: i32):
-    v11 = iadd_imm v10, -1
+    v22 = iconst.i32 -1
+    v11 = iadd v10, v22
     v12 = call fn0(v11)
-    v13 = iadd_imm v10, -2
+    v23 = iconst.i32 -2
+    v13 = iadd v10, v23
     v14 = call fn0(v13)
     v15 = iadd v12, v14
     return v15

--- a/cranelift/filetests/filetests/runtests/global_value.clif
+++ b/cranelift/filetests/filetests/runtests/global_value.clif
@@ -50,6 +50,7 @@ function %load_at_0_and_add(i64 vmctx) -> i64 {
 
 block0(v0: i64):
     v1 = global_value.i64 gv1
-    v2 = iadd_imm.i64 v1, 1
+    v3 = iconst.i64 1
+    v2 = iadd v1, v3
     return v2
 }

--- a/cranelift/filetests/filetests/runtests/i128-arithmetic.clif
+++ b/cranelift/filetests/filetests/runtests/i128-arithmetic.clif
@@ -105,7 +105,9 @@ block0(v0: i64, v1: i64, v2: i64, v3: i64):
 ; See: https://github.com/bytecodealliance/wasmtime/issues/4568
 function %iadd_imm_neg(i128) -> i128 {
 block0(v0: i128):
-    v1 = iadd_imm.i128 v0, -1
+    v2 = iconst.i64 -1
+    v3 = sextend.i128 v2
+    v1 = iadd v0, v3
     return v1
 }
 ; run: %iadd_imm_neg(1) == 0

--- a/cranelift/filetests/filetests/runtests/i128-call.clif
+++ b/cranelift/filetests/filetests/runtests/i128-call.clif
@@ -13,7 +13,9 @@ target s390x
 
 function %callee_i128(i128) -> i128 {
 block0(v0: i128):
-    v1 = iadd_imm.i128 v0, 10
+    v2 = iconst.i64 10
+    v3 = sextend.i128 v2
+    v1 = iadd v0, v3
     return v1
 }
 

--- a/cranelift/filetests/filetests/runtests/issue-6954.clif
+++ b/cranelift/filetests/filetests/runtests/issue-6954.clif
@@ -82,7 +82,8 @@ block0(v0: i16, v1: f32, v2: f64x2, v3: i32, v4: i8, v5: i64x2, v6: i8, v7: f32x
     v38 = ishl v32, v32
     v39 = select v30, v36, v36
     v40 = stack_addr.i64 ss0+3
-    v41 = iadd_imm v40, 0
+    v87 = iconst.i64 0
+    v41 = iadd v40, v87
     v42 = atomic_rmw.i8 and v41, v10
     v43 = select v30, v39, v39
     v44 = select v30, v43, v43

--- a/cranelift/filetests/filetests/runtests/return-call-indirect.clif
+++ b/cranelift/filetests/filetests/runtests/return-call-indirect.clif
@@ -19,7 +19,8 @@ target pulley64be
 
 function %callee_i64(i64) -> i64 tail {
 block0(v0: i64):
-    v1 = iadd_imm.i64 v0, 10
+    v2 = iconst.i64 10
+    v1 = iadd v0, v2
     return v1
 }
 

--- a/cranelift/filetests/filetests/runtests/return-call-loop.clif
+++ b/cranelift/filetests/filetests/runtests/return-call-loop.clif
@@ -30,7 +30,8 @@ block1:
 ;; Another iteration of the loop. Decrement the loop counter and, if this was
 ;; our first iteration, grab the initial SP.
 block2:
-    v4 = iadd_imm v0, -1
+    v7 = iconst.i64 -1
+    v4 = iadd v0, v7
     brif v1, block4(v1), block3
 
 ;; Grab the initial SP.
@@ -63,7 +64,8 @@ block1:
 ;; Another iteration of the loop. Decrement the loop counter and, if this was
 ;; our first iteration, grab the initial SP.
 block2:
-    v28 = iadd_imm v0, -1
+    v31 = iconst.i64 -1
+    v28 = iadd v0, v31
     brif v25, block4(v25), block3
 
 ;; Grab the initial SP.
@@ -112,7 +114,8 @@ function %mutual_loop_2(i64, i64) -> i8 tail {
     fn0 = %mutual_loop_1(i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64) -> i8 tail
 
 block0(v0: i64, v1: i64):
-    v2 = iadd_imm v0, -1
+    v4 = iconst.i64 -1
+    v2 = iadd v0, v4
     v3 = iconst.i64 42
     return_call fn0(v2, v1, v3, v3, v3, v3, v3, v3, v3, v3, v3, v3, v3, v3, v3, v3, v3, v3, v3, v3, v3, v3, v3, v3, v3, v3)
 }
@@ -141,7 +144,8 @@ block0(v0: i64):
 function %indirect_continue(i64) -> i8 tail {
     fn0 = %indirect_main(i64) -> i8 tail
 block0(v0: i64):
-    v1 = iadd_imm v0, -1
+    v2 = iconst.i64 -1
+    v1 = iadd v0, v2
     return_call fn0(v1)
 }
 

--- a/cranelift/filetests/filetests/runtests/return-call.clif
+++ b/cranelift/filetests/filetests/runtests/return-call.clif
@@ -15,7 +15,8 @@ target s390x
 
 function %callee_i64(i64) -> i64 tail {
 block0(v0: i64):
-    v1 = iadd_imm.i64 v0, 10
+    v2 = iconst.i64 10
+    v1 = iadd v0, v2
     return v1
 }
 

--- a/cranelift/filetests/filetests/runtests/stack-addr-32.clif
+++ b/cranelift/filetests/filetests/runtests/stack-addr-32.clif
@@ -7,12 +7,14 @@ function %stack_addr_iadd(i64) -> i8 {
 
 block0(v0: i64):
     v1 = stack_addr.i32 ss0
-    v2 = iadd_imm.i32 v1, 8
+    v10 = iconst.i32 8
+    v2 = iadd v1, v10
 
     stack_store.i64 v0, ss0+8
     v3 = load.i64 v2
 
-    v5 = iadd_imm.i64 v0, 20
+    v11 = iconst.i64 20
+    v5 = iadd v0, v11
     store.i64 v5, v2
     v6 = stack_load.i64 ss0+8
 

--- a/cranelift/filetests/filetests/runtests/stack-addr-64.clif
+++ b/cranelift/filetests/filetests/runtests/stack-addr-64.clif
@@ -13,12 +13,14 @@ function %stack_addr_iadd(i64) -> i8 {
 
 block0(v0: i64):
     v1 = stack_addr.i64 ss0
-    v2 = iadd_imm.i64 v1, 8
+    v10 = iconst.i64 8
+    v2 = iadd v1, v10
 
     stack_store.i64 v0, ss0+8
     v3 = load.i64 v2
 
-    v5 = iadd_imm.i64 v0, 20
+    v11 = iconst.i64 20
+    v5 = iadd v0, v11
     store.i64 v5, v2
     v6 = stack_load.i64 ss0+8
 

--- a/cranelift/filetests/filetests/runtests/tail-call-conv.clif
+++ b/cranelift/filetests/filetests/runtests/tail-call-conv.clif
@@ -15,10 +15,14 @@ target s390x
 
 function %tail_callee(i8, i16, i32, i64, f32, f64) -> f64, f32, i64, i32, i16, i8 tail {
 block0(v0: i8, v1: i16, v2: i32, v3: i64, v4: f32, v5: f64):
-    v6 = iadd_imm v0, 1
-    v7 = iadd_imm v1, 1
-    v8 = iadd_imm v2, 1
-    v9 = iadd_imm v3, 1
+    v12 = iconst.i8 1
+    v6 = iadd v0, v12
+    v13 = iconst.i16 1
+    v7 = iadd v1, v13
+    v14 = iconst.i32 1
+    v8 = iadd v2, v14
+    v15 = iconst.i64 1
+    v9 = iadd v3, v15
     v10 = fadd v4, v4
     v11 = fadd v5, v5
     return v11, v10, v9, v8, v7, v6

--- a/cranelift/filetests/filetests/runtests/try_call.clif
+++ b/cranelift/filetests/filetests/runtests/try_call.clif
@@ -10,7 +10,8 @@ target riscv64 has_c has_zcb
 
 function %callee_i64(i64) -> i64 tail {
 block0(v0: i64):
-    v1 = iadd_imm.i64 v0, 10
+    v2 = iconst.i64 10
+    v1 = iadd v0, v2
     return v1
 }
 

--- a/cranelift/filetests/filetests/verifier/unreachable_code.clif
+++ b/cranelift/filetests/filetests/verifier/unreachable_code.clif
@@ -25,11 +25,13 @@ block9(v7: i32):
 ; Using a function argument in an unreachable block is ok.
 function %arg(i32) -> i32 {
 block0(v0: i32):
-    v1 = iadd_imm v0, 1
+    v11 = iconst.i32 1
+    v1 = iadd v0, v11
     return v1
 
 block1:
-    v10 = iadd_imm v0, 10
+    v12 = iconst.i32 10
+    v10 = iadd v0, v12
     return v10
 }
 

--- a/cranelift/frontend/src/frontend/safepoints.rs
+++ b/cranelift/frontend/src/frontend/safepoints.rs
@@ -1090,7 +1090,8 @@ block2:
     return
 
 block3:
-    v2 = iadd_imm.i64 v1, 0  ; v1 = 0x1234_5678
+    v2 = iconst.i64 0
+    v3 = iadd.i64 v1, v2  ; v1 = 0x1234_5678, v2 = 0
     return
 }
             "#
@@ -1178,7 +1179,8 @@ block1:
     return
 
 block2:
-    v2 = iadd_imm.i64 v1, 0  ; v1 = 0x1234_5678
+    v2 = iconst.i64 0
+    v3 = iadd.i64 v1, v2  ; v1 = 0x1234_5678, v2 = 0
     return
 }
             "#
@@ -1246,7 +1248,8 @@ block0(v0: i32):
     brif v0, block1, block2
 
 block1:
-    v2 = iadd_imm.i64 v1, 0  ; v1 = 0x1234_5678
+    v2 = iconst.i64 0
+    v3 = iadd.i64 v1, v2  ; v1 = 0x1234_5678, v2 = 0
     return
 
 block2:
@@ -1336,7 +1339,8 @@ block1:
     return_call fn0()
 
 block2:
-    v2 = iadd_imm.i64 v1, 0  ; v1 = 0x1234_5678
+    v2 = iconst.i64 0
+    v3 = iadd.i64 v1, v2  ; v1 = 0x1234_5678, v2 = 0
     return
 }
             "#
@@ -1403,7 +1407,8 @@ block0(v0: i32):
     brif v0, block1, block2
 
 block1:
-    v2 = iadd_imm.i64 v1, 0  ; v1 = 0x1234_5678
+    v2 = iconst.i64 0
+    v3 = iadd.i64 v1, v2  ; v1 = 0x1234_5678, v2 = 0
     return
 
 block2:
@@ -1517,23 +1522,24 @@ block1:
     v2 = iconst.i64 2
     stack_store v2, ss1  ; v2 = 2
     call fn0(), stack_map=[i64 @ ss0+0, i64 @ ss1+0]
-    v9 = stack_load.i64 ss0
-    v10 = stack_load.i64 ss1
-    jump block3(v9, v10)
+    v10 = stack_load.i64 ss0
+    v11 = stack_load.i64 ss1
+    jump block3(v10, v11)
 
 block2:
     v3 = iconst.i64 3
     stack_store v3, ss0  ; v3 = 3
     v4 = iconst.i64 4
     call fn0(), stack_map=[i64 @ ss0+0, i64 @ ss0+0]
-    v11 = stack_load.i64 ss0
     v12 = stack_load.i64 ss0
-    jump block3(v11, v12)
+    v13 = stack_load.i64 ss0
+    jump block3(v12, v13)
 
 block3(v5: i64, v6: i64):
     call fn0(), stack_map=[i64 @ ss0+0]
-    v8 = stack_load.i64 ss0
-    v7 = iadd_imm v8, 0
+    v7 = iconst.i64 0
+    v9 = stack_load.i64 ss0
+    v8 = iadd v9, v7  ; v7 = 0
     return
 }
             "#
@@ -2438,23 +2444,24 @@ block0(v0: i32, v1: i32, v2: i32, v3: i32):
 
 block1(v4: i32):
     call fn0(), stack_map=[i32 @ ss0+0, i32 @ ss1+0, i32 @ ss2+0]
-    v8 = stack_load.i32 ss0
-    call fn1(v8), stack_map=[i32 @ ss0+0, i32 @ ss1+0, i32 @ ss2+0]
+    v9 = stack_load.i32 ss0
+    call fn1(v9), stack_map=[i32 @ ss0+0, i32 @ ss1+0, i32 @ ss2+0]
     call fn0(), stack_map=[i32 @ ss0+0, i32 @ ss1+0, i32 @ ss2+0]
     jump block2
 
 block2:
     call fn0(), stack_map=[i32 @ ss0+0, i32 @ ss1+0, i32 @ ss2+0]
-    v7 = stack_load.i32 ss1
-    call fn1(v7), stack_map=[i32 @ ss0+0, i32 @ ss1+0, i32 @ ss2+0]
+    v8 = stack_load.i32 ss1
+    call fn1(v8), stack_map=[i32 @ ss0+0, i32 @ ss1+0, i32 @ ss2+0]
     call fn0(), stack_map=[i32 @ ss0+0, i32 @ ss1+0, i32 @ ss2+0]
-    v5 = iadd_imm.i32 v4, -1
-    brif.i32 v4, block1(v5), block3
+    v5 = iconst.i32 -1
+    v6 = iadd.i32 v4, v5  ; v5 = -1
+    brif.i32 v4, block1(v6), block3
 
 block3:
     call fn0(), stack_map=[i32 @ ss0+0, i32 @ ss1+0, i32 @ ss2+0]
-    v6 = stack_load.i32 ss2
-    call fn1(v6), stack_map=[i32 @ ss0+0, i32 @ ss1+0, i32 @ ss2+0]
+    v7 = stack_load.i32 ss2
+    call fn1(v7), stack_map=[i32 @ ss0+0, i32 @ ss1+0, i32 @ ss2+0]
     call fn0(), stack_map=[i32 @ ss0+0, i32 @ ss1+0, i32 @ ss2+0]
     jump block2
 }

--- a/cranelift/frontend/src/switch.rs
+++ b/cranelift/frontend/src/switch.rs
@@ -441,23 +441,24 @@ block9:
     brif v4, block11, block10
 
 block11:
-    v5 = iadd_imm.i8 v0, -10  ; v0 = 0
-    v6 = uextend.i32 v5
-    br_table v6, block0, [block5, block6, block7]
+    v5 = iconst.i8 -10
+    v6 = iadd.i8 v0, v5  ; v0 = 0, v5 = -10
+    v7 = uextend.i32 v6
+    br_table v7, block0, [block5, block6, block7]
 
 block10:
-    v7 = iconst.i8 7
-    v8 = icmp.i8 eq v0, v7  ; v0 = 0, v7 = 7
-    brif v8, block4, block0
+    v8 = iconst.i8 7
+    v9 = icmp.i8 eq v0, v8  ; v0 = 0, v8 = 7
+    brif v9, block4, block0
 
 block8:
-    v9 = iconst.i8 5
-    v10 = icmp.i8 eq v0, v9  ; v0 = 0, v9 = 5
-    brif v10, block3, block12
+    v10 = iconst.i8 5
+    v11 = icmp.i8 eq v0, v10  ; v0 = 0, v10 = 5
+    brif v11, block3, block12
 
 block12:
-    v11 = uextend.i32 v0  ; v0 = 0
-    br_table v11, block0, [block1, block2]"
+    v12 = uextend.i32 v0  ; v0 = 0
+    br_table v12, block0, [block1, block2]"
         );
     }
 

--- a/cranelift/fuzzgen/src/function_generator.rs
+++ b/cranelift/fuzzgen/src/function_generator.rs
@@ -925,7 +925,6 @@ static OPCODE_SIGNATURES: LazyLock<Vec<OpcodeSignature>> = LazyLock::new(|| {
                 (Opcode::GetReturnAddress),
                 (Opcode::Blendv),
                 (Opcode::X86Pmulhrsw),
-                (Opcode::IaddImm),
                 (Opcode::ImulImm),
                 (Opcode::UdivImm),
                 (Opcode::SdivImm),

--- a/cranelift/interpreter/src/interpreter.rs
+++ b/cranelift/interpreter/src/interpreter.rs
@@ -575,7 +575,8 @@ mod tests {
         let code = "function %test() -> i8 {
         block0:
             v0 = iconst.i32 1
-            v1 = iadd_imm v0, 1
+            v5 = iconst.i32 1
+            v1 = iadd v0, v5
             v2 = irsub_imm v1, 44  ; 44 - 2 == 42 (see irsub_imm's semantics)
             v4 = iconst.i32 42
             v3 = icmp eq v2, v4
@@ -643,14 +644,16 @@ mod tests {
         let code = "
         function %child(i32) -> i32 {
         block0(v0: i32):
-            v1 = iadd_imm v0, -1
+            v2 = iconst.i32 -1
+            v1 = iadd v0, v2
             return v1
         }
 
         function %parent(i32) -> i32 {
             fn42 = %child(i32) -> i32
         block0(v0: i32):
-            v1 = iadd_imm v0, 1
+            v3 = iconst.i32 1
+            v1 = iadd v0, v3
             v2 = call fn42(v1)
             return v2
         }";
@@ -672,7 +675,8 @@ mod tests {
         let code = "function %test() -> i8 {
         block0:
             v0 = iconst.i32 1
-            v1 = iadd_imm v0, 1
+            v2 = iconst.i32 1
+            v1 = iadd v0, v2
             return v1
         }";
 
@@ -686,21 +690,21 @@ mod tests {
 
         assert_eq!(result, ControlFlow::Return(smallvec![DataValue::I32(2)]));
 
-        // With 2 fuel, we should execute the iconst and iadd, but not the return thus giving a
-        // fuel exhausted error
+        // With 3 fuel, we should execute the two iconsts and the iadd, but not the return thus
+        // giving a fuel exhausted error
         let state = InterpreterState::default().with_function_store(env.clone());
         let result = Interpreter::new(state)
-            .with_fuel(Some(2))
+            .with_fuel(Some(3))
             .call_by_name("%test", &[]);
         match result {
             Err(InterpreterError::FuelExhausted) => {}
             _ => panic!("Expected Err(FuelExhausted), but got {result:?}"),
         }
 
-        // With 3 fuel, we should be able to execute the return instruction, and complete the test
+        // With 4 fuel, we should be able to execute the return instruction, and complete the test
         let state = InterpreterState::default().with_function_store(env.clone());
         let result = Interpreter::new(state)
-            .with_fuel(Some(3))
+            .with_fuel(Some(4))
             .call_by_name("%test", &[])
             .unwrap();
 

--- a/cranelift/interpreter/src/step.rs
+++ b/cranelift/interpreter/src/step.rs
@@ -718,7 +718,6 @@ where
         Opcode::Sdiv => binary_can_trap(DataValueExt::sdiv, arg(0), arg(1))?,
         Opcode::Urem => binary_can_trap(DataValueExt::urem, arg(0), arg(1))?,
         Opcode::Srem => binary_can_trap(DataValueExt::srem, arg(0), arg(1))?,
-        Opcode::IaddImm => binary(DataValueExt::add, arg(0), imm_as_ctrl_ty()?)?,
         Opcode::ImulImm => binary(DataValueExt::mul, arg(0), imm_as_ctrl_ty()?)?,
         Opcode::UdivImm => binary_can_trap(DataValueExt::udiv, arg(0), imm_as_ctrl_ty()?)?,
         Opcode::SdivImm => binary_can_trap(DataValueExt::sdiv, arg(0), imm_as_ctrl_ty()?)?,

--- a/cranelift/reader/src/parser.rs
+++ b/cranelift/reader/src/parser.rs
@@ -3108,7 +3108,8 @@ mod tests {
                                            block0:
                                              v4 = iconst.i8 6
                                              v3 -> v4
-                                             v1 = iadd_imm v3, 17
+                                             v5 = iconst.i8 17
+                                             v1 = iadd v3, v5
                                            }",
         )
         .parse_function()

--- a/cranelift/tests/bugpoint_test.clif
+++ b/cranelift/tests/bugpoint_test.clif
@@ -430,7 +430,8 @@ block2:
     trap user1
 
 block3:
-    v125 = iadd_imm.i64 v124, 8
+    v1075 = iconst.i64 8
+    v125 = iadd v124, v1075
     v126 = load.i64 v125
     v127 = iconst.i64 0
     v128 = icmp ugt v126, v127
@@ -446,7 +447,8 @@ block4:
     trap user1
 
 block5:
-    v137 = iadd_imm.i64 v136, 16
+    v1076 = iconst.i64 16
+    v137 = iadd v136, v1076
     v138 = load.i64 v137+42
     v139 = iconst.i64 0
     v140 = icmp ugt v138, v139
@@ -463,7 +465,8 @@ block6:
 
 block7:
     v149 = load.i64 v148
-    v150 = iadd_imm.i64 v148, 16
+    v1077 = iconst.i64 16
+    v150 = iadd v148, v1077
     v151 = load.i64 v150
     call fn6(v7, v149, v151)
     jump block8
@@ -487,7 +490,8 @@ block10:
 
 block11:
     v161 = load.i64 v160
-    v162 = iadd_imm.i64 v160, 8
+    v1078 = iconst.i64 8
+    v162 = iadd v160, v1078
     v163 = load.i64 v162
     call fn10(v9, v161, v163)
     jump block12
@@ -532,7 +536,8 @@ block17:
 
 block18:
     v186 = load.i64 v185
-    v187 = iadd_imm.i64 v185, 16
+    v1079 = iconst.i64 16
+    v187 = iadd v185, v1079
     v188 = load.i64 v187
     v189 = iadd v186, v188
     v190 = iconst.i8 0
@@ -540,7 +545,8 @@ block18:
     v192 = stack_addr.i64 ss108
     v193 = load.i64 aligned v192
     v194 = load.i64 aligned v192+8
-    v195 = iadd_imm.i64 v12, 8
+    v1080 = iconst.i64 8
+    v195 = iadd v12, v1080
     v196 = load.i8 v195
     v197 = uextend.i32 v196
     brif v197, block164, block19
@@ -560,7 +566,8 @@ block19:
     v205 = stack_addr.i64 ss109
     v206 = load.i64 aligned v205
     v207 = load.i64 aligned v205+8
-    v208 = iadd_imm.i64 v13, 8
+    v1081 = iconst.i64 8
+    v208 = iadd v13, v1081
     v209 = load.i8 v208
     v210 = uextend.i32 v209
     brif v210, block163, block20
@@ -585,7 +592,8 @@ block21:
 
 block22:
     v223 = load.i64 v222
-    v224 = iadd_imm.i64 v222, 16
+    v1082 = iconst.i64 16
+    v224 = iadd v222, v1082
     v225 = load.i64 v224
     v226 = iadd v223, v225
     v227 = iconst.i8 0
@@ -593,7 +601,8 @@ block22:
     v229 = stack_addr.i64 ss110
     v230 = load.i64 aligned v229
     v231 = load.i64 aligned v229+8
-    v232 = iadd_imm.i64 v16, 8
+    v1083 = iconst.i64 8
+    v232 = iadd v16, v1083
     v233 = load.i8 v232
     v234 = uextend.i32 v233
     brif v234, block162, block23
@@ -604,15 +613,18 @@ block162:
 
 block23:
     v236 = load.i64 v16
-    v238 = iadd_imm.i64 v237, 24
+    v1084 = iconst.i64 24
+    v238 = iadd v237, v1084
     v239 = load.i16 v238
-    v240 = iadd_imm.i64 v15, 8
+    v1085 = iconst.i64 8
+    v240 = iadd v15, v1085
     call fn22(v14, v15)
     jump block24
 
 block24:
     v242 = load.i64 v241
-    v243 = iadd_imm.i64 v241, 8
+    v1086 = iconst.i64 8
+    v243 = iadd v241, v1086
     v244 = load.i64 v243
     v245 = isub v242, v244
     v246 = iconst.i8 0
@@ -620,7 +632,8 @@ block24:
     v248 = stack_addr.i64 ss111
     v249 = load.i64 aligned v248
     v250 = load.i64 aligned v248+8
-    v251 = iadd_imm.i64 v19, 8
+    v1087 = iconst.i64 8
+    v251 = iadd v19, v1087
     v252 = load.i8 v251
     v253 = uextend.i32 v252
     brif v253, block161, block25
@@ -631,26 +644,33 @@ block161:
 
 block25:
     v255 = load.i64 v19
-    v257 = iadd_imm.i64 v256, 24
+    v1088 = iconst.i64 24
+    v257 = iadd v256, v1088
     v258 = load.i16 v257
-    v259 = iadd_imm.i64 v18, 8
-    v260 = iadd_imm.i64 v14, 8
+    v1089 = iconst.i64 8
+    v259 = iadd v18, v1089
+    v1090 = iconst.i64 8
+    v260 = iadd v14, v1090
     v261 = load.i16 v260
     call fn24(v17, v18, v261)
     jump block26
 
 block26:
     v263 = load.i64 v262
-    v264 = iadd_imm.i64 v262, 24
+    v1091 = iconst.i64 24
+    v264 = iadd v262, v1091
     v265 = load.i16 v264
-    v266 = iadd_imm.i64 v21, 8
-    v267 = iadd_imm.i64 v14, 8
+    v1092 = iconst.i64 8
+    v266 = iadd v21, v1092
+    v1093 = iconst.i64 8
+    v267 = iadd v14, v1093
     v268 = load.i16 v267
     call fn25(v20, v21, v268)
     jump block27
 
 block27:
-    v269 = iadd_imm.i64 v14, 8
+    v1094 = iconst.i64 8
+    v269 = iadd v14, v1094
     v270 = load.i16 v269
     v271 = iconst.i16 -60
     v272 = isub v271, v270
@@ -658,7 +678,8 @@ block27:
     v274 = stack_addr.i64 ss112
     v275 = stack_addr.i64 ss112
     v276 = load.i32 aligned v275
-    v277 = iadd_imm.i64 v24, 2
+    v1095 = iconst.i64 2
+    v277 = iadd v24, v1095
     v278 = load.i8 v277
     v279 = uextend.i32 v278
     brif v279, block160, block28
@@ -675,7 +696,8 @@ block28:
     v285 = stack_addr.i64 ss113
     v286 = stack_addr.i64 ss113
     v287 = load.i32 aligned v286
-    v288 = iadd_imm.i64 v25, 2
+    v1096 = iconst.i64 2
+    v288 = iadd v25, v1096
     v289 = load.i8 v288
     v290 = uextend.i32 v289
     brif v290, block159, block29
@@ -687,7 +709,8 @@ block159:
 block29:
     v292 = load.i16 v25
         v317 -> v292
-    v293 = iadd_imm.i64 v14, 8
+    v1097 = iconst.i64 8
+    v293 = iadd v14, v1097
     v294 = load.i16 v293
     v295 = iconst.i16 -32
     v296 = isub v295, v294
@@ -695,7 +718,8 @@ block29:
     v298 = stack_addr.i64 ss114
     v299 = stack_addr.i64 ss114
     v300 = load.i32 aligned v299
-    v301 = iadd_imm.i64 v26, 2
+    v1098 = iconst.i64 2
+    v301 = iadd v26, v1098
     v302 = load.i8 v301
     v303 = uextend.i32 v302
     brif v303, block158, block30
@@ -712,7 +736,8 @@ block30:
     v309 = stack_addr.i64 ss115
     v310 = stack_addr.i64 ss115
     v311 = load.i32 aligned v310
-    v312 = iadd_imm.i64 v27, 2
+    v1099 = iconst.i64 2
+    v312 = iadd v27, v1099
     v313 = load.i8 v312
     v314 = uextend.i32 v313
     brif v314, block157, block31
@@ -729,7 +754,8 @@ block31:
 block32:
     v318 = load.i16 v23
         v1007 -> v318
-    v319 = iadd_imm.i64 v23, 8
+    v1100 = iconst.i64 8
+    v319 = iadd v23, v1100
     v320 = load.i64 aligned v319
     v321 = load.i64 aligned v319+8
     call fn31(v28, v14, v22)
@@ -749,12 +775,16 @@ block35:
     brif v323, block36, block42
 
 block36:
-    v324 = iadd_imm.i64 v28, 8
-    v325 = iadd_imm.i64 v29, 8
-    v326 = iadd_imm.i64 v31, 8
+    v1101 = iconst.i64 8
+    v324 = iadd v28, v1101
+    v1102 = iconst.i64 8
+    v325 = iadd v29, v1102
+    v1103 = iconst.i64 8
+    v326 = iadd v31, v1103
     v327 = load.i64 v31
         v340 -> v327
-    v328 = iadd_imm.i64 v31, 8
+    v1104 = iconst.i64 8
+    v328 = iadd v31, v1104
     v329 = load.i64 v328
         v341 -> v329
     v330 = load.i16 v327
@@ -769,9 +799,11 @@ block36:
 block37:
     v338 = global_value.i64 gv22
     v339 = iconst.i64 3
-    v342 = iadd_imm.i64 v36, 8
+    v1105 = iconst.i64 8
+    v342 = iadd v36, v1105
     v343 = load.i64 v36
-    v344 = iadd_imm.i64 v36, 8
+    v1106 = iconst.i64 8
+    v344 = iadd v36, v1106
     v345 = load.i64 v344
         v347 -> v345
     v346 = func_addr.i64 fn34
@@ -813,12 +845,16 @@ block42:
     brif v363, block43, block49(v1007)
 
 block43:
-    v364 = iadd_imm.i64 v28, 8
-    v365 = iadd_imm.i64 v30, 8
-    v366 = iadd_imm.i64 v41, 8
+    v1107 = iconst.i64 8
+    v364 = iadd v28, v1107
+    v1108 = iconst.i64 8
+    v365 = iadd v30, v1108
+    v1109 = iconst.i64 8
+    v366 = iadd v41, v1109
     v367 = load.i64 v41
         v380 -> v367
-    v368 = iadd_imm.i64 v41, 8
+    v1110 = iconst.i64 8
+    v368 = iadd v41, v1110
     v369 = load.i64 v368
         v381 -> v369
     v370 = load.i16 v367
@@ -833,9 +869,11 @@ block43:
 block44:
     v378 = global_value.i64 gv25
     v379 = iconst.i64 3
-    v382 = iadd_imm.i64 v46, 8
+    v1111 = iconst.i64 8
+    v382 = iadd v46, v1111
     v383 = load.i64 v46
-    v384 = iadd_imm.i64 v46, 8
+    v1112 = iconst.i64 8
+    v384 = iadd v46, v1112
     v385 = load.i64 v384
         v387 -> v385
     v386 = func_addr.i64 fn41
@@ -881,7 +919,8 @@ block49(v1006: i16):
     v407 = stack_addr.i64 ss116
     v408 = load.i64 aligned v407
     v409 = load.i64 aligned v407+8
-    v410 = iadd_imm.i64 v51, 8
+    v1113 = iconst.i64 8
+    v410 = iadd v51, v1113
     v411 = load.i8 v410
     v412 = uextend.i32 v411
     brif v412, block156, block50
@@ -904,7 +943,8 @@ block50:
     v420 = stack_addr.i64 ss117
     v421 = load.i64 aligned v420
     v422 = load.i64 aligned v420+8
-    v423 = iadd_imm.i64 v52, 8
+    v1114 = iconst.i64 8
+    v423 = iadd v52, v1114
     v424 = load.i8 v423
     v425 = uextend.i32 v424
     brif v425, block155, block51
@@ -916,7 +956,8 @@ block155:
 block51:
     v427 = load.i64 v52
         v509 -> v427
-    v428 = iadd_imm.i64 v28, 8
+    v1115 = iconst.i64 8
+    v428 = iadd v28, v1115
     v429 = load.i16 v428
         v435 -> v429
     v430 = iconst.i16 0x8000
@@ -940,7 +981,8 @@ block52:
     v443 = stack_addr.i64 ss118
     v444 = load.i64 aligned v443
     v445 = load.i64 aligned v443+8
-    v446 = iadd_imm.i64 v53, 8
+    v1116 = iconst.i64 8
+    v446 = iadd v53, v1116
     v447 = load.i8 v446
     v448 = uextend.i32 v447
     brif v448, block153, block53
@@ -961,7 +1003,8 @@ block53:
     v458 = stack_addr.i64 ss119
     v459 = load.i64 aligned v458
     v460 = load.i64 aligned v458+8
-    v461 = iadd_imm.i64 v54, 8
+    v1117 = iconst.i64 8
+    v461 = iadd v54, v1117
     v462 = load.i8 v461
     v463 = uextend.i32 v462
     brif v463, block152, block54
@@ -979,7 +1022,8 @@ block54:
     v470 = stack_addr.i64 ss120
     v471 = load.i64 aligned v470
     v472 = load.i64 aligned v470+8
-    v473 = iadd_imm.i64 v55, 8
+    v1118 = iconst.i64 8
+    v473 = iadd v55, v1118
     v474 = load.i8 v473
     v475 = uextend.i32 v474
     brif v475, block151, block55
@@ -997,7 +1041,8 @@ block55:
 block56:
     v481 = load.i8 v56
         v548 -> v481
-    v482 = iadd_imm.i64 v56, 4
+    v1119 = iconst.i64 4
+    v482 = iadd v56, v1119
     v483 = load.i32 v482
         v550 -> v483
     v484 = iconst.i64 0
@@ -1007,7 +1052,8 @@ block56:
     v489 = stack_addr.i64 ss121
     v490 = stack_addr.i64 ss121
     v491 = load.i32 aligned v490
-    v492 = iadd_imm.i64 v57, 2
+    v1120 = iconst.i64 2
+    v492 = iadd v57, v1120
     v493 = load.i8 v492
     v494 = uextend.i32 v493
     brif v494, block150, block57
@@ -1024,7 +1070,8 @@ block57:
     v500 = stack_addr.i64 ss122
     v501 = stack_addr.i64 ss122
     v502 = load.i32 aligned v501
-    v503 = iadd_imm.i64 v58, 2
+    v1121 = iconst.i64 2
+    v503 = iadd v58, v1121
     v504 = load.i8 v503
     v505 = uextend.i32 v504
     brif v505, block149, block58
@@ -1041,7 +1088,8 @@ block58:
     v513 = stack_addr.i64 ss123
     v514 = load.i64 aligned v513
     v515 = load.i64 aligned v513+8
-    v516 = iadd_imm.i64 v59, 8
+    v1122 = iconst.i64 8
+    v516 = iadd v59, v1122
     v517 = load.i8 v516
     v518 = uextend.i32 v517
     brif v518, block148, block59
@@ -1060,7 +1108,8 @@ block59:
     v526 = stack_addr.i64 ss124
     v527 = load.i64 aligned v526
     v528 = load.i64 aligned v526+8
-    v529 = iadd_imm.i64 v60, 8
+    v1123 = iconst.i64 8
+    v529 = iadd v60, v1123
     v530 = load.i8 v529
     v531 = uextend.i32 v530
     brif v531, block147, block60
@@ -1078,7 +1127,8 @@ block60:
     v538 = stack_addr.i64 ss125
     v539 = load.i64 aligned v538
     v540 = load.i64 aligned v538+8
-    v541 = iadd_imm.i64 v61, 8
+    v1124 = iconst.i64 8
+    v541 = iadd v61, v1124
     v542 = load.i8 v541
     v543 = uextend.i32 v542
     brif v543, block146, block61
@@ -1189,7 +1239,8 @@ block68(v584: i32):
     v589 = stack_addr.i64 ss126
     v590 = stack_addr.i64 ss126
     v591 = load.i16 aligned v590
-    v592 = iadd_imm.i64 v64, 1
+    v1125 = iconst.i64 1
+    v592 = iadd v64, v1125
     v593 = load.i8 v592
     v594 = uextend.i32 v593
     brif v594, block143, block69
@@ -1222,7 +1273,8 @@ block70:
     v614 = stack_addr.i64 ss127
     v615 = load.i64 aligned v614
     v616 = load.i64 aligned v614+8
-    v617 = iadd_imm.i64 v65, 8
+    v1126 = iconst.i64 8
+    v617 = iadd v65, v1126
     v618 = load.i8 v617
     v619 = uextend.i32 v618
     brif v619, block141, block71
@@ -1244,7 +1296,8 @@ block71:
     v628 = stack_addr.i64 ss128
     v629 = load.i64 aligned v628
     v630 = load.i64 aligned v628+8
-    v631 = iadd_imm.i64 v66, 8
+    v1127 = iconst.i64 8
+    v631 = iadd v66, v1127
     v632 = load.i8 v631
     v633 = uextend.i32 v632
     brif v633, block140, block72
@@ -1261,7 +1314,8 @@ block72:
     v640 = stack_addr.i64 ss129
     v641 = load.i64 aligned v640
     v642 = load.i64 aligned v640+8
-    v643 = iadd_imm.i64 v67, 8
+    v1128 = iconst.i64 8
+    v643 = iadd v67, v1128
     v644 = load.i8 v643
     v645 = uextend.i32 v644
     brif v645, block139, block73
@@ -1287,7 +1341,8 @@ block74:
     v658 = stack_addr.i64 ss130
     v659 = load.i64 aligned v658
     v660 = load.i64 aligned v658+8
-    v661 = iadd_imm.i64 v68, 8
+    v1129 = iconst.i64 8
+    v661 = iadd v68, v1129
     v662 = load.i8 v661
     v663 = uextend.i32 v662
     brif v663, block138, block75
@@ -1317,7 +1372,8 @@ block76:
     v682 = stack_addr.i64 ss131
     v683 = load.i64 aligned v682
     v684 = load.i64 aligned v682+8
-    v685 = iadd_imm.i64 v74, 8
+    v1130 = iconst.i64 8
+    v685 = iadd v74, v1130
     v686 = load.i8 v685
     v687 = uextend.i32 v686
     brif v687, block137, block77
@@ -1351,10 +1407,12 @@ block81:
 
 block82:
     v703 = global_value.i64 gv50
-    v704 = iadd_imm.i64 v75, 8
+    v1131 = iconst.i64 8
+    v704 = iadd v75, v1131
     v705 = load.i64 v75
         v718 -> v705
-    v706 = iadd_imm.i64 v75, 8
+    v1132 = iconst.i64 8
+    v706 = iadd v75, v1132
     v707 = load.i64 v706
         v719 -> v707
     v708 = load.i32 v705
@@ -1369,9 +1427,11 @@ block82:
 block83:
     v716 = global_value.i64 gv51
     v717 = iconst.i64 3
-    v720 = iadd_imm.i64 v80, 8
+    v1133 = iconst.i64 8
+    v720 = iadd v80, v1133
     v721 = load.i64 v80
-    v722 = iadd_imm.i64 v80, 8
+    v1134 = iconst.i64 8
+    v722 = iadd v80, v1134
     v723 = load.i64 v722
         v725 -> v723
     v724 = func_addr.i64 fn73
@@ -1414,10 +1474,12 @@ block88:
 
 block89:
     v742 = global_value.i64 gv54
-    v743 = iadd_imm.i64 v85, 8
+    v1135 = iconst.i64 8
+    v743 = iadd v85, v1135
     v744 = load.i64 v85
         v757 -> v744
-    v745 = iadd_imm.i64 v85, 8
+    v1136 = iconst.i64 8
+    v745 = iadd v85, v1136
     v746 = load.i64 v745
         v758 -> v746
     v747 = load.i16 v744
@@ -1432,9 +1494,11 @@ block89:
 block90:
     v755 = global_value.i64 gv55
     v756 = iconst.i64 3
-    v759 = iadd_imm.i64 v90, 8
+    v1137 = iconst.i64 8
+    v759 = iadd v90, v1137
     v760 = load.i64 v90
-    v761 = iadd_imm.i64 v90, 8
+    v1138 = iconst.i64 8
+    v761 = iadd v90, v1138
     v762 = load.i64 v761
         v764 -> v762
     v763 = func_addr.i64 fn80
@@ -1482,7 +1546,8 @@ block96:
     v786 = stack_addr.i64 ss132
     v787 = stack_addr.i64 ss132
     v788 = load.i32 aligned v787
-    v789 = iadd_imm.i64 v95, 2
+    v1139 = iconst.i64 2
+    v789 = iadd v95, v1139
     v790 = load.i8 v789
     v791 = uextend.i32 v790
     brif v791, block136, block97
@@ -1535,7 +1600,8 @@ block99(v804: i64, v1035: i64, v1037: i64, v1039: i64, v1044: i64, v1052: i16, v
     v809 = stack_addr.i64 ss133
     v810 = load.i64 aligned v809
     v811 = load.i64 aligned v809+8
-    v812 = iadd_imm.i64 v96, 8
+    v1140 = iconst.i64 8
+    v812 = iadd v96, v1140
     v813 = load.i8 v812
     v814 = uextend.i32 v813
     brif v814, block134, block100
@@ -1556,7 +1622,8 @@ block100:
     v822 = stack_addr.i64 ss134
     v823 = load.i64 aligned v822
     v824 = load.i64 aligned v822+8
-    v825 = iadd_imm.i64 v97, 8
+    v1141 = iconst.i64 8
+    v825 = iadd v97, v1141
     v826 = load.i8 v825
     v827 = uextend.i32 v826
     brif v827, block133, block101
@@ -1579,7 +1646,8 @@ block101:
     v835 = stack_addr.i64 ss135
     v836 = load.i64 aligned v835
     v837 = load.i64 aligned v835+8
-    v838 = iadd_imm.i64 v98, 8
+    v1142 = iconst.i64 8
+    v838 = iadd v98, v1142
     v839 = load.i8 v838
     v840 = uextend.i32 v839
     brif v840, block132, block102
@@ -1600,7 +1668,8 @@ block102:
     v848 = stack_addr.i64 ss136
     v849 = load.i64 aligned v848
     v850 = load.i64 aligned v848+8
-    v851 = iadd_imm.i64 v99, 8
+    v1143 = iconst.i64 8
+    v851 = iadd v99, v1143
     v852 = load.i8 v851
     v853 = uextend.i32 v852
     brif v853, block131, block103
@@ -1619,7 +1688,8 @@ block103:
     v862 = stack_addr.i64 ss137
     v863 = load.i64 aligned v862
     v864 = load.i64 aligned v862+8
-    v865 = iadd_imm.i64 v100, 8
+    v1144 = iconst.i64 8
+    v865 = iadd v100, v1144
     v866 = load.i8 v865
     v867 = uextend.i32 v866
     brif v867, block130, block104
@@ -1637,7 +1707,8 @@ block104:
     v874 = stack_addr.i64 ss138
     v875 = load.i64 aligned v874
     v876 = load.i64 aligned v874+8
-    v877 = iadd_imm.i64 v101, 8
+    v1145 = iconst.i64 8
+    v877 = iadd v101, v1145
     v878 = load.i8 v877
     v879 = uextend.i32 v878
     brif v879, block129, block105
@@ -1683,7 +1754,8 @@ block109(v896: i64):
     v901 = stack_addr.i64 ss139
     v902 = stack_addr.i64 ss139
     v903 = load.i16 aligned v902
-    v904 = iadd_imm.i64 v102, 1
+    v1146 = iconst.i64 1
+    v904 = iadd v102, v1146
     v905 = load.i8 v904
     v906 = uextend.i32 v905
     brif v906, block128, block110
@@ -1716,7 +1788,8 @@ block111:
     v926 = stack_addr.i64 ss140
     v927 = load.i64 aligned v926
     v928 = load.i64 aligned v926+8
-    v929 = iadd_imm.i64 v103, 8
+    v1147 = iconst.i64 8
+    v929 = iadd v103, v1147
     v930 = load.i8 v929
     v931 = uextend.i32 v930
     brif v931, block126, block112
@@ -1741,7 +1814,8 @@ block113:
     v944 = stack_addr.i64 ss141
     v945 = load.i64 aligned v944
     v946 = load.i64 aligned v944+8
-    v947 = iadd_imm.i64 v104, 8
+    v1148 = iconst.i64 8
+    v947 = iadd v104, v1148
     v948 = load.i8 v947
     v949 = uextend.i32 v948
     brif v949, block125, block114
@@ -1771,7 +1845,8 @@ block115:
     v968 = stack_addr.i64 ss142
     v969 = load.i64 aligned v968
     v970 = load.i64 aligned v968+8
-    v971 = iadd_imm.i64 v110, 8
+    v1149 = iconst.i64 8
+    v971 = iadd v110, v1149
     v972 = load.i8 v971
     v973 = uextend.i32 v972
     brif v973, block123, block116
@@ -1788,7 +1863,8 @@ block116:
     v980 = stack_addr.i64 ss143
     v981 = load.i64 aligned v980
     v982 = load.i64 aligned v980+8
-    v983 = iadd_imm.i64 v111, 8
+    v1150 = iconst.i64 8
+    v983 = iadd v111, v1150
     v984 = load.i8 v983
     v985 = uextend.i32 v984
     brif v985, block122, block117
@@ -1813,7 +1889,8 @@ block119:
     v997 = stack_addr.i64 ss144
     v998 = stack_addr.i64 ss144
     v999 = load.i32 aligned v998
-    v1000 = iadd_imm.i64 v112, 2
+    v1151 = iconst.i64 2
+    v1000 = iadd v112, v1151
     v1001 = load.i8 v1000
     v1002 = uextend.i32 v1001
     brif v1002, block121, block120

--- a/tests/disas/array-copy-anyref.wat
+++ b/tests/disas/array-copy-anyref.wat
@@ -36,64 +36,64 @@
 ;; @002b                               v18 = icmp ugt v17, v13
 ;; @002b                               trapnz v18, user17
 ;; @002b                               trapz v4, user16
-;; @002b                               v26 = uextend.i64 v4
-;; @002b                               v28 = iadd v8, v26
-;; @002b                               v30 = iadd v28, v10  ; v10 = 16
-;; @002b                               v31 = load.i32 user2 readonly region0 v30
-;; @002b                               v33 = uextend.i64 v5
-;; @002b                               v36 = iadd v33, v15
-;; @002b                               v32 = uextend.i64 v31
-;; @002b                               v37 = icmp ugt v36, v32
-;; @002b                               trapnz v37, user17
-;; @002b                               v49 = load.i64 notrap aligned v115+40
-;;                                     v111 = iconst.i64 20
-;; @002b                               v22 = iadd v9, v111  ; v111 = 20
+;; @002b                               v27 = uextend.i64 v4
+;; @002b                               v29 = iadd v8, v27
+;; @002b                               v31 = iadd v29, v10  ; v10 = 16
+;; @002b                               v32 = load.i32 user2 readonly region0 v31
+;; @002b                               v34 = uextend.i64 v5
+;; @002b                               v37 = iadd v34, v15
+;; @002b                               v33 = uextend.i64 v32
+;; @002b                               v38 = icmp ugt v37, v33
+;; @002b                               trapnz v38, user17
+;; @002b                               v51 = load.i64 notrap aligned v115+40
+;; @002b                               v22 = iconst.i64 20
+;; @002b                               v23 = iadd v9, v22  ; v22 = 20
 ;;                                     v119 = iconst.i64 2
 ;;                                     v120 = ishl v14, v119  ; v119 = 2
-;; @002b                               v25 = iadd v22, v120
+;; @002b                               v26 = iadd v23, v120
 ;;                                     v124 = ishl v15, v119  ; v119 = 2
-;; @002b                               v51 = uadd_overflow_trap v25, v124, user2
-;; @002b                               v50 = iadd v8, v49
-;; @002b                               v52 = icmp ugt v51, v50
-;; @002b                               trapnz v52, user2
-;; @002b                               v41 = iadd v28, v111  ; v111 = 20
-;;                                     v122 = ishl v33, v119  ; v119 = 2
-;; @002b                               v44 = iadd v41, v122
-;; @002b                               v56 = uadd_overflow_trap v44, v124, user2
-;; @002b                               v57 = icmp ugt v56, v50
-;; @002b                               trapnz v57, user2
+;; @002b                               v53 = uadd_overflow_trap v26, v124, user2
+;; @002b                               v52 = iadd v8, v51
+;; @002b                               v54 = icmp ugt v53, v52
+;; @002b                               trapnz v54, user2
+;; @002b                               v43 = iadd v29, v22  ; v22 = 20
+;;                                     v122 = ishl v34, v119  ; v119 = 2
+;; @002b                               v46 = iadd v43, v122
+;; @002b                               v58 = uadd_overflow_trap v46, v124, user2
+;; @002b                               v59 = icmp ugt v58, v52
+;; @002b                               trapnz v59, user2
 ;; @002b                               brif v15, block2, block5
 ;;
 ;;                                 block2:
-;; @002b                               v58 = icmp.i64 ult v25, v44
-;; @002b                               v61 = iadd.i64 v25, v124
-;; @002b                               v62 = iadd.i64 v44, v124
-;; @002b                               v64 = iadd.i32 v5, v6
-;;                                     v110 = iconst.i64 4
-;; @002b                               v84 = iconst.i32 1
-;; @002b                               brif v58, block3(v25, v44, v5), block4(v61, v62, v64)
+;; @002b                               v60 = icmp.i64 ult v26, v46
+;; @002b                               v63 = iadd.i64 v26, v124
+;; @002b                               v64 = iadd.i64 v46, v124
+;; @002b                               v66 = iadd.i32 v5, v6
+;;                                     v111 = iconst.i64 4
+;; @002b                               v89 = iconst.i32 1
+;; @002b                               brif v60, block3(v26, v46, v5), block4(v63, v64, v66)
 ;;
-;;                                 block3(v65: i64, v66: i64, v67: i32):
-;; @002b                               v70 = load.i32 user2 little region0 v66
-;; @002b                               store user2 little region0 v70, v65
+;;                                 block3(v67: i64, v68: i64, v69: i32):
+;; @002b                               v72 = load.i32 user2 little region0 v68
+;; @002b                               store user2 little region0 v72, v67
 ;;                                     v131 = iconst.i64 4
-;;                                     v132 = iadd v66, v131  ; v131 = 4
-;; @002b                               v74 = icmp eq v132, v62
-;;                                     v133 = iadd v65, v131  ; v131 = 4
+;;                                     v132 = iadd v68, v131  ; v131 = 4
+;; @002b                               v79 = icmp eq v132, v64
+;;                                     v133 = iadd v67, v131  ; v131 = 4
 ;;                                     v134 = iconst.i32 1
-;;                                     v135 = iadd v67, v134  ; v134 = 1
-;; @002b                               brif v74, block5, block3(v133, v132, v135)
+;;                                     v135 = iadd v69, v134  ; v134 = 1
+;; @002b                               brif v79, block5, block3(v133, v132, v135)
 ;;
-;;                                 block4(v75: i64, v76: i64, v77: i32):
+;;                                 block4(v80: i64, v81: i64, v82: i32):
 ;;                                     v126 = iconst.i64 4
-;;                                     v127 = isub v76, v126  ; v126 = 4
-;; @002b                               v86 = load.i32 user2 little region0 v127
-;;                                     v128 = isub v75, v126  ; v126 = 4
-;; @002b                               store user2 little region0 v86, v128
-;; @002b                               v87 = icmp eq v127, v44
+;;                                     v127 = isub v81, v126  ; v126 = 4
+;; @002b                               v91 = load.i32 user2 little region0 v127
+;;                                     v128 = isub v80, v126  ; v126 = 4
+;; @002b                               store user2 little region0 v91, v128
+;; @002b                               v92 = icmp eq v127, v46
 ;;                                     v129 = iconst.i32 1
-;;                                     v130 = isub v77, v129  ; v129 = 1
-;; @002b                               brif v87, block5, block4(v128, v127, v130)
+;;                                     v130 = isub v82, v129  ; v129 = 1
+;; @002b                               brif v92, block5, block4(v128, v127, v130)
 ;;
 ;;                                 block5:
 ;; @002f                               jump block1

--- a/tests/disas/array-copy-i64.wat
+++ b/tests/disas/array-copy-i64.wat
@@ -38,33 +38,33 @@
 ;; @002b                               v18 = icmp ugt v17, v13
 ;; @002b                               trapnz v18, user17
 ;; @002b                               trapz v4, user16
-;; @002b                               v26 = uextend.i64 v4
-;; @002b                               v28 = iadd v8, v26
-;; @002b                               v30 = iadd v28, v10  ; v10 = 16
-;; @002b                               v31 = load.i32 user2 readonly region0 v30
-;; @002b                               v33 = uextend.i64 v5
-;; @002b                               v36 = iadd v33, v15
-;; @002b                               v32 = uextend.i64 v31
-;; @002b                               v37 = icmp ugt v36, v32
-;; @002b                               trapnz v37, user17
-;; @002b                               v49 = load.i64 notrap aligned v81+40
-;;                                     v77 = iconst.i64 24
-;; @002b                               v22 = iadd v9, v77  ; v77 = 24
+;; @002b                               v27 = uextend.i64 v4
+;; @002b                               v29 = iadd v8, v27
+;; @002b                               v31 = iadd v29, v10  ; v10 = 16
+;; @002b                               v32 = load.i32 user2 readonly region0 v31
+;; @002b                               v34 = uextend.i64 v5
+;; @002b                               v37 = iadd v34, v15
+;; @002b                               v33 = uextend.i64 v32
+;; @002b                               v38 = icmp ugt v37, v33
+;; @002b                               trapnz v38, user17
+;; @002b                               v51 = load.i64 notrap aligned v81+40
+;; @002b                               v22 = iconst.i64 24
+;; @002b                               v23 = iadd v9, v22  ; v22 = 24
 ;;                                     v85 = iconst.i64 3
 ;;                                     v86 = ishl v14, v85  ; v85 = 3
-;; @002b                               v25 = iadd v22, v86
+;; @002b                               v26 = iadd v23, v86
 ;;                                     v90 = ishl v15, v85  ; v85 = 3
-;; @002b                               v51 = uadd_overflow_trap v25, v90, user2
-;; @002b                               v50 = iadd v8, v49
-;; @002b                               v52 = icmp ugt v51, v50
-;; @002b                               trapnz v52, user2
-;; @002b                               v41 = iadd v28, v77  ; v77 = 24
-;;                                     v88 = ishl v33, v85  ; v85 = 3
-;; @002b                               v44 = iadd v41, v88
-;; @002b                               v56 = uadd_overflow_trap v44, v90, user2
-;; @002b                               v57 = icmp ugt v56, v50
-;; @002b                               trapnz v57, user2
-;; @002b                               call fn0(v0, v25, v44, v90)
+;; @002b                               v53 = uadd_overflow_trap v26, v90, user2
+;; @002b                               v52 = iadd v8, v51
+;; @002b                               v54 = icmp ugt v53, v52
+;; @002b                               trapnz v54, user2
+;; @002b                               v43 = iadd v29, v22  ; v22 = 24
+;;                                     v88 = ishl v34, v85  ; v85 = 3
+;; @002b                               v46 = iadd v43, v88
+;; @002b                               v58 = uadd_overflow_trap v46, v90, user2
+;; @002b                               v59 = icmp ugt v58, v52
+;; @002b                               trapnz v59, user2
+;; @002b                               call fn0(v0, v26, v46, v90)
 ;; @002f                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/array-copy-i8.wat
+++ b/tests/disas/array-copy-i8.wat
@@ -38,29 +38,29 @@
 ;; @002b                               v18 = icmp ugt v17, v13
 ;; @002b                               trapnz v18, user17
 ;; @002b                               trapz v4, user16
-;; @002b                               v26 = uextend.i64 v4
-;; @002b                               v28 = iadd v8, v26
-;; @002b                               v30 = iadd v28, v10  ; v10 = 16
-;; @002b                               v31 = load.i32 user2 readonly region0 v30
-;; @002b                               v33 = uextend.i64 v5
-;; @002b                               v36 = iadd v33, v15
-;; @002b                               v32 = uextend.i64 v31
-;; @002b                               v37 = icmp ugt v36, v32
-;; @002b                               trapnz v37, user17
-;; @002b                               v49 = load.i64 notrap aligned v81+40
-;;                                     v77 = iconst.i64 20
-;; @002b                               v22 = iadd v9, v77  ; v77 = 20
-;; @002b                               v25 = iadd v22, v14
-;; @002b                               v51 = uadd_overflow_trap v25, v15, user2
-;; @002b                               v50 = iadd v8, v49
-;; @002b                               v52 = icmp ugt v51, v50
-;; @002b                               trapnz v52, user2
-;; @002b                               v41 = iadd v28, v77  ; v77 = 20
-;; @002b                               v44 = iadd v41, v33
-;; @002b                               v56 = uadd_overflow_trap v44, v15, user2
-;; @002b                               v57 = icmp ugt v56, v50
-;; @002b                               trapnz v57, user2
-;; @002b                               call fn0(v0, v25, v44, v15)
+;; @002b                               v27 = uextend.i64 v4
+;; @002b                               v29 = iadd v8, v27
+;; @002b                               v31 = iadd v29, v10  ; v10 = 16
+;; @002b                               v32 = load.i32 user2 readonly region0 v31
+;; @002b                               v34 = uextend.i64 v5
+;; @002b                               v37 = iadd v34, v15
+;; @002b                               v33 = uextend.i64 v32
+;; @002b                               v38 = icmp ugt v37, v33
+;; @002b                               trapnz v38, user17
+;; @002b                               v51 = load.i64 notrap aligned v81+40
+;; @002b                               v22 = iconst.i64 20
+;; @002b                               v23 = iadd v9, v22  ; v22 = 20
+;; @002b                               v26 = iadd v23, v14
+;; @002b                               v53 = uadd_overflow_trap v26, v15, user2
+;; @002b                               v52 = iadd v8, v51
+;; @002b                               v54 = icmp ugt v53, v52
+;; @002b                               trapnz v54, user2
+;; @002b                               v43 = iadd v29, v22  ; v22 = 20
+;; @002b                               v46 = iadd v43, v34
+;; @002b                               v58 = uadd_overflow_trap v46, v15, user2
+;; @002b                               v59 = icmp ugt v58, v52
+;; @002b                               trapnz v59, user2
+;; @002b                               call fn0(v0, v26, v46, v15)
 ;; @002f                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/array-copy-inline.wat
+++ b/tests/disas/array-copy-inline.wat
@@ -42,38 +42,38 @@
 ;; @002a                               v18 = icmp ugt v17, v13
 ;; @002a                               trapnz v18, user17
 ;; @002a                               trapz v4, user16
-;; @002a                               v26 = uextend.i64 v4
-;; @002a                               v28 = iadd v8, v26
-;; @002a                               v30 = iadd v28, v10  ; v10 = 16
-;; @002a                               v31 = load.i32 user2 readonly region0 v30
-;; @002a                               v33 = uextend.i64 v5
-;; @002a                               v36 = iadd v33, v85  ; v85 = 7
-;; @002a                               v32 = uextend.i64 v31
-;; @002a                               v37 = icmp ugt v36, v32
-;; @002a                               trapnz v37, user17
-;; @002a                               v49 = load.i64 notrap aligned v83+40
-;;                                     v79 = iconst.i64 20
-;; @002a                               v22 = iadd v9, v79  ; v79 = 20
+;; @002a                               v27 = uextend.i64 v4
+;; @002a                               v29 = iadd v8, v27
+;; @002a                               v31 = iadd v29, v10  ; v10 = 16
+;; @002a                               v32 = load.i32 user2 readonly region0 v31
+;; @002a                               v34 = uextend.i64 v5
+;; @002a                               v37 = iadd v34, v85  ; v85 = 7
+;; @002a                               v33 = uextend.i64 v32
+;; @002a                               v38 = icmp ugt v37, v33
+;; @002a                               trapnz v38, user17
+;; @002a                               v51 = load.i64 notrap aligned v83+40
+;; @002a                               v22 = iconst.i64 20
+;; @002a                               v23 = iadd v9, v22  ; v22 = 20
 ;;                                     v93 = iconst.i64 2
 ;;                                     v94 = ishl v14, v93  ; v93 = 2
-;; @002a                               v25 = iadd v22, v94
+;; @002a                               v26 = iadd v23, v94
 ;;                                     v98 = iconst.i64 28
-;; @002a                               v51 = uadd_overflow_trap v25, v98, user2  ; v98 = 28
-;; @002a                               v50 = iadd v8, v49
-;; @002a                               v52 = icmp ugt v51, v50
-;; @002a                               trapnz v52, user2
-;; @002a                               v41 = iadd v28, v79  ; v79 = 20
-;;                                     v96 = ishl v33, v93  ; v93 = 2
-;; @002a                               v44 = iadd v41, v96
-;; @002a                               v56 = uadd_overflow_trap v44, v98, user2  ; v98 = 28
-;; @002a                               v57 = icmp ugt v56, v50
-;; @002a                               trapnz v57, user2
-;; @002a                               v58 = load.i8x16 notrap aligned little v44
-;; @002a                               v59 = load.i64 notrap aligned little v44+16
-;; @002a                               v60 = load.i32 notrap aligned little v44+24
-;; @002a                               store notrap aligned little v58, v25
-;; @002a                               store notrap aligned little v59, v25+16
-;; @002a                               store notrap aligned little v60, v25+24
+;; @002a                               v53 = uadd_overflow_trap v26, v98, user2  ; v98 = 28
+;; @002a                               v52 = iadd v8, v51
+;; @002a                               v54 = icmp ugt v53, v52
+;; @002a                               trapnz v54, user2
+;; @002a                               v43 = iadd v29, v22  ; v22 = 20
+;;                                     v96 = ishl v34, v93  ; v93 = 2
+;; @002a                               v46 = iadd v43, v96
+;; @002a                               v58 = uadd_overflow_trap v46, v98, user2  ; v98 = 28
+;; @002a                               v59 = icmp ugt v58, v52
+;; @002a                               trapnz v59, user2
+;; @002a                               v60 = load.i8x16 notrap aligned little v46
+;; @002a                               v61 = load.i64 notrap aligned little v46+16
+;; @002a                               v62 = load.i32 notrap aligned little v46+24
+;; @002a                               store notrap aligned little v60, v26
+;; @002a                               store notrap aligned little v61, v26+16
+;; @002a                               store notrap aligned little v62, v26+24
 ;; @002e                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/array-fill-anyref.wat
+++ b/tests/disas/array-fill-anyref.wat
@@ -43,29 +43,29 @@
 ;; @0030                               v12 = uextend.i64 v11
 ;; @0030                               v17 = icmp ugt v16, v12
 ;; @0030                               trapnz v17, user17
-;; @0030                               v28 = load.i64 notrap aligned v49+40
-;;                                     v45 = iconst.i64 20
-;; @0030                               v21 = iadd v8, v45  ; v45 = 20
+;; @0030                               v29 = load.i64 notrap aligned v49+40
+;; @0030                               v21 = iconst.i64 20
+;; @0030                               v22 = iadd v8, v21  ; v21 = 20
 ;;                                     v53 = iconst.i64 2
 ;;                                     v54 = ishl v13, v53  ; v53 = 2
-;; @0030                               v24 = iadd v21, v54
+;; @0030                               v25 = iadd v22, v54
 ;;                                     v56 = ishl v14, v53  ; v53 = 2
-;; @0030                               v30 = uadd_overflow_trap v24, v56, user2
-;; @0030                               v29 = iadd v7, v28
-;; @0030                               v31 = icmp ugt v30, v29
-;; @0030                               trapnz v31, user2
+;; @0030                               v31 = uadd_overflow_trap v25, v56, user2
+;; @0030                               v30 = iadd v7, v29
+;; @0030                               v32 = icmp ugt v31, v30
+;; @0030                               trapnz v32, user2
 ;;                                     v51 = iconst.i64 0
-;; @0030                               v34 = icmp eq v14, v51  ; v51 = 0
-;;                                     v44 = iconst.i64 4
-;; @0030                               v32 = iadd v24, v56
-;; @0030                               brif v34, block3, block2(v24)
+;; @0030                               v35 = icmp eq v14, v51  ; v51 = 0
+;;                                     v45 = iconst.i64 4
+;; @0030                               v33 = iadd v25, v56
+;; @0030                               brif v35, block3, block2(v25)
 ;;
-;;                                 block2(v35: i64):
-;; @0030                               store.i32 user2 little region0 v4, v35
+;;                                 block2(v36: i64):
+;; @0030                               store.i32 user2 little region0 v4, v36
 ;;                                     v58 = iconst.i64 4
-;;                                     v59 = iadd v35, v58  ; v58 = 4
-;; @0030                               v37 = icmp eq v59, v32
-;; @0030                               brif v37, block3, block2(v59)
+;;                                     v59 = iadd v36, v58  ; v58 = 4
+;; @0030                               v39 = icmp eq v59, v33
+;; @0030                               brif v39, block3, block2(v59)
 ;;
 ;;                                 block3:
 ;; @0033                               jump block1
@@ -100,31 +100,31 @@
 ;; @003e                               v12 = uextend.i64 v11
 ;; @003e                               v17 = icmp ugt v16, v12
 ;; @003e                               trapnz v17, user17
-;; @003e                               v28 = load.i64 notrap aligned v49+40
-;;                                     v45 = iconst.i64 20
-;; @003e                               v21 = iadd v8, v45  ; v45 = 20
+;; @003e                               v29 = load.i64 notrap aligned v49+40
+;; @003e                               v21 = iconst.i64 20
+;; @003e                               v22 = iadd v8, v21  ; v21 = 20
 ;;                                     v53 = iconst.i64 2
 ;;                                     v54 = ishl v13, v53  ; v53 = 2
-;; @003e                               v24 = iadd v21, v54
+;; @003e                               v25 = iadd v22, v54
 ;;                                     v56 = ishl v14, v53  ; v53 = 2
-;; @003e                               v30 = uadd_overflow_trap v24, v56, user2
-;; @003e                               v29 = iadd v7, v28
-;; @003e                               v31 = icmp ugt v30, v29
-;; @003e                               trapnz v31, user2
+;; @003e                               v31 = uadd_overflow_trap v25, v56, user2
+;; @003e                               v30 = iadd v7, v29
+;; @003e                               v32 = icmp ugt v31, v30
+;; @003e                               trapnz v32, user2
 ;;                                     v51 = iconst.i64 0
-;; @003e                               v34 = icmp eq v14, v51  ; v51 = 0
+;; @003e                               v35 = icmp eq v14, v51  ; v51 = 0
 ;; @003a                               v5 = iconst.i32 0
-;;                                     v44 = iconst.i64 4
-;; @003e                               v32 = iadd v24, v56
-;; @003e                               brif v34, block3, block2(v24)
+;;                                     v45 = iconst.i64 4
+;; @003e                               v33 = iadd v25, v56
+;; @003e                               brif v35, block3, block2(v25)
 ;;
-;;                                 block2(v35: i64):
+;;                                 block2(v36: i64):
 ;;                                     v58 = iconst.i32 0
-;; @003e                               store user2 little region0 v58, v35  ; v58 = 0
+;; @003e                               store user2 little region0 v58, v36  ; v58 = 0
 ;;                                     v59 = iconst.i64 4
-;;                                     v60 = iadd v35, v59  ; v59 = 4
-;; @003e                               v37 = icmp eq v60, v32
-;; @003e                               brif v37, block3, block2(v60)
+;;                                     v60 = iadd v36, v59  ; v59 = 4
+;; @003e                               v39 = icmp eq v60, v33
+;; @003e                               brif v39, block3, block2(v60)
 ;;
 ;;                                 block3:
 ;; @0041                               jump block1
@@ -159,31 +159,31 @@
 ;; @004e                               v14 = uextend.i64 v13
 ;; @004e                               v19 = icmp ugt v18, v14
 ;; @004e                               trapnz v19, user17
-;; @004e                               v30 = load.i64 notrap aligned v51+40
-;;                                     v47 = iconst.i64 20
-;; @004e                               v23 = iadd v10, v47  ; v47 = 20
+;; @004e                               v31 = load.i64 notrap aligned v51+40
+;; @004e                               v23 = iconst.i64 20
+;; @004e                               v24 = iadd v10, v23  ; v23 = 20
 ;;                                     v63 = iconst.i64 2
 ;;                                     v64 = ishl v15, v63  ; v63 = 2
-;; @004e                               v26 = iadd v23, v64
+;; @004e                               v27 = iadd v24, v64
 ;;                                     v66 = ishl v16, v63  ; v63 = 2
-;; @004e                               v32 = uadd_overflow_trap v26, v66, user2
-;; @004e                               v31 = iadd v9, v30
-;; @004e                               v33 = icmp ugt v32, v31
-;; @004e                               trapnz v33, user2
+;; @004e                               v33 = uadd_overflow_trap v27, v66, user2
+;; @004e                               v32 = iadd v9, v31
+;; @004e                               v34 = icmp ugt v33, v32
+;; @004e                               trapnz v34, user2
 ;;                                     v61 = iconst.i64 0
-;; @004e                               v36 = icmp eq v16, v61  ; v61 = 0
+;; @004e                               v37 = icmp eq v16, v61  ; v61 = 0
 ;; @0048                               v5 = iconst.i32 -1
-;;                                     v46 = iconst.i64 4
-;; @004e                               v34 = iadd v26, v66
-;; @004e                               brif v36, block3, block2(v26)
+;;                                     v47 = iconst.i64 4
+;; @004e                               v35 = iadd v27, v66
+;; @004e                               brif v37, block3, block2(v27)
 ;;
-;;                                 block2(v37: i64):
+;;                                 block2(v38: i64):
 ;;                                     v68 = iconst.i32 -1
-;; @004e                               store user2 little region0 v68, v37  ; v68 = -1
+;; @004e                               store user2 little region0 v68, v38  ; v68 = -1
 ;;                                     v69 = iconst.i64 4
-;;                                     v70 = iadd v37, v69  ; v69 = 4
-;; @004e                               v39 = icmp eq v70, v34
-;; @004e                               brif v39, block3, block2(v70)
+;;                                     v70 = iadd v38, v69  ; v69 = 4
+;; @004e                               v41 = icmp eq v70, v35
+;; @004e                               brif v41, block3, block2(v70)
 ;;
 ;;                                 block3:
 ;; @0051                               jump block1

--- a/tests/disas/array-fill-externref.wat
+++ b/tests/disas/array-fill-externref.wat
@@ -39,29 +39,29 @@
 ;; @002f                               v12 = uextend.i64 v11
 ;; @002f                               v17 = icmp ugt v16, v12
 ;; @002f                               trapnz v17, user17
-;; @002f                               v28 = load.i64 notrap aligned v49+40
-;;                                     v45 = iconst.i64 20
-;; @002f                               v21 = iadd v8, v45  ; v45 = 20
+;; @002f                               v29 = load.i64 notrap aligned v49+40
+;; @002f                               v21 = iconst.i64 20
+;; @002f                               v22 = iadd v8, v21  ; v21 = 20
 ;;                                     v53 = iconst.i64 2
 ;;                                     v54 = ishl v13, v53  ; v53 = 2
-;; @002f                               v24 = iadd v21, v54
+;; @002f                               v25 = iadd v22, v54
 ;;                                     v56 = ishl v14, v53  ; v53 = 2
-;; @002f                               v30 = uadd_overflow_trap v24, v56, user2
-;; @002f                               v29 = iadd v7, v28
-;; @002f                               v31 = icmp ugt v30, v29
-;; @002f                               trapnz v31, user2
+;; @002f                               v31 = uadd_overflow_trap v25, v56, user2
+;; @002f                               v30 = iadd v7, v29
+;; @002f                               v32 = icmp ugt v31, v30
+;; @002f                               trapnz v32, user2
 ;;                                     v51 = iconst.i64 0
-;; @002f                               v34 = icmp eq v14, v51  ; v51 = 0
-;;                                     v44 = iconst.i64 4
-;; @002f                               v32 = iadd v24, v56
-;; @002f                               brif v34, block3, block2(v24)
+;; @002f                               v35 = icmp eq v14, v51  ; v51 = 0
+;;                                     v45 = iconst.i64 4
+;; @002f                               v33 = iadd v25, v56
+;; @002f                               brif v35, block3, block2(v25)
 ;;
-;;                                 block2(v35: i64):
-;; @002f                               store.i32 user2 little region0 v4, v35
+;;                                 block2(v36: i64):
+;; @002f                               store.i32 user2 little region0 v4, v36
 ;;                                     v58 = iconst.i64 4
-;;                                     v59 = iadd v35, v58  ; v58 = 4
-;; @002f                               v37 = icmp eq v59, v32
-;; @002f                               brif v37, block3, block2(v59)
+;;                                     v59 = iadd v36, v58  ; v58 = 4
+;; @002f                               v39 = icmp eq v59, v33
+;; @002f                               brif v39, block3, block2(v59)
 ;;
 ;;                                 block3:
 ;; @0032                               jump block1
@@ -96,31 +96,31 @@
 ;; @003d                               v12 = uextend.i64 v11
 ;; @003d                               v17 = icmp ugt v16, v12
 ;; @003d                               trapnz v17, user17
-;; @003d                               v28 = load.i64 notrap aligned v49+40
-;;                                     v45 = iconst.i64 20
-;; @003d                               v21 = iadd v8, v45  ; v45 = 20
+;; @003d                               v29 = load.i64 notrap aligned v49+40
+;; @003d                               v21 = iconst.i64 20
+;; @003d                               v22 = iadd v8, v21  ; v21 = 20
 ;;                                     v53 = iconst.i64 2
 ;;                                     v54 = ishl v13, v53  ; v53 = 2
-;; @003d                               v24 = iadd v21, v54
+;; @003d                               v25 = iadd v22, v54
 ;;                                     v56 = ishl v14, v53  ; v53 = 2
-;; @003d                               v30 = uadd_overflow_trap v24, v56, user2
-;; @003d                               v29 = iadd v7, v28
-;; @003d                               v31 = icmp ugt v30, v29
-;; @003d                               trapnz v31, user2
+;; @003d                               v31 = uadd_overflow_trap v25, v56, user2
+;; @003d                               v30 = iadd v7, v29
+;; @003d                               v32 = icmp ugt v31, v30
+;; @003d                               trapnz v32, user2
 ;;                                     v51 = iconst.i64 0
-;; @003d                               v34 = icmp eq v14, v51  ; v51 = 0
+;; @003d                               v35 = icmp eq v14, v51  ; v51 = 0
 ;; @0039                               v5 = iconst.i32 0
-;;                                     v44 = iconst.i64 4
-;; @003d                               v32 = iadd v24, v56
-;; @003d                               brif v34, block3, block2(v24)
+;;                                     v45 = iconst.i64 4
+;; @003d                               v33 = iadd v25, v56
+;; @003d                               brif v35, block3, block2(v25)
 ;;
-;;                                 block2(v35: i64):
+;;                                 block2(v36: i64):
 ;;                                     v58 = iconst.i32 0
-;; @003d                               store user2 little region0 v58, v35  ; v58 = 0
+;; @003d                               store user2 little region0 v58, v36  ; v58 = 0
 ;;                                     v59 = iconst.i64 4
-;;                                     v60 = iadd v35, v59  ; v59 = 4
-;; @003d                               v37 = icmp eq v60, v32
-;; @003d                               brif v37, block3, block2(v60)
+;;                                     v60 = iadd v36, v59  ; v59 = 4
+;; @003d                               v39 = icmp eq v60, v33
+;; @003d                               brif v39, block3, block2(v60)
 ;;
 ;;                                 block3:
 ;; @0040                               jump block1

--- a/tests/disas/array-fill-f32.wat
+++ b/tests/disas/array-fill-f32.wat
@@ -43,29 +43,29 @@
 ;; @0030                               v12 = uextend.i64 v11
 ;; @0030                               v17 = icmp ugt v16, v12
 ;; @0030                               trapnz v17, user17
-;; @0030                               v28 = load.i64 notrap aligned v49+40
-;;                                     v45 = iconst.i64 20
-;; @0030                               v21 = iadd v8, v45  ; v45 = 20
+;; @0030                               v29 = load.i64 notrap aligned v49+40
+;; @0030                               v21 = iconst.i64 20
+;; @0030                               v22 = iadd v8, v21  ; v21 = 20
 ;;                                     v53 = iconst.i64 2
 ;;                                     v54 = ishl v13, v53  ; v53 = 2
-;; @0030                               v24 = iadd v21, v54
+;; @0030                               v25 = iadd v22, v54
 ;;                                     v56 = ishl v14, v53  ; v53 = 2
-;; @0030                               v30 = uadd_overflow_trap v24, v56, user2
-;; @0030                               v29 = iadd v7, v28
-;; @0030                               v31 = icmp ugt v30, v29
-;; @0030                               trapnz v31, user2
+;; @0030                               v31 = uadd_overflow_trap v25, v56, user2
+;; @0030                               v30 = iadd v7, v29
+;; @0030                               v32 = icmp ugt v31, v30
+;; @0030                               trapnz v32, user2
 ;;                                     v51 = iconst.i64 0
-;; @0030                               v34 = icmp eq v14, v51  ; v51 = 0
-;;                                     v44 = iconst.i64 4
-;; @0030                               v32 = iadd v24, v56
-;; @0030                               brif v34, block3, block2(v24)
+;; @0030                               v35 = icmp eq v14, v51  ; v51 = 0
+;;                                     v45 = iconst.i64 4
+;; @0030                               v33 = iadd v25, v56
+;; @0030                               brif v35, block3, block2(v25)
 ;;
-;;                                 block2(v35: i64):
-;; @0030                               store.f32 user2 little region0 v4, v35
+;;                                 block2(v36: i64):
+;; @0030                               store.f32 user2 little region0 v4, v36
 ;;                                     v58 = iconst.i64 4
-;;                                     v59 = iadd v35, v58  ; v58 = 4
-;; @0030                               v37 = icmp eq v59, v32
-;; @0030                               brif v37, block3, block2(v59)
+;;                                     v59 = iadd v36, v58  ; v58 = 4
+;; @0030                               v39 = icmp eq v59, v33
+;; @0030                               brif v39, block3, block2(v59)
 ;;
 ;;                                 block3:
 ;; @0033                               jump block1
@@ -102,19 +102,19 @@
 ;; @0041                               v12 = uextend.i64 v11
 ;; @0041                               v17 = icmp ugt v16, v12
 ;; @0041                               trapnz v17, user17
-;; @0041                               v28 = load.i64 notrap aligned v44+40
-;;                                     v40 = iconst.i64 20
-;; @0041                               v21 = iadd v8, v40  ; v40 = 20
+;; @0041                               v29 = load.i64 notrap aligned v44+40
+;; @0041                               v21 = iconst.i64 20
+;; @0041                               v22 = iadd v8, v21  ; v21 = 20
 ;;                                     v48 = iconst.i64 2
 ;;                                     v49 = ishl v13, v48  ; v48 = 2
-;; @0041                               v24 = iadd v21, v49
+;; @0041                               v25 = iadd v22, v49
 ;;                                     v51 = ishl v14, v48  ; v48 = 2
-;; @0041                               v30 = uadd_overflow_trap v24, v51, user2
-;; @0041                               v29 = iadd v7, v28
-;; @0041                               v31 = icmp ugt v30, v29
-;; @0041                               trapnz v31, user2
-;; @0041                               v32 = iconst.i32 0
-;; @0041                               call fn0(v0, v24, v32, v51)  ; v32 = 0
+;; @0041                               v31 = uadd_overflow_trap v25, v51, user2
+;; @0041                               v30 = iadd v7, v29
+;; @0041                               v32 = icmp ugt v31, v30
+;; @0041                               trapnz v32, user2
+;; @0041                               v33 = iconst.i32 0
+;; @0041                               call fn0(v0, v25, v33, v51)  ; v33 = 0
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -147,31 +147,31 @@
 ;; @0052                               v12 = uextend.i64 v11
 ;; @0052                               v17 = icmp ugt v16, v12
 ;; @0052                               trapnz v17, user17
-;; @0052                               v28 = load.i64 notrap aligned v49+40
-;;                                     v45 = iconst.i64 20
-;; @0052                               v21 = iadd v8, v45  ; v45 = 20
+;; @0052                               v29 = load.i64 notrap aligned v49+40
+;; @0052                               v21 = iconst.i64 20
+;; @0052                               v22 = iadd v8, v21  ; v21 = 20
 ;;                                     v53 = iconst.i64 2
 ;;                                     v54 = ishl v13, v53  ; v53 = 2
-;; @0052                               v24 = iadd v21, v54
+;; @0052                               v25 = iadd v22, v54
 ;;                                     v56 = ishl v14, v53  ; v53 = 2
-;; @0052                               v30 = uadd_overflow_trap v24, v56, user2
-;; @0052                               v29 = iadd v7, v28
-;; @0052                               v31 = icmp ugt v30, v29
-;; @0052                               trapnz v31, user2
+;; @0052                               v31 = uadd_overflow_trap v25, v56, user2
+;; @0052                               v30 = iadd v7, v29
+;; @0052                               v32 = icmp ugt v31, v30
+;; @0052                               trapnz v32, user2
 ;;                                     v51 = iconst.i64 0
-;; @0052                               v34 = icmp eq v14, v51  ; v51 = 0
+;; @0052                               v35 = icmp eq v14, v51  ; v51 = 0
 ;; @004b                               v5 = f32const 0x1.000000p0
-;;                                     v44 = iconst.i64 4
-;; @0052                               v32 = iadd v24, v56
-;; @0052                               brif v34, block3, block2(v24)
+;;                                     v45 = iconst.i64 4
+;; @0052                               v33 = iadd v25, v56
+;; @0052                               brif v35, block3, block2(v25)
 ;;
-;;                                 block2(v35: i64):
+;;                                 block2(v36: i64):
 ;;                                     v58 = f32const 0x1.000000p0
-;; @0052                               store user2 little region0 v58, v35  ; v58 = 0x1.000000p0
+;; @0052                               store user2 little region0 v58, v36  ; v58 = 0x1.000000p0
 ;;                                     v59 = iconst.i64 4
-;;                                     v60 = iadd v35, v59  ; v59 = 4
-;; @0052                               v37 = icmp eq v60, v32
-;; @0052                               brif v37, block3, block2(v60)
+;;                                     v60 = iadd v36, v59  ; v59 = 4
+;; @0052                               v39 = icmp eq v60, v33
+;; @0052                               brif v39, block3, block2(v60)
 ;;
 ;;                                 block3:
 ;; @0055                               jump block1

--- a/tests/disas/array-fill-f64.wat
+++ b/tests/disas/array-fill-f64.wat
@@ -43,29 +43,29 @@
 ;; @0030                               v12 = uextend.i64 v11
 ;; @0030                               v17 = icmp ugt v16, v12
 ;; @0030                               trapnz v17, user17
-;; @0030                               v28 = load.i64 notrap aligned v49+40
-;;                                     v45 = iconst.i64 24
-;; @0030                               v21 = iadd v8, v45  ; v45 = 24
+;; @0030                               v29 = load.i64 notrap aligned v49+40
+;; @0030                               v21 = iconst.i64 24
+;; @0030                               v22 = iadd v8, v21  ; v21 = 24
 ;;                                     v53 = iconst.i64 3
 ;;                                     v54 = ishl v13, v53  ; v53 = 3
-;; @0030                               v24 = iadd v21, v54
+;; @0030                               v25 = iadd v22, v54
 ;;                                     v56 = ishl v14, v53  ; v53 = 3
-;; @0030                               v30 = uadd_overflow_trap v24, v56, user2
-;; @0030                               v29 = iadd v7, v28
-;; @0030                               v31 = icmp ugt v30, v29
-;; @0030                               trapnz v31, user2
+;; @0030                               v31 = uadd_overflow_trap v25, v56, user2
+;; @0030                               v30 = iadd v7, v29
+;; @0030                               v32 = icmp ugt v31, v30
+;; @0030                               trapnz v32, user2
 ;;                                     v51 = iconst.i64 0
-;; @0030                               v34 = icmp eq v14, v51  ; v51 = 0
-;;                                     v44 = iconst.i64 8
-;; @0030                               v32 = iadd v24, v56
-;; @0030                               brif v34, block3, block2(v24)
+;; @0030                               v35 = icmp eq v14, v51  ; v51 = 0
+;;                                     v45 = iconst.i64 8
+;; @0030                               v33 = iadd v25, v56
+;; @0030                               brif v35, block3, block2(v25)
 ;;
-;;                                 block2(v35: i64):
-;; @0030                               store.f64 user2 little region0 v4, v35
+;;                                 block2(v36: i64):
+;; @0030                               store.f64 user2 little region0 v4, v36
 ;;                                     v58 = iconst.i64 8
-;;                                     v59 = iadd v35, v58  ; v58 = 8
-;; @0030                               v37 = icmp eq v59, v32
-;; @0030                               brif v37, block3, block2(v59)
+;;                                     v59 = iadd v36, v58  ; v58 = 8
+;; @0030                               v39 = icmp eq v59, v33
+;; @0030                               brif v39, block3, block2(v59)
 ;;
 ;;                                 block3:
 ;; @0033                               jump block1
@@ -102,19 +102,19 @@
 ;; @0045                               v12 = uextend.i64 v11
 ;; @0045                               v17 = icmp ugt v16, v12
 ;; @0045                               trapnz v17, user17
-;; @0045                               v28 = load.i64 notrap aligned v44+40
-;;                                     v40 = iconst.i64 24
-;; @0045                               v21 = iadd v8, v40  ; v40 = 24
+;; @0045                               v29 = load.i64 notrap aligned v44+40
+;; @0045                               v21 = iconst.i64 24
+;; @0045                               v22 = iadd v8, v21  ; v21 = 24
 ;;                                     v48 = iconst.i64 3
 ;;                                     v49 = ishl v13, v48  ; v48 = 3
-;; @0045                               v24 = iadd v21, v49
+;; @0045                               v25 = iadd v22, v49
 ;;                                     v51 = ishl v14, v48  ; v48 = 3
-;; @0045                               v30 = uadd_overflow_trap v24, v51, user2
-;; @0045                               v29 = iadd v7, v28
-;; @0045                               v31 = icmp ugt v30, v29
-;; @0045                               trapnz v31, user2
-;; @0045                               v32 = iconst.i32 0
-;; @0045                               call fn0(v0, v24, v32, v51)  ; v32 = 0
+;; @0045                               v31 = uadd_overflow_trap v25, v51, user2
+;; @0045                               v30 = iadd v7, v29
+;; @0045                               v32 = icmp ugt v31, v30
+;; @0045                               trapnz v32, user2
+;; @0045                               v33 = iconst.i32 0
+;; @0045                               call fn0(v0, v25, v33, v51)  ; v33 = 0
 ;; @0048                               jump block1
 ;;
 ;;                                 block1:
@@ -147,31 +147,31 @@
 ;; @005a                               v12 = uextend.i64 v11
 ;; @005a                               v17 = icmp ugt v16, v12
 ;; @005a                               trapnz v17, user17
-;; @005a                               v28 = load.i64 notrap aligned v49+40
-;;                                     v45 = iconst.i64 24
-;; @005a                               v21 = iadd v8, v45  ; v45 = 24
+;; @005a                               v29 = load.i64 notrap aligned v49+40
+;; @005a                               v21 = iconst.i64 24
+;; @005a                               v22 = iadd v8, v21  ; v21 = 24
 ;;                                     v53 = iconst.i64 3
 ;;                                     v54 = ishl v13, v53  ; v53 = 3
-;; @005a                               v24 = iadd v21, v54
+;; @005a                               v25 = iadd v22, v54
 ;;                                     v56 = ishl v14, v53  ; v53 = 3
-;; @005a                               v30 = uadd_overflow_trap v24, v56, user2
-;; @005a                               v29 = iadd v7, v28
-;; @005a                               v31 = icmp ugt v30, v29
-;; @005a                               trapnz v31, user2
+;; @005a                               v31 = uadd_overflow_trap v25, v56, user2
+;; @005a                               v30 = iadd v7, v29
+;; @005a                               v32 = icmp ugt v31, v30
+;; @005a                               trapnz v32, user2
 ;;                                     v51 = iconst.i64 0
-;; @005a                               v34 = icmp eq v14, v51  ; v51 = 0
+;; @005a                               v35 = icmp eq v14, v51  ; v51 = 0
 ;; @004f                               v5 = f64const 0x1.0000000000000p0
-;;                                     v44 = iconst.i64 8
-;; @005a                               v32 = iadd v24, v56
-;; @005a                               brif v34, block3, block2(v24)
+;;                                     v45 = iconst.i64 8
+;; @005a                               v33 = iadd v25, v56
+;; @005a                               brif v35, block3, block2(v25)
 ;;
-;;                                 block2(v35: i64):
+;;                                 block2(v36: i64):
 ;;                                     v58 = f64const 0x1.0000000000000p0
-;; @005a                               store user2 little region0 v58, v35  ; v58 = 0x1.0000000000000p0
+;; @005a                               store user2 little region0 v58, v36  ; v58 = 0x1.0000000000000p0
 ;;                                     v59 = iconst.i64 8
-;;                                     v60 = iadd v35, v59  ; v59 = 8
-;; @005a                               v37 = icmp eq v60, v32
-;; @005a                               brif v37, block3, block2(v60)
+;;                                     v60 = iadd v36, v59  ; v59 = 8
+;; @005a                               v39 = icmp eq v60, v33
+;; @005a                               brif v39, block3, block2(v60)
 ;;
 ;;                                 block3:
 ;; @005d                               jump block1

--- a/tests/disas/array-fill-funcref.wat
+++ b/tests/disas/array-fill-funcref.wat
@@ -48,31 +48,31 @@
 ;; @003b                               v12 = uextend.i64 v11
 ;; @003b                               v17 = icmp ugt v16, v12
 ;; @003b                               trapnz v17, user17
-;; @003b                               v28 = load.i64 notrap aligned v52+40
-;;                                     v48 = iconst.i64 20
-;; @003b                               v21 = iadd v8, v48  ; v48 = 20
+;; @003b                               v29 = load.i64 notrap aligned v52+40
+;; @003b                               v21 = iconst.i64 20
+;; @003b                               v22 = iadd v8, v21  ; v21 = 20
 ;;                                     v56 = iconst.i64 2
 ;;                                     v57 = ishl v13, v56  ; v56 = 2
-;; @003b                               v24 = iadd v21, v57
+;; @003b                               v25 = iadd v22, v57
 ;;                                     v59 = ishl v14, v56  ; v56 = 2
-;; @003b                               v30 = uadd_overflow_trap v24, v59, user2
-;; @003b                               v29 = iadd v7, v28
-;; @003b                               v31 = icmp ugt v30, v29
-;; @003b                               trapnz v31, user2
-;; @003b                               v33 = call fn0(v0, v4)
+;; @003b                               v31 = uadd_overflow_trap v25, v59, user2
+;; @003b                               v30 = iadd v7, v29
+;; @003b                               v32 = icmp ugt v31, v30
+;; @003b                               trapnz v32, user2
+;; @003b                               v34 = call fn0(v0, v4)
 ;;                                     v54 = iconst.i64 0
-;; @003b                               v37 = icmp eq v14, v54  ; v54 = 0
-;; @003b                               v34 = ireduce.i32 v33
-;;                                     v47 = iconst.i64 4
-;; @003b                               v35 = iadd v24, v59
-;; @003b                               brif v37, block3, block2(v24)
+;; @003b                               v38 = icmp eq v14, v54  ; v54 = 0
+;; @003b                               v35 = ireduce.i32 v34
+;;                                     v48 = iconst.i64 4
+;; @003b                               v36 = iadd v25, v59
+;; @003b                               brif v38, block3, block2(v25)
 ;;
-;;                                 block2(v38: i64):
-;; @003b                               store.i32 notrap aligned little v34, v38
+;;                                 block2(v39: i64):
+;; @003b                               store.i32 notrap aligned little v35, v39
 ;;                                     v61 = iconst.i64 4
-;;                                     v62 = iadd v38, v61  ; v61 = 4
-;; @003b                               v40 = icmp eq v62, v35
-;; @003b                               brif v40, block3, block2(v62)
+;;                                     v62 = iadd v39, v61  ; v61 = 4
+;; @003b                               v42 = icmp eq v62, v36
+;; @003b                               brif v42, block3, block2(v62)
 ;;
 ;;                                 block3:
 ;; @003e                               jump block1
@@ -109,31 +109,31 @@
 ;; @0049                               v12 = uextend.i64 v11
 ;; @0049                               v17 = icmp ugt v16, v12
 ;; @0049                               trapnz v17, user17
-;; @0049                               v28 = load.i64 notrap aligned v52+40
-;;                                     v48 = iconst.i64 20
-;; @0049                               v21 = iadd v8, v48  ; v48 = 20
+;; @0049                               v29 = load.i64 notrap aligned v52+40
+;; @0049                               v21 = iconst.i64 20
+;; @0049                               v22 = iadd v8, v21  ; v21 = 20
 ;;                                     v55 = iconst.i64 2
 ;;                                     v56 = ishl v13, v55  ; v55 = 2
-;; @0049                               v24 = iadd v21, v56
+;; @0049                               v25 = iadd v22, v56
 ;;                                     v58 = ishl v14, v55  ; v55 = 2
-;; @0049                               v30 = uadd_overflow_trap v24, v58, user2
-;; @0049                               v29 = iadd v7, v28
-;; @0049                               v31 = icmp ugt v30, v29
-;; @0049                               trapnz v31, user2
+;; @0049                               v31 = uadd_overflow_trap v25, v58, user2
+;; @0049                               v30 = iadd v7, v29
+;; @0049                               v32 = icmp ugt v31, v30
+;; @0049                               trapnz v32, user2
 ;; @0045                               v5 = iconst.i64 0
-;; @0049                               v33 = call fn0(v0, v5)  ; v5 = 0
-;; @0049                               v37 = icmp eq v14, v5  ; v5 = 0
-;; @0049                               v34 = ireduce.i32 v33
-;;                                     v47 = iconst.i64 4
-;; @0049                               v35 = iadd v24, v58
-;; @0049                               brif v37, block3, block2(v24)
+;; @0049                               v34 = call fn0(v0, v5)  ; v5 = 0
+;; @0049                               v38 = icmp eq v14, v5  ; v5 = 0
+;; @0049                               v35 = ireduce.i32 v34
+;;                                     v48 = iconst.i64 4
+;; @0049                               v36 = iadd v25, v58
+;; @0049                               brif v38, block3, block2(v25)
 ;;
-;;                                 block2(v38: i64):
-;; @0049                               store.i32 notrap aligned little v34, v38
+;;                                 block2(v39: i64):
+;; @0049                               store.i32 notrap aligned little v35, v39
 ;;                                     v60 = iconst.i64 4
-;;                                     v61 = iadd v38, v60  ; v60 = 4
-;; @0049                               v40 = icmp eq v61, v35
-;; @0049                               brif v40, block3, block2(v61)
+;;                                     v61 = iadd v39, v60  ; v60 = 4
+;; @0049                               v42 = icmp eq v61, v36
+;; @0049                               brif v42, block3, block2(v61)
 ;;
 ;;                                 block3:
 ;; @004c                               jump block1
@@ -163,11 +163,11 @@
 ;;                                     store notrap v2, v62
 ;; @0053                               v5 = iconst.i32 3
 ;; @0053                               v7 = call fn0(v0, v5), stack_map=[i32 @ ss0+0]  ; v5 = 3
-;;                                     v45 = load.i32 notrap v62
-;; @0057                               trapz v45, user16
+;;                                     v47 = load.i32 notrap v62
+;; @0057                               trapz v47, user16
 ;; @0057                               v58 = load.i64 notrap aligned readonly can_move v0+8
 ;; @0057                               v9 = load.i64 notrap aligned readonly can_move v58+32
-;; @0057                               v8 = uextend.i64 v45
+;; @0057                               v8 = uextend.i64 v47
 ;; @0057                               v10 = iadd v9, v8
 ;; @0057                               v11 = iconst.i64 16
 ;; @0057                               v12 = iadd v10, v11  ; v11 = 16
@@ -178,31 +178,31 @@
 ;; @0057                               v14 = uextend.i64 v13
 ;; @0057                               v19 = icmp ugt v18, v14
 ;; @0057                               trapnz v19, user17
-;; @0057                               v30 = load.i64 notrap aligned v58+40
-;;                                     v53 = iconst.i64 20
-;; @0057                               v23 = iadd v10, v53  ; v53 = 20
+;; @0057                               v31 = load.i64 notrap aligned v58+40
+;; @0057                               v23 = iconst.i64 20
+;; @0057                               v24 = iadd v10, v23  ; v23 = 20
 ;;                                     v65 = iconst.i64 2
 ;;                                     v66 = ishl v15, v65  ; v65 = 2
-;; @0057                               v26 = iadd v23, v66
+;; @0057                               v27 = iadd v24, v66
 ;;                                     v68 = ishl v16, v65  ; v65 = 2
-;; @0057                               v32 = uadd_overflow_trap v26, v68, user2
-;; @0057                               v31 = iadd v9, v30
-;; @0057                               v33 = icmp ugt v32, v31
-;; @0057                               trapnz v33, user2
-;; @0057                               v35 = call fn1(v0, v7)
+;; @0057                               v33 = uadd_overflow_trap v27, v68, user2
+;; @0057                               v32 = iadd v9, v31
+;; @0057                               v34 = icmp ugt v33, v32
+;; @0057                               trapnz v34, user2
+;; @0057                               v36 = call fn1(v0, v7)
 ;;                                     v63 = iconst.i64 0
-;; @0057                               v39 = icmp eq v16, v63  ; v63 = 0
-;; @0057                               v36 = ireduce.i32 v35
-;;                                     v52 = iconst.i64 4
-;; @0057                               v37 = iadd v26, v68
-;; @0057                               brif v39, block3, block2(v26)
+;; @0057                               v40 = icmp eq v16, v63  ; v63 = 0
+;; @0057                               v37 = ireduce.i32 v36
+;;                                     v53 = iconst.i64 4
+;; @0057                               v38 = iadd v27, v68
+;; @0057                               brif v40, block3, block2(v27)
 ;;
-;;                                 block2(v40: i64):
-;; @0057                               store.i32 notrap aligned little v36, v40
+;;                                 block2(v41: i64):
+;; @0057                               store.i32 notrap aligned little v37, v41
 ;;                                     v70 = iconst.i64 4
-;;                                     v71 = iadd v40, v70  ; v70 = 4
-;; @0057                               v42 = icmp eq v71, v37
-;; @0057                               brif v42, block3, block2(v71)
+;;                                     v71 = iadd v41, v70  ; v70 = 4
+;; @0057                               v44 = icmp eq v71, v38
+;; @0057                               brif v44, block3, block2(v71)
 ;;
 ;;                                 block3:
 ;; @005a                               jump block1

--- a/tests/disas/array-fill-i16.wat
+++ b/tests/disas/array-fill-i16.wat
@@ -47,29 +47,29 @@
 ;; @0031                               v12 = uextend.i64 v11
 ;; @0031                               v17 = icmp ugt v16, v12
 ;; @0031                               trapnz v17, user17
-;; @0031                               v28 = load.i64 notrap aligned v49+40
-;;                                     v45 = iconst.i64 20
-;; @0031                               v21 = iadd v8, v45  ; v45 = 20
+;; @0031                               v29 = load.i64 notrap aligned v49+40
+;; @0031                               v21 = iconst.i64 20
+;; @0031                               v22 = iadd v8, v21  ; v21 = 20
 ;;                                     v48 = iconst.i64 1
 ;;                                     v54 = ishl v13, v48  ; v48 = 1
-;; @0031                               v24 = iadd v21, v54
+;; @0031                               v25 = iadd v22, v54
 ;;                                     v58 = ishl v14, v48  ; v48 = 1
-;; @0031                               v30 = uadd_overflow_trap v24, v58, user2
-;; @0031                               v29 = iadd v7, v28
-;; @0031                               v31 = icmp ugt v30, v29
-;; @0031                               trapnz v31, user2
+;; @0031                               v31 = uadd_overflow_trap v25, v58, user2
+;; @0031                               v30 = iadd v7, v29
+;; @0031                               v32 = icmp ugt v31, v30
+;; @0031                               trapnz v32, user2
 ;;                                     v51 = iconst.i64 0
-;; @0031                               v34 = icmp eq v14, v51  ; v51 = 0
-;;                                     v44 = iconst.i64 2
-;; @0031                               v32 = iadd v24, v58
-;; @0031                               brif v34, block3, block2(v24)
+;; @0031                               v35 = icmp eq v14, v51  ; v51 = 0
+;;                                     v45 = iconst.i64 2
+;; @0031                               v33 = iadd v25, v58
+;; @0031                               brif v35, block3, block2(v25)
 ;;
-;;                                 block2(v35: i64):
-;; @0031                               istore16.i32 user2 little region0 v4, v35
+;;                                 block2(v36: i64):
+;; @0031                               istore16.i32 user2 little region0 v4, v36
 ;;                                     v61 = iconst.i64 2
-;;                                     v62 = iadd v35, v61  ; v61 = 2
-;; @0031                               v37 = icmp eq v62, v32
-;; @0031                               brif v37, block3, block2(v62)
+;;                                     v62 = iadd v36, v61  ; v61 = 2
+;; @0031                               v39 = icmp eq v62, v33
+;; @0031                               brif v39, block3, block2(v62)
 ;;
 ;;                                 block3:
 ;; @0034                               jump block1
@@ -106,19 +106,19 @@
 ;; @003f                               v12 = uextend.i64 v11
 ;; @003f                               v17 = icmp ugt v16, v12
 ;; @003f                               trapnz v17, user17
-;; @003f                               v28 = load.i64 notrap aligned v44+40
-;;                                     v40 = iconst.i64 20
-;; @003f                               v21 = iadd v8, v40  ; v40 = 20
+;; @003f                               v29 = load.i64 notrap aligned v44+40
+;; @003f                               v21 = iconst.i64 20
+;; @003f                               v22 = iadd v8, v21  ; v21 = 20
 ;;                                     v43 = iconst.i64 1
 ;;                                     v49 = ishl v13, v43  ; v43 = 1
-;; @003f                               v24 = iadd v21, v49
+;; @003f                               v25 = iadd v22, v49
 ;;                                     v53 = ishl v14, v43  ; v43 = 1
-;; @003f                               v30 = uadd_overflow_trap v24, v53, user2
-;; @003f                               v29 = iadd v7, v28
-;; @003f                               v31 = icmp ugt v30, v29
-;; @003f                               trapnz v31, user2
+;; @003f                               v31 = uadd_overflow_trap v25, v53, user2
+;; @003f                               v30 = iadd v7, v29
+;; @003f                               v32 = icmp ugt v31, v30
+;; @003f                               trapnz v32, user2
 ;; @003b                               v5 = iconst.i32 0
-;; @003f                               call fn0(v0, v24, v5, v53)  ; v5 = 0
+;; @003f                               call fn0(v0, v25, v5, v53)  ; v5 = 0
 ;; @0042                               jump block1
 ;;
 ;;                                 block1:
@@ -153,19 +153,19 @@
 ;; @004d                               v12 = uextend.i64 v11
 ;; @004d                               v17 = icmp ugt v16, v12
 ;; @004d                               trapnz v17, user17
-;; @004d                               v28 = load.i64 notrap aligned v44+40
-;;                                     v40 = iconst.i64 20
-;; @004d                               v21 = iadd v8, v40  ; v40 = 20
+;; @004d                               v29 = load.i64 notrap aligned v44+40
+;; @004d                               v21 = iconst.i64 20
+;; @004d                               v22 = iadd v8, v21  ; v21 = 20
 ;;                                     v43 = iconst.i64 1
 ;;                                     v49 = ishl v13, v43  ; v43 = 1
-;; @004d                               v24 = iadd v21, v49
+;; @004d                               v25 = iadd v22, v49
 ;;                                     v53 = ishl v14, v43  ; v43 = 1
-;; @004d                               v30 = uadd_overflow_trap v24, v53, user2
-;; @004d                               v29 = iadd v7, v28
-;; @004d                               v31 = icmp ugt v30, v29
-;; @004d                               trapnz v31, user2
-;; @004d                               v32 = iconst.i32 255
-;; @004d                               call fn0(v0, v24, v32, v53)  ; v32 = 255
+;; @004d                               v31 = uadd_overflow_trap v25, v53, user2
+;; @004d                               v30 = iadd v7, v29
+;; @004d                               v32 = icmp ugt v31, v30
+;; @004d                               trapnz v32, user2
+;; @004d                               v33 = iconst.i32 255
+;; @004d                               call fn0(v0, v25, v33, v53)  ; v33 = 255
 ;; @0050                               jump block1
 ;;
 ;;                                 block1:
@@ -198,31 +198,31 @@
 ;; @005d                               v12 = uextend.i64 v11
 ;; @005d                               v17 = icmp ugt v16, v12
 ;; @005d                               trapnz v17, user17
-;; @005d                               v28 = load.i64 notrap aligned v49+40
-;;                                     v45 = iconst.i64 20
-;; @005d                               v21 = iadd v8, v45  ; v45 = 20
+;; @005d                               v29 = load.i64 notrap aligned v49+40
+;; @005d                               v21 = iconst.i64 20
+;; @005d                               v22 = iadd v8, v21  ; v21 = 20
 ;;                                     v48 = iconst.i64 1
 ;;                                     v54 = ishl v13, v48  ; v48 = 1
-;; @005d                               v24 = iadd v21, v54
+;; @005d                               v25 = iadd v22, v54
 ;;                                     v58 = ishl v14, v48  ; v48 = 1
-;; @005d                               v30 = uadd_overflow_trap v24, v58, user2
-;; @005d                               v29 = iadd v7, v28
-;; @005d                               v31 = icmp ugt v30, v29
-;; @005d                               trapnz v31, user2
+;; @005d                               v31 = uadd_overflow_trap v25, v58, user2
+;; @005d                               v30 = iadd v7, v29
+;; @005d                               v32 = icmp ugt v31, v30
+;; @005d                               trapnz v32, user2
 ;;                                     v51 = iconst.i64 0
-;; @005d                               v34 = icmp eq v14, v51  ; v51 = 0
+;; @005d                               v35 = icmp eq v14, v51  ; v51 = 0
 ;; @0057                               v5 = iconst.i32 0xdead
-;;                                     v44 = iconst.i64 2
-;; @005d                               v32 = iadd v24, v58
-;; @005d                               brif v34, block3, block2(v24)
+;;                                     v45 = iconst.i64 2
+;; @005d                               v33 = iadd v25, v58
+;; @005d                               brif v35, block3, block2(v25)
 ;;
-;;                                 block2(v35: i64):
+;;                                 block2(v36: i64):
 ;;                                     v61 = iconst.i32 0xdead
-;; @005d                               istore16 user2 little region0 v61, v35  ; v61 = 0xdead
+;; @005d                               istore16 user2 little region0 v61, v36  ; v61 = 0xdead
 ;;                                     v62 = iconst.i64 2
-;;                                     v63 = iadd v35, v62  ; v62 = 2
-;; @005d                               v37 = icmp eq v63, v32
-;; @005d                               brif v37, block3, block2(v63)
+;;                                     v63 = iadd v36, v62  ; v62 = 2
+;; @005d                               v39 = icmp eq v63, v33
+;; @005d                               brif v39, block3, block2(v63)
 ;;
 ;;                                 block3:
 ;; @0060                               jump block1

--- a/tests/disas/array-fill-i31ref.wat
+++ b/tests/disas/array-fill-i31ref.wat
@@ -43,29 +43,29 @@
 ;; @0030                               v12 = uextend.i64 v11
 ;; @0030                               v17 = icmp ugt v16, v12
 ;; @0030                               trapnz v17, user17
-;; @0030                               v28 = load.i64 notrap aligned v49+40
-;;                                     v45 = iconst.i64 20
-;; @0030                               v21 = iadd v8, v45  ; v45 = 20
+;; @0030                               v29 = load.i64 notrap aligned v49+40
+;; @0030                               v21 = iconst.i64 20
+;; @0030                               v22 = iadd v8, v21  ; v21 = 20
 ;;                                     v53 = iconst.i64 2
 ;;                                     v54 = ishl v13, v53  ; v53 = 2
-;; @0030                               v24 = iadd v21, v54
+;; @0030                               v25 = iadd v22, v54
 ;;                                     v56 = ishl v14, v53  ; v53 = 2
-;; @0030                               v30 = uadd_overflow_trap v24, v56, user2
-;; @0030                               v29 = iadd v7, v28
-;; @0030                               v31 = icmp ugt v30, v29
-;; @0030                               trapnz v31, user2
+;; @0030                               v31 = uadd_overflow_trap v25, v56, user2
+;; @0030                               v30 = iadd v7, v29
+;; @0030                               v32 = icmp ugt v31, v30
+;; @0030                               trapnz v32, user2
 ;;                                     v51 = iconst.i64 0
-;; @0030                               v34 = icmp eq v14, v51  ; v51 = 0
-;;                                     v44 = iconst.i64 4
-;; @0030                               v32 = iadd v24, v56
-;; @0030                               brif v34, block3, block2(v24)
+;; @0030                               v35 = icmp eq v14, v51  ; v51 = 0
+;;                                     v45 = iconst.i64 4
+;; @0030                               v33 = iadd v25, v56
+;; @0030                               brif v35, block3, block2(v25)
 ;;
-;;                                 block2(v35: i64):
-;; @0030                               store.i32 user2 little region0 v4, v35
+;;                                 block2(v36: i64):
+;; @0030                               store.i32 user2 little region0 v4, v36
 ;;                                     v58 = iconst.i64 4
-;;                                     v59 = iadd v35, v58  ; v58 = 4
-;; @0030                               v37 = icmp eq v59, v32
-;; @0030                               brif v37, block3, block2(v59)
+;;                                     v59 = iadd v36, v58  ; v58 = 4
+;; @0030                               v39 = icmp eq v59, v33
+;; @0030                               brif v39, block3, block2(v59)
 ;;
 ;;                                 block3:
 ;; @0033                               jump block1
@@ -100,31 +100,31 @@
 ;; @003e                               v12 = uextend.i64 v11
 ;; @003e                               v17 = icmp ugt v16, v12
 ;; @003e                               trapnz v17, user17
-;; @003e                               v28 = load.i64 notrap aligned v49+40
-;;                                     v45 = iconst.i64 20
-;; @003e                               v21 = iadd v8, v45  ; v45 = 20
+;; @003e                               v29 = load.i64 notrap aligned v49+40
+;; @003e                               v21 = iconst.i64 20
+;; @003e                               v22 = iadd v8, v21  ; v21 = 20
 ;;                                     v53 = iconst.i64 2
 ;;                                     v54 = ishl v13, v53  ; v53 = 2
-;; @003e                               v24 = iadd v21, v54
+;; @003e                               v25 = iadd v22, v54
 ;;                                     v56 = ishl v14, v53  ; v53 = 2
-;; @003e                               v30 = uadd_overflow_trap v24, v56, user2
-;; @003e                               v29 = iadd v7, v28
-;; @003e                               v31 = icmp ugt v30, v29
-;; @003e                               trapnz v31, user2
+;; @003e                               v31 = uadd_overflow_trap v25, v56, user2
+;; @003e                               v30 = iadd v7, v29
+;; @003e                               v32 = icmp ugt v31, v30
+;; @003e                               trapnz v32, user2
 ;;                                     v51 = iconst.i64 0
-;; @003e                               v34 = icmp eq v14, v51  ; v51 = 0
+;; @003e                               v35 = icmp eq v14, v51  ; v51 = 0
 ;; @003a                               v5 = iconst.i32 0
-;;                                     v44 = iconst.i64 4
-;; @003e                               v32 = iadd v24, v56
-;; @003e                               brif v34, block3, block2(v24)
+;;                                     v45 = iconst.i64 4
+;; @003e                               v33 = iadd v25, v56
+;; @003e                               brif v35, block3, block2(v25)
 ;;
-;;                                 block2(v35: i64):
+;;                                 block2(v36: i64):
 ;;                                     v58 = iconst.i32 0
-;; @003e                               store user2 little region0 v58, v35  ; v58 = 0
+;; @003e                               store user2 little region0 v58, v36  ; v58 = 0
 ;;                                     v59 = iconst.i64 4
-;;                                     v60 = iadd v35, v59  ; v59 = 4
-;; @003e                               v37 = icmp eq v60, v32
-;; @003e                               brif v37, block3, block2(v60)
+;;                                     v60 = iadd v36, v59  ; v59 = 4
+;; @003e                               v39 = icmp eq v60, v33
+;; @003e                               brif v39, block3, block2(v60)
 ;;
 ;;                                 block3:
 ;; @0041                               jump block1
@@ -159,31 +159,31 @@
 ;; @004e                               v14 = uextend.i64 v13
 ;; @004e                               v19 = icmp ugt v18, v14
 ;; @004e                               trapnz v19, user17
-;; @004e                               v30 = load.i64 notrap aligned v51+40
-;;                                     v47 = iconst.i64 20
-;; @004e                               v23 = iadd v10, v47  ; v47 = 20
+;; @004e                               v31 = load.i64 notrap aligned v51+40
+;; @004e                               v23 = iconst.i64 20
+;; @004e                               v24 = iadd v10, v23  ; v23 = 20
 ;;                                     v63 = iconst.i64 2
 ;;                                     v64 = ishl v15, v63  ; v63 = 2
-;; @004e                               v26 = iadd v23, v64
+;; @004e                               v27 = iadd v24, v64
 ;;                                     v66 = ishl v16, v63  ; v63 = 2
-;; @004e                               v32 = uadd_overflow_trap v26, v66, user2
-;; @004e                               v31 = iadd v9, v30
-;; @004e                               v33 = icmp ugt v32, v31
-;; @004e                               trapnz v33, user2
+;; @004e                               v33 = uadd_overflow_trap v27, v66, user2
+;; @004e                               v32 = iadd v9, v31
+;; @004e                               v34 = icmp ugt v33, v32
+;; @004e                               trapnz v34, user2
 ;;                                     v61 = iconst.i64 0
-;; @004e                               v36 = icmp eq v16, v61  ; v61 = 0
+;; @004e                               v37 = icmp eq v16, v61  ; v61 = 0
 ;; @0048                               v5 = iconst.i32 -1
-;;                                     v46 = iconst.i64 4
-;; @004e                               v34 = iadd v26, v66
-;; @004e                               brif v36, block3, block2(v26)
+;;                                     v47 = iconst.i64 4
+;; @004e                               v35 = iadd v27, v66
+;; @004e                               brif v37, block3, block2(v27)
 ;;
-;;                                 block2(v37: i64):
+;;                                 block2(v38: i64):
 ;;                                     v68 = iconst.i32 -1
-;; @004e                               store user2 little region0 v68, v37  ; v68 = -1
+;; @004e                               store user2 little region0 v68, v38  ; v68 = -1
 ;;                                     v69 = iconst.i64 4
-;;                                     v70 = iadd v37, v69  ; v69 = 4
-;; @004e                               v39 = icmp eq v70, v34
-;; @004e                               brif v39, block3, block2(v70)
+;;                                     v70 = iadd v38, v69  ; v69 = 4
+;; @004e                               v41 = icmp eq v70, v35
+;; @004e                               brif v41, block3, block2(v70)
 ;;
 ;;                                 block3:
 ;; @0051                               jump block1

--- a/tests/disas/array-fill-i32.wat
+++ b/tests/disas/array-fill-i32.wat
@@ -47,29 +47,29 @@
 ;; @0031                               v12 = uextend.i64 v11
 ;; @0031                               v17 = icmp ugt v16, v12
 ;; @0031                               trapnz v17, user17
-;; @0031                               v28 = load.i64 notrap aligned v49+40
-;;                                     v45 = iconst.i64 20
-;; @0031                               v21 = iadd v8, v45  ; v45 = 20
+;; @0031                               v29 = load.i64 notrap aligned v49+40
+;; @0031                               v21 = iconst.i64 20
+;; @0031                               v22 = iadd v8, v21  ; v21 = 20
 ;;                                     v53 = iconst.i64 2
 ;;                                     v54 = ishl v13, v53  ; v53 = 2
-;; @0031                               v24 = iadd v21, v54
+;; @0031                               v25 = iadd v22, v54
 ;;                                     v56 = ishl v14, v53  ; v53 = 2
-;; @0031                               v30 = uadd_overflow_trap v24, v56, user2
-;; @0031                               v29 = iadd v7, v28
-;; @0031                               v31 = icmp ugt v30, v29
-;; @0031                               trapnz v31, user2
+;; @0031                               v31 = uadd_overflow_trap v25, v56, user2
+;; @0031                               v30 = iadd v7, v29
+;; @0031                               v32 = icmp ugt v31, v30
+;; @0031                               trapnz v32, user2
 ;;                                     v51 = iconst.i64 0
-;; @0031                               v34 = icmp eq v14, v51  ; v51 = 0
-;;                                     v44 = iconst.i64 4
-;; @0031                               v32 = iadd v24, v56
-;; @0031                               brif v34, block3, block2(v24)
+;; @0031                               v35 = icmp eq v14, v51  ; v51 = 0
+;;                                     v45 = iconst.i64 4
+;; @0031                               v33 = iadd v25, v56
+;; @0031                               brif v35, block3, block2(v25)
 ;;
-;;                                 block2(v35: i64):
-;; @0031                               store.i32 user2 little region0 v4, v35
+;;                                 block2(v36: i64):
+;; @0031                               store.i32 user2 little region0 v4, v36
 ;;                                     v58 = iconst.i64 4
-;;                                     v59 = iadd v35, v58  ; v58 = 4
-;; @0031                               v37 = icmp eq v59, v32
-;; @0031                               brif v37, block3, block2(v59)
+;;                                     v59 = iadd v36, v58  ; v58 = 4
+;; @0031                               v39 = icmp eq v59, v33
+;; @0031                               brif v39, block3, block2(v59)
 ;;
 ;;                                 block3:
 ;; @0034                               jump block1
@@ -106,19 +106,19 @@
 ;; @003f                               v12 = uextend.i64 v11
 ;; @003f                               v17 = icmp ugt v16, v12
 ;; @003f                               trapnz v17, user17
-;; @003f                               v28 = load.i64 notrap aligned v44+40
-;;                                     v40 = iconst.i64 20
-;; @003f                               v21 = iadd v8, v40  ; v40 = 20
+;; @003f                               v29 = load.i64 notrap aligned v44+40
+;; @003f                               v21 = iconst.i64 20
+;; @003f                               v22 = iadd v8, v21  ; v21 = 20
 ;;                                     v48 = iconst.i64 2
 ;;                                     v49 = ishl v13, v48  ; v48 = 2
-;; @003f                               v24 = iadd v21, v49
+;; @003f                               v25 = iadd v22, v49
 ;;                                     v51 = ishl v14, v48  ; v48 = 2
-;; @003f                               v30 = uadd_overflow_trap v24, v51, user2
-;; @003f                               v29 = iadd v7, v28
-;; @003f                               v31 = icmp ugt v30, v29
-;; @003f                               trapnz v31, user2
+;; @003f                               v31 = uadd_overflow_trap v25, v51, user2
+;; @003f                               v30 = iadd v7, v29
+;; @003f                               v32 = icmp ugt v31, v30
+;; @003f                               trapnz v32, user2
 ;; @003b                               v5 = iconst.i32 0
-;; @003f                               call fn0(v0, v24, v5, v51)  ; v5 = 0
+;; @003f                               call fn0(v0, v25, v5, v51)  ; v5 = 0
 ;; @0042                               jump block1
 ;;
 ;;                                 block1:
@@ -153,19 +153,19 @@
 ;; @004d                               v12 = uextend.i64 v11
 ;; @004d                               v17 = icmp ugt v16, v12
 ;; @004d                               trapnz v17, user17
-;; @004d                               v28 = load.i64 notrap aligned v44+40
-;;                                     v40 = iconst.i64 20
-;; @004d                               v21 = iadd v8, v40  ; v40 = 20
+;; @004d                               v29 = load.i64 notrap aligned v44+40
+;; @004d                               v21 = iconst.i64 20
+;; @004d                               v22 = iadd v8, v21  ; v21 = 20
 ;;                                     v48 = iconst.i64 2
 ;;                                     v49 = ishl v13, v48  ; v48 = 2
-;; @004d                               v24 = iadd v21, v49
+;; @004d                               v25 = iadd v22, v49
 ;;                                     v51 = ishl v14, v48  ; v48 = 2
-;; @004d                               v30 = uadd_overflow_trap v24, v51, user2
-;; @004d                               v29 = iadd v7, v28
-;; @004d                               v31 = icmp ugt v30, v29
-;; @004d                               trapnz v31, user2
-;; @004d                               v32 = iconst.i32 255
-;; @004d                               call fn0(v0, v24, v32, v51)  ; v32 = 255
+;; @004d                               v31 = uadd_overflow_trap v25, v51, user2
+;; @004d                               v30 = iadd v7, v29
+;; @004d                               v32 = icmp ugt v31, v30
+;; @004d                               trapnz v32, user2
+;; @004d                               v33 = iconst.i32 255
+;; @004d                               call fn0(v0, v25, v33, v51)  ; v33 = 255
 ;; @0050                               jump block1
 ;;
 ;;                                 block1:
@@ -198,31 +198,31 @@
 ;; @005d                               v12 = uextend.i64 v11
 ;; @005d                               v17 = icmp ugt v16, v12
 ;; @005d                               trapnz v17, user17
-;; @005d                               v28 = load.i64 notrap aligned v49+40
-;;                                     v45 = iconst.i64 20
-;; @005d                               v21 = iadd v8, v45  ; v45 = 20
+;; @005d                               v29 = load.i64 notrap aligned v49+40
+;; @005d                               v21 = iconst.i64 20
+;; @005d                               v22 = iadd v8, v21  ; v21 = 20
 ;;                                     v53 = iconst.i64 2
 ;;                                     v54 = ishl v13, v53  ; v53 = 2
-;; @005d                               v24 = iadd v21, v54
+;; @005d                               v25 = iadd v22, v54
 ;;                                     v56 = ishl v14, v53  ; v53 = 2
-;; @005d                               v30 = uadd_overflow_trap v24, v56, user2
-;; @005d                               v29 = iadd v7, v28
-;; @005d                               v31 = icmp ugt v30, v29
-;; @005d                               trapnz v31, user2
+;; @005d                               v31 = uadd_overflow_trap v25, v56, user2
+;; @005d                               v30 = iadd v7, v29
+;; @005d                               v32 = icmp ugt v31, v30
+;; @005d                               trapnz v32, user2
 ;;                                     v51 = iconst.i64 0
-;; @005d                               v34 = icmp eq v14, v51  ; v51 = 0
+;; @005d                               v35 = icmp eq v14, v51  ; v51 = 0
 ;; @0057                               v5 = iconst.i32 0xdead
-;;                                     v44 = iconst.i64 4
-;; @005d                               v32 = iadd v24, v56
-;; @005d                               brif v34, block3, block2(v24)
+;;                                     v45 = iconst.i64 4
+;; @005d                               v33 = iadd v25, v56
+;; @005d                               brif v35, block3, block2(v25)
 ;;
-;;                                 block2(v35: i64):
+;;                                 block2(v36: i64):
 ;;                                     v58 = iconst.i32 0xdead
-;; @005d                               store user2 little region0 v58, v35  ; v58 = 0xdead
+;; @005d                               store user2 little region0 v58, v36  ; v58 = 0xdead
 ;;                                     v59 = iconst.i64 4
-;;                                     v60 = iadd v35, v59  ; v59 = 4
-;; @005d                               v37 = icmp eq v60, v32
-;; @005d                               brif v37, block3, block2(v60)
+;;                                     v60 = iadd v36, v59  ; v59 = 4
+;; @005d                               v39 = icmp eq v60, v33
+;; @005d                               brif v39, block3, block2(v60)
 ;;
 ;;                                 block3:
 ;; @0060                               jump block1

--- a/tests/disas/array-fill-i64.wat
+++ b/tests/disas/array-fill-i64.wat
@@ -47,29 +47,29 @@
 ;; @0031                               v12 = uextend.i64 v11
 ;; @0031                               v17 = icmp ugt v16, v12
 ;; @0031                               trapnz v17, user17
-;; @0031                               v28 = load.i64 notrap aligned v49+40
-;;                                     v45 = iconst.i64 24
-;; @0031                               v21 = iadd v8, v45  ; v45 = 24
+;; @0031                               v29 = load.i64 notrap aligned v49+40
+;; @0031                               v21 = iconst.i64 24
+;; @0031                               v22 = iadd v8, v21  ; v21 = 24
 ;;                                     v53 = iconst.i64 3
 ;;                                     v54 = ishl v13, v53  ; v53 = 3
-;; @0031                               v24 = iadd v21, v54
+;; @0031                               v25 = iadd v22, v54
 ;;                                     v56 = ishl v14, v53  ; v53 = 3
-;; @0031                               v30 = uadd_overflow_trap v24, v56, user2
-;; @0031                               v29 = iadd v7, v28
-;; @0031                               v31 = icmp ugt v30, v29
-;; @0031                               trapnz v31, user2
+;; @0031                               v31 = uadd_overflow_trap v25, v56, user2
+;; @0031                               v30 = iadd v7, v29
+;; @0031                               v32 = icmp ugt v31, v30
+;; @0031                               trapnz v32, user2
 ;;                                     v51 = iconst.i64 0
-;; @0031                               v34 = icmp eq v14, v51  ; v51 = 0
-;;                                     v44 = iconst.i64 8
-;; @0031                               v32 = iadd v24, v56
-;; @0031                               brif v34, block3, block2(v24)
+;; @0031                               v35 = icmp eq v14, v51  ; v51 = 0
+;;                                     v45 = iconst.i64 8
+;; @0031                               v33 = iadd v25, v56
+;; @0031                               brif v35, block3, block2(v25)
 ;;
-;;                                 block2(v35: i64):
-;; @0031                               store.i64 user2 little region0 v4, v35
+;;                                 block2(v36: i64):
+;; @0031                               store.i64 user2 little region0 v4, v36
 ;;                                     v58 = iconst.i64 8
-;;                                     v59 = iadd v35, v58  ; v58 = 8
-;; @0031                               v37 = icmp eq v59, v32
-;; @0031                               brif v37, block3, block2(v59)
+;;                                     v59 = iadd v36, v58  ; v58 = 8
+;; @0031                               v39 = icmp eq v59, v33
+;; @0031                               brif v39, block3, block2(v59)
 ;;
 ;;                                 block3:
 ;; @0034                               jump block1
@@ -106,19 +106,19 @@
 ;; @003f                               v12 = uextend.i64 v11
 ;; @003f                               v17 = icmp ugt v16, v12
 ;; @003f                               trapnz v17, user17
-;; @003f                               v28 = load.i64 notrap aligned v44+40
-;;                                     v40 = iconst.i64 24
-;; @003f                               v21 = iadd v8, v40  ; v40 = 24
+;; @003f                               v29 = load.i64 notrap aligned v44+40
+;; @003f                               v21 = iconst.i64 24
+;; @003f                               v22 = iadd v8, v21  ; v21 = 24
 ;;                                     v47 = iconst.i64 3
 ;;                                     v48 = ishl v13, v47  ; v47 = 3
-;; @003f                               v24 = iadd v21, v48
+;; @003f                               v25 = iadd v22, v48
 ;;                                     v50 = ishl v14, v47  ; v47 = 3
-;; @003f                               v30 = uadd_overflow_trap v24, v50, user2
-;; @003f                               v29 = iadd v7, v28
-;; @003f                               v31 = icmp ugt v30, v29
-;; @003f                               trapnz v31, user2
-;; @003f                               v32 = iconst.i32 0
-;; @003f                               call fn0(v0, v24, v32, v50)  ; v32 = 0
+;; @003f                               v31 = uadd_overflow_trap v25, v50, user2
+;; @003f                               v30 = iadd v7, v29
+;; @003f                               v32 = icmp ugt v31, v30
+;; @003f                               trapnz v32, user2
+;; @003f                               v33 = iconst.i32 0
+;; @003f                               call fn0(v0, v25, v33, v50)  ; v33 = 0
 ;; @0042                               jump block1
 ;;
 ;;                                 block1:
@@ -153,19 +153,19 @@
 ;; @004d                               v12 = uextend.i64 v11
 ;; @004d                               v17 = icmp ugt v16, v12
 ;; @004d                               trapnz v17, user17
-;; @004d                               v28 = load.i64 notrap aligned v44+40
-;;                                     v40 = iconst.i64 24
-;; @004d                               v21 = iadd v8, v40  ; v40 = 24
+;; @004d                               v29 = load.i64 notrap aligned v44+40
+;; @004d                               v21 = iconst.i64 24
+;; @004d                               v22 = iadd v8, v21  ; v21 = 24
 ;;                                     v48 = iconst.i64 3
 ;;                                     v49 = ishl v13, v48  ; v48 = 3
-;; @004d                               v24 = iadd v21, v49
+;; @004d                               v25 = iadd v22, v49
 ;;                                     v51 = ishl v14, v48  ; v48 = 3
-;; @004d                               v30 = uadd_overflow_trap v24, v51, user2
-;; @004d                               v29 = iadd v7, v28
-;; @004d                               v31 = icmp ugt v30, v29
-;; @004d                               trapnz v31, user2
-;; @004d                               v32 = iconst.i32 255
-;; @004d                               call fn0(v0, v24, v32, v51)  ; v32 = 255
+;; @004d                               v31 = uadd_overflow_trap v25, v51, user2
+;; @004d                               v30 = iadd v7, v29
+;; @004d                               v32 = icmp ugt v31, v30
+;; @004d                               trapnz v32, user2
+;; @004d                               v33 = iconst.i32 255
+;; @004d                               call fn0(v0, v25, v33, v51)  ; v33 = 255
 ;; @0050                               jump block1
 ;;
 ;;                                 block1:
@@ -198,31 +198,31 @@
 ;; @005b                               v12 = uextend.i64 v11
 ;; @005b                               v17 = icmp ugt v16, v12
 ;; @005b                               trapnz v17, user17
-;; @005b                               v28 = load.i64 notrap aligned v49+40
-;;                                     v45 = iconst.i64 24
-;; @005b                               v21 = iadd v8, v45  ; v45 = 24
+;; @005b                               v29 = load.i64 notrap aligned v49+40
+;; @005b                               v21 = iconst.i64 24
+;; @005b                               v22 = iadd v8, v21  ; v21 = 24
 ;;                                     v53 = iconst.i64 3
 ;;                                     v54 = ishl v13, v53  ; v53 = 3
-;; @005b                               v24 = iadd v21, v54
+;; @005b                               v25 = iadd v22, v54
 ;;                                     v56 = ishl v14, v53  ; v53 = 3
-;; @005b                               v30 = uadd_overflow_trap v24, v56, user2
-;; @005b                               v29 = iadd v7, v28
-;; @005b                               v31 = icmp ugt v30, v29
-;; @005b                               trapnz v31, user2
+;; @005b                               v31 = uadd_overflow_trap v25, v56, user2
+;; @005b                               v30 = iadd v7, v29
+;; @005b                               v32 = icmp ugt v31, v30
+;; @005b                               trapnz v32, user2
 ;;                                     v51 = iconst.i64 0
-;; @005b                               v34 = icmp eq v14, v51  ; v51 = 0
+;; @005b                               v35 = icmp eq v14, v51  ; v51 = 0
 ;; @0057                               v5 = iconst.i64 1
-;;                                     v44 = iconst.i64 8
-;; @005b                               v32 = iadd v24, v56
-;; @005b                               brif v34, block3, block2(v24)
+;;                                     v45 = iconst.i64 8
+;; @005b                               v33 = iadd v25, v56
+;; @005b                               brif v35, block3, block2(v25)
 ;;
-;;                                 block2(v35: i64):
+;;                                 block2(v36: i64):
 ;;                                     v58 = iconst.i64 1
-;; @005b                               store user2 little region0 v58, v35  ; v58 = 1
+;; @005b                               store user2 little region0 v58, v36  ; v58 = 1
 ;;                                     v59 = iconst.i64 8
-;;                                     v60 = iadd v35, v59  ; v59 = 8
-;; @005b                               v37 = icmp eq v60, v32
-;; @005b                               brif v37, block3, block2(v60)
+;;                                     v60 = iadd v36, v59  ; v59 = 8
+;; @005b                               v39 = icmp eq v60, v33
+;; @005b                               brif v39, block3, block2(v60)
 ;;
 ;;                                 block3:
 ;; @005e                               jump block1

--- a/tests/disas/gc/array-copy-with-fuel.wat
+++ b/tests/disas/gc/array-copy-with-fuel.wat
@@ -31,138 +31,138 @@
 ;;                                     store notrap v4, v200
 ;; @0020                               v7 = load.i64 notrap aligned readonly can_move v0+8
 ;; @0020                               v8 = load.i64 notrap aligned v7
-;;                                     v198 = iconst.i64 1
-;; @0020                               v9 = iadd v8, v198  ; v198 = 1
-;; @0020                               v10 = iconst.i64 0
-;; @0020                               v11 = icmp sge v9, v10  ; v10 = 0
-;; @0020                               brif v11, block2, block3(v9)
+;; @0020                               v9 = iconst.i64 1
+;; @0020                               v10 = iadd v8, v9  ; v9 = 1
+;; @0020                               v11 = iconst.i64 0
+;; @0020                               v12 = icmp sge v10, v11  ; v11 = 0
+;; @0020                               brif v12, block2, block3(v10)
 ;;
 ;;                                 block2:
-;;                                     v210 = iadd.i64 v8, v198  ; v198 = 1
+;;                                     v210 = iadd.i64 v8, v9  ; v9 = 1
 ;; @0020                               store notrap aligned v210, v7
-;; @0020                               v14 = call fn0(v0), stack_map=[i32 @ ss0+0, i32 @ ss1+0]
-;; @0020                               v16 = load.i64 notrap aligned v7
-;; @0020                               jump block3(v16)
+;; @0020                               v15 = call fn0(v0), stack_map=[i32 @ ss0+0, i32 @ ss1+0]
+;; @0020                               v17 = load.i64 notrap aligned v7
+;; @0020                               jump block3(v17)
 ;;
-;;                                 block3(v73: i64):
-;;                                     v140 = load.i32 notrap v201
-;; @002b                               trapz v140, user16
-;; @002b                               v23 = load.i64 notrap aligned readonly can_move v7+32
-;; @002b                               v22 = uextend.i64 v140
-;; @002b                               v24 = iadd v23, v22
-;; @002b                               v25 = iconst.i64 16
-;; @002b                               v26 = iadd v24, v25  ; v25 = 16
-;; @002b                               v27 = load.i32 user2 readonly region0 v26
-;; @002b                               v29 = uextend.i64 v3
-;; @002b                               v30 = uextend.i64 v6
-;; @002b                               v32 = iadd v29, v30
-;; @002b                               v28 = uextend.i64 v27
-;; @002b                               v33 = icmp ugt v32, v28
-;; @002b                               trapnz v33, user17
-;;                                     v137 = load.i32 notrap v200
-;; @002b                               trapz v137, user16
-;; @002b                               v41 = uextend.i64 v137
-;; @002b                               v43 = iadd v23, v41
-;; @002b                               v45 = iadd v43, v25  ; v25 = 16
-;; @002b                               v46 = load.i32 user2 readonly region0 v45
-;; @002b                               v48 = uextend.i64 v5
-;; @002b                               v51 = iadd v48, v30
-;; @002b                               v47 = uextend.i64 v46
-;; @002b                               v52 = icmp ugt v51, v47
-;; @002b                               trapnz v52, user17
-;; @002b                               v64 = load.i64 notrap aligned v7+40
-;;                                     v187 = iconst.i64 20
-;; @002b                               v37 = iadd v24, v187  ; v187 = 20
+;;                                 block3(v76: i64):
+;;                                     v149 = load.i32 notrap v201
+;; @002b                               trapz v149, user16
+;; @002b                               v24 = load.i64 notrap aligned readonly can_move v7+32
+;; @002b                               v23 = uextend.i64 v149
+;; @002b                               v25 = iadd v24, v23
+;; @002b                               v26 = iconst.i64 16
+;; @002b                               v27 = iadd v25, v26  ; v26 = 16
+;; @002b                               v28 = load.i32 user2 readonly region0 v27
+;; @002b                               v30 = uextend.i64 v3
+;; @002b                               v31 = uextend.i64 v6
+;; @002b                               v33 = iadd v30, v31
+;; @002b                               v29 = uextend.i64 v28
+;; @002b                               v34 = icmp ugt v33, v29
+;; @002b                               trapnz v34, user17
+;;                                     v146 = load.i32 notrap v200
+;; @002b                               trapz v146, user16
+;; @002b                               v43 = uextend.i64 v146
+;; @002b                               v45 = iadd v24, v43
+;; @002b                               v47 = iadd v45, v26  ; v26 = 16
+;; @002b                               v48 = load.i32 user2 readonly region0 v47
+;; @002b                               v50 = uextend.i64 v5
+;; @002b                               v53 = iadd v50, v31
+;; @002b                               v49 = uextend.i64 v48
+;; @002b                               v54 = icmp ugt v53, v49
+;; @002b                               trapnz v54, user17
+;; @002b                               v67 = load.i64 notrap aligned v7+40
+;; @002b                               v38 = iconst.i64 20
+;; @002b                               v39 = iadd v25, v38  ; v38 = 20
 ;;                                     v203 = iconst.i64 2
-;;                                     v204 = ishl v29, v203  ; v203 = 2
-;; @002b                               v40 = iadd v37, v204
-;;                                     v208 = ishl v30, v203  ; v203 = 2
-;; @002b                               v66 = uadd_overflow_trap v40, v208, user2
-;; @002b                               v65 = iadd v23, v64
-;; @002b                               v67 = icmp ugt v66, v65
-;; @002b                               trapnz v67, user2
-;; @002b                               v56 = iadd v43, v187  ; v187 = 20
-;;                                     v206 = ishl v48, v203  ; v203 = 2
-;; @002b                               v59 = iadd v56, v206
-;; @002b                               v71 = uadd_overflow_trap v59, v208, user2
-;; @002b                               v72 = icmp ugt v71, v65
-;; @002b                               trapnz v72, user2
-;;                                     v165 = iconst.i64 6
-;; @002b                               v74 = iadd v73, v165  ; v165 = 6
-;; @002b                               brif v30, block4, block7(v74)
+;;                                     v204 = ishl v30, v203  ; v203 = 2
+;; @002b                               v42 = iadd v39, v204
+;;                                     v208 = ishl v31, v203  ; v203 = 2
+;; @002b                               v69 = uadd_overflow_trap v42, v208, user2
+;; @002b                               v68 = iadd v24, v67
+;; @002b                               v70 = icmp ugt v69, v68
+;; @002b                               trapnz v70, user2
+;; @002b                               v59 = iadd v45, v38  ; v38 = 20
+;;                                     v206 = ishl v50, v203  ; v203 = 2
+;; @002b                               v62 = iadd v59, v206
+;; @002b                               v74 = uadd_overflow_trap v62, v208, user2
+;; @002b                               v75 = icmp ugt v74, v68
+;; @002b                               trapnz v75, user2
+;; @002b                               v77 = iconst.i64 6
+;; @002b                               v78 = iadd v76, v77  ; v77 = 6
+;; @002b                               brif v31, block4, block7(v78)
 ;;
 ;;                                 block4:
-;;                                     v131 = load.i32 notrap v201
-;;                                     v132 = load.i32 notrap v200
-;; @002b                               v75 = icmp.i64 ult v40, v59
-;;                                     v211 = iadd.i64 v73, v165  ; v165 = 6
-;; @002b                               v78 = iadd.i64 v40, v208
-;; @002b                               v79 = iadd.i64 v59, v208
-;; @002b                               v81 = iadd.i32 v5, v6
-;;                                     v186 = iconst.i64 4
-;; @002b                               v119 = iconst.i32 1
-;; @002b                               brif v75, block5(v40, v59, v5, v131, v132, v211), block6(v78, v79, v81, v131, v132, v211)
+;;                                     v140 = load.i32 notrap v201
+;;                                     v141 = load.i32 notrap v200
+;; @002b                               v79 = icmp.i64 ult v42, v62
+;;                                     v211 = iadd.i64 v76, v77  ; v77 = 6
+;; @002b                               v82 = iadd.i64 v42, v208
+;; @002b                               v83 = iadd.i64 v62, v208
+;; @002b                               v85 = iadd.i32 v5, v6
+;;                                     v188 = iconst.i64 4
+;; @002b                               v128 = iconst.i32 1
+;; @002b                               brif v79, block5(v42, v62, v5, v140, v141, v211), block6(v82, v83, v85, v140, v141, v211)
 ;;
-;;                                 block5(v82: i64, v83: i64, v84: i32, v85: i32, v86: i32, v87: i64):
-;;                                     store notrap v85, v201
-;;                                     store notrap v86, v200
+;;                                 block5(v86: i64, v87: i64, v88: i32, v89: i32, v90: i32, v91: i64):
+;;                                     store notrap v89, v201
+;;                                     store notrap v90, v200
 ;;                                     v221 = iconst.i64 1
-;;                                     v222 = iadd v87, v221  ; v221 = 1
+;;                                     v222 = iadd v91, v221  ; v221 = 1
 ;;                                     v223 = iconst.i64 0
 ;;                                     v224 = icmp sge v222, v223  ; v223 = 0
 ;; @002b                               brif v224, block8, block9(v222)
 ;;
-;;                                 block6(v101: i64, v102: i64, v103: i32, v104: i32, v105: i32, v106: i64):
-;;                                     store notrap v104, v200
-;;                                     store notrap v105, v201
+;;                                 block6(v109: i64, v110: i64, v111: i32, v112: i32, v113: i32, v114: i64):
+;;                                     store notrap v112, v200
+;;                                     store notrap v113, v201
 ;;                                     v212 = iconst.i64 1
-;;                                     v213 = iadd v106, v212  ; v212 = 1
+;;                                     v213 = iadd v114, v212  ; v212 = 1
 ;;                                     v214 = iconst.i64 0
 ;;                                     v215 = icmp sge v213, v214  ; v214 = 0
 ;; @002b                               brif v215, block10, block11(v213)
 ;;
-;;                                 block7(v126: i64):
+;;                                 block7(v135: i64):
 ;; @002f                               jump block1
 ;;
 ;;                                 block8:
 ;; @002b                               store.i64 notrap aligned v222, v7
-;; @002b                               v93 = call fn0(v0), stack_map=[i32 @ ss0+0, i32 @ ss1+0]
-;; @002b                               v95 = load.i64 notrap aligned v7
-;; @002b                               jump block9(v95)
+;; @002b                               v98 = call fn0(v0), stack_map=[i32 @ ss0+0, i32 @ ss1+0]
+;; @002b                               v100 = load.i64 notrap aligned v7
+;; @002b                               jump block9(v100)
 ;;
-;;                                 block9(v123: i64):
-;; @002b                               v96 = load.i32 user2 little region0 v83
-;; @002b                               store user2 little region0 v96, v82
-;;                                     v127 = load.i32 notrap v201
-;;                                     v128 = load.i32 notrap v200
+;;                                 block9(v132: i64):
+;; @002b                               v101 = load.i32 user2 little region0 v87
+;; @002b                               store user2 little region0 v101, v86
+;;                                     v136 = load.i32 notrap v201
+;;                                     v137 = load.i32 notrap v200
 ;;                                     v225 = iconst.i64 4
-;;                                     v226 = iadd.i64 v83, v225  ; v225 = 4
-;; @002b                               v100 = icmp eq v226, v79
-;;                                     v227 = iadd.i64 v82, v225  ; v225 = 4
+;;                                     v226 = iadd.i64 v87, v225  ; v225 = 4
+;; @002b                               v108 = icmp eq v226, v83
+;;                                     v227 = iadd.i64 v86, v225  ; v225 = 4
 ;;                                     v228 = iconst.i32 1
-;;                                     v229 = iadd.i32 v84, v228  ; v228 = 1
-;; @002b                               brif v100, block7(v123), block5(v227, v226, v229, v127, v128, v123)
+;;                                     v229 = iadd.i32 v88, v228  ; v228 = 1
+;; @002b                               brif v108, block7(v132), block5(v227, v226, v229, v136, v137, v132)
 ;;
 ;;                                 block10:
 ;; @002b                               store.i64 notrap aligned v213, v7
-;; @002b                               v112 = call fn0(v0), stack_map=[i32 @ ss1+0, i32 @ ss0+0]
-;; @002b                               v114 = load.i64 notrap aligned v7
-;; @002b                               jump block11(v114)
+;; @002b                               v121 = call fn0(v0), stack_map=[i32 @ ss1+0, i32 @ ss0+0]
+;; @002b                               v123 = load.i64 notrap aligned v7
+;; @002b                               jump block11(v123)
 ;;
-;;                                 block11(v124: i64):
+;;                                 block11(v133: i64):
 ;;                                     v216 = iconst.i64 4
-;;                                     v217 = isub.i64 v102, v216  ; v216 = 4
-;; @002b                               v121 = load.i32 user2 little region0 v217
-;;                                     v218 = isub.i64 v101, v216  ; v216 = 4
-;; @002b                               store user2 little region0 v121, v218
-;;                                     v129 = load.i32 notrap v200
-;;                                     v130 = load.i32 notrap v201
-;; @002b                               v122 = icmp eq v217, v59
+;;                                     v217 = isub.i64 v110, v216  ; v216 = 4
+;; @002b                               v130 = load.i32 user2 little region0 v217
+;;                                     v218 = isub.i64 v109, v216  ; v216 = 4
+;; @002b                               store user2 little region0 v130, v218
+;;                                     v138 = load.i32 notrap v200
+;;                                     v139 = load.i32 notrap v201
+;; @002b                               v131 = icmp eq v217, v62
 ;;                                     v219 = iconst.i32 1
-;;                                     v220 = isub.i32 v103, v219  ; v219 = 1
-;; @002b                               brif v122, block7(v124), block6(v218, v217, v220, v129, v130, v124)
+;;                                     v220 = isub.i32 v111, v219  ; v219 = 1
+;; @002b                               brif v131, block7(v133), block6(v218, v217, v220, v138, v139, v133)
 ;;
 ;;                                 block1:
-;; @002f                               store.i64 notrap aligned v126, v7
+;; @002f                               store.i64 notrap aligned v135, v7
 ;; @002f                               return
 ;; }

--- a/tests/disas/gc/array-fill-i8.wat
+++ b/tests/disas/gc/array-fill-i8.wat
@@ -37,15 +37,15 @@
 ;; @0027                               v12 = uextend.i64 v11
 ;; @0027                               v17 = icmp ugt v16, v12
 ;; @0027                               trapnz v17, user17
-;; @0027                               v28 = load.i64 notrap aligned v43+40
-;;                                     v39 = iconst.i64 20
-;; @0027                               v21 = iadd v8, v39  ; v39 = 20
-;; @0027                               v24 = iadd v21, v13
-;; @0027                               v30 = uadd_overflow_trap v24, v14, user2
-;; @0027                               v29 = iadd v7, v28
-;; @0027                               v31 = icmp ugt v30, v29
-;; @0027                               trapnz v31, user2
-;; @0027                               call fn0(v0, v24, v4, v14)
+;; @0027                               v29 = load.i64 notrap aligned v43+40
+;; @0027                               v21 = iconst.i64 20
+;; @0027                               v22 = iadd v8, v21  ; v21 = 20
+;; @0027                               v25 = iadd v22, v13
+;; @0027                               v31 = uadd_overflow_trap v25, v14, user2
+;; @0027                               v30 = iadd v7, v29
+;; @0027                               v32 = icmp ugt v31, v30
+;; @0027                               trapnz v32, user2
+;; @0027                               call fn0(v0, v25, v4, v14)
 ;; @002a                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/array-init-data.wat
+++ b/tests/disas/gc/array-init-data.wat
@@ -41,23 +41,23 @@
 ;; @002a                               v12 = uextend.i64 v11
 ;; @002a                               v17 = icmp ugt v16, v12
 ;; @002a                               trapnz v17, user17
-;; @002a                               v26 = load.i32 notrap aligned v0+56
-;; @002a                               v28 = uextend.i64 v4
-;; @002a                               v31 = iadd v28, v14
-;; @002a                               v27 = uextend.i64 v26
-;; @002a                               v32 = icmp ugt v31, v27
-;; @002a                               trapnz v32, heap_oob
-;; @002a                               v34 = load.i64 notrap aligned v0+48
-;; @002a                               v41 = load.i64 notrap aligned v58+40
-;;                                     v54 = iconst.i64 20
-;; @002a                               v21 = iadd v8, v54  ; v54 = 20
-;; @002a                               v24 = iadd v21, v13
-;; @002a                               v43 = uadd_overflow_trap v24, v14, user2
-;; @002a                               v42 = iadd v7, v41
-;; @002a                               v44 = icmp ugt v43, v42
-;; @002a                               trapnz v44, user2
-;; @002a                               v36 = iadd v34, v28
-;; @002a                               call fn0(v0, v24, v36, v14)
+;; @002a                               v27 = load.i32 notrap aligned v0+56
+;; @002a                               v29 = uextend.i64 v4
+;; @002a                               v32 = iadd v29, v14
+;; @002a                               v28 = uextend.i64 v27
+;; @002a                               v33 = icmp ugt v32, v28
+;; @002a                               trapnz v33, heap_oob
+;; @002a                               v35 = load.i64 notrap aligned v0+48
+;; @002a                               v42 = load.i64 notrap aligned v58+40
+;; @002a                               v21 = iconst.i64 20
+;; @002a                               v22 = iadd v8, v21  ; v21 = 20
+;; @002a                               v25 = iadd v22, v13
+;; @002a                               v44 = uadd_overflow_trap v25, v14, user2
+;; @002a                               v43 = iadd v7, v42
+;; @002a                               v45 = icmp ugt v44, v43
+;; @002a                               trapnz v45, user2
+;; @002a                               v37 = iadd v35, v29
+;; @002a                               call fn0(v0, v25, v37, v14)
 ;; @002e                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/array-new-data.wat
+++ b/tests/disas/gc/array-new-data.wat
@@ -154,36 +154,36 @@
 ;;                                 block4(v54: i32, v55: i64):
 ;;                                     v121 = stack_addr.i64 ss0
 ;;                                     store notrap v54, v121
-;;                                     v120 = iconst.i64 16
-;; @0025                               v56 = iadd v55, v120  ; v120 = 16
-;; @0025                               store.i32 user2 region1 v3, v56
+;; @0025                               v56 = iconst.i64 16
+;; @0025                               v57 = iadd v55, v56  ; v56 = 16
+;; @0025                               store.i32 user2 region1 v3, v57
 ;; @0025                               trapz v54, user16
 ;;                                     v163 = load.i64 notrap aligned readonly can_move v0+8
 ;;                                     v164 = load.i64 notrap aligned readonly can_move v163+32
-;; @0025                               v58 = uextend.i64 v54
-;; @0025                               v60 = iadd v164, v58
-;; @0025                               v62 = iadd v60, v120  ; v120 = 16
-;; @0025                               v63 = load.i32 user2 readonly region1 v62
-;; @0025                               v64 = uextend.i64 v63
-;; @0025                               v69 = icmp.i64 ugt v9, v64
-;; @0025                               trapnz v69, user17
-;; @0025                               v78 = load.i32 notrap aligned v0+56
-;; @0025                               v79 = uextend.i64 v78
-;; @0025                               v84 = icmp.i64 ugt v11, v79
-;; @0025                               trapnz v84, heap_oob
-;; @0025                               v86 = load.i64 notrap aligned v0+48
-;; @0025                               v93 = load.i64 notrap aligned v163+40
-;;                                     v111 = iconst.i64 20
-;; @0025                               v73 = iadd v60, v111  ; v111 = 20
-;; @0025                               v95 = uadd_overflow_trap v73, v9, user2
-;; @0025                               v94 = iadd v164, v93
-;; @0025                               v96 = icmp ugt v95, v94
-;; @0025                               trapnz v96, user2
-;; @0025                               v88 = iadd v86, v8
-;; @0025                               call fn1(v0, v73, v88, v9), stack_map=[i32 @ ss0+0]
-;;                                     v98 = load.i32 notrap v121
+;; @0025                               v59 = uextend.i64 v54
+;; @0025                               v61 = iadd v164, v59
+;; @0025                               v63 = iadd v61, v56  ; v56 = 16
+;; @0025                               v64 = load.i32 user2 readonly region1 v63
+;; @0025                               v65 = uextend.i64 v64
+;; @0025                               v70 = icmp.i64 ugt v9, v65
+;; @0025                               trapnz v70, user17
+;; @0025                               v80 = load.i32 notrap aligned v0+56
+;; @0025                               v81 = uextend.i64 v80
+;; @0025                               v86 = icmp.i64 ugt v11, v81
+;; @0025                               trapnz v86, heap_oob
+;; @0025                               v88 = load.i64 notrap aligned v0+48
+;; @0025                               v95 = load.i64 notrap aligned v163+40
+;; @0025                               v74 = iconst.i64 20
+;; @0025                               v75 = iadd v61, v74  ; v74 = 20
+;; @0025                               v97 = uadd_overflow_trap v75, v9, user2
+;; @0025                               v96 = iadd v164, v95
+;; @0025                               v98 = icmp ugt v97, v96
+;; @0025                               trapnz v98, user2
+;; @0025                               v90 = iadd v88, v8
+;; @0025                               call fn1(v0, v75, v90, v9), stack_map=[i32 @ ss0+0]
+;;                                     v100 = load.i32 notrap v121
 ;; @0029                               jump block1
 ;;
 ;;                                 block1:
-;; @0029                               return v98
+;; @0029                               return v100
 ;; }

--- a/tests/disas/gc/array-new-default-anyref.wat
+++ b/tests/disas/gc/array-new-default-anyref.wat
@@ -80,40 +80,40 @@
 ;; @001f                               jump block4(v29, v32)
 ;;
 ;;                                 block4(v41: i32, v42: i64):
-;;                                     v91 = iconst.i64 16
-;; @001f                               v43 = iadd v42, v91  ; v91 = 16
-;; @001f                               store.i32 user2 region1 v2, v43
+;; @001f                               v43 = iconst.i64 16
+;; @001f                               v44 = iadd v42, v43  ; v43 = 16
+;; @001f                               store.i32 user2 region1 v2, v44
 ;; @001f                               trapz v41, user16
 ;;                                     v143 = load.i64 notrap aligned readonly can_move v0+8
 ;;                                     v144 = load.i64 notrap aligned readonly can_move v143+32
-;; @001f                               v46 = uextend.i64 v41
-;; @001f                               v48 = iadd v144, v46
-;; @001f                               v50 = iadd v48, v91  ; v91 = 16
-;; @001f                               v51 = load.i32 user2 readonly region1 v50
-;; @001f                               v52 = uextend.i64 v51
-;; @001f                               v57 = icmp.i64 ugt v5, v52
-;; @001f                               trapnz v57, user17
-;; @001f                               v68 = load.i64 notrap aligned v143+40
-;;                                     v85 = iconst.i64 20
-;; @001f                               v61 = iadd v48, v85  ; v85 = 20
-;; @001f                               v70 = uadd_overflow_trap v61, v99, user2
-;; @001f                               v69 = iadd v144, v68
-;; @001f                               v71 = icmp ugt v70, v69
-;; @001f                               trapnz v71, user2
+;; @001f                               v47 = uextend.i64 v41
+;; @001f                               v49 = iadd v144, v47
+;; @001f                               v51 = iadd v49, v43  ; v43 = 16
+;; @001f                               v52 = load.i32 user2 readonly region1 v51
+;; @001f                               v53 = uextend.i64 v52
+;; @001f                               v58 = icmp.i64 ugt v5, v53
+;; @001f                               trapnz v58, user17
+;; @001f                               v70 = load.i64 notrap aligned v143+40
+;; @001f                               v62 = iconst.i64 20
+;; @001f                               v63 = iadd v49, v62  ; v62 = 20
+;; @001f                               v72 = uadd_overflow_trap v63, v99, user2
+;; @001f                               v71 = iadd v144, v70
+;; @001f                               v73 = icmp ugt v72, v71
+;; @001f                               trapnz v73, user2
 ;;                                     v123 = iconst.i64 0
-;; @001f                               v74 = icmp.i64 eq v5, v123  ; v123 = 0
-;; @001f                               v44 = iconst.i32 0
+;; @001f                               v76 = icmp.i64 eq v5, v123  ; v123 = 0
+;; @001f                               v45 = iconst.i32 0
 ;;                                     v97 = iconst.i64 4
-;; @001f                               v72 = iadd v61, v99
-;; @001f                               brif v74, block6, block5(v61)
+;; @001f                               v74 = iadd v63, v99
+;; @001f                               brif v76, block6, block5(v63)
 ;;
-;;                                 block5(v75: i64):
+;;                                 block5(v77: i64):
 ;;                                     v145 = iconst.i32 0
-;; @001f                               store user2 little region1 v145, v75  ; v145 = 0
+;; @001f                               store user2 little region1 v145, v77  ; v145 = 0
 ;;                                     v146 = iconst.i64 4
-;;                                     v147 = iadd v75, v146  ; v146 = 4
-;; @001f                               v77 = icmp eq v147, v72
-;; @001f                               brif v77, block6, block5(v147)
+;;                                     v147 = iadd v77, v146  ; v146 = 4
+;; @001f                               v80 = icmp eq v147, v74
+;; @001f                               brif v80, block6, block5(v147)
 ;;
 ;;                                 block6:
 ;; @0022                               jump block1(v41)

--- a/tests/disas/gc/array-new-default-exnref.wat
+++ b/tests/disas/gc/array-new-default-exnref.wat
@@ -80,40 +80,40 @@
 ;; @001f                               jump block4(v29, v32)
 ;;
 ;;                                 block4(v41: i32, v42: i64):
-;;                                     v91 = iconst.i64 16
-;; @001f                               v43 = iadd v42, v91  ; v91 = 16
-;; @001f                               store.i32 user2 region1 v2, v43
+;; @001f                               v43 = iconst.i64 16
+;; @001f                               v44 = iadd v42, v43  ; v43 = 16
+;; @001f                               store.i32 user2 region1 v2, v44
 ;; @001f                               trapz v41, user16
 ;;                                     v143 = load.i64 notrap aligned readonly can_move v0+8
 ;;                                     v144 = load.i64 notrap aligned readonly can_move v143+32
-;; @001f                               v46 = uextend.i64 v41
-;; @001f                               v48 = iadd v144, v46
-;; @001f                               v50 = iadd v48, v91  ; v91 = 16
-;; @001f                               v51 = load.i32 user2 readonly region1 v50
-;; @001f                               v52 = uextend.i64 v51
-;; @001f                               v57 = icmp.i64 ugt v5, v52
-;; @001f                               trapnz v57, user17
-;; @001f                               v68 = load.i64 notrap aligned v143+40
-;;                                     v85 = iconst.i64 20
-;; @001f                               v61 = iadd v48, v85  ; v85 = 20
-;; @001f                               v70 = uadd_overflow_trap v61, v99, user2
-;; @001f                               v69 = iadd v144, v68
-;; @001f                               v71 = icmp ugt v70, v69
-;; @001f                               trapnz v71, user2
+;; @001f                               v47 = uextend.i64 v41
+;; @001f                               v49 = iadd v144, v47
+;; @001f                               v51 = iadd v49, v43  ; v43 = 16
+;; @001f                               v52 = load.i32 user2 readonly region1 v51
+;; @001f                               v53 = uextend.i64 v52
+;; @001f                               v58 = icmp.i64 ugt v5, v53
+;; @001f                               trapnz v58, user17
+;; @001f                               v70 = load.i64 notrap aligned v143+40
+;; @001f                               v62 = iconst.i64 20
+;; @001f                               v63 = iadd v49, v62  ; v62 = 20
+;; @001f                               v72 = uadd_overflow_trap v63, v99, user2
+;; @001f                               v71 = iadd v144, v70
+;; @001f                               v73 = icmp ugt v72, v71
+;; @001f                               trapnz v73, user2
 ;;                                     v123 = iconst.i64 0
-;; @001f                               v74 = icmp.i64 eq v5, v123  ; v123 = 0
-;; @001f                               v44 = iconst.i32 0
+;; @001f                               v76 = icmp.i64 eq v5, v123  ; v123 = 0
+;; @001f                               v45 = iconst.i32 0
 ;;                                     v97 = iconst.i64 4
-;; @001f                               v72 = iadd v61, v99
-;; @001f                               brif v74, block6, block5(v61)
+;; @001f                               v74 = iadd v63, v99
+;; @001f                               brif v76, block6, block5(v63)
 ;;
-;;                                 block5(v75: i64):
+;;                                 block5(v77: i64):
 ;;                                     v145 = iconst.i32 0
-;; @001f                               store user2 little region1 v145, v75  ; v145 = 0
+;; @001f                               store user2 little region1 v145, v77  ; v145 = 0
 ;;                                     v146 = iconst.i64 4
-;;                                     v147 = iadd v75, v146  ; v146 = 4
-;; @001f                               v77 = icmp eq v147, v72
-;; @001f                               brif v77, block6, block5(v147)
+;;                                     v147 = iadd v77, v146  ; v146 = 4
+;; @001f                               v80 = icmp eq v147, v74
+;; @001f                               brif v80, block6, block5(v147)
 ;;
 ;;                                 block6:
 ;; @0022                               jump block1(v41)

--- a/tests/disas/gc/array-new-default-externref.wat
+++ b/tests/disas/gc/array-new-default-externref.wat
@@ -80,40 +80,40 @@
 ;; @001f                               jump block4(v29, v32)
 ;;
 ;;                                 block4(v41: i32, v42: i64):
-;;                                     v91 = iconst.i64 16
-;; @001f                               v43 = iadd v42, v91  ; v91 = 16
-;; @001f                               store.i32 user2 region1 v2, v43
+;; @001f                               v43 = iconst.i64 16
+;; @001f                               v44 = iadd v42, v43  ; v43 = 16
+;; @001f                               store.i32 user2 region1 v2, v44
 ;; @001f                               trapz v41, user16
 ;;                                     v143 = load.i64 notrap aligned readonly can_move v0+8
 ;;                                     v144 = load.i64 notrap aligned readonly can_move v143+32
-;; @001f                               v46 = uextend.i64 v41
-;; @001f                               v48 = iadd v144, v46
-;; @001f                               v50 = iadd v48, v91  ; v91 = 16
-;; @001f                               v51 = load.i32 user2 readonly region1 v50
-;; @001f                               v52 = uextend.i64 v51
-;; @001f                               v57 = icmp.i64 ugt v5, v52
-;; @001f                               trapnz v57, user17
-;; @001f                               v68 = load.i64 notrap aligned v143+40
-;;                                     v85 = iconst.i64 20
-;; @001f                               v61 = iadd v48, v85  ; v85 = 20
-;; @001f                               v70 = uadd_overflow_trap v61, v99, user2
-;; @001f                               v69 = iadd v144, v68
-;; @001f                               v71 = icmp ugt v70, v69
-;; @001f                               trapnz v71, user2
+;; @001f                               v47 = uextend.i64 v41
+;; @001f                               v49 = iadd v144, v47
+;; @001f                               v51 = iadd v49, v43  ; v43 = 16
+;; @001f                               v52 = load.i32 user2 readonly region1 v51
+;; @001f                               v53 = uextend.i64 v52
+;; @001f                               v58 = icmp.i64 ugt v5, v53
+;; @001f                               trapnz v58, user17
+;; @001f                               v70 = load.i64 notrap aligned v143+40
+;; @001f                               v62 = iconst.i64 20
+;; @001f                               v63 = iadd v49, v62  ; v62 = 20
+;; @001f                               v72 = uadd_overflow_trap v63, v99, user2
+;; @001f                               v71 = iadd v144, v70
+;; @001f                               v73 = icmp ugt v72, v71
+;; @001f                               trapnz v73, user2
 ;;                                     v123 = iconst.i64 0
-;; @001f                               v74 = icmp.i64 eq v5, v123  ; v123 = 0
-;; @001f                               v44 = iconst.i32 0
+;; @001f                               v76 = icmp.i64 eq v5, v123  ; v123 = 0
+;; @001f                               v45 = iconst.i32 0
 ;;                                     v97 = iconst.i64 4
-;; @001f                               v72 = iadd v61, v99
-;; @001f                               brif v74, block6, block5(v61)
+;; @001f                               v74 = iadd v63, v99
+;; @001f                               brif v76, block6, block5(v63)
 ;;
-;;                                 block5(v75: i64):
+;;                                 block5(v77: i64):
 ;;                                     v145 = iconst.i32 0
-;; @001f                               store user2 little region1 v145, v75  ; v145 = 0
+;; @001f                               store user2 little region1 v145, v77  ; v145 = 0
 ;;                                     v146 = iconst.i64 4
-;;                                     v147 = iadd v75, v146  ; v146 = 4
-;; @001f                               v77 = icmp eq v147, v72
-;; @001f                               brif v77, block6, block5(v147)
+;;                                     v147 = iadd v77, v146  ; v146 = 4
+;; @001f                               v80 = icmp eq v147, v74
+;; @001f                               brif v80, block6, block5(v147)
 ;;
 ;;                                 block6:
 ;; @0022                               jump block1(v41)

--- a/tests/disas/gc/array-new-default-f32.wat
+++ b/tests/disas/gc/array-new-default-f32.wat
@@ -85,31 +85,31 @@
 ;;                                 block4(v41: i32, v42: i64):
 ;;                                     v95 = stack_addr.i64 ss0
 ;;                                     store notrap v41, v95
-;;                                     v94 = iconst.i64 16
-;; @001f                               v43 = iadd v42, v94  ; v94 = 16
-;; @001f                               store.i32 user2 region1 v2, v43
+;; @001f                               v43 = iconst.i64 16
+;; @001f                               v44 = iadd v42, v43  ; v43 = 16
+;; @001f                               store.i32 user2 region1 v2, v44
 ;; @001f                               trapz v41, user16
 ;;                                     v147 = load.i64 notrap aligned readonly can_move v0+8
 ;;                                     v148 = load.i64 notrap aligned readonly can_move v147+32
-;; @001f                               v46 = uextend.i64 v41
-;; @001f                               v48 = iadd v148, v46
-;; @001f                               v50 = iadd v48, v94  ; v94 = 16
-;; @001f                               v51 = load.i32 user2 readonly region1 v50
-;; @001f                               v52 = uextend.i64 v51
-;; @001f                               v57 = icmp.i64 ugt v5, v52
-;; @001f                               trapnz v57, user17
-;; @001f                               v68 = load.i64 notrap aligned v147+40
-;;                                     v85 = iconst.i64 20
-;; @001f                               v61 = iadd v48, v85  ; v85 = 20
-;; @001f                               v70 = uadd_overflow_trap v61, v103, user2
-;; @001f                               v69 = iadd v148, v68
-;; @001f                               v71 = icmp ugt v70, v69
-;; @001f                               trapnz v71, user2
-;; @001f                               v45 = iconst.i32 0
-;; @001f                               call fn1(v0, v61, v45, v103), stack_map=[i32 @ ss0+0]  ; v45 = 0
-;;                                     v74 = load.i32 notrap v95
+;; @001f                               v47 = uextend.i64 v41
+;; @001f                               v49 = iadd v148, v47
+;; @001f                               v51 = iadd v49, v43  ; v43 = 16
+;; @001f                               v52 = load.i32 user2 readonly region1 v51
+;; @001f                               v53 = uextend.i64 v52
+;; @001f                               v58 = icmp.i64 ugt v5, v53
+;; @001f                               trapnz v58, user17
+;; @001f                               v70 = load.i64 notrap aligned v147+40
+;; @001f                               v62 = iconst.i64 20
+;; @001f                               v63 = iadd v49, v62  ; v62 = 20
+;; @001f                               v72 = uadd_overflow_trap v63, v103, user2
+;; @001f                               v71 = iadd v148, v70
+;; @001f                               v73 = icmp ugt v72, v71
+;; @001f                               trapnz v73, user2
+;; @001f                               v46 = iconst.i32 0
+;; @001f                               call fn1(v0, v63, v46, v103), stack_map=[i32 @ ss0+0]  ; v46 = 0
+;;                                     v76 = load.i32 notrap v95
 ;; @0022                               jump block1
 ;;
 ;;                                 block1:
-;; @0022                               return v74
+;; @0022                               return v76
 ;; }

--- a/tests/disas/gc/array-new-default-f64.wat
+++ b/tests/disas/gc/array-new-default-f64.wat
@@ -85,31 +85,31 @@
 ;;                                 block4(v41: i32, v42: i64):
 ;;                                     v95 = stack_addr.i64 ss0
 ;;                                     store notrap v41, v95
-;;                                     v94 = iconst.i64 16
-;; @001f                               v43 = iadd v42, v94  ; v94 = 16
-;; @001f                               store.i32 user2 region1 v2, v43
+;; @001f                               v43 = iconst.i64 16
+;; @001f                               v44 = iadd v42, v43  ; v43 = 16
+;; @001f                               store.i32 user2 region1 v2, v44
 ;; @001f                               trapz v41, user16
 ;;                                     v147 = load.i64 notrap aligned readonly can_move v0+8
 ;;                                     v148 = load.i64 notrap aligned readonly can_move v147+32
-;; @001f                               v46 = uextend.i64 v41
-;; @001f                               v48 = iadd v148, v46
-;; @001f                               v50 = iadd v48, v94  ; v94 = 16
-;; @001f                               v51 = load.i32 user2 readonly region1 v50
-;; @001f                               v52 = uextend.i64 v51
-;; @001f                               v57 = icmp.i64 ugt v5, v52
-;; @001f                               trapnz v57, user17
-;; @001f                               v68 = load.i64 notrap aligned v147+40
-;;                                     v85 = iconst.i64 24
-;; @001f                               v61 = iadd v48, v85  ; v85 = 24
-;; @001f                               v70 = uadd_overflow_trap v61, v103, user2
-;; @001f                               v69 = iadd v148, v68
-;; @001f                               v71 = icmp ugt v70, v69
-;; @001f                               trapnz v71, user2
-;; @001f                               v45 = iconst.i32 0
-;; @001f                               call fn1(v0, v61, v45, v103), stack_map=[i32 @ ss0+0]  ; v45 = 0
-;;                                     v74 = load.i32 notrap v95
+;; @001f                               v47 = uextend.i64 v41
+;; @001f                               v49 = iadd v148, v47
+;; @001f                               v51 = iadd v49, v43  ; v43 = 16
+;; @001f                               v52 = load.i32 user2 readonly region1 v51
+;; @001f                               v53 = uextend.i64 v52
+;; @001f                               v58 = icmp.i64 ugt v5, v53
+;; @001f                               trapnz v58, user17
+;; @001f                               v70 = load.i64 notrap aligned v147+40
+;; @001f                               v62 = iconst.i64 24
+;; @001f                               v63 = iadd v49, v62  ; v62 = 24
+;; @001f                               v72 = uadd_overflow_trap v63, v103, user2
+;; @001f                               v71 = iadd v148, v70
+;; @001f                               v73 = icmp ugt v72, v71
+;; @001f                               trapnz v73, user2
+;; @001f                               v46 = iconst.i32 0
+;; @001f                               call fn1(v0, v63, v46, v103), stack_map=[i32 @ ss0+0]  ; v46 = 0
+;;                                     v76 = load.i32 notrap v95
 ;; @0022                               jump block1
 ;;
 ;;                                 block1:
-;; @0022                               return v74
+;; @0022                               return v76
 ;; }

--- a/tests/disas/gc/array-new-default-funcref.wat
+++ b/tests/disas/gc/array-new-default-funcref.wat
@@ -85,45 +85,45 @@
 ;;                                 block4(v41: i32, v42: i64):
 ;;                                     v103 = stack_addr.i64 ss0
 ;;                                     store notrap v41, v103
-;;                                     v102 = iconst.i64 16
-;; @001f                               v43 = iadd v42, v102  ; v102 = 16
-;; @001f                               store.i32 user2 region1 v2, v43
+;; @001f                               v43 = iconst.i64 16
+;; @001f                               v44 = iadd v42, v43  ; v43 = 16
+;; @001f                               store.i32 user2 region1 v2, v44
 ;; @001f                               trapz v41, user16
 ;;                                     v154 = load.i64 notrap aligned readonly can_move v0+8
 ;;                                     v155 = load.i64 notrap aligned readonly can_move v154+32
-;; @001f                               v46 = uextend.i64 v41
-;; @001f                               v48 = iadd v155, v46
-;; @001f                               v50 = iadd v48, v102  ; v102 = 16
-;; @001f                               v51 = load.i32 user2 readonly region1 v50
-;; @001f                               v52 = uextend.i64 v51
-;; @001f                               v57 = icmp.i64 ugt v5, v52
-;; @001f                               trapnz v57, user17
-;; @001f                               v68 = load.i64 notrap aligned v154+40
-;;                                     v93 = iconst.i64 20
-;; @001f                               v61 = iadd v48, v93  ; v93 = 20
-;; @001f                               v70 = uadd_overflow_trap v61, v111, user2
-;; @001f                               v69 = iadd v155, v68
-;; @001f                               v71 = icmp ugt v70, v69
-;; @001f                               trapnz v71, user2
-;; @001f                               v44 = iconst.i64 0
-;; @001f                               v73 = call fn1(v0, v44), stack_map=[i32 @ ss0+0]  ; v44 = 0
-;; @001f                               v77 = icmp.i64 eq v5, v44  ; v44 = 0
-;; @001f                               v74 = ireduce.i32 v73
+;; @001f                               v47 = uextend.i64 v41
+;; @001f                               v49 = iadd v155, v47
+;; @001f                               v51 = iadd v49, v43  ; v43 = 16
+;; @001f                               v52 = load.i32 user2 readonly region1 v51
+;; @001f                               v53 = uextend.i64 v52
+;; @001f                               v58 = icmp.i64 ugt v5, v53
+;; @001f                               trapnz v58, user17
+;; @001f                               v70 = load.i64 notrap aligned v154+40
+;; @001f                               v62 = iconst.i64 20
+;; @001f                               v63 = iadd v49, v62  ; v62 = 20
+;; @001f                               v72 = uadd_overflow_trap v63, v111, user2
+;; @001f                               v71 = iadd v155, v70
+;; @001f                               v73 = icmp ugt v72, v71
+;; @001f                               trapnz v73, user2
+;; @001f                               v45 = iconst.i64 0
+;; @001f                               v75 = call fn1(v0, v45), stack_map=[i32 @ ss0+0]  ; v45 = 0
+;; @001f                               v79 = icmp.i64 eq v5, v45  ; v45 = 0
+;; @001f                               v76 = ireduce.i32 v75
 ;;                                     v109 = iconst.i64 4
-;; @001f                               v75 = iadd v61, v111
-;; @001f                               brif v77, block6, block5(v61)
+;; @001f                               v77 = iadd v63, v111
+;; @001f                               brif v79, block6, block5(v63)
 ;;
-;;                                 block5(v78: i64):
-;; @001f                               store.i32 notrap aligned little v74, v78
+;;                                 block5(v80: i64):
+;; @001f                               store.i32 notrap aligned little v76, v80
 ;;                                     v156 = iconst.i64 4
-;;                                     v157 = iadd v78, v156  ; v156 = 4
-;; @001f                               v80 = icmp eq v157, v75
-;; @001f                               brif v80, block6, block5(v157)
+;;                                     v157 = iadd v80, v156  ; v156 = 4
+;; @001f                               v83 = icmp eq v157, v77
+;; @001f                               brif v83, block6, block5(v157)
 ;;
 ;;                                 block6:
-;;                                     v81 = load.i32 notrap v103
+;;                                     v84 = load.i32 notrap v103
 ;; @0022                               jump block1
 ;;
 ;;                                 block1:
-;; @0022                               return v81
+;; @0022                               return v84
 ;; }

--- a/tests/disas/gc/array-new-default-i16.wat
+++ b/tests/disas/gc/array-new-default-i16.wat
@@ -84,31 +84,31 @@
 ;;                                 block4(v41: i32, v42: i64):
 ;;                                     v95 = stack_addr.i64 ss0
 ;;                                     store notrap v41, v95
-;;                                     v94 = iconst.i64 16
-;; @001f                               v43 = iadd v42, v94  ; v94 = 16
-;; @001f                               store.i32 user2 region1 v2, v43
+;; @001f                               v43 = iconst.i64 16
+;; @001f                               v44 = iadd v42, v43  ; v43 = 16
+;; @001f                               store.i32 user2 region1 v2, v44
 ;; @001f                               trapz v41, user16
 ;;                                     v157 = load.i64 notrap aligned readonly can_move v0+8
 ;;                                     v158 = load.i64 notrap aligned readonly can_move v157+32
-;; @001f                               v46 = uextend.i64 v41
-;; @001f                               v48 = iadd v158, v46
-;; @001f                               v50 = iadd v48, v94  ; v94 = 16
-;; @001f                               v51 = load.i32 user2 readonly region1 v50
-;; @001f                               v52 = uextend.i64 v51
-;; @001f                               v57 = icmp.i64 ugt v5, v52
-;; @001f                               trapnz v57, user17
-;; @001f                               v68 = load.i64 notrap aligned v157+40
-;;                                     v85 = iconst.i64 20
-;; @001f                               v61 = iadd v48, v85  ; v85 = 20
-;; @001f                               v70 = uadd_overflow_trap v61, v104, user2
-;; @001f                               v69 = iadd v158, v68
-;; @001f                               v71 = icmp ugt v70, v69
-;; @001f                               trapnz v71, user2
-;; @001f                               v44 = iconst.i32 0
-;; @001f                               call fn1(v0, v61, v44, v104), stack_map=[i32 @ ss0+0]  ; v44 = 0
-;;                                     v74 = load.i32 notrap v95
+;; @001f                               v47 = uextend.i64 v41
+;; @001f                               v49 = iadd v158, v47
+;; @001f                               v51 = iadd v49, v43  ; v43 = 16
+;; @001f                               v52 = load.i32 user2 readonly region1 v51
+;; @001f                               v53 = uextend.i64 v52
+;; @001f                               v58 = icmp.i64 ugt v5, v53
+;; @001f                               trapnz v58, user17
+;; @001f                               v70 = load.i64 notrap aligned v157+40
+;; @001f                               v62 = iconst.i64 20
+;; @001f                               v63 = iadd v49, v62  ; v62 = 20
+;; @001f                               v72 = uadd_overflow_trap v63, v104, user2
+;; @001f                               v71 = iadd v158, v70
+;; @001f                               v73 = icmp ugt v72, v71
+;; @001f                               trapnz v73, user2
+;; @001f                               v45 = iconst.i32 0
+;; @001f                               call fn1(v0, v63, v45, v104), stack_map=[i32 @ ss0+0]  ; v45 = 0
+;;                                     v76 = load.i32 notrap v95
 ;; @0022                               jump block1
 ;;
 ;;                                 block1:
-;; @0022                               return v74
+;; @0022                               return v76
 ;; }

--- a/tests/disas/gc/array-new-default-i32.wat
+++ b/tests/disas/gc/array-new-default-i32.wat
@@ -85,31 +85,31 @@
 ;;                                 block4(v41: i32, v42: i64):
 ;;                                     v95 = stack_addr.i64 ss0
 ;;                                     store notrap v41, v95
-;;                                     v94 = iconst.i64 16
-;; @001f                               v43 = iadd v42, v94  ; v94 = 16
-;; @001f                               store.i32 user2 region1 v2, v43
+;; @001f                               v43 = iconst.i64 16
+;; @001f                               v44 = iadd v42, v43  ; v43 = 16
+;; @001f                               store.i32 user2 region1 v2, v44
 ;; @001f                               trapz v41, user16
 ;;                                     v147 = load.i64 notrap aligned readonly can_move v0+8
 ;;                                     v148 = load.i64 notrap aligned readonly can_move v147+32
-;; @001f                               v46 = uextend.i64 v41
-;; @001f                               v48 = iadd v148, v46
-;; @001f                               v50 = iadd v48, v94  ; v94 = 16
-;; @001f                               v51 = load.i32 user2 readonly region1 v50
-;; @001f                               v52 = uextend.i64 v51
-;; @001f                               v57 = icmp.i64 ugt v5, v52
-;; @001f                               trapnz v57, user17
-;; @001f                               v68 = load.i64 notrap aligned v147+40
-;;                                     v85 = iconst.i64 20
-;; @001f                               v61 = iadd v48, v85  ; v85 = 20
-;; @001f                               v70 = uadd_overflow_trap v61, v103, user2
-;; @001f                               v69 = iadd v148, v68
-;; @001f                               v71 = icmp ugt v70, v69
-;; @001f                               trapnz v71, user2
-;; @001f                               v44 = iconst.i32 0
-;; @001f                               call fn1(v0, v61, v44, v103), stack_map=[i32 @ ss0+0]  ; v44 = 0
-;;                                     v74 = load.i32 notrap v95
+;; @001f                               v47 = uextend.i64 v41
+;; @001f                               v49 = iadd v148, v47
+;; @001f                               v51 = iadd v49, v43  ; v43 = 16
+;; @001f                               v52 = load.i32 user2 readonly region1 v51
+;; @001f                               v53 = uextend.i64 v52
+;; @001f                               v58 = icmp.i64 ugt v5, v53
+;; @001f                               trapnz v58, user17
+;; @001f                               v70 = load.i64 notrap aligned v147+40
+;; @001f                               v62 = iconst.i64 20
+;; @001f                               v63 = iadd v49, v62  ; v62 = 20
+;; @001f                               v72 = uadd_overflow_trap v63, v103, user2
+;; @001f                               v71 = iadd v148, v70
+;; @001f                               v73 = icmp ugt v72, v71
+;; @001f                               trapnz v73, user2
+;; @001f                               v45 = iconst.i32 0
+;; @001f                               call fn1(v0, v63, v45, v103), stack_map=[i32 @ ss0+0]  ; v45 = 0
+;;                                     v76 = load.i32 notrap v95
 ;; @0022                               jump block1
 ;;
 ;;                                 block1:
-;; @0022                               return v74
+;; @0022                               return v76
 ;; }

--- a/tests/disas/gc/array-new-default-i64.wat
+++ b/tests/disas/gc/array-new-default-i64.wat
@@ -85,31 +85,31 @@
 ;;                                 block4(v41: i32, v42: i64):
 ;;                                     v95 = stack_addr.i64 ss0
 ;;                                     store notrap v41, v95
-;;                                     v94 = iconst.i64 16
-;; @001f                               v43 = iadd v42, v94  ; v94 = 16
-;; @001f                               store.i32 user2 region1 v2, v43
+;; @001f                               v43 = iconst.i64 16
+;; @001f                               v44 = iadd v42, v43  ; v43 = 16
+;; @001f                               store.i32 user2 region1 v2, v44
 ;; @001f                               trapz v41, user16
 ;;                                     v146 = load.i64 notrap aligned readonly can_move v0+8
 ;;                                     v147 = load.i64 notrap aligned readonly can_move v146+32
-;; @001f                               v46 = uextend.i64 v41
-;; @001f                               v48 = iadd v147, v46
-;; @001f                               v50 = iadd v48, v94  ; v94 = 16
-;; @001f                               v51 = load.i32 user2 readonly region1 v50
-;; @001f                               v52 = uextend.i64 v51
-;; @001f                               v57 = icmp.i64 ugt v5, v52
-;; @001f                               trapnz v57, user17
-;; @001f                               v68 = load.i64 notrap aligned v146+40
-;;                                     v85 = iconst.i64 24
-;; @001f                               v61 = iadd v48, v85  ; v85 = 24
-;; @001f                               v70 = uadd_overflow_trap v61, v103, user2
-;; @001f                               v69 = iadd v147, v68
-;; @001f                               v71 = icmp ugt v70, v69
-;; @001f                               trapnz v71, user2
-;; @001f                               v45 = iconst.i32 0
-;; @001f                               call fn1(v0, v61, v45, v103), stack_map=[i32 @ ss0+0]  ; v45 = 0
-;;                                     v74 = load.i32 notrap v95
+;; @001f                               v47 = uextend.i64 v41
+;; @001f                               v49 = iadd v147, v47
+;; @001f                               v51 = iadd v49, v43  ; v43 = 16
+;; @001f                               v52 = load.i32 user2 readonly region1 v51
+;; @001f                               v53 = uextend.i64 v52
+;; @001f                               v58 = icmp.i64 ugt v5, v53
+;; @001f                               trapnz v58, user17
+;; @001f                               v70 = load.i64 notrap aligned v146+40
+;; @001f                               v62 = iconst.i64 24
+;; @001f                               v63 = iadd v49, v62  ; v62 = 24
+;; @001f                               v72 = uadd_overflow_trap v63, v103, user2
+;; @001f                               v71 = iadd v147, v70
+;; @001f                               v73 = icmp ugt v72, v71
+;; @001f                               trapnz v73, user2
+;; @001f                               v46 = iconst.i32 0
+;; @001f                               call fn1(v0, v63, v46, v103), stack_map=[i32 @ ss0+0]  ; v46 = 0
+;;                                     v76 = load.i32 notrap v95
 ;; @0022                               jump block1
 ;;
 ;;                                 block1:
-;; @0022                               return v74
+;; @0022                               return v76
 ;; }

--- a/tests/disas/gc/array-new-default-i8.wat
+++ b/tests/disas/gc/array-new-default-i8.wat
@@ -81,31 +81,31 @@
 ;;                                 block4(v41: i32, v42: i64):
 ;;                                     v94 = stack_addr.i64 ss0
 ;;                                     store notrap v41, v94
-;;                                     v93 = iconst.i64 16
-;; @001f                               v43 = iadd v42, v93  ; v93 = 16
-;; @001f                               store.i32 user2 region1 v2, v43
+;; @001f                               v43 = iconst.i64 16
+;; @001f                               v44 = iadd v42, v43  ; v43 = 16
+;; @001f                               store.i32 user2 region1 v2, v44
 ;; @001f                               trapz v41, user16
 ;;                                     v135 = load.i64 notrap aligned readonly can_move v0+8
 ;;                                     v136 = load.i64 notrap aligned readonly can_move v135+32
-;; @001f                               v46 = uextend.i64 v41
-;; @001f                               v48 = iadd v136, v46
-;; @001f                               v50 = iadd v48, v93  ; v93 = 16
-;; @001f                               v51 = load.i32 user2 readonly region1 v50
-;; @001f                               v52 = uextend.i64 v51
-;; @001f                               v57 = icmp.i64 ugt v5, v52
-;; @001f                               trapnz v57, user17
-;; @001f                               v68 = load.i64 notrap aligned v135+40
-;;                                     v84 = iconst.i64 20
-;; @001f                               v61 = iadd v48, v84  ; v84 = 20
-;; @001f                               v70 = uadd_overflow_trap v61, v5, user2
-;; @001f                               v69 = iadd v136, v68
-;; @001f                               v71 = icmp ugt v70, v69
-;; @001f                               trapnz v71, user2
-;; @001f                               v44 = iconst.i32 0
-;; @001f                               call fn1(v0, v61, v44, v5), stack_map=[i32 @ ss0+0]  ; v44 = 0
-;;                                     v73 = load.i32 notrap v94
+;; @001f                               v47 = uextend.i64 v41
+;; @001f                               v49 = iadd v136, v47
+;; @001f                               v51 = iadd v49, v43  ; v43 = 16
+;; @001f                               v52 = load.i32 user2 readonly region1 v51
+;; @001f                               v53 = uextend.i64 v52
+;; @001f                               v58 = icmp.i64 ugt v5, v53
+;; @001f                               trapnz v58, user17
+;; @001f                               v70 = load.i64 notrap aligned v135+40
+;; @001f                               v62 = iconst.i64 20
+;; @001f                               v63 = iadd v49, v62  ; v62 = 20
+;; @001f                               v72 = uadd_overflow_trap v63, v5, user2
+;; @001f                               v71 = iadd v136, v70
+;; @001f                               v73 = icmp ugt v72, v71
+;; @001f                               trapnz v73, user2
+;; @001f                               v45 = iconst.i32 0
+;; @001f                               call fn1(v0, v63, v45, v5), stack_map=[i32 @ ss0+0]  ; v45 = 0
+;;                                     v75 = load.i32 notrap v94
 ;; @0022                               jump block1
 ;;
 ;;                                 block1:
-;; @0022                               return v73
+;; @0022                               return v75
 ;; }

--- a/tests/disas/gc/copying/array-fill.wat
+++ b/tests/disas/gc/copying/array-fill.wat
@@ -34,29 +34,29 @@
 ;; @0027                               v12 = uextend.i64 v11
 ;; @0027                               v17 = icmp ugt v16, v12
 ;; @0027                               trapnz v17, user17
-;; @0027                               v28 = load.i64 notrap aligned v49+40
-;;                                     v45 = iconst.i64 24
-;; @0027                               v21 = iadd v8, v45  ; v45 = 24
+;; @0027                               v29 = load.i64 notrap aligned v49+40
+;; @0027                               v21 = iconst.i64 24
+;; @0027                               v22 = iadd v8, v21  ; v21 = 24
 ;;                                     v53 = iconst.i64 3
 ;;                                     v54 = ishl v13, v53  ; v53 = 3
-;; @0027                               v24 = iadd v21, v54
+;; @0027                               v25 = iadd v22, v54
 ;;                                     v56 = ishl v14, v53  ; v53 = 3
-;; @0027                               v30 = uadd_overflow_trap v24, v56, user2
-;; @0027                               v29 = iadd v7, v28
-;; @0027                               v31 = icmp ugt v30, v29
-;; @0027                               trapnz v31, user2
+;; @0027                               v31 = uadd_overflow_trap v25, v56, user2
+;; @0027                               v30 = iadd v7, v29
+;; @0027                               v32 = icmp ugt v31, v30
+;; @0027                               trapnz v32, user2
 ;;                                     v51 = iconst.i64 0
-;; @0027                               v34 = icmp eq v14, v51  ; v51 = 0
-;;                                     v44 = iconst.i64 8
-;; @0027                               v32 = iadd v24, v56
-;; @0027                               brif v34, block3, block2(v24)
+;; @0027                               v35 = icmp eq v14, v51  ; v51 = 0
+;;                                     v45 = iconst.i64 8
+;; @0027                               v33 = iadd v25, v56
+;; @0027                               brif v35, block3, block2(v25)
 ;;
-;;                                 block2(v35: i64):
-;; @0027                               store.i64 user2 little region0 v4, v35
+;;                                 block2(v36: i64):
+;; @0027                               store.i64 user2 little region0 v4, v36
 ;;                                     v58 = iconst.i64 8
-;;                                     v59 = iadd v35, v58  ; v58 = 8
-;; @0027                               v37 = icmp eq v59, v32
-;; @0027                               brif v37, block3, block2(v59)
+;;                                     v59 = iadd v36, v58  ; v58 = 8
+;; @0027                               v39 = icmp eq v59, v33
+;; @0027                               brif v39, block3, block2(v59)
 ;;
 ;;                                 block3:
 ;; @002a                               jump block1

--- a/tests/disas/gc/copying/array-new-fixed-of-gc-refs.wat
+++ b/tests/disas/gc/copying/array-new-fixed-of-gc-refs.wat
@@ -73,74 +73,74 @@
 ;;
 ;;                                 block4(v44: i32, v45: i64):
 ;; @0025                               v6 = iconst.i32 3
-;;                                     v143 = iconst.i64 16
-;; @0025                               v46 = iadd v45, v143  ; v143 = 16
-;; @0025                               store user2 region1 v6, v46  ; v6 = 3
+;; @0025                               v46 = iconst.i64 16
+;; @0025                               v47 = iadd v45, v46  ; v46 = 16
+;; @0025                               store user2 region1 v6, v47  ; v6 = 3
 ;; @0025                               trapz v44, user16
 ;;                                     v279 = load.i64 notrap aligned readonly can_move v0+8
 ;;                                     v280 = load.i64 notrap aligned readonly can_move v279+32
-;; @0025                               v48 = uextend.i64 v44
-;; @0025                               v50 = iadd v280, v48
-;; @0025                               v52 = iadd v50, v143  ; v143 = 16
-;; @0025                               v53 = load.i32 user2 readonly region1 v52
-;; @0025                               v47 = iconst.i32 0
-;;                                     v181 = icmp ne v53, v47  ; v47 = 0
+;; @0025                               v49 = uextend.i64 v44
+;; @0025                               v51 = iadd v280, v49
+;; @0025                               v53 = iadd v51, v46  ; v46 = 16
+;; @0025                               v54 = load.i32 user2 readonly region1 v53
+;; @0025                               v48 = iconst.i32 0
+;;                                     v181 = icmp ne v54, v48  ; v48 = 0
 ;; @0025                               trapz v181, user17
-;; @0025                               v56 = uextend.i64 v53
+;; @0025                               v57 = uextend.i64 v54
 ;;                                     v155 = iconst.i64 2
-;;                                     v184 = ishl v56, v155  ; v155 = 2
+;;                                     v184 = ishl v57, v155  ; v155 = 2
 ;;                                     v281 = iconst.i64 32
 ;;                                     v282 = ushr v184, v281  ; v281 = 32
 ;; @0025                               trapnz v282, user2
 ;;                                     v193 = iconst.i32 2
-;;                                     v194 = ishl v53, v193  ; v193 = 2
+;;                                     v194 = ishl v54, v193  ; v193 = 2
 ;; @0025                               v7 = iconst.i32 20
-;; @0025                               v61 = uadd_overflow_trap v194, v7, user2  ; v7 = 20
-;; @0025                               v65 = uadd_overflow_trap v44, v61, user2
-;;                                     v124 = load.i32 notrap v152
-;; @0025                               v66 = uextend.i64 v65
-;; @0025                               v68 = iadd v280, v66
-;; @0025                               v69 = isub v61, v7  ; v7 = 20
-;; @0025                               v70 = uextend.i64 v69
-;; @0025                               v71 = isub v68, v70
-;; @0025                               store user2 little region1 v124, v71
-;; @0025                               v78 = load.i32 user2 readonly region1 v52
-;; @0025                               v72 = iconst.i32 1
-;;                                     v211 = icmp ugt v78, v72  ; v72 = 1
+;; @0025                               v62 = uadd_overflow_trap v194, v7, user2  ; v7 = 20
+;; @0025                               v66 = uadd_overflow_trap v44, v62, user2
+;;                                     v125 = load.i32 notrap v152
+;; @0025                               v67 = uextend.i64 v66
+;; @0025                               v69 = iadd v280, v67
+;; @0025                               v70 = isub v62, v7  ; v7 = 20
+;; @0025                               v71 = uextend.i64 v70
+;; @0025                               v72 = isub v69, v71
+;; @0025                               store user2 little region1 v125, v72
+;; @0025                               v79 = load.i32 user2 readonly region1 v53
+;; @0025                               v73 = iconst.i32 1
+;;                                     v211 = icmp ugt v79, v73  ; v73 = 1
 ;; @0025                               trapz v211, user17
-;; @0025                               v81 = uextend.i64 v78
-;;                                     v213 = ishl v81, v155  ; v155 = 2
+;; @0025                               v82 = uextend.i64 v79
+;;                                     v213 = ishl v82, v155  ; v155 = 2
 ;;                                     v283 = ushr v213, v281  ; v281 = 32
 ;; @0025                               trapnz v283, user2
-;;                                     v220 = ishl v78, v193  ; v193 = 2
-;; @0025                               v86 = uadd_overflow_trap v220, v7, user2  ; v7 = 20
-;; @0025                               v90 = uadd_overflow_trap v44, v86, user2
-;;                                     v123 = load.i32 notrap v151
-;; @0025                               v91 = uextend.i64 v90
-;; @0025                               v93 = iadd v280, v91
+;;                                     v220 = ishl v79, v193  ; v193 = 2
+;; @0025                               v87 = uadd_overflow_trap v220, v7, user2  ; v7 = 20
+;; @0025                               v91 = uadd_overflow_trap v44, v87, user2
+;;                                     v124 = load.i32 notrap v151
+;; @0025                               v92 = uextend.i64 v91
+;; @0025                               v94 = iadd v280, v92
 ;;                                     v233 = iconst.i32 24
-;; @0025                               v94 = isub v86, v233  ; v233 = 24
-;; @0025                               v95 = uextend.i64 v94
-;; @0025                               v96 = isub v93, v95
-;; @0025                               store user2 little region1 v123, v96
-;; @0025                               v103 = load.i32 user2 readonly region1 v52
-;;                                     v239 = icmp ugt v103, v193  ; v193 = 2
+;; @0025                               v95 = isub v87, v233  ; v233 = 24
+;; @0025                               v96 = uextend.i64 v95
+;; @0025                               v97 = isub v94, v96
+;; @0025                               store user2 little region1 v124, v97
+;; @0025                               v104 = load.i32 user2 readonly region1 v53
+;;                                     v239 = icmp ugt v104, v193  ; v193 = 2
 ;; @0025                               trapz v239, user17
-;; @0025                               v106 = uextend.i64 v103
-;;                                     v241 = ishl v106, v155  ; v155 = 2
+;; @0025                               v107 = uextend.i64 v104
+;;                                     v241 = ishl v107, v155  ; v155 = 2
 ;;                                     v284 = ushr v241, v281  ; v281 = 32
 ;; @0025                               trapnz v284, user2
-;;                                     v248 = ishl v103, v193  ; v193 = 2
-;; @0025                               v111 = uadd_overflow_trap v248, v7, user2  ; v7 = 20
-;; @0025                               v115 = uadd_overflow_trap v44, v111, user2
-;;                                     v122 = load.i32 notrap v150
-;; @0025                               v116 = uextend.i64 v115
-;; @0025                               v118 = iadd v280, v116
+;;                                     v248 = ishl v104, v193  ; v193 = 2
+;; @0025                               v112 = uadd_overflow_trap v248, v7, user2  ; v7 = 20
+;; @0025                               v116 = uadd_overflow_trap v44, v112, user2
+;;                                     v123 = load.i32 notrap v150
+;; @0025                               v117 = uextend.i64 v116
+;; @0025                               v119 = iadd v280, v117
 ;;                                     v266 = iconst.i32 28
-;; @0025                               v119 = isub v111, v266  ; v266 = 28
-;; @0025                               v120 = uextend.i64 v119
-;; @0025                               v121 = isub v118, v120
-;; @0025                               store user2 little region1 v122, v121
+;; @0025                               v120 = isub v112, v266  ; v266 = 28
+;; @0025                               v121 = uextend.i64 v120
+;; @0025                               v122 = isub v119, v121
+;; @0025                               store user2 little region1 v123, v122
 ;; @0029                               jump block1(v44)
 ;;
 ;;                                 block1(v5: i32):

--- a/tests/disas/gc/copying/array-new-fixed.wat
+++ b/tests/disas/gc/copying/array-new-fixed.wat
@@ -64,71 +64,71 @@
 ;;
 ;;                                 block4(v44: i32, v45: i64):
 ;; @0025                               v6 = iconst.i32 3
-;;                                     v137 = iconst.i64 16
-;; @0025                               v46 = iadd v45, v137  ; v137 = 16
-;; @0025                               store user2 region1 v6, v46  ; v6 = 3
+;; @0025                               v46 = iconst.i64 16
+;; @0025                               v47 = iadd v45, v46  ; v46 = 16
+;; @0025                               store user2 region1 v6, v47  ; v6 = 3
 ;; @0025                               trapz v44, user16
 ;;                                     v267 = load.i64 notrap aligned readonly can_move v0+8
 ;;                                     v268 = load.i64 notrap aligned readonly can_move v267+32
-;; @0025                               v48 = uextend.i64 v44
-;; @0025                               v50 = iadd v268, v48
-;; @0025                               v52 = iadd v50, v137  ; v137 = 16
-;; @0025                               v53 = load.i32 user2 readonly region1 v52
-;; @0025                               v47 = iconst.i32 0
-;;                                     v171 = icmp ne v53, v47  ; v47 = 0
+;; @0025                               v49 = uextend.i64 v44
+;; @0025                               v51 = iadd v268, v49
+;; @0025                               v53 = iadd v51, v46  ; v46 = 16
+;; @0025                               v54 = load.i32 user2 readonly region1 v53
+;; @0025                               v48 = iconst.i32 0
+;;                                     v171 = icmp ne v54, v48  ; v48 = 0
 ;; @0025                               trapz v171, user17
-;; @0025                               v56 = uextend.i64 v53
+;; @0025                               v57 = uextend.i64 v54
 ;;                                     v144 = iconst.i64 3
-;;                                     v174 = ishl v56, v144  ; v144 = 3
+;;                                     v174 = ishl v57, v144  ; v144 = 3
 ;;                                     v142 = iconst.i64 32
-;; @0025                               v58 = ushr v174, v142  ; v142 = 32
-;; @0025                               trapnz v58, user2
-;;                                     v183 = ishl v53, v6  ; v6 = 3
+;; @0025                               v59 = ushr v174, v142  ; v142 = 32
+;; @0025                               trapnz v59, user2
+;;                                     v183 = ishl v54, v6  ; v6 = 3
 ;; @0025                               v7 = iconst.i32 24
-;; @0025                               v61 = uadd_overflow_trap v183, v7, user2  ; v7 = 24
-;; @0025                               v65 = uadd_overflow_trap v44, v61, user2
-;; @0025                               v66 = uextend.i64 v65
-;; @0025                               v68 = iadd v268, v66
-;; @0025                               v69 = isub v61, v7  ; v7 = 24
-;; @0025                               v70 = uextend.i64 v69
-;; @0025                               v71 = isub v68, v70
-;; @0025                               store.i64 user2 little region1 v2, v71
-;; @0025                               v78 = load.i32 user2 readonly region1 v52
-;; @0025                               v72 = iconst.i32 1
-;;                                     v200 = icmp ugt v78, v72  ; v72 = 1
+;; @0025                               v62 = uadd_overflow_trap v183, v7, user2  ; v7 = 24
+;; @0025                               v66 = uadd_overflow_trap v44, v62, user2
+;; @0025                               v67 = uextend.i64 v66
+;; @0025                               v69 = iadd v268, v67
+;; @0025                               v70 = isub v62, v7  ; v7 = 24
+;; @0025                               v71 = uextend.i64 v70
+;; @0025                               v72 = isub v69, v71
+;; @0025                               store.i64 user2 little region1 v2, v72
+;; @0025                               v79 = load.i32 user2 readonly region1 v53
+;; @0025                               v73 = iconst.i32 1
+;;                                     v200 = icmp ugt v79, v73  ; v73 = 1
 ;; @0025                               trapz v200, user17
-;; @0025                               v81 = uextend.i64 v78
-;;                                     v202 = ishl v81, v144  ; v144 = 3
-;; @0025                               v83 = ushr v202, v142  ; v142 = 32
-;; @0025                               trapnz v83, user2
-;;                                     v209 = ishl v78, v6  ; v6 = 3
-;; @0025                               v86 = uadd_overflow_trap v209, v7, user2  ; v7 = 24
-;; @0025                               v90 = uadd_overflow_trap v44, v86, user2
-;; @0025                               v91 = uextend.i64 v90
-;; @0025                               v93 = iadd v268, v91
+;; @0025                               v82 = uextend.i64 v79
+;;                                     v202 = ishl v82, v144  ; v144 = 3
+;; @0025                               v84 = ushr v202, v142  ; v142 = 32
+;; @0025                               trapnz v84, user2
+;;                                     v209 = ishl v79, v6  ; v6 = 3
+;; @0025                               v87 = uadd_overflow_trap v209, v7, user2  ; v7 = 24
+;; @0025                               v91 = uadd_overflow_trap v44, v87, user2
+;; @0025                               v92 = uextend.i64 v91
+;; @0025                               v94 = iadd v268, v92
 ;;                                     v222 = iconst.i32 32
-;; @0025                               v94 = isub v86, v222  ; v222 = 32
-;; @0025                               v95 = uextend.i64 v94
-;; @0025                               v96 = isub v93, v95
-;; @0025                               store.i64 user2 little region1 v3, v96
-;; @0025                               v103 = load.i32 user2 readonly region1 v52
-;; @0025                               v97 = iconst.i32 2
-;;                                     v228 = icmp ugt v103, v97  ; v97 = 2
+;; @0025                               v95 = isub v87, v222  ; v222 = 32
+;; @0025                               v96 = uextend.i64 v95
+;; @0025                               v97 = isub v94, v96
+;; @0025                               store.i64 user2 little region1 v3, v97
+;; @0025                               v104 = load.i32 user2 readonly region1 v53
+;; @0025                               v98 = iconst.i32 2
+;;                                     v228 = icmp ugt v104, v98  ; v98 = 2
 ;; @0025                               trapz v228, user17
-;; @0025                               v106 = uextend.i64 v103
-;;                                     v230 = ishl v106, v144  ; v144 = 3
-;; @0025                               v108 = ushr v230, v142  ; v142 = 32
-;; @0025                               trapnz v108, user2
-;;                                     v237 = ishl v103, v6  ; v6 = 3
-;; @0025                               v111 = uadd_overflow_trap v237, v7, user2  ; v7 = 24
-;; @0025                               v115 = uadd_overflow_trap v44, v111, user2
-;; @0025                               v116 = uextend.i64 v115
-;; @0025                               v118 = iadd v268, v116
+;; @0025                               v107 = uextend.i64 v104
+;;                                     v230 = ishl v107, v144  ; v144 = 3
+;; @0025                               v109 = ushr v230, v142  ; v142 = 32
+;; @0025                               trapnz v109, user2
+;;                                     v237 = ishl v104, v6  ; v6 = 3
+;; @0025                               v112 = uadd_overflow_trap v237, v7, user2  ; v7 = 24
+;; @0025                               v116 = uadd_overflow_trap v44, v112, user2
+;; @0025                               v117 = uextend.i64 v116
+;; @0025                               v119 = iadd v268, v117
 ;;                                     v254 = iconst.i32 40
-;; @0025                               v119 = isub v111, v254  ; v254 = 40
-;; @0025                               v120 = uextend.i64 v119
-;; @0025                               v121 = isub v118, v120
-;; @0025                               store.i64 user2 little region1 v4, v121
+;; @0025                               v120 = isub v112, v254  ; v254 = 40
+;; @0025                               v121 = uextend.i64 v120
+;; @0025                               v122 = isub v119, v121
+;; @0025                               store.i64 user2 little region1 v4, v122
 ;; @0029                               jump block1(v44)
 ;;
 ;;                                 block1(v5: i32):

--- a/tests/disas/gc/copying/array-new.wat
+++ b/tests/disas/gc/copying/array-new.wat
@@ -79,38 +79,38 @@
 ;; @0022                               jump block4(v30, v33)
 ;;
 ;;                                 block4(v42: i32, v43: i64):
-;;                                     v91 = iconst.i64 16
-;; @0022                               v44 = iadd v43, v91  ; v91 = 16
-;; @0022                               store.i32 user2 region1 v3, v44
+;; @0022                               v44 = iconst.i64 16
+;; @0022                               v45 = iadd v43, v44  ; v44 = 16
+;; @0022                               store.i32 user2 region1 v3, v45
 ;; @0022                               trapz v42, user16
 ;;                                     v143 = load.i64 notrap aligned readonly can_move v0+8
 ;;                                     v144 = load.i64 notrap aligned readonly can_move v143+32
-;; @0022                               v46 = uextend.i64 v42
-;; @0022                               v48 = iadd v144, v46
-;; @0022                               v50 = iadd v48, v91  ; v91 = 16
-;; @0022                               v51 = load.i32 user2 readonly region1 v50
-;; @0022                               v52 = uextend.i64 v51
-;; @0022                               v57 = icmp.i64 ugt v6, v52
-;; @0022                               trapnz v57, user17
-;; @0022                               v68 = load.i64 notrap aligned v143+40
-;;                                     v85 = iconst.i64 24
-;; @0022                               v61 = iadd v48, v85  ; v85 = 24
-;; @0022                               v70 = uadd_overflow_trap v61, v99, user2
-;; @0022                               v69 = iadd v144, v68
-;; @0022                               v71 = icmp ugt v70, v69
-;; @0022                               trapnz v71, user2
+;; @0022                               v47 = uextend.i64 v42
+;; @0022                               v49 = iadd v144, v47
+;; @0022                               v51 = iadd v49, v44  ; v44 = 16
+;; @0022                               v52 = load.i32 user2 readonly region1 v51
+;; @0022                               v53 = uextend.i64 v52
+;; @0022                               v58 = icmp.i64 ugt v6, v53
+;; @0022                               trapnz v58, user17
+;; @0022                               v70 = load.i64 notrap aligned v143+40
+;; @0022                               v62 = iconst.i64 24
+;; @0022                               v63 = iadd v49, v62  ; v62 = 24
+;; @0022                               v72 = uadd_overflow_trap v63, v99, user2
+;; @0022                               v71 = iadd v144, v70
+;; @0022                               v73 = icmp ugt v72, v71
+;; @0022                               trapnz v73, user2
 ;;                                     v123 = iconst.i64 0
-;; @0022                               v74 = icmp.i64 eq v6, v123  ; v123 = 0
+;; @0022                               v76 = icmp.i64 eq v6, v123  ; v123 = 0
 ;;                                     v97 = iconst.i64 8
-;; @0022                               v72 = iadd v61, v99
-;; @0022                               brif v74, block6, block5(v61)
+;; @0022                               v74 = iadd v63, v99
+;; @0022                               brif v76, block6, block5(v63)
 ;;
-;;                                 block5(v75: i64):
-;; @0022                               store.i64 user2 little region1 v2, v75
+;;                                 block5(v77: i64):
+;; @0022                               store.i64 user2 little region1 v2, v77
 ;;                                     v145 = iconst.i64 8
-;;                                     v146 = iadd v75, v145  ; v145 = 8
-;; @0022                               v77 = icmp eq v146, v72
-;; @0022                               brif v77, block6, block5(v146)
+;;                                     v146 = iadd v77, v145  ; v145 = 8
+;; @0022                               v80 = icmp eq v146, v74
+;; @0022                               brif v80, block6, block5(v146)
 ;;
 ;;                                 block6:
 ;; @0025                               jump block1(v42)

--- a/tests/disas/gc/copying/externref-globals.wat
+++ b/tests/disas/gc/copying/externref-globals.wat
@@ -18,13 +18,13 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;;                                     v6 = iconst.i64 48
-;; @0034                               v4 = iadd v0, v6  ; v6 = 48
-;; @0034                               v5 = load.i32 notrap aligned v4
+;; @0034                               v4 = iconst.i64 48
+;; @0034                               v5 = iadd v0, v4  ; v4 = 48
+;; @0034                               v6 = load.i32 notrap aligned v5
 ;; @0036                               jump block1
 ;;
 ;;                                 block1:
-;; @0036                               return v5
+;; @0036                               return v6
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) tail {
@@ -35,9 +35,9 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;;                                     v5 = iconst.i64 48
-;; @003b                               v4 = iadd v0, v5  ; v5 = 48
-;; @003b                               store notrap aligned v2, v4
+;; @003b                               v4 = iconst.i64 48
+;; @003b                               v5 = iadd v0, v4  ; v4 = 48
+;; @003b                               store notrap aligned v2, v5
 ;; @003d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/copying/funcref-in-gc-heap-new.wat
+++ b/tests/disas/gc/copying/funcref-in-gc-heap-new.wat
@@ -67,14 +67,14 @@
 ;;                                 block4(v36: i32, v37: i64):
 ;;                                     v45 = stack_addr.i64 ss0
 ;;                                     store notrap v36, v45
-;; @0020                               v40 = call fn1(v0, v2), stack_map=[i32 @ ss0+0]
-;; @0020                               v41 = ireduce.i32 v40
-;;                                     v44 = iconst.i64 16
-;; @0020                               v38 = iadd v37, v44  ; v44 = 16
-;; @0020                               store user2 little region1 v41, v38
-;;                                     v42 = load.i32 notrap v45
+;; @0020                               v41 = call fn1(v0, v2), stack_map=[i32 @ ss0+0]
+;; @0020                               v42 = ireduce.i32 v41
+;; @0020                               v38 = iconst.i64 16
+;; @0020                               v39 = iadd v37, v38  ; v38 = 16
+;; @0020                               store user2 little region1 v42, v39
+;;                                     v43 = load.i32 notrap v45
 ;; @0023                               jump block1
 ;;
 ;;                                 block1:
-;; @0023                               return v42
+;; @0023                               return v43
 ;; }

--- a/tests/disas/gc/copying/i31ref-globals.wat
+++ b/tests/disas/gc/copying/i31ref-globals.wat
@@ -18,13 +18,13 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;;                                     v6 = iconst.i64 48
-;; @0036                               v4 = iadd v0, v6  ; v6 = 48
-;; @0036                               v5 = load.i32 notrap aligned v4
+;; @0036                               v4 = iconst.i64 48
+;; @0036                               v5 = iadd v0, v4  ; v4 = 48
+;; @0036                               v6 = load.i32 notrap aligned v5
 ;; @0038                               jump block1
 ;;
 ;;                                 block1:
-;; @0038                               return v5
+;; @0038                               return v6
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) tail {
@@ -35,9 +35,9 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;;                                     v5 = iconst.i64 48
-;; @003d                               v4 = iadd v0, v5  ; v5 = 48
-;; @003d                               store notrap aligned v2, v4
+;; @003d                               v4 = iconst.i64 48
+;; @003d                               v5 = iadd v0, v4  ; v4 = 48
+;; @003d                               store notrap aligned v2, v5
 ;; @003f                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/copying/struct-new-default.wat
+++ b/tests/disas/gc/copying/struct-new-default.wat
@@ -65,16 +65,16 @@
 ;;
 ;;                                 block4(v38: i32, v39: i64):
 ;; @0021                               v3 = f32const 0.0
-;;                                     v45 = iconst.i64 16
-;; @0021                               v40 = iadd v39, v45  ; v45 = 16
-;; @0021                               store user2 little region1 v3, v40  ; v3 = 0.0
+;; @0021                               v40 = iconst.i64 16
+;; @0021                               v41 = iadd v39, v40  ; v40 = 16
+;; @0021                               store user2 little region1 v3, v41  ; v3 = 0.0
 ;; @0021                               v4 = iconst.i32 0
-;;                                     v44 = iconst.i64 20
-;; @0021                               v41 = iadd v39, v44  ; v44 = 20
-;; @0021                               istore8 user2 little region1 v4, v41  ; v4 = 0
-;;                                     v43 = iconst.i64 24
-;; @0021                               v42 = iadd v39, v43  ; v43 = 24
-;; @0021                               store user2 little region1 v4, v42  ; v4 = 0
+;; @0021                               v42 = iconst.i64 20
+;; @0021                               v43 = iadd v39, v42  ; v42 = 20
+;; @0021                               istore8 user2 little region1 v4, v43  ; v4 = 0
+;; @0021                               v44 = iconst.i64 24
+;; @0021                               v45 = iadd v39, v44  ; v44 = 24
+;; @0021                               store user2 little region1 v4, v45  ; v4 = 0
 ;; @0024                               jump block1(v38)
 ;;
 ;;                                 block1(v2: i32):

--- a/tests/disas/gc/copying/struct-new.wat
+++ b/tests/disas/gc/copying/struct-new.wat
@@ -67,16 +67,16 @@
 ;; @002a                               jump block4(v26, v29)
 ;;
 ;;                                 block4(v38: i32, v39: i64):
-;;                                     v47 = iconst.i64 16
-;; @002a                               v40 = iadd v39, v47  ; v47 = 16
-;; @002a                               store.f32 user2 little region1 v2, v40
-;;                                     v46 = iconst.i64 20
-;; @002a                               v41 = iadd v39, v46  ; v46 = 20
-;; @002a                               istore8.i32 user2 little region1 v3, v41
-;;                                     v43 = load.i32 notrap v52
-;;                                     v45 = iconst.i64 24
-;; @002a                               v42 = iadd v39, v45  ; v45 = 24
-;; @002a                               store user2 little region1 v43, v42
+;; @002a                               v40 = iconst.i64 16
+;; @002a                               v41 = iadd v39, v40  ; v40 = 16
+;; @002a                               store.f32 user2 little region1 v2, v41
+;; @002a                               v42 = iconst.i64 20
+;; @002a                               v43 = iadd v39, v42  ; v42 = 20
+;; @002a                               istore8.i32 user2 little region1 v3, v43
+;;                                     v46 = load.i32 notrap v52
+;; @002a                               v44 = iconst.i64 24
+;; @002a                               v45 = iadd v39, v44  ; v44 = 24
+;; @002a                               store user2 little region1 v46, v45
 ;; @002d                               jump block1(v38)
 ;;
 ;;                                 block1(v5: i32):

--- a/tests/disas/gc/drc/array-fill.wat
+++ b/tests/disas/gc/drc/array-fill.wat
@@ -35,29 +35,29 @@
 ;; @0027                               v12 = uextend.i64 v11
 ;; @0027                               v17 = icmp ugt v16, v12
 ;; @0027                               trapnz v17, user17
-;; @0027                               v28 = load.i64 notrap aligned v49+40
-;;                                     v45 = iconst.i64 32
-;; @0027                               v21 = iadd v8, v45  ; v45 = 32
+;; @0027                               v29 = load.i64 notrap aligned v49+40
+;; @0027                               v21 = iconst.i64 32
+;; @0027                               v22 = iadd v8, v21  ; v21 = 32
 ;;                                     v53 = iconst.i64 3
 ;;                                     v54 = ishl v13, v53  ; v53 = 3
-;; @0027                               v24 = iadd v21, v54
+;; @0027                               v25 = iadd v22, v54
 ;;                                     v56 = ishl v14, v53  ; v53 = 3
-;; @0027                               v30 = uadd_overflow_trap v24, v56, user2
-;; @0027                               v29 = iadd v7, v28
-;; @0027                               v31 = icmp ugt v30, v29
-;; @0027                               trapnz v31, user2
+;; @0027                               v31 = uadd_overflow_trap v25, v56, user2
+;; @0027                               v30 = iadd v7, v29
+;; @0027                               v32 = icmp ugt v31, v30
+;; @0027                               trapnz v32, user2
 ;;                                     v51 = iconst.i64 0
-;; @0027                               v34 = icmp eq v14, v51  ; v51 = 0
-;;                                     v44 = iconst.i64 8
-;; @0027                               v32 = iadd v24, v56
-;; @0027                               brif v34, block3, block2(v24)
+;; @0027                               v35 = icmp eq v14, v51  ; v51 = 0
+;;                                     v45 = iconst.i64 8
+;; @0027                               v33 = iadd v25, v56
+;; @0027                               brif v35, block3, block2(v25)
 ;;
-;;                                 block2(v35: i64):
-;; @0027                               store.i64 user2 little region0 v4, v35
+;;                                 block2(v36: i64):
+;; @0027                               store.i64 user2 little region0 v4, v36
 ;;                                     v58 = iconst.i64 8
-;;                                     v59 = iadd v35, v58  ; v58 = 8
-;; @0027                               v37 = icmp eq v59, v32
-;; @0027                               brif v37, block3, block2(v59)
+;;                                     v59 = iadd v36, v58  ; v58 = 8
+;; @0027                               v39 = icmp eq v59, v33
+;; @0027                               brif v39, block3, block2(v59)
 ;;
 ;;                                 block3:
 ;; @002a                               jump block1

--- a/tests/disas/gc/drc/array-new-fixed-of-gc-refs.wat
+++ b/tests/disas/gc/drc/array-new-fixed-of-gc-refs.wat
@@ -43,129 +43,129 @@
 ;; @0025                               v20 = load.i64 notrap aligned readonly can_move v214+32
 ;; @0025                               v21 = uextend.i64 v19
 ;; @0025                               v22 = iadd v20, v21
-;;                                     v213 = iconst.i64 24
-;; @0025                               v23 = iadd v22, v213  ; v213 = 24
-;; @0025                               store user2 region0 v6, v23  ; v6 = 3
+;; @0025                               v23 = iconst.i64 24
+;; @0025                               v24 = iadd v22, v23  ; v23 = 24
+;; @0025                               store user2 region0 v6, v24  ; v6 = 3
 ;; @0025                               trapz v19, user16
-;; @0025                               v42 = uadd_overflow_trap v19, v232, user2  ; v232 = 40
-;;                                     v164 = load.i32 notrap v220
-;;                                     v206 = iconst.i32 1
-;; @0025                               v49 = band v164, v206  ; v206 = 1
-;; @0025                               v24 = iconst.i32 0
-;; @0025                               v51 = icmp eq v164, v24  ; v24 = 0
-;; @0025                               v52 = uextend.i32 v51
-;; @0025                               v53 = bor v49, v52
-;; @0025                               brif v53, block3, block2
+;; @0025                               v43 = uadd_overflow_trap v19, v232, user2  ; v232 = 40
+;;                                     v168 = load.i32 notrap v220
+;;                                     v207 = iconst.i32 1
+;; @0025                               v50 = band v168, v207  ; v207 = 1
+;; @0025                               v25 = iconst.i32 0
+;; @0025                               v52 = icmp eq v168, v25  ; v25 = 0
+;; @0025                               v53 = uextend.i32 v52
+;; @0025                               v54 = bor v50, v53
+;; @0025                               brif v54, block3, block2
 ;;
 ;;                                 block2:
-;;                                     v162 = load.i32 notrap v220
-;; @0025                               v54 = uextend.i64 v162
-;; @0025                               v56 = iadd.i64 v20, v54
-;; @0025                               v57 = iconst.i64 8
-;; @0025                               v58 = iadd v56, v57  ; v57 = 8
-;; @0025                               v59 = load.i64 user2 region0 v58
-;;                                     v201 = iconst.i64 1
-;; @0025                               v60 = iadd v59, v201  ; v201 = 1
-;; @0025                               store user2 region0 v60, v58
+;;                                     v166 = load.i32 notrap v220
+;; @0025                               v55 = uextend.i64 v166
+;; @0025                               v57 = iadd.i64 v20, v55
+;; @0025                               v58 = iconst.i64 8
+;; @0025                               v59 = iadd v57, v58  ; v58 = 8
+;; @0025                               v60 = load.i64 user2 region0 v59
+;; @0025                               v61 = iconst.i64 1
+;; @0025                               v62 = iadd v60, v61  ; v61 = 1
+;; @0025                               store user2 region0 v62, v59
 ;; @0025                               jump block3
 ;;
 ;;                                 block3:
-;;                                     v160 = load.i32 notrap v220
-;; @0025                               v43 = uextend.i64 v42
-;; @0025                               v45 = iadd.i64 v20, v43
+;;                                     v164 = load.i32 notrap v220
+;; @0025                               v44 = uextend.i64 v43
+;; @0025                               v46 = iadd.i64 v20, v44
 ;;                                     v222 = iconst.i64 12
-;; @0025                               v48 = isub v45, v222  ; v222 = 12
-;; @0025                               store user2 little region0 v160, v48
-;;                                     v325 = iadd.i64 v22, v213  ; v213 = 24
-;; @0025                               v72 = load.i32 user2 readonly region0 v325
+;; @0025                               v49 = isub v46, v222  ; v222 = 12
+;; @0025                               store user2 little region0 v164, v49
+;;                                     v325 = iadd.i64 v22, v23  ; v23 = 24
+;; @0025                               v74 = load.i32 user2 readonly region0 v325
 ;;                                     v326 = iconst.i32 1
-;;                                     v327 = icmp ugt v72, v326  ; v326 = 1
+;;                                     v327 = icmp ugt v74, v326  ; v326 = 1
 ;; @0025                               trapz v327, user17
-;; @0025                               v75 = uextend.i64 v72
+;; @0025                               v77 = uextend.i64 v74
 ;;                                     v223 = iconst.i64 2
-;;                                     v267 = ishl v75, v223  ; v223 = 2
+;;                                     v267 = ishl v77, v223  ; v223 = 2
 ;;                                     v216 = iconst.i64 32
-;; @0025                               v77 = ushr v267, v216  ; v216 = 32
-;; @0025                               trapnz v77, user2
+;; @0025                               v79 = ushr v267, v216  ; v216 = 32
+;; @0025                               trapnz v79, user2
 ;;                                     v244 = iconst.i32 2
-;;                                     v274 = ishl v72, v244  ; v244 = 2
+;;                                     v274 = ishl v74, v244  ; v244 = 2
 ;; @0025                               v7 = iconst.i32 28
-;; @0025                               v80 = uadd_overflow_trap v274, v7, user2  ; v7 = 28
-;; @0025                               v84 = uadd_overflow_trap.i32 v19, v80, user2
-;;                                     v159 = load.i32 notrap v219
-;;                                     v328 = band v159, v326  ; v326 = 1
+;; @0025                               v82 = uadd_overflow_trap v274, v7, user2  ; v7 = 28
+;; @0025                               v86 = uadd_overflow_trap.i32 v19, v82, user2
+;;                                     v163 = load.i32 notrap v219
+;;                                     v328 = band v163, v326  ; v326 = 1
 ;;                                     v329 = iconst.i32 0
-;;                                     v330 = icmp eq v159, v329  ; v329 = 0
-;; @0025                               v94 = uextend.i32 v330
-;; @0025                               v95 = bor v328, v94
-;; @0025                               brif v95, block5, block4
+;;                                     v330 = icmp eq v163, v329  ; v329 = 0
+;; @0025                               v96 = uextend.i32 v330
+;; @0025                               v97 = bor v328, v96
+;; @0025                               brif v97, block5, block4
 ;;
 ;;                                 block4:
-;;                                     v157 = load.i32 notrap v219
-;; @0025                               v96 = uextend.i64 v157
-;; @0025                               v98 = iadd.i64 v20, v96
+;;                                     v161 = load.i32 notrap v219
+;; @0025                               v98 = uextend.i64 v161
+;; @0025                               v100 = iadd.i64 v20, v98
 ;;                                     v331 = iconst.i64 8
-;; @0025                               v100 = iadd v98, v331  ; v331 = 8
-;; @0025                               v101 = load.i64 user2 region0 v100
+;; @0025                               v102 = iadd v100, v331  ; v331 = 8
+;; @0025                               v103 = load.i64 user2 region0 v102
 ;;                                     v332 = iconst.i64 1
-;; @0025                               v102 = iadd v101, v332  ; v332 = 1
-;; @0025                               store user2 region0 v102, v100
+;; @0025                               v105 = iadd v103, v332  ; v332 = 1
+;; @0025                               store user2 region0 v105, v102
 ;; @0025                               jump block5
 ;;
 ;;                                 block5:
-;;                                     v155 = load.i32 notrap v219
-;; @0025                               v85 = uextend.i64 v84
-;; @0025                               v87 = iadd.i64 v20, v85
+;;                                     v159 = load.i32 notrap v219
+;; @0025                               v87 = uextend.i64 v86
+;; @0025                               v89 = iadd.i64 v20, v87
 ;;                                     v287 = iconst.i32 32
-;; @0025                               v88 = isub.i32 v80, v287  ; v287 = 32
-;; @0025                               v89 = uextend.i64 v88
-;; @0025                               v90 = isub v87, v89
-;; @0025                               store user2 little region0 v155, v90
-;;                                     v333 = iadd.i64 v22, v213  ; v213 = 24
-;; @0025                               v114 = load.i32 user2 readonly region0 v333
+;; @0025                               v90 = isub.i32 v82, v287  ; v287 = 32
+;; @0025                               v91 = uextend.i64 v90
+;; @0025                               v92 = isub v89, v91
+;; @0025                               store user2 little region0 v159, v92
+;;                                     v333 = iadd.i64 v22, v23  ; v23 = 24
+;; @0025                               v117 = load.i32 user2 readonly region0 v333
 ;;                                     v334 = iconst.i32 2
-;;                                     v335 = icmp ugt v114, v334  ; v334 = 2
+;;                                     v335 = icmp ugt v117, v334  ; v334 = 2
 ;; @0025                               trapz v335, user17
-;; @0025                               v117 = uextend.i64 v114
+;; @0025                               v120 = uextend.i64 v117
 ;;                                     v336 = iconst.i64 2
-;;                                     v337 = ishl v117, v336  ; v336 = 2
+;;                                     v337 = ishl v120, v336  ; v336 = 2
 ;;                                     v338 = iconst.i64 32
 ;;                                     v339 = ushr v337, v338  ; v338 = 32
 ;; @0025                               trapnz v339, user2
-;;                                     v340 = ishl v114, v334  ; v334 = 2
+;;                                     v340 = ishl v117, v334  ; v334 = 2
 ;;                                     v341 = iconst.i32 28
-;; @0025                               v122 = uadd_overflow_trap v340, v341, user2  ; v341 = 28
-;; @0025                               v126 = uadd_overflow_trap.i32 v19, v122, user2
-;;                                     v154 = load.i32 notrap v218
+;; @0025                               v125 = uadd_overflow_trap v340, v341, user2  ; v341 = 28
+;; @0025                               v129 = uadd_overflow_trap.i32 v19, v125, user2
+;;                                     v158 = load.i32 notrap v218
 ;;                                     v342 = iconst.i32 1
-;;                                     v343 = band v154, v342  ; v342 = 1
+;;                                     v343 = band v158, v342  ; v342 = 1
 ;;                                     v344 = iconst.i32 0
-;;                                     v345 = icmp eq v154, v344  ; v344 = 0
-;; @0025                               v136 = uextend.i32 v345
-;; @0025                               v137 = bor v343, v136
-;; @0025                               brif v137, block7, block6
+;;                                     v345 = icmp eq v158, v344  ; v344 = 0
+;; @0025                               v139 = uextend.i32 v345
+;; @0025                               v140 = bor v343, v139
+;; @0025                               brif v140, block7, block6
 ;;
 ;;                                 block6:
-;;                                     v152 = load.i32 notrap v218
-;; @0025                               v138 = uextend.i64 v152
-;; @0025                               v140 = iadd.i64 v20, v138
+;;                                     v156 = load.i32 notrap v218
+;; @0025                               v141 = uextend.i64 v156
+;; @0025                               v143 = iadd.i64 v20, v141
 ;;                                     v346 = iconst.i64 8
-;; @0025                               v142 = iadd v140, v346  ; v346 = 8
-;; @0025                               v143 = load.i64 user2 region0 v142
+;; @0025                               v145 = iadd v143, v346  ; v346 = 8
+;; @0025                               v146 = load.i64 user2 region0 v145
 ;;                                     v347 = iconst.i64 1
-;; @0025                               v144 = iadd v143, v347  ; v347 = 1
-;; @0025                               store user2 region0 v144, v142
+;; @0025                               v148 = iadd v146, v347  ; v347 = 1
+;; @0025                               store user2 region0 v148, v145
 ;; @0025                               jump block7
 ;;
 ;;                                 block7:
-;;                                     v150 = load.i32 notrap v218
-;; @0025                               v127 = uextend.i64 v126
-;; @0025                               v129 = iadd.i64 v20, v127
+;;                                     v154 = load.i32 notrap v218
+;; @0025                               v130 = uextend.i64 v129
+;; @0025                               v132 = iadd.i64 v20, v130
 ;;                                     v319 = iconst.i32 36
-;; @0025                               v130 = isub.i32 v122, v319  ; v319 = 36
-;; @0025                               v131 = uextend.i64 v130
-;; @0025                               v132 = isub v129, v131
-;; @0025                               store user2 little region0 v150, v132
+;; @0025                               v133 = isub.i32 v125, v319  ; v319 = 36
+;; @0025                               v134 = uextend.i64 v133
+;; @0025                               v135 = isub v132, v134
+;; @0025                               store user2 little region0 v154, v135
 ;; @0029                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/drc/array-new-fixed.wat
+++ b/tests/disas/gc/drc/array-new-fixed.wat
@@ -35,53 +35,53 @@
 ;; @0025                               v21 = uextend.i64 v19
 ;; @0025                               v22 = iadd v20, v21
 ;;                                     v120 = iconst.i64 24
-;; @0025                               v23 = iadd v22, v120  ; v120 = 24
-;; @0025                               store user2 region0 v6, v23  ; v6 = 3
+;; @0025                               v24 = iadd v22, v120  ; v120 = 24
+;; @0025                               store user2 region0 v6, v24  ; v6 = 3
 ;; @0025                               trapz v19, user16
-;; @0025                               v42 = uadd_overflow_trap v19, v129, user2  ; v129 = 56
-;; @0025                               v43 = uextend.i64 v42
-;; @0025                               v45 = iadd v20, v43
-;; @0025                               v48 = isub v45, v120  ; v120 = 24
-;; @0025                               store user2 little region0 v2, v48
-;; @0025                               v55 = load.i32 user2 readonly region0 v23
-;; @0025                               v49 = iconst.i32 1
-;;                                     v160 = icmp ugt v55, v49  ; v49 = 1
+;; @0025                               v43 = uadd_overflow_trap v19, v129, user2  ; v129 = 56
+;; @0025                               v44 = uextend.i64 v43
+;; @0025                               v46 = iadd v20, v44
+;; @0025                               v49 = isub v46, v120  ; v120 = 24
+;; @0025                               store user2 little region0 v2, v49
+;; @0025                               v56 = load.i32 user2 readonly region0 v24
+;; @0025                               v50 = iconst.i32 1
+;;                                     v160 = icmp ugt v56, v50  ; v50 = 1
 ;; @0025                               trapz v160, user17
-;; @0025                               v58 = uextend.i64 v55
+;; @0025                               v59 = uextend.i64 v56
 ;;                                     v119 = iconst.i64 3
-;;                                     v162 = ishl v58, v119  ; v119 = 3
+;;                                     v162 = ishl v59, v119  ; v119 = 3
 ;;                                     v117 = iconst.i64 32
-;; @0025                               v60 = ushr v162, v117  ; v117 = 32
-;; @0025                               trapnz v60, user2
-;;                                     v169 = ishl v55, v6  ; v6 = 3
+;; @0025                               v61 = ushr v162, v117  ; v117 = 32
+;; @0025                               trapnz v61, user2
+;;                                     v169 = ishl v56, v6  ; v6 = 3
 ;; @0025                               v7 = iconst.i32 32
-;; @0025                               v63 = uadd_overflow_trap v169, v7, user2  ; v7 = 32
-;; @0025                               v67 = uadd_overflow_trap v19, v63, user2
-;; @0025                               v68 = uextend.i64 v67
-;; @0025                               v70 = iadd v20, v68
+;; @0025                               v64 = uadd_overflow_trap v169, v7, user2  ; v7 = 32
+;; @0025                               v68 = uadd_overflow_trap v19, v64, user2
+;; @0025                               v69 = uextend.i64 v68
+;; @0025                               v71 = iadd v20, v69
 ;;                                     v182 = iconst.i32 40
-;; @0025                               v71 = isub v63, v182  ; v182 = 40
-;; @0025                               v72 = uextend.i64 v71
-;; @0025                               v73 = isub v70, v72
-;; @0025                               store user2 little region0 v3, v73
-;; @0025                               v80 = load.i32 user2 readonly region0 v23
-;; @0025                               v74 = iconst.i32 2
-;;                                     v188 = icmp ugt v80, v74  ; v74 = 2
+;; @0025                               v72 = isub v64, v182  ; v182 = 40
+;; @0025                               v73 = uextend.i64 v72
+;; @0025                               v74 = isub v71, v73
+;; @0025                               store user2 little region0 v3, v74
+;; @0025                               v81 = load.i32 user2 readonly region0 v24
+;; @0025                               v75 = iconst.i32 2
+;;                                     v188 = icmp ugt v81, v75  ; v75 = 2
 ;; @0025                               trapz v188, user17
-;; @0025                               v83 = uextend.i64 v80
-;;                                     v190 = ishl v83, v119  ; v119 = 3
-;; @0025                               v85 = ushr v190, v117  ; v117 = 32
-;; @0025                               trapnz v85, user2
-;;                                     v197 = ishl v80, v6  ; v6 = 3
-;; @0025                               v88 = uadd_overflow_trap v197, v7, user2  ; v7 = 32
-;; @0025                               v92 = uadd_overflow_trap v19, v88, user2
-;; @0025                               v93 = uextend.i64 v92
-;; @0025                               v95 = iadd v20, v93
+;; @0025                               v84 = uextend.i64 v81
+;;                                     v190 = ishl v84, v119  ; v119 = 3
+;; @0025                               v86 = ushr v190, v117  ; v117 = 32
+;; @0025                               trapnz v86, user2
+;;                                     v197 = ishl v81, v6  ; v6 = 3
+;; @0025                               v89 = uadd_overflow_trap v197, v7, user2  ; v7 = 32
+;; @0025                               v93 = uadd_overflow_trap v19, v89, user2
+;; @0025                               v94 = uextend.i64 v93
+;; @0025                               v96 = iadd v20, v94
 ;;                                     v215 = iconst.i32 48
-;; @0025                               v96 = isub v88, v215  ; v215 = 48
-;; @0025                               v97 = uextend.i64 v96
-;; @0025                               v98 = isub v95, v97
-;; @0025                               store user2 little region0 v4, v98
+;; @0025                               v97 = isub v89, v215  ; v215 = 48
+;; @0025                               v98 = uextend.i64 v97
+;; @0025                               v99 = isub v96, v98
+;; @0025                               store user2 little region0 v4, v99
 ;; @0029                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/drc/array-new.wat
+++ b/tests/disas/gc/drc/array-new.wat
@@ -42,28 +42,28 @@
 ;; @0022                               v18 = load.i64 notrap aligned readonly can_move v69+32
 ;; @0022                               v19 = uextend.i64 v17
 ;; @0022                               v20 = iadd v18, v19
-;;                                     v68 = iconst.i64 24
-;; @0022                               v21 = iadd v20, v68  ; v68 = 24
-;; @0022                               store user2 region0 v3, v21
+;; @0022                               v21 = iconst.i64 24
+;; @0022                               v22 = iadd v20, v21  ; v21 = 24
+;; @0022                               store user2 region0 v3, v22
 ;; @0022                               trapz v17, user16
-;; @0022                               v45 = load.i64 notrap aligned v69+40
-;; @0022                               v38 = iadd v20, v71  ; v71 = 32
-;; @0022                               v47 = uadd_overflow_trap v38, v74, user2
-;; @0022                               v46 = iadd v18, v45
-;; @0022                               v48 = icmp ugt v47, v46
-;; @0022                               trapnz v48, user2
+;; @0022                               v47 = load.i64 notrap aligned v69+40
+;; @0022                               v40 = iadd v20, v71  ; v71 = 32
+;; @0022                               v49 = uadd_overflow_trap v40, v74, user2
+;; @0022                               v48 = iadd v18, v47
+;; @0022                               v50 = icmp ugt v49, v48
+;; @0022                               trapnz v50, user2
 ;;                                     v84 = iconst.i64 0
-;; @0022                               v51 = icmp eq v6, v84  ; v84 = 0
+;; @0022                               v53 = icmp eq v6, v84  ; v84 = 0
 ;;                                     v72 = iconst.i64 8
-;; @0022                               v49 = iadd v38, v74
-;; @0022                               brif v51, block3, block2(v38)
+;; @0022                               v51 = iadd v40, v74
+;; @0022                               brif v53, block3, block2(v40)
 ;;
-;;                                 block2(v52: i64):
-;; @0022                               store.i64 user2 little region0 v2, v52
+;;                                 block2(v54: i64):
+;; @0022                               store.i64 user2 little region0 v2, v54
 ;;                                     v99 = iconst.i64 8
-;;                                     v100 = iadd v52, v99  ; v99 = 8
-;; @0022                               v54 = icmp eq v100, v49
-;; @0022                               brif v54, block3, block2(v100)
+;;                                     v100 = iadd v54, v99  ; v99 = 8
+;; @0022                               v57 = icmp eq v100, v51
+;; @0022                               brif v57, block3, block2(v100)
 ;;
 ;;                                 block3:
 ;; @0025                               jump block1

--- a/tests/disas/gc/drc/externref-globals.wat
+++ b/tests/disas/gc/drc/externref-globals.wat
@@ -28,69 +28,69 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;;                                     v92 = iconst.i64 48
-;; @0034                               v4 = iadd v0, v92  ; v92 = 48
-;; @0034                               v5 = load.i32 notrap aligned v4
-;;                                     v91 = stack_addr.i64 ss0
-;;                                     store notrap v5, v91
-;;                                     v89 = iconst.i32 1
-;; @0034                               v6 = band v5, v89  ; v89 = 1
-;; @0034                               v7 = iconst.i32 0
-;; @0034                               v8 = icmp eq v5, v7  ; v7 = 0
-;; @0034                               v9 = uextend.i32 v8
-;; @0034                               v10 = bor v6, v9
-;; @0034                               brif v10, block4, block2
+;; @0034                               v4 = iconst.i64 48
+;; @0034                               v5 = iadd v0, v4  ; v4 = 48
+;; @0034                               v6 = load.i32 notrap aligned v5
+;;                                     v92 = stack_addr.i64 ss0
+;;                                     store notrap v6, v92
+;;                                     v90 = iconst.i32 1
+;; @0034                               v7 = band v6, v90  ; v90 = 1
+;; @0034                               v8 = iconst.i32 0
+;; @0034                               v9 = icmp eq v6, v8  ; v8 = 0
+;; @0034                               v10 = uextend.i32 v9
+;; @0034                               v11 = bor v7, v10
+;; @0034                               brif v11, block4, block2
 ;;
 ;;                                 block2:
-;; @0034                               v85 = load.i64 notrap aligned readonly can_move v0+8
-;; @0034                               v12 = load.i64 notrap aligned readonly can_move v85+32
-;; @0034                               v11 = uextend.i64 v5
-;; @0034                               v13 = iadd v12, v11
-;; @0034                               v14 = load.i32 user2 region0 v13
-;; @0034                               v15 = iconst.i32 2
-;; @0034                               v16 = band v14, v15  ; v15 = 2
-;; @0034                               brif v16, block4, block3
+;; @0034                               v86 = load.i64 notrap aligned readonly can_move v0+8
+;; @0034                               v13 = load.i64 notrap aligned readonly can_move v86+32
+;; @0034                               v12 = uextend.i64 v6
+;; @0034                               v14 = iadd v13, v12
+;; @0034                               v15 = load.i32 user2 region0 v14
+;; @0034                               v16 = iconst.i32 2
+;; @0034                               v17 = band v15, v16  ; v16 = 2
+;; @0034                               brif v17, block4, block3
 ;;
 ;;                                 block3:
-;; @0034                               v18 = load.i64 notrap aligned readonly can_move region1 v0+32
-;; @0034                               v19 = load.i32 user2 region0 v18
-;; @0034                               v23 = iconst.i64 16
-;; @0034                               v24 = iadd.i64 v13, v23  ; v23 = 16
-;; @0034                               store user2 region0 v19, v24
+;; @0034                               v19 = load.i64 notrap aligned readonly can_move region1 v0+32
+;; @0034                               v20 = load.i32 user2 region0 v19
+;; @0034                               v24 = iconst.i64 16
+;; @0034                               v25 = iadd.i64 v14, v24  ; v24 = 16
+;; @0034                               store user2 region0 v20, v25
 ;;                                     v93 = iconst.i32 2
-;;                                     v94 = bor.i32 v14, v93  ; v93 = 2
-;; @0034                               store user2 region0 v94, v13
-;; @0034                               v33 = iconst.i64 8
-;; @0034                               v34 = iadd.i64 v13, v33  ; v33 = 8
-;; @0034                               v35 = load.i64 user2 region0 v34
-;;                                     v75 = iconst.i64 1
-;; @0034                               v36 = iadd v35, v75  ; v75 = 1
-;; @0034                               store user2 region0 v36, v34
-;; @0034                               store.i32 user2 region0 v5, v18
-;; @0034                               v44 = load.i32 notrap aligned v18+4
+;;                                     v94 = bor.i32 v15, v93  ; v93 = 2
+;; @0034                               store user2 region0 v94, v14
+;; @0034                               v34 = iconst.i64 8
+;; @0034                               v35 = iadd.i64 v14, v34  ; v34 = 8
+;; @0034                               v36 = load.i64 user2 region0 v35
+;; @0034                               v37 = iconst.i64 1
+;; @0034                               v38 = iadd v36, v37  ; v37 = 1
+;; @0034                               store user2 region0 v38, v35
+;; @0034                               store.i32 user2 region0 v6, v19
+;; @0034                               v46 = load.i32 notrap aligned v19+4
 ;;                                     v95 = iconst.i32 1
-;;                                     v96 = iadd v44, v95  ; v95 = 1
-;; @0034                               store notrap aligned v96, v18+4
-;; @0034                               v53 = load.i32 notrap aligned v18+8
-;; @0034                               v54 = iadd v53, v53
-;; @0034                               v55 = iconst.i32 1024
-;; @0034                               v56 = umax v54, v55  ; v55 = 1024
-;; @0034                               v57 = icmp uge v96, v56
-;; @0034                               brif v57, block5, block6
+;;                                     v96 = iadd v46, v95  ; v95 = 1
+;; @0034                               store notrap aligned v96, v19+4
+;; @0034                               v56 = load.i32 notrap aligned v19+8
+;; @0034                               v57 = iadd v56, v56
+;; @0034                               v58 = iconst.i32 1024
+;; @0034                               v59 = umax v57, v58  ; v58 = 1024
+;; @0034                               v60 = icmp uge v96, v59
+;; @0034                               brif v60, block5, block6
 ;;
 ;;                                 block5 cold:
-;; @0034                               v59 = call fn0(v0), stack_map=[i32 @ ss0+0]
+;; @0034                               v62 = call fn0(v0), stack_map=[i32 @ ss0+0]
 ;; @0034                               jump block6
 ;;
 ;;                                 block6:
 ;; @0034                               jump block4
 ;;
 ;;                                 block4:
-;;                                     v60 = load.i32 notrap v91
+;;                                     v63 = load.i32 notrap v92
 ;; @0036                               jump block1
 ;;
 ;;                                 block1:
-;; @0036                               return v60
+;; @0036                               return v63
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) tail {
@@ -107,62 +107,62 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;;                                     v55 = iconst.i64 48
-;; @003b                               v4 = iadd v0, v55  ; v55 = 48
-;; @003b                               v5 = load.i32 notrap aligned v4
-;;                                     v54 = iconst.i32 1
-;; @003b                               v6 = band v2, v54  ; v54 = 1
-;; @003b                               v7 = iconst.i32 0
-;; @003b                               v8 = icmp eq v2, v7  ; v7 = 0
-;; @003b                               v9 = uextend.i32 v8
-;; @003b                               v10 = bor v6, v9
-;; @003b                               brif v10, block3, block2
+;; @003b                               v4 = iconst.i64 48
+;; @003b                               v5 = iadd v0, v4  ; v4 = 48
+;; @003b                               v6 = load.i32 notrap aligned v5
+;;                                     v55 = iconst.i32 1
+;; @003b                               v7 = band v2, v55  ; v55 = 1
+;; @003b                               v8 = iconst.i32 0
+;; @003b                               v9 = icmp eq v2, v8  ; v8 = 0
+;; @003b                               v10 = uextend.i32 v9
+;; @003b                               v11 = bor v7, v10
+;; @003b                               brif v11, block3, block2
 ;;
 ;;                                 block2:
-;; @003b                               v52 = load.i64 notrap aligned readonly can_move v0+8
-;; @003b                               v12 = load.i64 notrap aligned readonly can_move v52+32
-;; @003b                               v11 = uextend.i64 v2
-;; @003b                               v13 = iadd v12, v11
-;; @003b                               v14 = iconst.i64 8
-;; @003b                               v15 = iadd v13, v14  ; v14 = 8
-;; @003b                               v16 = load.i64 user2 region0 v15
-;;                                     v51 = iconst.i64 1
-;; @003b                               v17 = iadd v16, v51  ; v51 = 1
-;; @003b                               store user2 region0 v17, v15
+;; @003b                               v53 = load.i64 notrap aligned readonly can_move v0+8
+;; @003b                               v13 = load.i64 notrap aligned readonly can_move v53+32
+;; @003b                               v12 = uextend.i64 v2
+;; @003b                               v14 = iadd v13, v12
+;; @003b                               v15 = iconst.i64 8
+;; @003b                               v16 = iadd v14, v15  ; v15 = 8
+;; @003b                               v17 = load.i64 user2 region0 v16
+;; @003b                               v18 = iconst.i64 1
+;; @003b                               v19 = iadd v17, v18  ; v18 = 1
+;; @003b                               store user2 region0 v19, v16
 ;; @003b                               jump block3
 ;;
 ;;                                 block3:
-;;                                     v68 = iadd.i64 v0, v55  ; v55 = 48
+;;                                     v68 = iadd.i64 v0, v4  ; v4 = 48
 ;; @003b                               store.i32 notrap aligned v2, v68
 ;;                                     v69 = iconst.i32 1
-;;                                     v70 = band.i32 v5, v69  ; v69 = 1
+;;                                     v70 = band.i32 v6, v69  ; v69 = 1
 ;;                                     v71 = iconst.i32 0
-;;                                     v72 = icmp.i32 eq v5, v71  ; v71 = 0
-;; @003b                               v26 = uextend.i32 v72
-;; @003b                               v27 = bor v70, v26
-;; @003b                               brif v27, block7, block4
+;;                                     v72 = icmp.i32 eq v6, v71  ; v71 = 0
+;; @003b                               v28 = uextend.i32 v72
+;; @003b                               v29 = bor v70, v28
+;; @003b                               brif v29, block7, block4
 ;;
 ;;                                 block4:
 ;;                                     v73 = load.i64 notrap aligned readonly can_move v0+8
 ;;                                     v74 = load.i64 notrap aligned readonly can_move v73+32
-;; @003b                               v28 = uextend.i64 v5
-;; @003b                               v30 = iadd v74, v28
+;; @003b                               v30 = uextend.i64 v6
+;; @003b                               v32 = iadd v74, v30
 ;;                                     v75 = iconst.i64 8
-;; @003b                               v32 = iadd v30, v75  ; v75 = 8
-;; @003b                               v33 = load.i64 user2 region0 v32
+;; @003b                               v34 = iadd v32, v75  ; v75 = 8
+;; @003b                               v35 = load.i64 user2 region0 v34
 ;;                                     v76 = iconst.i64 1
-;;                                     v66 = icmp eq v33, v76  ; v76 = 1
+;;                                     v66 = icmp eq v35, v76  ; v76 = 1
 ;; @003b                               brif v66, block5, block6
 ;;
 ;;                                 block5 cold:
-;; @003b                               call fn0(v0, v5)
+;; @003b                               call fn0(v0, v6)
 ;; @003b                               jump block7
 ;;
 ;;                                 block6:
-;;                                     v45 = iconst.i64 -1
-;; @003b                               v34 = iadd.i64 v33, v45  ; v45 = -1
-;;                                     v77 = iadd.i64 v30, v75  ; v75 = 8
-;; @003b                               store user2 region0 v34, v77
+;; @003b                               v36 = iconst.i64 -1
+;; @003b                               v37 = iadd.i64 v35, v36  ; v36 = -1
+;;                                     v77 = iadd.i64 v32, v75  ; v75 = 8
+;; @003b                               store user2 region0 v37, v77
 ;; @003b                               jump block7
 ;;
 ;;                                 block7:

--- a/tests/disas/gc/drc/funcref-in-gc-heap-new.wat
+++ b/tests/disas/gc/drc/funcref-in-gc-heap-new.wat
@@ -33,18 +33,18 @@
 ;; @0020                               v11 = call fn0(v0, v6, v9, v4, v10)  ; v6 = -1342177280, v4 = 32, v10 = 8
 ;;                                     v26 = stack_addr.i64 ss0
 ;;                                     store notrap v11, v26
-;; @0020                               v17 = call fn1(v0, v2), stack_map=[i32 @ ss0+0]
-;; @0020                               v18 = ireduce.i32 v17
+;; @0020                               v18 = call fn1(v0, v2), stack_map=[i32 @ ss0+0]
+;; @0020                               v19 = ireduce.i32 v18
 ;; @0020                               v24 = load.i64 notrap aligned readonly can_move v0+8
 ;; @0020                               v12 = load.i64 notrap aligned readonly can_move v24+32
 ;; @0020                               v13 = uextend.i64 v11
 ;; @0020                               v14 = iadd v12, v13
-;;                                     v22 = iconst.i64 24
-;; @0020                               v15 = iadd v14, v22  ; v22 = 24
-;; @0020                               store user2 little region0 v18, v15
-;;                                     v19 = load.i32 notrap v26
+;; @0020                               v15 = iconst.i64 24
+;; @0020                               v16 = iadd v14, v15  ; v15 = 24
+;; @0020                               store user2 little region0 v19, v16
+;;                                     v20 = load.i32 notrap v26
 ;; @0023                               jump block1
 ;;
 ;;                                 block1:
-;; @0023                               return v19
+;; @0023                               return v20
 ;; }

--- a/tests/disas/gc/drc/i31ref-globals.wat
+++ b/tests/disas/gc/drc/i31ref-globals.wat
@@ -20,13 +20,13 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;;                                     v6 = iconst.i64 48
-;; @0036                               v4 = iadd v0, v6  ; v6 = 48
-;; @0036                               v5 = load.i32 notrap aligned v4
+;; @0036                               v4 = iconst.i64 48
+;; @0036                               v5 = iadd v0, v4  ; v4 = 48
+;; @0036                               v6 = load.i32 notrap aligned v5
 ;; @0038                               jump block1
 ;;
 ;;                                 block1:
-;; @0038                               return v5
+;; @0038                               return v6
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) tail {
@@ -37,9 +37,9 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;;                                     v5 = iconst.i64 48
-;; @003d                               v4 = iadd v0, v5  ; v5 = 48
-;; @003d                               store notrap aligned v2, v4
+;; @003d                               v4 = iconst.i64 48
+;; @003d                               v5 = iadd v0, v4  ; v4 = 48
+;; @003d                               store notrap aligned v2, v5
 ;; @003f                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/drc/struct-get.wat
+++ b/tests/disas/gc/drc/struct-get.wat
@@ -157,32 +157,32 @@
 ;; @004e                               v37 = iconst.i64 8
 ;; @004e                               v38 = iadd.i64 v17, v37  ; v37 = 8
 ;; @004e                               v39 = load.i64 user2 region0 v38
-;;                                     v79 = iconst.i64 1
-;; @004e                               v40 = iadd v39, v79  ; v79 = 1
-;; @004e                               store user2 region0 v40, v38
+;; @004e                               v40 = iconst.i64 1
+;; @004e                               v41 = iadd v39, v40  ; v40 = 1
+;; @004e                               store user2 region0 v41, v38
 ;; @004e                               store.i32 user2 region0 v9, v22
-;; @004e                               v48 = load.i32 notrap aligned v22+4
+;; @004e                               v49 = load.i32 notrap aligned v22+4
 ;;                                     v100 = iconst.i32 1
-;;                                     v101 = iadd v48, v100  ; v100 = 1
+;;                                     v101 = iadd v49, v100  ; v100 = 1
 ;; @004e                               store notrap aligned v101, v22+4
-;; @004e                               v57 = load.i32 notrap aligned v22+8
-;; @004e                               v58 = iadd v57, v57
-;; @004e                               v59 = iconst.i32 1024
-;; @004e                               v60 = umax v58, v59  ; v59 = 1024
-;; @004e                               v61 = icmp uge v101, v60
-;; @004e                               brif v61, block5, block6
+;; @004e                               v59 = load.i32 notrap aligned v22+8
+;; @004e                               v60 = iadd v59, v59
+;; @004e                               v61 = iconst.i32 1024
+;; @004e                               v62 = umax v60, v61  ; v61 = 1024
+;; @004e                               v63 = icmp uge v101, v62
+;; @004e                               brif v63, block5, block6
 ;;
 ;;                                 block5 cold:
-;; @004e                               v63 = call fn0(v0), stack_map=[i32 @ ss0+0]
+;; @004e                               v65 = call fn0(v0), stack_map=[i32 @ ss0+0]
 ;; @004e                               jump block6
 ;;
 ;;                                 block6:
 ;; @004e                               jump block4
 ;;
 ;;                                 block4:
-;;                                     v64 = load.i32 notrap v95
+;;                                     v66 = load.i32 notrap v95
 ;; @0052                               jump block1
 ;;
 ;;                                 block1:
-;; @0052                               return v64
+;; @0052                               return v66
 ;; }

--- a/tests/disas/gc/drc/struct-new-default.wat
+++ b/tests/disas/gc/drc/struct-new-default.wat
@@ -36,20 +36,20 @@
 ;; @0021                               v14 = load.i64 notrap aligned readonly can_move v46+32
 ;; @0021                               v15 = uextend.i64 v13
 ;; @0021                               v16 = iadd v14, v15
-;;                                     v45 = iconst.i64 24
-;; @0021                               v17 = iadd v16, v45  ; v45 = 24
-;; @0021                               store user2 little region0 v3, v17  ; v3 = 0.0
+;; @0021                               v17 = iconst.i64 24
+;; @0021                               v18 = iadd v16, v17  ; v17 = 24
+;; @0021                               store user2 little region0 v3, v18  ; v3 = 0.0
 ;; @0021                               v4 = iconst.i32 0
-;;                                     v44 = iconst.i64 28
-;; @0021                               v18 = iadd v16, v44  ; v44 = 28
-;; @0021                               istore8 user2 little region0 v4, v18  ; v4 = 0
+;; @0021                               v19 = iconst.i64 28
+;; @0021                               v20 = iadd v16, v19  ; v19 = 28
+;; @0021                               istore8 user2 little region0 v4, v20  ; v4 = 0
 ;;                                     jump block3
 ;;
 ;;                                 block3:
 ;;                                     v65 = iconst.i32 0
-;;                                     v43 = iconst.i64 32
-;; @0021                               v19 = iadd.i64 v16, v43  ; v43 = 32
-;; @0021                               store user2 little region0 v65, v19  ; v65 = 0
+;; @0021                               v21 = iconst.i64 32
+;; @0021                               v22 = iadd.i64 v16, v21  ; v21 = 32
+;; @0021                               store user2 little region0 v65, v22  ; v65 = 0
 ;; @0024                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/drc/struct-new.wat
+++ b/tests/disas/gc/drc/struct-new.wat
@@ -38,36 +38,36 @@
 ;; @002a                               v14 = load.i64 notrap aligned readonly can_move v56+32
 ;; @002a                               v15 = uextend.i64 v13
 ;; @002a                               v16 = iadd v14, v15
-;;                                     v55 = iconst.i64 24
-;; @002a                               v17 = iadd v16, v55  ; v55 = 24
-;; @002a                               store user2 little region0 v2, v17
-;;                                     v54 = iconst.i64 28
-;; @002a                               v18 = iadd v16, v54  ; v54 = 28
-;; @002a                               istore8 user2 little region0 v3, v18
-;;                                     v41 = load.i32 notrap v58
-;;                                     v51 = iconst.i32 1
-;; @002a                               v20 = band v41, v51  ; v51 = 1
-;; @002a                               v21 = iconst.i32 0
-;; @002a                               v22 = icmp eq v41, v21  ; v21 = 0
-;; @002a                               v23 = uextend.i32 v22
-;; @002a                               v24 = bor v20, v23
-;; @002a                               brif v24, block3, block2
+;; @002a                               v17 = iconst.i64 24
+;; @002a                               v18 = iadd v16, v17  ; v17 = 24
+;; @002a                               store user2 little region0 v2, v18
+;; @002a                               v19 = iconst.i64 28
+;; @002a                               v20 = iadd v16, v19  ; v19 = 28
+;; @002a                               istore8 user2 little region0 v3, v20
+;;                                     v45 = load.i32 notrap v58
+;;                                     v54 = iconst.i32 1
+;; @002a                               v23 = band v45, v54  ; v54 = 1
+;; @002a                               v24 = iconst.i32 0
+;; @002a                               v25 = icmp eq v45, v24  ; v24 = 0
+;; @002a                               v26 = uextend.i32 v25
+;; @002a                               v27 = bor v23, v26
+;; @002a                               brif v27, block3, block2
 ;;
 ;;                                 block2:
-;; @002a                               v25 = uextend.i64 v41
-;; @002a                               v27 = iadd.i64 v14, v25
-;; @002a                               v28 = iconst.i64 8
-;; @002a                               v29 = iadd v27, v28  ; v28 = 8
-;; @002a                               v30 = load.i64 user2 region0 v29
-;;                                     v46 = iconst.i64 1
-;; @002a                               v31 = iadd v30, v46  ; v46 = 1
-;; @002a                               store user2 region0 v31, v29
+;; @002a                               v28 = uextend.i64 v45
+;; @002a                               v30 = iadd.i64 v14, v28
+;; @002a                               v31 = iconst.i64 8
+;; @002a                               v32 = iadd v30, v31  ; v31 = 8
+;; @002a                               v33 = load.i64 user2 region0 v32
+;; @002a                               v34 = iconst.i64 1
+;; @002a                               v35 = iadd v33, v34  ; v34 = 1
+;; @002a                               store user2 region0 v35, v32
 ;; @002a                               jump block3
 ;;
 ;;                                 block3:
-;;                                     v53 = iconst.i64 32
-;; @002a                               v19 = iadd.i64 v16, v53  ; v53 = 32
-;; @002a                               store.i32 user2 little region0 v41, v19
+;; @002a                               v21 = iconst.i64 32
+;; @002a                               v22 = iadd.i64 v16, v21  ; v21 = 32
+;; @002a                               store.i32 user2 little region0 v45, v22
 ;; @002d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/drc/struct-set.wat
+++ b/tests/disas/gc/drc/struct-set.wat
@@ -107,9 +107,9 @@
 ;; @004a                               v18 = iconst.i64 8
 ;; @004a                               v19 = iadd v17, v18  ; v18 = 8
 ;; @004a                               v20 = load.i64 user2 region0 v19
-;;                                     v55 = iconst.i64 1
-;; @004a                               v21 = iadd v20, v55  ; v55 = 1
-;; @004a                               store user2 region0 v21, v19
+;; @004a                               v21 = iconst.i64 1
+;; @004a                               v22 = iadd v20, v21  ; v21 = 1
+;; @004a                               store user2 region0 v22, v19
 ;; @004a                               jump block3
 ;;
 ;;                                 block3:
@@ -119,18 +119,18 @@
 ;;                                     v75 = band.i32 v9, v74  ; v74 = 1
 ;;                                     v76 = iconst.i32 0
 ;;                                     v77 = icmp.i32 eq v9, v76  ; v76 = 0
-;; @004a                               v30 = uextend.i32 v77
-;; @004a                               v31 = bor v75, v30
-;; @004a                               brif v31, block7, block4
+;; @004a                               v31 = uextend.i32 v77
+;; @004a                               v32 = bor v75, v31
+;; @004a                               brif v32, block7, block4
 ;;
 ;;                                 block4:
-;; @004a                               v32 = uextend.i64 v9
-;; @004a                               v34 = iadd.i64 v5, v32
+;; @004a                               v33 = uextend.i64 v9
+;; @004a                               v35 = iadd.i64 v5, v33
 ;;                                     v78 = iconst.i64 8
-;; @004a                               v36 = iadd v34, v78  ; v78 = 8
-;; @004a                               v37 = load.i64 user2 region0 v36
+;; @004a                               v37 = iadd v35, v78  ; v78 = 8
+;; @004a                               v38 = load.i64 user2 region0 v37
 ;;                                     v79 = iconst.i64 1
-;;                                     v71 = icmp eq v37, v79  ; v79 = 1
+;;                                     v71 = icmp eq v38, v79  ; v79 = 1
 ;; @004a                               brif v71, block5, block6
 ;;
 ;;                                 block5 cold:
@@ -138,10 +138,10 @@
 ;; @004a                               jump block7
 ;;
 ;;                                 block6:
-;;                                     v49 = iconst.i64 -1
-;; @004a                               v38 = iadd.i64 v37, v49  ; v49 = -1
-;;                                     v80 = iadd.i64 v34, v78  ; v78 = 8
-;; @004a                               store user2 region0 v38, v80
+;; @004a                               v39 = iconst.i64 -1
+;; @004a                               v40 = iadd.i64 v38, v39  ; v39 = -1
+;;                                     v80 = iadd.i64 v35, v78  ; v78 = 8
+;; @004a                               store user2 region0 v40, v80
 ;; @004a                               jump block7
 ;;
 ;;                                 block7:

--- a/tests/disas/gc/null/array-fill.wat
+++ b/tests/disas/gc/null/array-fill.wat
@@ -35,28 +35,28 @@
 ;; @0027                               v12 = uextend.i64 v11
 ;; @0027                               v17 = icmp ugt v16, v12
 ;; @0027                               trapnz v17, user17
-;; @0027                               v28 = load.i64 notrap aligned v49+40
-;;                                     v45 = iconst.i64 16
-;; @0027                               v21 = iadd v8, v45  ; v45 = 16
+;; @0027                               v29 = load.i64 notrap aligned v49+40
+;; @0027                               v21 = iconst.i64 16
+;; @0027                               v22 = iadd v8, v21  ; v21 = 16
 ;;                                     v53 = iconst.i64 3
 ;;                                     v54 = ishl v13, v53  ; v53 = 3
-;; @0027                               v24 = iadd v21, v54
+;; @0027                               v25 = iadd v22, v54
 ;;                                     v56 = ishl v14, v53  ; v53 = 3
-;; @0027                               v30 = uadd_overflow_trap v24, v56, user2
-;; @0027                               v29 = iadd v7, v28
-;; @0027                               v31 = icmp ugt v30, v29
-;; @0027                               trapnz v31, user2
+;; @0027                               v31 = uadd_overflow_trap v25, v56, user2
+;; @0027                               v30 = iadd v7, v29
+;; @0027                               v32 = icmp ugt v31, v30
+;; @0027                               trapnz v32, user2
 ;;                                     v51 = iconst.i64 0
-;; @0027                               v34 = icmp eq v14, v51  ; v51 = 0
-;; @0027                               v32 = iadd v24, v56
-;; @0027                               brif v34, block3, block2(v24)
+;; @0027                               v35 = icmp eq v14, v51  ; v51 = 0
+;; @0027                               v33 = iadd v25, v56
+;; @0027                               brif v35, block3, block2(v25)
 ;;
-;;                                 block2(v35: i64):
-;; @0027                               store.i64 user2 little region0 v4, v35
+;;                                 block2(v36: i64):
+;; @0027                               store.i64 user2 little region0 v4, v36
 ;;                                     v58 = iconst.i64 8
-;;                                     v59 = iadd v35, v58  ; v58 = 8
-;; @0027                               v37 = icmp eq v59, v32
-;; @0027                               brif v37, block3, block2(v59)
+;;                                     v59 = iadd v36, v58  ; v58 = 8
+;; @0027                               v39 = icmp eq v59, v33
+;; @0027                               brif v39, block3, block2(v59)
 ;;
 ;;                                 block3:
 ;; @002a                               jump block1

--- a/tests/disas/gc/null/array-new-fixed-of-gc-refs.wat
+++ b/tests/disas/gc/null/array-new-fixed-of-gc-refs.wat
@@ -59,59 +59,59 @@
 ;; @0025                               store user2 region1 v38, v33+4
 ;; @0025                               store.i32 user2 region1 v24, v17
 ;; @0025                               v6 = iconst.i32 3
-;;                                     v136 = iconst.i64 8
-;; @0025                               v39 = iadd v33, v136  ; v136 = 8
-;; @0025                               store user2 region1 v6, v39  ; v6 = 3
+;; @0025                               v39 = iconst.i64 8
+;; @0025                               v40 = iadd v33, v39  ; v39 = 8
+;; @0025                               store user2 region1 v6, v40  ; v6 = 3
 ;; @0025                               trapz v268, user16
 ;;                                     v270 = iconst.i32 24
-;; @0025                               v58 = uadd_overflow_trap v268, v270, user2  ; v270 = 24
-;;                                     v117 = load.i32 notrap v145
-;; @0025                               v59 = uextend.i64 v58
-;; @0025                               v61 = iadd v31, v59
+;; @0025                               v59 = uadd_overflow_trap v268, v270, user2  ; v270 = 24
+;;                                     v118 = load.i32 notrap v145
+;; @0025                               v60 = uextend.i64 v59
+;; @0025                               v62 = iadd v31, v60
 ;;                                     v147 = iconst.i64 12
-;; @0025                               v64 = isub v61, v147  ; v147 = 12
-;; @0025                               store user2 little region1 v117, v64
-;; @0025                               v71 = load.i32 user2 readonly region1 v39
-;; @0025                               v65 = iconst.i32 1
-;;                                     v208 = icmp ugt v71, v65  ; v65 = 1
+;; @0025                               v65 = isub v62, v147  ; v147 = 12
+;; @0025                               store user2 little region1 v118, v65
+;; @0025                               v72 = load.i32 user2 readonly region1 v40
+;; @0025                               v66 = iconst.i32 1
+;;                                     v208 = icmp ugt v72, v66  ; v66 = 1
 ;; @0025                               trapz v208, user17
-;; @0025                               v74 = uextend.i64 v71
+;; @0025                               v75 = uextend.i64 v72
 ;;                                     v148 = iconst.i64 2
-;;                                     v210 = ishl v74, v148  ; v148 = 2
+;;                                     v210 = ishl v75, v148  ; v148 = 2
 ;;                                     v141 = iconst.i64 32
-;; @0025                               v76 = ushr v210, v141  ; v141 = 32
-;; @0025                               trapnz v76, user2
+;; @0025                               v77 = ushr v210, v141  ; v141 = 32
+;; @0025                               trapnz v77, user2
 ;;                                     v187 = iconst.i32 2
-;;                                     v217 = ishl v71, v187  ; v187 = 2
+;;                                     v217 = ishl v72, v187  ; v187 = 2
 ;; @0025                               v7 = iconst.i32 12
-;; @0025                               v79 = uadd_overflow_trap v217, v7, user2  ; v7 = 12
-;; @0025                               v83 = uadd_overflow_trap v268, v79, user2
-;;                                     v116 = load.i32 notrap v144
-;; @0025                               v84 = uextend.i64 v83
-;; @0025                               v86 = iadd v31, v84
+;; @0025                               v80 = uadd_overflow_trap v217, v7, user2  ; v7 = 12
+;; @0025                               v84 = uadd_overflow_trap v268, v80, user2
+;;                                     v117 = load.i32 notrap v144
+;; @0025                               v85 = uextend.i64 v84
+;; @0025                               v87 = iadd v31, v85
 ;;                                     v230 = iconst.i32 16
-;; @0025                               v87 = isub v79, v230  ; v230 = 16
-;; @0025                               v88 = uextend.i64 v87
-;; @0025                               v89 = isub v86, v88
-;; @0025                               store user2 little region1 v116, v89
-;; @0025                               v96 = load.i32 user2 readonly region1 v39
-;;                                     v236 = icmp ugt v96, v187  ; v187 = 2
+;; @0025                               v88 = isub v80, v230  ; v230 = 16
+;; @0025                               v89 = uextend.i64 v88
+;; @0025                               v90 = isub v87, v89
+;; @0025                               store user2 little region1 v117, v90
+;; @0025                               v97 = load.i32 user2 readonly region1 v40
+;;                                     v236 = icmp ugt v97, v187  ; v187 = 2
 ;; @0025                               trapz v236, user17
-;; @0025                               v99 = uextend.i64 v96
-;;                                     v238 = ishl v99, v148  ; v148 = 2
-;; @0025                               v101 = ushr v238, v141  ; v141 = 32
-;; @0025                               trapnz v101, user2
-;;                                     v245 = ishl v96, v187  ; v187 = 2
-;; @0025                               v104 = uadd_overflow_trap v245, v7, user2  ; v7 = 12
-;; @0025                               v108 = uadd_overflow_trap v268, v104, user2
-;;                                     v115 = load.i32 notrap v143
-;; @0025                               v109 = uextend.i64 v108
-;; @0025                               v111 = iadd v31, v109
+;; @0025                               v100 = uextend.i64 v97
+;;                                     v238 = ishl v100, v148  ; v148 = 2
+;; @0025                               v102 = ushr v238, v141  ; v141 = 32
+;; @0025                               trapnz v102, user2
+;;                                     v245 = ishl v97, v187  ; v187 = 2
+;; @0025                               v105 = uadd_overflow_trap v245, v7, user2  ; v7 = 12
+;; @0025                               v109 = uadd_overflow_trap v268, v105, user2
+;;                                     v116 = load.i32 notrap v143
+;; @0025                               v110 = uextend.i64 v109
+;; @0025                               v112 = iadd v31, v110
 ;;                                     v262 = iconst.i32 20
-;; @0025                               v112 = isub v104, v262  ; v262 = 20
-;; @0025                               v113 = uextend.i64 v112
-;; @0025                               v114 = isub v111, v113
-;; @0025                               store user2 little region1 v115, v114
+;; @0025                               v113 = isub v105, v262  ; v262 = 20
+;; @0025                               v114 = uextend.i64 v113
+;; @0025                               v115 = isub v112, v114
+;; @0025                               store user2 little region1 v116, v115
 ;; @0029                               jump block1
 ;;
 ;;                                 block3 cold:

--- a/tests/disas/gc/null/array-new-fixed.wat
+++ b/tests/disas/gc/null/array-new-fixed.wat
@@ -51,55 +51,55 @@
 ;; @0025                               store.i32 user2 region1 v24, v17
 ;; @0025                               v6 = iconst.i32 3
 ;;                                     v136 = iconst.i64 8
-;; @0025                               v39 = iadd v33, v136  ; v136 = 8
-;; @0025                               store user2 region1 v6, v39  ; v6 = 3
+;; @0025                               v40 = iadd v33, v136  ; v136 = 8
+;; @0025                               store user2 region1 v6, v40  ; v6 = 3
 ;; @0025                               trapz v256, user16
 ;;                                     v258 = iconst.i32 40
-;; @0025                               v58 = uadd_overflow_trap v256, v258, user2  ; v258 = 40
-;; @0025                               v59 = uextend.i64 v58
-;; @0025                               v61 = iadd v31, v59
+;; @0025                               v59 = uadd_overflow_trap v256, v258, user2  ; v258 = 40
+;; @0025                               v60 = uextend.i64 v59
+;; @0025                               v62 = iadd v31, v60
 ;;                                     v138 = iconst.i64 24
-;; @0025                               v64 = isub v61, v138  ; v138 = 24
-;; @0025                               store.i64 user2 little region1 v2, v64
-;; @0025                               v71 = load.i32 user2 readonly region1 v39
-;; @0025                               v65 = iconst.i32 1
-;;                                     v197 = icmp ugt v71, v65  ; v65 = 1
+;; @0025                               v65 = isub v62, v138  ; v138 = 24
+;; @0025                               store.i64 user2 little region1 v2, v65
+;; @0025                               v72 = load.i32 user2 readonly region1 v40
+;; @0025                               v66 = iconst.i32 1
+;;                                     v197 = icmp ugt v72, v66  ; v66 = 1
 ;; @0025                               trapz v197, user17
-;; @0025                               v74 = uextend.i64 v71
+;; @0025                               v75 = uextend.i64 v72
 ;;                                     v137 = iconst.i64 3
-;;                                     v199 = ishl v74, v137  ; v137 = 3
+;;                                     v199 = ishl v75, v137  ; v137 = 3
 ;;                                     v135 = iconst.i64 32
-;; @0025                               v76 = ushr v199, v135  ; v135 = 32
-;; @0025                               trapnz v76, user2
-;;                                     v206 = ishl v71, v6  ; v6 = 3
+;; @0025                               v77 = ushr v199, v135  ; v135 = 32
+;; @0025                               trapnz v77, user2
+;;                                     v206 = ishl v72, v6  ; v6 = 3
 ;; @0025                               v7 = iconst.i32 16
-;; @0025                               v79 = uadd_overflow_trap v206, v7, user2  ; v7 = 16
-;; @0025                               v83 = uadd_overflow_trap v256, v79, user2
-;; @0025                               v84 = uextend.i64 v83
-;; @0025                               v86 = iadd v31, v84
+;; @0025                               v80 = uadd_overflow_trap v206, v7, user2  ; v7 = 16
+;; @0025                               v84 = uadd_overflow_trap v256, v80, user2
+;; @0025                               v85 = uextend.i64 v84
+;; @0025                               v87 = iadd v31, v85
 ;;                                     v146 = iconst.i32 24
-;; @0025                               v87 = isub v79, v146  ; v146 = 24
-;; @0025                               v88 = uextend.i64 v87
-;; @0025                               v89 = isub v86, v88
-;; @0025                               store.i64 user2 little region1 v3, v89
-;; @0025                               v96 = load.i32 user2 readonly region1 v39
-;; @0025                               v90 = iconst.i32 2
-;;                                     v224 = icmp ugt v96, v90  ; v90 = 2
+;; @0025                               v88 = isub v80, v146  ; v146 = 24
+;; @0025                               v89 = uextend.i64 v88
+;; @0025                               v90 = isub v87, v89
+;; @0025                               store.i64 user2 little region1 v3, v90
+;; @0025                               v97 = load.i32 user2 readonly region1 v40
+;; @0025                               v91 = iconst.i32 2
+;;                                     v224 = icmp ugt v97, v91  ; v91 = 2
 ;; @0025                               trapz v224, user17
-;; @0025                               v99 = uextend.i64 v96
-;;                                     v226 = ishl v99, v137  ; v137 = 3
-;; @0025                               v101 = ushr v226, v135  ; v135 = 32
-;; @0025                               trapnz v101, user2
-;;                                     v233 = ishl v96, v6  ; v6 = 3
-;; @0025                               v104 = uadd_overflow_trap v233, v7, user2  ; v7 = 16
-;; @0025                               v108 = uadd_overflow_trap v256, v104, user2
-;; @0025                               v109 = uextend.i64 v108
-;; @0025                               v111 = iadd v31, v109
+;; @0025                               v100 = uextend.i64 v97
+;;                                     v226 = ishl v100, v137  ; v137 = 3
+;; @0025                               v102 = ushr v226, v135  ; v135 = 32
+;; @0025                               trapnz v102, user2
+;;                                     v233 = ishl v97, v6  ; v6 = 3
+;; @0025                               v105 = uadd_overflow_trap v233, v7, user2  ; v7 = 16
+;; @0025                               v109 = uadd_overflow_trap v256, v105, user2
+;; @0025                               v110 = uextend.i64 v109
+;; @0025                               v112 = iadd v31, v110
 ;;                                     v250 = iconst.i32 32
-;; @0025                               v112 = isub v104, v250  ; v250 = 32
-;; @0025                               v113 = uextend.i64 v112
-;; @0025                               v114 = isub v111, v113
-;; @0025                               store.i64 user2 little region1 v4, v114
+;; @0025                               v113 = isub v105, v250  ; v250 = 32
+;; @0025                               v114 = uextend.i64 v113
+;; @0025                               v115 = isub v112, v114
+;; @0025                               store.i64 user2 little region1 v4, v115
 ;; @0029                               jump block1
 ;;
 ;;                                 block3 cold:

--- a/tests/disas/gc/null/array-new.wat
+++ b/tests/disas/gc/null/array-new.wat
@@ -63,27 +63,27 @@
 ;; @0022                               store user2 region1 v36, v31+4
 ;; @0022                               store.i32 user2 region1 v22, v15
 ;;                                     v90 = iconst.i64 8
-;; @0022                               v37 = iadd v31, v90  ; v90 = 8
-;; @0022                               store.i32 user2 region1 v3, v37
+;; @0022                               v38 = iadd v31, v90  ; v90 = 8
+;; @0022                               store.i32 user2 region1 v3, v38
 ;; @0022                               trapz v126, user16
-;; @0022                               v61 = load.i64 notrap aligned v87+40
-;;                                     v78 = iconst.i64 16
-;; @0022                               v54 = iadd v31, v78  ; v78 = 16
-;; @0022                               v63 = uadd_overflow_trap v54, v92, user2
-;; @0022                               v62 = iadd v29, v61
-;; @0022                               v64 = icmp ugt v63, v62
-;; @0022                               trapnz v64, user2
+;; @0022                               v63 = load.i64 notrap aligned v87+40
+;; @0022                               v55 = iconst.i64 16
+;; @0022                               v56 = iadd v31, v55  ; v55 = 16
+;; @0022                               v65 = uadd_overflow_trap v56, v92, user2
+;; @0022                               v64 = iadd v29, v63
+;; @0022                               v66 = icmp ugt v65, v64
+;; @0022                               trapnz v66, user2
 ;;                                     v111 = iconst.i64 0
-;; @0022                               v67 = icmp.i64 eq v6, v111  ; v111 = 0
-;; @0022                               v65 = iadd v54, v92
-;; @0022                               brif v67, block5, block4(v54)
+;; @0022                               v69 = icmp.i64 eq v6, v111  ; v111 = 0
+;; @0022                               v67 = iadd v56, v92
+;; @0022                               brif v69, block5, block4(v56)
 ;;
-;;                                 block4(v68: i64):
-;; @0022                               store.i64 user2 little region1 v2, v68
+;;                                 block4(v70: i64):
+;; @0022                               store.i64 user2 little region1 v2, v70
 ;;                                     v128 = iconst.i64 8
-;;                                     v129 = iadd v68, v128  ; v128 = 8
-;; @0022                               v70 = icmp eq v129, v65
-;; @0022                               brif v70, block5, block4(v129)
+;;                                     v129 = iadd v70, v128  ; v128 = 8
+;; @0022                               v73 = icmp eq v129, v67
+;; @0022                               brif v73, block5, block4(v129)
 ;;
 ;;                                 block5:
 ;; @0025                               jump block1

--- a/tests/disas/gc/null/externref-globals.wat
+++ b/tests/disas/gc/null/externref-globals.wat
@@ -20,13 +20,13 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;;                                     v6 = iconst.i64 48
-;; @0034                               v4 = iadd v0, v6  ; v6 = 48
-;; @0034                               v5 = load.i32 notrap aligned v4
+;; @0034                               v4 = iconst.i64 48
+;; @0034                               v5 = iadd v0, v4  ; v4 = 48
+;; @0034                               v6 = load.i32 notrap aligned v5
 ;; @0036                               jump block1
 ;;
 ;;                                 block1:
-;; @0036                               return v5
+;; @0036                               return v6
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) tail {
@@ -37,9 +37,9 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;;                                     v5 = iconst.i64 48
-;; @003b                               v4 = iadd v0, v5  ; v5 = 48
-;; @003b                               store notrap aligned v2, v4
+;; @003b                               v4 = iconst.i64 48
+;; @003b                               v5 = iadd v0, v4  ; v4 = 48
+;; @003b                               store notrap aligned v2, v5
 ;; @003d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/null/funcref-in-gc-heap-new.wat
+++ b/tests/disas/gc/null/funcref-in-gc-heap-new.wat
@@ -51,11 +51,11 @@
 ;; @0020                               v30 = load.i32 notrap aligned readonly can_move v29
 ;; @0020                               store user2 region1 v30, v25+4
 ;; @0020                               store.i32 user2 region1 v16, v9
-;; @0020                               v33 = call fn1(v0, v2)
-;; @0020                               v34 = ireduce.i32 v33
-;;                                     v35 = iconst.i64 8
-;; @0020                               v31 = iadd v25, v35  ; v35 = 8
-;; @0020                               store user2 little region1 v34, v31
+;; @0020                               v34 = call fn1(v0, v2)
+;; @0020                               v35 = ireduce.i32 v34
+;; @0020                               v31 = iconst.i64 8
+;; @0020                               v32 = iadd v25, v31  ; v31 = 8
+;; @0020                               store user2 little region1 v35, v32
 ;; @0023                               jump block1
 ;;
 ;;                                 block3 cold:

--- a/tests/disas/gc/null/i31ref-globals.wat
+++ b/tests/disas/gc/null/i31ref-globals.wat
@@ -20,13 +20,13 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;;                                     v6 = iconst.i64 48
-;; @0036                               v4 = iadd v0, v6  ; v6 = 48
-;; @0036                               v5 = load.i32 notrap aligned v4
+;; @0036                               v4 = iconst.i64 48
+;; @0036                               v5 = iadd v0, v4  ; v4 = 48
+;; @0036                               v6 = load.i32 notrap aligned v5
 ;; @0038                               jump block1
 ;;
 ;;                                 block1:
-;; @0038                               return v5
+;; @0038                               return v6
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) tail {
@@ -37,9 +37,9 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;;                                     v5 = iconst.i64 48
-;; @003d                               v4 = iadd v0, v5  ; v5 = 48
-;; @003d                               store notrap aligned v2, v4
+;; @003d                               v4 = iconst.i64 48
+;; @003d                               v5 = iadd v0, v4  ; v4 = 48
+;; @003d                               store notrap aligned v2, v5
 ;; @003f                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/null/struct-new-default.wat
+++ b/tests/disas/gc/null/struct-new-default.wat
@@ -52,16 +52,16 @@
 ;; @0021                               store user2 region1 v32, v27+4
 ;; @0021                               store.i32 user2 region1 v18, v11
 ;; @0021                               v3 = f32const 0.0
-;;                                     v38 = iconst.i64 8
-;; @0021                               v33 = iadd v27, v38  ; v38 = 8
-;; @0021                               store user2 little region1 v3, v33  ; v3 = 0.0
+;; @0021                               v33 = iconst.i64 8
+;; @0021                               v34 = iadd v27, v33  ; v33 = 8
+;; @0021                               store user2 little region1 v3, v34  ; v3 = 0.0
 ;; @0021                               v4 = iconst.i32 0
-;;                                     v37 = iconst.i64 12
-;; @0021                               v34 = iadd v27, v37  ; v37 = 12
-;; @0021                               istore8 user2 little region1 v4, v34  ; v4 = 0
-;;                                     v36 = iconst.i64 16
-;; @0021                               v35 = iadd v27, v36  ; v36 = 16
-;; @0021                               store user2 little region1 v4, v35  ; v4 = 0
+;; @0021                               v35 = iconst.i64 12
+;; @0021                               v36 = iadd v27, v35  ; v35 = 12
+;; @0021                               istore8 user2 little region1 v4, v36  ; v4 = 0
+;; @0021                               v37 = iconst.i64 16
+;; @0021                               v38 = iadd v27, v37  ; v37 = 16
+;; @0021                               store user2 little region1 v4, v38  ; v4 = 0
 ;; @0024                               jump block1
 ;;
 ;;                                 block3 cold:

--- a/tests/disas/gc/null/struct-new.wat
+++ b/tests/disas/gc/null/struct-new.wat
@@ -54,16 +54,16 @@
 ;; @002a                               v32 = load.i32 notrap aligned readonly can_move v31
 ;; @002a                               store user2 region1 v32, v27+4
 ;; @002a                               store.i32 user2 region1 v18, v11
-;;                                     v40 = iconst.i64 8
-;; @002a                               v33 = iadd v27, v40  ; v40 = 8
-;; @002a                               store.f32 user2 little region1 v2, v33
-;;                                     v39 = iconst.i64 12
-;; @002a                               v34 = iadd v27, v39  ; v39 = 12
-;; @002a                               istore8.i32 user2 little region1 v3, v34
-;;                                     v36 = load.i32 notrap v45
-;;                                     v38 = iconst.i64 16
-;; @002a                               v35 = iadd v27, v38  ; v38 = 16
-;; @002a                               store user2 little region1 v36, v35
+;; @002a                               v33 = iconst.i64 8
+;; @002a                               v34 = iadd v27, v33  ; v33 = 8
+;; @002a                               store.f32 user2 little region1 v2, v34
+;; @002a                               v35 = iconst.i64 12
+;; @002a                               v36 = iadd v27, v35  ; v35 = 12
+;; @002a                               istore8.i32 user2 little region1 v3, v36
+;;                                     v39 = load.i32 notrap v45
+;; @002a                               v37 = iconst.i64 16
+;; @002a                               v38 = iadd v27, v37  ; v37 = 16
+;; @002a                               store user2 little region1 v39, v38
 ;; @002d                               jump block1
 ;;
 ;;                                 block3 cold:

--- a/tests/disas/gc/struct-new-default.wat
+++ b/tests/disas/gc/struct-new-default.wat
@@ -68,20 +68,20 @@
 ;;
 ;;                                 block4(v39: i32, v40: i64):
 ;; @0023                               v3 = f32const 0.0
-;;                                     v48 = iconst.i64 16
-;; @0023                               v41 = iadd v40, v48  ; v48 = 16
-;; @0023                               store user2 little region1 v3, v41  ; v3 = 0.0
+;; @0023                               v41 = iconst.i64 16
+;; @0023                               v42 = iadd v40, v41  ; v41 = 16
+;; @0023                               store user2 little region1 v3, v42  ; v3 = 0.0
 ;; @0023                               v4 = iconst.i32 0
-;;                                     v47 = iconst.i64 20
-;; @0023                               v42 = iadd v40, v47  ; v47 = 20
-;; @0023                               istore8 user2 little region1 v4, v42  ; v4 = 0
-;;                                     v46 = iconst.i64 24
-;; @0023                               v43 = iadd v40, v46  ; v46 = 24
-;; @0023                               store user2 little region1 v4, v43  ; v4 = 0
+;; @0023                               v43 = iconst.i64 20
+;; @0023                               v44 = iadd v40, v43  ; v43 = 20
+;; @0023                               istore8 user2 little region1 v4, v44  ; v4 = 0
+;; @0023                               v45 = iconst.i64 24
+;; @0023                               v46 = iadd v40, v45  ; v45 = 24
+;; @0023                               store user2 little region1 v4, v46  ; v4 = 0
 ;; @0023                               v6 = vconst.i8x16 const0
-;;                                     v45 = iconst.i64 32
-;; @0023                               v44 = iadd v40, v45  ; v45 = 32
-;; @0023                               store user2 little region1 v6, v44  ; v6 = const0
+;; @0023                               v47 = iconst.i64 32
+;; @0023                               v48 = iadd v40, v47  ; v47 = 32
+;; @0023                               store user2 little region1 v6, v48  ; v6 = const0
 ;; @0026                               jump block1(v39)
 ;;
 ;;                                 block1(v2: i32):

--- a/tests/disas/gc/struct-new.wat
+++ b/tests/disas/gc/struct-new.wat
@@ -68,16 +68,16 @@
 ;; @002a                               jump block4(v26, v29)
 ;;
 ;;                                 block4(v38: i32, v39: i64):
-;;                                     v47 = iconst.i64 16
-;; @002a                               v40 = iadd v39, v47  ; v47 = 16
-;; @002a                               store.f32 user2 little region1 v2, v40
-;;                                     v46 = iconst.i64 20
-;; @002a                               v41 = iadd v39, v46  ; v46 = 20
-;; @002a                               istore8.i32 user2 little region1 v3, v41
-;;                                     v43 = load.i32 notrap v52
-;;                                     v45 = iconst.i64 24
-;; @002a                               v42 = iadd v39, v45  ; v45 = 24
-;; @002a                               store user2 little region1 v43, v42
+;; @002a                               v40 = iconst.i64 16
+;; @002a                               v41 = iadd v39, v40  ; v40 = 16
+;; @002a                               store.f32 user2 little region1 v2, v41
+;; @002a                               v42 = iconst.i64 20
+;; @002a                               v43 = iadd v39, v42  ; v42 = 20
+;; @002a                               istore8.i32 user2 little region1 v3, v43
+;;                                     v46 = load.i32 notrap v52
+;; @002a                               v44 = iconst.i64 24
+;; @002a                               v45 = iadd v39, v44  ; v44 = 24
+;; @002a                               store user2 little region1 v46, v45
 ;; @002d                               jump block1(v38)
 ;;
 ;;                                 block1(v5: i32):

--- a/tests/disas/memory-copy-fuel.wat
+++ b/tests/disas/memory-copy-fuel.wat
@@ -25,78 +25,78 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
 ;; @001e                               v5 = load.i64 notrap aligned readonly can_move v0+8
 ;; @001e                               v6 = load.i64 notrap aligned v5
-;;                                     v91 = iconst.i64 1
-;; @001e                               v7 = iadd v6, v91  ; v91 = 1
-;; @001e                               v8 = iconst.i64 0
-;; @001e                               v9 = icmp sge v7, v8  ; v8 = 0
-;; @001e                               brif v9, block2, block3(v7)
+;; @001e                               v7 = iconst.i64 1
+;; @001e                               v8 = iadd v6, v7  ; v7 = 1
+;; @001e                               v9 = iconst.i64 0
+;; @001e                               v10 = icmp sge v8, v9  ; v9 = 0
+;; @001e                               brif v10, block2, block3(v8)
 ;;
 ;;                                 block2:
-;;                                     v96 = iadd.i64 v6, v91  ; v91 = 1
+;;                                     v96 = iadd.i64 v6, v7  ; v7 = 1
 ;; @001e                               store notrap aligned v96, v5
-;; @001e                               v12 = call fn0(v0)
-;; @001e                               v14 = load.i64 notrap aligned v5
-;; @001e                               jump block3(v14)
+;; @001e                               v13 = call fn0(v0)
+;; @001e                               v15 = load.i64 notrap aligned v5
+;; @001e                               jump block3(v15)
 ;;
-;;                                 block3(v42: i64):
-;; @0025                               v19 = load.i64 notrap aligned v0+64
-;; @0025                               v20 = uextend.i64 v2
-;; @0025                               v21 = uextend.i64 v4
-;; @0025                               v23 = iadd v20, v21
-;; @0025                               v24 = icmp ugt v23, v19
-;; @0025                               trapnz v24, heap_oob
-;; @0025                               v31 = uextend.i64 v3
-;; @0025                               v34 = iadd v31, v21
-;; @0025                               v35 = icmp ugt v34, v19
-;; @0025                               trapnz v35, heap_oob
-;; @0025                               v44 = iconst.i64 0x0800_0000
-;; @0025                               v45 = icmp ugt v21, v44  ; v44 = 0x0800_0000
-;; @0025                               v25 = load.i64 notrap aligned readonly can_move v0+56
-;; @0025                               v28 = iadd v25, v20
-;; @0025                               v39 = iadd v25, v31
-;;                                     v82 = iconst.i64 4
-;; @0025                               v43 = iadd v42, v82  ; v82 = 4
-;; @0025                               brif v45, block4(v28, v39, v21, v43), block5(v28, v39, v21, v43)
+;;                                 block3(v43: i64):
+;; @0025                               v20 = load.i64 notrap aligned v0+64
+;; @0025                               v21 = uextend.i64 v2
+;; @0025                               v22 = uextend.i64 v4
+;; @0025                               v24 = iadd v21, v22
+;; @0025                               v25 = icmp ugt v24, v20
+;; @0025                               trapnz v25, heap_oob
+;; @0025                               v32 = uextend.i64 v3
+;; @0025                               v35 = iadd v32, v22
+;; @0025                               v36 = icmp ugt v35, v20
+;; @0025                               trapnz v36, heap_oob
+;; @0025                               v46 = iconst.i64 0x0800_0000
+;; @0025                               v47 = icmp ugt v22, v46  ; v46 = 0x0800_0000
+;; @0025                               v26 = load.i64 notrap aligned readonly can_move v0+56
+;; @0025                               v29 = iadd v26, v21
+;; @0025                               v40 = iadd v26, v32
+;; @0025                               v44 = iconst.i64 4
+;; @0025                               v45 = iadd v43, v44  ; v44 = 4
+;; @0025                               brif v47, block4(v29, v40, v22, v45), block5(v29, v40, v22, v45)
 ;;
-;;                                 block4(v46: i64, v47: i64, v48: i64, v49: i64):
+;;                                 block4(v48: i64, v49: i64, v50: i64, v51: i64):
 ;;                                     v97 = iconst.i64 0x0800_0000
-;;                                     v98 = iadd v49, v97  ; v97 = 0x0800_0000
+;;                                     v98 = iadd v51, v97  ; v97 = 0x0800_0000
 ;;                                     v99 = iconst.i64 0
 ;;                                     v100 = icmp sge v98, v99  ; v99 = 0
 ;; @0025                               brif v100, block6, block7(v98)
 ;;
-;;                                 block5(v62: i64, v63: i64, v64: i64, v65: i64):
-;; @0025                               v66 = iadd v65, v64
+;;                                 block5(v64: i64, v65: i64, v66: i64, v67: i64):
+;; @0025                               v68 = iadd v67, v66
 ;;                                     v106 = iconst.i64 0
-;;                                     v107 = icmp sge v66, v106  ; v106 = 0
-;; @0025                               brif v107, block8, block9(v66)
+;;                                     v107 = icmp sge v68, v106  ; v106 = 0
+;; @0025                               brif v107, block8, block9(v68)
 ;;
 ;;                                 block6:
 ;; @0025                               store.i64 notrap aligned v98, v5
-;; @0025                               v55 = call fn0(v0)
-;; @0025                               v57 = load.i64 notrap aligned v5
-;; @0025                               jump block7(v57)
+;; @0025                               v57 = call fn0(v0)
+;; @0025                               v59 = load.i64 notrap aligned v5
+;; @0025                               jump block7(v59)
 ;;
-;;                                 block7(v74: i64):
+;;                                 block7(v76: i64):
 ;;                                     v101 = iconst.i64 0x0800_0000
-;; @0025                               call fn1(v0, v46, v47, v101)  ; v101 = 0x0800_0000
-;;                                     v102 = isub.i64 v48, v101  ; v101 = 0x0800_0000
+;; @0025                               call fn1(v0, v48, v49, v101)  ; v101 = 0x0800_0000
+;;                                     v102 = isub.i64 v50, v101  ; v101 = 0x0800_0000
 ;;                                     v103 = icmp ugt v102, v101  ; v101 = 0x0800_0000
-;;                                     v104 = iadd.i64 v46, v101  ; v101 = 0x0800_0000
-;;                                     v105 = iadd.i64 v47, v101  ; v101 = 0x0800_0000
-;; @0025                               brif v103, block4(v104, v105, v102, v74), block5(v104, v105, v102, v74)
+;;                                     v104 = iadd.i64 v48, v101  ; v101 = 0x0800_0000
+;;                                     v105 = iadd.i64 v49, v101  ; v101 = 0x0800_0000
+;; @0025                               brif v103, block4(v104, v105, v102, v76), block5(v104, v105, v102, v76)
 ;;
 ;;                                 block8:
-;; @0025                               store.i64 notrap aligned v66, v5
-;; @0025                               v71 = call fn0(v0)
-;; @0025                               v73 = load.i64 notrap aligned v5
-;; @0025                               jump block9(v73)
+;; @0025                               store.i64 notrap aligned v68, v5
+;; @0025                               v73 = call fn0(v0)
+;; @0025                               v75 = load.i64 notrap aligned v5
+;; @0025                               jump block9(v75)
 ;;
-;;                                 block9(v76: i64):
-;; @0025                               call fn1(v0, v62, v63, v64)
+;;                                 block9(v78: i64):
+;; @0025                               call fn1(v0, v64, v65, v66)
 ;; @0029                               jump block1
 ;;
 ;;                                 block1:
-;; @0029                               store.i64 notrap aligned v76, v5
+;; @0029                               store.i64 notrap aligned v78, v5
 ;; @0029                               return
 ;; }

--- a/tests/disas/ref-func-0.wat
+++ b/tests/disas/ref-func-0.wat
@@ -23,16 +23,16 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;;                                     v17 = iconst.i64 80
-;; @008f                               v7 = iadd v0, v17  ; v17 = 80
-;; @008f                               v8 = load.i32 notrap aligned v7
-;;                                     v16 = iconst.i64 96
-;; @0091                               v10 = iadd v0, v16  ; v16 = 96
-;; @0091                               v11 = load.i32 notrap aligned v10
-;; @0093                               v13 = load.i64 notrap aligned region0 v0+112
-;; @0095                               v15 = load.i64 notrap aligned region1 v0+128
+;; @008f                               v7 = iconst.i64 80
+;; @008f                               v8 = iadd v0, v7  ; v7 = 80
+;; @008f                               v9 = load.i32 notrap aligned v8
+;; @0091                               v11 = iconst.i64 96
+;; @0091                               v12 = iadd v0, v11  ; v11 = 96
+;; @0091                               v13 = load.i32 notrap aligned v12
+;; @0093                               v15 = load.i64 notrap aligned region0 v0+112
+;; @0095                               v17 = load.i64 notrap aligned region1 v0+128
 ;; @0097                               jump block1
 ;;
 ;;                                 block1:
-;; @0097                               return v8, v11, v13, v15
+;; @0097                               return v9, v13, v15, v17
 ;; }

--- a/tests/disas/stack-switching/resume-suspend-data-passing.wat
+++ b/tests/disas/stack-switching/resume-suspend-data-passing.wat
@@ -47,91 +47,91 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64):
 ;; @003c                               v3 = iconst.i32 10
-;;                                     v62 = iconst.i64 120
-;; @0044                               v31 = stack_addr.i64 ss0
-;;                                     v60 = iconst.i64 16
-;;                                     v61 = iconst.i64 0
-;;                                     v58 = iconst.i64 80
-;;                                     v57 = iconst.i64 -24
+;; @0044                               v32 = iconst.i64 120
+;; @0044                               v35 = stack_addr.i64 ss0
+;; @0044                               v41 = iconst.i64 16
+;; @0044                               v38 = iconst.i64 0
+;; @0044                               v49 = iconst.i64 80
+;; @0044                               v52 = iconst.i64 -24
 ;;                                     v70 = iconst.i64 0x0002_0000_0000
 ;; @0040                               jump block2(v3)  ; v3 = 10
 ;;
 ;;                                 block2(v4: i32):
-;; @0044                               v8 = load.i64 notrap aligned v0+8
-;; @0044                               v9 = load.i64 notrap aligned v8+88
-;; @0044                               v10 = load.i64 notrap aligned v8+96
-;; @0044                               v13 = iconst.i64 1
-;;                                     v65 = iconst.i64 24
+;; @0044                               v9 = load.i64 notrap aligned v0+8
+;; @0044                               v10 = load.i64 notrap aligned v9+88
+;; @0044                               v11 = load.i64 notrap aligned v9+96
+;; @0044                               v14 = iconst.i64 1
+;; @0044                               v18 = iconst.i64 24
 ;; @003a                               v2 = iconst.i32 0
-;; @0044                               jump block4(v9, v10, v4)
+;; @0044                               jump block4(v10, v11, v4)
 ;;
-;;                                 block4(v11: i64, v12: i64, v53: i32):
+;;                                 block4(v12: i64, v13: i64, v62: i32):
 ;;                                     v73 = iconst.i64 1
-;;                                     v74 = icmp eq v11, v73  ; v73 = 1
+;;                                     v74 = icmp eq v12, v73  ; v73 = 1
 ;; @0044                               trapnz v74, user22
 ;; @0044                               jump block5
 ;;
 ;;                                 block5:
-;; @0044                               v15 = load.i64 notrap aligned v12+48
-;; @0044                               v16 = load.i64 notrap aligned v12+56
+;; @0044                               v16 = load.i64 notrap aligned v13+48
+;; @0044                               v17 = load.i64 notrap aligned v13+56
 ;;                                     v75 = iconst.i64 24
-;;                                     v76 = iadd v16, v75  ; v75 = 24
-;; @0044                               v18 = load.i64 notrap aligned v76+8
-;; @0044                               v19 = load.i32 notrap aligned v16+40
+;;                                     v76 = iadd v17, v75  ; v75 = 24
+;; @0044                               v20 = load.i64 notrap aligned v76+8
+;; @0044                               v21 = load.i32 notrap aligned v17+40
 ;;                                     v77 = iconst.i32 0
 ;;                                     v67 = iconst.i32 3
-;;                                     v66 = iconst.i64 48
-;; @0044                               v6 = iadd.i64 v0, v66  ; v66 = 48
-;;                                     v63 = iconst.i32 1
+;; @0044                               v6 = iconst.i64 48
+;; @0044                               v7 = iadd.i64 v0, v6  ; v6 = 48
+;; @0044                               v30 = iconst.i32 1
 ;; @0044                               jump block6(v77)  ; v77 = 0
 ;;
-;;                                 block6(v21: i32):
-;; @0044                               v22 = icmp ult v21, v19
-;; @0044                               brif v22, block7, block4(v15, v16, v53)
+;;                                 block6(v23: i32):
+;; @0044                               v24 = icmp ult v23, v21
+;; @0044                               brif v24, block7, block4(v16, v17, v62)
 ;;
 ;;                                 block7:
 ;;                                     v78 = iconst.i32 3
-;;                                     v79 = ishl.i32 v21, v78  ; v78 = 3
-;; @0044                               v24 = uextend.i64 v79
-;; @0044                               v25 = iadd.i64 v18, v24
-;; @0044                               v26 = load.i64 notrap aligned v25
-;;                                     v80 = iadd.i64 v0, v66  ; v66 = 48
-;;                                     v81 = icmp eq v26, v80
+;;                                     v79 = ishl.i32 v23, v78  ; v78 = 3
+;; @0044                               v26 = uextend.i64 v79
+;; @0044                               v27 = iadd.i64 v20, v26
+;; @0044                               v28 = load.i64 notrap aligned v27
+;;                                     v80 = iadd.i64 v0, v6  ; v6 = 48
+;;                                     v81 = icmp eq v28, v80
 ;;                                     v82 = iconst.i32 1
-;;                                     v83 = iadd.i32 v21, v82  ; v82 = 1
+;;                                     v83 = iadd.i32 v23, v82  ; v82 = 1
 ;; @0044                               brif v81, block8, block6(v83)
 ;;
 ;;                                 block8:
-;; @0044                               store.i64 notrap aligned v12, v10+64
+;; @0044                               store.i64 notrap aligned v13, v11+64
 ;;                                     v84 = iconst.i32 1
 ;;                                     v85 = iconst.i64 120
-;;                                     v86 = iadd.i64 v10, v85  ; v85 = 120
+;;                                     v86 = iadd.i64 v11, v85  ; v85 = 120
 ;; @0044                               store notrap aligned v84, v86+4  ; v84 = 1
-;; @0044                               store.i64 notrap aligned v31, v86+8
-;; @0044                               store.i32 notrap aligned v4, v31
+;; @0044                               store.i64 notrap aligned v35, v86+8
+;; @0044                               store.i32 notrap aligned v4, v35
 ;; @0044                               store notrap aligned v84, v86  ; v84 = 1
 ;;                                     v87 = iconst.i32 3
 ;;                                     v88 = iconst.i64 16
-;;                                     v89 = iadd.i64 v10, v88  ; v88 = 16
+;;                                     v89 = iadd.i64 v11, v88  ; v88 = 16
 ;; @0044                               store notrap aligned v87, v89  ; v87 = 3
 ;;                                     v90 = iconst.i64 0
-;; @0044                               store notrap aligned v90, v12+48  ; v90 = 0
-;; @0044                               store notrap aligned v90, v12+56  ; v90 = 0
+;; @0044                               store notrap aligned v90, v13+48  ; v90 = 0
+;; @0044                               store notrap aligned v90, v13+56  ; v90 = 0
 ;;                                     v91 = iconst.i64 80
-;;                                     v92 = iadd.i64 v12, v91  ; v91 = 80
-;; @0044                               v44 = load.i64 notrap aligned v92
+;;                                     v92 = iadd.i64 v13, v91  ; v91 = 80
+;; @0044                               v51 = load.i64 notrap aligned v92
 ;;                                     v93 = iconst.i64 -24
-;;                                     v94 = iadd v44, v93  ; v93 = -24
-;; @0044                               v41 = uextend.i64 v21
+;;                                     v94 = iadd v51, v93  ; v93 = -24
+;; @0044                               v47 = uextend.i64 v23
 ;;                                     v95 = iconst.i64 0x0002_0000_0000
-;;                                     v96 = bor v41, v95  ; v95 = 0x0002_0000_0000
-;; @0044                               v46 = stack_switch v94, v94, v96
-;; @0044                               v48 = load.i64 notrap aligned v86+8
+;;                                     v96 = bor v47, v95  ; v95 = 0x0002_0000_0000
+;; @0044                               v54 = stack_switch v94, v94, v96
+;; @0044                               v57 = load.i64 notrap aligned v86+8
 ;;                                     v97 = iconst.i32 0
 ;; @0044                               store notrap aligned v97, v86  ; v97 = 0
 ;; @0044                               store notrap aligned v97, v86+4  ; v97 = 0
 ;; @0044                               store notrap aligned v90, v86+8  ; v90 = 0
-;;                                     v98 = isub.i32 v53, v84  ; v84 = 1
+;;                                     v98 = isub.i32 v62, v84  ; v84 = 1
 ;; @004d                               brif v98, block2(v98), block10
 ;;
 ;;                                 block10:
@@ -167,20 +167,20 @@
 ;;                                     v121 = ishl v11, v119  ; v119 = 64
 ;; @0058                               v10 = uextend.i128 v8
 ;; @0058                               v13 = bor v121, v10
-;;                                     v116 = iconst.i64 1
-;; @0062                               v28 = iconst.i64 0
-;; @0062                               v29 = iconst.i64 2
-;; @0062                               v32 = iconst.i32 1
-;;                                     v114 = iconst.i64 16
-;; @0062                               v34 = iconst.i32 2
-;;                                     v110 = iconst.i64 24
-;; @0062                               v45 = stack_addr.i64 ss0
-;;                                     v109 = iconst.i64 48
-;; @0062                               v47 = iadd v0, v109  ; v109 = 48
-;;                                     v107 = iconst.i64 80
-;;                                     v106 = iconst.i64 -24
+;; @0062                               v23 = iconst.i64 1
+;; @0062                               v29 = iconst.i64 0
+;; @0062                               v30 = iconst.i64 2
+;; @0062                               v34 = iconst.i32 1
+;; @0062                               v35 = iconst.i64 16
+;; @0062                               v37 = iconst.i32 2
+;; @0062                               v49 = iconst.i64 24
+;; @0062                               v52 = stack_addr.i64 ss0
+;; @0062                               v54 = iconst.i64 48
+;; @0062                               v55 = iadd v0, v54  ; v54 = 48
+;; @0062                               v61 = iconst.i64 80
+;; @0062                               v64 = iconst.i64 -24
 ;;                                     v125 = iconst.i64 0x0001_0000_0000
-;;                                     v108 = iconst.i64 32
+;;                                     v116 = iconst.i64 32
 ;; @005c                               jump block2(v13)
 ;;
 ;;                                 block2(v16: i128):
@@ -198,114 +198,114 @@
 ;;                                     v130 = iconst.i64 1
 ;;                                     v131 = iadd v21, v130  ; v130 = 1
 ;; @0062                               store notrap aligned v131, v18+72
-;; @0062                               v24 = load.i64 notrap aligned v18+64
-;; @0062                               v25 = load.i64 notrap aligned v0+8
-;; @0062                               v26 = load.i64 notrap aligned v25+88
-;; @0062                               v27 = load.i64 notrap aligned v25+96
-;; @0062                               store notrap aligned v26, v24+48
-;; @0062                               store notrap aligned v27, v24+56
+;; @0062                               v25 = load.i64 notrap aligned v18+64
+;; @0062                               v26 = load.i64 notrap aligned v0+8
+;; @0062                               v27 = load.i64 notrap aligned v26+88
+;; @0062                               v28 = load.i64 notrap aligned v26+96
+;; @0062                               store notrap aligned v27, v25+48
+;; @0062                               store notrap aligned v28, v25+56
 ;;                                     v132 = iconst.i64 0
 ;; @0062                               store notrap aligned v132, v18+64  ; v132 = 0
-;; @0062                               v30 = load.i64 notrap aligned v0+8
+;; @0062                               v31 = load.i64 notrap aligned v0+8
 ;;                                     v133 = iconst.i64 2
-;; @0062                               store notrap aligned v133, v30+88  ; v133 = 2
-;; @0062                               store notrap aligned v18, v30+96
+;; @0062                               store notrap aligned v133, v31+88  ; v133 = 2
+;; @0062                               store notrap aligned v18, v31+96
 ;;                                     v134 = iconst.i32 1
 ;;                                     v135 = iconst.i64 16
 ;;                                     v136 = iadd v18, v135  ; v135 = 16
 ;; @0062                               store notrap aligned v134, v136  ; v134 = 1
 ;;                                     v137 = iconst.i32 2
-;;                                     v138 = iadd v27, v135  ; v135 = 16
+;;                                     v138 = iadd v28, v135  ; v135 = 16
 ;; @0062                               store notrap aligned v137, v138  ; v137 = 2
-;; @0062                               v36 = load.i64 notrap aligned readonly v0+8
-;; @0062                               v38 = load.i64 notrap aligned v36+72
-;; @0062                               store notrap aligned v38, v27+8
-;; @0062                               v39 = load.i64 notrap aligned v36+24
-;; @0062                               store notrap aligned v39, v27
-;; @0062                               v41 = load.i64 notrap aligned v18
-;; @0062                               store notrap aligned v41, v36+24
-;; @0062                               v42 = load.i64 notrap aligned v18+8
-;; @0062                               store notrap aligned v42, v36+72
+;; @0062                               v40 = load.i64 notrap aligned readonly v0+8
+;; @0062                               v43 = load.i64 notrap aligned v40+72
+;; @0062                               store notrap aligned v43, v28+8
+;; @0062                               v44 = load.i64 notrap aligned v40+24
+;; @0062                               store notrap aligned v44, v28
+;; @0062                               v47 = load.i64 notrap aligned v18
+;; @0062                               store notrap aligned v47, v40+24
+;; @0062                               v48 = load.i64 notrap aligned v18+8
+;; @0062                               store notrap aligned v48, v40+72
 ;;                                     v139 = iconst.i64 24
-;;                                     v140 = iadd v27, v139  ; v139 = 24
+;;                                     v140 = iadd v28, v139  ; v139 = 24
 ;; @0062                               store notrap aligned v134, v140+4  ; v134 = 1
-;; @0062                               store.i64 notrap aligned v45, v140+8
-;;                                     v141 = iadd.i64 v0, v109  ; v109 = 48
-;; @0062                               store notrap aligned v141, v45
+;; @0062                               store.i64 notrap aligned v52, v140+8
+;;                                     v141 = iadd.i64 v0, v54  ; v54 = 48
+;; @0062                               store notrap aligned v141, v52
 ;; @0062                               store notrap aligned v134, v140  ; v134 = 1
-;; @0062                               store notrap aligned v134, v27+40  ; v134 = 1
+;; @0062                               store notrap aligned v134, v28+40  ; v134 = 1
 ;;                                     v142 = iconst.i64 80
-;;                                     v143 = iadd v24, v142  ; v142 = 80
-;; @0062                               v54 = load.i64 notrap aligned v143
+;;                                     v143 = iadd v25, v142  ; v142 = 80
+;; @0062                               v63 = load.i64 notrap aligned v143
 ;;                                     v144 = iconst.i64 -24
-;;                                     v145 = iadd v54, v144  ; v144 = -24
+;;                                     v145 = iadd v63, v144  ; v144 = -24
 ;;                                     v146 = iconst.i64 0x0001_0000_0000
-;; @0062                               v56 = stack_switch v145, v145, v146  ; v146 = 0x0001_0000_0000
-;; @0062                               v57 = load.i64 notrap aligned v0+8
-;; @0062                               v58 = load.i64 notrap aligned v57+88
-;; @0062                               v59 = load.i64 notrap aligned v57+96
-;; @0062                               store notrap aligned v26, v57+88
-;; @0062                               store notrap aligned v27, v57+96
+;; @0062                               v66 = stack_switch v145, v145, v146  ; v146 = 0x0001_0000_0000
+;; @0062                               v67 = load.i64 notrap aligned v0+8
+;; @0062                               v68 = load.i64 notrap aligned v67+88
+;; @0062                               v69 = load.i64 notrap aligned v67+96
+;; @0062                               store notrap aligned v27, v67+88
+;; @0062                               store notrap aligned v28, v67+96
 ;; @0062                               store notrap aligned v134, v138  ; v134 = 1
 ;;                                     v147 = iconst.i32 0
 ;; @0062                               store notrap aligned v147, v140  ; v147 = 0
 ;; @0062                               store notrap aligned v147, v140+4  ; v147 = 0
 ;; @0062                               store notrap aligned v132, v140+8  ; v132 = 0
-;; @0062                               store notrap aligned v132, v27+40  ; v132 = 0
+;; @0062                               store notrap aligned v132, v28+40  ; v132 = 0
 ;;                                     v148 = iconst.i64 32
-;;                                     v149 = ushr v56, v148  ; v148 = 32
+;;                                     v149 = ushr v66, v148  ; v148 = 32
 ;; @0062                               brif v149, block7, block6
 ;;
 ;;                                 block7:
-;; @0062                               v69 = load.i64 notrap aligned v36+72
-;; @0062                               store notrap aligned v69, v59+8
-;; @0062                               v71 = load.i64 notrap aligned v27
-;; @0062                               store notrap aligned v71, v36+24
-;; @0062                               v72 = load.i64 notrap aligned v27+8
-;; @0062                               store notrap aligned v72, v36+72
-;; @0062                               v74 = load.i64 notrap aligned v59+72
+;; @0062                               v82 = load.i64 notrap aligned v40+72
+;; @0062                               store notrap aligned v82, v69+8
+;; @0062                               v85 = load.i64 notrap aligned v28
+;; @0062                               store notrap aligned v85, v40+24
+;; @0062                               v86 = load.i64 notrap aligned v28+8
+;; @0062                               store notrap aligned v86, v40+72
+;; @0062                               v88 = load.i64 notrap aligned v69+72
 ;; @0062                               jump block8
 ;;
 ;;                                 block9 cold:
 ;; @0062                               trap user12
 ;;
 ;;                                 block10:
-;;                                     v98 = iconst.i64 120
-;; @0062                               v79 = iadd.i64 v59, v98  ; v98 = 120
-;; @0062                               v80 = load.i64 notrap aligned v79+8
-;; @0062                               v81 = load.i32 notrap aligned v80
+;; @0062                               v93 = iconst.i64 120
+;; @0062                               v94 = iadd.i64 v69, v93  ; v93 = 120
+;; @0062                               v95 = load.i64 notrap aligned v94+8
+;; @0062                               v96 = load.i32 notrap aligned v95
 ;;                                     v154 = iconst.i32 0
-;; @0062                               store notrap aligned v154, v79  ; v154 = 0
+;; @0062                               store notrap aligned v154, v94  ; v154 = 0
 ;; @0062                               jump block4
 ;;
 ;;                                 block8:
-;; @0062                               v73 = ireduce.i32 v56
-;; @0062                               br_table v73, block9, [block10]
+;; @0062                               v87 = ireduce.i32 v66
+;; @0062                               br_table v87, block9, [block10]
 ;;
 ;;                                 block6:
-;; @0062                               v84 = load.i64 notrap aligned v27
-;; @0062                               store notrap aligned v84, v36+24
-;; @0062                               v85 = load.i64 notrap aligned v27+8
-;; @0062                               store notrap aligned v85, v36+72
-;; @0062                               v87 = iconst.i32 4
+;; @0062                               v100 = load.i64 notrap aligned v28
+;; @0062                               store notrap aligned v100, v40+24
+;; @0062                               v101 = load.i64 notrap aligned v28+8
+;; @0062                               store notrap aligned v101, v40+72
+;; @0062                               v104 = iconst.i32 4
 ;;                                     v150 = iconst.i64 16
-;;                                     v151 = iadd.i64 v59, v150  ; v150 = 16
-;; @0062                               store notrap aligned v87, v151  ; v87 = 4
-;;                                     v94 = iconst.i64 104
-;; @0062                               v89 = iadd.i64 v59, v94  ; v94 = 104
-;; @0062                               v90 = load.i64 notrap aligned v89+8
+;;                                     v151 = iadd.i64 v69, v150  ; v150 = 16
+;; @0062                               store notrap aligned v104, v151  ; v104 = 4
+;; @0062                               v107 = iconst.i64 104
+;; @0062                               v108 = iadd.i64 v69, v107  ; v107 = 104
+;; @0062                               v109 = load.i64 notrap aligned v108+8
 ;;                                     v152 = iconst.i32 0
-;; @0062                               store notrap aligned v152, v89  ; v152 = 0
-;; @0062                               store notrap aligned v152, v89+4  ; v152 = 0
+;; @0062                               store notrap aligned v152, v108  ; v152 = 0
+;; @0062                               store notrap aligned v152, v108+4  ; v152 = 0
 ;;                                     v153 = iconst.i64 0
-;; @0062                               store notrap aligned v153, v89+8  ; v153 = 0
+;; @0062                               store notrap aligned v153, v108+8  ; v153 = 0
 ;; @0068                               return
 ;;
 ;;                                 block4:
-;; @0062                               v76 = uextend.i128 v74
+;; @0062                               v90 = uextend.i128 v88
 ;;                                     v155 = iconst.i64 64
-;;                                     v156 = ishl v76, v155  ; v155 = 64
-;; @0062                               v75 = uextend.i128 v59
-;; @0062                               v78 = bor v156, v75
-;; @006d                               jump block2(v78)
+;;                                     v156 = ishl v90, v155  ; v155 = 64
+;; @0062                               v89 = uextend.i128 v69
+;; @0062                               v92 = bor v156, v89
+;; @006d                               jump block2(v92)
 ;; }

--- a/tests/disas/stack-switching/resume-suspend.wat
+++ b/tests/disas/stack-switching/resume-suspend.wat
@@ -30,75 +30,75 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @003b                               v5 = load.i64 notrap aligned v0+8
-;; @003b                               v6 = load.i64 notrap aligned v5+88
-;; @003b                               v7 = load.i64 notrap aligned v5+96
-;; @003b                               v10 = iconst.i64 1
-;;                                     v54 = iconst.i64 24
-;; @003b                               v17 = iconst.i32 0
-;; @003b                               jump block2(v6, v7)
+;; @003b                               v6 = load.i64 notrap aligned v0+8
+;; @003b                               v7 = load.i64 notrap aligned v6+88
+;; @003b                               v8 = load.i64 notrap aligned v6+96
+;; @003b                               v11 = iconst.i64 1
+;; @003b                               v15 = iconst.i64 24
+;; @003b                               v19 = iconst.i32 0
+;; @003b                               jump block2(v7, v8)
 ;;
-;;                                 block2(v8: i64, v9: i64):
+;;                                 block2(v9: i64, v10: i64):
 ;;                                     v62 = iconst.i64 1
-;;                                     v63 = icmp eq v8, v62  ; v62 = 1
+;;                                     v63 = icmp eq v9, v62  ; v62 = 1
 ;; @003b                               trapnz v63, user22
 ;; @003b                               jump block3
 ;;
 ;;                                 block3:
-;; @003b                               v12 = load.i64 notrap aligned v9+48
-;; @003b                               v13 = load.i64 notrap aligned v9+56
+;; @003b                               v13 = load.i64 notrap aligned v10+48
+;; @003b                               v14 = load.i64 notrap aligned v10+56
 ;;                                     v64 = iconst.i64 24
-;;                                     v65 = iadd v13, v64  ; v64 = 24
-;; @003b                               v15 = load.i64 notrap aligned v65+8
-;; @003b                               v16 = load.i32 notrap aligned v13+40
+;;                                     v65 = iadd v14, v64  ; v64 = 24
+;; @003b                               v17 = load.i64 notrap aligned v65+8
+;; @003b                               v18 = load.i32 notrap aligned v14+40
 ;;                                     v66 = iconst.i32 0
 ;;                                     v56 = iconst.i32 3
-;;                                     v55 = iconst.i64 48
-;; @003b                               v3 = iadd.i64 v0, v55  ; v55 = 48
-;;                                     v52 = iconst.i32 1
+;; @003b                               v3 = iconst.i64 48
+;; @003b                               v4 = iadd.i64 v0, v3  ; v3 = 48
+;; @003b                               v27 = iconst.i32 1
 ;; @003b                               jump block4(v66)  ; v66 = 0
 ;;
-;;                                 block4(v18: i32):
-;; @003b                               v19 = icmp ult v18, v16
-;; @003b                               brif v19, block5, block2(v12, v13)
+;;                                 block4(v20: i32):
+;; @003b                               v21 = icmp ult v20, v18
+;; @003b                               brif v21, block5, block2(v13, v14)
 ;;
 ;;                                 block5:
 ;;                                     v67 = iconst.i32 3
-;;                                     v68 = ishl.i32 v18, v67  ; v67 = 3
-;; @003b                               v21 = uextend.i64 v68
-;; @003b                               v22 = iadd.i64 v15, v21
-;; @003b                               v23 = load.i64 notrap aligned v22
-;;                                     v69 = iadd.i64 v0, v55  ; v55 = 48
-;;                                     v70 = icmp eq v23, v69
+;;                                     v68 = ishl.i32 v20, v67  ; v67 = 3
+;; @003b                               v23 = uextend.i64 v68
+;; @003b                               v24 = iadd.i64 v17, v23
+;; @003b                               v25 = load.i64 notrap aligned v24
+;;                                     v69 = iadd.i64 v0, v3  ; v3 = 48
+;;                                     v70 = icmp eq v25, v69
 ;;                                     v71 = iconst.i32 1
-;;                                     v72 = iadd.i32 v18, v71  ; v71 = 1
+;;                                     v72 = iadd.i32 v20, v71  ; v71 = 1
 ;; @003b                               brif v70, block6, block4(v72)
 ;;
 ;;                                 block6:
-;; @003b                               store.i64 notrap aligned v9, v7+64
+;; @003b                               store.i64 notrap aligned v10, v8+64
 ;;                                     v73 = iconst.i32 3
-;;                                     v49 = iconst.i64 16
-;; @003b                               v29 = iadd.i64 v7, v49  ; v49 = 16
-;; @003b                               store notrap aligned v73, v29  ; v73 = 3
-;;                                     v50 = iconst.i64 0
-;; @003b                               store notrap aligned v50, v9+48  ; v50 = 0
-;; @003b                               store notrap aligned v50, v9+56  ; v50 = 0
-;;                                     v47 = iconst.i64 80
-;; @003b                               v36 = iadd.i64 v9, v47  ; v47 = 80
-;; @003b                               v37 = load.i64 notrap aligned v36
-;;                                     v46 = iconst.i64 -24
-;; @003b                               v38 = iadd v37, v46  ; v46 = -24
-;; @003b                               v34 = uextend.i64 v18
+;; @003b                               v34 = iconst.i64 16
+;; @003b                               v35 = iadd.i64 v8, v34  ; v34 = 16
+;; @003b                               store notrap aligned v73, v35  ; v73 = 3
+;; @003b                               v31 = iconst.i64 0
+;; @003b                               store notrap aligned v31, v10+48  ; v31 = 0
+;; @003b                               store notrap aligned v31, v10+56  ; v31 = 0
+;; @003b                               v42 = iconst.i64 80
+;; @003b                               v43 = iadd.i64 v10, v42  ; v42 = 80
+;; @003b                               v44 = load.i64 notrap aligned v43
+;; @003b                               v45 = iconst.i64 -24
+;; @003b                               v46 = iadd v44, v45  ; v45 = -24
+;; @003b                               v40 = uextend.i64 v20
 ;;                                     v59 = iconst.i64 0x0002_0000_0000
-;;                                     v60 = bor v34, v59  ; v59 = 0x0002_0000_0000
-;; @003b                               v39 = stack_switch v38, v38, v60
-;;                                     v51 = iconst.i64 120
-;; @003b                               v26 = iadd.i64 v7, v51  ; v51 = 120
-;; @003b                               v41 = load.i64 notrap aligned v26+8
+;;                                     v60 = bor v40, v59  ; v59 = 0x0002_0000_0000
+;; @003b                               v47 = stack_switch v46, v46, v60
+;; @003b                               v29 = iconst.i64 120
+;; @003b                               v30 = iadd.i64 v8, v29  ; v29 = 120
+;; @003b                               v50 = load.i64 notrap aligned v30+8
 ;;                                     v74 = iconst.i32 0
-;; @003b                               store notrap aligned v74, v26  ; v74 = 0
-;; @003b                               store notrap aligned v74, v26+4  ; v74 = 0
-;; @003b                               store notrap aligned v50, v26+8  ; v50 = 0
+;; @003b                               store notrap aligned v74, v30  ; v74 = 0
+;; @003b                               store notrap aligned v74, v30+4  ; v74 = 0
+;; @003b                               store notrap aligned v31, v30+8  ; v31 = 0
 ;; @003d                               jump block1
 ;;
 ;;                                 block1:
@@ -139,116 +139,116 @@
 ;; @004e                               v23 = ireduce.i64 v140
 ;; @004e                               v25 = icmp eq v24, v23
 ;; @004e                               trapz v25, user23
-;;                                     v125 = iconst.i64 1
-;; @004e                               v26 = iadd v24, v125  ; v125 = 1
-;; @004e                               store notrap aligned v26, v138+72
-;; @004e                               v27 = load.i64 notrap aligned v138+64
-;; @004e                               v28 = load.i64 notrap aligned v0+8
-;; @004e                               v29 = load.i64 notrap aligned v28+88
-;; @004e                               v30 = load.i64 notrap aligned v28+96
-;; @004e                               store notrap aligned v29, v27+48
-;; @004e                               store notrap aligned v30, v27+56
+;; @004e                               v26 = iconst.i64 1
+;; @004e                               v27 = iadd v24, v26  ; v26 = 1
+;; @004e                               store notrap aligned v27, v138+72
+;; @004e                               v28 = load.i64 notrap aligned v138+64
+;; @004e                               v29 = load.i64 notrap aligned v0+8
+;; @004e                               v30 = load.i64 notrap aligned v29+88
+;; @004e                               v31 = load.i64 notrap aligned v29+96
+;; @004e                               store notrap aligned v30, v28+48
+;; @004e                               store notrap aligned v31, v28+56
 ;; @0040                               v2 = iconst.i64 0
 ;; @004e                               store notrap aligned v2, v138+64  ; v2 = 0
-;; @004e                               v33 = load.i64 notrap aligned v0+8
-;; @004e                               v32 = iconst.i64 2
-;; @004e                               store notrap aligned v32, v33+88  ; v32 = 2
-;; @004e                               store notrap aligned v138, v33+96
-;; @004e                               v35 = iconst.i32 1
-;;                                     v123 = iconst.i64 16
-;; @004e                               v36 = iadd v138, v123  ; v123 = 16
-;; @004e                               store notrap aligned v35, v36  ; v35 = 1
-;; @004e                               v37 = iconst.i32 2
-;; @004e                               v38 = iadd v30, v123  ; v123 = 16
-;; @004e                               store notrap aligned v37, v38  ; v37 = 2
-;; @004e                               v39 = load.i64 notrap aligned readonly v0+8
-;; @004e                               v41 = load.i64 notrap aligned v39+72
-;; @004e                               store notrap aligned v41, v30+8
-;; @004e                               v42 = load.i64 notrap aligned v39+24
-;; @004e                               store notrap aligned v42, v30
-;; @004e                               v44 = load.i64 notrap aligned v138
-;; @004e                               store notrap aligned v44, v39+24
-;; @004e                               v45 = load.i64 notrap aligned v138+8
-;; @004e                               store notrap aligned v45, v39+72
-;;                                     v119 = iconst.i64 24
-;; @004e                               v46 = iadd v30, v119  ; v119 = 24
-;; @004e                               store notrap aligned v35, v46+4  ; v35 = 1
-;; @004e                               v48 = stack_addr.i64 ss0
-;; @004e                               store notrap aligned v48, v46+8
-;;                                     v118 = iconst.i64 48
-;; @004e                               v50 = iadd.i64 v0, v118  ; v118 = 48
-;; @004e                               store notrap aligned v50, v48
-;; @004e                               store notrap aligned v35, v46  ; v35 = 1
-;; @004e                               store notrap aligned v35, v30+40  ; v35 = 1
-;;                                     v116 = iconst.i64 80
-;; @004e                               v56 = iadd v27, v116  ; v116 = 80
-;; @004e                               v57 = load.i64 notrap aligned v56
-;;                                     v115 = iconst.i64 -24
-;; @004e                               v58 = iadd v57, v115  ; v115 = -24
+;; @004e                               v34 = load.i64 notrap aligned v0+8
+;; @004e                               v33 = iconst.i64 2
+;; @004e                               store notrap aligned v33, v34+88  ; v33 = 2
+;; @004e                               store notrap aligned v138, v34+96
+;; @004e                               v37 = iconst.i32 1
+;; @004e                               v38 = iconst.i64 16
+;; @004e                               v39 = iadd v138, v38  ; v38 = 16
+;; @004e                               store notrap aligned v37, v39  ; v37 = 1
+;; @004e                               v40 = iconst.i32 2
+;; @004e                               v42 = iadd v31, v38  ; v38 = 16
+;; @004e                               store notrap aligned v40, v42  ; v40 = 2
+;; @004e                               v43 = load.i64 notrap aligned readonly v0+8
+;; @004e                               v46 = load.i64 notrap aligned v43+72
+;; @004e                               store notrap aligned v46, v31+8
+;; @004e                               v47 = load.i64 notrap aligned v43+24
+;; @004e                               store notrap aligned v47, v31
+;; @004e                               v50 = load.i64 notrap aligned v138
+;; @004e                               store notrap aligned v50, v43+24
+;; @004e                               v51 = load.i64 notrap aligned v138+8
+;; @004e                               store notrap aligned v51, v43+72
+;; @004e                               v52 = iconst.i64 24
+;; @004e                               v53 = iadd v31, v52  ; v52 = 24
+;; @004e                               store notrap aligned v37, v53+4  ; v37 = 1
+;; @004e                               v55 = stack_addr.i64 ss0
+;; @004e                               store notrap aligned v55, v53+8
+;; @004e                               v57 = iconst.i64 48
+;; @004e                               v58 = iadd.i64 v0, v57  ; v57 = 48
+;; @004e                               store notrap aligned v58, v55
+;; @004e                               store notrap aligned v37, v53  ; v37 = 1
+;; @004e                               store notrap aligned v37, v31+40  ; v37 = 1
+;; @004e                               v64 = iconst.i64 80
+;; @004e                               v65 = iadd v28, v64  ; v64 = 80
+;; @004e                               v66 = load.i64 notrap aligned v65
+;; @004e                               v67 = iconst.i64 -24
+;; @004e                               v68 = iadd v66, v67  ; v67 = -24
 ;;                                     v142 = iconst.i64 0x0001_0000_0000
-;; @004e                               v59 = stack_switch v58, v58, v142  ; v142 = 0x0001_0000_0000
-;; @004e                               v60 = load.i64 notrap aligned v0+8
-;; @004e                               v61 = load.i64 notrap aligned v60+88
-;; @004e                               v62 = load.i64 notrap aligned v60+96
-;; @004e                               store notrap aligned v29, v60+88
-;; @004e                               store notrap aligned v30, v60+96
-;; @004e                               store notrap aligned v35, v38  ; v35 = 1
+;; @004e                               v69 = stack_switch v68, v68, v142  ; v142 = 0x0001_0000_0000
+;; @004e                               v70 = load.i64 notrap aligned v0+8
+;; @004e                               v71 = load.i64 notrap aligned v70+88
+;; @004e                               v72 = load.i64 notrap aligned v70+96
+;; @004e                               store notrap aligned v30, v70+88
+;; @004e                               store notrap aligned v31, v70+96
+;; @004e                               store notrap aligned v37, v42  ; v37 = 1
 ;;                                     v145 = iconst.i32 0
-;; @004e                               store notrap aligned v145, v46  ; v145 = 0
-;; @004e                               store notrap aligned v145, v46+4  ; v145 = 0
-;; @004e                               store notrap aligned v2, v46+8  ; v2 = 0
-;; @004e                               store notrap aligned v2, v30+40  ; v2 = 0
-;;                                     v117 = iconst.i64 32
-;; @004e                               v69 = ushr v59, v117  ; v117 = 32
-;; @004e                               brif v69, block5, block4
+;; @004e                               store notrap aligned v145, v53  ; v145 = 0
+;; @004e                               store notrap aligned v145, v53+4  ; v145 = 0
+;; @004e                               store notrap aligned v2, v53+8  ; v2 = 0
+;; @004e                               store notrap aligned v2, v31+40  ; v2 = 0
+;;                                     v125 = iconst.i64 32
+;; @004e                               v80 = ushr v69, v125  ; v125 = 32
+;; @004e                               brif v80, block5, block4
 ;;
 ;;                                 block5:
-;; @004e                               v72 = load.i64 notrap aligned v39+72
-;; @004e                               store notrap aligned v72, v62+8
-;; @004e                               v74 = load.i64 notrap aligned v30
-;; @004e                               store notrap aligned v74, v39+24
-;; @004e                               v75 = load.i64 notrap aligned v30+8
-;; @004e                               store notrap aligned v75, v39+72
-;; @004e                               v77 = load.i64 notrap aligned v62+72
+;; @004e                               v85 = load.i64 notrap aligned v43+72
+;; @004e                               store notrap aligned v85, v72+8
+;; @004e                               v88 = load.i64 notrap aligned v31
+;; @004e                               store notrap aligned v88, v43+24
+;; @004e                               v89 = load.i64 notrap aligned v31+8
+;; @004e                               store notrap aligned v89, v43+72
+;; @004e                               v91 = load.i64 notrap aligned v72+72
 ;; @004e                               jump block6
 ;;
 ;;                                 block7 cold:
 ;; @004e                               trap user12
 ;;
 ;;                                 block8:
-;;                                     v107 = iconst.i64 120
-;; @004e                               v82 = iadd.i64 v62, v107  ; v107 = 120
-;; @004e                               v83 = load.i64 notrap aligned v82+8
+;; @004e                               v96 = iconst.i64 120
+;; @004e                               v97 = iadd.i64 v72, v96  ; v96 = 120
+;; @004e                               v98 = load.i64 notrap aligned v97+8
 ;;                                     v153 = iconst.i32 0
-;; @004e                               store notrap aligned v153, v82  ; v153 = 0
-;; @004e                               v79 = uextend.i128 v77
+;; @004e                               store notrap aligned v153, v97  ; v153 = 0
+;; @004e                               v93 = uextend.i128 v91
 ;;                                     v154 = iconst.i64 64
-;;                                     v155 = ishl v79, v154  ; v154 = 64
-;; @004e                               v78 = uextend.i128 v62
-;; @004e                               v81 = bor v155, v78
-;; @004e                               jump block2(v81)
+;;                                     v155 = ishl v93, v154  ; v154 = 64
+;; @004e                               v92 = uextend.i128 v72
+;; @004e                               v95 = bor v155, v92
+;; @004e                               jump block2(v95)
 ;;
 ;;                                 block6:
-;; @004e                               v76 = ireduce.i32 v59
-;; @004e                               br_table v76, block7, [block8]
+;; @004e                               v90 = ireduce.i32 v69
+;; @004e                               br_table v90, block7, [block8]
 ;;
 ;;                                 block4:
-;; @004e                               v86 = load.i64 notrap aligned v30
-;; @004e                               store notrap aligned v86, v39+24
-;; @004e                               v87 = load.i64 notrap aligned v30+8
-;; @004e                               store notrap aligned v87, v39+72
-;; @004e                               v89 = iconst.i32 4
+;; @004e                               v102 = load.i64 notrap aligned v31
+;; @004e                               store notrap aligned v102, v43+24
+;; @004e                               v103 = load.i64 notrap aligned v31+8
+;; @004e                               store notrap aligned v103, v43+72
+;; @004e                               v106 = iconst.i32 4
 ;;                                     v146 = iconst.i64 16
-;;                                     v147 = iadd.i64 v62, v146  ; v146 = 16
-;; @004e                               store notrap aligned v89, v147  ; v89 = 4
-;;                                     v103 = iconst.i64 104
-;; @004e                               v91 = iadd.i64 v62, v103  ; v103 = 104
-;; @004e                               v92 = load.i64 notrap aligned v91+8
+;;                                     v147 = iadd.i64 v72, v146  ; v146 = 16
+;; @004e                               store notrap aligned v106, v147  ; v106 = 4
+;; @004e                               v109 = iconst.i64 104
+;; @004e                               v110 = iadd.i64 v72, v109  ; v109 = 104
+;; @004e                               v111 = load.i64 notrap aligned v110+8
 ;;                                     v148 = iconst.i32 0
-;; @004e                               store notrap aligned v148, v91  ; v148 = 0
-;; @004e                               store notrap aligned v148, v91+4  ; v148 = 0
+;; @004e                               store notrap aligned v148, v110  ; v148 = 0
+;; @004e                               store notrap aligned v148, v110+4  ; v148 = 0
 ;;                                     v149 = iconst.i64 0
-;; @004e                               store notrap aligned v149, v91+8  ; v149 = 0
+;; @004e                               store notrap aligned v149, v110+8  ; v149 = 0
 ;;                                     v150 = uextend.i128 v149  ; v149 = 0
 ;;                                     v151 = iconst.i64 64
 ;;                                     v152 = ishl v150, v151  ; v151 = 64

--- a/tests/disas/stack-switching/symmetric-switch.wat
+++ b/tests/disas/stack-switching/symmetric-switch.wat
@@ -60,167 +60,167 @@
 ;; @003e                               v18 = load.i64 notrap aligned v15+72
 ;; @003e                               v19 = icmp eq v18, v17
 ;; @003e                               trapz v19, user23
-;;                                     v135 = iconst.i64 1
-;; @003e                               v20 = iadd v18, v135  ; v135 = 1
-;; @003e                               store notrap aligned v20, v15+72
-;;                                     v134 = iconst.i64 48
-;; @003e                               v22 = iadd v0, v134  ; v134 = 48
-;; @003e                               v23 = load.i64 notrap aligned v0+8
-;; @003e                               v24 = load.i64 notrap aligned v23+88
-;; @003e                               v25 = load.i64 notrap aligned v23+96
-;; @003e                               jump block2(v24, v25)
+;; @003e                               v20 = iconst.i64 1
+;; @003e                               v21 = iadd v18, v20  ; v20 = 1
+;; @003e                               store notrap aligned v21, v15+72
+;; @003e                               v23 = iconst.i64 48
+;; @003e                               v24 = iadd v0, v23  ; v23 = 48
+;; @003e                               v25 = load.i64 notrap aligned v0+8
+;; @003e                               v26 = load.i64 notrap aligned v25+88
+;; @003e                               v27 = load.i64 notrap aligned v25+96
+;; @003e                               jump block2(v26, v27)
 ;;
-;;                                 block2(v26: i64, v27: i64):
-;; @003e                               v28 = iconst.i64 1
-;; @003e                               v29 = icmp eq v26, v28  ; v28 = 1
-;; @003e                               trapnz v29, user22
+;;                                 block2(v28: i64, v29: i64):
+;; @003e                               v30 = iconst.i64 1
+;; @003e                               v31 = icmp eq v28, v30  ; v30 = 1
+;; @003e                               trapnz v31, user22
 ;; @003e                               jump block3
 ;;
 ;;                                 block3:
-;; @003e                               v30 = load.i64 notrap aligned v27+48
-;; @003e                               v31 = load.i64 notrap aligned v27+56
-;;                                     v133 = iconst.i64 24
-;; @003e                               v32 = iadd v31, v133  ; v133 = 24
-;; @003e                               v33 = load.i64 notrap aligned v32+8
-;; @003e                               v34 = load.i32 notrap aligned v31+40
-;; @003e                               v35 = load.i32 notrap aligned v32
-;; @003e                               jump block4(v34)
+;; @003e                               v32 = load.i64 notrap aligned v29+48
+;; @003e                               v33 = load.i64 notrap aligned v29+56
+;; @003e                               v34 = iconst.i64 24
+;; @003e                               v35 = iadd v33, v34  ; v34 = 24
+;; @003e                               v36 = load.i64 notrap aligned v35+8
+;; @003e                               v37 = load.i32 notrap aligned v33+40
+;; @003e                               v38 = load.i32 notrap aligned v35
+;; @003e                               jump block4(v37)
 ;;
-;;                                 block4(v36: i32):
-;; @003e                               v37 = icmp ult v36, v35
-;; @003e                               brif v37, block5, block2(v30, v31)
+;;                                 block4(v39: i32):
+;; @003e                               v40 = icmp ult v39, v38
+;; @003e                               brif v40, block5, block2(v32, v33)
 ;;
 ;;                                 block5:
-;;                                     v132 = iconst.i32 8
-;; @003e                               v38 = imul.i32 v36, v132  ; v132 = 8
-;; @003e                               v39 = uextend.i64 v38
-;; @003e                               v40 = iadd.i64 v33, v39
-;; @003e                               v41 = load.i64 notrap aligned v40
-;; @003e                               v42 = icmp eq v41, v22
-;;                                     v131 = iconst.i32 1
-;; @003e                               v43 = iadd.i32 v36, v131  ; v131 = 1
-;; @003e                               brif v42, block6, block4(v43)
+;;                                     v135 = iconst.i32 8
+;; @003e                               v41 = imul.i32 v39, v135  ; v135 = 8
+;; @003e                               v42 = uextend.i64 v41
+;; @003e                               v43 = iadd.i64 v36, v42
+;; @003e                               v44 = load.i64 notrap aligned v43
+;; @003e                               v45 = icmp eq v44, v24
+;; @003e                               v46 = iconst.i32 1
+;; @003e                               v47 = iadd.i32 v39, v46  ; v46 = 1
+;; @003e                               brif v45, block6, block4(v47)
 ;;
 ;;                                 block6:
-;; @003e                               store.i64 notrap aligned v27, v25+64
-;;                                     v130 = iconst.i64 120
-;; @003e                               v44 = iadd.i64 v25, v130  ; v130 = 120
-;;                                     v129 = iconst.i64 0
-;; @003e                               v45 = iadd.i64 v25, v129  ; v129 = 0
-;; @003e                               v46 = iconst.i32 3
-;;                                     v128 = iconst.i64 16
-;; @003e                               v47 = iadd v45, v128  ; v128 = 16
-;; @003e                               store notrap aligned v46, v47  ; v46 = 3
-;; @003e                               v48 = iconst.i64 0
-;; @003e                               v49 = iconst.i64 0
-;; @003e                               store notrap aligned v48, v27+48  ; v48 = 0
-;; @003e                               store notrap aligned v49, v27+56  ; v49 = 0
-;; @003e                               v50 = load.i64 notrap aligned readonly v0+8
-;;                                     v127 = iconst.i64 0
-;; @003e                               v51 = iadd v45, v127  ; v127 = 0
-;; @003e                               v52 = load.i64 notrap aligned v50+72
-;; @003e                               store notrap aligned v52, v51+8
-;; @003e                               v53 = load.i64 notrap aligned v25+72
-;; @003e                               v54 = uextend.i128 v25
-;; @003e                               v55 = uextend.i128 v53
-;;                                     v125 = iconst.i64 64
-;;                                     v126 = uextend.i128 v125  ; v125 = 64
-;; @003e                               v56 = ishl v55, v126
-;; @003e                               v57 = bor v56, v54
-;;                                     v124 = iconst.i64 0
-;; @003e                               v59 = iadd.i64 v15, v124  ; v124 = 0
-;;                                     v123 = iconst.i64 16
-;; @003e                               v60 = iadd v59, v123  ; v123 = 16
-;; @003e                               v61 = load.i32 notrap aligned v60
-;; @003e                               v62 = iconst.i32 0
-;; @003e                               v63 = icmp ne v61, v62  ; v62 = 0
-;; @003e                               brif v63, block9, block8
+;; @003e                               store.i64 notrap aligned v29, v27+64
+;; @003e                               v48 = iconst.i64 120
+;; @003e                               v49 = iadd.i64 v27, v48  ; v48 = 120
+;; @003e                               v50 = iconst.i64 0
+;; @003e                               v51 = iadd.i64 v27, v50  ; v50 = 0
+;; @003e                               v52 = iconst.i32 3
+;; @003e                               v53 = iconst.i64 16
+;; @003e                               v54 = iadd v51, v53  ; v53 = 16
+;; @003e                               store notrap aligned v52, v54  ; v52 = 3
+;; @003e                               v55 = iconst.i64 0
+;; @003e                               v56 = iconst.i64 0
+;; @003e                               store notrap aligned v55, v29+48  ; v55 = 0
+;; @003e                               store notrap aligned v56, v29+56  ; v56 = 0
+;; @003e                               v57 = load.i64 notrap aligned readonly v0+8
+;; @003e                               v58 = iconst.i64 0
+;; @003e                               v59 = iadd v51, v58  ; v58 = 0
+;; @003e                               v60 = load.i64 notrap aligned v57+72
+;; @003e                               store notrap aligned v60, v59+8
+;; @003e                               v61 = load.i64 notrap aligned v27+72
+;; @003e                               v62 = uextend.i128 v27
+;; @003e                               v63 = uextend.i128 v61
+;;                                     v133 = iconst.i64 64
+;;                                     v134 = uextend.i128 v133  ; v133 = 64
+;; @003e                               v64 = ishl v63, v134
+;; @003e                               v65 = bor v64, v62
+;; @003e                               v67 = iconst.i64 0
+;; @003e                               v68 = iadd.i64 v15, v67  ; v67 = 0
+;; @003e                               v69 = iconst.i64 16
+;; @003e                               v70 = iadd v68, v69  ; v69 = 16
+;; @003e                               v71 = load.i32 notrap aligned v70
+;; @003e                               v72 = iconst.i32 0
+;; @003e                               v73 = icmp ne v71, v72  ; v72 = 0
+;; @003e                               brif v73, block9, block8
 ;;
 ;;                                 block8:
-;;                                     v122 = iconst.i64 104
-;; @003e                               v64 = iadd.i64 v15, v122  ; v122 = 104
-;; @003e                               v65 = load.i64 notrap aligned v64+8
-;; @003e                               v66 = load.i32 notrap aligned v64
-;;                                     v121 = iconst.i32 1
-;; @003e                               v67 = iadd v66, v121  ; v121 = 1
-;; @003e                               store notrap aligned v67, v64
-;; @003e                               v68 = uextend.i64 v66
-;;                                     v120 = iconst.i64 16
-;; @003e                               v69 = imul v68, v120  ; v120 = 16
-;; @003e                               v70 = iadd v65, v69
-;; @003e                               jump block10(v70)
+;; @003e                               v74 = iconst.i64 104
+;; @003e                               v75 = iadd.i64 v15, v74  ; v74 = 104
+;; @003e                               v76 = load.i64 notrap aligned v75+8
+;; @003e                               v77 = load.i32 notrap aligned v75
+;; @003e                               v78 = iconst.i32 1
+;; @003e                               v79 = iadd v77, v78  ; v78 = 1
+;; @003e                               store notrap aligned v79, v75
+;; @003e                               v80 = uextend.i64 v77
+;;                                     v132 = iconst.i64 16
+;; @003e                               v81 = imul v80, v132  ; v132 = 16
+;; @003e                               v82 = iadd v76, v81
+;; @003e                               jump block10(v82)
 ;;
 ;;                                 block9:
-;;                                     v119 = iconst.i64 120
-;; @003e                               v71 = iadd.i64 v15, v119  ; v119 = 120
-;; @003e                               v72 = load.i64 notrap aligned v71+8
-;; @003e                               v73 = load.i32 notrap aligned v71
-;;                                     v118 = iconst.i32 1
-;; @003e                               v74 = iadd v73, v118  ; v118 = 1
-;; @003e                               store notrap aligned v74, v71
-;; @003e                               v75 = uextend.i64 v73
-;;                                     v117 = iconst.i64 16
-;; @003e                               v76 = imul v75, v117  ; v117 = 16
-;; @003e                               v77 = iadd v72, v76
-;; @003e                               jump block10(v77)
+;; @003e                               v83 = iconst.i64 120
+;; @003e                               v84 = iadd.i64 v15, v83  ; v83 = 120
+;; @003e                               v85 = load.i64 notrap aligned v84+8
+;; @003e                               v86 = load.i32 notrap aligned v84
+;; @003e                               v87 = iconst.i32 1
+;; @003e                               v88 = iadd v86, v87  ; v87 = 1
+;; @003e                               store notrap aligned v88, v84
+;; @003e                               v89 = uextend.i64 v86
+;;                                     v131 = iconst.i64 16
+;; @003e                               v90 = imul v89, v131  ; v131 = 16
+;; @003e                               v91 = iadd v85, v90
+;; @003e                               jump block10(v91)
 ;;
-;;                                 block10(v58: i64):
-;; @003e                               store.i128 notrap aligned v57, v58
-;;                                     v116 = iconst.i64 0
-;; @003e                               v78 = iadd.i64 v15, v116  ; v116 = 0
-;; @003e                               v79 = iconst.i32 1
-;;                                     v115 = iconst.i64 16
-;; @003e                               v80 = iadd v78, v115  ; v115 = 16
-;; @003e                               store notrap aligned v79, v80  ; v79 = 1
-;; @003e                               v81 = load.i64 notrap aligned v15+64
-;; @003e                               store.i64 notrap aligned v30, v81+48
-;; @003e                               store.i64 notrap aligned v31, v81+56
-;; @003e                               v82 = iconst.i64 2
-;; @003e                               v83 = load.i64 notrap aligned v0+8
-;; @003e                               store notrap aligned v82, v83+88  ; v82 = 2
-;; @003e                               store.i64 notrap aligned v15, v83+96
-;;                                     v114 = iconst.i64 0
-;; @003e                               v84 = iadd v78, v114  ; v114 = 0
-;; @003e                               v85 = load.i64 notrap aligned v84
-;; @003e                               store notrap aligned v85, v50+24
-;; @003e                               v86 = load.i64 notrap aligned v84+8
-;; @003e                               store notrap aligned v86, v50+72
-;;                                     v113 = iconst.i64 80
-;; @003e                               v87 = iadd.i64 v27, v113  ; v113 = 80
-;; @003e                               v88 = load.i64 notrap aligned v87
-;;                                     v112 = iconst.i64 -24
-;; @003e                               v89 = iadd v88, v112  ; v112 = -24
-;;                                     v111 = iconst.i64 80
-;; @003e                               v90 = iadd v81, v111  ; v111 = 80
-;; @003e                               v91 = load.i64 notrap aligned v90
-;;                                     v110 = iconst.i64 -24
-;; @003e                               v92 = iadd v91, v110  ; v110 = -24
-;; @003e                               v93 = stack_addr.i64 ss0
-;; @003e                               v94 = load.i64 notrap aligned v92
-;; @003e                               store notrap aligned v94, v93
-;; @003e                               v95 = load.i64 notrap aligned v89
-;; @003e                               store notrap aligned v95, v92
-;; @003e                               v96 = load.i64 notrap aligned v92+8
-;; @003e                               store notrap aligned v96, v93+8
-;; @003e                               v97 = load.i64 notrap aligned v89+8
-;; @003e                               store notrap aligned v97, v92+8
-;; @003e                               v98 = load.i64 notrap aligned v92+16
-;; @003e                               store notrap aligned v98, v93+16
-;; @003e                               v99 = load.i64 notrap aligned v89+16
-;; @003e                               store notrap aligned v99, v92+16
-;; @003e                               v100 = iconst.i64 3
-;;                                     v109 = iconst.i64 32
-;; @003e                               v101 = ishl v100, v109  ; v100 = 3, v109 = 32
-;; @003e                               v102 = stack_switch v89, v93, v101
-;;                                     v108 = iconst.i64 120
-;; @003e                               v103 = iadd.i64 v25, v108  ; v108 = 120
-;; @003e                               v104 = load.i64 notrap aligned v103+8
-;; @003e                               v105 = iconst.i32 0
-;; @003e                               store notrap aligned v105, v103  ; v105 = 0
-;; @003e                               v106 = iconst.i32 0
-;; @003e                               store notrap aligned v106, v103+4  ; v106 = 0
-;; @003e                               v107 = iconst.i64 0
-;; @003e                               store notrap aligned v107, v103+8  ; v107 = 0
+;;                                 block10(v66: i64):
+;; @003e                               store.i128 notrap aligned v65, v66
+;; @003e                               v92 = iconst.i64 0
+;; @003e                               v93 = iadd.i64 v15, v92  ; v92 = 0
+;; @003e                               v94 = iconst.i32 1
+;; @003e                               v95 = iconst.i64 16
+;; @003e                               v96 = iadd v93, v95  ; v95 = 16
+;; @003e                               store notrap aligned v94, v96  ; v94 = 1
+;; @003e                               v97 = load.i64 notrap aligned v15+64
+;; @003e                               store.i64 notrap aligned v32, v97+48
+;; @003e                               store.i64 notrap aligned v33, v97+56
+;; @003e                               v98 = iconst.i64 2
+;; @003e                               v99 = load.i64 notrap aligned v0+8
+;; @003e                               store notrap aligned v98, v99+88  ; v98 = 2
+;; @003e                               store.i64 notrap aligned v15, v99+96
+;; @003e                               v100 = iconst.i64 0
+;; @003e                               v101 = iadd v93, v100  ; v100 = 0
+;; @003e                               v102 = load.i64 notrap aligned v101
+;; @003e                               store notrap aligned v102, v57+24
+;; @003e                               v103 = load.i64 notrap aligned v101+8
+;; @003e                               store notrap aligned v103, v57+72
+;; @003e                               v104 = iconst.i64 80
+;; @003e                               v105 = iadd.i64 v29, v104  ; v104 = 80
+;; @003e                               v106 = load.i64 notrap aligned v105
+;; @003e                               v107 = iconst.i64 -24
+;; @003e                               v108 = iadd v106, v107  ; v107 = -24
+;; @003e                               v109 = iconst.i64 80
+;; @003e                               v110 = iadd v97, v109  ; v109 = 80
+;; @003e                               v111 = load.i64 notrap aligned v110
+;; @003e                               v112 = iconst.i64 -24
+;; @003e                               v113 = iadd v111, v112  ; v112 = -24
+;; @003e                               v114 = stack_addr.i64 ss0
+;; @003e                               v115 = load.i64 notrap aligned v113
+;; @003e                               store notrap aligned v115, v114
+;; @003e                               v116 = load.i64 notrap aligned v108
+;; @003e                               store notrap aligned v116, v113
+;; @003e                               v117 = load.i64 notrap aligned v113+8
+;; @003e                               store notrap aligned v117, v114+8
+;; @003e                               v118 = load.i64 notrap aligned v108+8
+;; @003e                               store notrap aligned v118, v113+8
+;; @003e                               v119 = load.i64 notrap aligned v113+16
+;; @003e                               store notrap aligned v119, v114+16
+;; @003e                               v120 = load.i64 notrap aligned v108+16
+;; @003e                               store notrap aligned v120, v113+16
+;; @003e                               v121 = iconst.i64 3
+;;                                     v130 = iconst.i64 32
+;; @003e                               v122 = ishl v121, v130  ; v121 = 3, v130 = 32
+;; @003e                               v123 = stack_switch v108, v114, v122
+;; @003e                               v124 = iconst.i64 120
+;; @003e                               v125 = iadd.i64 v27, v124  ; v124 = 120
+;; @003e                               v126 = load.i64 notrap aligned v125+8
+;; @003e                               v127 = iconst.i32 0
+;; @003e                               store notrap aligned v127, v125  ; v127 = 0
+;; @003e                               v128 = iconst.i32 0
+;; @003e                               store notrap aligned v128, v125+4  ; v128 = 0
+;; @003e                               v129 = iconst.i64 0
+;; @003e                               store notrap aligned v129, v125+8  ; v129 = 0
 ;; @0041                               jump block1
 ;;
 ;;                                 block1:
@@ -278,139 +278,139 @@
 ;; @004b                               v18 = load.i64 notrap aligned v15+72
 ;; @004b                               v19 = icmp eq v18, v17
 ;; @004b                               trapz v19, user23
-;;                                     v108 = iconst.i64 1
-;; @004b                               v20 = iadd v18, v108  ; v108 = 1
-;; @004b                               store notrap aligned v20, v15+72
-;; @004b                               v21 = load.i64 notrap aligned v15+64
-;; @004b                               v22 = load.i64 notrap aligned v0+8
-;; @004b                               v23 = load.i64 notrap aligned v22+88
-;; @004b                               v24 = load.i64 notrap aligned v22+96
-;; @004b                               store notrap aligned v23, v21+48
-;; @004b                               store notrap aligned v24, v21+56
-;; @004b                               v25 = iconst.i64 0
-;; @004b                               store notrap aligned v25, v15+64  ; v25 = 0
-;; @004b                               v26 = iconst.i64 2
-;; @004b                               v27 = load.i64 notrap aligned v0+8
-;; @004b                               store notrap aligned v26, v27+88  ; v26 = 2
-;; @004b                               store notrap aligned v15, v27+96
-;;                                     v107 = iconst.i64 0
-;; @004b                               v28 = iadd v15, v107  ; v107 = 0
-;; @004b                               v29 = iconst.i32 1
-;;                                     v106 = iconst.i64 16
-;; @004b                               v30 = iadd v28, v106  ; v106 = 16
-;; @004b                               store notrap aligned v29, v30  ; v29 = 1
-;; @004b                               v31 = iconst.i32 2
-;;                                     v105 = iconst.i64 16
-;; @004b                               v32 = iadd v24, v105  ; v105 = 16
-;; @004b                               store notrap aligned v31, v32  ; v31 = 2
-;; @004b                               v33 = load.i64 notrap aligned readonly v0+8
-;;                                     v104 = iconst.i64 0
-;; @004b                               v34 = iadd v24, v104  ; v104 = 0
-;; @004b                               v35 = load.i64 notrap aligned v33+72
-;; @004b                               store notrap aligned v35, v34+8
-;; @004b                               v36 = load.i64 notrap aligned v33+24
-;; @004b                               store notrap aligned v36, v34
-;;                                     v103 = iconst.i64 0
-;; @004b                               v37 = iadd v28, v103  ; v103 = 0
-;; @004b                               v38 = load.i64 notrap aligned v37
-;; @004b                               store notrap aligned v38, v33+24
-;; @004b                               v39 = load.i64 notrap aligned v37+8
-;; @004b                               store notrap aligned v39, v33+72
-;;                                     v102 = iconst.i64 24
-;; @004b                               v40 = iadd v24, v102  ; v102 = 24
-;; @004b                               v41 = iconst.i32 1
-;; @004b                               v42 = stack_addr.i64 ss0
-;; @004b                               store notrap aligned v41, v40+4  ; v41 = 1
-;; @004b                               store notrap aligned v42, v40+8
-;;                                     v101 = iconst.i64 48
-;; @004b                               v44 = iadd.i64 v0, v101  ; v101 = 48
-;; @004b                               v45 = iconst.i32 1
-;; @004b                               v46 = load.i64 notrap aligned v40+8
-;; @004b                               store notrap aligned v44, v46
-;; @004b                               store notrap aligned v45, v40  ; v45 = 1
-;; @004b                               v47 = iconst.i32 0
-;; @004b                               store notrap aligned v47, v24+40  ; v47 = 0
-;; @004b                               v48 = iconst.i64 1
-;;                                     v100 = iconst.i64 32
-;; @004b                               v49 = ishl v48, v100  ; v48 = 1, v100 = 32
-;;                                     v99 = iconst.i64 80
-;; @004b                               v50 = iadd v21, v99  ; v99 = 80
-;; @004b                               v51 = load.i64 notrap aligned v50
-;;                                     v98 = iconst.i64 -24
-;; @004b                               v52 = iadd v51, v98  ; v98 = -24
-;; @004b                               v53 = stack_switch v52, v52, v49
-;; @004b                               v54 = load.i64 notrap aligned v0+8
-;; @004b                               v55 = load.i64 notrap aligned v54+88
-;; @004b                               v56 = load.i64 notrap aligned v54+96
-;; @004b                               v57 = load.i64 notrap aligned v0+8
-;; @004b                               store notrap aligned v23, v57+88
-;; @004b                               store notrap aligned v24, v57+96
-;; @004b                               v58 = iconst.i32 1
-;;                                     v97 = iconst.i64 16
-;; @004b                               v59 = iadd v24, v97  ; v97 = 16
-;; @004b                               store notrap aligned v58, v59  ; v58 = 1
-;; @004b                               v60 = iconst.i32 0
-;; @004b                               store notrap aligned v60, v40  ; v60 = 0
-;; @004b                               v61 = iconst.i32 0
-;; @004b                               store notrap aligned v61, v40+4  ; v61 = 0
-;; @004b                               v62 = iconst.i64 0
-;; @004b                               store notrap aligned v62, v40+8  ; v62 = 0
-;; @004b                               store notrap aligned v25, v24+40  ; v25 = 0
-;;                                     v96 = iconst.i64 32
-;; @004b                               v63 = ushr v53, v96  ; v96 = 32
-;; @004b                               brif v63, block4, block3
+;; @004b                               v20 = iconst.i64 1
+;; @004b                               v21 = iadd v18, v20  ; v20 = 1
+;; @004b                               store notrap aligned v21, v15+72
+;; @004b                               v22 = load.i64 notrap aligned v15+64
+;; @004b                               v23 = load.i64 notrap aligned v0+8
+;; @004b                               v24 = load.i64 notrap aligned v23+88
+;; @004b                               v25 = load.i64 notrap aligned v23+96
+;; @004b                               store notrap aligned v24, v22+48
+;; @004b                               store notrap aligned v25, v22+56
+;; @004b                               v26 = iconst.i64 0
+;; @004b                               store notrap aligned v26, v15+64  ; v26 = 0
+;; @004b                               v27 = iconst.i64 2
+;; @004b                               v28 = load.i64 notrap aligned v0+8
+;; @004b                               store notrap aligned v27, v28+88  ; v27 = 2
+;; @004b                               store notrap aligned v15, v28+96
+;; @004b                               v29 = iconst.i64 0
+;; @004b                               v30 = iadd v15, v29  ; v29 = 0
+;; @004b                               v31 = iconst.i32 1
+;; @004b                               v32 = iconst.i64 16
+;; @004b                               v33 = iadd v30, v32  ; v32 = 16
+;; @004b                               store notrap aligned v31, v33  ; v31 = 1
+;; @004b                               v34 = iconst.i32 2
+;; @004b                               v35 = iconst.i64 16
+;; @004b                               v36 = iadd v25, v35  ; v35 = 16
+;; @004b                               store notrap aligned v34, v36  ; v34 = 2
+;; @004b                               v37 = load.i64 notrap aligned readonly v0+8
+;; @004b                               v38 = iconst.i64 0
+;; @004b                               v39 = iadd v25, v38  ; v38 = 0
+;; @004b                               v40 = load.i64 notrap aligned v37+72
+;; @004b                               store notrap aligned v40, v39+8
+;; @004b                               v41 = load.i64 notrap aligned v37+24
+;; @004b                               store notrap aligned v41, v39
+;; @004b                               v42 = iconst.i64 0
+;; @004b                               v43 = iadd v30, v42  ; v42 = 0
+;; @004b                               v44 = load.i64 notrap aligned v43
+;; @004b                               store notrap aligned v44, v37+24
+;; @004b                               v45 = load.i64 notrap aligned v43+8
+;; @004b                               store notrap aligned v45, v37+72
+;; @004b                               v46 = iconst.i64 24
+;; @004b                               v47 = iadd v25, v46  ; v46 = 24
+;; @004b                               v48 = iconst.i32 1
+;; @004b                               v49 = stack_addr.i64 ss0
+;; @004b                               store notrap aligned v48, v47+4  ; v48 = 1
+;; @004b                               store notrap aligned v49, v47+8
+;; @004b                               v51 = iconst.i64 48
+;; @004b                               v52 = iadd.i64 v0, v51  ; v51 = 48
+;; @004b                               v53 = iconst.i32 1
+;; @004b                               v54 = load.i64 notrap aligned v47+8
+;; @004b                               store notrap aligned v52, v54
+;; @004b                               store notrap aligned v53, v47  ; v53 = 1
+;; @004b                               v55 = iconst.i32 0
+;; @004b                               store notrap aligned v55, v25+40  ; v55 = 0
+;; @004b                               v56 = iconst.i64 1
+;;                                     v108 = iconst.i64 32
+;; @004b                               v57 = ishl v56, v108  ; v56 = 1, v108 = 32
+;; @004b                               v58 = iconst.i64 80
+;; @004b                               v59 = iadd v22, v58  ; v58 = 80
+;; @004b                               v60 = load.i64 notrap aligned v59
+;; @004b                               v61 = iconst.i64 -24
+;; @004b                               v62 = iadd v60, v61  ; v61 = -24
+;; @004b                               v63 = stack_switch v62, v62, v57
+;; @004b                               v64 = load.i64 notrap aligned v0+8
+;; @004b                               v65 = load.i64 notrap aligned v64+88
+;; @004b                               v66 = load.i64 notrap aligned v64+96
+;; @004b                               v67 = load.i64 notrap aligned v0+8
+;; @004b                               store notrap aligned v24, v67+88
+;; @004b                               store notrap aligned v25, v67+96
+;; @004b                               v68 = iconst.i32 1
+;; @004b                               v69 = iconst.i64 16
+;; @004b                               v70 = iadd v25, v69  ; v69 = 16
+;; @004b                               store notrap aligned v68, v70  ; v68 = 1
+;; @004b                               v71 = iconst.i32 0
+;; @004b                               store notrap aligned v71, v47  ; v71 = 0
+;; @004b                               v72 = iconst.i32 0
+;; @004b                               store notrap aligned v72, v47+4  ; v72 = 0
+;; @004b                               v73 = iconst.i64 0
+;; @004b                               store notrap aligned v73, v47+8  ; v73 = 0
+;; @004b                               store notrap aligned v26, v25+40  ; v26 = 0
+;;                                     v107 = iconst.i64 32
+;; @004b                               v74 = ushr v63, v107  ; v107 = 32
+;; @004b                               brif v74, block4, block3
 ;;
 ;;                                 block4:
-;;                                     v95 = iconst.i64 0
-;; @004b                               v64 = iadd.i64 v56, v95  ; v95 = 0
-;;                                     v94 = iconst.i64 0
-;; @004b                               v65 = iadd v64, v94  ; v94 = 0
-;; @004b                               v66 = load.i64 notrap aligned v33+72
-;; @004b                               store notrap aligned v66, v65+8
-;;                                     v93 = iconst.i64 0
-;; @004b                               v67 = iadd.i64 v24, v93  ; v93 = 0
-;; @004b                               v68 = load.i64 notrap aligned v67
-;; @004b                               store notrap aligned v68, v33+24
-;; @004b                               v69 = load.i64 notrap aligned v67+8
-;; @004b                               store notrap aligned v69, v33+72
-;; @004b                               v70 = ireduce.i32 v53
-;; @004b                               v71 = load.i64 notrap aligned v56+72
-;; @004b                               v72 = uextend.i128 v56
-;; @004b                               v73 = uextend.i128 v71
-;;                                     v91 = iconst.i64 64
-;;                                     v92 = uextend.i128 v91  ; v91 = 64
-;; @004b                               v74 = ishl v73, v92
-;; @004b                               v75 = bor v74, v72
+;; @004b                               v75 = iconst.i64 0
+;; @004b                               v76 = iadd.i64 v66, v75  ; v75 = 0
+;; @004b                               v77 = iconst.i64 0
+;; @004b                               v78 = iadd v76, v77  ; v77 = 0
+;; @004b                               v79 = load.i64 notrap aligned v37+72
+;; @004b                               store notrap aligned v79, v78+8
+;; @004b                               v80 = iconst.i64 0
+;; @004b                               v81 = iadd.i64 v25, v80  ; v80 = 0
+;; @004b                               v82 = load.i64 notrap aligned v81
+;; @004b                               store notrap aligned v82, v37+24
+;; @004b                               v83 = load.i64 notrap aligned v81+8
+;; @004b                               store notrap aligned v83, v37+72
+;; @004b                               v84 = ireduce.i32 v63
+;; @004b                               v85 = load.i64 notrap aligned v66+72
+;; @004b                               v86 = uextend.i128 v66
+;; @004b                               v87 = uextend.i128 v85
+;;                                     v105 = iconst.i64 64
+;;                                     v106 = uextend.i128 v105  ; v105 = 64
+;; @004b                               v88 = ishl v87, v106
+;; @004b                               v89 = bor v88, v86
 ;; @004b                               jump block5
 ;;
 ;;                                 block6 cold:
 ;; @004b                               trap user12
 ;;
 ;;                                 block5:
-;; @004b                               br_table v70, block6, []
+;; @004b                               br_table v84, block6, []
 ;;
 ;;                                 block3:
-;;                                     v90 = iconst.i64 0
-;; @004b                               v76 = iadd.i64 v24, v90  ; v90 = 0
-;; @004b                               v77 = load.i64 notrap aligned v76
-;; @004b                               store notrap aligned v77, v33+24
-;; @004b                               v78 = load.i64 notrap aligned v76+8
-;; @004b                               store notrap aligned v78, v33+72
-;;                                     v89 = iconst.i64 0
-;; @004b                               v79 = iadd.i64 v56, v89  ; v89 = 0
-;; @004b                               v80 = iconst.i32 4
-;;                                     v88 = iconst.i64 16
-;; @004b                               v81 = iadd v79, v88  ; v88 = 16
-;; @004b                               store notrap aligned v80, v81  ; v80 = 4
-;;                                     v87 = iconst.i64 104
-;; @004b                               v82 = iadd.i64 v56, v87  ; v87 = 104
-;; @004b                               v83 = load.i64 notrap aligned v82+8
-;; @004b                               v84 = iconst.i32 0
-;; @004b                               store notrap aligned v84, v82  ; v84 = 0
-;; @004b                               v85 = iconst.i32 0
-;; @004b                               store notrap aligned v85, v82+4  ; v85 = 0
-;; @004b                               v86 = iconst.i64 0
-;; @004b                               store notrap aligned v86, v82+8  ; v86 = 0
+;; @004b                               v90 = iconst.i64 0
+;; @004b                               v91 = iadd.i64 v25, v90  ; v90 = 0
+;; @004b                               v92 = load.i64 notrap aligned v91
+;; @004b                               store notrap aligned v92, v37+24
+;; @004b                               v93 = load.i64 notrap aligned v91+8
+;; @004b                               store notrap aligned v93, v37+72
+;; @004b                               v94 = iconst.i64 0
+;; @004b                               v95 = iadd.i64 v66, v94  ; v94 = 0
+;; @004b                               v96 = iconst.i32 4
+;; @004b                               v97 = iconst.i64 16
+;; @004b                               v98 = iadd v95, v97  ; v97 = 16
+;; @004b                               store notrap aligned v96, v98  ; v96 = 4
+;; @004b                               v99 = iconst.i64 104
+;; @004b                               v100 = iadd.i64 v66, v99  ; v99 = 104
+;; @004b                               v101 = load.i64 notrap aligned v100+8
+;; @004b                               v102 = iconst.i32 0
+;; @004b                               store notrap aligned v102, v100  ; v102 = 0
+;; @004b                               v103 = iconst.i32 0
+;; @004b                               store notrap aligned v103, v100+4  ; v103 = 0
+;; @004b                               v104 = iconst.i64 0
+;; @004b                               store notrap aligned v104, v100+8  ; v104 = 0
 ;; @0050                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/startup-elem-active.wat
+++ b/tests/disas/startup-elem-active.wat
@@ -57,21 +57,21 @@
 ;;     v114 = icmp ule v5, v2  ; v2 = 1
 ;;     v79 = iconst.i64 0
 ;;     v15 = iadd v12, v86  ; v86 = 4
-;;     v28 = select_spectre_guard v114, v79, v15  ; v79 = 0
-;;     store user6 aligned region0 v103, v28  ; v103 = 21
+;;     v29 = select_spectre_guard v114, v79, v15  ; v79 = 0
+;;     store user6 aligned region0 v103, v29  ; v103 = 21
 ;;     v117 = iconst.i32 23
 ;;     v123 = iconst.i32 2
 ;;     v129 = icmp ule v5, v123  ; v123 = 2
 ;;     v131 = iconst.i64 8
-;;     v39 = iadd v12, v131  ; v131 = 8
-;;     v41 = select_spectre_guard v129, v79, v39  ; v79 = 0
-;;     store user6 aligned region0 v117, v41  ; v117 = 23
+;;     v41 = iadd v12, v131  ; v131 = 8
+;;     v43 = select_spectre_guard v129, v79, v41  ; v79 = 0
+;;     store user6 aligned region0 v117, v43  ; v117 = 23
 ;;     v133 = iconst.i32 25
 ;;     v3 = iconst.i32 3
 ;;     v144 = icmp ule v5, v3  ; v3 = 3
 ;;     v146 = iconst.i64 12
-;;     v52 = iadd v12, v146  ; v146 = 12
-;;     v54 = select_spectre_guard v144, v79, v52  ; v79 = 0
-;;     store user6 aligned region0 v133, v54  ; v133 = 25
+;;     v55 = iadd v12, v146  ; v146 = 12
+;;     v57 = select_spectre_guard v144, v79, v55  ; v79 = 0
+;;     store user6 aligned region0 v133, v57  ; v133 = 25
 ;;     return
 ;; }

--- a/tests/disas/startup-passive-segment.wat
+++ b/tests/disas/startup-passive-segment.wat
@@ -45,7 +45,7 @@
 ;;     store user2 little region0 v18, v4  ; v18 = 1
 ;;     v25 = iconst.i32 3
 ;;     v13 = iconst.i64 16
-;;     v12 = iadd v4, v13  ; v13 = 16
-;;     store user2 little region0 v25, v12  ; v25 = 3
+;;     v14 = iadd v4, v13  ; v13 = 16
+;;     store user2 little region0 v25, v14  ; v25 = 3
 ;;     return
 ;; }

--- a/tests/disas/table-copy.wat
+++ b/tests/disas/table-copy.wat
@@ -142,26 +142,26 @@
 ;; @0090                               v52 = band v51, v97  ; v97 = -2
 ;; @0090                               brif v51, block7(v52), block6
 ;;
-;;                                 block4(v63: i64, v64: i64, v65: i32):
-;; @0090                               v66 = iconst.i64 8
-;; @0090                               v67 = isub v63, v66  ; v66 = 8
-;; @0090                               v68 = iconst.i64 8
-;; @0090                               v69 = isub v64, v68  ; v68 = 8
-;; @0090                               v70 = iconst.i32 1
-;; @0090                               v71 = isub v65, v70  ; v70 = 1
-;; @0090                               v72 = iconst.i32 6
-;; @0090                               v73 = icmp uge v71, v72  ; v72 = 6
-;; @0090                               v74 = uextend.i64 v71
-;; @0090                               v75 = load.i64 notrap aligned readonly can_move v0+72
+;;                                 block4(v66: i64, v67: i64, v68: i32):
+;; @0090                               v69 = iconst.i64 8
+;; @0090                               v70 = isub v66, v69  ; v69 = 8
+;; @0090                               v71 = iconst.i64 8
+;; @0090                               v72 = isub v67, v71  ; v71 = 8
+;; @0090                               v73 = iconst.i32 1
+;; @0090                               v74 = isub v68, v73  ; v73 = 1
+;; @0090                               v75 = iconst.i32 6
+;; @0090                               v76 = icmp uge v74, v75  ; v75 = 6
+;; @0090                               v77 = uextend.i64 v74
+;; @0090                               v78 = load.i64 notrap aligned readonly can_move v0+72
 ;;                                     v95 = iconst.i64 3
-;; @0090                               v76 = ishl v74, v95  ; v95 = 3
-;; @0090                               v77 = iadd v75, v76
-;; @0090                               v78 = iconst.i64 0
-;; @0090                               v79 = select_spectre_guard v73, v78, v77  ; v78 = 0
-;; @0090                               v80 = load.i64 user6 aligned region0 v79
+;; @0090                               v79 = ishl v77, v95  ; v95 = 3
+;; @0090                               v80 = iadd v78, v79
+;; @0090                               v81 = iconst.i64 0
+;; @0090                               v82 = select_spectre_guard v76, v81, v80  ; v81 = 0
+;; @0090                               v83 = load.i64 user6 aligned region0 v82
 ;;                                     v94 = iconst.i64 -2
-;; @0090                               v81 = band v80, v94  ; v94 = -2
-;; @0090                               brif v80, block9(v81), block8
+;; @0090                               v84 = band v83, v94  ; v94 = -2
+;; @0090                               brif v83, block9(v84), block8
 ;;
 ;;                                 block5:
 ;; @0094                               jump block1
@@ -176,27 +176,27 @@
 ;;                                     v93 = iconst.i64 1
 ;; @0090                               v58 = bor v53, v93  ; v93 = 1
 ;; @0090                               store notrap aligned v58, v40
-;;                                     v92 = iconst.i64 8
-;; @0090                               v59 = iadd.i64 v40, v92  ; v92 = 8
-;;                                     v91 = iconst.i64 8
-;; @0090                               v60 = iadd.i64 v41, v91  ; v91 = 8
-;;                                     v90 = iconst.i32 1
-;; @0090                               v61 = iadd.i32 v42, v90  ; v90 = 1
-;; @0090                               v62 = icmp eq v60, v37
-;; @0090                               brif v62, block5, block3(v59, v60, v61)
+;; @0090                               v59 = iconst.i64 8
+;; @0090                               v60 = iadd.i64 v40, v59  ; v59 = 8
+;; @0090                               v61 = iconst.i64 8
+;; @0090                               v62 = iadd.i64 v41, v61  ; v61 = 8
+;; @0090                               v63 = iconst.i32 1
+;; @0090                               v64 = iadd.i32 v42, v63  ; v63 = 1
+;; @0090                               v65 = icmp eq v62, v37
+;; @0090                               brif v65, block5, block3(v60, v62, v64)
 ;;
 ;;                                 block8 cold:
-;; @0090                               v83 = iconst.i32 1
-;; @0090                               v85 = uextend.i64 v71
-;; @0090                               v86 = call fn0(v0, v83, v85)  ; v83 = 1
-;; @0090                               jump block9(v86)
+;; @0090                               v86 = iconst.i32 1
+;; @0090                               v88 = uextend.i64 v74
+;; @0090                               v89 = call fn0(v0, v86, v88)  ; v86 = 1
+;; @0090                               jump block9(v89)
 ;;
-;;                                 block9(v82: i64):
-;;                                     v89 = iconst.i64 1
-;; @0090                               v87 = bor v82, v89  ; v89 = 1
-;; @0090                               store notrap aligned v87, v67
-;; @0090                               v88 = icmp.i64 eq v69, v29
-;; @0090                               brif v88, block5, block4(v67, v69, v71)
+;;                                 block9(v85: i64):
+;;                                     v92 = iconst.i64 1
+;; @0090                               v90 = bor v85, v92  ; v92 = 1
+;; @0090                               store notrap aligned v90, v70
+;; @0090                               v91 = icmp.i64 eq v72, v29
+;; @0090                               brif v91, block5, block4(v70, v72, v74)
 ;;
 ;;                                 block1:
 ;; @0094                               return v2
@@ -285,29 +285,29 @@
 ;; @009f                               v53 = band v52, v102  ; v102 = -2
 ;; @009f                               brif v52, block7(v53), block6
 ;;
-;;                                 block4(v64: i64, v65: i64, v66: i32):
-;; @009f                               v67 = iconst.i64 8
-;; @009f                               v68 = isub v64, v67  ; v67 = 8
-;; @009f                               v69 = iconst.i64 8
-;; @009f                               v70 = isub v65, v69  ; v69 = 8
-;; @009f                               v71 = iconst.i32 1
-;; @009f                               v72 = isub v66, v71  ; v71 = 1
+;;                                 block4(v67: i64, v68: i64, v69: i32):
+;; @009f                               v70 = iconst.i64 8
+;; @009f                               v71 = isub v67, v70  ; v70 = 8
+;; @009f                               v72 = iconst.i64 8
+;; @009f                               v73 = isub v68, v72  ; v72 = 8
+;; @009f                               v74 = iconst.i32 1
+;; @009f                               v75 = isub v69, v74  ; v74 = 1
 ;; @009f                               v100 = load.i64 notrap aligned readonly can_move v0+48
-;; @009f                               v73 = load.i64 notrap aligned v100+8
-;; @009f                               v74 = ireduce.i32 v73
-;; @009f                               v75 = icmp uge v72, v74
-;; @009f                               v76 = uextend.i64 v72
+;; @009f                               v76 = load.i64 notrap aligned v100+8
+;; @009f                               v77 = ireduce.i32 v76
+;; @009f                               v78 = icmp uge v75, v77
+;; @009f                               v79 = uextend.i64 v75
 ;; @009f                               v98 = load.i64 notrap aligned readonly can_move v0+48
-;; @009f                               v77 = load.i64 notrap aligned v98
+;; @009f                               v80 = load.i64 notrap aligned v98
 ;;                                     v97 = iconst.i64 3
-;; @009f                               v78 = ishl v76, v97  ; v97 = 3
-;; @009f                               v79 = iadd v77, v78
-;; @009f                               v80 = iconst.i64 0
-;; @009f                               v81 = select_spectre_guard v75, v80, v79  ; v80 = 0
-;; @009f                               v82 = load.i64 user6 aligned region0 v81
+;; @009f                               v81 = ishl v79, v97  ; v97 = 3
+;; @009f                               v82 = iadd v80, v81
+;; @009f                               v83 = iconst.i64 0
+;; @009f                               v84 = select_spectre_guard v78, v83, v82  ; v83 = 0
+;; @009f                               v85 = load.i64 user6 aligned region0 v84
 ;;                                     v96 = iconst.i64 -2
-;; @009f                               v83 = band v82, v96  ; v96 = -2
-;; @009f                               brif v82, block9(v83), block8
+;; @009f                               v86 = band v85, v96  ; v96 = -2
+;; @009f                               brif v85, block9(v86), block8
 ;;
 ;;                                 block5:
 ;; @00a3                               jump block1
@@ -322,27 +322,27 @@
 ;;                                     v95 = iconst.i64 1
 ;; @009f                               v59 = bor v54, v95  ; v95 = 1
 ;; @009f                               store notrap aligned v59, v40
-;;                                     v94 = iconst.i64 8
-;; @009f                               v60 = iadd.i64 v40, v94  ; v94 = 8
-;;                                     v93 = iconst.i64 8
-;; @009f                               v61 = iadd.i64 v41, v93  ; v93 = 8
-;;                                     v92 = iconst.i32 1
-;; @009f                               v62 = iadd.i32 v42, v92  ; v92 = 1
-;; @009f                               v63 = icmp eq v61, v37
-;; @009f                               brif v63, block5, block3(v60, v61, v62)
+;; @009f                               v60 = iconst.i64 8
+;; @009f                               v61 = iadd.i64 v40, v60  ; v60 = 8
+;; @009f                               v62 = iconst.i64 8
+;; @009f                               v63 = iadd.i64 v41, v62  ; v62 = 8
+;; @009f                               v64 = iconst.i32 1
+;; @009f                               v65 = iadd.i32 v42, v64  ; v64 = 1
+;; @009f                               v66 = icmp eq v63, v37
+;; @009f                               brif v66, block5, block3(v61, v63, v65)
 ;;
 ;;                                 block8 cold:
-;; @009f                               v85 = iconst.i32 0
-;; @009f                               v87 = uextend.i64 v72
-;; @009f                               v88 = call fn0(v0, v85, v87)  ; v85 = 0
-;; @009f                               jump block9(v88)
+;; @009f                               v88 = iconst.i32 0
+;; @009f                               v90 = uextend.i64 v75
+;; @009f                               v91 = call fn0(v0, v88, v90)  ; v88 = 0
+;; @009f                               jump block9(v91)
 ;;
-;;                                 block9(v84: i64):
-;;                                     v91 = iconst.i64 1
-;; @009f                               v89 = bor v84, v91  ; v91 = 1
-;; @009f                               store notrap aligned v89, v68
-;; @009f                               v90 = icmp.i64 eq v70, v29
-;; @009f                               brif v90, block5, block4(v68, v70, v72)
+;;                                 block9(v87: i64):
+;;                                     v94 = iconst.i64 1
+;; @009f                               v92 = bor v87, v94  ; v94 = 1
+;; @009f                               store notrap aligned v92, v71
+;; @009f                               v93 = icmp.i64 eq v73, v29
+;; @009f                               brif v93, block5, block4(v71, v73, v75)
 ;;
 ;;                                 block1:
 ;; @00a3                               return v2


### PR DESCRIPTION
Small change, but lots of filetest/disas expectation updates.