### PR TITLE
Fix generated component adapters without concurrency

### DIFF
--- a/crates/environ/src/fact/trampoline.rs
+++ b/crates/environ/src/fact/trampoline.rs
@@ -798,6 +798,14 @@ impl<'a, 'b> Compiler<'a, 'b> {
 
             old_task_may_block
         } else if self.emit_resource_call {
+            assert!(!self.types[adapter.lift.ty].async_);
+            self.instruction(I32Const(
+                i32::try_from(adapter.lower.instance.as_u32()).unwrap(),
+            ));
+            self.instruction(I32Const(0));
+            self.instruction(I32Const(
+                i32::try_from(adapter.lift.instance.as_u32()).unwrap(),
+            ));
             let enter_sync_call = self.module.import_enter_sync_call();
             self.instruction(Call(enter_sync_call.as_u32()));
             None

--- a/tests/all/component_model/aot.rs
+++ b/tests/all/component_model/aot.rs
@@ -235,3 +235,36 @@ fn implements_shows_up() -> Result<()> {
 
     Ok(())
 }
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn issue_13540_resources_in_adapter_no_concurrency() -> Result<()> {
+    let mut config = Config::new();
+    config.concurrency_support(false);
+    let engine = Engine::new(&config)?;
+    engine.precompile_component(
+        br#"
+(component
+  (component $A
+    (type $t' (resource (rep i32)))
+    (export $t "t" (type $t'))
+
+    (core module $m (func (export "r") (param i32)))
+    (core instance $i (instantiate $m))
+    (func (export "r") (param "a" (borrow $t)) (canon lift (core func $i "r")))
+  )
+  (component $B
+    (import "a" (instance $a
+      (export "t" (type $t (sub resource)))
+      (export "r" (func (param "a" (borrow $t))))
+    ))
+
+    (core func $r (canon lower (func $a "r")))
+  )
+  (instance $a (instantiate $A))
+  (instance $b (instantiate $B (with "a" (instance $a))))
+)
+    "#,
+    )?;
+    Ok(())
+}


### PR DESCRIPTION
This commit fixes an accidental regression introduced in #12550 where when compiling an adapter for a cross-component function call that contained resources but was using `-Wconcurrency-support=n` it would generate an invalid wasm module. The fix here is a relatively simple adaptation of the preexisting code toe nsure the no-concurrency path works the same as the concurrency-path.

Closes #13540

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
