### PR TITLE
Cranelift: remove the `imul_imm` instruction

### DIFF
--- a/cranelift/codegen/meta/src/shared/instructions.rs
+++ b/cranelift/codegen/meta/src/shared/instructions.rs
@@ -1839,7 +1839,8 @@ pub(crate) fn define(
             &formats.binary,
         )
         .operands_in(vec![Operand::new("x", Int), Operand::new("y", Int)])
-        .operands_out(vec![Operand::new("a", Int)]),
+        .operands_out(vec![Operand::new("a", Int)])
+        .inst_builder_imm_method(true),
     );
 
     ig.push(
@@ -1978,23 +1979,6 @@ pub(crate) fn define(
         .operands_out(vec![Operand::new("a", iB)])
         .can_trap()
         .side_effects_idempotent(),
-    );
-
-    ig.push(
-        Inst::new(
-            "imul_imm",
-            r#"
-        Integer multiplication by immediate constant.
-
-        Same as `imul`, but one operand is a sign extended 64 bit immediate constant.
-
-        Polymorphic over all scalar integer types, but does not support vector
-        types.
-        "#,
-            &formats.binary_imm64,
-        )
-        .operands_in(vec![Operand::new("x", iB), Operand::new("Y", &imm.imm64)])
-        .operands_out(vec![Operand::new("a", iB)]),
     );
 
     ig.push(

--- a/cranelift/codegen/src/legalizer/mod.rs
+++ b/cranelift/codegen/src/legalizer/mod.rs
@@ -204,9 +204,7 @@ fn expand_binary_imm64(
     pos.goto_inst(inst);
 
     let is_signed = match opcode {
-        ir::Opcode::IrsubImm | ir::Opcode::ImulImm | ir::Opcode::SdivImm | ir::Opcode::SremImm => {
-            true
-        }
+        ir::Opcode::IrsubImm | ir::Opcode::SdivImm | ir::Opcode::SremImm => true,
         _ => false,
     };
 
@@ -244,9 +242,6 @@ fn expand_binary_imm64(
         ir::Opcode::IrsubImm => {
             // note: arg order reversed
             replace.isub(imm, arg);
-        }
-        ir::Opcode::ImulImm => {
-            replace.imul(arg, imm);
         }
         ir::Opcode::SdivImm => {
             replace.sdiv(arg, imm);

--- a/cranelift/codegen/src/souper_harvest.rs
+++ b/cranelift/codegen/src/souper_harvest.rs
@@ -97,7 +97,6 @@ fn harvest_candidate_lhs(
                 ir::Opcode::Iadd
                 | ir::Opcode::IrsubImm
                 | ir::Opcode::Imul
-                | ir::Opcode::ImulImm
                 | ir::Opcode::Udiv
                 | ir::Opcode::UdivImm
                 | ir::Opcode::Sdiv
@@ -198,17 +197,6 @@ fn harvest_candidate_lhs(
                     (ir::Opcode::Imul, _) => {
                         let a = arg(allocs, 0);
                         let b = arg(allocs, 1);
-                        ast::Instruction::Mul { a, b }.into()
-                    }
-                    (ir::Opcode::ImulImm, ir::InstructionData::BinaryImm64 { imm, .. }) => {
-                        let a = arg(allocs, 0);
-                        let value: i64 = (*imm).into();
-                        let value: i128 = value.into();
-                        let b = ast::Constant {
-                            value,
-                            r#type: souper_type_of(&func.dfg, val),
-                        }
-                        .into();
                         ast::Instruction::Mul { a, b }.into()
                     }
                     (ir::Opcode::Udiv, _) => {

--- a/cranelift/filetests/filetests/cfg/loop.clif
+++ b/cranelift/filetests/filetests/cfg/loop.clif
@@ -30,7 +30,8 @@ block3:
     jump block1(v4)           ; unordered: block3:$JUMP3 -> block1
 
 block1(v5: i32):
-    v6 = imul_imm v5, 4
+    v102 = iconst.i32 4
+    v6 = imul v5, v102
     v7 = iadd v1, v6
     v8 = f32const 0.0
     v9 = f32const 0.0

--- a/cranelift/filetests/filetests/egraph/issue-7999.clif
+++ b/cranelift/filetests/filetests/egraph/issue-7999.clif
@@ -5,11 +5,12 @@ target x86_64
 function u0:11(i8) -> i8 system_v {
 block0(v0: i8):
     v1 = uextend.i64 v0
-    v2 = imul_imm v1, 256
+    v11 = iconst.i64 256
+    v2 = imul v1, v11
     v3 = ireduce.i8 v2
     return v3
 
     ;; This function should get optimized down to simply returning zero:
 
-    ; check: return v10  ; v10 = 0
+    ; check: return v17  ; v17 = 0
 }

--- a/cranelift/filetests/filetests/isa/aarch64/simd-splat.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/simd-splat.clif
@@ -103,7 +103,8 @@ block0(v0: i64, v1: i64):
 
 function %splat_load6(i64, i64) -> i64x2 {
 block0(v0: i64, v1: i64):
-    v2 = imul_imm v1, 2
+    v6 = iconst.i64 2
+    v2 = imul v1, v6
     v3 = iadd v0, v2
     v4 = load.i64 v3+100
     v5 = splat.i64x2 v4

--- a/cranelift/filetests/filetests/isa/pulley64/imul.clif
+++ b/cranelift/filetests/filetests/isa/pulley64/imul.clif
@@ -3,7 +3,8 @@ target pulley64
 
 function %i8_imm(i8) -> i8 {
 block0(v0: i8):
-  v2 = imul_imm v0, 7
+  v3 = iconst.i8 7
+  v2 = imul v0, v3
   return v2
 }
 
@@ -18,7 +19,8 @@ block0(v0: i8):
 
 function %i8_imm2(i8) -> i8 {
 block0(v0: i8):
-  v2 = imul_imm v0, -7
+  v3 = iconst.i8 -7
+  v2 = imul v0, v3
   return v2
 }
 
@@ -33,7 +35,8 @@ block0(v0: i8):
 
 function %i16_imm(i16) -> i16 {
 block0(v0: i16):
-  v2 = imul_imm v0, 7
+  v3 = iconst.i16 7
+  v2 = imul v0, v3
   return v2
 }
 
@@ -48,7 +51,8 @@ block0(v0: i16):
 
 function %i16_imm2(i16) -> i16 {
 block0(v0: i16):
-  v2 = imul_imm v0, -7
+  v3 = iconst.i16 -7
+  v2 = imul v0, v3
   return v2
 }
 
@@ -63,7 +67,8 @@ block0(v0: i16):
 
 function %i32_imm(i32) -> i32 {
 block0(v0: i32):
-  v2 = imul_imm v0, 7
+  v3 = iconst.i32 7
+  v2 = imul v0, v3
   return v2
 }
 
@@ -78,7 +83,8 @@ block0(v0: i32):
 
 function %i32_imm2(i32) -> i32 {
 block0(v0: i32):
-  v2 = imul_imm v0, -7
+  v3 = iconst.i32 -7
+  v2 = imul v0, v3
   return v2
 }
 
@@ -93,7 +99,8 @@ block0(v0: i32):
 
 function %i32_imm_big(i32) -> i32 {
 block0(v0: i32):
-  v2 = imul_imm v0, 77777
+  v3 = iconst.i32 77777
+  v2 = imul v0, v3
   return v2
 }
 
@@ -108,7 +115,8 @@ block0(v0: i32):
 
 function %i32_imm_big2(i32) -> i32 {
 block0(v0: i32):
-  v2 = imul_imm v0, -77777
+  v3 = iconst.i32 -77777
+  v2 = imul v0, v3
   return v2
 }
 
@@ -123,7 +131,8 @@ block0(v0: i32):
 
 function %i64_imm(i64) -> i64 {
 block0(v0: i64):
-  v2 = imul_imm v0, 7
+  v3 = iconst.i64 7
+  v2 = imul v0, v3
   return v2
 }
 
@@ -138,7 +147,8 @@ block0(v0: i64):
 
 function %i64_imm2(i64) -> i64 {
 block0(v0: i64):
-  v2 = imul_imm v0, -7
+  v3 = iconst.i64 -7
+  v2 = imul v0, v3
   return v2
 }
 
@@ -153,7 +163,8 @@ block0(v0: i64):
 
 function %i64_imm_big(i64) -> i64 {
 block0(v0: i64):
-  v2 = imul_imm v0, 77777
+  v3 = iconst.i64 77777
+  v2 = imul v0, v3
   return v2
 }
 
@@ -168,7 +179,8 @@ block0(v0: i64):
 
 function %i64_imm_big2(i64) -> i64 {
 block0(v0: i64):
-  v2 = imul_imm v0, -77777
+  v3 = iconst.i64 -77777
+  v2 = imul v0, v3
   return v2
 }
 

--- a/cranelift/filetests/filetests/isa/riscv64/arithmetic.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/arithmetic.clif
@@ -806,7 +806,8 @@ block0(v0: i8):
 
 function %imul_i8_const(i8) -> i8 {
 block0(v0: i8):
-    v3 = imul_imm v0, 97
+    v4 = iconst.i8 97
+    v3 = imul v0, v4
     return v3
 }
 
@@ -824,7 +825,8 @@ block0(v0: i8):
 
 function %imul_i16_const(i16) -> i16 {
 block0(v0: i16):
-    v3 = imul_imm v0, 97
+    v4 = iconst.i16 97
+    v3 = imul v0, v4
     return v3
 }
 
@@ -842,7 +844,8 @@ block0(v0: i16):
 
 function %imul_i32_const(i32) -> i32 {
 block0(v0: i32):
-    v3 = imul_imm v0, 97
+    v4 = iconst.i32 97
+    v3 = imul v0, v4
     return v3
 }
 
@@ -860,7 +863,8 @@ block0(v0: i32):
 
 function %imul_i64_const(i64) -> i64 {
 block0(v0: i64):
-    v3 = imul_imm v0, 97
+    v4 = iconst.i64 97
+    v3 = imul v0, v4
     return v3
 }
 

--- a/cranelift/filetests/filetests/isa/x64/mul-with-optimizations.clif
+++ b/cranelift/filetests/filetests/isa/x64/mul-with-optimizations.clif
@@ -5,7 +5,8 @@ target x86_64
 
 function %imul_i16_const_unsigned_but_big(i32) -> i16 {
 block0(v0: i32):
-    v3 = imul_imm v0, 0x81111
+    v5 = iconst.i32 528657
+    v3 = imul v0, v5
     v4 = ireduce.i16 v3
     return v4
 }

--- a/cranelift/filetests/filetests/isa/x64/mul.clif
+++ b/cranelift/filetests/filetests/isa/x64/mul.clif
@@ -228,7 +228,8 @@ block0(v0: i64, v1: i64):
 
 function %imul_i8_const(i8) -> i8{
 block0(v0: i8):
-    v3 = imul_imm v0, 97
+    v4 = iconst.i8 97
+    v3 = imul v0, v4
     return v3
 }
 
@@ -261,7 +262,8 @@ block0(v0: i8):
 
 function %imul_i16_const(i16) -> i16{
 block0(v0: i16):
-    v3 = imul_imm v0, 97
+    v4 = iconst.i16 97
+    v3 = imul v0, v4
     return v3
 }
 
@@ -286,7 +288,8 @@ block0(v0: i16):
 
 function %imul_i16_const_negative(i16) -> i16 {
 block0(v0: i16):
-    v3 = imul_imm v0, -97
+    v4 = iconst.i16 -97
+    v3 = imul v0, v4
     return v3
 }
 
@@ -311,7 +314,8 @@ block0(v0: i16):
 
 function %imul_i16_const_unsigned_but_big(i16) -> i16 {
 block0(v0: i16):
-    v3 = imul_imm v0, 0x8000
+    v4 = iconst.i16 -32768
+    v3 = imul v0, v4
     return v3
 }
 
@@ -336,7 +340,8 @@ block0(v0: i16):
 
 function %imul_i16_const_out_of_bounds(i16) -> i16 {
 block0(v0: i16):
-    v3 = imul_imm v0, 0x80000
+    v4 = iconst.i16 0
+    v3 = imul v0, v4
     return v3
 }
 
@@ -361,7 +366,8 @@ block0(v0: i16):
 
 function %imul_i32_const(i32) -> i32{
 block0(v0: i32):
-    v3 = imul_imm v0, 97
+    v4 = iconst.i32 97
+    v3 = imul v0, v4
     return v3
 }
 
@@ -386,7 +392,8 @@ block0(v0: i32):
 
 function %imul_i64_const(i64) -> i64{
 block0(v0: i64):
-    v3 = imul_imm v0, 97
+    v4 = iconst.i64 97
+    v3 = imul v0, v4
     return v3
 }
 
@@ -411,7 +418,8 @@ block0(v0: i64):
 
 function %imul_i16_bigger_const(i16) -> i16{
 block0(v0: i16):
-    v3 = imul_imm v0, 1021
+    v4 = iconst.i16 1021
+    v3 = imul v0, v4
     return v3
 }
 
@@ -436,7 +444,8 @@ block0(v0: i16):
 
 function %imul_i32_bigger_const(i32) -> i32{
 block0(v0: i32):
-    v3 = imul_imm v0, 1021
+    v4 = iconst.i32 1021
+    v3 = imul v0, v4
     return v3
 }
 
@@ -461,7 +470,8 @@ block0(v0: i32):
 
 function %imul_i64_bigger_const(i64) -> i64{
 block0(v0: i64):
-    v3 = imul_imm v0, 1021
+    v4 = iconst.i64 1021
+    v3 = imul v0, v4
     return v3
 }
 
@@ -487,7 +497,8 @@ block0(v0: i64):
 function %imul_i16_const_and_load(i64) -> i16{
 block0(v0: i64):
     v1 = load.i16 v0
-    v2 = imul_imm v1, 1021
+    v3 = iconst.i16 1021
+    v2 = imul v1, v3
     return v2
 }
 
@@ -515,7 +526,8 @@ block0(v0: i64):
 function %imul_i32_const_and_load(i64) -> i32{
 block0(v0: i64):
     v1 = load.i32 v0
-    v2 = imul_imm v1, 1021
+    v3 = iconst.i32 1021
+    v2 = imul v1, v3
     return v2
 }
 
@@ -541,7 +553,8 @@ block0(v0: i64):
 function %imul_i64_const_and_load(i64) -> i64{
 block0(v0: i64):
     v1 = load.i64 v0+100
-    v2 = imul_imm v1, 1021
+    v3 = iconst.i64 1021
+    v2 = imul v1, v3
     return v2
 }
 

--- a/cranelift/fuzzgen/src/function_generator.rs
+++ b/cranelift/fuzzgen/src/function_generator.rs
@@ -925,7 +925,6 @@ static OPCODE_SIGNATURES: LazyLock<Vec<OpcodeSignature>> = LazyLock::new(|| {
                 (Opcode::GetReturnAddress),
                 (Opcode::Blendv),
                 (Opcode::X86Pmulhrsw),
-                (Opcode::ImulImm),
                 (Opcode::UdivImm),
                 (Opcode::SdivImm),
                 (Opcode::UremImm),

--- a/cranelift/interpreter/src/step.rs
+++ b/cranelift/interpreter/src/step.rs
@@ -718,7 +718,6 @@ where
         Opcode::Sdiv => binary_can_trap(DataValueExt::sdiv, arg(0), arg(1))?,
         Opcode::Urem => binary_can_trap(DataValueExt::urem, arg(0), arg(1))?,
         Opcode::Srem => binary_can_trap(DataValueExt::srem, arg(0), arg(1))?,
-        Opcode::ImulImm => binary(DataValueExt::mul, arg(0), imm_as_ctrl_ty()?)?,
         Opcode::UdivImm => binary_can_trap(DataValueExt::udiv, arg(0), imm_as_ctrl_ty()?)?,
         Opcode::SdivImm => binary_can_trap(DataValueExt::sdiv, arg(0), imm_as_ctrl_ty()?)?,
         Opcode::UremImm => binary_can_trap(DataValueExt::urem, arg(0), imm_as_ctrl_ty()?)?,

--- a/cranelift/tests/bugpoint_test.clif
+++ b/cranelift/tests/bugpoint_test.clif
@@ -820,12 +820,14 @@ block39:
 
 block40:
     v349 = iconst.i64 0
-    v350 = imul_imm v349, 16
+    v1152 = iconst.i64 16
+    v350 = imul v349, v1152
     v351 = iadd.i64 v35, v350
     v352 = load.i64 aligned v39
     v353 = load.i64 aligned v39+8
     v354 = iconst.i64 1
-    v355 = imul_imm v354, 16
+    v1153 = iconst.i64 16
+    v355 = imul v354, v1153
     v356 = iadd.i64 v35, v355
     v357 = load.i64 aligned v40
     v358 = load.i64 aligned v40+8
@@ -890,12 +892,14 @@ block46:
 
 block47:
     v389 = iconst.i64 0
-    v390 = imul_imm v389, 16
+    v1154 = iconst.i64 16
+    v390 = imul v389, v1154
     v391 = iadd.i64 v45, v390
     v392 = load.i64 aligned v49
     v393 = load.i64 aligned v49+8
     v394 = iconst.i64 1
-    v395 = imul_imm v394, 16
+    v1155 = iconst.i64 16
+    v395 = imul v394, v1155
     v396 = iadd.i64 v45, v395
     v397 = load.i64 aligned v50
     v398 = load.i64 aligned v50+8
@@ -1263,7 +1267,8 @@ block142:
 block70:
     v603 = load.i64 v3
     v604 = load.i64 v3+8
-    v606 = imul_imm.i64 v605, 1
+    v1156 = iconst.i64 1
+    v606 = imul v605, v1156
     v607 = iadd v603, v606
     v608 = load.i8 aligned v64
     v610 = iconst.i64 1
@@ -1448,12 +1453,14 @@ block85:
 
 block86:
     v727 = iconst.i64 0
-    v728 = imul_imm v727, 16
+    v1157 = iconst.i64 16
+    v728 = imul v727, v1157
     v729 = iadd.i64 v79, v728
     v730 = load.i64 aligned v83
     v731 = load.i64 aligned v83+8
     v732 = iconst.i64 1
-    v733 = imul_imm v732, 16
+    v1158 = iconst.i64 16
+    v733 = imul v732, v1158
     v734 = iadd.i64 v79, v733
     v735 = load.i64 aligned v84
     v736 = load.i64 aligned v84+8
@@ -1515,12 +1522,14 @@ block92:
 
 block93:
     v766 = iconst.i64 0
-    v767 = imul_imm v766, 16
+    v1159 = iconst.i64 16
+    v767 = imul v766, v1159
     v768 = iadd.i64 v89, v767
     v769 = load.i64 aligned v93
     v770 = load.i64 aligned v93+8
     v771 = iconst.i64 1
-    v772 = imul_imm v771, 16
+    v1160 = iconst.i64 16
+    v772 = imul v771, v1160
     v773 = iadd.i64 v89, v772
     v774 = load.i64 aligned v94
     v775 = load.i64 aligned v94+8
@@ -1778,7 +1787,8 @@ block127:
 block111:
     v915 = load.i64 v3
     v916 = load.i64 v3+8
-    v918 = imul_imm.i64 v917, 1
+    v1161 = iconst.i64 1
+    v918 = imul v917, v1161
     v919 = iadd v915, v918
     v920 = load.i8 aligned v102
     v922 = iconst.i64 1

--- a/tests/disas/array-copy-anyref.wat
+++ b/tests/disas/array-copy-anyref.wat
@@ -31,69 +31,69 @@
 ;; @002b                               v12 = load.i32 user2 readonly region0 v11
 ;; @002b                               v14 = uextend.i64 v3
 ;; @002b                               v15 = uextend.i64 v6
-;; @002b                               v17 = iadd v14, v15
+;; @002b                               v18 = iadd v14, v15
 ;; @002b                               v13 = uextend.i64 v12
-;; @002b                               v18 = icmp ugt v17, v13
-;; @002b                               trapnz v18, user17
+;; @002b                               v19 = icmp ugt v18, v13
+;; @002b                               trapnz v19, user17
 ;; @002b                               trapz v4, user16
-;; @002b                               v27 = uextend.i64 v4
-;; @002b                               v29 = iadd v8, v27
-;; @002b                               v31 = iadd v29, v10  ; v10 = 16
-;; @002b                               v32 = load.i32 user2 readonly region0 v31
-;; @002b                               v34 = uextend.i64 v5
-;; @002b                               v37 = iadd v34, v15
-;; @002b                               v33 = uextend.i64 v32
-;; @002b                               v38 = icmp ugt v37, v33
-;; @002b                               trapnz v38, user17
-;; @002b                               v51 = load.i64 notrap aligned v115+40
-;; @002b                               v22 = iconst.i64 20
-;; @002b                               v23 = iadd v9, v22  ; v22 = 20
+;; @002b                               v29 = uextend.i64 v4
+;; @002b                               v31 = iadd v8, v29
+;; @002b                               v33 = iadd v31, v10  ; v10 = 16
+;; @002b                               v34 = load.i32 user2 readonly region0 v33
+;; @002b                               v36 = uextend.i64 v5
+;; @002b                               v40 = iadd v36, v15
+;; @002b                               v35 = uextend.i64 v34
+;; @002b                               v41 = icmp ugt v40, v35
+;; @002b                               trapnz v41, user17
+;; @002b                               v57 = load.i64 notrap aligned v115+40
+;; @002b                               v23 = iconst.i64 20
+;; @002b                               v24 = iadd v9, v23  ; v23 = 20
 ;;                                     v119 = iconst.i64 2
 ;;                                     v120 = ishl v14, v119  ; v119 = 2
-;; @002b                               v26 = iadd v23, v120
+;; @002b                               v28 = iadd v24, v120
 ;;                                     v124 = ishl v15, v119  ; v119 = 2
-;; @002b                               v53 = uadd_overflow_trap v26, v124, user2
-;; @002b                               v52 = iadd v8, v51
-;; @002b                               v54 = icmp ugt v53, v52
-;; @002b                               trapnz v54, user2
-;; @002b                               v43 = iadd v29, v22  ; v22 = 20
-;;                                     v122 = ishl v34, v119  ; v119 = 2
-;; @002b                               v46 = iadd v43, v122
-;; @002b                               v58 = uadd_overflow_trap v46, v124, user2
-;; @002b                               v59 = icmp ugt v58, v52
-;; @002b                               trapnz v59, user2
+;; @002b                               v59 = uadd_overflow_trap v28, v124, user2
+;; @002b                               v58 = iadd v8, v57
+;; @002b                               v60 = icmp ugt v59, v58
+;; @002b                               trapnz v60, user2
+;; @002b                               v46 = iadd v31, v23  ; v23 = 20
+;;                                     v122 = ishl v36, v119  ; v119 = 2
+;; @002b                               v50 = iadd v46, v122
+;; @002b                               v64 = uadd_overflow_trap v50, v124, user2
+;; @002b                               v65 = icmp ugt v64, v58
+;; @002b                               trapnz v65, user2
 ;; @002b                               brif v15, block2, block5
 ;;
 ;;                                 block2:
-;; @002b                               v60 = icmp.i64 ult v26, v46
-;; @002b                               v63 = iadd.i64 v26, v124
-;; @002b                               v64 = iadd.i64 v46, v124
-;; @002b                               v66 = iadd.i32 v5, v6
-;;                                     v111 = iconst.i64 4
-;; @002b                               v89 = iconst.i32 1
-;; @002b                               brif v60, block3(v26, v46, v5), block4(v63, v64, v66)
+;; @002b                               v66 = icmp.i64 ult v28, v50
+;; @002b                               v71 = iadd.i64 v28, v124
+;; @002b                               v72 = iadd.i64 v50, v124
+;; @002b                               v74 = iadd.i32 v5, v6
+;; @002b                               v26 = iconst.i64 4
+;; @002b                               v97 = iconst.i32 1
+;; @002b                               brif v66, block3(v28, v50, v5), block4(v71, v72, v74)
 ;;
-;;                                 block3(v67: i64, v68: i64, v69: i32):
-;; @002b                               v72 = load.i32 user2 little region0 v68
-;; @002b                               store user2 little region0 v72, v67
+;;                                 block3(v75: i64, v76: i64, v77: i32):
+;; @002b                               v80 = load.i32 user2 little region0 v76
+;; @002b                               store user2 little region0 v80, v75
 ;;                                     v131 = iconst.i64 4
-;;                                     v132 = iadd v68, v131  ; v131 = 4
-;; @002b                               v79 = icmp eq v132, v64
-;;                                     v133 = iadd v67, v131  ; v131 = 4
+;;                                     v132 = iadd v76, v131  ; v131 = 4
+;; @002b                               v87 = icmp eq v132, v72
+;;                                     v133 = iadd v75, v131  ; v131 = 4
 ;;                                     v134 = iconst.i32 1
-;;                                     v135 = iadd v69, v134  ; v134 = 1
-;; @002b                               brif v79, block5, block3(v133, v132, v135)
+;;                                     v135 = iadd v77, v134  ; v134 = 1
+;; @002b                               brif v87, block5, block3(v133, v132, v135)
 ;;
-;;                                 block4(v80: i64, v81: i64, v82: i32):
+;;                                 block4(v88: i64, v89: i64, v90: i32):
 ;;                                     v126 = iconst.i64 4
-;;                                     v127 = isub v81, v126  ; v126 = 4
-;; @002b                               v91 = load.i32 user2 little region0 v127
-;;                                     v128 = isub v80, v126  ; v126 = 4
-;; @002b                               store user2 little region0 v91, v128
-;; @002b                               v92 = icmp eq v127, v46
+;;                                     v127 = isub v89, v126  ; v126 = 4
+;; @002b                               v99 = load.i32 user2 little region0 v127
+;;                                     v128 = isub v88, v126  ; v126 = 4
+;; @002b                               store user2 little region0 v99, v128
+;; @002b                               v100 = icmp eq v127, v50
 ;;                                     v129 = iconst.i32 1
-;;                                     v130 = isub v82, v129  ; v129 = 1
-;; @002b                               brif v92, block5, block4(v128, v127, v130)
+;;                                     v130 = isub v90, v129  ; v129 = 1
+;; @002b                               brif v100, block5, block4(v128, v127, v130)
 ;;
 ;;                                 block5:
 ;; @002f                               jump block1

--- a/tests/disas/array-copy-i64.wat
+++ b/tests/disas/array-copy-i64.wat
@@ -33,38 +33,38 @@
 ;; @002b                               v12 = load.i32 user2 readonly region0 v11
 ;; @002b                               v14 = uextend.i64 v3
 ;; @002b                               v15 = uextend.i64 v6
-;; @002b                               v17 = iadd v14, v15
+;; @002b                               v18 = iadd v14, v15
 ;; @002b                               v13 = uextend.i64 v12
-;; @002b                               v18 = icmp ugt v17, v13
-;; @002b                               trapnz v18, user17
+;; @002b                               v19 = icmp ugt v18, v13
+;; @002b                               trapnz v19, user17
 ;; @002b                               trapz v4, user16
-;; @002b                               v27 = uextend.i64 v4
-;; @002b                               v29 = iadd v8, v27
-;; @002b                               v31 = iadd v29, v10  ; v10 = 16
-;; @002b                               v32 = load.i32 user2 readonly region0 v31
-;; @002b                               v34 = uextend.i64 v5
-;; @002b                               v37 = iadd v34, v15
-;; @002b                               v33 = uextend.i64 v32
-;; @002b                               v38 = icmp ugt v37, v33
-;; @002b                               trapnz v38, user17
-;; @002b                               v51 = load.i64 notrap aligned v81+40
-;; @002b                               v22 = iconst.i64 24
-;; @002b                               v23 = iadd v9, v22  ; v22 = 24
+;; @002b                               v29 = uextend.i64 v4
+;; @002b                               v31 = iadd v8, v29
+;; @002b                               v33 = iadd v31, v10  ; v10 = 16
+;; @002b                               v34 = load.i32 user2 readonly region0 v33
+;; @002b                               v36 = uextend.i64 v5
+;; @002b                               v40 = iadd v36, v15
+;; @002b                               v35 = uextend.i64 v34
+;; @002b                               v41 = icmp ugt v40, v35
+;; @002b                               trapnz v41, user17
+;; @002b                               v57 = load.i64 notrap aligned v81+40
+;; @002b                               v23 = iconst.i64 24
+;; @002b                               v24 = iadd v9, v23  ; v23 = 24
 ;;                                     v85 = iconst.i64 3
 ;;                                     v86 = ishl v14, v85  ; v85 = 3
-;; @002b                               v26 = iadd v23, v86
+;; @002b                               v28 = iadd v24, v86
 ;;                                     v90 = ishl v15, v85  ; v85 = 3
-;; @002b                               v53 = uadd_overflow_trap v26, v90, user2
-;; @002b                               v52 = iadd v8, v51
-;; @002b                               v54 = icmp ugt v53, v52
-;; @002b                               trapnz v54, user2
-;; @002b                               v43 = iadd v29, v22  ; v22 = 24
-;;                                     v88 = ishl v34, v85  ; v85 = 3
-;; @002b                               v46 = iadd v43, v88
-;; @002b                               v58 = uadd_overflow_trap v46, v90, user2
-;; @002b                               v59 = icmp ugt v58, v52
-;; @002b                               trapnz v59, user2
-;; @002b                               call fn0(v0, v26, v46, v90)
+;; @002b                               v59 = uadd_overflow_trap v28, v90, user2
+;; @002b                               v58 = iadd v8, v57
+;; @002b                               v60 = icmp ugt v59, v58
+;; @002b                               trapnz v60, user2
+;; @002b                               v46 = iadd v31, v23  ; v23 = 24
+;;                                     v88 = ishl v36, v85  ; v85 = 3
+;; @002b                               v50 = iadd v46, v88
+;; @002b                               v64 = uadd_overflow_trap v50, v90, user2
+;; @002b                               v65 = icmp ugt v64, v58
+;; @002b                               trapnz v65, user2
+;; @002b                               call fn0(v0, v28, v50, v90)
 ;; @002f                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/array-copy-i8.wat
+++ b/tests/disas/array-copy-i8.wat
@@ -33,34 +33,34 @@
 ;; @002b                               v12 = load.i32 user2 readonly region0 v11
 ;; @002b                               v14 = uextend.i64 v3
 ;; @002b                               v15 = uextend.i64 v6
-;; @002b                               v17 = iadd v14, v15
+;; @002b                               v18 = iadd v14, v15
 ;; @002b                               v13 = uextend.i64 v12
-;; @002b                               v18 = icmp ugt v17, v13
-;; @002b                               trapnz v18, user17
+;; @002b                               v19 = icmp ugt v18, v13
+;; @002b                               trapnz v19, user17
 ;; @002b                               trapz v4, user16
-;; @002b                               v27 = uextend.i64 v4
-;; @002b                               v29 = iadd v8, v27
-;; @002b                               v31 = iadd v29, v10  ; v10 = 16
-;; @002b                               v32 = load.i32 user2 readonly region0 v31
-;; @002b                               v34 = uextend.i64 v5
-;; @002b                               v37 = iadd v34, v15
-;; @002b                               v33 = uextend.i64 v32
-;; @002b                               v38 = icmp ugt v37, v33
-;; @002b                               trapnz v38, user17
-;; @002b                               v51 = load.i64 notrap aligned v81+40
-;; @002b                               v22 = iconst.i64 20
-;; @002b                               v23 = iadd v9, v22  ; v22 = 20
-;; @002b                               v26 = iadd v23, v14
-;; @002b                               v53 = uadd_overflow_trap v26, v15, user2
-;; @002b                               v52 = iadd v8, v51
-;; @002b                               v54 = icmp ugt v53, v52
-;; @002b                               trapnz v54, user2
-;; @002b                               v43 = iadd v29, v22  ; v22 = 20
-;; @002b                               v46 = iadd v43, v34
-;; @002b                               v58 = uadd_overflow_trap v46, v15, user2
-;; @002b                               v59 = icmp ugt v58, v52
-;; @002b                               trapnz v59, user2
-;; @002b                               call fn0(v0, v26, v46, v15)
+;; @002b                               v29 = uextend.i64 v4
+;; @002b                               v31 = iadd v8, v29
+;; @002b                               v33 = iadd v31, v10  ; v10 = 16
+;; @002b                               v34 = load.i32 user2 readonly region0 v33
+;; @002b                               v36 = uextend.i64 v5
+;; @002b                               v40 = iadd v36, v15
+;; @002b                               v35 = uextend.i64 v34
+;; @002b                               v41 = icmp ugt v40, v35
+;; @002b                               trapnz v41, user17
+;; @002b                               v57 = load.i64 notrap aligned v81+40
+;; @002b                               v23 = iconst.i64 20
+;; @002b                               v24 = iadd v9, v23  ; v23 = 20
+;; @002b                               v28 = iadd v24, v14
+;; @002b                               v59 = uadd_overflow_trap v28, v15, user2
+;; @002b                               v58 = iadd v8, v57
+;; @002b                               v60 = icmp ugt v59, v58
+;; @002b                               trapnz v60, user2
+;; @002b                               v46 = iadd v31, v23  ; v23 = 20
+;; @002b                               v50 = iadd v46, v36
+;; @002b                               v64 = uadd_overflow_trap v50, v15, user2
+;; @002b                               v65 = icmp ugt v64, v58
+;; @002b                               trapnz v65, user2
+;; @002b                               call fn0(v0, v28, v50, v15)
 ;; @002f                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/array-copy-inline.wat
+++ b/tests/disas/array-copy-inline.wat
@@ -37,43 +37,43 @@
 ;; @002a                               v12 = load.i32 user2 readonly region0 v11
 ;; @002a                               v14 = uextend.i64 v3
 ;;                                     v85 = iconst.i64 7
-;; @002a                               v17 = iadd v14, v85  ; v85 = 7
+;; @002a                               v18 = iadd v14, v85  ; v85 = 7
 ;; @002a                               v13 = uextend.i64 v12
-;; @002a                               v18 = icmp ugt v17, v13
-;; @002a                               trapnz v18, user17
+;; @002a                               v19 = icmp ugt v18, v13
+;; @002a                               trapnz v19, user17
 ;; @002a                               trapz v4, user16
-;; @002a                               v27 = uextend.i64 v4
-;; @002a                               v29 = iadd v8, v27
-;; @002a                               v31 = iadd v29, v10  ; v10 = 16
-;; @002a                               v32 = load.i32 user2 readonly region0 v31
-;; @002a                               v34 = uextend.i64 v5
-;; @002a                               v37 = iadd v34, v85  ; v85 = 7
-;; @002a                               v33 = uextend.i64 v32
-;; @002a                               v38 = icmp ugt v37, v33
-;; @002a                               trapnz v38, user17
-;; @002a                               v51 = load.i64 notrap aligned v83+40
-;; @002a                               v22 = iconst.i64 20
-;; @002a                               v23 = iadd v9, v22  ; v22 = 20
+;; @002a                               v29 = uextend.i64 v4
+;; @002a                               v31 = iadd v8, v29
+;; @002a                               v33 = iadd v31, v10  ; v10 = 16
+;; @002a                               v34 = load.i32 user2 readonly region0 v33
+;; @002a                               v36 = uextend.i64 v5
+;; @002a                               v40 = iadd v36, v85  ; v85 = 7
+;; @002a                               v35 = uextend.i64 v34
+;; @002a                               v41 = icmp ugt v40, v35
+;; @002a                               trapnz v41, user17
+;; @002a                               v57 = load.i64 notrap aligned v83+40
+;; @002a                               v23 = iconst.i64 20
+;; @002a                               v24 = iadd v9, v23  ; v23 = 20
 ;;                                     v93 = iconst.i64 2
 ;;                                     v94 = ishl v14, v93  ; v93 = 2
-;; @002a                               v26 = iadd v23, v94
+;; @002a                               v28 = iadd v24, v94
 ;;                                     v98 = iconst.i64 28
-;; @002a                               v53 = uadd_overflow_trap v26, v98, user2  ; v98 = 28
-;; @002a                               v52 = iadd v8, v51
-;; @002a                               v54 = icmp ugt v53, v52
-;; @002a                               trapnz v54, user2
-;; @002a                               v43 = iadd v29, v22  ; v22 = 20
-;;                                     v96 = ishl v34, v93  ; v93 = 2
-;; @002a                               v46 = iadd v43, v96
-;; @002a                               v58 = uadd_overflow_trap v46, v98, user2  ; v98 = 28
-;; @002a                               v59 = icmp ugt v58, v52
-;; @002a                               trapnz v59, user2
-;; @002a                               v60 = load.i8x16 notrap aligned little v46
-;; @002a                               v61 = load.i64 notrap aligned little v46+16
-;; @002a                               v62 = load.i32 notrap aligned little v46+24
-;; @002a                               store notrap aligned little v60, v26
-;; @002a                               store notrap aligned little v61, v26+16
-;; @002a                               store notrap aligned little v62, v26+24
+;; @002a                               v59 = uadd_overflow_trap v28, v98, user2  ; v98 = 28
+;; @002a                               v58 = iadd v8, v57
+;; @002a                               v60 = icmp ugt v59, v58
+;; @002a                               trapnz v60, user2
+;; @002a                               v46 = iadd v31, v23  ; v23 = 20
+;;                                     v96 = ishl v36, v93  ; v93 = 2
+;; @002a                               v50 = iadd v46, v96
+;; @002a                               v64 = uadd_overflow_trap v50, v98, user2  ; v98 = 28
+;; @002a                               v65 = icmp ugt v64, v58
+;; @002a                               trapnz v65, user2
+;; @002a                               v66 = load.i8x16 notrap aligned little v50
+;; @002a                               v67 = load.i64 notrap aligned little v50+16
+;; @002a                               v68 = load.i32 notrap aligned little v50+24
+;; @002a                               store notrap aligned little v66, v28
+;; @002a                               store notrap aligned little v67, v28+16
+;; @002a                               store notrap aligned little v68, v28+24
 ;; @002e                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/array-fill-anyref.wat
+++ b/tests/disas/array-fill-anyref.wat
@@ -39,33 +39,33 @@
 ;; @0030                               v11 = load.i32 user2 readonly region0 v10
 ;; @0030                               v13 = uextend.i64 v3
 ;; @0030                               v14 = uextend.i64 v5
-;; @0030                               v16 = iadd v13, v14
+;; @0030                               v17 = iadd v13, v14
 ;; @0030                               v12 = uextend.i64 v11
-;; @0030                               v17 = icmp ugt v16, v12
-;; @0030                               trapnz v17, user17
-;; @0030                               v29 = load.i64 notrap aligned v49+40
-;; @0030                               v21 = iconst.i64 20
-;; @0030                               v22 = iadd v8, v21  ; v21 = 20
+;; @0030                               v18 = icmp ugt v17, v12
+;; @0030                               trapnz v18, user17
+;; @0030                               v32 = load.i64 notrap aligned v49+40
+;; @0030                               v22 = iconst.i64 20
+;; @0030                               v23 = iadd v8, v22  ; v22 = 20
 ;;                                     v53 = iconst.i64 2
 ;;                                     v54 = ishl v13, v53  ; v53 = 2
-;; @0030                               v25 = iadd v22, v54
+;; @0030                               v27 = iadd v23, v54
 ;;                                     v56 = ishl v14, v53  ; v53 = 2
-;; @0030                               v31 = uadd_overflow_trap v25, v56, user2
-;; @0030                               v30 = iadd v7, v29
-;; @0030                               v32 = icmp ugt v31, v30
-;; @0030                               trapnz v32, user2
+;; @0030                               v34 = uadd_overflow_trap v27, v56, user2
+;; @0030                               v33 = iadd v7, v32
+;; @0030                               v35 = icmp ugt v34, v33
+;; @0030                               trapnz v35, user2
 ;;                                     v51 = iconst.i64 0
-;; @0030                               v35 = icmp eq v14, v51  ; v51 = 0
-;;                                     v45 = iconst.i64 4
-;; @0030                               v33 = iadd v25, v56
-;; @0030                               brif v35, block3, block2(v25)
+;; @0030                               v38 = icmp eq v14, v51  ; v51 = 0
+;; @0030                               v25 = iconst.i64 4
+;; @0030                               v36 = iadd v27, v56
+;; @0030                               brif v38, block3, block2(v27)
 ;;
-;;                                 block2(v36: i64):
-;; @0030                               store.i32 user2 little region0 v4, v36
+;;                                 block2(v39: i64):
+;; @0030                               store.i32 user2 little region0 v4, v39
 ;;                                     v58 = iconst.i64 4
-;;                                     v59 = iadd v36, v58  ; v58 = 4
-;; @0030                               v39 = icmp eq v59, v33
-;; @0030                               brif v39, block3, block2(v59)
+;;                                     v59 = iadd v39, v58  ; v58 = 4
+;; @0030                               v42 = icmp eq v59, v36
+;; @0030                               brif v42, block3, block2(v59)
 ;;
 ;;                                 block3:
 ;; @0033                               jump block1
@@ -96,35 +96,35 @@
 ;; @003e                               v11 = load.i32 user2 readonly region0 v10
 ;; @003e                               v13 = uextend.i64 v3
 ;; @003e                               v14 = uextend.i64 v4
-;; @003e                               v16 = iadd v13, v14
+;; @003e                               v17 = iadd v13, v14
 ;; @003e                               v12 = uextend.i64 v11
-;; @003e                               v17 = icmp ugt v16, v12
-;; @003e                               trapnz v17, user17
-;; @003e                               v29 = load.i64 notrap aligned v49+40
-;; @003e                               v21 = iconst.i64 20
-;; @003e                               v22 = iadd v8, v21  ; v21 = 20
+;; @003e                               v18 = icmp ugt v17, v12
+;; @003e                               trapnz v18, user17
+;; @003e                               v32 = load.i64 notrap aligned v49+40
+;; @003e                               v22 = iconst.i64 20
+;; @003e                               v23 = iadd v8, v22  ; v22 = 20
 ;;                                     v53 = iconst.i64 2
 ;;                                     v54 = ishl v13, v53  ; v53 = 2
-;; @003e                               v25 = iadd v22, v54
+;; @003e                               v27 = iadd v23, v54
 ;;                                     v56 = ishl v14, v53  ; v53 = 2
-;; @003e                               v31 = uadd_overflow_trap v25, v56, user2
-;; @003e                               v30 = iadd v7, v29
-;; @003e                               v32 = icmp ugt v31, v30
-;; @003e                               trapnz v32, user2
+;; @003e                               v34 = uadd_overflow_trap v27, v56, user2
+;; @003e                               v33 = iadd v7, v32
+;; @003e                               v35 = icmp ugt v34, v33
+;; @003e                               trapnz v35, user2
 ;;                                     v51 = iconst.i64 0
-;; @003e                               v35 = icmp eq v14, v51  ; v51 = 0
+;; @003e                               v38 = icmp eq v14, v51  ; v51 = 0
 ;; @003a                               v5 = iconst.i32 0
-;;                                     v45 = iconst.i64 4
-;; @003e                               v33 = iadd v25, v56
-;; @003e                               brif v35, block3, block2(v25)
+;; @003e                               v25 = iconst.i64 4
+;; @003e                               v36 = iadd v27, v56
+;; @003e                               brif v38, block3, block2(v27)
 ;;
-;;                                 block2(v36: i64):
+;;                                 block2(v39: i64):
 ;;                                     v58 = iconst.i32 0
-;; @003e                               store user2 little region0 v58, v36  ; v58 = 0
+;; @003e                               store user2 little region0 v58, v39  ; v58 = 0
 ;;                                     v59 = iconst.i64 4
-;;                                     v60 = iadd v36, v59  ; v59 = 4
-;; @003e                               v39 = icmp eq v60, v33
-;; @003e                               brif v39, block3, block2(v60)
+;;                                     v60 = iadd v39, v59  ; v59 = 4
+;; @003e                               v42 = icmp eq v60, v36
+;; @003e                               brif v42, block3, block2(v60)
 ;;
 ;;                                 block3:
 ;; @0041                               jump block1
@@ -155,35 +155,35 @@
 ;; @004e                               v13 = load.i32 user2 readonly region0 v12
 ;; @004e                               v15 = uextend.i64 v3
 ;; @004e                               v16 = uextend.i64 v4
-;; @004e                               v18 = iadd v15, v16
+;; @004e                               v19 = iadd v15, v16
 ;; @004e                               v14 = uextend.i64 v13
-;; @004e                               v19 = icmp ugt v18, v14
-;; @004e                               trapnz v19, user17
-;; @004e                               v31 = load.i64 notrap aligned v51+40
-;; @004e                               v23 = iconst.i64 20
-;; @004e                               v24 = iadd v10, v23  ; v23 = 20
+;; @004e                               v20 = icmp ugt v19, v14
+;; @004e                               trapnz v20, user17
+;; @004e                               v34 = load.i64 notrap aligned v51+40
+;; @004e                               v24 = iconst.i64 20
+;; @004e                               v25 = iadd v10, v24  ; v24 = 20
 ;;                                     v63 = iconst.i64 2
 ;;                                     v64 = ishl v15, v63  ; v63 = 2
-;; @004e                               v27 = iadd v24, v64
+;; @004e                               v29 = iadd v25, v64
 ;;                                     v66 = ishl v16, v63  ; v63 = 2
-;; @004e                               v33 = uadd_overflow_trap v27, v66, user2
-;; @004e                               v32 = iadd v9, v31
-;; @004e                               v34 = icmp ugt v33, v32
-;; @004e                               trapnz v34, user2
+;; @004e                               v36 = uadd_overflow_trap v29, v66, user2
+;; @004e                               v35 = iadd v9, v34
+;; @004e                               v37 = icmp ugt v36, v35
+;; @004e                               trapnz v37, user2
 ;;                                     v61 = iconst.i64 0
-;; @004e                               v37 = icmp eq v16, v61  ; v61 = 0
+;; @004e                               v40 = icmp eq v16, v61  ; v61 = 0
 ;; @0048                               v5 = iconst.i32 -1
-;;                                     v47 = iconst.i64 4
-;; @004e                               v35 = iadd v27, v66
-;; @004e                               brif v37, block3, block2(v27)
+;; @004e                               v27 = iconst.i64 4
+;; @004e                               v38 = iadd v29, v66
+;; @004e                               brif v40, block3, block2(v29)
 ;;
-;;                                 block2(v38: i64):
+;;                                 block2(v41: i64):
 ;;                                     v68 = iconst.i32 -1
-;; @004e                               store user2 little region0 v68, v38  ; v68 = -1
+;; @004e                               store user2 little region0 v68, v41  ; v68 = -1
 ;;                                     v69 = iconst.i64 4
-;;                                     v70 = iadd v38, v69  ; v69 = 4
-;; @004e                               v41 = icmp eq v70, v35
-;; @004e                               brif v41, block3, block2(v70)
+;;                                     v70 = iadd v41, v69  ; v69 = 4
+;; @004e                               v44 = icmp eq v70, v38
+;; @004e                               brif v44, block3, block2(v70)
 ;;
 ;;                                 block3:
 ;; @0051                               jump block1

--- a/tests/disas/array-fill-externref.wat
+++ b/tests/disas/array-fill-externref.wat
@@ -35,33 +35,33 @@
 ;; @002f                               v11 = load.i32 user2 readonly region0 v10
 ;; @002f                               v13 = uextend.i64 v3
 ;; @002f                               v14 = uextend.i64 v5
-;; @002f                               v16 = iadd v13, v14
+;; @002f                               v17 = iadd v13, v14
 ;; @002f                               v12 = uextend.i64 v11
-;; @002f                               v17 = icmp ugt v16, v12
-;; @002f                               trapnz v17, user17
-;; @002f                               v29 = load.i64 notrap aligned v49+40
-;; @002f                               v21 = iconst.i64 20
-;; @002f                               v22 = iadd v8, v21  ; v21 = 20
+;; @002f                               v18 = icmp ugt v17, v12
+;; @002f                               trapnz v18, user17
+;; @002f                               v32 = load.i64 notrap aligned v49+40
+;; @002f                               v22 = iconst.i64 20
+;; @002f                               v23 = iadd v8, v22  ; v22 = 20
 ;;                                     v53 = iconst.i64 2
 ;;                                     v54 = ishl v13, v53  ; v53 = 2
-;; @002f                               v25 = iadd v22, v54
+;; @002f                               v27 = iadd v23, v54
 ;;                                     v56 = ishl v14, v53  ; v53 = 2
-;; @002f                               v31 = uadd_overflow_trap v25, v56, user2
-;; @002f                               v30 = iadd v7, v29
-;; @002f                               v32 = icmp ugt v31, v30
-;; @002f                               trapnz v32, user2
+;; @002f                               v34 = uadd_overflow_trap v27, v56, user2
+;; @002f                               v33 = iadd v7, v32
+;; @002f                               v35 = icmp ugt v34, v33
+;; @002f                               trapnz v35, user2
 ;;                                     v51 = iconst.i64 0
-;; @002f                               v35 = icmp eq v14, v51  ; v51 = 0
-;;                                     v45 = iconst.i64 4
-;; @002f                               v33 = iadd v25, v56
-;; @002f                               brif v35, block3, block2(v25)
+;; @002f                               v38 = icmp eq v14, v51  ; v51 = 0
+;; @002f                               v25 = iconst.i64 4
+;; @002f                               v36 = iadd v27, v56
+;; @002f                               brif v38, block3, block2(v27)
 ;;
-;;                                 block2(v36: i64):
-;; @002f                               store.i32 user2 little region0 v4, v36
+;;                                 block2(v39: i64):
+;; @002f                               store.i32 user2 little region0 v4, v39
 ;;                                     v58 = iconst.i64 4
-;;                                     v59 = iadd v36, v58  ; v58 = 4
-;; @002f                               v39 = icmp eq v59, v33
-;; @002f                               brif v39, block3, block2(v59)
+;;                                     v59 = iadd v39, v58  ; v58 = 4
+;; @002f                               v42 = icmp eq v59, v36
+;; @002f                               brif v42, block3, block2(v59)
 ;;
 ;;                                 block3:
 ;; @0032                               jump block1
@@ -92,35 +92,35 @@
 ;; @003d                               v11 = load.i32 user2 readonly region0 v10
 ;; @003d                               v13 = uextend.i64 v3
 ;; @003d                               v14 = uextend.i64 v4
-;; @003d                               v16 = iadd v13, v14
+;; @003d                               v17 = iadd v13, v14
 ;; @003d                               v12 = uextend.i64 v11
-;; @003d                               v17 = icmp ugt v16, v12
-;; @003d                               trapnz v17, user17
-;; @003d                               v29 = load.i64 notrap aligned v49+40
-;; @003d                               v21 = iconst.i64 20
-;; @003d                               v22 = iadd v8, v21  ; v21 = 20
+;; @003d                               v18 = icmp ugt v17, v12
+;; @003d                               trapnz v18, user17
+;; @003d                               v32 = load.i64 notrap aligned v49+40
+;; @003d                               v22 = iconst.i64 20
+;; @003d                               v23 = iadd v8, v22  ; v22 = 20
 ;;                                     v53 = iconst.i64 2
 ;;                                     v54 = ishl v13, v53  ; v53 = 2
-;; @003d                               v25 = iadd v22, v54
+;; @003d                               v27 = iadd v23, v54
 ;;                                     v56 = ishl v14, v53  ; v53 = 2
-;; @003d                               v31 = uadd_overflow_trap v25, v56, user2
-;; @003d                               v30 = iadd v7, v29
-;; @003d                               v32 = icmp ugt v31, v30
-;; @003d                               trapnz v32, user2
+;; @003d                               v34 = uadd_overflow_trap v27, v56, user2
+;; @003d                               v33 = iadd v7, v32
+;; @003d                               v35 = icmp ugt v34, v33
+;; @003d                               trapnz v35, user2
 ;;                                     v51 = iconst.i64 0
-;; @003d                               v35 = icmp eq v14, v51  ; v51 = 0
+;; @003d                               v38 = icmp eq v14, v51  ; v51 = 0
 ;; @0039                               v5 = iconst.i32 0
-;;                                     v45 = iconst.i64 4
-;; @003d                               v33 = iadd v25, v56
-;; @003d                               brif v35, block3, block2(v25)
+;; @003d                               v25 = iconst.i64 4
+;; @003d                               v36 = iadd v27, v56
+;; @003d                               brif v38, block3, block2(v27)
 ;;
-;;                                 block2(v36: i64):
+;;                                 block2(v39: i64):
 ;;                                     v58 = iconst.i32 0
-;; @003d                               store user2 little region0 v58, v36  ; v58 = 0
+;; @003d                               store user2 little region0 v58, v39  ; v58 = 0
 ;;                                     v59 = iconst.i64 4
-;;                                     v60 = iadd v36, v59  ; v59 = 4
-;; @003d                               v39 = icmp eq v60, v33
-;; @003d                               brif v39, block3, block2(v60)
+;;                                     v60 = iadd v39, v59  ; v59 = 4
+;; @003d                               v42 = icmp eq v60, v36
+;; @003d                               brif v42, block3, block2(v60)
 ;;
 ;;                                 block3:
 ;; @0040                               jump block1

--- a/tests/disas/array-fill-f32.wat
+++ b/tests/disas/array-fill-f32.wat
@@ -39,33 +39,33 @@
 ;; @0030                               v11 = load.i32 user2 readonly region0 v10
 ;; @0030                               v13 = uextend.i64 v3
 ;; @0030                               v14 = uextend.i64 v5
-;; @0030                               v16 = iadd v13, v14
+;; @0030                               v17 = iadd v13, v14
 ;; @0030                               v12 = uextend.i64 v11
-;; @0030                               v17 = icmp ugt v16, v12
-;; @0030                               trapnz v17, user17
-;; @0030                               v29 = load.i64 notrap aligned v49+40
-;; @0030                               v21 = iconst.i64 20
-;; @0030                               v22 = iadd v8, v21  ; v21 = 20
+;; @0030                               v18 = icmp ugt v17, v12
+;; @0030                               trapnz v18, user17
+;; @0030                               v32 = load.i64 notrap aligned v49+40
+;; @0030                               v22 = iconst.i64 20
+;; @0030                               v23 = iadd v8, v22  ; v22 = 20
 ;;                                     v53 = iconst.i64 2
 ;;                                     v54 = ishl v13, v53  ; v53 = 2
-;; @0030                               v25 = iadd v22, v54
+;; @0030                               v27 = iadd v23, v54
 ;;                                     v56 = ishl v14, v53  ; v53 = 2
-;; @0030                               v31 = uadd_overflow_trap v25, v56, user2
-;; @0030                               v30 = iadd v7, v29
-;; @0030                               v32 = icmp ugt v31, v30
-;; @0030                               trapnz v32, user2
+;; @0030                               v34 = uadd_overflow_trap v27, v56, user2
+;; @0030                               v33 = iadd v7, v32
+;; @0030                               v35 = icmp ugt v34, v33
+;; @0030                               trapnz v35, user2
 ;;                                     v51 = iconst.i64 0
-;; @0030                               v35 = icmp eq v14, v51  ; v51 = 0
-;;                                     v45 = iconst.i64 4
-;; @0030                               v33 = iadd v25, v56
-;; @0030                               brif v35, block3, block2(v25)
+;; @0030                               v38 = icmp eq v14, v51  ; v51 = 0
+;; @0030                               v25 = iconst.i64 4
+;; @0030                               v36 = iadd v27, v56
+;; @0030                               brif v38, block3, block2(v27)
 ;;
-;;                                 block2(v36: i64):
-;; @0030                               store.f32 user2 little region0 v4, v36
+;;                                 block2(v39: i64):
+;; @0030                               store.f32 user2 little region0 v4, v39
 ;;                                     v58 = iconst.i64 4
-;;                                     v59 = iadd v36, v58  ; v58 = 4
-;; @0030                               v39 = icmp eq v59, v33
-;; @0030                               brif v39, block3, block2(v59)
+;;                                     v59 = iadd v39, v58  ; v58 = 4
+;; @0030                               v42 = icmp eq v59, v36
+;; @0030                               brif v42, block3, block2(v59)
 ;;
 ;;                                 block3:
 ;; @0033                               jump block1
@@ -98,23 +98,23 @@
 ;; @0041                               v11 = load.i32 user2 readonly region0 v10
 ;; @0041                               v13 = uextend.i64 v3
 ;; @0041                               v14 = uextend.i64 v4
-;; @0041                               v16 = iadd v13, v14
+;; @0041                               v17 = iadd v13, v14
 ;; @0041                               v12 = uextend.i64 v11
-;; @0041                               v17 = icmp ugt v16, v12
-;; @0041                               trapnz v17, user17
-;; @0041                               v29 = load.i64 notrap aligned v44+40
-;; @0041                               v21 = iconst.i64 20
-;; @0041                               v22 = iadd v8, v21  ; v21 = 20
+;; @0041                               v18 = icmp ugt v17, v12
+;; @0041                               trapnz v18, user17
+;; @0041                               v32 = load.i64 notrap aligned v44+40
+;; @0041                               v22 = iconst.i64 20
+;; @0041                               v23 = iadd v8, v22  ; v22 = 20
 ;;                                     v48 = iconst.i64 2
 ;;                                     v49 = ishl v13, v48  ; v48 = 2
-;; @0041                               v25 = iadd v22, v49
+;; @0041                               v27 = iadd v23, v49
 ;;                                     v51 = ishl v14, v48  ; v48 = 2
-;; @0041                               v31 = uadd_overflow_trap v25, v51, user2
-;; @0041                               v30 = iadd v7, v29
-;; @0041                               v32 = icmp ugt v31, v30
-;; @0041                               trapnz v32, user2
-;; @0041                               v33 = iconst.i32 0
-;; @0041                               call fn0(v0, v25, v33, v51)  ; v33 = 0
+;; @0041                               v34 = uadd_overflow_trap v27, v51, user2
+;; @0041                               v33 = iadd v7, v32
+;; @0041                               v35 = icmp ugt v34, v33
+;; @0041                               trapnz v35, user2
+;; @0041                               v36 = iconst.i32 0
+;; @0041                               call fn0(v0, v27, v36, v51)  ; v36 = 0
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -143,35 +143,35 @@
 ;; @0052                               v11 = load.i32 user2 readonly region0 v10
 ;; @0052                               v13 = uextend.i64 v3
 ;; @0052                               v14 = uextend.i64 v4
-;; @0052                               v16 = iadd v13, v14
+;; @0052                               v17 = iadd v13, v14
 ;; @0052                               v12 = uextend.i64 v11
-;; @0052                               v17 = icmp ugt v16, v12
-;; @0052                               trapnz v17, user17
-;; @0052                               v29 = load.i64 notrap aligned v49+40
-;; @0052                               v21 = iconst.i64 20
-;; @0052                               v22 = iadd v8, v21  ; v21 = 20
+;; @0052                               v18 = icmp ugt v17, v12
+;; @0052                               trapnz v18, user17
+;; @0052                               v32 = load.i64 notrap aligned v49+40
+;; @0052                               v22 = iconst.i64 20
+;; @0052                               v23 = iadd v8, v22  ; v22 = 20
 ;;                                     v53 = iconst.i64 2
 ;;                                     v54 = ishl v13, v53  ; v53 = 2
-;; @0052                               v25 = iadd v22, v54
+;; @0052                               v27 = iadd v23, v54
 ;;                                     v56 = ishl v14, v53  ; v53 = 2
-;; @0052                               v31 = uadd_overflow_trap v25, v56, user2
-;; @0052                               v30 = iadd v7, v29
-;; @0052                               v32 = icmp ugt v31, v30
-;; @0052                               trapnz v32, user2
+;; @0052                               v34 = uadd_overflow_trap v27, v56, user2
+;; @0052                               v33 = iadd v7, v32
+;; @0052                               v35 = icmp ugt v34, v33
+;; @0052                               trapnz v35, user2
 ;;                                     v51 = iconst.i64 0
-;; @0052                               v35 = icmp eq v14, v51  ; v51 = 0
+;; @0052                               v38 = icmp eq v14, v51  ; v51 = 0
 ;; @004b                               v5 = f32const 0x1.000000p0
-;;                                     v45 = iconst.i64 4
-;; @0052                               v33 = iadd v25, v56
-;; @0052                               brif v35, block3, block2(v25)
+;; @0052                               v25 = iconst.i64 4
+;; @0052                               v36 = iadd v27, v56
+;; @0052                               brif v38, block3, block2(v27)
 ;;
-;;                                 block2(v36: i64):
+;;                                 block2(v39: i64):
 ;;                                     v58 = f32const 0x1.000000p0
-;; @0052                               store user2 little region0 v58, v36  ; v58 = 0x1.000000p0
+;; @0052                               store user2 little region0 v58, v39  ; v58 = 0x1.000000p0
 ;;                                     v59 = iconst.i64 4
-;;                                     v60 = iadd v36, v59  ; v59 = 4
-;; @0052                               v39 = icmp eq v60, v33
-;; @0052                               brif v39, block3, block2(v60)
+;;                                     v60 = iadd v39, v59  ; v59 = 4
+;; @0052                               v42 = icmp eq v60, v36
+;; @0052                               brif v42, block3, block2(v60)
 ;;
 ;;                                 block3:
 ;; @0055                               jump block1

--- a/tests/disas/array-fill-f64.wat
+++ b/tests/disas/array-fill-f64.wat
@@ -39,33 +39,33 @@
 ;; @0030                               v11 = load.i32 user2 readonly region0 v10
 ;; @0030                               v13 = uextend.i64 v3
 ;; @0030                               v14 = uextend.i64 v5
-;; @0030                               v16 = iadd v13, v14
+;; @0030                               v17 = iadd v13, v14
 ;; @0030                               v12 = uextend.i64 v11
-;; @0030                               v17 = icmp ugt v16, v12
-;; @0030                               trapnz v17, user17
-;; @0030                               v29 = load.i64 notrap aligned v49+40
-;; @0030                               v21 = iconst.i64 24
-;; @0030                               v22 = iadd v8, v21  ; v21 = 24
+;; @0030                               v18 = icmp ugt v17, v12
+;; @0030                               trapnz v18, user17
+;; @0030                               v32 = load.i64 notrap aligned v49+40
+;; @0030                               v22 = iconst.i64 24
+;; @0030                               v23 = iadd v8, v22  ; v22 = 24
 ;;                                     v53 = iconst.i64 3
 ;;                                     v54 = ishl v13, v53  ; v53 = 3
-;; @0030                               v25 = iadd v22, v54
+;; @0030                               v27 = iadd v23, v54
 ;;                                     v56 = ishl v14, v53  ; v53 = 3
-;; @0030                               v31 = uadd_overflow_trap v25, v56, user2
-;; @0030                               v30 = iadd v7, v29
-;; @0030                               v32 = icmp ugt v31, v30
-;; @0030                               trapnz v32, user2
+;; @0030                               v34 = uadd_overflow_trap v27, v56, user2
+;; @0030                               v33 = iadd v7, v32
+;; @0030                               v35 = icmp ugt v34, v33
+;; @0030                               trapnz v35, user2
 ;;                                     v51 = iconst.i64 0
-;; @0030                               v35 = icmp eq v14, v51  ; v51 = 0
-;;                                     v45 = iconst.i64 8
-;; @0030                               v33 = iadd v25, v56
-;; @0030                               brif v35, block3, block2(v25)
+;; @0030                               v38 = icmp eq v14, v51  ; v51 = 0
+;; @0030                               v25 = iconst.i64 8
+;; @0030                               v36 = iadd v27, v56
+;; @0030                               brif v38, block3, block2(v27)
 ;;
-;;                                 block2(v36: i64):
-;; @0030                               store.f64 user2 little region0 v4, v36
+;;                                 block2(v39: i64):
+;; @0030                               store.f64 user2 little region0 v4, v39
 ;;                                     v58 = iconst.i64 8
-;;                                     v59 = iadd v36, v58  ; v58 = 8
-;; @0030                               v39 = icmp eq v59, v33
-;; @0030                               brif v39, block3, block2(v59)
+;;                                     v59 = iadd v39, v58  ; v58 = 8
+;; @0030                               v42 = icmp eq v59, v36
+;; @0030                               brif v42, block3, block2(v59)
 ;;
 ;;                                 block3:
 ;; @0033                               jump block1
@@ -98,23 +98,23 @@
 ;; @0045                               v11 = load.i32 user2 readonly region0 v10
 ;; @0045                               v13 = uextend.i64 v3
 ;; @0045                               v14 = uextend.i64 v4
-;; @0045                               v16 = iadd v13, v14
+;; @0045                               v17 = iadd v13, v14
 ;; @0045                               v12 = uextend.i64 v11
-;; @0045                               v17 = icmp ugt v16, v12
-;; @0045                               trapnz v17, user17
-;; @0045                               v29 = load.i64 notrap aligned v44+40
-;; @0045                               v21 = iconst.i64 24
-;; @0045                               v22 = iadd v8, v21  ; v21 = 24
+;; @0045                               v18 = icmp ugt v17, v12
+;; @0045                               trapnz v18, user17
+;; @0045                               v32 = load.i64 notrap aligned v44+40
+;; @0045                               v22 = iconst.i64 24
+;; @0045                               v23 = iadd v8, v22  ; v22 = 24
 ;;                                     v48 = iconst.i64 3
 ;;                                     v49 = ishl v13, v48  ; v48 = 3
-;; @0045                               v25 = iadd v22, v49
+;; @0045                               v27 = iadd v23, v49
 ;;                                     v51 = ishl v14, v48  ; v48 = 3
-;; @0045                               v31 = uadd_overflow_trap v25, v51, user2
-;; @0045                               v30 = iadd v7, v29
-;; @0045                               v32 = icmp ugt v31, v30
-;; @0045                               trapnz v32, user2
-;; @0045                               v33 = iconst.i32 0
-;; @0045                               call fn0(v0, v25, v33, v51)  ; v33 = 0
+;; @0045                               v34 = uadd_overflow_trap v27, v51, user2
+;; @0045                               v33 = iadd v7, v32
+;; @0045                               v35 = icmp ugt v34, v33
+;; @0045                               trapnz v35, user2
+;; @0045                               v36 = iconst.i32 0
+;; @0045                               call fn0(v0, v27, v36, v51)  ; v36 = 0
 ;; @0048                               jump block1
 ;;
 ;;                                 block1:
@@ -143,35 +143,35 @@
 ;; @005a                               v11 = load.i32 user2 readonly region0 v10
 ;; @005a                               v13 = uextend.i64 v3
 ;; @005a                               v14 = uextend.i64 v4
-;; @005a                               v16 = iadd v13, v14
+;; @005a                               v17 = iadd v13, v14
 ;; @005a                               v12 = uextend.i64 v11
-;; @005a                               v17 = icmp ugt v16, v12
-;; @005a                               trapnz v17, user17
-;; @005a                               v29 = load.i64 notrap aligned v49+40
-;; @005a                               v21 = iconst.i64 24
-;; @005a                               v22 = iadd v8, v21  ; v21 = 24
+;; @005a                               v18 = icmp ugt v17, v12
+;; @005a                               trapnz v18, user17
+;; @005a                               v32 = load.i64 notrap aligned v49+40
+;; @005a                               v22 = iconst.i64 24
+;; @005a                               v23 = iadd v8, v22  ; v22 = 24
 ;;                                     v53 = iconst.i64 3
 ;;                                     v54 = ishl v13, v53  ; v53 = 3
-;; @005a                               v25 = iadd v22, v54
+;; @005a                               v27 = iadd v23, v54
 ;;                                     v56 = ishl v14, v53  ; v53 = 3
-;; @005a                               v31 = uadd_overflow_trap v25, v56, user2
-;; @005a                               v30 = iadd v7, v29
-;; @005a                               v32 = icmp ugt v31, v30
-;; @005a                               trapnz v32, user2
+;; @005a                               v34 = uadd_overflow_trap v27, v56, user2
+;; @005a                               v33 = iadd v7, v32
+;; @005a                               v35 = icmp ugt v34, v33
+;; @005a                               trapnz v35, user2
 ;;                                     v51 = iconst.i64 0
-;; @005a                               v35 = icmp eq v14, v51  ; v51 = 0
+;; @005a                               v38 = icmp eq v14, v51  ; v51 = 0
 ;; @004f                               v5 = f64const 0x1.0000000000000p0
-;;                                     v45 = iconst.i64 8
-;; @005a                               v33 = iadd v25, v56
-;; @005a                               brif v35, block3, block2(v25)
+;; @005a                               v25 = iconst.i64 8
+;; @005a                               v36 = iadd v27, v56
+;; @005a                               brif v38, block3, block2(v27)
 ;;
-;;                                 block2(v36: i64):
+;;                                 block2(v39: i64):
 ;;                                     v58 = f64const 0x1.0000000000000p0
-;; @005a                               store user2 little region0 v58, v36  ; v58 = 0x1.0000000000000p0
+;; @005a                               store user2 little region0 v58, v39  ; v58 = 0x1.0000000000000p0
 ;;                                     v59 = iconst.i64 8
-;;                                     v60 = iadd v36, v59  ; v59 = 8
-;; @005a                               v39 = icmp eq v60, v33
-;; @005a                               brif v39, block3, block2(v60)
+;;                                     v60 = iadd v39, v59  ; v59 = 8
+;; @005a                               v42 = icmp eq v60, v36
+;; @005a                               brif v42, block3, block2(v60)
 ;;
 ;;                                 block3:
 ;; @005d                               jump block1

--- a/tests/disas/array-fill-funcref.wat
+++ b/tests/disas/array-fill-funcref.wat
@@ -44,35 +44,35 @@
 ;; @003b                               v11 = load.i32 user2 readonly region0 v10
 ;; @003b                               v13 = uextend.i64 v3
 ;; @003b                               v14 = uextend.i64 v5
-;; @003b                               v16 = iadd v13, v14
+;; @003b                               v17 = iadd v13, v14
 ;; @003b                               v12 = uextend.i64 v11
-;; @003b                               v17 = icmp ugt v16, v12
-;; @003b                               trapnz v17, user17
-;; @003b                               v29 = load.i64 notrap aligned v52+40
-;; @003b                               v21 = iconst.i64 20
-;; @003b                               v22 = iadd v8, v21  ; v21 = 20
+;; @003b                               v18 = icmp ugt v17, v12
+;; @003b                               trapnz v18, user17
+;; @003b                               v32 = load.i64 notrap aligned v52+40
+;; @003b                               v22 = iconst.i64 20
+;; @003b                               v23 = iadd v8, v22  ; v22 = 20
 ;;                                     v56 = iconst.i64 2
 ;;                                     v57 = ishl v13, v56  ; v56 = 2
-;; @003b                               v25 = iadd v22, v57
+;; @003b                               v27 = iadd v23, v57
 ;;                                     v59 = ishl v14, v56  ; v56 = 2
-;; @003b                               v31 = uadd_overflow_trap v25, v59, user2
-;; @003b                               v30 = iadd v7, v29
-;; @003b                               v32 = icmp ugt v31, v30
-;; @003b                               trapnz v32, user2
-;; @003b                               v34 = call fn0(v0, v4)
+;; @003b                               v34 = uadd_overflow_trap v27, v59, user2
+;; @003b                               v33 = iadd v7, v32
+;; @003b                               v35 = icmp ugt v34, v33
+;; @003b                               trapnz v35, user2
+;; @003b                               v37 = call fn0(v0, v4)
 ;;                                     v54 = iconst.i64 0
-;; @003b                               v38 = icmp eq v14, v54  ; v54 = 0
-;; @003b                               v35 = ireduce.i32 v34
-;;                                     v48 = iconst.i64 4
-;; @003b                               v36 = iadd v25, v59
-;; @003b                               brif v38, block3, block2(v25)
+;; @003b                               v41 = icmp eq v14, v54  ; v54 = 0
+;; @003b                               v38 = ireduce.i32 v37
+;; @003b                               v25 = iconst.i64 4
+;; @003b                               v39 = iadd v27, v59
+;; @003b                               brif v41, block3, block2(v27)
 ;;
-;;                                 block2(v39: i64):
-;; @003b                               store.i32 notrap aligned little v35, v39
+;;                                 block2(v42: i64):
+;; @003b                               store.i32 notrap aligned little v38, v42
 ;;                                     v61 = iconst.i64 4
-;;                                     v62 = iadd v39, v61  ; v61 = 4
-;; @003b                               v42 = icmp eq v62, v36
-;; @003b                               brif v42, block3, block2(v62)
+;;                                     v62 = iadd v42, v61  ; v61 = 4
+;; @003b                               v45 = icmp eq v62, v39
+;; @003b                               brif v45, block3, block2(v62)
 ;;
 ;;                                 block3:
 ;; @003e                               jump block1
@@ -105,35 +105,35 @@
 ;; @0049                               v11 = load.i32 user2 readonly region0 v10
 ;; @0049                               v13 = uextend.i64 v3
 ;; @0049                               v14 = uextend.i64 v4
-;; @0049                               v16 = iadd v13, v14
+;; @0049                               v17 = iadd v13, v14
 ;; @0049                               v12 = uextend.i64 v11
-;; @0049                               v17 = icmp ugt v16, v12
-;; @0049                               trapnz v17, user17
-;; @0049                               v29 = load.i64 notrap aligned v52+40
-;; @0049                               v21 = iconst.i64 20
-;; @0049                               v22 = iadd v8, v21  ; v21 = 20
+;; @0049                               v18 = icmp ugt v17, v12
+;; @0049                               trapnz v18, user17
+;; @0049                               v32 = load.i64 notrap aligned v52+40
+;; @0049                               v22 = iconst.i64 20
+;; @0049                               v23 = iadd v8, v22  ; v22 = 20
 ;;                                     v55 = iconst.i64 2
 ;;                                     v56 = ishl v13, v55  ; v55 = 2
-;; @0049                               v25 = iadd v22, v56
+;; @0049                               v27 = iadd v23, v56
 ;;                                     v58 = ishl v14, v55  ; v55 = 2
-;; @0049                               v31 = uadd_overflow_trap v25, v58, user2
-;; @0049                               v30 = iadd v7, v29
-;; @0049                               v32 = icmp ugt v31, v30
-;; @0049                               trapnz v32, user2
+;; @0049                               v34 = uadd_overflow_trap v27, v58, user2
+;; @0049                               v33 = iadd v7, v32
+;; @0049                               v35 = icmp ugt v34, v33
+;; @0049                               trapnz v35, user2
 ;; @0045                               v5 = iconst.i64 0
-;; @0049                               v34 = call fn0(v0, v5)  ; v5 = 0
-;; @0049                               v38 = icmp eq v14, v5  ; v5 = 0
-;; @0049                               v35 = ireduce.i32 v34
-;;                                     v48 = iconst.i64 4
-;; @0049                               v36 = iadd v25, v58
-;; @0049                               brif v38, block3, block2(v25)
+;; @0049                               v37 = call fn0(v0, v5)  ; v5 = 0
+;; @0049                               v41 = icmp eq v14, v5  ; v5 = 0
+;; @0049                               v38 = ireduce.i32 v37
+;; @0049                               v25 = iconst.i64 4
+;; @0049                               v39 = iadd v27, v58
+;; @0049                               brif v41, block3, block2(v27)
 ;;
-;;                                 block2(v39: i64):
-;; @0049                               store.i32 notrap aligned little v35, v39
+;;                                 block2(v42: i64):
+;; @0049                               store.i32 notrap aligned little v38, v42
 ;;                                     v60 = iconst.i64 4
-;;                                     v61 = iadd v39, v60  ; v60 = 4
-;; @0049                               v42 = icmp eq v61, v36
-;; @0049                               brif v42, block3, block2(v61)
+;;                                     v61 = iadd v42, v60  ; v60 = 4
+;; @0049                               v45 = icmp eq v61, v39
+;; @0049                               brif v45, block3, block2(v61)
 ;;
 ;;                                 block3:
 ;; @004c                               jump block1
@@ -163,46 +163,46 @@
 ;;                                     store notrap v2, v62
 ;; @0053                               v5 = iconst.i32 3
 ;; @0053                               v7 = call fn0(v0, v5), stack_map=[i32 @ ss0+0]  ; v5 = 3
-;;                                     v47 = load.i32 notrap v62
-;; @0057                               trapz v47, user16
+;;                                     v50 = load.i32 notrap v62
+;; @0057                               trapz v50, user16
 ;; @0057                               v58 = load.i64 notrap aligned readonly can_move v0+8
 ;; @0057                               v9 = load.i64 notrap aligned readonly can_move v58+32
-;; @0057                               v8 = uextend.i64 v47
+;; @0057                               v8 = uextend.i64 v50
 ;; @0057                               v10 = iadd v9, v8
 ;; @0057                               v11 = iconst.i64 16
 ;; @0057                               v12 = iadd v10, v11  ; v11 = 16
 ;; @0057                               v13 = load.i32 user2 readonly region0 v12
 ;; @0057                               v15 = uextend.i64 v3
 ;; @0057                               v16 = uextend.i64 v4
-;; @0057                               v18 = iadd v15, v16
+;; @0057                               v19 = iadd v15, v16
 ;; @0057                               v14 = uextend.i64 v13
-;; @0057                               v19 = icmp ugt v18, v14
-;; @0057                               trapnz v19, user17
-;; @0057                               v31 = load.i64 notrap aligned v58+40
-;; @0057                               v23 = iconst.i64 20
-;; @0057                               v24 = iadd v10, v23  ; v23 = 20
+;; @0057                               v20 = icmp ugt v19, v14
+;; @0057                               trapnz v20, user17
+;; @0057                               v34 = load.i64 notrap aligned v58+40
+;; @0057                               v24 = iconst.i64 20
+;; @0057                               v25 = iadd v10, v24  ; v24 = 20
 ;;                                     v65 = iconst.i64 2
 ;;                                     v66 = ishl v15, v65  ; v65 = 2
-;; @0057                               v27 = iadd v24, v66
+;; @0057                               v29 = iadd v25, v66
 ;;                                     v68 = ishl v16, v65  ; v65 = 2
-;; @0057                               v33 = uadd_overflow_trap v27, v68, user2
-;; @0057                               v32 = iadd v9, v31
-;; @0057                               v34 = icmp ugt v33, v32
-;; @0057                               trapnz v34, user2
-;; @0057                               v36 = call fn1(v0, v7)
+;; @0057                               v36 = uadd_overflow_trap v29, v68, user2
+;; @0057                               v35 = iadd v9, v34
+;; @0057                               v37 = icmp ugt v36, v35
+;; @0057                               trapnz v37, user2
+;; @0057                               v39 = call fn1(v0, v7)
 ;;                                     v63 = iconst.i64 0
-;; @0057                               v40 = icmp eq v16, v63  ; v63 = 0
-;; @0057                               v37 = ireduce.i32 v36
-;;                                     v53 = iconst.i64 4
-;; @0057                               v38 = iadd v27, v68
-;; @0057                               brif v40, block3, block2(v27)
+;; @0057                               v43 = icmp eq v16, v63  ; v63 = 0
+;; @0057                               v40 = ireduce.i32 v39
+;; @0057                               v27 = iconst.i64 4
+;; @0057                               v41 = iadd v29, v68
+;; @0057                               brif v43, block3, block2(v29)
 ;;
-;;                                 block2(v41: i64):
-;; @0057                               store.i32 notrap aligned little v37, v41
+;;                                 block2(v44: i64):
+;; @0057                               store.i32 notrap aligned little v40, v44
 ;;                                     v70 = iconst.i64 4
-;;                                     v71 = iadd v41, v70  ; v70 = 4
-;; @0057                               v44 = icmp eq v71, v38
-;; @0057                               brif v44, block3, block2(v71)
+;;                                     v71 = iadd v44, v70  ; v70 = 4
+;; @0057                               v47 = icmp eq v71, v41
+;; @0057                               brif v47, block3, block2(v71)
 ;;
 ;;                                 block3:
 ;; @005a                               jump block1

--- a/tests/disas/array-fill-i16.wat
+++ b/tests/disas/array-fill-i16.wat
@@ -43,33 +43,33 @@
 ;; @0031                               v11 = load.i32 user2 readonly region0 v10
 ;; @0031                               v13 = uextend.i64 v3
 ;; @0031                               v14 = uextend.i64 v5
-;; @0031                               v16 = iadd v13, v14
+;; @0031                               v17 = iadd v13, v14
 ;; @0031                               v12 = uextend.i64 v11
-;; @0031                               v17 = icmp ugt v16, v12
-;; @0031                               trapnz v17, user17
-;; @0031                               v29 = load.i64 notrap aligned v49+40
-;; @0031                               v21 = iconst.i64 20
-;; @0031                               v22 = iadd v8, v21  ; v21 = 20
-;;                                     v48 = iconst.i64 1
-;;                                     v54 = ishl v13, v48  ; v48 = 1
-;; @0031                               v25 = iadd v22, v54
-;;                                     v58 = ishl v14, v48  ; v48 = 1
-;; @0031                               v31 = uadd_overflow_trap v25, v58, user2
-;; @0031                               v30 = iadd v7, v29
-;; @0031                               v32 = icmp ugt v31, v30
-;; @0031                               trapnz v32, user2
+;; @0031                               v18 = icmp ugt v17, v12
+;; @0031                               trapnz v18, user17
+;; @0031                               v32 = load.i64 notrap aligned v49+40
+;; @0031                               v22 = iconst.i64 20
+;; @0031                               v23 = iadd v8, v22  ; v22 = 20
+;; @0031                               v15 = iconst.i64 1
+;;                                     v54 = ishl v13, v15  ; v15 = 1
+;; @0031                               v27 = iadd v23, v54
+;;                                     v58 = ishl v14, v15  ; v15 = 1
+;; @0031                               v34 = uadd_overflow_trap v27, v58, user2
+;; @0031                               v33 = iadd v7, v32
+;; @0031                               v35 = icmp ugt v34, v33
+;; @0031                               trapnz v35, user2
 ;;                                     v51 = iconst.i64 0
-;; @0031                               v35 = icmp eq v14, v51  ; v51 = 0
-;;                                     v45 = iconst.i64 2
-;; @0031                               v33 = iadd v25, v58
-;; @0031                               brif v35, block3, block2(v25)
+;; @0031                               v38 = icmp eq v14, v51  ; v51 = 0
+;; @0031                               v25 = iconst.i64 2
+;; @0031                               v36 = iadd v27, v58
+;; @0031                               brif v38, block3, block2(v27)
 ;;
-;;                                 block2(v36: i64):
-;; @0031                               istore16.i32 user2 little region0 v4, v36
+;;                                 block2(v39: i64):
+;; @0031                               istore16.i32 user2 little region0 v4, v39
 ;;                                     v61 = iconst.i64 2
-;;                                     v62 = iadd v36, v61  ; v61 = 2
-;; @0031                               v39 = icmp eq v62, v33
-;; @0031                               brif v39, block3, block2(v62)
+;;                                     v62 = iadd v39, v61  ; v61 = 2
+;; @0031                               v42 = icmp eq v62, v36
+;; @0031                               brif v42, block3, block2(v62)
 ;;
 ;;                                 block3:
 ;; @0034                               jump block1
@@ -102,23 +102,23 @@
 ;; @003f                               v11 = load.i32 user2 readonly region0 v10
 ;; @003f                               v13 = uextend.i64 v3
 ;; @003f                               v14 = uextend.i64 v4
-;; @003f                               v16 = iadd v13, v14
+;; @003f                               v17 = iadd v13, v14
 ;; @003f                               v12 = uextend.i64 v11
-;; @003f                               v17 = icmp ugt v16, v12
-;; @003f                               trapnz v17, user17
-;; @003f                               v29 = load.i64 notrap aligned v44+40
-;; @003f                               v21 = iconst.i64 20
-;; @003f                               v22 = iadd v8, v21  ; v21 = 20
-;;                                     v43 = iconst.i64 1
-;;                                     v49 = ishl v13, v43  ; v43 = 1
-;; @003f                               v25 = iadd v22, v49
-;;                                     v53 = ishl v14, v43  ; v43 = 1
-;; @003f                               v31 = uadd_overflow_trap v25, v53, user2
-;; @003f                               v30 = iadd v7, v29
-;; @003f                               v32 = icmp ugt v31, v30
-;; @003f                               trapnz v32, user2
+;; @003f                               v18 = icmp ugt v17, v12
+;; @003f                               trapnz v18, user17
+;; @003f                               v32 = load.i64 notrap aligned v44+40
+;; @003f                               v22 = iconst.i64 20
+;; @003f                               v23 = iadd v8, v22  ; v22 = 20
+;; @003f                               v15 = iconst.i64 1
+;;                                     v49 = ishl v13, v15  ; v15 = 1
+;; @003f                               v27 = iadd v23, v49
+;;                                     v53 = ishl v14, v15  ; v15 = 1
+;; @003f                               v34 = uadd_overflow_trap v27, v53, user2
+;; @003f                               v33 = iadd v7, v32
+;; @003f                               v35 = icmp ugt v34, v33
+;; @003f                               trapnz v35, user2
 ;; @003b                               v5 = iconst.i32 0
-;; @003f                               call fn0(v0, v25, v5, v53)  ; v5 = 0
+;; @003f                               call fn0(v0, v27, v5, v53)  ; v5 = 0
 ;; @0042                               jump block1
 ;;
 ;;                                 block1:
@@ -149,23 +149,23 @@
 ;; @004d                               v11 = load.i32 user2 readonly region0 v10
 ;; @004d                               v13 = uextend.i64 v3
 ;; @004d                               v14 = uextend.i64 v4
-;; @004d                               v16 = iadd v13, v14
+;; @004d                               v17 = iadd v13, v14
 ;; @004d                               v12 = uextend.i64 v11
-;; @004d                               v17 = icmp ugt v16, v12
-;; @004d                               trapnz v17, user17
-;; @004d                               v29 = load.i64 notrap aligned v44+40
-;; @004d                               v21 = iconst.i64 20
-;; @004d                               v22 = iadd v8, v21  ; v21 = 20
-;;                                     v43 = iconst.i64 1
-;;                                     v49 = ishl v13, v43  ; v43 = 1
-;; @004d                               v25 = iadd v22, v49
-;;                                     v53 = ishl v14, v43  ; v43 = 1
-;; @004d                               v31 = uadd_overflow_trap v25, v53, user2
-;; @004d                               v30 = iadd v7, v29
-;; @004d                               v32 = icmp ugt v31, v30
-;; @004d                               trapnz v32, user2
-;; @004d                               v33 = iconst.i32 255
-;; @004d                               call fn0(v0, v25, v33, v53)  ; v33 = 255
+;; @004d                               v18 = icmp ugt v17, v12
+;; @004d                               trapnz v18, user17
+;; @004d                               v32 = load.i64 notrap aligned v44+40
+;; @004d                               v22 = iconst.i64 20
+;; @004d                               v23 = iadd v8, v22  ; v22 = 20
+;; @004d                               v15 = iconst.i64 1
+;;                                     v49 = ishl v13, v15  ; v15 = 1
+;; @004d                               v27 = iadd v23, v49
+;;                                     v53 = ishl v14, v15  ; v15 = 1
+;; @004d                               v34 = uadd_overflow_trap v27, v53, user2
+;; @004d                               v33 = iadd v7, v32
+;; @004d                               v35 = icmp ugt v34, v33
+;; @004d                               trapnz v35, user2
+;; @004d                               v36 = iconst.i32 255
+;; @004d                               call fn0(v0, v27, v36, v53)  ; v36 = 255
 ;; @0050                               jump block1
 ;;
 ;;                                 block1:
@@ -194,35 +194,35 @@
 ;; @005d                               v11 = load.i32 user2 readonly region0 v10
 ;; @005d                               v13 = uextend.i64 v3
 ;; @005d                               v14 = uextend.i64 v4
-;; @005d                               v16 = iadd v13, v14
+;; @005d                               v17 = iadd v13, v14
 ;; @005d                               v12 = uextend.i64 v11
-;; @005d                               v17 = icmp ugt v16, v12
-;; @005d                               trapnz v17, user17
-;; @005d                               v29 = load.i64 notrap aligned v49+40
-;; @005d                               v21 = iconst.i64 20
-;; @005d                               v22 = iadd v8, v21  ; v21 = 20
-;;                                     v48 = iconst.i64 1
-;;                                     v54 = ishl v13, v48  ; v48 = 1
-;; @005d                               v25 = iadd v22, v54
-;;                                     v58 = ishl v14, v48  ; v48 = 1
-;; @005d                               v31 = uadd_overflow_trap v25, v58, user2
-;; @005d                               v30 = iadd v7, v29
-;; @005d                               v32 = icmp ugt v31, v30
-;; @005d                               trapnz v32, user2
+;; @005d                               v18 = icmp ugt v17, v12
+;; @005d                               trapnz v18, user17
+;; @005d                               v32 = load.i64 notrap aligned v49+40
+;; @005d                               v22 = iconst.i64 20
+;; @005d                               v23 = iadd v8, v22  ; v22 = 20
+;; @005d                               v15 = iconst.i64 1
+;;                                     v54 = ishl v13, v15  ; v15 = 1
+;; @005d                               v27 = iadd v23, v54
+;;                                     v58 = ishl v14, v15  ; v15 = 1
+;; @005d                               v34 = uadd_overflow_trap v27, v58, user2
+;; @005d                               v33 = iadd v7, v32
+;; @005d                               v35 = icmp ugt v34, v33
+;; @005d                               trapnz v35, user2
 ;;                                     v51 = iconst.i64 0
-;; @005d                               v35 = icmp eq v14, v51  ; v51 = 0
+;; @005d                               v38 = icmp eq v14, v51  ; v51 = 0
 ;; @0057                               v5 = iconst.i32 0xdead
-;;                                     v45 = iconst.i64 2
-;; @005d                               v33 = iadd v25, v58
-;; @005d                               brif v35, block3, block2(v25)
+;; @005d                               v25 = iconst.i64 2
+;; @005d                               v36 = iadd v27, v58
+;; @005d                               brif v38, block3, block2(v27)
 ;;
-;;                                 block2(v36: i64):
+;;                                 block2(v39: i64):
 ;;                                     v61 = iconst.i32 0xdead
-;; @005d                               istore16 user2 little region0 v61, v36  ; v61 = 0xdead
+;; @005d                               istore16 user2 little region0 v61, v39  ; v61 = 0xdead
 ;;                                     v62 = iconst.i64 2
-;;                                     v63 = iadd v36, v62  ; v62 = 2
-;; @005d                               v39 = icmp eq v63, v33
-;; @005d                               brif v39, block3, block2(v63)
+;;                                     v63 = iadd v39, v62  ; v62 = 2
+;; @005d                               v42 = icmp eq v63, v36
+;; @005d                               brif v42, block3, block2(v63)
 ;;
 ;;                                 block3:
 ;; @0060                               jump block1

--- a/tests/disas/array-fill-i31ref.wat
+++ b/tests/disas/array-fill-i31ref.wat
@@ -39,33 +39,33 @@
 ;; @0030                               v11 = load.i32 user2 readonly region0 v10
 ;; @0030                               v13 = uextend.i64 v3
 ;; @0030                               v14 = uextend.i64 v5
-;; @0030                               v16 = iadd v13, v14
+;; @0030                               v17 = iadd v13, v14
 ;; @0030                               v12 = uextend.i64 v11
-;; @0030                               v17 = icmp ugt v16, v12
-;; @0030                               trapnz v17, user17
-;; @0030                               v29 = load.i64 notrap aligned v49+40
-;; @0030                               v21 = iconst.i64 20
-;; @0030                               v22 = iadd v8, v21  ; v21 = 20
+;; @0030                               v18 = icmp ugt v17, v12
+;; @0030                               trapnz v18, user17
+;; @0030                               v32 = load.i64 notrap aligned v49+40
+;; @0030                               v22 = iconst.i64 20
+;; @0030                               v23 = iadd v8, v22  ; v22 = 20
 ;;                                     v53 = iconst.i64 2
 ;;                                     v54 = ishl v13, v53  ; v53 = 2
-;; @0030                               v25 = iadd v22, v54
+;; @0030                               v27 = iadd v23, v54
 ;;                                     v56 = ishl v14, v53  ; v53 = 2
-;; @0030                               v31 = uadd_overflow_trap v25, v56, user2
-;; @0030                               v30 = iadd v7, v29
-;; @0030                               v32 = icmp ugt v31, v30
-;; @0030                               trapnz v32, user2
+;; @0030                               v34 = uadd_overflow_trap v27, v56, user2
+;; @0030                               v33 = iadd v7, v32
+;; @0030                               v35 = icmp ugt v34, v33
+;; @0030                               trapnz v35, user2
 ;;                                     v51 = iconst.i64 0
-;; @0030                               v35 = icmp eq v14, v51  ; v51 = 0
-;;                                     v45 = iconst.i64 4
-;; @0030                               v33 = iadd v25, v56
-;; @0030                               brif v35, block3, block2(v25)
+;; @0030                               v38 = icmp eq v14, v51  ; v51 = 0
+;; @0030                               v25 = iconst.i64 4
+;; @0030                               v36 = iadd v27, v56
+;; @0030                               brif v38, block3, block2(v27)
 ;;
-;;                                 block2(v36: i64):
-;; @0030                               store.i32 user2 little region0 v4, v36
+;;                                 block2(v39: i64):
+;; @0030                               store.i32 user2 little region0 v4, v39
 ;;                                     v58 = iconst.i64 4
-;;                                     v59 = iadd v36, v58  ; v58 = 4
-;; @0030                               v39 = icmp eq v59, v33
-;; @0030                               brif v39, block3, block2(v59)
+;;                                     v59 = iadd v39, v58  ; v58 = 4
+;; @0030                               v42 = icmp eq v59, v36
+;; @0030                               brif v42, block3, block2(v59)
 ;;
 ;;                                 block3:
 ;; @0033                               jump block1
@@ -96,35 +96,35 @@
 ;; @003e                               v11 = load.i32 user2 readonly region0 v10
 ;; @003e                               v13 = uextend.i64 v3
 ;; @003e                               v14 = uextend.i64 v4
-;; @003e                               v16 = iadd v13, v14
+;; @003e                               v17 = iadd v13, v14
 ;; @003e                               v12 = uextend.i64 v11
-;; @003e                               v17 = icmp ugt v16, v12
-;; @003e                               trapnz v17, user17
-;; @003e                               v29 = load.i64 notrap aligned v49+40
-;; @003e                               v21 = iconst.i64 20
-;; @003e                               v22 = iadd v8, v21  ; v21 = 20
+;; @003e                               v18 = icmp ugt v17, v12
+;; @003e                               trapnz v18, user17
+;; @003e                               v32 = load.i64 notrap aligned v49+40
+;; @003e                               v22 = iconst.i64 20
+;; @003e                               v23 = iadd v8, v22  ; v22 = 20
 ;;                                     v53 = iconst.i64 2
 ;;                                     v54 = ishl v13, v53  ; v53 = 2
-;; @003e                               v25 = iadd v22, v54
+;; @003e                               v27 = iadd v23, v54
 ;;                                     v56 = ishl v14, v53  ; v53 = 2
-;; @003e                               v31 = uadd_overflow_trap v25, v56, user2
-;; @003e                               v30 = iadd v7, v29
-;; @003e                               v32 = icmp ugt v31, v30
-;; @003e                               trapnz v32, user2
+;; @003e                               v34 = uadd_overflow_trap v27, v56, user2
+;; @003e                               v33 = iadd v7, v32
+;; @003e                               v35 = icmp ugt v34, v33
+;; @003e                               trapnz v35, user2
 ;;                                     v51 = iconst.i64 0
-;; @003e                               v35 = icmp eq v14, v51  ; v51 = 0
+;; @003e                               v38 = icmp eq v14, v51  ; v51 = 0
 ;; @003a                               v5 = iconst.i32 0
-;;                                     v45 = iconst.i64 4
-;; @003e                               v33 = iadd v25, v56
-;; @003e                               brif v35, block3, block2(v25)
+;; @003e                               v25 = iconst.i64 4
+;; @003e                               v36 = iadd v27, v56
+;; @003e                               brif v38, block3, block2(v27)
 ;;
-;;                                 block2(v36: i64):
+;;                                 block2(v39: i64):
 ;;                                     v58 = iconst.i32 0
-;; @003e                               store user2 little region0 v58, v36  ; v58 = 0
+;; @003e                               store user2 little region0 v58, v39  ; v58 = 0
 ;;                                     v59 = iconst.i64 4
-;;                                     v60 = iadd v36, v59  ; v59 = 4
-;; @003e                               v39 = icmp eq v60, v33
-;; @003e                               brif v39, block3, block2(v60)
+;;                                     v60 = iadd v39, v59  ; v59 = 4
+;; @003e                               v42 = icmp eq v60, v36
+;; @003e                               brif v42, block3, block2(v60)
 ;;
 ;;                                 block3:
 ;; @0041                               jump block1
@@ -155,35 +155,35 @@
 ;; @004e                               v13 = load.i32 user2 readonly region0 v12
 ;; @004e                               v15 = uextend.i64 v3
 ;; @004e                               v16 = uextend.i64 v4
-;; @004e                               v18 = iadd v15, v16
+;; @004e                               v19 = iadd v15, v16
 ;; @004e                               v14 = uextend.i64 v13
-;; @004e                               v19 = icmp ugt v18, v14
-;; @004e                               trapnz v19, user17
-;; @004e                               v31 = load.i64 notrap aligned v51+40
-;; @004e                               v23 = iconst.i64 20
-;; @004e                               v24 = iadd v10, v23  ; v23 = 20
+;; @004e                               v20 = icmp ugt v19, v14
+;; @004e                               trapnz v20, user17
+;; @004e                               v34 = load.i64 notrap aligned v51+40
+;; @004e                               v24 = iconst.i64 20
+;; @004e                               v25 = iadd v10, v24  ; v24 = 20
 ;;                                     v63 = iconst.i64 2
 ;;                                     v64 = ishl v15, v63  ; v63 = 2
-;; @004e                               v27 = iadd v24, v64
+;; @004e                               v29 = iadd v25, v64
 ;;                                     v66 = ishl v16, v63  ; v63 = 2
-;; @004e                               v33 = uadd_overflow_trap v27, v66, user2
-;; @004e                               v32 = iadd v9, v31
-;; @004e                               v34 = icmp ugt v33, v32
-;; @004e                               trapnz v34, user2
+;; @004e                               v36 = uadd_overflow_trap v29, v66, user2
+;; @004e                               v35 = iadd v9, v34
+;; @004e                               v37 = icmp ugt v36, v35
+;; @004e                               trapnz v37, user2
 ;;                                     v61 = iconst.i64 0
-;; @004e                               v37 = icmp eq v16, v61  ; v61 = 0
+;; @004e                               v40 = icmp eq v16, v61  ; v61 = 0
 ;; @0048                               v5 = iconst.i32 -1
-;;                                     v47 = iconst.i64 4
-;; @004e                               v35 = iadd v27, v66
-;; @004e                               brif v37, block3, block2(v27)
+;; @004e                               v27 = iconst.i64 4
+;; @004e                               v38 = iadd v29, v66
+;; @004e                               brif v40, block3, block2(v29)
 ;;
-;;                                 block2(v38: i64):
+;;                                 block2(v41: i64):
 ;;                                     v68 = iconst.i32 -1
-;; @004e                               store user2 little region0 v68, v38  ; v68 = -1
+;; @004e                               store user2 little region0 v68, v41  ; v68 = -1
 ;;                                     v69 = iconst.i64 4
-;;                                     v70 = iadd v38, v69  ; v69 = 4
-;; @004e                               v41 = icmp eq v70, v35
-;; @004e                               brif v41, block3, block2(v70)
+;;                                     v70 = iadd v41, v69  ; v69 = 4
+;; @004e                               v44 = icmp eq v70, v38
+;; @004e                               brif v44, block3, block2(v70)
 ;;
 ;;                                 block3:
 ;; @0051                               jump block1

--- a/tests/disas/array-fill-i32.wat
+++ b/tests/disas/array-fill-i32.wat
@@ -43,33 +43,33 @@
 ;; @0031                               v11 = load.i32 user2 readonly region0 v10
 ;; @0031                               v13 = uextend.i64 v3
 ;; @0031                               v14 = uextend.i64 v5
-;; @0031                               v16 = iadd v13, v14
+;; @0031                               v17 = iadd v13, v14
 ;; @0031                               v12 = uextend.i64 v11
-;; @0031                               v17 = icmp ugt v16, v12
-;; @0031                               trapnz v17, user17
-;; @0031                               v29 = load.i64 notrap aligned v49+40
-;; @0031                               v21 = iconst.i64 20
-;; @0031                               v22 = iadd v8, v21  ; v21 = 20
+;; @0031                               v18 = icmp ugt v17, v12
+;; @0031                               trapnz v18, user17
+;; @0031                               v32 = load.i64 notrap aligned v49+40
+;; @0031                               v22 = iconst.i64 20
+;; @0031                               v23 = iadd v8, v22  ; v22 = 20
 ;;                                     v53 = iconst.i64 2
 ;;                                     v54 = ishl v13, v53  ; v53 = 2
-;; @0031                               v25 = iadd v22, v54
+;; @0031                               v27 = iadd v23, v54
 ;;                                     v56 = ishl v14, v53  ; v53 = 2
-;; @0031                               v31 = uadd_overflow_trap v25, v56, user2
-;; @0031                               v30 = iadd v7, v29
-;; @0031                               v32 = icmp ugt v31, v30
-;; @0031                               trapnz v32, user2
+;; @0031                               v34 = uadd_overflow_trap v27, v56, user2
+;; @0031                               v33 = iadd v7, v32
+;; @0031                               v35 = icmp ugt v34, v33
+;; @0031                               trapnz v35, user2
 ;;                                     v51 = iconst.i64 0
-;; @0031                               v35 = icmp eq v14, v51  ; v51 = 0
-;;                                     v45 = iconst.i64 4
-;; @0031                               v33 = iadd v25, v56
-;; @0031                               brif v35, block3, block2(v25)
+;; @0031                               v38 = icmp eq v14, v51  ; v51 = 0
+;; @0031                               v25 = iconst.i64 4
+;; @0031                               v36 = iadd v27, v56
+;; @0031                               brif v38, block3, block2(v27)
 ;;
-;;                                 block2(v36: i64):
-;; @0031                               store.i32 user2 little region0 v4, v36
+;;                                 block2(v39: i64):
+;; @0031                               store.i32 user2 little region0 v4, v39
 ;;                                     v58 = iconst.i64 4
-;;                                     v59 = iadd v36, v58  ; v58 = 4
-;; @0031                               v39 = icmp eq v59, v33
-;; @0031                               brif v39, block3, block2(v59)
+;;                                     v59 = iadd v39, v58  ; v58 = 4
+;; @0031                               v42 = icmp eq v59, v36
+;; @0031                               brif v42, block3, block2(v59)
 ;;
 ;;                                 block3:
 ;; @0034                               jump block1
@@ -102,23 +102,23 @@
 ;; @003f                               v11 = load.i32 user2 readonly region0 v10
 ;; @003f                               v13 = uextend.i64 v3
 ;; @003f                               v14 = uextend.i64 v4
-;; @003f                               v16 = iadd v13, v14
+;; @003f                               v17 = iadd v13, v14
 ;; @003f                               v12 = uextend.i64 v11
-;; @003f                               v17 = icmp ugt v16, v12
-;; @003f                               trapnz v17, user17
-;; @003f                               v29 = load.i64 notrap aligned v44+40
-;; @003f                               v21 = iconst.i64 20
-;; @003f                               v22 = iadd v8, v21  ; v21 = 20
+;; @003f                               v18 = icmp ugt v17, v12
+;; @003f                               trapnz v18, user17
+;; @003f                               v32 = load.i64 notrap aligned v44+40
+;; @003f                               v22 = iconst.i64 20
+;; @003f                               v23 = iadd v8, v22  ; v22 = 20
 ;;                                     v48 = iconst.i64 2
 ;;                                     v49 = ishl v13, v48  ; v48 = 2
-;; @003f                               v25 = iadd v22, v49
+;; @003f                               v27 = iadd v23, v49
 ;;                                     v51 = ishl v14, v48  ; v48 = 2
-;; @003f                               v31 = uadd_overflow_trap v25, v51, user2
-;; @003f                               v30 = iadd v7, v29
-;; @003f                               v32 = icmp ugt v31, v30
-;; @003f                               trapnz v32, user2
+;; @003f                               v34 = uadd_overflow_trap v27, v51, user2
+;; @003f                               v33 = iadd v7, v32
+;; @003f                               v35 = icmp ugt v34, v33
+;; @003f                               trapnz v35, user2
 ;; @003b                               v5 = iconst.i32 0
-;; @003f                               call fn0(v0, v25, v5, v51)  ; v5 = 0
+;; @003f                               call fn0(v0, v27, v5, v51)  ; v5 = 0
 ;; @0042                               jump block1
 ;;
 ;;                                 block1:
@@ -149,23 +149,23 @@
 ;; @004d                               v11 = load.i32 user2 readonly region0 v10
 ;; @004d                               v13 = uextend.i64 v3
 ;; @004d                               v14 = uextend.i64 v4
-;; @004d                               v16 = iadd v13, v14
+;; @004d                               v17 = iadd v13, v14
 ;; @004d                               v12 = uextend.i64 v11
-;; @004d                               v17 = icmp ugt v16, v12
-;; @004d                               trapnz v17, user17
-;; @004d                               v29 = load.i64 notrap aligned v44+40
-;; @004d                               v21 = iconst.i64 20
-;; @004d                               v22 = iadd v8, v21  ; v21 = 20
+;; @004d                               v18 = icmp ugt v17, v12
+;; @004d                               trapnz v18, user17
+;; @004d                               v32 = load.i64 notrap aligned v44+40
+;; @004d                               v22 = iconst.i64 20
+;; @004d                               v23 = iadd v8, v22  ; v22 = 20
 ;;                                     v48 = iconst.i64 2
 ;;                                     v49 = ishl v13, v48  ; v48 = 2
-;; @004d                               v25 = iadd v22, v49
+;; @004d                               v27 = iadd v23, v49
 ;;                                     v51 = ishl v14, v48  ; v48 = 2
-;; @004d                               v31 = uadd_overflow_trap v25, v51, user2
-;; @004d                               v30 = iadd v7, v29
-;; @004d                               v32 = icmp ugt v31, v30
-;; @004d                               trapnz v32, user2
-;; @004d                               v33 = iconst.i32 255
-;; @004d                               call fn0(v0, v25, v33, v51)  ; v33 = 255
+;; @004d                               v34 = uadd_overflow_trap v27, v51, user2
+;; @004d                               v33 = iadd v7, v32
+;; @004d                               v35 = icmp ugt v34, v33
+;; @004d                               trapnz v35, user2
+;; @004d                               v36 = iconst.i32 255
+;; @004d                               call fn0(v0, v27, v36, v51)  ; v36 = 255
 ;; @0050                               jump block1
 ;;
 ;;                                 block1:
@@ -194,35 +194,35 @@
 ;; @005d                               v11 = load.i32 user2 readonly region0 v10
 ;; @005d                               v13 = uextend.i64 v3
 ;; @005d                               v14 = uextend.i64 v4
-;; @005d                               v16 = iadd v13, v14
+;; @005d                               v17 = iadd v13, v14
 ;; @005d                               v12 = uextend.i64 v11
-;; @005d                               v17 = icmp ugt v16, v12
-;; @005d                               trapnz v17, user17
-;; @005d                               v29 = load.i64 notrap aligned v49+40
-;; @005d                               v21 = iconst.i64 20
-;; @005d                               v22 = iadd v8, v21  ; v21 = 20
+;; @005d                               v18 = icmp ugt v17, v12
+;; @005d                               trapnz v18, user17
+;; @005d                               v32 = load.i64 notrap aligned v49+40
+;; @005d                               v22 = iconst.i64 20
+;; @005d                               v23 = iadd v8, v22  ; v22 = 20
 ;;                                     v53 = iconst.i64 2
 ;;                                     v54 = ishl v13, v53  ; v53 = 2
-;; @005d                               v25 = iadd v22, v54
+;; @005d                               v27 = iadd v23, v54
 ;;                                     v56 = ishl v14, v53  ; v53 = 2
-;; @005d                               v31 = uadd_overflow_trap v25, v56, user2
-;; @005d                               v30 = iadd v7, v29
-;; @005d                               v32 = icmp ugt v31, v30
-;; @005d                               trapnz v32, user2
+;; @005d                               v34 = uadd_overflow_trap v27, v56, user2
+;; @005d                               v33 = iadd v7, v32
+;; @005d                               v35 = icmp ugt v34, v33
+;; @005d                               trapnz v35, user2
 ;;                                     v51 = iconst.i64 0
-;; @005d                               v35 = icmp eq v14, v51  ; v51 = 0
+;; @005d                               v38 = icmp eq v14, v51  ; v51 = 0
 ;; @0057                               v5 = iconst.i32 0xdead
-;;                                     v45 = iconst.i64 4
-;; @005d                               v33 = iadd v25, v56
-;; @005d                               brif v35, block3, block2(v25)
+;; @005d                               v25 = iconst.i64 4
+;; @005d                               v36 = iadd v27, v56
+;; @005d                               brif v38, block3, block2(v27)
 ;;
-;;                                 block2(v36: i64):
+;;                                 block2(v39: i64):
 ;;                                     v58 = iconst.i32 0xdead
-;; @005d                               store user2 little region0 v58, v36  ; v58 = 0xdead
+;; @005d                               store user2 little region0 v58, v39  ; v58 = 0xdead
 ;;                                     v59 = iconst.i64 4
-;;                                     v60 = iadd v36, v59  ; v59 = 4
-;; @005d                               v39 = icmp eq v60, v33
-;; @005d                               brif v39, block3, block2(v60)
+;;                                     v60 = iadd v39, v59  ; v59 = 4
+;; @005d                               v42 = icmp eq v60, v36
+;; @005d                               brif v42, block3, block2(v60)
 ;;
 ;;                                 block3:
 ;; @0060                               jump block1

--- a/tests/disas/array-fill-i64.wat
+++ b/tests/disas/array-fill-i64.wat
@@ -43,33 +43,33 @@
 ;; @0031                               v11 = load.i32 user2 readonly region0 v10
 ;; @0031                               v13 = uextend.i64 v3
 ;; @0031                               v14 = uextend.i64 v5
-;; @0031                               v16 = iadd v13, v14
+;; @0031                               v17 = iadd v13, v14
 ;; @0031                               v12 = uextend.i64 v11
-;; @0031                               v17 = icmp ugt v16, v12
-;; @0031                               trapnz v17, user17
-;; @0031                               v29 = load.i64 notrap aligned v49+40
-;; @0031                               v21 = iconst.i64 24
-;; @0031                               v22 = iadd v8, v21  ; v21 = 24
+;; @0031                               v18 = icmp ugt v17, v12
+;; @0031                               trapnz v18, user17
+;; @0031                               v32 = load.i64 notrap aligned v49+40
+;; @0031                               v22 = iconst.i64 24
+;; @0031                               v23 = iadd v8, v22  ; v22 = 24
 ;;                                     v53 = iconst.i64 3
 ;;                                     v54 = ishl v13, v53  ; v53 = 3
-;; @0031                               v25 = iadd v22, v54
+;; @0031                               v27 = iadd v23, v54
 ;;                                     v56 = ishl v14, v53  ; v53 = 3
-;; @0031                               v31 = uadd_overflow_trap v25, v56, user2
-;; @0031                               v30 = iadd v7, v29
-;; @0031                               v32 = icmp ugt v31, v30
-;; @0031                               trapnz v32, user2
+;; @0031                               v34 = uadd_overflow_trap v27, v56, user2
+;; @0031                               v33 = iadd v7, v32
+;; @0031                               v35 = icmp ugt v34, v33
+;; @0031                               trapnz v35, user2
 ;;                                     v51 = iconst.i64 0
-;; @0031                               v35 = icmp eq v14, v51  ; v51 = 0
-;;                                     v45 = iconst.i64 8
-;; @0031                               v33 = iadd v25, v56
-;; @0031                               brif v35, block3, block2(v25)
+;; @0031                               v38 = icmp eq v14, v51  ; v51 = 0
+;; @0031                               v25 = iconst.i64 8
+;; @0031                               v36 = iadd v27, v56
+;; @0031                               brif v38, block3, block2(v27)
 ;;
-;;                                 block2(v36: i64):
-;; @0031                               store.i64 user2 little region0 v4, v36
+;;                                 block2(v39: i64):
+;; @0031                               store.i64 user2 little region0 v4, v39
 ;;                                     v58 = iconst.i64 8
-;;                                     v59 = iadd v36, v58  ; v58 = 8
-;; @0031                               v39 = icmp eq v59, v33
-;; @0031                               brif v39, block3, block2(v59)
+;;                                     v59 = iadd v39, v58  ; v58 = 8
+;; @0031                               v42 = icmp eq v59, v36
+;; @0031                               brif v42, block3, block2(v59)
 ;;
 ;;                                 block3:
 ;; @0034                               jump block1
@@ -102,23 +102,23 @@
 ;; @003f                               v11 = load.i32 user2 readonly region0 v10
 ;; @003f                               v13 = uextend.i64 v3
 ;; @003f                               v14 = uextend.i64 v4
-;; @003f                               v16 = iadd v13, v14
+;; @003f                               v17 = iadd v13, v14
 ;; @003f                               v12 = uextend.i64 v11
-;; @003f                               v17 = icmp ugt v16, v12
-;; @003f                               trapnz v17, user17
-;; @003f                               v29 = load.i64 notrap aligned v44+40
-;; @003f                               v21 = iconst.i64 24
-;; @003f                               v22 = iadd v8, v21  ; v21 = 24
+;; @003f                               v18 = icmp ugt v17, v12
+;; @003f                               trapnz v18, user17
+;; @003f                               v32 = load.i64 notrap aligned v44+40
+;; @003f                               v22 = iconst.i64 24
+;; @003f                               v23 = iadd v8, v22  ; v22 = 24
 ;;                                     v47 = iconst.i64 3
 ;;                                     v48 = ishl v13, v47  ; v47 = 3
-;; @003f                               v25 = iadd v22, v48
+;; @003f                               v27 = iadd v23, v48
 ;;                                     v50 = ishl v14, v47  ; v47 = 3
-;; @003f                               v31 = uadd_overflow_trap v25, v50, user2
-;; @003f                               v30 = iadd v7, v29
-;; @003f                               v32 = icmp ugt v31, v30
-;; @003f                               trapnz v32, user2
-;; @003f                               v33 = iconst.i32 0
-;; @003f                               call fn0(v0, v25, v33, v50)  ; v33 = 0
+;; @003f                               v34 = uadd_overflow_trap v27, v50, user2
+;; @003f                               v33 = iadd v7, v32
+;; @003f                               v35 = icmp ugt v34, v33
+;; @003f                               trapnz v35, user2
+;; @003f                               v36 = iconst.i32 0
+;; @003f                               call fn0(v0, v27, v36, v50)  ; v36 = 0
 ;; @0042                               jump block1
 ;;
 ;;                                 block1:
@@ -149,23 +149,23 @@
 ;; @004d                               v11 = load.i32 user2 readonly region0 v10
 ;; @004d                               v13 = uextend.i64 v3
 ;; @004d                               v14 = uextend.i64 v4
-;; @004d                               v16 = iadd v13, v14
+;; @004d                               v17 = iadd v13, v14
 ;; @004d                               v12 = uextend.i64 v11
-;; @004d                               v17 = icmp ugt v16, v12
-;; @004d                               trapnz v17, user17
-;; @004d                               v29 = load.i64 notrap aligned v44+40
-;; @004d                               v21 = iconst.i64 24
-;; @004d                               v22 = iadd v8, v21  ; v21 = 24
+;; @004d                               v18 = icmp ugt v17, v12
+;; @004d                               trapnz v18, user17
+;; @004d                               v32 = load.i64 notrap aligned v44+40
+;; @004d                               v22 = iconst.i64 24
+;; @004d                               v23 = iadd v8, v22  ; v22 = 24
 ;;                                     v48 = iconst.i64 3
 ;;                                     v49 = ishl v13, v48  ; v48 = 3
-;; @004d                               v25 = iadd v22, v49
+;; @004d                               v27 = iadd v23, v49
 ;;                                     v51 = ishl v14, v48  ; v48 = 3
-;; @004d                               v31 = uadd_overflow_trap v25, v51, user2
-;; @004d                               v30 = iadd v7, v29
-;; @004d                               v32 = icmp ugt v31, v30
-;; @004d                               trapnz v32, user2
-;; @004d                               v33 = iconst.i32 255
-;; @004d                               call fn0(v0, v25, v33, v51)  ; v33 = 255
+;; @004d                               v34 = uadd_overflow_trap v27, v51, user2
+;; @004d                               v33 = iadd v7, v32
+;; @004d                               v35 = icmp ugt v34, v33
+;; @004d                               trapnz v35, user2
+;; @004d                               v36 = iconst.i32 255
+;; @004d                               call fn0(v0, v27, v36, v51)  ; v36 = 255
 ;; @0050                               jump block1
 ;;
 ;;                                 block1:
@@ -194,35 +194,35 @@
 ;; @005b                               v11 = load.i32 user2 readonly region0 v10
 ;; @005b                               v13 = uextend.i64 v3
 ;; @005b                               v14 = uextend.i64 v4
-;; @005b                               v16 = iadd v13, v14
+;; @005b                               v17 = iadd v13, v14
 ;; @005b                               v12 = uextend.i64 v11
-;; @005b                               v17 = icmp ugt v16, v12
-;; @005b                               trapnz v17, user17
-;; @005b                               v29 = load.i64 notrap aligned v49+40
-;; @005b                               v21 = iconst.i64 24
-;; @005b                               v22 = iadd v8, v21  ; v21 = 24
+;; @005b                               v18 = icmp ugt v17, v12
+;; @005b                               trapnz v18, user17
+;; @005b                               v32 = load.i64 notrap aligned v49+40
+;; @005b                               v22 = iconst.i64 24
+;; @005b                               v23 = iadd v8, v22  ; v22 = 24
 ;;                                     v53 = iconst.i64 3
 ;;                                     v54 = ishl v13, v53  ; v53 = 3
-;; @005b                               v25 = iadd v22, v54
+;; @005b                               v27 = iadd v23, v54
 ;;                                     v56 = ishl v14, v53  ; v53 = 3
-;; @005b                               v31 = uadd_overflow_trap v25, v56, user2
-;; @005b                               v30 = iadd v7, v29
-;; @005b                               v32 = icmp ugt v31, v30
-;; @005b                               trapnz v32, user2
+;; @005b                               v34 = uadd_overflow_trap v27, v56, user2
+;; @005b                               v33 = iadd v7, v32
+;; @005b                               v35 = icmp ugt v34, v33
+;; @005b                               trapnz v35, user2
 ;;                                     v51 = iconst.i64 0
-;; @005b                               v35 = icmp eq v14, v51  ; v51 = 0
+;; @005b                               v38 = icmp eq v14, v51  ; v51 = 0
 ;; @0057                               v5 = iconst.i64 1
-;;                                     v45 = iconst.i64 8
-;; @005b                               v33 = iadd v25, v56
-;; @005b                               brif v35, block3, block2(v25)
+;; @005b                               v25 = iconst.i64 8
+;; @005b                               v36 = iadd v27, v56
+;; @005b                               brif v38, block3, block2(v27)
 ;;
-;;                                 block2(v36: i64):
+;;                                 block2(v39: i64):
 ;;                                     v58 = iconst.i64 1
-;; @005b                               store user2 little region0 v58, v36  ; v58 = 1
+;; @005b                               store user2 little region0 v58, v39  ; v58 = 1
 ;;                                     v59 = iconst.i64 8
-;;                                     v60 = iadd v36, v59  ; v59 = 8
-;; @005b                               v39 = icmp eq v60, v33
-;; @005b                               brif v39, block3, block2(v60)
+;;                                     v60 = iadd v39, v59  ; v59 = 8
+;; @005b                               v42 = icmp eq v60, v36
+;; @005b                               brif v42, block3, block2(v60)
 ;;
 ;;                                 block3:
 ;; @005e                               jump block1

--- a/tests/disas/gc/array-copy-with-fuel.wat
+++ b/tests/disas/gc/array-copy-with-fuel.wat
@@ -44,125 +44,125 @@
 ;; @0020                               v17 = load.i64 notrap aligned v7
 ;; @0020                               jump block3(v17)
 ;;
-;;                                 block3(v76: i64):
-;;                                     v149 = load.i32 notrap v201
-;; @002b                               trapz v149, user16
+;;                                 block3(v82: i64):
+;;                                     v157 = load.i32 notrap v201
+;; @002b                               trapz v157, user16
 ;; @002b                               v24 = load.i64 notrap aligned readonly can_move v7+32
-;; @002b                               v23 = uextend.i64 v149
+;; @002b                               v23 = uextend.i64 v157
 ;; @002b                               v25 = iadd v24, v23
 ;; @002b                               v26 = iconst.i64 16
 ;; @002b                               v27 = iadd v25, v26  ; v26 = 16
 ;; @002b                               v28 = load.i32 user2 readonly region0 v27
 ;; @002b                               v30 = uextend.i64 v3
 ;; @002b                               v31 = uextend.i64 v6
-;; @002b                               v33 = iadd v30, v31
+;; @002b                               v34 = iadd v30, v31
 ;; @002b                               v29 = uextend.i64 v28
-;; @002b                               v34 = icmp ugt v33, v29
-;; @002b                               trapnz v34, user17
-;;                                     v146 = load.i32 notrap v200
-;; @002b                               trapz v146, user16
-;; @002b                               v43 = uextend.i64 v146
-;; @002b                               v45 = iadd v24, v43
-;; @002b                               v47 = iadd v45, v26  ; v26 = 16
-;; @002b                               v48 = load.i32 user2 readonly region0 v47
-;; @002b                               v50 = uextend.i64 v5
-;; @002b                               v53 = iadd v50, v31
-;; @002b                               v49 = uextend.i64 v48
-;; @002b                               v54 = icmp ugt v53, v49
-;; @002b                               trapnz v54, user17
-;; @002b                               v67 = load.i64 notrap aligned v7+40
-;; @002b                               v38 = iconst.i64 20
-;; @002b                               v39 = iadd v25, v38  ; v38 = 20
+;; @002b                               v35 = icmp ugt v34, v29
+;; @002b                               trapnz v35, user17
+;;                                     v154 = load.i32 notrap v200
+;; @002b                               trapz v154, user16
+;; @002b                               v45 = uextend.i64 v154
+;; @002b                               v47 = iadd v24, v45
+;; @002b                               v49 = iadd v47, v26  ; v26 = 16
+;; @002b                               v50 = load.i32 user2 readonly region0 v49
+;; @002b                               v52 = uextend.i64 v5
+;; @002b                               v56 = iadd v52, v31
+;; @002b                               v51 = uextend.i64 v50
+;; @002b                               v57 = icmp ugt v56, v51
+;; @002b                               trapnz v57, user17
+;; @002b                               v73 = load.i64 notrap aligned v7+40
+;; @002b                               v39 = iconst.i64 20
+;; @002b                               v40 = iadd v25, v39  ; v39 = 20
 ;;                                     v203 = iconst.i64 2
 ;;                                     v204 = ishl v30, v203  ; v203 = 2
-;; @002b                               v42 = iadd v39, v204
+;; @002b                               v44 = iadd v40, v204
 ;;                                     v208 = ishl v31, v203  ; v203 = 2
-;; @002b                               v69 = uadd_overflow_trap v42, v208, user2
-;; @002b                               v68 = iadd v24, v67
-;; @002b                               v70 = icmp ugt v69, v68
-;; @002b                               trapnz v70, user2
-;; @002b                               v59 = iadd v45, v38  ; v38 = 20
-;;                                     v206 = ishl v50, v203  ; v203 = 2
-;; @002b                               v62 = iadd v59, v206
-;; @002b                               v74 = uadd_overflow_trap v62, v208, user2
-;; @002b                               v75 = icmp ugt v74, v68
-;; @002b                               trapnz v75, user2
-;; @002b                               v77 = iconst.i64 6
-;; @002b                               v78 = iadd v76, v77  ; v77 = 6
-;; @002b                               brif v31, block4, block7(v78)
+;; @002b                               v75 = uadd_overflow_trap v44, v208, user2
+;; @002b                               v74 = iadd v24, v73
+;; @002b                               v76 = icmp ugt v75, v74
+;; @002b                               trapnz v76, user2
+;; @002b                               v62 = iadd v47, v39  ; v39 = 20
+;;                                     v206 = ishl v52, v203  ; v203 = 2
+;; @002b                               v66 = iadd v62, v206
+;; @002b                               v80 = uadd_overflow_trap v66, v208, user2
+;; @002b                               v81 = icmp ugt v80, v74
+;; @002b                               trapnz v81, user2
+;; @002b                               v83 = iconst.i64 6
+;; @002b                               v84 = iadd v82, v83  ; v83 = 6
+;; @002b                               brif v31, block4, block7(v84)
 ;;
 ;;                                 block4:
-;;                                     v140 = load.i32 notrap v201
-;;                                     v141 = load.i32 notrap v200
-;; @002b                               v79 = icmp.i64 ult v42, v62
-;;                                     v211 = iadd.i64 v76, v77  ; v77 = 6
-;; @002b                               v82 = iadd.i64 v42, v208
-;; @002b                               v83 = iadd.i64 v62, v208
-;; @002b                               v85 = iadd.i32 v5, v6
-;;                                     v188 = iconst.i64 4
-;; @002b                               v128 = iconst.i32 1
-;; @002b                               brif v79, block5(v42, v62, v5, v140, v141, v211), block6(v82, v83, v85, v140, v141, v211)
+;;                                     v148 = load.i32 notrap v201
+;;                                     v149 = load.i32 notrap v200
+;; @002b                               v85 = icmp.i64 ult v44, v66
+;;                                     v211 = iadd.i64 v82, v83  ; v83 = 6
+;; @002b                               v90 = iadd.i64 v44, v208
+;; @002b                               v91 = iadd.i64 v66, v208
+;; @002b                               v93 = iadd.i32 v5, v6
+;; @002b                               v42 = iconst.i64 4
+;; @002b                               v136 = iconst.i32 1
+;; @002b                               brif v85, block5(v44, v66, v5, v148, v149, v211), block6(v90, v91, v93, v148, v149, v211)
 ;;
-;;                                 block5(v86: i64, v87: i64, v88: i32, v89: i32, v90: i32, v91: i64):
-;;                                     store notrap v89, v201
-;;                                     store notrap v90, v200
+;;                                 block5(v94: i64, v95: i64, v96: i32, v97: i32, v98: i32, v99: i64):
+;;                                     store notrap v97, v201
+;;                                     store notrap v98, v200
 ;;                                     v221 = iconst.i64 1
-;;                                     v222 = iadd v91, v221  ; v221 = 1
+;;                                     v222 = iadd v99, v221  ; v221 = 1
 ;;                                     v223 = iconst.i64 0
 ;;                                     v224 = icmp sge v222, v223  ; v223 = 0
 ;; @002b                               brif v224, block8, block9(v222)
 ;;
-;;                                 block6(v109: i64, v110: i64, v111: i32, v112: i32, v113: i32, v114: i64):
-;;                                     store notrap v112, v200
-;;                                     store notrap v113, v201
+;;                                 block6(v117: i64, v118: i64, v119: i32, v120: i32, v121: i32, v122: i64):
+;;                                     store notrap v120, v200
+;;                                     store notrap v121, v201
 ;;                                     v212 = iconst.i64 1
-;;                                     v213 = iadd v114, v212  ; v212 = 1
+;;                                     v213 = iadd v122, v212  ; v212 = 1
 ;;                                     v214 = iconst.i64 0
 ;;                                     v215 = icmp sge v213, v214  ; v214 = 0
 ;; @002b                               brif v215, block10, block11(v213)
 ;;
-;;                                 block7(v135: i64):
+;;                                 block7(v143: i64):
 ;; @002f                               jump block1
 ;;
 ;;                                 block8:
 ;; @002b                               store.i64 notrap aligned v222, v7
-;; @002b                               v98 = call fn0(v0), stack_map=[i32 @ ss0+0, i32 @ ss1+0]
-;; @002b                               v100 = load.i64 notrap aligned v7
-;; @002b                               jump block9(v100)
+;; @002b                               v106 = call fn0(v0), stack_map=[i32 @ ss0+0, i32 @ ss1+0]
+;; @002b                               v108 = load.i64 notrap aligned v7
+;; @002b                               jump block9(v108)
 ;;
-;;                                 block9(v132: i64):
-;; @002b                               v101 = load.i32 user2 little region0 v87
-;; @002b                               store user2 little region0 v101, v86
-;;                                     v136 = load.i32 notrap v201
-;;                                     v137 = load.i32 notrap v200
+;;                                 block9(v140: i64):
+;; @002b                               v109 = load.i32 user2 little region0 v95
+;; @002b                               store user2 little region0 v109, v94
+;;                                     v144 = load.i32 notrap v201
+;;                                     v145 = load.i32 notrap v200
 ;;                                     v225 = iconst.i64 4
-;;                                     v226 = iadd.i64 v87, v225  ; v225 = 4
-;; @002b                               v108 = icmp eq v226, v83
-;;                                     v227 = iadd.i64 v86, v225  ; v225 = 4
+;;                                     v226 = iadd.i64 v95, v225  ; v225 = 4
+;; @002b                               v116 = icmp eq v226, v91
+;;                                     v227 = iadd.i64 v94, v225  ; v225 = 4
 ;;                                     v228 = iconst.i32 1
-;;                                     v229 = iadd.i32 v88, v228  ; v228 = 1
-;; @002b                               brif v108, block7(v132), block5(v227, v226, v229, v136, v137, v132)
+;;                                     v229 = iadd.i32 v96, v228  ; v228 = 1
+;; @002b                               brif v116, block7(v140), block5(v227, v226, v229, v144, v145, v140)
 ;;
 ;;                                 block10:
 ;; @002b                               store.i64 notrap aligned v213, v7
-;; @002b                               v121 = call fn0(v0), stack_map=[i32 @ ss1+0, i32 @ ss0+0]
-;; @002b                               v123 = load.i64 notrap aligned v7
-;; @002b                               jump block11(v123)
+;; @002b                               v129 = call fn0(v0), stack_map=[i32 @ ss1+0, i32 @ ss0+0]
+;; @002b                               v131 = load.i64 notrap aligned v7
+;; @002b                               jump block11(v131)
 ;;
-;;                                 block11(v133: i64):
+;;                                 block11(v141: i64):
 ;;                                     v216 = iconst.i64 4
-;;                                     v217 = isub.i64 v110, v216  ; v216 = 4
-;; @002b                               v130 = load.i32 user2 little region0 v217
-;;                                     v218 = isub.i64 v109, v216  ; v216 = 4
-;; @002b                               store user2 little region0 v130, v218
-;;                                     v138 = load.i32 notrap v200
-;;                                     v139 = load.i32 notrap v201
-;; @002b                               v131 = icmp eq v217, v62
+;;                                     v217 = isub.i64 v118, v216  ; v216 = 4
+;; @002b                               v138 = load.i32 user2 little region0 v217
+;;                                     v218 = isub.i64 v117, v216  ; v216 = 4
+;; @002b                               store user2 little region0 v138, v218
+;;                                     v146 = load.i32 notrap v200
+;;                                     v147 = load.i32 notrap v201
+;; @002b                               v139 = icmp eq v217, v66
 ;;                                     v219 = iconst.i32 1
-;;                                     v220 = isub.i32 v111, v219  ; v219 = 1
-;; @002b                               brif v131, block7(v133), block6(v218, v217, v220, v138, v139, v133)
+;;                                     v220 = isub.i32 v119, v219  ; v219 = 1
+;; @002b                               brif v139, block7(v141), block6(v218, v217, v220, v146, v147, v141)
 ;;
 ;;                                 block1:
-;; @002f                               store.i64 notrap aligned v135, v7
+;; @002f                               store.i64 notrap aligned v143, v7
 ;; @002f                               return
 ;; }

--- a/tests/disas/gc/array-fill-i8.wat
+++ b/tests/disas/gc/array-fill-i8.wat
@@ -33,19 +33,19 @@
 ;; @0027                               v11 = load.i32 user2 readonly region0 v10
 ;; @0027                               v13 = uextend.i64 v3
 ;; @0027                               v14 = uextend.i64 v5
-;; @0027                               v16 = iadd v13, v14
+;; @0027                               v17 = iadd v13, v14
 ;; @0027                               v12 = uextend.i64 v11
-;; @0027                               v17 = icmp ugt v16, v12
-;; @0027                               trapnz v17, user17
-;; @0027                               v29 = load.i64 notrap aligned v43+40
-;; @0027                               v21 = iconst.i64 20
-;; @0027                               v22 = iadd v8, v21  ; v21 = 20
-;; @0027                               v25 = iadd v22, v13
-;; @0027                               v31 = uadd_overflow_trap v25, v14, user2
-;; @0027                               v30 = iadd v7, v29
-;; @0027                               v32 = icmp ugt v31, v30
-;; @0027                               trapnz v32, user2
-;; @0027                               call fn0(v0, v25, v4, v14)
+;; @0027                               v18 = icmp ugt v17, v12
+;; @0027                               trapnz v18, user17
+;; @0027                               v32 = load.i64 notrap aligned v43+40
+;; @0027                               v22 = iconst.i64 20
+;; @0027                               v23 = iadd v8, v22  ; v22 = 20
+;; @0027                               v27 = iadd v23, v13
+;; @0027                               v34 = uadd_overflow_trap v27, v14, user2
+;; @0027                               v33 = iadd v7, v32
+;; @0027                               v35 = icmp ugt v34, v33
+;; @0027                               trapnz v35, user2
+;; @0027                               call fn0(v0, v27, v4, v14)
 ;; @002a                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/array-init-data.wat
+++ b/tests/disas/gc/array-init-data.wat
@@ -37,27 +37,27 @@
 ;; @002a                               v11 = load.i32 user2 readonly region0 v10
 ;; @002a                               v13 = uextend.i64 v3
 ;; @002a                               v14 = uextend.i64 v5
-;; @002a                               v16 = iadd v13, v14
+;; @002a                               v17 = iadd v13, v14
 ;; @002a                               v12 = uextend.i64 v11
-;; @002a                               v17 = icmp ugt v16, v12
-;; @002a                               trapnz v17, user17
-;; @002a                               v27 = load.i32 notrap aligned v0+56
-;; @002a                               v29 = uextend.i64 v4
-;; @002a                               v32 = iadd v29, v14
-;; @002a                               v28 = uextend.i64 v27
-;; @002a                               v33 = icmp ugt v32, v28
-;; @002a                               trapnz v33, heap_oob
-;; @002a                               v35 = load.i64 notrap aligned v0+48
-;; @002a                               v42 = load.i64 notrap aligned v58+40
-;; @002a                               v21 = iconst.i64 20
-;; @002a                               v22 = iadd v8, v21  ; v21 = 20
-;; @002a                               v25 = iadd v22, v13
-;; @002a                               v44 = uadd_overflow_trap v25, v14, user2
-;; @002a                               v43 = iadd v7, v42
-;; @002a                               v45 = icmp ugt v44, v43
-;; @002a                               trapnz v45, user2
-;; @002a                               v37 = iadd v35, v29
-;; @002a                               call fn0(v0, v25, v37, v14)
+;; @002a                               v18 = icmp ugt v17, v12
+;; @002a                               trapnz v18, user17
+;; @002a                               v29 = load.i32 notrap aligned v0+56
+;; @002a                               v31 = uextend.i64 v4
+;; @002a                               v35 = iadd v31, v14
+;; @002a                               v30 = uextend.i64 v29
+;; @002a                               v36 = icmp ugt v35, v30
+;; @002a                               trapnz v36, heap_oob
+;; @002a                               v38 = load.i64 notrap aligned v0+48
+;; @002a                               v47 = load.i64 notrap aligned v58+40
+;; @002a                               v22 = iconst.i64 20
+;; @002a                               v23 = iadd v8, v22  ; v22 = 20
+;; @002a                               v27 = iadd v23, v13
+;; @002a                               v49 = uadd_overflow_trap v27, v14, user2
+;; @002a                               v48 = iadd v7, v47
+;; @002a                               v50 = icmp ugt v49, v48
+;; @002a                               trapnz v50, user2
+;; @002a                               v40 = iadd v38, v31
+;; @002a                               call fn0(v0, v27, v40, v14)
 ;; @002e                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/array-new-data.wat
+++ b/tests/disas/gc/array-new-data.wat
@@ -96,94 +96,94 @@
 ;; @0025                               v6 = load.i32 notrap aligned v0+56
 ;; @0025                               v8 = uextend.i64 v2
 ;; @0025                               v9 = uextend.i64 v3
-;; @0025                               v11 = iadd v8, v9
+;; @0025                               v12 = iadd v8, v9
 ;; @0025                               v7 = uextend.i64 v6
-;; @0025                               v12 = icmp ugt v11, v7
-;; @0025                               trapnz v12, heap_oob
-;; @0025                               v14 = load.i64 notrap aligned v0+48
-;;                                     v126 = iconst.i64 32
-;; @0025                               v20 = ushr v9, v126  ; v126 = 32
-;; @0025                               trapnz v20, user18
-;; @0025                               v17 = iconst.i32 20
-;; @0025                               v22 = uadd_overflow_trap v17, v3, user18  ; v17 = 20
-;; @0025                               v24 = load.i64 notrap aligned readonly can_move v0+32
-;; @0025                               v25 = load.i32 notrap aligned v24
-;; @0025                               v26 = load.i32 notrap aligned v24+4
-;; @0025                               v32 = uextend.i64 v25
-;; @0025                               v27 = uextend.i64 v22
-;; @0025                               v28 = iconst.i64 15
-;; @0025                               v30 = iadd v27, v28  ; v28 = 15
-;; @0025                               v29 = iconst.i64 -16
-;; @0025                               v31 = band v30, v29  ; v29 = -16
-;; @0025                               v33 = iadd v32, v31
-;; @0025                               v34 = uextend.i64 v26
-;; @0025                               v35 = icmp ule v33, v34
-;; @0025                               brif v35, block2, block3
+;; @0025                               v13 = icmp ugt v12, v7
+;; @0025                               trapnz v13, heap_oob
+;; @0025                               v15 = load.i64 notrap aligned v0+48
+;;                                     v128 = iconst.i64 32
+;; @0025                               v22 = ushr v9, v128  ; v128 = 32
+;; @0025                               trapnz v22, user18
+;; @0025                               v18 = iconst.i32 20
+;; @0025                               v24 = uadd_overflow_trap v18, v3, user18  ; v18 = 20
+;; @0025                               v26 = load.i64 notrap aligned readonly can_move v0+32
+;; @0025                               v27 = load.i32 notrap aligned v26
+;; @0025                               v28 = load.i32 notrap aligned v26+4
+;; @0025                               v34 = uextend.i64 v27
+;; @0025                               v29 = uextend.i64 v24
+;; @0025                               v30 = iconst.i64 15
+;; @0025                               v32 = iadd v29, v30  ; v30 = 15
+;; @0025                               v31 = iconst.i64 -16
+;; @0025                               v33 = band v32, v31  ; v31 = -16
+;; @0025                               v35 = iadd v34, v33
+;; @0025                               v36 = uextend.i64 v28
+;; @0025                               v37 = icmp ule v35, v36
+;; @0025                               brif v37, block2, block3
 ;;
 ;;                                 block2:
 ;;                                     v136 = iconst.i32 15
-;;                                     v137 = iadd.i32 v22, v136  ; v136 = 15
+;;                                     v137 = iadd.i32 v24, v136  ; v136 = 15
 ;;                                     v140 = iconst.i32 -16
 ;;                                     v141 = band v137, v140  ; v140 = -16
-;;                                     v143 = iadd.i32 v25, v141
-;; @0025                               store notrap aligned region0 v143, v24
+;;                                     v143 = iadd.i32 v27, v141
+;; @0025                               store notrap aligned region0 v143, v26
 ;;                                     v157 = iconst.i32 -1476395002
 ;;                                     v158 = load.i64 notrap aligned readonly can_move v0+8
 ;;                                     v159 = load.i64 notrap aligned readonly can_move v158+32
-;; @0025                               v49 = iadd v159, v32
-;; @0025                               store notrap aligned v157, v49  ; v157 = -1476395002
+;; @0025                               v51 = iadd v159, v34
+;; @0025                               store notrap aligned v157, v51  ; v157 = -1476395002
 ;;                                     v160 = load.i64 notrap aligned readonly can_move v0+40
 ;;                                     v161 = load.i32 notrap aligned readonly can_move v160
-;; @0025                               store notrap aligned v161, v49+4
-;;                                     v162 = band.i64 v30, v29  ; v29 = -16
-;; @0025                               istore32 notrap aligned v162, v49+8
-;; @0025                               jump block4(v25, v49)
+;; @0025                               store notrap aligned v161, v51+4
+;;                                     v162 = band.i64 v32, v31  ; v31 = -16
+;; @0025                               istore32 notrap aligned v162, v51+8
+;; @0025                               jump block4(v27, v51)
 ;;
 ;;                                 block3 cold:
-;; @0025                               v37 = iconst.i32 -1476395002
-;; @0025                               v39 = load.i64 notrap aligned readonly can_move v0+40
-;; @0025                               v40 = load.i32 notrap aligned readonly can_move v39
-;; @0025                               v41 = iconst.i32 16
-;; @0025                               v42 = call fn0(v0, v37, v40, v22, v41)  ; v37 = -1476395002, v41 = 16
-;; @0025                               v122 = load.i64 notrap aligned readonly can_move v0+8
-;; @0025                               v43 = load.i64 notrap aligned readonly can_move v122+32
-;; @0025                               v44 = uextend.i64 v42
-;; @0025                               v45 = iadd v43, v44
-;; @0025                               jump block4(v42, v45)
+;; @0025                               v39 = iconst.i32 -1476395002
+;; @0025                               v41 = load.i64 notrap aligned readonly can_move v0+40
+;; @0025                               v42 = load.i32 notrap aligned readonly can_move v41
+;; @0025                               v43 = iconst.i32 16
+;; @0025                               v44 = call fn0(v0, v39, v42, v24, v43)  ; v39 = -1476395002, v43 = 16
+;; @0025                               v124 = load.i64 notrap aligned readonly can_move v0+8
+;; @0025                               v45 = load.i64 notrap aligned readonly can_move v124+32
+;; @0025                               v46 = uextend.i64 v44
+;; @0025                               v47 = iadd v45, v46
+;; @0025                               jump block4(v44, v47)
 ;;
-;;                                 block4(v54: i32, v55: i64):
-;;                                     v121 = stack_addr.i64 ss0
-;;                                     store notrap v54, v121
-;; @0025                               v56 = iconst.i64 16
-;; @0025                               v57 = iadd v55, v56  ; v56 = 16
-;; @0025                               store.i32 user2 region1 v3, v57
-;; @0025                               trapz v54, user16
+;;                                 block4(v56: i32, v57: i64):
+;;                                     v123 = stack_addr.i64 ss0
+;;                                     store notrap v56, v123
+;; @0025                               v58 = iconst.i64 16
+;; @0025                               v59 = iadd v57, v58  ; v58 = 16
+;; @0025                               store.i32 user2 region1 v3, v59
+;; @0025                               trapz v56, user16
 ;;                                     v163 = load.i64 notrap aligned readonly can_move v0+8
 ;;                                     v164 = load.i64 notrap aligned readonly can_move v163+32
-;; @0025                               v59 = uextend.i64 v54
-;; @0025                               v61 = iadd v164, v59
-;; @0025                               v63 = iadd v61, v56  ; v56 = 16
-;; @0025                               v64 = load.i32 user2 readonly region1 v63
-;; @0025                               v65 = uextend.i64 v64
-;; @0025                               v70 = icmp.i64 ugt v9, v65
-;; @0025                               trapnz v70, user17
-;; @0025                               v80 = load.i32 notrap aligned v0+56
-;; @0025                               v81 = uextend.i64 v80
-;; @0025                               v86 = icmp.i64 ugt v11, v81
-;; @0025                               trapnz v86, heap_oob
-;; @0025                               v88 = load.i64 notrap aligned v0+48
-;; @0025                               v95 = load.i64 notrap aligned v163+40
-;; @0025                               v74 = iconst.i64 20
-;; @0025                               v75 = iadd v61, v74  ; v74 = 20
-;; @0025                               v97 = uadd_overflow_trap v75, v9, user2
-;; @0025                               v96 = iadd v164, v95
-;; @0025                               v98 = icmp ugt v97, v96
-;; @0025                               trapnz v98, user2
-;; @0025                               v90 = iadd v88, v8
-;; @0025                               call fn1(v0, v75, v90, v9), stack_map=[i32 @ ss0+0]
-;;                                     v100 = load.i32 notrap v121
+;; @0025                               v61 = uextend.i64 v56
+;; @0025                               v63 = iadd v164, v61
+;; @0025                               v65 = iadd v63, v58  ; v58 = 16
+;; @0025                               v66 = load.i32 user2 readonly region1 v65
+;; @0025                               v67 = uextend.i64 v66
+;; @0025                               v73 = icmp.i64 ugt v9, v67
+;; @0025                               trapnz v73, user17
+;; @0025                               v84 = load.i32 notrap aligned v0+56
+;; @0025                               v85 = uextend.i64 v84
+;; @0025                               v91 = icmp.i64 ugt v12, v85
+;; @0025                               trapnz v91, heap_oob
+;; @0025                               v93 = load.i64 notrap aligned v0+48
+;; @0025                               v102 = load.i64 notrap aligned v163+40
+;; @0025                               v77 = iconst.i64 20
+;; @0025                               v78 = iadd v63, v77  ; v77 = 20
+;; @0025                               v104 = uadd_overflow_trap v78, v9, user2
+;; @0025                               v103 = iadd v164, v102
+;; @0025                               v105 = icmp ugt v104, v103
+;; @0025                               trapnz v105, user2
+;; @0025                               v95 = iadd v93, v8
+;; @0025                               call fn1(v0, v78, v95, v9), stack_map=[i32 @ ss0+0]
+;;                                     v107 = load.i32 notrap v123
 ;; @0029                               jump block1
 ;;
 ;;                                 block1:
-;; @0029                               return v100
+;; @0029                               return v107
 ;; }

--- a/tests/disas/gc/array-new-default-anyref.wat
+++ b/tests/disas/gc/array-new-default-anyref.wat
@@ -27,96 +27,96 @@
 ;; @001f                               v5 = uextend.i64 v2
 ;;                                     v98 = iconst.i64 2
 ;;                                     v99 = ishl v5, v98  ; v98 = 2
-;;                                     v96 = iconst.i64 32
-;; @001f                               v7 = ushr v99, v96  ; v96 = 32
-;; @001f                               trapnz v7, user18
+;;                                     v97 = iconst.i64 32
+;; @001f                               v8 = ushr v99, v97  ; v97 = 32
+;; @001f                               trapnz v8, user18
 ;; @001f                               v4 = iconst.i32 20
 ;;                                     v105 = iconst.i32 2
 ;;                                     v106 = ishl v2, v105  ; v105 = 2
-;; @001f                               v9 = uadd_overflow_trap v4, v106, user18  ; v4 = 20
-;; @001f                               v11 = load.i64 notrap aligned readonly can_move v0+32
-;; @001f                               v12 = load.i32 notrap aligned v11
-;; @001f                               v13 = load.i32 notrap aligned v11+4
-;; @001f                               v19 = uextend.i64 v12
-;; @001f                               v14 = uextend.i64 v9
-;; @001f                               v15 = iconst.i64 15
-;; @001f                               v17 = iadd v14, v15  ; v15 = 15
-;; @001f                               v16 = iconst.i64 -16
-;; @001f                               v18 = band v17, v16  ; v16 = -16
-;; @001f                               v20 = iadd v19, v18
-;; @001f                               v21 = uextend.i64 v13
-;; @001f                               v22 = icmp ule v20, v21
-;; @001f                               brif v22, block2, block3
+;; @001f                               v10 = uadd_overflow_trap v4, v106, user18  ; v4 = 20
+;; @001f                               v12 = load.i64 notrap aligned readonly can_move v0+32
+;; @001f                               v13 = load.i32 notrap aligned v12
+;; @001f                               v14 = load.i32 notrap aligned v12+4
+;; @001f                               v20 = uextend.i64 v13
+;; @001f                               v15 = uextend.i64 v10
+;; @001f                               v16 = iconst.i64 15
+;; @001f                               v18 = iadd v15, v16  ; v16 = 15
+;; @001f                               v17 = iconst.i64 -16
+;; @001f                               v19 = band v18, v17  ; v17 = -16
+;; @001f                               v21 = iadd v20, v19
+;; @001f                               v22 = uextend.i64 v14
+;; @001f                               v23 = icmp ule v21, v22
+;; @001f                               brif v23, block2, block3
 ;;
 ;;                                 block2:
 ;;                                     v114 = iconst.i32 15
-;;                                     v115 = iadd.i32 v9, v114  ; v114 = 15
+;;                                     v115 = iadd.i32 v10, v114  ; v114 = 15
 ;;                                     v118 = iconst.i32 -16
 ;;                                     v119 = band v115, v118  ; v118 = -16
-;;                                     v121 = iadd.i32 v12, v119
-;; @001f                               store notrap aligned region0 v121, v11
+;;                                     v121 = iadd.i32 v13, v119
+;; @001f                               store notrap aligned region0 v121, v12
 ;;                                     v137 = iconst.i32 -1476394994
 ;;                                     v138 = load.i64 notrap aligned readonly can_move v0+8
 ;;                                     v139 = load.i64 notrap aligned readonly can_move v138+32
-;; @001f                               v36 = iadd v139, v19
-;; @001f                               store notrap aligned v137, v36  ; v137 = -1476394994
+;; @001f                               v37 = iadd v139, v20
+;; @001f                               store notrap aligned v137, v37  ; v137 = -1476394994
 ;;                                     v140 = load.i64 notrap aligned readonly can_move v0+40
 ;;                                     v141 = load.i32 notrap aligned readonly can_move v140
-;; @001f                               store notrap aligned v141, v36+4
-;;                                     v142 = band.i64 v17, v16  ; v16 = -16
-;; @001f                               istore32 notrap aligned v142, v36+8
-;; @001f                               jump block4(v12, v36)
+;; @001f                               store notrap aligned v141, v37+4
+;;                                     v142 = band.i64 v18, v17  ; v17 = -16
+;; @001f                               istore32 notrap aligned v142, v37+8
+;; @001f                               jump block4(v13, v37)
 ;;
 ;;                                 block3 cold:
-;; @001f                               v24 = iconst.i32 -1476394994
-;; @001f                               v26 = load.i64 notrap aligned readonly can_move v0+40
-;; @001f                               v27 = load.i32 notrap aligned readonly can_move v26
-;; @001f                               v28 = iconst.i32 16
-;; @001f                               v29 = call fn0(v0, v24, v27, v9, v28)  ; v24 = -1476394994, v28 = 16
-;; @001f                               v92 = load.i64 notrap aligned readonly can_move v0+8
-;; @001f                               v30 = load.i64 notrap aligned readonly can_move v92+32
-;; @001f                               v31 = uextend.i64 v29
-;; @001f                               v32 = iadd v30, v31
-;; @001f                               jump block4(v29, v32)
+;; @001f                               v25 = iconst.i32 -1476394994
+;; @001f                               v27 = load.i64 notrap aligned readonly can_move v0+40
+;; @001f                               v28 = load.i32 notrap aligned readonly can_move v27
+;; @001f                               v29 = iconst.i32 16
+;; @001f                               v30 = call fn0(v0, v25, v28, v10, v29)  ; v25 = -1476394994, v29 = 16
+;; @001f                               v93 = load.i64 notrap aligned readonly can_move v0+8
+;; @001f                               v31 = load.i64 notrap aligned readonly can_move v93+32
+;; @001f                               v32 = uextend.i64 v30
+;; @001f                               v33 = iadd v31, v32
+;; @001f                               jump block4(v30, v33)
 ;;
-;;                                 block4(v41: i32, v42: i64):
-;; @001f                               v43 = iconst.i64 16
-;; @001f                               v44 = iadd v42, v43  ; v43 = 16
-;; @001f                               store.i32 user2 region1 v2, v44
-;; @001f                               trapz v41, user16
+;;                                 block4(v42: i32, v43: i64):
+;; @001f                               v44 = iconst.i64 16
+;; @001f                               v45 = iadd v43, v44  ; v44 = 16
+;; @001f                               store.i32 user2 region1 v2, v45
+;; @001f                               trapz v42, user16
 ;;                                     v143 = load.i64 notrap aligned readonly can_move v0+8
 ;;                                     v144 = load.i64 notrap aligned readonly can_move v143+32
-;; @001f                               v47 = uextend.i64 v41
-;; @001f                               v49 = iadd v144, v47
-;; @001f                               v51 = iadd v49, v43  ; v43 = 16
-;; @001f                               v52 = load.i32 user2 readonly region1 v51
-;; @001f                               v53 = uextend.i64 v52
-;; @001f                               v58 = icmp.i64 ugt v5, v53
-;; @001f                               trapnz v58, user17
-;; @001f                               v70 = load.i64 notrap aligned v143+40
-;; @001f                               v62 = iconst.i64 20
-;; @001f                               v63 = iadd v49, v62  ; v62 = 20
-;; @001f                               v72 = uadd_overflow_trap v63, v99, user2
-;; @001f                               v71 = iadd v144, v70
-;; @001f                               v73 = icmp ugt v72, v71
-;; @001f                               trapnz v73, user2
+;; @001f                               v48 = uextend.i64 v42
+;; @001f                               v50 = iadd v144, v48
+;; @001f                               v52 = iadd v50, v44  ; v44 = 16
+;; @001f                               v53 = load.i32 user2 readonly region1 v52
+;; @001f                               v54 = uextend.i64 v53
+;; @001f                               v60 = icmp.i64 ugt v5, v54
+;; @001f                               trapnz v60, user17
+;; @001f                               v74 = load.i64 notrap aligned v143+40
+;; @001f                               v64 = iconst.i64 20
+;; @001f                               v65 = iadd v50, v64  ; v64 = 20
+;; @001f                               v76 = uadd_overflow_trap v65, v99, user2
+;; @001f                               v75 = iadd v144, v74
+;; @001f                               v77 = icmp ugt v76, v75
+;; @001f                               trapnz v77, user2
 ;;                                     v123 = iconst.i64 0
-;; @001f                               v76 = icmp.i64 eq v5, v123  ; v123 = 0
-;; @001f                               v45 = iconst.i32 0
-;;                                     v97 = iconst.i64 4
-;; @001f                               v74 = iadd v63, v99
-;; @001f                               brif v76, block6, block5(v63)
+;; @001f                               v80 = icmp.i64 eq v5, v123  ; v123 = 0
+;; @001f                               v46 = iconst.i32 0
+;; @001f                               v6 = iconst.i64 4
+;; @001f                               v78 = iadd v65, v99
+;; @001f                               brif v80, block6, block5(v65)
 ;;
-;;                                 block5(v77: i64):
+;;                                 block5(v81: i64):
 ;;                                     v145 = iconst.i32 0
-;; @001f                               store user2 little region1 v145, v77  ; v145 = 0
+;; @001f                               store user2 little region1 v145, v81  ; v145 = 0
 ;;                                     v146 = iconst.i64 4
-;;                                     v147 = iadd v77, v146  ; v146 = 4
-;; @001f                               v80 = icmp eq v147, v74
-;; @001f                               brif v80, block6, block5(v147)
+;;                                     v147 = iadd v81, v146  ; v146 = 4
+;; @001f                               v84 = icmp eq v147, v78
+;; @001f                               brif v84, block6, block5(v147)
 ;;
 ;;                                 block6:
-;; @0022                               jump block1(v41)
+;; @0022                               jump block1(v42)
 ;;
 ;;                                 block1(v3: i32):
 ;; @0022                               return v3

--- a/tests/disas/gc/array-new-default-exnref.wat
+++ b/tests/disas/gc/array-new-default-exnref.wat
@@ -27,96 +27,96 @@
 ;; @001f                               v5 = uextend.i64 v2
 ;;                                     v98 = iconst.i64 2
 ;;                                     v99 = ishl v5, v98  ; v98 = 2
-;;                                     v96 = iconst.i64 32
-;; @001f                               v7 = ushr v99, v96  ; v96 = 32
-;; @001f                               trapnz v7, user18
+;;                                     v97 = iconst.i64 32
+;; @001f                               v8 = ushr v99, v97  ; v97 = 32
+;; @001f                               trapnz v8, user18
 ;; @001f                               v4 = iconst.i32 20
 ;;                                     v105 = iconst.i32 2
 ;;                                     v106 = ishl v2, v105  ; v105 = 2
-;; @001f                               v9 = uadd_overflow_trap v4, v106, user18  ; v4 = 20
-;; @001f                               v11 = load.i64 notrap aligned readonly can_move v0+32
-;; @001f                               v12 = load.i32 notrap aligned v11
-;; @001f                               v13 = load.i32 notrap aligned v11+4
-;; @001f                               v19 = uextend.i64 v12
-;; @001f                               v14 = uextend.i64 v9
-;; @001f                               v15 = iconst.i64 15
-;; @001f                               v17 = iadd v14, v15  ; v15 = 15
-;; @001f                               v16 = iconst.i64 -16
-;; @001f                               v18 = band v17, v16  ; v16 = -16
-;; @001f                               v20 = iadd v19, v18
-;; @001f                               v21 = uextend.i64 v13
-;; @001f                               v22 = icmp ule v20, v21
-;; @001f                               brif v22, block2, block3
+;; @001f                               v10 = uadd_overflow_trap v4, v106, user18  ; v4 = 20
+;; @001f                               v12 = load.i64 notrap aligned readonly can_move v0+32
+;; @001f                               v13 = load.i32 notrap aligned v12
+;; @001f                               v14 = load.i32 notrap aligned v12+4
+;; @001f                               v20 = uextend.i64 v13
+;; @001f                               v15 = uextend.i64 v10
+;; @001f                               v16 = iconst.i64 15
+;; @001f                               v18 = iadd v15, v16  ; v16 = 15
+;; @001f                               v17 = iconst.i64 -16
+;; @001f                               v19 = band v18, v17  ; v17 = -16
+;; @001f                               v21 = iadd v20, v19
+;; @001f                               v22 = uextend.i64 v14
+;; @001f                               v23 = icmp ule v21, v22
+;; @001f                               brif v23, block2, block3
 ;;
 ;;                                 block2:
 ;;                                     v114 = iconst.i32 15
-;;                                     v115 = iadd.i32 v9, v114  ; v114 = 15
+;;                                     v115 = iadd.i32 v10, v114  ; v114 = 15
 ;;                                     v118 = iconst.i32 -16
 ;;                                     v119 = band v115, v118  ; v118 = -16
-;;                                     v121 = iadd.i32 v12, v119
-;; @001f                               store notrap aligned region0 v121, v11
+;;                                     v121 = iadd.i32 v13, v119
+;; @001f                               store notrap aligned region0 v121, v12
 ;;                                     v137 = iconst.i32 -1476394994
 ;;                                     v138 = load.i64 notrap aligned readonly can_move v0+8
 ;;                                     v139 = load.i64 notrap aligned readonly can_move v138+32
-;; @001f                               v36 = iadd v139, v19
-;; @001f                               store notrap aligned v137, v36  ; v137 = -1476394994
+;; @001f                               v37 = iadd v139, v20
+;; @001f                               store notrap aligned v137, v37  ; v137 = -1476394994
 ;;                                     v140 = load.i64 notrap aligned readonly can_move v0+40
 ;;                                     v141 = load.i32 notrap aligned readonly can_move v140
-;; @001f                               store notrap aligned v141, v36+4
-;;                                     v142 = band.i64 v17, v16  ; v16 = -16
-;; @001f                               istore32 notrap aligned v142, v36+8
-;; @001f                               jump block4(v12, v36)
+;; @001f                               store notrap aligned v141, v37+4
+;;                                     v142 = band.i64 v18, v17  ; v17 = -16
+;; @001f                               istore32 notrap aligned v142, v37+8
+;; @001f                               jump block4(v13, v37)
 ;;
 ;;                                 block3 cold:
-;; @001f                               v24 = iconst.i32 -1476394994
-;; @001f                               v26 = load.i64 notrap aligned readonly can_move v0+40
-;; @001f                               v27 = load.i32 notrap aligned readonly can_move v26
-;; @001f                               v28 = iconst.i32 16
-;; @001f                               v29 = call fn0(v0, v24, v27, v9, v28)  ; v24 = -1476394994, v28 = 16
-;; @001f                               v92 = load.i64 notrap aligned readonly can_move v0+8
-;; @001f                               v30 = load.i64 notrap aligned readonly can_move v92+32
-;; @001f                               v31 = uextend.i64 v29
-;; @001f                               v32 = iadd v30, v31
-;; @001f                               jump block4(v29, v32)
+;; @001f                               v25 = iconst.i32 -1476394994
+;; @001f                               v27 = load.i64 notrap aligned readonly can_move v0+40
+;; @001f                               v28 = load.i32 notrap aligned readonly can_move v27
+;; @001f                               v29 = iconst.i32 16
+;; @001f                               v30 = call fn0(v0, v25, v28, v10, v29)  ; v25 = -1476394994, v29 = 16
+;; @001f                               v93 = load.i64 notrap aligned readonly can_move v0+8
+;; @001f                               v31 = load.i64 notrap aligned readonly can_move v93+32
+;; @001f                               v32 = uextend.i64 v30
+;; @001f                               v33 = iadd v31, v32
+;; @001f                               jump block4(v30, v33)
 ;;
-;;                                 block4(v41: i32, v42: i64):
-;; @001f                               v43 = iconst.i64 16
-;; @001f                               v44 = iadd v42, v43  ; v43 = 16
-;; @001f                               store.i32 user2 region1 v2, v44
-;; @001f                               trapz v41, user16
+;;                                 block4(v42: i32, v43: i64):
+;; @001f                               v44 = iconst.i64 16
+;; @001f                               v45 = iadd v43, v44  ; v44 = 16
+;; @001f                               store.i32 user2 region1 v2, v45
+;; @001f                               trapz v42, user16
 ;;                                     v143 = load.i64 notrap aligned readonly can_move v0+8
 ;;                                     v144 = load.i64 notrap aligned readonly can_move v143+32
-;; @001f                               v47 = uextend.i64 v41
-;; @001f                               v49 = iadd v144, v47
-;; @001f                               v51 = iadd v49, v43  ; v43 = 16
-;; @001f                               v52 = load.i32 user2 readonly region1 v51
-;; @001f                               v53 = uextend.i64 v52
-;; @001f                               v58 = icmp.i64 ugt v5, v53
-;; @001f                               trapnz v58, user17
-;; @001f                               v70 = load.i64 notrap aligned v143+40
-;; @001f                               v62 = iconst.i64 20
-;; @001f                               v63 = iadd v49, v62  ; v62 = 20
-;; @001f                               v72 = uadd_overflow_trap v63, v99, user2
-;; @001f                               v71 = iadd v144, v70
-;; @001f                               v73 = icmp ugt v72, v71
-;; @001f                               trapnz v73, user2
+;; @001f                               v48 = uextend.i64 v42
+;; @001f                               v50 = iadd v144, v48
+;; @001f                               v52 = iadd v50, v44  ; v44 = 16
+;; @001f                               v53 = load.i32 user2 readonly region1 v52
+;; @001f                               v54 = uextend.i64 v53
+;; @001f                               v60 = icmp.i64 ugt v5, v54
+;; @001f                               trapnz v60, user17
+;; @001f                               v74 = load.i64 notrap aligned v143+40
+;; @001f                               v64 = iconst.i64 20
+;; @001f                               v65 = iadd v50, v64  ; v64 = 20
+;; @001f                               v76 = uadd_overflow_trap v65, v99, user2
+;; @001f                               v75 = iadd v144, v74
+;; @001f                               v77 = icmp ugt v76, v75
+;; @001f                               trapnz v77, user2
 ;;                                     v123 = iconst.i64 0
-;; @001f                               v76 = icmp.i64 eq v5, v123  ; v123 = 0
-;; @001f                               v45 = iconst.i32 0
-;;                                     v97 = iconst.i64 4
-;; @001f                               v74 = iadd v63, v99
-;; @001f                               brif v76, block6, block5(v63)
+;; @001f                               v80 = icmp.i64 eq v5, v123  ; v123 = 0
+;; @001f                               v46 = iconst.i32 0
+;; @001f                               v6 = iconst.i64 4
+;; @001f                               v78 = iadd v65, v99
+;; @001f                               brif v80, block6, block5(v65)
 ;;
-;;                                 block5(v77: i64):
+;;                                 block5(v81: i64):
 ;;                                     v145 = iconst.i32 0
-;; @001f                               store user2 little region1 v145, v77  ; v145 = 0
+;; @001f                               store user2 little region1 v145, v81  ; v145 = 0
 ;;                                     v146 = iconst.i64 4
-;;                                     v147 = iadd v77, v146  ; v146 = 4
-;; @001f                               v80 = icmp eq v147, v74
-;; @001f                               brif v80, block6, block5(v147)
+;;                                     v147 = iadd v81, v146  ; v146 = 4
+;; @001f                               v84 = icmp eq v147, v78
+;; @001f                               brif v84, block6, block5(v147)
 ;;
 ;;                                 block6:
-;; @0022                               jump block1(v41)
+;; @0022                               jump block1(v42)
 ;;
 ;;                                 block1(v3: i32):
 ;; @0022                               return v3

--- a/tests/disas/gc/array-new-default-externref.wat
+++ b/tests/disas/gc/array-new-default-externref.wat
@@ -27,96 +27,96 @@
 ;; @001f                               v5 = uextend.i64 v2
 ;;                                     v98 = iconst.i64 2
 ;;                                     v99 = ishl v5, v98  ; v98 = 2
-;;                                     v96 = iconst.i64 32
-;; @001f                               v7 = ushr v99, v96  ; v96 = 32
-;; @001f                               trapnz v7, user18
+;;                                     v97 = iconst.i64 32
+;; @001f                               v8 = ushr v99, v97  ; v97 = 32
+;; @001f                               trapnz v8, user18
 ;; @001f                               v4 = iconst.i32 20
 ;;                                     v105 = iconst.i32 2
 ;;                                     v106 = ishl v2, v105  ; v105 = 2
-;; @001f                               v9 = uadd_overflow_trap v4, v106, user18  ; v4 = 20
-;; @001f                               v11 = load.i64 notrap aligned readonly can_move v0+32
-;; @001f                               v12 = load.i32 notrap aligned v11
-;; @001f                               v13 = load.i32 notrap aligned v11+4
-;; @001f                               v19 = uextend.i64 v12
-;; @001f                               v14 = uextend.i64 v9
-;; @001f                               v15 = iconst.i64 15
-;; @001f                               v17 = iadd v14, v15  ; v15 = 15
-;; @001f                               v16 = iconst.i64 -16
-;; @001f                               v18 = band v17, v16  ; v16 = -16
-;; @001f                               v20 = iadd v19, v18
-;; @001f                               v21 = uextend.i64 v13
-;; @001f                               v22 = icmp ule v20, v21
-;; @001f                               brif v22, block2, block3
+;; @001f                               v10 = uadd_overflow_trap v4, v106, user18  ; v4 = 20
+;; @001f                               v12 = load.i64 notrap aligned readonly can_move v0+32
+;; @001f                               v13 = load.i32 notrap aligned v12
+;; @001f                               v14 = load.i32 notrap aligned v12+4
+;; @001f                               v20 = uextend.i64 v13
+;; @001f                               v15 = uextend.i64 v10
+;; @001f                               v16 = iconst.i64 15
+;; @001f                               v18 = iadd v15, v16  ; v16 = 15
+;; @001f                               v17 = iconst.i64 -16
+;; @001f                               v19 = band v18, v17  ; v17 = -16
+;; @001f                               v21 = iadd v20, v19
+;; @001f                               v22 = uextend.i64 v14
+;; @001f                               v23 = icmp ule v21, v22
+;; @001f                               brif v23, block2, block3
 ;;
 ;;                                 block2:
 ;;                                     v114 = iconst.i32 15
-;;                                     v115 = iadd.i32 v9, v114  ; v114 = 15
+;;                                     v115 = iadd.i32 v10, v114  ; v114 = 15
 ;;                                     v118 = iconst.i32 -16
 ;;                                     v119 = band v115, v118  ; v118 = -16
-;;                                     v121 = iadd.i32 v12, v119
-;; @001f                               store notrap aligned region0 v121, v11
+;;                                     v121 = iadd.i32 v13, v119
+;; @001f                               store notrap aligned region0 v121, v12
 ;;                                     v137 = iconst.i32 -1476394994
 ;;                                     v138 = load.i64 notrap aligned readonly can_move v0+8
 ;;                                     v139 = load.i64 notrap aligned readonly can_move v138+32
-;; @001f                               v36 = iadd v139, v19
-;; @001f                               store notrap aligned v137, v36  ; v137 = -1476394994
+;; @001f                               v37 = iadd v139, v20
+;; @001f                               store notrap aligned v137, v37  ; v137 = -1476394994
 ;;                                     v140 = load.i64 notrap aligned readonly can_move v0+40
 ;;                                     v141 = load.i32 notrap aligned readonly can_move v140
-;; @001f                               store notrap aligned v141, v36+4
-;;                                     v142 = band.i64 v17, v16  ; v16 = -16
-;; @001f                               istore32 notrap aligned v142, v36+8
-;; @001f                               jump block4(v12, v36)
+;; @001f                               store notrap aligned v141, v37+4
+;;                                     v142 = band.i64 v18, v17  ; v17 = -16
+;; @001f                               istore32 notrap aligned v142, v37+8
+;; @001f                               jump block4(v13, v37)
 ;;
 ;;                                 block3 cold:
-;; @001f                               v24 = iconst.i32 -1476394994
-;; @001f                               v26 = load.i64 notrap aligned readonly can_move v0+40
-;; @001f                               v27 = load.i32 notrap aligned readonly can_move v26
-;; @001f                               v28 = iconst.i32 16
-;; @001f                               v29 = call fn0(v0, v24, v27, v9, v28)  ; v24 = -1476394994, v28 = 16
-;; @001f                               v92 = load.i64 notrap aligned readonly can_move v0+8
-;; @001f                               v30 = load.i64 notrap aligned readonly can_move v92+32
-;; @001f                               v31 = uextend.i64 v29
-;; @001f                               v32 = iadd v30, v31
-;; @001f                               jump block4(v29, v32)
+;; @001f                               v25 = iconst.i32 -1476394994
+;; @001f                               v27 = load.i64 notrap aligned readonly can_move v0+40
+;; @001f                               v28 = load.i32 notrap aligned readonly can_move v27
+;; @001f                               v29 = iconst.i32 16
+;; @001f                               v30 = call fn0(v0, v25, v28, v10, v29)  ; v25 = -1476394994, v29 = 16
+;; @001f                               v93 = load.i64 notrap aligned readonly can_move v0+8
+;; @001f                               v31 = load.i64 notrap aligned readonly can_move v93+32
+;; @001f                               v32 = uextend.i64 v30
+;; @001f                               v33 = iadd v31, v32
+;; @001f                               jump block4(v30, v33)
 ;;
-;;                                 block4(v41: i32, v42: i64):
-;; @001f                               v43 = iconst.i64 16
-;; @001f                               v44 = iadd v42, v43  ; v43 = 16
-;; @001f                               store.i32 user2 region1 v2, v44
-;; @001f                               trapz v41, user16
+;;                                 block4(v42: i32, v43: i64):
+;; @001f                               v44 = iconst.i64 16
+;; @001f                               v45 = iadd v43, v44  ; v44 = 16
+;; @001f                               store.i32 user2 region1 v2, v45
+;; @001f                               trapz v42, user16
 ;;                                     v143 = load.i64 notrap aligned readonly can_move v0+8
 ;;                                     v144 = load.i64 notrap aligned readonly can_move v143+32
-;; @001f                               v47 = uextend.i64 v41
-;; @001f                               v49 = iadd v144, v47
-;; @001f                               v51 = iadd v49, v43  ; v43 = 16
-;; @001f                               v52 = load.i32 user2 readonly region1 v51
-;; @001f                               v53 = uextend.i64 v52
-;; @001f                               v58 = icmp.i64 ugt v5, v53
-;; @001f                               trapnz v58, user17
-;; @001f                               v70 = load.i64 notrap aligned v143+40
-;; @001f                               v62 = iconst.i64 20
-;; @001f                               v63 = iadd v49, v62  ; v62 = 20
-;; @001f                               v72 = uadd_overflow_trap v63, v99, user2
-;; @001f                               v71 = iadd v144, v70
-;; @001f                               v73 = icmp ugt v72, v71
-;; @001f                               trapnz v73, user2
+;; @001f                               v48 = uextend.i64 v42
+;; @001f                               v50 = iadd v144, v48
+;; @001f                               v52 = iadd v50, v44  ; v44 = 16
+;; @001f                               v53 = load.i32 user2 readonly region1 v52
+;; @001f                               v54 = uextend.i64 v53
+;; @001f                               v60 = icmp.i64 ugt v5, v54
+;; @001f                               trapnz v60, user17
+;; @001f                               v74 = load.i64 notrap aligned v143+40
+;; @001f                               v64 = iconst.i64 20
+;; @001f                               v65 = iadd v50, v64  ; v64 = 20
+;; @001f                               v76 = uadd_overflow_trap v65, v99, user2
+;; @001f                               v75 = iadd v144, v74
+;; @001f                               v77 = icmp ugt v76, v75
+;; @001f                               trapnz v77, user2
 ;;                                     v123 = iconst.i64 0
-;; @001f                               v76 = icmp.i64 eq v5, v123  ; v123 = 0
-;; @001f                               v45 = iconst.i32 0
-;;                                     v97 = iconst.i64 4
-;; @001f                               v74 = iadd v63, v99
-;; @001f                               brif v76, block6, block5(v63)
+;; @001f                               v80 = icmp.i64 eq v5, v123  ; v123 = 0
+;; @001f                               v46 = iconst.i32 0
+;; @001f                               v6 = iconst.i64 4
+;; @001f                               v78 = iadd v65, v99
+;; @001f                               brif v80, block6, block5(v65)
 ;;
-;;                                 block5(v77: i64):
+;;                                 block5(v81: i64):
 ;;                                     v145 = iconst.i32 0
-;; @001f                               store user2 little region1 v145, v77  ; v145 = 0
+;; @001f                               store user2 little region1 v145, v81  ; v145 = 0
 ;;                                     v146 = iconst.i64 4
-;;                                     v147 = iadd v77, v146  ; v146 = 4
-;; @001f                               v80 = icmp eq v147, v74
-;; @001f                               brif v80, block6, block5(v147)
+;;                                     v147 = iadd v81, v146  ; v146 = 4
+;; @001f                               v84 = icmp eq v147, v78
+;; @001f                               brif v84, block6, block5(v147)
 ;;
 ;;                                 block6:
-;; @0022                               jump block1(v41)
+;; @0022                               jump block1(v42)
 ;;
 ;;                                 block1(v3: i32):
 ;; @0022                               return v3

--- a/tests/disas/gc/array-new-default-f32.wat
+++ b/tests/disas/gc/array-new-default-f32.wat
@@ -30,86 +30,86 @@
 ;; @001f                               v5 = uextend.i64 v2
 ;;                                     v102 = iconst.i64 2
 ;;                                     v103 = ishl v5, v102  ; v102 = 2
-;;                                     v100 = iconst.i64 32
-;; @001f                               v7 = ushr v103, v100  ; v100 = 32
-;; @001f                               trapnz v7, user18
+;;                                     v101 = iconst.i64 32
+;; @001f                               v8 = ushr v103, v101  ; v101 = 32
+;; @001f                               trapnz v8, user18
 ;; @001f                               v4 = iconst.i32 20
 ;;                                     v109 = iconst.i32 2
 ;;                                     v110 = ishl v2, v109  ; v109 = 2
-;; @001f                               v9 = uadd_overflow_trap v4, v110, user18  ; v4 = 20
-;; @001f                               v11 = load.i64 notrap aligned readonly can_move v0+32
-;; @001f                               v12 = load.i32 notrap aligned v11
-;; @001f                               v13 = load.i32 notrap aligned v11+4
-;; @001f                               v19 = uextend.i64 v12
-;; @001f                               v14 = uextend.i64 v9
-;; @001f                               v15 = iconst.i64 15
-;; @001f                               v17 = iadd v14, v15  ; v15 = 15
-;; @001f                               v16 = iconst.i64 -16
-;; @001f                               v18 = band v17, v16  ; v16 = -16
-;; @001f                               v20 = iadd v19, v18
-;; @001f                               v21 = uextend.i64 v13
-;; @001f                               v22 = icmp ule v20, v21
-;; @001f                               brif v22, block2, block3
+;; @001f                               v10 = uadd_overflow_trap v4, v110, user18  ; v4 = 20
+;; @001f                               v12 = load.i64 notrap aligned readonly can_move v0+32
+;; @001f                               v13 = load.i32 notrap aligned v12
+;; @001f                               v14 = load.i32 notrap aligned v12+4
+;; @001f                               v20 = uextend.i64 v13
+;; @001f                               v15 = uextend.i64 v10
+;; @001f                               v16 = iconst.i64 15
+;; @001f                               v18 = iadd v15, v16  ; v16 = 15
+;; @001f                               v17 = iconst.i64 -16
+;; @001f                               v19 = band v18, v17  ; v17 = -16
+;; @001f                               v21 = iadd v20, v19
+;; @001f                               v22 = uextend.i64 v14
+;; @001f                               v23 = icmp ule v21, v22
+;; @001f                               brif v23, block2, block3
 ;;
 ;;                                 block2:
 ;;                                     v118 = iconst.i32 15
-;;                                     v119 = iadd.i32 v9, v118  ; v118 = 15
+;;                                     v119 = iadd.i32 v10, v118  ; v118 = 15
 ;;                                     v122 = iconst.i32 -16
 ;;                                     v123 = band v119, v122  ; v122 = -16
-;;                                     v125 = iadd.i32 v12, v123
-;; @001f                               store notrap aligned region0 v125, v11
+;;                                     v125 = iadd.i32 v13, v123
+;; @001f                               store notrap aligned region0 v125, v12
 ;;                                     v141 = iconst.i32 -1476395002
 ;;                                     v142 = load.i64 notrap aligned readonly can_move v0+8
 ;;                                     v143 = load.i64 notrap aligned readonly can_move v142+32
-;; @001f                               v36 = iadd v143, v19
-;; @001f                               store notrap aligned v141, v36  ; v141 = -1476395002
+;; @001f                               v37 = iadd v143, v20
+;; @001f                               store notrap aligned v141, v37  ; v141 = -1476395002
 ;;                                     v144 = load.i64 notrap aligned readonly can_move v0+40
 ;;                                     v145 = load.i32 notrap aligned readonly can_move v144
-;; @001f                               store notrap aligned v145, v36+4
-;;                                     v146 = band.i64 v17, v16  ; v16 = -16
-;; @001f                               istore32 notrap aligned v146, v36+8
-;; @001f                               jump block4(v12, v36)
+;; @001f                               store notrap aligned v145, v37+4
+;;                                     v146 = band.i64 v18, v17  ; v17 = -16
+;; @001f                               istore32 notrap aligned v146, v37+8
+;; @001f                               jump block4(v13, v37)
 ;;
 ;;                                 block3 cold:
-;; @001f                               v24 = iconst.i32 -1476395002
-;; @001f                               v26 = load.i64 notrap aligned readonly can_move v0+40
-;; @001f                               v27 = load.i32 notrap aligned readonly can_move v26
-;; @001f                               v28 = iconst.i32 16
-;; @001f                               v29 = call fn0(v0, v24, v27, v9, v28)  ; v24 = -1476395002, v28 = 16
-;; @001f                               v96 = load.i64 notrap aligned readonly can_move v0+8
-;; @001f                               v30 = load.i64 notrap aligned readonly can_move v96+32
-;; @001f                               v31 = uextend.i64 v29
-;; @001f                               v32 = iadd v30, v31
-;; @001f                               jump block4(v29, v32)
+;; @001f                               v25 = iconst.i32 -1476395002
+;; @001f                               v27 = load.i64 notrap aligned readonly can_move v0+40
+;; @001f                               v28 = load.i32 notrap aligned readonly can_move v27
+;; @001f                               v29 = iconst.i32 16
+;; @001f                               v30 = call fn0(v0, v25, v28, v10, v29)  ; v25 = -1476395002, v29 = 16
+;; @001f                               v97 = load.i64 notrap aligned readonly can_move v0+8
+;; @001f                               v31 = load.i64 notrap aligned readonly can_move v97+32
+;; @001f                               v32 = uextend.i64 v30
+;; @001f                               v33 = iadd v31, v32
+;; @001f                               jump block4(v30, v33)
 ;;
-;;                                 block4(v41: i32, v42: i64):
-;;                                     v95 = stack_addr.i64 ss0
-;;                                     store notrap v41, v95
-;; @001f                               v43 = iconst.i64 16
-;; @001f                               v44 = iadd v42, v43  ; v43 = 16
-;; @001f                               store.i32 user2 region1 v2, v44
-;; @001f                               trapz v41, user16
+;;                                 block4(v42: i32, v43: i64):
+;;                                     v96 = stack_addr.i64 ss0
+;;                                     store notrap v42, v96
+;; @001f                               v44 = iconst.i64 16
+;; @001f                               v45 = iadd v43, v44  ; v44 = 16
+;; @001f                               store.i32 user2 region1 v2, v45
+;; @001f                               trapz v42, user16
 ;;                                     v147 = load.i64 notrap aligned readonly can_move v0+8
 ;;                                     v148 = load.i64 notrap aligned readonly can_move v147+32
-;; @001f                               v47 = uextend.i64 v41
-;; @001f                               v49 = iadd v148, v47
-;; @001f                               v51 = iadd v49, v43  ; v43 = 16
-;; @001f                               v52 = load.i32 user2 readonly region1 v51
-;; @001f                               v53 = uextend.i64 v52
-;; @001f                               v58 = icmp.i64 ugt v5, v53
-;; @001f                               trapnz v58, user17
-;; @001f                               v70 = load.i64 notrap aligned v147+40
-;; @001f                               v62 = iconst.i64 20
-;; @001f                               v63 = iadd v49, v62  ; v62 = 20
-;; @001f                               v72 = uadd_overflow_trap v63, v103, user2
-;; @001f                               v71 = iadd v148, v70
-;; @001f                               v73 = icmp ugt v72, v71
-;; @001f                               trapnz v73, user2
-;; @001f                               v46 = iconst.i32 0
-;; @001f                               call fn1(v0, v63, v46, v103), stack_map=[i32 @ ss0+0]  ; v46 = 0
-;;                                     v76 = load.i32 notrap v95
+;; @001f                               v48 = uextend.i64 v42
+;; @001f                               v50 = iadd v148, v48
+;; @001f                               v52 = iadd v50, v44  ; v44 = 16
+;; @001f                               v53 = load.i32 user2 readonly region1 v52
+;; @001f                               v54 = uextend.i64 v53
+;; @001f                               v60 = icmp.i64 ugt v5, v54
+;; @001f                               trapnz v60, user17
+;; @001f                               v74 = load.i64 notrap aligned v147+40
+;; @001f                               v64 = iconst.i64 20
+;; @001f                               v65 = iadd v50, v64  ; v64 = 20
+;; @001f                               v76 = uadd_overflow_trap v65, v103, user2
+;; @001f                               v75 = iadd v148, v74
+;; @001f                               v77 = icmp ugt v76, v75
+;; @001f                               trapnz v77, user2
+;; @001f                               v47 = iconst.i32 0
+;; @001f                               call fn1(v0, v65, v47, v103), stack_map=[i32 @ ss0+0]  ; v47 = 0
+;;                                     v80 = load.i32 notrap v96
 ;; @0022                               jump block1
 ;;
 ;;                                 block1:
-;; @0022                               return v76
+;; @0022                               return v80
 ;; }

--- a/tests/disas/gc/array-new-default-f64.wat
+++ b/tests/disas/gc/array-new-default-f64.wat
@@ -30,86 +30,86 @@
 ;; @001f                               v5 = uextend.i64 v2
 ;;                                     v102 = iconst.i64 3
 ;;                                     v103 = ishl v5, v102  ; v102 = 3
-;;                                     v100 = iconst.i64 32
-;; @001f                               v7 = ushr v103, v100  ; v100 = 32
-;; @001f                               trapnz v7, user18
+;;                                     v101 = iconst.i64 32
+;; @001f                               v8 = ushr v103, v101  ; v101 = 32
+;; @001f                               trapnz v8, user18
 ;; @001f                               v4 = iconst.i32 24
 ;;                                     v109 = iconst.i32 3
 ;;                                     v110 = ishl v2, v109  ; v109 = 3
-;; @001f                               v9 = uadd_overflow_trap v4, v110, user18  ; v4 = 24
-;; @001f                               v11 = load.i64 notrap aligned readonly can_move v0+32
-;; @001f                               v12 = load.i32 notrap aligned v11
-;; @001f                               v13 = load.i32 notrap aligned v11+4
-;; @001f                               v19 = uextend.i64 v12
-;; @001f                               v14 = uextend.i64 v9
-;; @001f                               v15 = iconst.i64 15
-;; @001f                               v17 = iadd v14, v15  ; v15 = 15
-;; @001f                               v16 = iconst.i64 -16
-;; @001f                               v18 = band v17, v16  ; v16 = -16
-;; @001f                               v20 = iadd v19, v18
-;; @001f                               v21 = uextend.i64 v13
-;; @001f                               v22 = icmp ule v20, v21
-;; @001f                               brif v22, block2, block3
+;; @001f                               v10 = uadd_overflow_trap v4, v110, user18  ; v4 = 24
+;; @001f                               v12 = load.i64 notrap aligned readonly can_move v0+32
+;; @001f                               v13 = load.i32 notrap aligned v12
+;; @001f                               v14 = load.i32 notrap aligned v12+4
+;; @001f                               v20 = uextend.i64 v13
+;; @001f                               v15 = uextend.i64 v10
+;; @001f                               v16 = iconst.i64 15
+;; @001f                               v18 = iadd v15, v16  ; v16 = 15
+;; @001f                               v17 = iconst.i64 -16
+;; @001f                               v19 = band v18, v17  ; v17 = -16
+;; @001f                               v21 = iadd v20, v19
+;; @001f                               v22 = uextend.i64 v14
+;; @001f                               v23 = icmp ule v21, v22
+;; @001f                               brif v23, block2, block3
 ;;
 ;;                                 block2:
 ;;                                     v118 = iconst.i32 15
-;;                                     v119 = iadd.i32 v9, v118  ; v118 = 15
+;;                                     v119 = iadd.i32 v10, v118  ; v118 = 15
 ;;                                     v122 = iconst.i32 -16
 ;;                                     v123 = band v119, v122  ; v122 = -16
-;;                                     v125 = iadd.i32 v12, v123
-;; @001f                               store notrap aligned region0 v125, v11
+;;                                     v125 = iadd.i32 v13, v123
+;; @001f                               store notrap aligned region0 v125, v12
 ;;                                     v141 = iconst.i32 -1476395002
 ;;                                     v142 = load.i64 notrap aligned readonly can_move v0+8
 ;;                                     v143 = load.i64 notrap aligned readonly can_move v142+32
-;; @001f                               v36 = iadd v143, v19
-;; @001f                               store notrap aligned v141, v36  ; v141 = -1476395002
+;; @001f                               v37 = iadd v143, v20
+;; @001f                               store notrap aligned v141, v37  ; v141 = -1476395002
 ;;                                     v144 = load.i64 notrap aligned readonly can_move v0+40
 ;;                                     v145 = load.i32 notrap aligned readonly can_move v144
-;; @001f                               store notrap aligned v145, v36+4
-;;                                     v146 = band.i64 v17, v16  ; v16 = -16
-;; @001f                               istore32 notrap aligned v146, v36+8
-;; @001f                               jump block4(v12, v36)
+;; @001f                               store notrap aligned v145, v37+4
+;;                                     v146 = band.i64 v18, v17  ; v17 = -16
+;; @001f                               istore32 notrap aligned v146, v37+8
+;; @001f                               jump block4(v13, v37)
 ;;
 ;;                                 block3 cold:
-;; @001f                               v24 = iconst.i32 -1476395002
-;; @001f                               v26 = load.i64 notrap aligned readonly can_move v0+40
-;; @001f                               v27 = load.i32 notrap aligned readonly can_move v26
-;; @001f                               v28 = iconst.i32 16
-;; @001f                               v29 = call fn0(v0, v24, v27, v9, v28)  ; v24 = -1476395002, v28 = 16
-;; @001f                               v96 = load.i64 notrap aligned readonly can_move v0+8
-;; @001f                               v30 = load.i64 notrap aligned readonly can_move v96+32
-;; @001f                               v31 = uextend.i64 v29
-;; @001f                               v32 = iadd v30, v31
-;; @001f                               jump block4(v29, v32)
+;; @001f                               v25 = iconst.i32 -1476395002
+;; @001f                               v27 = load.i64 notrap aligned readonly can_move v0+40
+;; @001f                               v28 = load.i32 notrap aligned readonly can_move v27
+;; @001f                               v29 = iconst.i32 16
+;; @001f                               v30 = call fn0(v0, v25, v28, v10, v29)  ; v25 = -1476395002, v29 = 16
+;; @001f                               v97 = load.i64 notrap aligned readonly can_move v0+8
+;; @001f                               v31 = load.i64 notrap aligned readonly can_move v97+32
+;; @001f                               v32 = uextend.i64 v30
+;; @001f                               v33 = iadd v31, v32
+;; @001f                               jump block4(v30, v33)
 ;;
-;;                                 block4(v41: i32, v42: i64):
-;;                                     v95 = stack_addr.i64 ss0
-;;                                     store notrap v41, v95
-;; @001f                               v43 = iconst.i64 16
-;; @001f                               v44 = iadd v42, v43  ; v43 = 16
-;; @001f                               store.i32 user2 region1 v2, v44
-;; @001f                               trapz v41, user16
+;;                                 block4(v42: i32, v43: i64):
+;;                                     v96 = stack_addr.i64 ss0
+;;                                     store notrap v42, v96
+;; @001f                               v44 = iconst.i64 16
+;; @001f                               v45 = iadd v43, v44  ; v44 = 16
+;; @001f                               store.i32 user2 region1 v2, v45
+;; @001f                               trapz v42, user16
 ;;                                     v147 = load.i64 notrap aligned readonly can_move v0+8
 ;;                                     v148 = load.i64 notrap aligned readonly can_move v147+32
-;; @001f                               v47 = uextend.i64 v41
-;; @001f                               v49 = iadd v148, v47
-;; @001f                               v51 = iadd v49, v43  ; v43 = 16
-;; @001f                               v52 = load.i32 user2 readonly region1 v51
-;; @001f                               v53 = uextend.i64 v52
-;; @001f                               v58 = icmp.i64 ugt v5, v53
-;; @001f                               trapnz v58, user17
-;; @001f                               v70 = load.i64 notrap aligned v147+40
-;; @001f                               v62 = iconst.i64 24
-;; @001f                               v63 = iadd v49, v62  ; v62 = 24
-;; @001f                               v72 = uadd_overflow_trap v63, v103, user2
-;; @001f                               v71 = iadd v148, v70
-;; @001f                               v73 = icmp ugt v72, v71
-;; @001f                               trapnz v73, user2
-;; @001f                               v46 = iconst.i32 0
-;; @001f                               call fn1(v0, v63, v46, v103), stack_map=[i32 @ ss0+0]  ; v46 = 0
-;;                                     v76 = load.i32 notrap v95
+;; @001f                               v48 = uextend.i64 v42
+;; @001f                               v50 = iadd v148, v48
+;; @001f                               v52 = iadd v50, v44  ; v44 = 16
+;; @001f                               v53 = load.i32 user2 readonly region1 v52
+;; @001f                               v54 = uextend.i64 v53
+;; @001f                               v60 = icmp.i64 ugt v5, v54
+;; @001f                               trapnz v60, user17
+;; @001f                               v74 = load.i64 notrap aligned v147+40
+;; @001f                               v64 = iconst.i64 24
+;; @001f                               v65 = iadd v50, v64  ; v64 = 24
+;; @001f                               v76 = uadd_overflow_trap v65, v103, user2
+;; @001f                               v75 = iadd v148, v74
+;; @001f                               v77 = icmp ugt v76, v75
+;; @001f                               trapnz v77, user2
+;; @001f                               v47 = iconst.i32 0
+;; @001f                               call fn1(v0, v65, v47, v103), stack_map=[i32 @ ss0+0]  ; v47 = 0
+;;                                     v80 = load.i32 notrap v96
 ;; @0022                               jump block1
 ;;
 ;;                                 block1:
-;; @0022                               return v76
+;; @0022                               return v80
 ;; }

--- a/tests/disas/gc/array-new-default-funcref.wat
+++ b/tests/disas/gc/array-new-default-funcref.wat
@@ -30,100 +30,100 @@
 ;; @001f                               v5 = uextend.i64 v2
 ;;                                     v110 = iconst.i64 2
 ;;                                     v111 = ishl v5, v110  ; v110 = 2
-;;                                     v108 = iconst.i64 32
-;; @001f                               v7 = ushr v111, v108  ; v108 = 32
-;; @001f                               trapnz v7, user18
+;;                                     v109 = iconst.i64 32
+;; @001f                               v8 = ushr v111, v109  ; v109 = 32
+;; @001f                               trapnz v8, user18
 ;; @001f                               v4 = iconst.i32 20
 ;;                                     v117 = iconst.i32 2
 ;;                                     v118 = ishl v2, v117  ; v117 = 2
-;; @001f                               v9 = uadd_overflow_trap v4, v118, user18  ; v4 = 20
-;; @001f                               v11 = load.i64 notrap aligned readonly can_move v0+32
-;; @001f                               v12 = load.i32 notrap aligned v11
-;; @001f                               v13 = load.i32 notrap aligned v11+4
-;; @001f                               v19 = uextend.i64 v12
-;; @001f                               v14 = uextend.i64 v9
-;; @001f                               v15 = iconst.i64 15
-;; @001f                               v17 = iadd v14, v15  ; v15 = 15
-;; @001f                               v16 = iconst.i64 -16
-;; @001f                               v18 = band v17, v16  ; v16 = -16
-;; @001f                               v20 = iadd v19, v18
-;; @001f                               v21 = uextend.i64 v13
-;; @001f                               v22 = icmp ule v20, v21
-;; @001f                               brif v22, block2, block3
+;; @001f                               v10 = uadd_overflow_trap v4, v118, user18  ; v4 = 20
+;; @001f                               v12 = load.i64 notrap aligned readonly can_move v0+32
+;; @001f                               v13 = load.i32 notrap aligned v12
+;; @001f                               v14 = load.i32 notrap aligned v12+4
+;; @001f                               v20 = uextend.i64 v13
+;; @001f                               v15 = uextend.i64 v10
+;; @001f                               v16 = iconst.i64 15
+;; @001f                               v18 = iadd v15, v16  ; v16 = 15
+;; @001f                               v17 = iconst.i64 -16
+;; @001f                               v19 = band v18, v17  ; v17 = -16
+;; @001f                               v21 = iadd v20, v19
+;; @001f                               v22 = uextend.i64 v14
+;; @001f                               v23 = icmp ule v21, v22
+;; @001f                               brif v23, block2, block3
 ;;
 ;;                                 block2:
 ;;                                     v126 = iconst.i32 15
-;;                                     v127 = iadd.i32 v9, v126  ; v126 = 15
+;;                                     v127 = iadd.i32 v10, v126  ; v126 = 15
 ;;                                     v130 = iconst.i32 -16
 ;;                                     v131 = band v127, v130  ; v130 = -16
-;;                                     v133 = iadd.i32 v12, v131
-;; @001f                               store notrap aligned region0 v133, v11
+;;                                     v133 = iadd.i32 v13, v131
+;; @001f                               store notrap aligned region0 v133, v12
 ;;                                     v148 = iconst.i32 -1476395002
 ;;                                     v149 = load.i64 notrap aligned readonly can_move v0+8
 ;;                                     v150 = load.i64 notrap aligned readonly can_move v149+32
-;; @001f                               v36 = iadd v150, v19
-;; @001f                               store notrap aligned v148, v36  ; v148 = -1476395002
+;; @001f                               v37 = iadd v150, v20
+;; @001f                               store notrap aligned v148, v37  ; v148 = -1476395002
 ;;                                     v151 = load.i64 notrap aligned readonly can_move v0+40
 ;;                                     v152 = load.i32 notrap aligned readonly can_move v151
-;; @001f                               store notrap aligned v152, v36+4
-;;                                     v153 = band.i64 v17, v16  ; v16 = -16
-;; @001f                               istore32 notrap aligned v153, v36+8
-;; @001f                               jump block4(v12, v36)
+;; @001f                               store notrap aligned v152, v37+4
+;;                                     v153 = band.i64 v18, v17  ; v17 = -16
+;; @001f                               istore32 notrap aligned v153, v37+8
+;; @001f                               jump block4(v13, v37)
 ;;
 ;;                                 block3 cold:
-;; @001f                               v24 = iconst.i32 -1476395002
-;; @001f                               v26 = load.i64 notrap aligned readonly can_move v0+40
-;; @001f                               v27 = load.i32 notrap aligned readonly can_move v26
-;; @001f                               v28 = iconst.i32 16
-;; @001f                               v29 = call fn0(v0, v24, v27, v9, v28)  ; v24 = -1476395002, v28 = 16
-;; @001f                               v104 = load.i64 notrap aligned readonly can_move v0+8
-;; @001f                               v30 = load.i64 notrap aligned readonly can_move v104+32
-;; @001f                               v31 = uextend.i64 v29
-;; @001f                               v32 = iadd v30, v31
-;; @001f                               jump block4(v29, v32)
+;; @001f                               v25 = iconst.i32 -1476395002
+;; @001f                               v27 = load.i64 notrap aligned readonly can_move v0+40
+;; @001f                               v28 = load.i32 notrap aligned readonly can_move v27
+;; @001f                               v29 = iconst.i32 16
+;; @001f                               v30 = call fn0(v0, v25, v28, v10, v29)  ; v25 = -1476395002, v29 = 16
+;; @001f                               v105 = load.i64 notrap aligned readonly can_move v0+8
+;; @001f                               v31 = load.i64 notrap aligned readonly can_move v105+32
+;; @001f                               v32 = uextend.i64 v30
+;; @001f                               v33 = iadd v31, v32
+;; @001f                               jump block4(v30, v33)
 ;;
-;;                                 block4(v41: i32, v42: i64):
-;;                                     v103 = stack_addr.i64 ss0
-;;                                     store notrap v41, v103
-;; @001f                               v43 = iconst.i64 16
-;; @001f                               v44 = iadd v42, v43  ; v43 = 16
-;; @001f                               store.i32 user2 region1 v2, v44
-;; @001f                               trapz v41, user16
+;;                                 block4(v42: i32, v43: i64):
+;;                                     v104 = stack_addr.i64 ss0
+;;                                     store notrap v42, v104
+;; @001f                               v44 = iconst.i64 16
+;; @001f                               v45 = iadd v43, v44  ; v44 = 16
+;; @001f                               store.i32 user2 region1 v2, v45
+;; @001f                               trapz v42, user16
 ;;                                     v154 = load.i64 notrap aligned readonly can_move v0+8
 ;;                                     v155 = load.i64 notrap aligned readonly can_move v154+32
-;; @001f                               v47 = uextend.i64 v41
-;; @001f                               v49 = iadd v155, v47
-;; @001f                               v51 = iadd v49, v43  ; v43 = 16
-;; @001f                               v52 = load.i32 user2 readonly region1 v51
-;; @001f                               v53 = uextend.i64 v52
-;; @001f                               v58 = icmp.i64 ugt v5, v53
-;; @001f                               trapnz v58, user17
-;; @001f                               v70 = load.i64 notrap aligned v154+40
-;; @001f                               v62 = iconst.i64 20
-;; @001f                               v63 = iadd v49, v62  ; v62 = 20
-;; @001f                               v72 = uadd_overflow_trap v63, v111, user2
-;; @001f                               v71 = iadd v155, v70
-;; @001f                               v73 = icmp ugt v72, v71
-;; @001f                               trapnz v73, user2
-;; @001f                               v45 = iconst.i64 0
-;; @001f                               v75 = call fn1(v0, v45), stack_map=[i32 @ ss0+0]  ; v45 = 0
-;; @001f                               v79 = icmp.i64 eq v5, v45  ; v45 = 0
-;; @001f                               v76 = ireduce.i32 v75
-;;                                     v109 = iconst.i64 4
-;; @001f                               v77 = iadd v63, v111
-;; @001f                               brif v79, block6, block5(v63)
+;; @001f                               v48 = uextend.i64 v42
+;; @001f                               v50 = iadd v155, v48
+;; @001f                               v52 = iadd v50, v44  ; v44 = 16
+;; @001f                               v53 = load.i32 user2 readonly region1 v52
+;; @001f                               v54 = uextend.i64 v53
+;; @001f                               v60 = icmp.i64 ugt v5, v54
+;; @001f                               trapnz v60, user17
+;; @001f                               v74 = load.i64 notrap aligned v154+40
+;; @001f                               v64 = iconst.i64 20
+;; @001f                               v65 = iadd v50, v64  ; v64 = 20
+;; @001f                               v76 = uadd_overflow_trap v65, v111, user2
+;; @001f                               v75 = iadd v155, v74
+;; @001f                               v77 = icmp ugt v76, v75
+;; @001f                               trapnz v77, user2
+;; @001f                               v46 = iconst.i64 0
+;; @001f                               v79 = call fn1(v0, v46), stack_map=[i32 @ ss0+0]  ; v46 = 0
+;; @001f                               v83 = icmp.i64 eq v5, v46  ; v46 = 0
+;; @001f                               v80 = ireduce.i32 v79
+;; @001f                               v6 = iconst.i64 4
+;; @001f                               v81 = iadd v65, v111
+;; @001f                               brif v83, block6, block5(v65)
 ;;
-;;                                 block5(v80: i64):
-;; @001f                               store.i32 notrap aligned little v76, v80
+;;                                 block5(v84: i64):
+;; @001f                               store.i32 notrap aligned little v80, v84
 ;;                                     v156 = iconst.i64 4
-;;                                     v157 = iadd v80, v156  ; v156 = 4
-;; @001f                               v83 = icmp eq v157, v77
-;; @001f                               brif v83, block6, block5(v157)
+;;                                     v157 = iadd v84, v156  ; v156 = 4
+;; @001f                               v87 = icmp eq v157, v81
+;; @001f                               brif v87, block6, block5(v157)
 ;;
 ;;                                 block6:
-;;                                     v84 = load.i32 notrap v103
+;;                                     v88 = load.i32 notrap v104
 ;; @0022                               jump block1
 ;;
 ;;                                 block1:
-;; @0022                               return v84
+;; @0022                               return v88
 ;; }

--- a/tests/disas/gc/array-new-default-i16.wat
+++ b/tests/disas/gc/array-new-default-i16.wat
@@ -30,85 +30,85 @@
 ;; @001f                               v5 = uextend.i64 v2
 ;;                                     v103 = iconst.i64 1
 ;;                                     v104 = ishl v5, v103  ; v103 = 1
-;;                                     v100 = iconst.i64 32
-;; @001f                               v7 = ushr v104, v100  ; v100 = 32
-;; @001f                               trapnz v7, user18
+;;                                     v101 = iconst.i64 32
+;; @001f                               v8 = ushr v104, v101  ; v101 = 32
+;; @001f                               trapnz v8, user18
 ;; @001f                               v4 = iconst.i32 20
 ;;                                     v108 = iadd v2, v2
-;; @001f                               v9 = uadd_overflow_trap v4, v108, user18  ; v4 = 20
-;; @001f                               v11 = load.i64 notrap aligned readonly can_move v0+32
-;; @001f                               v12 = load.i32 notrap aligned v11
-;; @001f                               v13 = load.i32 notrap aligned v11+4
-;; @001f                               v19 = uextend.i64 v12
-;; @001f                               v14 = uextend.i64 v9
-;; @001f                               v15 = iconst.i64 15
-;; @001f                               v17 = iadd v14, v15  ; v15 = 15
-;; @001f                               v16 = iconst.i64 -16
-;; @001f                               v18 = band v17, v16  ; v16 = -16
-;; @001f                               v20 = iadd v19, v18
-;; @001f                               v21 = uextend.i64 v13
-;; @001f                               v22 = icmp ule v20, v21
-;; @001f                               brif v22, block2, block3
+;; @001f                               v10 = uadd_overflow_trap v4, v108, user18  ; v4 = 20
+;; @001f                               v12 = load.i64 notrap aligned readonly can_move v0+32
+;; @001f                               v13 = load.i32 notrap aligned v12
+;; @001f                               v14 = load.i32 notrap aligned v12+4
+;; @001f                               v20 = uextend.i64 v13
+;; @001f                               v15 = uextend.i64 v10
+;; @001f                               v16 = iconst.i64 15
+;; @001f                               v18 = iadd v15, v16  ; v16 = 15
+;; @001f                               v17 = iconst.i64 -16
+;; @001f                               v19 = band v18, v17  ; v17 = -16
+;; @001f                               v21 = iadd v20, v19
+;; @001f                               v22 = uextend.i64 v14
+;; @001f                               v23 = icmp ule v21, v22
+;; @001f                               brif v23, block2, block3
 ;;
 ;;                                 block2:
 ;;                                     v123 = iconst.i32 15
-;;                                     v124 = iadd.i32 v9, v123  ; v123 = 15
+;;                                     v124 = iadd.i32 v10, v123  ; v123 = 15
 ;;                                     v127 = iconst.i32 -16
 ;;                                     v128 = band v124, v127  ; v127 = -16
-;;                                     v130 = iadd.i32 v12, v128
-;; @001f                               store notrap aligned region0 v130, v11
+;;                                     v130 = iadd.i32 v13, v128
+;; @001f                               store notrap aligned region0 v130, v12
 ;;                                     v151 = iconst.i32 -1476395002
 ;;                                     v152 = load.i64 notrap aligned readonly can_move v0+8
 ;;                                     v153 = load.i64 notrap aligned readonly can_move v152+32
-;; @001f                               v36 = iadd v153, v19
-;; @001f                               store notrap aligned v151, v36  ; v151 = -1476395002
+;; @001f                               v37 = iadd v153, v20
+;; @001f                               store notrap aligned v151, v37  ; v151 = -1476395002
 ;;                                     v154 = load.i64 notrap aligned readonly can_move v0+40
 ;;                                     v155 = load.i32 notrap aligned readonly can_move v154
-;; @001f                               store notrap aligned v155, v36+4
-;;                                     v156 = band.i64 v17, v16  ; v16 = -16
-;; @001f                               istore32 notrap aligned v156, v36+8
-;; @001f                               jump block4(v12, v36)
+;; @001f                               store notrap aligned v155, v37+4
+;;                                     v156 = band.i64 v18, v17  ; v17 = -16
+;; @001f                               istore32 notrap aligned v156, v37+8
+;; @001f                               jump block4(v13, v37)
 ;;
 ;;                                 block3 cold:
-;; @001f                               v24 = iconst.i32 -1476395002
-;; @001f                               v26 = load.i64 notrap aligned readonly can_move v0+40
-;; @001f                               v27 = load.i32 notrap aligned readonly can_move v26
-;; @001f                               v28 = iconst.i32 16
-;; @001f                               v29 = call fn0(v0, v24, v27, v9, v28)  ; v24 = -1476395002, v28 = 16
-;; @001f                               v96 = load.i64 notrap aligned readonly can_move v0+8
-;; @001f                               v30 = load.i64 notrap aligned readonly can_move v96+32
-;; @001f                               v31 = uextend.i64 v29
-;; @001f                               v32 = iadd v30, v31
-;; @001f                               jump block4(v29, v32)
+;; @001f                               v25 = iconst.i32 -1476395002
+;; @001f                               v27 = load.i64 notrap aligned readonly can_move v0+40
+;; @001f                               v28 = load.i32 notrap aligned readonly can_move v27
+;; @001f                               v29 = iconst.i32 16
+;; @001f                               v30 = call fn0(v0, v25, v28, v10, v29)  ; v25 = -1476395002, v29 = 16
+;; @001f                               v97 = load.i64 notrap aligned readonly can_move v0+8
+;; @001f                               v31 = load.i64 notrap aligned readonly can_move v97+32
+;; @001f                               v32 = uextend.i64 v30
+;; @001f                               v33 = iadd v31, v32
+;; @001f                               jump block4(v30, v33)
 ;;
-;;                                 block4(v41: i32, v42: i64):
-;;                                     v95 = stack_addr.i64 ss0
-;;                                     store notrap v41, v95
-;; @001f                               v43 = iconst.i64 16
-;; @001f                               v44 = iadd v42, v43  ; v43 = 16
-;; @001f                               store.i32 user2 region1 v2, v44
-;; @001f                               trapz v41, user16
+;;                                 block4(v42: i32, v43: i64):
+;;                                     v96 = stack_addr.i64 ss0
+;;                                     store notrap v42, v96
+;; @001f                               v44 = iconst.i64 16
+;; @001f                               v45 = iadd v43, v44  ; v44 = 16
+;; @001f                               store.i32 user2 region1 v2, v45
+;; @001f                               trapz v42, user16
 ;;                                     v157 = load.i64 notrap aligned readonly can_move v0+8
 ;;                                     v158 = load.i64 notrap aligned readonly can_move v157+32
-;; @001f                               v47 = uextend.i64 v41
-;; @001f                               v49 = iadd v158, v47
-;; @001f                               v51 = iadd v49, v43  ; v43 = 16
-;; @001f                               v52 = load.i32 user2 readonly region1 v51
-;; @001f                               v53 = uextend.i64 v52
-;; @001f                               v58 = icmp.i64 ugt v5, v53
-;; @001f                               trapnz v58, user17
-;; @001f                               v70 = load.i64 notrap aligned v157+40
-;; @001f                               v62 = iconst.i64 20
-;; @001f                               v63 = iadd v49, v62  ; v62 = 20
-;; @001f                               v72 = uadd_overflow_trap v63, v104, user2
-;; @001f                               v71 = iadd v158, v70
-;; @001f                               v73 = icmp ugt v72, v71
-;; @001f                               trapnz v73, user2
-;; @001f                               v45 = iconst.i32 0
-;; @001f                               call fn1(v0, v63, v45, v104), stack_map=[i32 @ ss0+0]  ; v45 = 0
-;;                                     v76 = load.i32 notrap v95
+;; @001f                               v48 = uextend.i64 v42
+;; @001f                               v50 = iadd v158, v48
+;; @001f                               v52 = iadd v50, v44  ; v44 = 16
+;; @001f                               v53 = load.i32 user2 readonly region1 v52
+;; @001f                               v54 = uextend.i64 v53
+;; @001f                               v60 = icmp.i64 ugt v5, v54
+;; @001f                               trapnz v60, user17
+;; @001f                               v74 = load.i64 notrap aligned v157+40
+;; @001f                               v64 = iconst.i64 20
+;; @001f                               v65 = iadd v50, v64  ; v64 = 20
+;; @001f                               v76 = uadd_overflow_trap v65, v104, user2
+;; @001f                               v75 = iadd v158, v74
+;; @001f                               v77 = icmp ugt v76, v75
+;; @001f                               trapnz v77, user2
+;; @001f                               v46 = iconst.i32 0
+;; @001f                               call fn1(v0, v65, v46, v104), stack_map=[i32 @ ss0+0]  ; v46 = 0
+;;                                     v80 = load.i32 notrap v96
 ;; @0022                               jump block1
 ;;
 ;;                                 block1:
-;; @0022                               return v76
+;; @0022                               return v80
 ;; }

--- a/tests/disas/gc/array-new-default-i32.wat
+++ b/tests/disas/gc/array-new-default-i32.wat
@@ -30,86 +30,86 @@
 ;; @001f                               v5 = uextend.i64 v2
 ;;                                     v102 = iconst.i64 2
 ;;                                     v103 = ishl v5, v102  ; v102 = 2
-;;                                     v100 = iconst.i64 32
-;; @001f                               v7 = ushr v103, v100  ; v100 = 32
-;; @001f                               trapnz v7, user18
+;;                                     v101 = iconst.i64 32
+;; @001f                               v8 = ushr v103, v101  ; v101 = 32
+;; @001f                               trapnz v8, user18
 ;; @001f                               v4 = iconst.i32 20
 ;;                                     v109 = iconst.i32 2
 ;;                                     v110 = ishl v2, v109  ; v109 = 2
-;; @001f                               v9 = uadd_overflow_trap v4, v110, user18  ; v4 = 20
-;; @001f                               v11 = load.i64 notrap aligned readonly can_move v0+32
-;; @001f                               v12 = load.i32 notrap aligned v11
-;; @001f                               v13 = load.i32 notrap aligned v11+4
-;; @001f                               v19 = uextend.i64 v12
-;; @001f                               v14 = uextend.i64 v9
-;; @001f                               v15 = iconst.i64 15
-;; @001f                               v17 = iadd v14, v15  ; v15 = 15
-;; @001f                               v16 = iconst.i64 -16
-;; @001f                               v18 = band v17, v16  ; v16 = -16
-;; @001f                               v20 = iadd v19, v18
-;; @001f                               v21 = uextend.i64 v13
-;; @001f                               v22 = icmp ule v20, v21
-;; @001f                               brif v22, block2, block3
+;; @001f                               v10 = uadd_overflow_trap v4, v110, user18  ; v4 = 20
+;; @001f                               v12 = load.i64 notrap aligned readonly can_move v0+32
+;; @001f                               v13 = load.i32 notrap aligned v12
+;; @001f                               v14 = load.i32 notrap aligned v12+4
+;; @001f                               v20 = uextend.i64 v13
+;; @001f                               v15 = uextend.i64 v10
+;; @001f                               v16 = iconst.i64 15
+;; @001f                               v18 = iadd v15, v16  ; v16 = 15
+;; @001f                               v17 = iconst.i64 -16
+;; @001f                               v19 = band v18, v17  ; v17 = -16
+;; @001f                               v21 = iadd v20, v19
+;; @001f                               v22 = uextend.i64 v14
+;; @001f                               v23 = icmp ule v21, v22
+;; @001f                               brif v23, block2, block3
 ;;
 ;;                                 block2:
 ;;                                     v118 = iconst.i32 15
-;;                                     v119 = iadd.i32 v9, v118  ; v118 = 15
+;;                                     v119 = iadd.i32 v10, v118  ; v118 = 15
 ;;                                     v122 = iconst.i32 -16
 ;;                                     v123 = band v119, v122  ; v122 = -16
-;;                                     v125 = iadd.i32 v12, v123
-;; @001f                               store notrap aligned region0 v125, v11
+;;                                     v125 = iadd.i32 v13, v123
+;; @001f                               store notrap aligned region0 v125, v12
 ;;                                     v141 = iconst.i32 -1476395002
 ;;                                     v142 = load.i64 notrap aligned readonly can_move v0+8
 ;;                                     v143 = load.i64 notrap aligned readonly can_move v142+32
-;; @001f                               v36 = iadd v143, v19
-;; @001f                               store notrap aligned v141, v36  ; v141 = -1476395002
+;; @001f                               v37 = iadd v143, v20
+;; @001f                               store notrap aligned v141, v37  ; v141 = -1476395002
 ;;                                     v144 = load.i64 notrap aligned readonly can_move v0+40
 ;;                                     v145 = load.i32 notrap aligned readonly can_move v144
-;; @001f                               store notrap aligned v145, v36+4
-;;                                     v146 = band.i64 v17, v16  ; v16 = -16
-;; @001f                               istore32 notrap aligned v146, v36+8
-;; @001f                               jump block4(v12, v36)
+;; @001f                               store notrap aligned v145, v37+4
+;;                                     v146 = band.i64 v18, v17  ; v17 = -16
+;; @001f                               istore32 notrap aligned v146, v37+8
+;; @001f                               jump block4(v13, v37)
 ;;
 ;;                                 block3 cold:
-;; @001f                               v24 = iconst.i32 -1476395002
-;; @001f                               v26 = load.i64 notrap aligned readonly can_move v0+40
-;; @001f                               v27 = load.i32 notrap aligned readonly can_move v26
-;; @001f                               v28 = iconst.i32 16
-;; @001f                               v29 = call fn0(v0, v24, v27, v9, v28)  ; v24 = -1476395002, v28 = 16
-;; @001f                               v96 = load.i64 notrap aligned readonly can_move v0+8
-;; @001f                               v30 = load.i64 notrap aligned readonly can_move v96+32
-;; @001f                               v31 = uextend.i64 v29
-;; @001f                               v32 = iadd v30, v31
-;; @001f                               jump block4(v29, v32)
+;; @001f                               v25 = iconst.i32 -1476395002
+;; @001f                               v27 = load.i64 notrap aligned readonly can_move v0+40
+;; @001f                               v28 = load.i32 notrap aligned readonly can_move v27
+;; @001f                               v29 = iconst.i32 16
+;; @001f                               v30 = call fn0(v0, v25, v28, v10, v29)  ; v25 = -1476395002, v29 = 16
+;; @001f                               v97 = load.i64 notrap aligned readonly can_move v0+8
+;; @001f                               v31 = load.i64 notrap aligned readonly can_move v97+32
+;; @001f                               v32 = uextend.i64 v30
+;; @001f                               v33 = iadd v31, v32
+;; @001f                               jump block4(v30, v33)
 ;;
-;;                                 block4(v41: i32, v42: i64):
-;;                                     v95 = stack_addr.i64 ss0
-;;                                     store notrap v41, v95
-;; @001f                               v43 = iconst.i64 16
-;; @001f                               v44 = iadd v42, v43  ; v43 = 16
-;; @001f                               store.i32 user2 region1 v2, v44
-;; @001f                               trapz v41, user16
+;;                                 block4(v42: i32, v43: i64):
+;;                                     v96 = stack_addr.i64 ss0
+;;                                     store notrap v42, v96
+;; @001f                               v44 = iconst.i64 16
+;; @001f                               v45 = iadd v43, v44  ; v44 = 16
+;; @001f                               store.i32 user2 region1 v2, v45
+;; @001f                               trapz v42, user16
 ;;                                     v147 = load.i64 notrap aligned readonly can_move v0+8
 ;;                                     v148 = load.i64 notrap aligned readonly can_move v147+32
-;; @001f                               v47 = uextend.i64 v41
-;; @001f                               v49 = iadd v148, v47
-;; @001f                               v51 = iadd v49, v43  ; v43 = 16
-;; @001f                               v52 = load.i32 user2 readonly region1 v51
-;; @001f                               v53 = uextend.i64 v52
-;; @001f                               v58 = icmp.i64 ugt v5, v53
-;; @001f                               trapnz v58, user17
-;; @001f                               v70 = load.i64 notrap aligned v147+40
-;; @001f                               v62 = iconst.i64 20
-;; @001f                               v63 = iadd v49, v62  ; v62 = 20
-;; @001f                               v72 = uadd_overflow_trap v63, v103, user2
-;; @001f                               v71 = iadd v148, v70
-;; @001f                               v73 = icmp ugt v72, v71
-;; @001f                               trapnz v73, user2
-;; @001f                               v45 = iconst.i32 0
-;; @001f                               call fn1(v0, v63, v45, v103), stack_map=[i32 @ ss0+0]  ; v45 = 0
-;;                                     v76 = load.i32 notrap v95
+;; @001f                               v48 = uextend.i64 v42
+;; @001f                               v50 = iadd v148, v48
+;; @001f                               v52 = iadd v50, v44  ; v44 = 16
+;; @001f                               v53 = load.i32 user2 readonly region1 v52
+;; @001f                               v54 = uextend.i64 v53
+;; @001f                               v60 = icmp.i64 ugt v5, v54
+;; @001f                               trapnz v60, user17
+;; @001f                               v74 = load.i64 notrap aligned v147+40
+;; @001f                               v64 = iconst.i64 20
+;; @001f                               v65 = iadd v50, v64  ; v64 = 20
+;; @001f                               v76 = uadd_overflow_trap v65, v103, user2
+;; @001f                               v75 = iadd v148, v74
+;; @001f                               v77 = icmp ugt v76, v75
+;; @001f                               trapnz v77, user2
+;; @001f                               v46 = iconst.i32 0
+;; @001f                               call fn1(v0, v65, v46, v103), stack_map=[i32 @ ss0+0]  ; v46 = 0
+;;                                     v80 = load.i32 notrap v96
 ;; @0022                               jump block1
 ;;
 ;;                                 block1:
-;; @0022                               return v76
+;; @0022                               return v80
 ;; }

--- a/tests/disas/gc/array-new-default-i64.wat
+++ b/tests/disas/gc/array-new-default-i64.wat
@@ -30,86 +30,86 @@
 ;; @001f                               v5 = uextend.i64 v2
 ;;                                     v102 = iconst.i64 3
 ;;                                     v103 = ishl v5, v102  ; v102 = 3
-;;                                     v100 = iconst.i64 32
-;; @001f                               v7 = ushr v103, v100  ; v100 = 32
-;; @001f                               trapnz v7, user18
+;;                                     v101 = iconst.i64 32
+;; @001f                               v8 = ushr v103, v101  ; v101 = 32
+;; @001f                               trapnz v8, user18
 ;; @001f                               v4 = iconst.i32 24
 ;;                                     v109 = iconst.i32 3
 ;;                                     v110 = ishl v2, v109  ; v109 = 3
-;; @001f                               v9 = uadd_overflow_trap v4, v110, user18  ; v4 = 24
-;; @001f                               v11 = load.i64 notrap aligned readonly can_move v0+32
-;; @001f                               v12 = load.i32 notrap aligned v11
-;; @001f                               v13 = load.i32 notrap aligned v11+4
-;; @001f                               v19 = uextend.i64 v12
-;; @001f                               v14 = uextend.i64 v9
-;; @001f                               v15 = iconst.i64 15
-;; @001f                               v17 = iadd v14, v15  ; v15 = 15
-;; @001f                               v16 = iconst.i64 -16
-;; @001f                               v18 = band v17, v16  ; v16 = -16
-;; @001f                               v20 = iadd v19, v18
-;; @001f                               v21 = uextend.i64 v13
-;; @001f                               v22 = icmp ule v20, v21
-;; @001f                               brif v22, block2, block3
+;; @001f                               v10 = uadd_overflow_trap v4, v110, user18  ; v4 = 24
+;; @001f                               v12 = load.i64 notrap aligned readonly can_move v0+32
+;; @001f                               v13 = load.i32 notrap aligned v12
+;; @001f                               v14 = load.i32 notrap aligned v12+4
+;; @001f                               v20 = uextend.i64 v13
+;; @001f                               v15 = uextend.i64 v10
+;; @001f                               v16 = iconst.i64 15
+;; @001f                               v18 = iadd v15, v16  ; v16 = 15
+;; @001f                               v17 = iconst.i64 -16
+;; @001f                               v19 = band v18, v17  ; v17 = -16
+;; @001f                               v21 = iadd v20, v19
+;; @001f                               v22 = uextend.i64 v14
+;; @001f                               v23 = icmp ule v21, v22
+;; @001f                               brif v23, block2, block3
 ;;
 ;;                                 block2:
 ;;                                     v118 = iconst.i32 15
-;;                                     v119 = iadd.i32 v9, v118  ; v118 = 15
+;;                                     v119 = iadd.i32 v10, v118  ; v118 = 15
 ;;                                     v122 = iconst.i32 -16
 ;;                                     v123 = band v119, v122  ; v122 = -16
-;;                                     v125 = iadd.i32 v12, v123
-;; @001f                               store notrap aligned region0 v125, v11
+;;                                     v125 = iadd.i32 v13, v123
+;; @001f                               store notrap aligned region0 v125, v12
 ;;                                     v140 = iconst.i32 -1476395002
 ;;                                     v141 = load.i64 notrap aligned readonly can_move v0+8
 ;;                                     v142 = load.i64 notrap aligned readonly can_move v141+32
-;; @001f                               v36 = iadd v142, v19
-;; @001f                               store notrap aligned v140, v36  ; v140 = -1476395002
+;; @001f                               v37 = iadd v142, v20
+;; @001f                               store notrap aligned v140, v37  ; v140 = -1476395002
 ;;                                     v143 = load.i64 notrap aligned readonly can_move v0+40
 ;;                                     v144 = load.i32 notrap aligned readonly can_move v143
-;; @001f                               store notrap aligned v144, v36+4
-;;                                     v145 = band.i64 v17, v16  ; v16 = -16
-;; @001f                               istore32 notrap aligned v145, v36+8
-;; @001f                               jump block4(v12, v36)
+;; @001f                               store notrap aligned v144, v37+4
+;;                                     v145 = band.i64 v18, v17  ; v17 = -16
+;; @001f                               istore32 notrap aligned v145, v37+8
+;; @001f                               jump block4(v13, v37)
 ;;
 ;;                                 block3 cold:
-;; @001f                               v24 = iconst.i32 -1476395002
-;; @001f                               v26 = load.i64 notrap aligned readonly can_move v0+40
-;; @001f                               v27 = load.i32 notrap aligned readonly can_move v26
-;; @001f                               v28 = iconst.i32 16
-;; @001f                               v29 = call fn0(v0, v24, v27, v9, v28)  ; v24 = -1476395002, v28 = 16
-;; @001f                               v96 = load.i64 notrap aligned readonly can_move v0+8
-;; @001f                               v30 = load.i64 notrap aligned readonly can_move v96+32
-;; @001f                               v31 = uextend.i64 v29
-;; @001f                               v32 = iadd v30, v31
-;; @001f                               jump block4(v29, v32)
+;; @001f                               v25 = iconst.i32 -1476395002
+;; @001f                               v27 = load.i64 notrap aligned readonly can_move v0+40
+;; @001f                               v28 = load.i32 notrap aligned readonly can_move v27
+;; @001f                               v29 = iconst.i32 16
+;; @001f                               v30 = call fn0(v0, v25, v28, v10, v29)  ; v25 = -1476395002, v29 = 16
+;; @001f                               v97 = load.i64 notrap aligned readonly can_move v0+8
+;; @001f                               v31 = load.i64 notrap aligned readonly can_move v97+32
+;; @001f                               v32 = uextend.i64 v30
+;; @001f                               v33 = iadd v31, v32
+;; @001f                               jump block4(v30, v33)
 ;;
-;;                                 block4(v41: i32, v42: i64):
-;;                                     v95 = stack_addr.i64 ss0
-;;                                     store notrap v41, v95
-;; @001f                               v43 = iconst.i64 16
-;; @001f                               v44 = iadd v42, v43  ; v43 = 16
-;; @001f                               store.i32 user2 region1 v2, v44
-;; @001f                               trapz v41, user16
+;;                                 block4(v42: i32, v43: i64):
+;;                                     v96 = stack_addr.i64 ss0
+;;                                     store notrap v42, v96
+;; @001f                               v44 = iconst.i64 16
+;; @001f                               v45 = iadd v43, v44  ; v44 = 16
+;; @001f                               store.i32 user2 region1 v2, v45
+;; @001f                               trapz v42, user16
 ;;                                     v146 = load.i64 notrap aligned readonly can_move v0+8
 ;;                                     v147 = load.i64 notrap aligned readonly can_move v146+32
-;; @001f                               v47 = uextend.i64 v41
-;; @001f                               v49 = iadd v147, v47
-;; @001f                               v51 = iadd v49, v43  ; v43 = 16
-;; @001f                               v52 = load.i32 user2 readonly region1 v51
-;; @001f                               v53 = uextend.i64 v52
-;; @001f                               v58 = icmp.i64 ugt v5, v53
-;; @001f                               trapnz v58, user17
-;; @001f                               v70 = load.i64 notrap aligned v146+40
-;; @001f                               v62 = iconst.i64 24
-;; @001f                               v63 = iadd v49, v62  ; v62 = 24
-;; @001f                               v72 = uadd_overflow_trap v63, v103, user2
-;; @001f                               v71 = iadd v147, v70
-;; @001f                               v73 = icmp ugt v72, v71
-;; @001f                               trapnz v73, user2
-;; @001f                               v46 = iconst.i32 0
-;; @001f                               call fn1(v0, v63, v46, v103), stack_map=[i32 @ ss0+0]  ; v46 = 0
-;;                                     v76 = load.i32 notrap v95
+;; @001f                               v48 = uextend.i64 v42
+;; @001f                               v50 = iadd v147, v48
+;; @001f                               v52 = iadd v50, v44  ; v44 = 16
+;; @001f                               v53 = load.i32 user2 readonly region1 v52
+;; @001f                               v54 = uextend.i64 v53
+;; @001f                               v60 = icmp.i64 ugt v5, v54
+;; @001f                               trapnz v60, user17
+;; @001f                               v74 = load.i64 notrap aligned v146+40
+;; @001f                               v64 = iconst.i64 24
+;; @001f                               v65 = iadd v50, v64  ; v64 = 24
+;; @001f                               v76 = uadd_overflow_trap v65, v103, user2
+;; @001f                               v75 = iadd v147, v74
+;; @001f                               v77 = icmp ugt v76, v75
+;; @001f                               trapnz v77, user2
+;; @001f                               v47 = iconst.i32 0
+;; @001f                               call fn1(v0, v65, v47, v103), stack_map=[i32 @ ss0+0]  ; v47 = 0
+;;                                     v80 = load.i32 notrap v96
 ;; @0022                               jump block1
 ;;
 ;;                                 block1:
-;; @0022                               return v76
+;; @0022                               return v80
 ;; }

--- a/tests/disas/gc/array-new-default-i8.wat
+++ b/tests/disas/gc/array-new-default-i8.wat
@@ -28,84 +28,84 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @001f                               v5 = uextend.i64 v2
-;;                                     v99 = iconst.i64 32
-;; @001f                               v7 = ushr v5, v99  ; v99 = 32
-;; @001f                               trapnz v7, user18
+;;                                     v100 = iconst.i64 32
+;; @001f                               v8 = ushr v5, v100  ; v100 = 32
+;; @001f                               trapnz v8, user18
 ;; @001f                               v4 = iconst.i32 20
-;; @001f                               v9 = uadd_overflow_trap v4, v2, user18  ; v4 = 20
-;; @001f                               v11 = load.i64 notrap aligned readonly can_move v0+32
-;; @001f                               v12 = load.i32 notrap aligned v11
-;; @001f                               v13 = load.i32 notrap aligned v11+4
-;; @001f                               v19 = uextend.i64 v12
-;; @001f                               v14 = uextend.i64 v9
-;; @001f                               v15 = iconst.i64 15
-;; @001f                               v17 = iadd v14, v15  ; v15 = 15
-;; @001f                               v16 = iconst.i64 -16
-;; @001f                               v18 = band v17, v16  ; v16 = -16
-;; @001f                               v20 = iadd v19, v18
-;; @001f                               v21 = uextend.i64 v13
-;; @001f                               v22 = icmp ule v20, v21
-;; @001f                               brif v22, block2, block3
+;; @001f                               v10 = uadd_overflow_trap v4, v2, user18  ; v4 = 20
+;; @001f                               v12 = load.i64 notrap aligned readonly can_move v0+32
+;; @001f                               v13 = load.i32 notrap aligned v12
+;; @001f                               v14 = load.i32 notrap aligned v12+4
+;; @001f                               v20 = uextend.i64 v13
+;; @001f                               v15 = uextend.i64 v10
+;; @001f                               v16 = iconst.i64 15
+;; @001f                               v18 = iadd v15, v16  ; v16 = 15
+;; @001f                               v17 = iconst.i64 -16
+;; @001f                               v19 = band v18, v17  ; v17 = -16
+;; @001f                               v21 = iadd v20, v19
+;; @001f                               v22 = uextend.i64 v14
+;; @001f                               v23 = icmp ule v21, v22
+;; @001f                               brif v23, block2, block3
 ;;
 ;;                                 block2:
 ;;                                     v108 = iconst.i32 15
-;;                                     v109 = iadd.i32 v9, v108  ; v108 = 15
+;;                                     v109 = iadd.i32 v10, v108  ; v108 = 15
 ;;                                     v112 = iconst.i32 -16
 ;;                                     v113 = band v109, v112  ; v112 = -16
-;;                                     v115 = iadd.i32 v12, v113
-;; @001f                               store notrap aligned region0 v115, v11
+;;                                     v115 = iadd.i32 v13, v113
+;; @001f                               store notrap aligned region0 v115, v12
 ;;                                     v129 = iconst.i32 -1476395002
 ;;                                     v130 = load.i64 notrap aligned readonly can_move v0+8
 ;;                                     v131 = load.i64 notrap aligned readonly can_move v130+32
-;; @001f                               v36 = iadd v131, v19
-;; @001f                               store notrap aligned v129, v36  ; v129 = -1476395002
+;; @001f                               v37 = iadd v131, v20
+;; @001f                               store notrap aligned v129, v37  ; v129 = -1476395002
 ;;                                     v132 = load.i64 notrap aligned readonly can_move v0+40
 ;;                                     v133 = load.i32 notrap aligned readonly can_move v132
-;; @001f                               store notrap aligned v133, v36+4
-;;                                     v134 = band.i64 v17, v16  ; v16 = -16
-;; @001f                               istore32 notrap aligned v134, v36+8
-;; @001f                               jump block4(v12, v36)
+;; @001f                               store notrap aligned v133, v37+4
+;;                                     v134 = band.i64 v18, v17  ; v17 = -16
+;; @001f                               istore32 notrap aligned v134, v37+8
+;; @001f                               jump block4(v13, v37)
 ;;
 ;;                                 block3 cold:
-;; @001f                               v24 = iconst.i32 -1476395002
-;; @001f                               v26 = load.i64 notrap aligned readonly can_move v0+40
-;; @001f                               v27 = load.i32 notrap aligned readonly can_move v26
-;; @001f                               v28 = iconst.i32 16
-;; @001f                               v29 = call fn0(v0, v24, v27, v9, v28)  ; v24 = -1476395002, v28 = 16
-;; @001f                               v95 = load.i64 notrap aligned readonly can_move v0+8
-;; @001f                               v30 = load.i64 notrap aligned readonly can_move v95+32
-;; @001f                               v31 = uextend.i64 v29
-;; @001f                               v32 = iadd v30, v31
-;; @001f                               jump block4(v29, v32)
+;; @001f                               v25 = iconst.i32 -1476395002
+;; @001f                               v27 = load.i64 notrap aligned readonly can_move v0+40
+;; @001f                               v28 = load.i32 notrap aligned readonly can_move v27
+;; @001f                               v29 = iconst.i32 16
+;; @001f                               v30 = call fn0(v0, v25, v28, v10, v29)  ; v25 = -1476395002, v29 = 16
+;; @001f                               v96 = load.i64 notrap aligned readonly can_move v0+8
+;; @001f                               v31 = load.i64 notrap aligned readonly can_move v96+32
+;; @001f                               v32 = uextend.i64 v30
+;; @001f                               v33 = iadd v31, v32
+;; @001f                               jump block4(v30, v33)
 ;;
-;;                                 block4(v41: i32, v42: i64):
-;;                                     v94 = stack_addr.i64 ss0
-;;                                     store notrap v41, v94
-;; @001f                               v43 = iconst.i64 16
-;; @001f                               v44 = iadd v42, v43  ; v43 = 16
-;; @001f                               store.i32 user2 region1 v2, v44
-;; @001f                               trapz v41, user16
+;;                                 block4(v42: i32, v43: i64):
+;;                                     v95 = stack_addr.i64 ss0
+;;                                     store notrap v42, v95
+;; @001f                               v44 = iconst.i64 16
+;; @001f                               v45 = iadd v43, v44  ; v44 = 16
+;; @001f                               store.i32 user2 region1 v2, v45
+;; @001f                               trapz v42, user16
 ;;                                     v135 = load.i64 notrap aligned readonly can_move v0+8
 ;;                                     v136 = load.i64 notrap aligned readonly can_move v135+32
-;; @001f                               v47 = uextend.i64 v41
-;; @001f                               v49 = iadd v136, v47
-;; @001f                               v51 = iadd v49, v43  ; v43 = 16
-;; @001f                               v52 = load.i32 user2 readonly region1 v51
-;; @001f                               v53 = uextend.i64 v52
-;; @001f                               v58 = icmp.i64 ugt v5, v53
-;; @001f                               trapnz v58, user17
-;; @001f                               v70 = load.i64 notrap aligned v135+40
-;; @001f                               v62 = iconst.i64 20
-;; @001f                               v63 = iadd v49, v62  ; v62 = 20
-;; @001f                               v72 = uadd_overflow_trap v63, v5, user2
-;; @001f                               v71 = iadd v136, v70
-;; @001f                               v73 = icmp ugt v72, v71
-;; @001f                               trapnz v73, user2
-;; @001f                               v45 = iconst.i32 0
-;; @001f                               call fn1(v0, v63, v45, v5), stack_map=[i32 @ ss0+0]  ; v45 = 0
-;;                                     v75 = load.i32 notrap v94
+;; @001f                               v48 = uextend.i64 v42
+;; @001f                               v50 = iadd v136, v48
+;; @001f                               v52 = iadd v50, v44  ; v44 = 16
+;; @001f                               v53 = load.i32 user2 readonly region1 v52
+;; @001f                               v54 = uextend.i64 v53
+;; @001f                               v60 = icmp.i64 ugt v5, v54
+;; @001f                               trapnz v60, user17
+;; @001f                               v74 = load.i64 notrap aligned v135+40
+;; @001f                               v64 = iconst.i64 20
+;; @001f                               v65 = iadd v50, v64  ; v64 = 20
+;; @001f                               v76 = uadd_overflow_trap v65, v5, user2
+;; @001f                               v75 = iadd v136, v74
+;; @001f                               v77 = icmp ugt v76, v75
+;; @001f                               trapnz v77, user2
+;; @001f                               v46 = iconst.i32 0
+;; @001f                               call fn1(v0, v65, v46, v5), stack_map=[i32 @ ss0+0]  ; v46 = 0
+;;                                     v79 = load.i32 notrap v95
 ;; @0022                               jump block1
 ;;
 ;;                                 block1:
-;; @0022                               return v75
+;; @0022                               return v79
 ;; }

--- a/tests/disas/gc/copying/array-fill.wat
+++ b/tests/disas/gc/copying/array-fill.wat
@@ -30,33 +30,33 @@
 ;; @0027                               v11 = load.i32 user2 readonly region0 v10
 ;; @0027                               v13 = uextend.i64 v3
 ;; @0027                               v14 = uextend.i64 v5
-;; @0027                               v16 = iadd v13, v14
+;; @0027                               v17 = iadd v13, v14
 ;; @0027                               v12 = uextend.i64 v11
-;; @0027                               v17 = icmp ugt v16, v12
-;; @0027                               trapnz v17, user17
-;; @0027                               v29 = load.i64 notrap aligned v49+40
-;; @0027                               v21 = iconst.i64 24
-;; @0027                               v22 = iadd v8, v21  ; v21 = 24
+;; @0027                               v18 = icmp ugt v17, v12
+;; @0027                               trapnz v18, user17
+;; @0027                               v32 = load.i64 notrap aligned v49+40
+;; @0027                               v22 = iconst.i64 24
+;; @0027                               v23 = iadd v8, v22  ; v22 = 24
 ;;                                     v53 = iconst.i64 3
 ;;                                     v54 = ishl v13, v53  ; v53 = 3
-;; @0027                               v25 = iadd v22, v54
+;; @0027                               v27 = iadd v23, v54
 ;;                                     v56 = ishl v14, v53  ; v53 = 3
-;; @0027                               v31 = uadd_overflow_trap v25, v56, user2
-;; @0027                               v30 = iadd v7, v29
-;; @0027                               v32 = icmp ugt v31, v30
-;; @0027                               trapnz v32, user2
+;; @0027                               v34 = uadd_overflow_trap v27, v56, user2
+;; @0027                               v33 = iadd v7, v32
+;; @0027                               v35 = icmp ugt v34, v33
+;; @0027                               trapnz v35, user2
 ;;                                     v51 = iconst.i64 0
-;; @0027                               v35 = icmp eq v14, v51  ; v51 = 0
-;;                                     v45 = iconst.i64 8
-;; @0027                               v33 = iadd v25, v56
-;; @0027                               brif v35, block3, block2(v25)
+;; @0027                               v38 = icmp eq v14, v51  ; v51 = 0
+;; @0027                               v25 = iconst.i64 8
+;; @0027                               v36 = iadd v27, v56
+;; @0027                               brif v38, block3, block2(v27)
 ;;
-;;                                 block2(v36: i64):
-;; @0027                               store.i64 user2 little region0 v4, v36
+;;                                 block2(v39: i64):
+;; @0027                               store.i64 user2 little region0 v4, v39
 ;;                                     v58 = iconst.i64 8
-;;                                     v59 = iadd v36, v58  ; v58 = 8
-;; @0027                               v39 = icmp eq v59, v33
-;; @0027                               brif v39, block3, block2(v59)
+;;                                     v59 = iadd v39, v58  ; v58 = 8
+;; @0027                               v42 = icmp eq v59, v36
+;; @0027                               brif v42, block3, block2(v59)
 ;;
 ;;                                 block3:
 ;; @002a                               jump block1

--- a/tests/disas/gc/copying/array-new-fixed-of-gc-refs.wat
+++ b/tests/disas/gc/copying/array-new-fixed-of-gc-refs.wat
@@ -32,116 +32,116 @@
 ;;                                     store notrap v3, v151
 ;;                                     v150 = stack_addr.i64 ss0
 ;;                                     store notrap v4, v150
-;; @0025                               v14 = load.i64 notrap aligned readonly can_move v0+32
-;; @0025                               v15 = load.i32 notrap aligned v14
-;; @0025                               v16 = load.i32 notrap aligned v14+4
-;; @0025                               v22 = uextend.i64 v15
-;;                                     v148 = iconst.i64 32
-;; @0025                               v23 = iadd v22, v148  ; v148 = 32
-;; @0025                               v24 = uextend.i64 v16
-;; @0025                               v25 = icmp ule v23, v24
-;; @0025                               brif v25, block2, block3
+;; @0025                               v15 = load.i64 notrap aligned readonly can_move v0+32
+;; @0025                               v16 = load.i32 notrap aligned v15
+;; @0025                               v17 = load.i32 notrap aligned v15+4
+;; @0025                               v23 = uextend.i64 v16
+;;                                     v149 = iconst.i64 32
+;; @0025                               v24 = iadd v23, v149  ; v149 = 32
+;; @0025                               v25 = uextend.i64 v17
+;; @0025                               v26 = icmp ule v24, v25
+;; @0025                               brif v26, block2, block3
 ;;
 ;;                                 block2:
 ;;                                     v272 = iconst.i32 32
-;;                                     v178 = iadd.i32 v15, v272  ; v272 = 32
-;; @0025                               store notrap aligned region0 v178, v14
+;;                                     v178 = iadd.i32 v16, v272  ; v272 = 32
+;; @0025                               store notrap aligned region0 v178, v15
 ;;                                     v273 = iconst.i32 -1476394994
 ;;                                     v274 = load.i64 notrap aligned readonly can_move v0+8
 ;;                                     v275 = load.i64 notrap aligned readonly can_move v274+32
-;; @0025                               v39 = iadd v275, v22
-;; @0025                               store notrap aligned v273, v39  ; v273 = -1476394994
+;; @0025                               v40 = iadd v275, v23
+;; @0025                               store notrap aligned v273, v40  ; v273 = -1476394994
 ;;                                     v276 = load.i64 notrap aligned readonly can_move v0+40
 ;;                                     v277 = load.i32 notrap aligned readonly can_move v276
-;; @0025                               store notrap aligned v277, v39+4
+;; @0025                               store notrap aligned v277, v40+4
 ;;                                     v278 = iconst.i64 32
-;; @0025                               istore32 notrap aligned v278, v39+8  ; v278 = 32
-;; @0025                               jump block4(v15, v39)
+;; @0025                               istore32 notrap aligned v278, v40+8  ; v278 = 32
+;; @0025                               jump block4(v16, v40)
 ;;
 ;;                                 block3 cold:
-;; @0025                               v27 = iconst.i32 -1476394994
-;; @0025                               v29 = load.i64 notrap aligned readonly can_move v0+40
-;; @0025                               v30 = load.i32 notrap aligned readonly can_move v29
+;; @0025                               v28 = iconst.i32 -1476394994
+;; @0025                               v30 = load.i64 notrap aligned readonly can_move v0+40
+;; @0025                               v31 = load.i32 notrap aligned readonly can_move v30
 ;;                                     v164 = iconst.i32 32
-;; @0025                               v31 = iconst.i32 16
-;; @0025                               v32 = call fn0(v0, v27, v30, v164, v31), stack_map=[i32 @ ss2+0, i32 @ ss1+0, i32 @ ss0+0]  ; v27 = -1476394994, v164 = 32, v31 = 16
-;; @0025                               v144 = load.i64 notrap aligned readonly can_move v0+8
-;; @0025                               v33 = load.i64 notrap aligned readonly can_move v144+32
-;; @0025                               v34 = uextend.i64 v32
-;; @0025                               v35 = iadd v33, v34
-;; @0025                               jump block4(v32, v35)
+;; @0025                               v32 = iconst.i32 16
+;; @0025                               v33 = call fn0(v0, v28, v31, v164, v32), stack_map=[i32 @ ss2+0, i32 @ ss1+0, i32 @ ss0+0]  ; v28 = -1476394994, v164 = 32, v32 = 16
+;; @0025                               v145 = load.i64 notrap aligned readonly can_move v0+8
+;; @0025                               v34 = load.i64 notrap aligned readonly can_move v145+32
+;; @0025                               v35 = uextend.i64 v33
+;; @0025                               v36 = iadd v34, v35
+;; @0025                               jump block4(v33, v36)
 ;;
-;;                                 block4(v44: i32, v45: i64):
+;;                                 block4(v45: i32, v46: i64):
 ;; @0025                               v6 = iconst.i32 3
-;; @0025                               v46 = iconst.i64 16
-;; @0025                               v47 = iadd v45, v46  ; v46 = 16
-;; @0025                               store user2 region1 v6, v47  ; v6 = 3
-;; @0025                               trapz v44, user16
+;; @0025                               v47 = iconst.i64 16
+;; @0025                               v48 = iadd v46, v47  ; v47 = 16
+;; @0025                               store user2 region1 v6, v48  ; v6 = 3
+;; @0025                               trapz v45, user16
 ;;                                     v279 = load.i64 notrap aligned readonly can_move v0+8
 ;;                                     v280 = load.i64 notrap aligned readonly can_move v279+32
-;; @0025                               v49 = uextend.i64 v44
-;; @0025                               v51 = iadd v280, v49
-;; @0025                               v53 = iadd v51, v46  ; v46 = 16
-;; @0025                               v54 = load.i32 user2 readonly region1 v53
-;; @0025                               v48 = iconst.i32 0
-;;                                     v181 = icmp ne v54, v48  ; v48 = 0
+;; @0025                               v50 = uextend.i64 v45
+;; @0025                               v52 = iadd v280, v50
+;; @0025                               v54 = iadd v52, v47  ; v47 = 16
+;; @0025                               v55 = load.i32 user2 readonly region1 v54
+;; @0025                               v49 = iconst.i32 0
+;;                                     v181 = icmp ne v55, v49  ; v49 = 0
 ;; @0025                               trapz v181, user17
-;; @0025                               v57 = uextend.i64 v54
+;; @0025                               v58 = uextend.i64 v55
 ;;                                     v155 = iconst.i64 2
-;;                                     v184 = ishl v57, v155  ; v155 = 2
+;;                                     v184 = ishl v58, v155  ; v155 = 2
 ;;                                     v281 = iconst.i64 32
 ;;                                     v282 = ushr v184, v281  ; v281 = 32
 ;; @0025                               trapnz v282, user2
 ;;                                     v193 = iconst.i32 2
-;;                                     v194 = ishl v54, v193  ; v193 = 2
+;;                                     v194 = ishl v55, v193  ; v193 = 2
 ;; @0025                               v7 = iconst.i32 20
-;; @0025                               v62 = uadd_overflow_trap v194, v7, user2  ; v7 = 20
-;; @0025                               v66 = uadd_overflow_trap v44, v62, user2
-;;                                     v125 = load.i32 notrap v152
-;; @0025                               v67 = uextend.i64 v66
-;; @0025                               v69 = iadd v280, v67
-;; @0025                               v70 = isub v62, v7  ; v7 = 20
-;; @0025                               v71 = uextend.i64 v70
-;; @0025                               v72 = isub v69, v71
-;; @0025                               store user2 little region1 v125, v72
-;; @0025                               v79 = load.i32 user2 readonly region1 v53
-;; @0025                               v73 = iconst.i32 1
-;;                                     v211 = icmp ugt v79, v73  ; v73 = 1
+;; @0025                               v63 = uadd_overflow_trap v194, v7, user2  ; v7 = 20
+;; @0025                               v67 = uadd_overflow_trap v45, v63, user2
+;;                                     v126 = load.i32 notrap v152
+;; @0025                               v68 = uextend.i64 v67
+;; @0025                               v70 = iadd v280, v68
+;; @0025                               v71 = isub v63, v7  ; v7 = 20
+;; @0025                               v72 = uextend.i64 v71
+;; @0025                               v73 = isub v70, v72
+;; @0025                               store user2 little region1 v126, v73
+;; @0025                               v80 = load.i32 user2 readonly region1 v54
+;; @0025                               v74 = iconst.i32 1
+;;                                     v211 = icmp ugt v80, v74  ; v74 = 1
 ;; @0025                               trapz v211, user17
-;; @0025                               v82 = uextend.i64 v79
-;;                                     v213 = ishl v82, v155  ; v155 = 2
+;; @0025                               v83 = uextend.i64 v80
+;;                                     v213 = ishl v83, v155  ; v155 = 2
 ;;                                     v283 = ushr v213, v281  ; v281 = 32
 ;; @0025                               trapnz v283, user2
-;;                                     v220 = ishl v79, v193  ; v193 = 2
-;; @0025                               v87 = uadd_overflow_trap v220, v7, user2  ; v7 = 20
-;; @0025                               v91 = uadd_overflow_trap v44, v87, user2
-;;                                     v124 = load.i32 notrap v151
-;; @0025                               v92 = uextend.i64 v91
-;; @0025                               v94 = iadd v280, v92
+;;                                     v220 = ishl v80, v193  ; v193 = 2
+;; @0025                               v88 = uadd_overflow_trap v220, v7, user2  ; v7 = 20
+;; @0025                               v92 = uadd_overflow_trap v45, v88, user2
+;;                                     v125 = load.i32 notrap v151
+;; @0025                               v93 = uextend.i64 v92
+;; @0025                               v95 = iadd v280, v93
 ;;                                     v233 = iconst.i32 24
-;; @0025                               v95 = isub v87, v233  ; v233 = 24
-;; @0025                               v96 = uextend.i64 v95
-;; @0025                               v97 = isub v94, v96
-;; @0025                               store user2 little region1 v124, v97
-;; @0025                               v104 = load.i32 user2 readonly region1 v53
-;;                                     v239 = icmp ugt v104, v193  ; v193 = 2
+;; @0025                               v96 = isub v88, v233  ; v233 = 24
+;; @0025                               v97 = uextend.i64 v96
+;; @0025                               v98 = isub v95, v97
+;; @0025                               store user2 little region1 v125, v98
+;; @0025                               v105 = load.i32 user2 readonly region1 v54
+;;                                     v239 = icmp ugt v105, v193  ; v193 = 2
 ;; @0025                               trapz v239, user17
-;; @0025                               v107 = uextend.i64 v104
-;;                                     v241 = ishl v107, v155  ; v155 = 2
+;; @0025                               v108 = uextend.i64 v105
+;;                                     v241 = ishl v108, v155  ; v155 = 2
 ;;                                     v284 = ushr v241, v281  ; v281 = 32
 ;; @0025                               trapnz v284, user2
-;;                                     v248 = ishl v104, v193  ; v193 = 2
-;; @0025                               v112 = uadd_overflow_trap v248, v7, user2  ; v7 = 20
-;; @0025                               v116 = uadd_overflow_trap v44, v112, user2
-;;                                     v123 = load.i32 notrap v150
-;; @0025                               v117 = uextend.i64 v116
-;; @0025                               v119 = iadd v280, v117
+;;                                     v248 = ishl v105, v193  ; v193 = 2
+;; @0025                               v113 = uadd_overflow_trap v248, v7, user2  ; v7 = 20
+;; @0025                               v117 = uadd_overflow_trap v45, v113, user2
+;;                                     v124 = load.i32 notrap v150
+;; @0025                               v118 = uextend.i64 v117
+;; @0025                               v120 = iadd v280, v118
 ;;                                     v266 = iconst.i32 28
-;; @0025                               v120 = isub v112, v266  ; v266 = 28
-;; @0025                               v121 = uextend.i64 v120
-;; @0025                               v122 = isub v119, v121
-;; @0025                               store user2 little region1 v123, v122
-;; @0029                               jump block1(v44)
+;; @0025                               v121 = isub v113, v266  ; v266 = 28
+;; @0025                               v122 = uextend.i64 v121
+;; @0025                               v123 = isub v120, v122
+;; @0025                               store user2 little region1 v124, v123
+;; @0029                               jump block1(v45)
 ;;
 ;;                                 block1(v5: i32):
 ;; @0029                               return v5

--- a/tests/disas/gc/copying/array-new-fixed.wat
+++ b/tests/disas/gc/copying/array-new-fixed.wat
@@ -23,113 +23,113 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i64, v4: i64):
-;; @0025                               v14 = load.i64 notrap aligned readonly can_move v0+32
-;; @0025                               v15 = load.i32 notrap aligned v14
-;; @0025                               v16 = load.i32 notrap aligned v14+4
-;; @0025                               v22 = uextend.i64 v15
+;; @0025                               v15 = load.i64 notrap aligned readonly can_move v0+32
+;; @0025                               v16 = load.i32 notrap aligned v15
+;; @0025                               v17 = load.i32 notrap aligned v15+4
+;; @0025                               v23 = uextend.i64 v16
 ;;                                     v154 = iconst.i64 48
-;; @0025                               v23 = iadd v22, v154  ; v154 = 48
-;; @0025                               v24 = uextend.i64 v16
-;; @0025                               v25 = icmp ule v23, v24
-;; @0025                               brif v25, block2, block3
+;; @0025                               v24 = iadd v23, v154  ; v154 = 48
+;; @0025                               v25 = uextend.i64 v17
+;; @0025                               v26 = icmp ule v24, v25
+;; @0025                               brif v26, block2, block3
 ;;
 ;;                                 block2:
 ;;                                     v260 = iconst.i32 48
-;;                                     v168 = iadd.i32 v15, v260  ; v260 = 48
-;; @0025                               store notrap aligned region0 v168, v14
+;;                                     v168 = iadd.i32 v16, v260  ; v260 = 48
+;; @0025                               store notrap aligned region0 v168, v15
 ;;                                     v261 = iconst.i32 -1476395002
 ;;                                     v262 = load.i64 notrap aligned readonly can_move v0+8
 ;;                                     v263 = load.i64 notrap aligned readonly can_move v262+32
-;; @0025                               v39 = iadd v263, v22
-;; @0025                               store notrap aligned v261, v39  ; v261 = -1476395002
+;; @0025                               v40 = iadd v263, v23
+;; @0025                               store notrap aligned v261, v40  ; v261 = -1476395002
 ;;                                     v264 = load.i64 notrap aligned readonly can_move v0+40
 ;;                                     v265 = load.i32 notrap aligned readonly can_move v264
-;; @0025                               store notrap aligned v265, v39+4
+;; @0025                               store notrap aligned v265, v40+4
 ;;                                     v266 = iconst.i64 48
-;; @0025                               istore32 notrap aligned v266, v39+8  ; v266 = 48
-;; @0025                               jump block4(v15, v39)
+;; @0025                               istore32 notrap aligned v266, v40+8  ; v266 = 48
+;; @0025                               jump block4(v16, v40)
 ;;
 ;;                                 block3 cold:
-;; @0025                               v27 = iconst.i32 -1476395002
-;; @0025                               v29 = load.i64 notrap aligned readonly can_move v0+40
-;; @0025                               v30 = load.i32 notrap aligned readonly can_move v29
+;; @0025                               v28 = iconst.i32 -1476395002
+;; @0025                               v30 = load.i64 notrap aligned readonly can_move v0+40
+;; @0025                               v31 = load.i32 notrap aligned readonly can_move v30
 ;;                                     v153 = iconst.i32 48
-;; @0025                               v31 = iconst.i32 16
-;; @0025                               v32 = call fn0(v0, v27, v30, v153, v31)  ; v27 = -1476395002, v153 = 48, v31 = 16
-;; @0025                               v138 = load.i64 notrap aligned readonly can_move v0+8
-;; @0025                               v33 = load.i64 notrap aligned readonly can_move v138+32
-;; @0025                               v34 = uextend.i64 v32
-;; @0025                               v35 = iadd v33, v34
-;; @0025                               jump block4(v32, v35)
+;; @0025                               v32 = iconst.i32 16
+;; @0025                               v33 = call fn0(v0, v28, v31, v153, v32)  ; v28 = -1476395002, v153 = 48, v32 = 16
+;; @0025                               v139 = load.i64 notrap aligned readonly can_move v0+8
+;; @0025                               v34 = load.i64 notrap aligned readonly can_move v139+32
+;; @0025                               v35 = uextend.i64 v33
+;; @0025                               v36 = iadd v34, v35
+;; @0025                               jump block4(v33, v36)
 ;;
-;;                                 block4(v44: i32, v45: i64):
+;;                                 block4(v45: i32, v46: i64):
 ;; @0025                               v6 = iconst.i32 3
-;; @0025                               v46 = iconst.i64 16
-;; @0025                               v47 = iadd v45, v46  ; v46 = 16
-;; @0025                               store user2 region1 v6, v47  ; v6 = 3
-;; @0025                               trapz v44, user16
+;; @0025                               v47 = iconst.i64 16
+;; @0025                               v48 = iadd v46, v47  ; v47 = 16
+;; @0025                               store user2 region1 v6, v48  ; v6 = 3
+;; @0025                               trapz v45, user16
 ;;                                     v267 = load.i64 notrap aligned readonly can_move v0+8
 ;;                                     v268 = load.i64 notrap aligned readonly can_move v267+32
-;; @0025                               v49 = uextend.i64 v44
-;; @0025                               v51 = iadd v268, v49
-;; @0025                               v53 = iadd v51, v46  ; v46 = 16
-;; @0025                               v54 = load.i32 user2 readonly region1 v53
-;; @0025                               v48 = iconst.i32 0
-;;                                     v171 = icmp ne v54, v48  ; v48 = 0
+;; @0025                               v50 = uextend.i64 v45
+;; @0025                               v52 = iadd v268, v50
+;; @0025                               v54 = iadd v52, v47  ; v47 = 16
+;; @0025                               v55 = load.i32 user2 readonly region1 v54
+;; @0025                               v49 = iconst.i32 0
+;;                                     v171 = icmp ne v55, v49  ; v49 = 0
 ;; @0025                               trapz v171, user17
-;; @0025                               v57 = uextend.i64 v54
+;; @0025                               v58 = uextend.i64 v55
 ;;                                     v144 = iconst.i64 3
-;;                                     v174 = ishl v57, v144  ; v144 = 3
-;;                                     v142 = iconst.i64 32
-;; @0025                               v59 = ushr v174, v142  ; v142 = 32
-;; @0025                               trapnz v59, user2
-;;                                     v183 = ishl v54, v6  ; v6 = 3
+;;                                     v174 = ishl v58, v144  ; v144 = 3
+;;                                     v143 = iconst.i64 32
+;; @0025                               v60 = ushr v174, v143  ; v143 = 32
+;; @0025                               trapnz v60, user2
+;;                                     v183 = ishl v55, v6  ; v6 = 3
 ;; @0025                               v7 = iconst.i32 24
-;; @0025                               v62 = uadd_overflow_trap v183, v7, user2  ; v7 = 24
-;; @0025                               v66 = uadd_overflow_trap v44, v62, user2
-;; @0025                               v67 = uextend.i64 v66
-;; @0025                               v69 = iadd v268, v67
-;; @0025                               v70 = isub v62, v7  ; v7 = 24
-;; @0025                               v71 = uextend.i64 v70
-;; @0025                               v72 = isub v69, v71
-;; @0025                               store.i64 user2 little region1 v2, v72
-;; @0025                               v79 = load.i32 user2 readonly region1 v53
-;; @0025                               v73 = iconst.i32 1
-;;                                     v200 = icmp ugt v79, v73  ; v73 = 1
+;; @0025                               v63 = uadd_overflow_trap v183, v7, user2  ; v7 = 24
+;; @0025                               v67 = uadd_overflow_trap v45, v63, user2
+;; @0025                               v68 = uextend.i64 v67
+;; @0025                               v70 = iadd v268, v68
+;; @0025                               v71 = isub v63, v7  ; v7 = 24
+;; @0025                               v72 = uextend.i64 v71
+;; @0025                               v73 = isub v70, v72
+;; @0025                               store.i64 user2 little region1 v2, v73
+;; @0025                               v80 = load.i32 user2 readonly region1 v54
+;; @0025                               v74 = iconst.i32 1
+;;                                     v200 = icmp ugt v80, v74  ; v74 = 1
 ;; @0025                               trapz v200, user17
-;; @0025                               v82 = uextend.i64 v79
-;;                                     v202 = ishl v82, v144  ; v144 = 3
-;; @0025                               v84 = ushr v202, v142  ; v142 = 32
-;; @0025                               trapnz v84, user2
-;;                                     v209 = ishl v79, v6  ; v6 = 3
-;; @0025                               v87 = uadd_overflow_trap v209, v7, user2  ; v7 = 24
-;; @0025                               v91 = uadd_overflow_trap v44, v87, user2
-;; @0025                               v92 = uextend.i64 v91
-;; @0025                               v94 = iadd v268, v92
+;; @0025                               v83 = uextend.i64 v80
+;;                                     v202 = ishl v83, v144  ; v144 = 3
+;; @0025                               v85 = ushr v202, v143  ; v143 = 32
+;; @0025                               trapnz v85, user2
+;;                                     v209 = ishl v80, v6  ; v6 = 3
+;; @0025                               v88 = uadd_overflow_trap v209, v7, user2  ; v7 = 24
+;; @0025                               v92 = uadd_overflow_trap v45, v88, user2
+;; @0025                               v93 = uextend.i64 v92
+;; @0025                               v95 = iadd v268, v93
 ;;                                     v222 = iconst.i32 32
-;; @0025                               v95 = isub v87, v222  ; v222 = 32
-;; @0025                               v96 = uextend.i64 v95
-;; @0025                               v97 = isub v94, v96
-;; @0025                               store.i64 user2 little region1 v3, v97
-;; @0025                               v104 = load.i32 user2 readonly region1 v53
-;; @0025                               v98 = iconst.i32 2
-;;                                     v228 = icmp ugt v104, v98  ; v98 = 2
+;; @0025                               v96 = isub v88, v222  ; v222 = 32
+;; @0025                               v97 = uextend.i64 v96
+;; @0025                               v98 = isub v95, v97
+;; @0025                               store.i64 user2 little region1 v3, v98
+;; @0025                               v105 = load.i32 user2 readonly region1 v54
+;; @0025                               v99 = iconst.i32 2
+;;                                     v228 = icmp ugt v105, v99  ; v99 = 2
 ;; @0025                               trapz v228, user17
-;; @0025                               v107 = uextend.i64 v104
-;;                                     v230 = ishl v107, v144  ; v144 = 3
-;; @0025                               v109 = ushr v230, v142  ; v142 = 32
-;; @0025                               trapnz v109, user2
-;;                                     v237 = ishl v104, v6  ; v6 = 3
-;; @0025                               v112 = uadd_overflow_trap v237, v7, user2  ; v7 = 24
-;; @0025                               v116 = uadd_overflow_trap v44, v112, user2
-;; @0025                               v117 = uextend.i64 v116
-;; @0025                               v119 = iadd v268, v117
+;; @0025                               v108 = uextend.i64 v105
+;;                                     v230 = ishl v108, v144  ; v144 = 3
+;; @0025                               v110 = ushr v230, v143  ; v143 = 32
+;; @0025                               trapnz v110, user2
+;;                                     v237 = ishl v105, v6  ; v6 = 3
+;; @0025                               v113 = uadd_overflow_trap v237, v7, user2  ; v7 = 24
+;; @0025                               v117 = uadd_overflow_trap v45, v113, user2
+;; @0025                               v118 = uextend.i64 v117
+;; @0025                               v120 = iadd v268, v118
 ;;                                     v254 = iconst.i32 40
-;; @0025                               v120 = isub v112, v254  ; v254 = 40
-;; @0025                               v121 = uextend.i64 v120
-;; @0025                               v122 = isub v119, v121
-;; @0025                               store.i64 user2 little region1 v4, v122
-;; @0029                               jump block1(v44)
+;; @0025                               v121 = isub v113, v254  ; v254 = 40
+;; @0025                               v122 = uextend.i64 v121
+;; @0025                               v123 = isub v120, v122
+;; @0025                               store.i64 user2 little region1 v4, v123
+;; @0029                               jump block1(v45)
 ;;
 ;;                                 block1(v5: i32):
 ;; @0029                               return v5

--- a/tests/disas/gc/copying/array-new.wat
+++ b/tests/disas/gc/copying/array-new.wat
@@ -26,94 +26,94 @@
 ;; @0022                               v6 = uextend.i64 v3
 ;;                                     v98 = iconst.i64 3
 ;;                                     v99 = ishl v6, v98  ; v98 = 3
-;;                                     v96 = iconst.i64 32
-;; @0022                               v8 = ushr v99, v96  ; v96 = 32
-;; @0022                               trapnz v8, user18
+;;                                     v97 = iconst.i64 32
+;; @0022                               v9 = ushr v99, v97  ; v97 = 32
+;; @0022                               trapnz v9, user18
 ;; @0022                               v5 = iconst.i32 24
 ;;                                     v105 = iconst.i32 3
 ;;                                     v106 = ishl v3, v105  ; v105 = 3
-;; @0022                               v10 = uadd_overflow_trap v5, v106, user18  ; v5 = 24
-;; @0022                               v12 = load.i64 notrap aligned readonly can_move v0+32
-;; @0022                               v13 = load.i32 notrap aligned v12
-;; @0022                               v14 = load.i32 notrap aligned v12+4
-;; @0022                               v20 = uextend.i64 v13
-;; @0022                               v15 = uextend.i64 v10
-;; @0022                               v16 = iconst.i64 15
-;; @0022                               v18 = iadd v15, v16  ; v16 = 15
-;; @0022                               v17 = iconst.i64 -16
-;; @0022                               v19 = band v18, v17  ; v17 = -16
-;; @0022                               v21 = iadd v20, v19
-;; @0022                               v22 = uextend.i64 v14
-;; @0022                               v23 = icmp ule v21, v22
-;; @0022                               brif v23, block2, block3
+;; @0022                               v11 = uadd_overflow_trap v5, v106, user18  ; v5 = 24
+;; @0022                               v13 = load.i64 notrap aligned readonly can_move v0+32
+;; @0022                               v14 = load.i32 notrap aligned v13
+;; @0022                               v15 = load.i32 notrap aligned v13+4
+;; @0022                               v21 = uextend.i64 v14
+;; @0022                               v16 = uextend.i64 v11
+;; @0022                               v17 = iconst.i64 15
+;; @0022                               v19 = iadd v16, v17  ; v17 = 15
+;; @0022                               v18 = iconst.i64 -16
+;; @0022                               v20 = band v19, v18  ; v18 = -16
+;; @0022                               v22 = iadd v21, v20
+;; @0022                               v23 = uextend.i64 v15
+;; @0022                               v24 = icmp ule v22, v23
+;; @0022                               brif v24, block2, block3
 ;;
 ;;                                 block2:
 ;;                                     v114 = iconst.i32 15
-;;                                     v115 = iadd.i32 v10, v114  ; v114 = 15
+;;                                     v115 = iadd.i32 v11, v114  ; v114 = 15
 ;;                                     v118 = iconst.i32 -16
 ;;                                     v119 = band v115, v118  ; v118 = -16
-;;                                     v121 = iadd.i32 v13, v119
-;; @0022                               store notrap aligned region0 v121, v12
+;;                                     v121 = iadd.i32 v14, v119
+;; @0022                               store notrap aligned region0 v121, v13
 ;;                                     v137 = iconst.i32 -1476395002
 ;;                                     v138 = load.i64 notrap aligned readonly can_move v0+8
 ;;                                     v139 = load.i64 notrap aligned readonly can_move v138+32
-;; @0022                               v37 = iadd v139, v20
-;; @0022                               store notrap aligned v137, v37  ; v137 = -1476395002
+;; @0022                               v38 = iadd v139, v21
+;; @0022                               store notrap aligned v137, v38  ; v137 = -1476395002
 ;;                                     v140 = load.i64 notrap aligned readonly can_move v0+40
 ;;                                     v141 = load.i32 notrap aligned readonly can_move v140
-;; @0022                               store notrap aligned v141, v37+4
-;;                                     v142 = band.i64 v18, v17  ; v17 = -16
-;; @0022                               istore32 notrap aligned v142, v37+8
-;; @0022                               jump block4(v13, v37)
+;; @0022                               store notrap aligned v141, v38+4
+;;                                     v142 = band.i64 v19, v18  ; v18 = -16
+;; @0022                               istore32 notrap aligned v142, v38+8
+;; @0022                               jump block4(v14, v38)
 ;;
 ;;                                 block3 cold:
-;; @0022                               v25 = iconst.i32 -1476395002
-;; @0022                               v27 = load.i64 notrap aligned readonly can_move v0+40
-;; @0022                               v28 = load.i32 notrap aligned readonly can_move v27
-;; @0022                               v29 = iconst.i32 16
-;; @0022                               v30 = call fn0(v0, v25, v28, v10, v29)  ; v25 = -1476395002, v29 = 16
-;; @0022                               v92 = load.i64 notrap aligned readonly can_move v0+8
-;; @0022                               v31 = load.i64 notrap aligned readonly can_move v92+32
-;; @0022                               v32 = uextend.i64 v30
-;; @0022                               v33 = iadd v31, v32
-;; @0022                               jump block4(v30, v33)
+;; @0022                               v26 = iconst.i32 -1476395002
+;; @0022                               v28 = load.i64 notrap aligned readonly can_move v0+40
+;; @0022                               v29 = load.i32 notrap aligned readonly can_move v28
+;; @0022                               v30 = iconst.i32 16
+;; @0022                               v31 = call fn0(v0, v26, v29, v11, v30)  ; v26 = -1476395002, v30 = 16
+;; @0022                               v93 = load.i64 notrap aligned readonly can_move v0+8
+;; @0022                               v32 = load.i64 notrap aligned readonly can_move v93+32
+;; @0022                               v33 = uextend.i64 v31
+;; @0022                               v34 = iadd v32, v33
+;; @0022                               jump block4(v31, v34)
 ;;
-;;                                 block4(v42: i32, v43: i64):
-;; @0022                               v44 = iconst.i64 16
-;; @0022                               v45 = iadd v43, v44  ; v44 = 16
-;; @0022                               store.i32 user2 region1 v3, v45
-;; @0022                               trapz v42, user16
+;;                                 block4(v43: i32, v44: i64):
+;; @0022                               v45 = iconst.i64 16
+;; @0022                               v46 = iadd v44, v45  ; v45 = 16
+;; @0022                               store.i32 user2 region1 v3, v46
+;; @0022                               trapz v43, user16
 ;;                                     v143 = load.i64 notrap aligned readonly can_move v0+8
 ;;                                     v144 = load.i64 notrap aligned readonly can_move v143+32
-;; @0022                               v47 = uextend.i64 v42
-;; @0022                               v49 = iadd v144, v47
-;; @0022                               v51 = iadd v49, v44  ; v44 = 16
-;; @0022                               v52 = load.i32 user2 readonly region1 v51
-;; @0022                               v53 = uextend.i64 v52
-;; @0022                               v58 = icmp.i64 ugt v6, v53
-;; @0022                               trapnz v58, user17
-;; @0022                               v70 = load.i64 notrap aligned v143+40
-;; @0022                               v62 = iconst.i64 24
-;; @0022                               v63 = iadd v49, v62  ; v62 = 24
-;; @0022                               v72 = uadd_overflow_trap v63, v99, user2
-;; @0022                               v71 = iadd v144, v70
-;; @0022                               v73 = icmp ugt v72, v71
-;; @0022                               trapnz v73, user2
+;; @0022                               v48 = uextend.i64 v43
+;; @0022                               v50 = iadd v144, v48
+;; @0022                               v52 = iadd v50, v45  ; v45 = 16
+;; @0022                               v53 = load.i32 user2 readonly region1 v52
+;; @0022                               v54 = uextend.i64 v53
+;; @0022                               v60 = icmp.i64 ugt v6, v54
+;; @0022                               trapnz v60, user17
+;; @0022                               v74 = load.i64 notrap aligned v143+40
+;; @0022                               v64 = iconst.i64 24
+;; @0022                               v65 = iadd v50, v64  ; v64 = 24
+;; @0022                               v76 = uadd_overflow_trap v65, v99, user2
+;; @0022                               v75 = iadd v144, v74
+;; @0022                               v77 = icmp ugt v76, v75
+;; @0022                               trapnz v77, user2
 ;;                                     v123 = iconst.i64 0
-;; @0022                               v76 = icmp.i64 eq v6, v123  ; v123 = 0
-;;                                     v97 = iconst.i64 8
-;; @0022                               v74 = iadd v63, v99
-;; @0022                               brif v76, block6, block5(v63)
+;; @0022                               v80 = icmp.i64 eq v6, v123  ; v123 = 0
+;; @0022                               v7 = iconst.i64 8
+;; @0022                               v78 = iadd v65, v99
+;; @0022                               brif v80, block6, block5(v65)
 ;;
-;;                                 block5(v77: i64):
-;; @0022                               store.i64 user2 little region1 v2, v77
+;;                                 block5(v81: i64):
+;; @0022                               store.i64 user2 little region1 v2, v81
 ;;                                     v145 = iconst.i64 8
-;;                                     v146 = iadd v77, v145  ; v145 = 8
-;; @0022                               v80 = icmp eq v146, v74
-;; @0022                               brif v80, block6, block5(v146)
+;;                                     v146 = iadd v81, v145  ; v145 = 8
+;; @0022                               v84 = icmp eq v146, v78
+;; @0022                               brif v84, block6, block5(v146)
 ;;
 ;;                                 block6:
-;; @0025                               jump block1(v42)
+;; @0025                               jump block1(v43)
 ;;
 ;;                                 block1(v4: i32):
 ;; @0025                               return v4

--- a/tests/disas/gc/drc/array-fill.wat
+++ b/tests/disas/gc/drc/array-fill.wat
@@ -31,33 +31,33 @@
 ;; @0027                               v11 = load.i32 user2 readonly region0 v10
 ;; @0027                               v13 = uextend.i64 v3
 ;; @0027                               v14 = uextend.i64 v5
-;; @0027                               v16 = iadd v13, v14
+;; @0027                               v17 = iadd v13, v14
 ;; @0027                               v12 = uextend.i64 v11
-;; @0027                               v17 = icmp ugt v16, v12
-;; @0027                               trapnz v17, user17
-;; @0027                               v29 = load.i64 notrap aligned v49+40
-;; @0027                               v21 = iconst.i64 32
-;; @0027                               v22 = iadd v8, v21  ; v21 = 32
+;; @0027                               v18 = icmp ugt v17, v12
+;; @0027                               trapnz v18, user17
+;; @0027                               v32 = load.i64 notrap aligned v49+40
+;; @0027                               v22 = iconst.i64 32
+;; @0027                               v23 = iadd v8, v22  ; v22 = 32
 ;;                                     v53 = iconst.i64 3
 ;;                                     v54 = ishl v13, v53  ; v53 = 3
-;; @0027                               v25 = iadd v22, v54
+;; @0027                               v27 = iadd v23, v54
 ;;                                     v56 = ishl v14, v53  ; v53 = 3
-;; @0027                               v31 = uadd_overflow_trap v25, v56, user2
-;; @0027                               v30 = iadd v7, v29
-;; @0027                               v32 = icmp ugt v31, v30
-;; @0027                               trapnz v32, user2
+;; @0027                               v34 = uadd_overflow_trap v27, v56, user2
+;; @0027                               v33 = iadd v7, v32
+;; @0027                               v35 = icmp ugt v34, v33
+;; @0027                               trapnz v35, user2
 ;;                                     v51 = iconst.i64 0
-;; @0027                               v35 = icmp eq v14, v51  ; v51 = 0
-;;                                     v45 = iconst.i64 8
-;; @0027                               v33 = iadd v25, v56
-;; @0027                               brif v35, block3, block2(v25)
+;; @0027                               v38 = icmp eq v14, v51  ; v51 = 0
+;; @0027                               v25 = iconst.i64 8
+;; @0027                               v36 = iadd v27, v56
+;; @0027                               brif v38, block3, block2(v27)
 ;;
-;;                                 block2(v36: i64):
-;; @0027                               store.i64 user2 little region0 v4, v36
+;;                                 block2(v39: i64):
+;; @0027                               store.i64 user2 little region0 v4, v39
 ;;                                     v58 = iconst.i64 8
-;;                                     v59 = iadd v36, v58  ; v58 = 8
-;; @0027                               v39 = icmp eq v59, v33
-;; @0027                               brif v39, block3, block2(v59)
+;;                                     v59 = iadd v39, v58  ; v58 = 8
+;; @0027                               v42 = icmp eq v59, v36
+;; @0027                               brif v42, block3, block2(v59)
 ;;
 ;;                                 block3:
 ;; @002a                               jump block1

--- a/tests/disas/gc/drc/array-new-fixed-of-gc-refs.wat
+++ b/tests/disas/gc/drc/array-new-fixed-of-gc-refs.wat
@@ -32,142 +32,142 @@
 ;;                                     store notrap v3, v219
 ;;                                     v218 = stack_addr.i64 ss0
 ;;                                     store notrap v4, v218
-;; @0025                               v14 = iconst.i32 -1476395008
-;; @0025                               v16 = load.i64 notrap aligned readonly can_move v0+40
-;; @0025                               v17 = load.i32 notrap aligned readonly can_move v16
+;; @0025                               v15 = iconst.i32 -1476395008
+;; @0025                               v17 = load.i64 notrap aligned readonly can_move v0+40
+;; @0025                               v18 = load.i32 notrap aligned readonly can_move v17
 ;;                                     v232 = iconst.i32 40
-;; @0025                               v18 = iconst.i32 8
-;; @0025                               v19 = call fn0(v0, v14, v17, v232, v18), stack_map=[i32 @ ss2+0, i32 @ ss1+0, i32 @ ss0+0]  ; v14 = -1476395008, v232 = 40, v18 = 8
+;; @0025                               v19 = iconst.i32 8
+;; @0025                               v20 = call fn0(v0, v15, v18, v232, v19), stack_map=[i32 @ ss2+0, i32 @ ss1+0, i32 @ ss0+0]  ; v15 = -1476395008, v232 = 40, v19 = 8
 ;; @0025                               v6 = iconst.i32 3
-;; @0025                               v214 = load.i64 notrap aligned readonly can_move v0+8
-;; @0025                               v20 = load.i64 notrap aligned readonly can_move v214+32
-;; @0025                               v21 = uextend.i64 v19
-;; @0025                               v22 = iadd v20, v21
-;; @0025                               v23 = iconst.i64 24
-;; @0025                               v24 = iadd v22, v23  ; v23 = 24
-;; @0025                               store user2 region0 v6, v24  ; v6 = 3
-;; @0025                               trapz v19, user16
-;; @0025                               v43 = uadd_overflow_trap v19, v232, user2  ; v232 = 40
-;;                                     v168 = load.i32 notrap v220
-;;                                     v207 = iconst.i32 1
-;; @0025                               v50 = band v168, v207  ; v207 = 1
-;; @0025                               v25 = iconst.i32 0
-;; @0025                               v52 = icmp eq v168, v25  ; v25 = 0
-;; @0025                               v53 = uextend.i32 v52
-;; @0025                               v54 = bor v50, v53
-;; @0025                               brif v54, block3, block2
+;; @0025                               v215 = load.i64 notrap aligned readonly can_move v0+8
+;; @0025                               v21 = load.i64 notrap aligned readonly can_move v215+32
+;; @0025                               v22 = uextend.i64 v20
+;; @0025                               v23 = iadd v21, v22
+;; @0025                               v24 = iconst.i64 24
+;; @0025                               v25 = iadd v23, v24  ; v24 = 24
+;; @0025                               store user2 region0 v6, v25  ; v6 = 3
+;; @0025                               trapz v20, user16
+;; @0025                               v44 = uadd_overflow_trap v20, v232, user2  ; v232 = 40
+;;                                     v169 = load.i32 notrap v220
+;;                                     v208 = iconst.i32 1
+;; @0025                               v51 = band v169, v208  ; v208 = 1
+;; @0025                               v26 = iconst.i32 0
+;; @0025                               v53 = icmp eq v169, v26  ; v26 = 0
+;; @0025                               v54 = uextend.i32 v53
+;; @0025                               v55 = bor v51, v54
+;; @0025                               brif v55, block3, block2
 ;;
 ;;                                 block2:
-;;                                     v166 = load.i32 notrap v220
-;; @0025                               v55 = uextend.i64 v166
-;; @0025                               v57 = iadd.i64 v20, v55
-;; @0025                               v58 = iconst.i64 8
-;; @0025                               v59 = iadd v57, v58  ; v58 = 8
-;; @0025                               v60 = load.i64 user2 region0 v59
-;; @0025                               v61 = iconst.i64 1
-;; @0025                               v62 = iadd v60, v61  ; v61 = 1
-;; @0025                               store user2 region0 v62, v59
+;;                                     v167 = load.i32 notrap v220
+;; @0025                               v56 = uextend.i64 v167
+;; @0025                               v58 = iadd.i64 v21, v56
+;; @0025                               v59 = iconst.i64 8
+;; @0025                               v60 = iadd v58, v59  ; v59 = 8
+;; @0025                               v61 = load.i64 user2 region0 v60
+;; @0025                               v62 = iconst.i64 1
+;; @0025                               v63 = iadd v61, v62  ; v62 = 1
+;; @0025                               store user2 region0 v63, v60
 ;; @0025                               jump block3
 ;;
 ;;                                 block3:
-;;                                     v164 = load.i32 notrap v220
-;; @0025                               v44 = uextend.i64 v43
-;; @0025                               v46 = iadd.i64 v20, v44
+;;                                     v165 = load.i32 notrap v220
+;; @0025                               v45 = uextend.i64 v44
+;; @0025                               v47 = iadd.i64 v21, v45
 ;;                                     v222 = iconst.i64 12
-;; @0025                               v49 = isub v46, v222  ; v222 = 12
-;; @0025                               store user2 little region0 v164, v49
-;;                                     v325 = iadd.i64 v22, v23  ; v23 = 24
-;; @0025                               v74 = load.i32 user2 readonly region0 v325
+;; @0025                               v50 = isub v47, v222  ; v222 = 12
+;; @0025                               store user2 little region0 v165, v50
+;;                                     v325 = iadd.i64 v23, v24  ; v24 = 24
+;; @0025                               v75 = load.i32 user2 readonly region0 v325
 ;;                                     v326 = iconst.i32 1
-;;                                     v327 = icmp ugt v74, v326  ; v326 = 1
+;;                                     v327 = icmp ugt v75, v326  ; v326 = 1
 ;; @0025                               trapz v327, user17
-;; @0025                               v77 = uextend.i64 v74
+;; @0025                               v78 = uextend.i64 v75
 ;;                                     v223 = iconst.i64 2
-;;                                     v267 = ishl v77, v223  ; v223 = 2
-;;                                     v216 = iconst.i64 32
-;; @0025                               v79 = ushr v267, v216  ; v216 = 32
-;; @0025                               trapnz v79, user2
+;;                                     v267 = ishl v78, v223  ; v223 = 2
+;;                                     v217 = iconst.i64 32
+;; @0025                               v80 = ushr v267, v217  ; v217 = 32
+;; @0025                               trapnz v80, user2
 ;;                                     v244 = iconst.i32 2
-;;                                     v274 = ishl v74, v244  ; v244 = 2
+;;                                     v274 = ishl v75, v244  ; v244 = 2
 ;; @0025                               v7 = iconst.i32 28
-;; @0025                               v82 = uadd_overflow_trap v274, v7, user2  ; v7 = 28
-;; @0025                               v86 = uadd_overflow_trap.i32 v19, v82, user2
-;;                                     v163 = load.i32 notrap v219
-;;                                     v328 = band v163, v326  ; v326 = 1
+;; @0025                               v83 = uadd_overflow_trap v274, v7, user2  ; v7 = 28
+;; @0025                               v87 = uadd_overflow_trap.i32 v20, v83, user2
+;;                                     v164 = load.i32 notrap v219
+;;                                     v328 = band v164, v326  ; v326 = 1
 ;;                                     v329 = iconst.i32 0
-;;                                     v330 = icmp eq v163, v329  ; v329 = 0
-;; @0025                               v96 = uextend.i32 v330
-;; @0025                               v97 = bor v328, v96
-;; @0025                               brif v97, block5, block4
+;;                                     v330 = icmp eq v164, v329  ; v329 = 0
+;; @0025                               v97 = uextend.i32 v330
+;; @0025                               v98 = bor v328, v97
+;; @0025                               brif v98, block5, block4
 ;;
 ;;                                 block4:
-;;                                     v161 = load.i32 notrap v219
-;; @0025                               v98 = uextend.i64 v161
-;; @0025                               v100 = iadd.i64 v20, v98
+;;                                     v162 = load.i32 notrap v219
+;; @0025                               v99 = uextend.i64 v162
+;; @0025                               v101 = iadd.i64 v21, v99
 ;;                                     v331 = iconst.i64 8
-;; @0025                               v102 = iadd v100, v331  ; v331 = 8
-;; @0025                               v103 = load.i64 user2 region0 v102
+;; @0025                               v103 = iadd v101, v331  ; v331 = 8
+;; @0025                               v104 = load.i64 user2 region0 v103
 ;;                                     v332 = iconst.i64 1
-;; @0025                               v105 = iadd v103, v332  ; v332 = 1
-;; @0025                               store user2 region0 v105, v102
+;; @0025                               v106 = iadd v104, v332  ; v332 = 1
+;; @0025                               store user2 region0 v106, v103
 ;; @0025                               jump block5
 ;;
 ;;                                 block5:
-;;                                     v159 = load.i32 notrap v219
-;; @0025                               v87 = uextend.i64 v86
-;; @0025                               v89 = iadd.i64 v20, v87
+;;                                     v160 = load.i32 notrap v219
+;; @0025                               v88 = uextend.i64 v87
+;; @0025                               v90 = iadd.i64 v21, v88
 ;;                                     v287 = iconst.i32 32
-;; @0025                               v90 = isub.i32 v82, v287  ; v287 = 32
-;; @0025                               v91 = uextend.i64 v90
-;; @0025                               v92 = isub v89, v91
-;; @0025                               store user2 little region0 v159, v92
-;;                                     v333 = iadd.i64 v22, v23  ; v23 = 24
-;; @0025                               v117 = load.i32 user2 readonly region0 v333
+;; @0025                               v91 = isub.i32 v83, v287  ; v287 = 32
+;; @0025                               v92 = uextend.i64 v91
+;; @0025                               v93 = isub v90, v92
+;; @0025                               store user2 little region0 v160, v93
+;;                                     v333 = iadd.i64 v23, v24  ; v24 = 24
+;; @0025                               v118 = load.i32 user2 readonly region0 v333
 ;;                                     v334 = iconst.i32 2
-;;                                     v335 = icmp ugt v117, v334  ; v334 = 2
+;;                                     v335 = icmp ugt v118, v334  ; v334 = 2
 ;; @0025                               trapz v335, user17
-;; @0025                               v120 = uextend.i64 v117
+;; @0025                               v121 = uextend.i64 v118
 ;;                                     v336 = iconst.i64 2
-;;                                     v337 = ishl v120, v336  ; v336 = 2
+;;                                     v337 = ishl v121, v336  ; v336 = 2
 ;;                                     v338 = iconst.i64 32
 ;;                                     v339 = ushr v337, v338  ; v338 = 32
 ;; @0025                               trapnz v339, user2
-;;                                     v340 = ishl v117, v334  ; v334 = 2
+;;                                     v340 = ishl v118, v334  ; v334 = 2
 ;;                                     v341 = iconst.i32 28
-;; @0025                               v125 = uadd_overflow_trap v340, v341, user2  ; v341 = 28
-;; @0025                               v129 = uadd_overflow_trap.i32 v19, v125, user2
-;;                                     v158 = load.i32 notrap v218
+;; @0025                               v126 = uadd_overflow_trap v340, v341, user2  ; v341 = 28
+;; @0025                               v130 = uadd_overflow_trap.i32 v20, v126, user2
+;;                                     v159 = load.i32 notrap v218
 ;;                                     v342 = iconst.i32 1
-;;                                     v343 = band v158, v342  ; v342 = 1
+;;                                     v343 = band v159, v342  ; v342 = 1
 ;;                                     v344 = iconst.i32 0
-;;                                     v345 = icmp eq v158, v344  ; v344 = 0
-;; @0025                               v139 = uextend.i32 v345
-;; @0025                               v140 = bor v343, v139
-;; @0025                               brif v140, block7, block6
+;;                                     v345 = icmp eq v159, v344  ; v344 = 0
+;; @0025                               v140 = uextend.i32 v345
+;; @0025                               v141 = bor v343, v140
+;; @0025                               brif v141, block7, block6
 ;;
 ;;                                 block6:
-;;                                     v156 = load.i32 notrap v218
-;; @0025                               v141 = uextend.i64 v156
-;; @0025                               v143 = iadd.i64 v20, v141
+;;                                     v157 = load.i32 notrap v218
+;; @0025                               v142 = uextend.i64 v157
+;; @0025                               v144 = iadd.i64 v21, v142
 ;;                                     v346 = iconst.i64 8
-;; @0025                               v145 = iadd v143, v346  ; v346 = 8
-;; @0025                               v146 = load.i64 user2 region0 v145
+;; @0025                               v146 = iadd v144, v346  ; v346 = 8
+;; @0025                               v147 = load.i64 user2 region0 v146
 ;;                                     v347 = iconst.i64 1
-;; @0025                               v148 = iadd v146, v347  ; v347 = 1
-;; @0025                               store user2 region0 v148, v145
+;; @0025                               v149 = iadd v147, v347  ; v347 = 1
+;; @0025                               store user2 region0 v149, v146
 ;; @0025                               jump block7
 ;;
 ;;                                 block7:
-;;                                     v154 = load.i32 notrap v218
-;; @0025                               v130 = uextend.i64 v129
-;; @0025                               v132 = iadd.i64 v20, v130
+;;                                     v155 = load.i32 notrap v218
+;; @0025                               v131 = uextend.i64 v130
+;; @0025                               v133 = iadd.i64 v21, v131
 ;;                                     v319 = iconst.i32 36
-;; @0025                               v133 = isub.i32 v125, v319  ; v319 = 36
-;; @0025                               v134 = uextend.i64 v133
-;; @0025                               v135 = isub v132, v134
-;; @0025                               store user2 little region0 v154, v135
+;; @0025                               v134 = isub.i32 v126, v319  ; v319 = 36
+;; @0025                               v135 = uextend.i64 v134
+;; @0025                               v136 = isub v133, v135
+;; @0025                               store user2 little region0 v155, v136
 ;; @0029                               jump block1
 ;;
 ;;                                 block1:
-;; @0029                               return v19
+;; @0029                               return v20
 ;; }

--- a/tests/disas/gc/drc/array-new-fixed.wat
+++ b/tests/disas/gc/drc/array-new-fixed.wat
@@ -23,67 +23,67 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i64, v4: i64):
-;; @0025                               v14 = iconst.i32 -1476395008
-;; @0025                               v16 = load.i64 notrap aligned readonly can_move v0+40
-;; @0025                               v17 = load.i32 notrap aligned readonly can_move v16
+;; @0025                               v15 = iconst.i32 -1476395008
+;; @0025                               v17 = load.i64 notrap aligned readonly can_move v0+40
+;; @0025                               v18 = load.i32 notrap aligned readonly can_move v17
 ;;                                     v129 = iconst.i32 56
-;; @0025                               v18 = iconst.i32 8
-;; @0025                               v19 = call fn0(v0, v14, v17, v129, v18)  ; v14 = -1476395008, v129 = 56, v18 = 8
+;; @0025                               v19 = iconst.i32 8
+;; @0025                               v20 = call fn0(v0, v15, v18, v129, v19)  ; v15 = -1476395008, v129 = 56, v19 = 8
 ;; @0025                               v6 = iconst.i32 3
-;; @0025                               v115 = load.i64 notrap aligned readonly can_move v0+8
-;; @0025                               v20 = load.i64 notrap aligned readonly can_move v115+32
-;; @0025                               v21 = uextend.i64 v19
-;; @0025                               v22 = iadd v20, v21
+;; @0025                               v116 = load.i64 notrap aligned readonly can_move v0+8
+;; @0025                               v21 = load.i64 notrap aligned readonly can_move v116+32
+;; @0025                               v22 = uextend.i64 v20
+;; @0025                               v23 = iadd v21, v22
 ;;                                     v120 = iconst.i64 24
-;; @0025                               v24 = iadd v22, v120  ; v120 = 24
-;; @0025                               store user2 region0 v6, v24  ; v6 = 3
-;; @0025                               trapz v19, user16
-;; @0025                               v43 = uadd_overflow_trap v19, v129, user2  ; v129 = 56
-;; @0025                               v44 = uextend.i64 v43
-;; @0025                               v46 = iadd v20, v44
-;; @0025                               v49 = isub v46, v120  ; v120 = 24
-;; @0025                               store user2 little region0 v2, v49
-;; @0025                               v56 = load.i32 user2 readonly region0 v24
-;; @0025                               v50 = iconst.i32 1
-;;                                     v160 = icmp ugt v56, v50  ; v50 = 1
+;; @0025                               v25 = iadd v23, v120  ; v120 = 24
+;; @0025                               store user2 region0 v6, v25  ; v6 = 3
+;; @0025                               trapz v20, user16
+;; @0025                               v44 = uadd_overflow_trap v20, v129, user2  ; v129 = 56
+;; @0025                               v45 = uextend.i64 v44
+;; @0025                               v47 = iadd v21, v45
+;; @0025                               v50 = isub v47, v120  ; v120 = 24
+;; @0025                               store user2 little region0 v2, v50
+;; @0025                               v57 = load.i32 user2 readonly region0 v25
+;; @0025                               v51 = iconst.i32 1
+;;                                     v160 = icmp ugt v57, v51  ; v51 = 1
 ;; @0025                               trapz v160, user17
-;; @0025                               v59 = uextend.i64 v56
+;; @0025                               v60 = uextend.i64 v57
 ;;                                     v119 = iconst.i64 3
-;;                                     v162 = ishl v59, v119  ; v119 = 3
-;;                                     v117 = iconst.i64 32
-;; @0025                               v61 = ushr v162, v117  ; v117 = 32
-;; @0025                               trapnz v61, user2
-;;                                     v169 = ishl v56, v6  ; v6 = 3
+;;                                     v162 = ishl v60, v119  ; v119 = 3
+;;                                     v118 = iconst.i64 32
+;; @0025                               v62 = ushr v162, v118  ; v118 = 32
+;; @0025                               trapnz v62, user2
+;;                                     v169 = ishl v57, v6  ; v6 = 3
 ;; @0025                               v7 = iconst.i32 32
-;; @0025                               v64 = uadd_overflow_trap v169, v7, user2  ; v7 = 32
-;; @0025                               v68 = uadd_overflow_trap v19, v64, user2
-;; @0025                               v69 = uextend.i64 v68
-;; @0025                               v71 = iadd v20, v69
+;; @0025                               v65 = uadd_overflow_trap v169, v7, user2  ; v7 = 32
+;; @0025                               v69 = uadd_overflow_trap v20, v65, user2
+;; @0025                               v70 = uextend.i64 v69
+;; @0025                               v72 = iadd v21, v70
 ;;                                     v182 = iconst.i32 40
-;; @0025                               v72 = isub v64, v182  ; v182 = 40
-;; @0025                               v73 = uextend.i64 v72
-;; @0025                               v74 = isub v71, v73
-;; @0025                               store user2 little region0 v3, v74
-;; @0025                               v81 = load.i32 user2 readonly region0 v24
-;; @0025                               v75 = iconst.i32 2
-;;                                     v188 = icmp ugt v81, v75  ; v75 = 2
+;; @0025                               v73 = isub v65, v182  ; v182 = 40
+;; @0025                               v74 = uextend.i64 v73
+;; @0025                               v75 = isub v72, v74
+;; @0025                               store user2 little region0 v3, v75
+;; @0025                               v82 = load.i32 user2 readonly region0 v25
+;; @0025                               v76 = iconst.i32 2
+;;                                     v188 = icmp ugt v82, v76  ; v76 = 2
 ;; @0025                               trapz v188, user17
-;; @0025                               v84 = uextend.i64 v81
-;;                                     v190 = ishl v84, v119  ; v119 = 3
-;; @0025                               v86 = ushr v190, v117  ; v117 = 32
-;; @0025                               trapnz v86, user2
-;;                                     v197 = ishl v81, v6  ; v6 = 3
-;; @0025                               v89 = uadd_overflow_trap v197, v7, user2  ; v7 = 32
-;; @0025                               v93 = uadd_overflow_trap v19, v89, user2
-;; @0025                               v94 = uextend.i64 v93
-;; @0025                               v96 = iadd v20, v94
+;; @0025                               v85 = uextend.i64 v82
+;;                                     v190 = ishl v85, v119  ; v119 = 3
+;; @0025                               v87 = ushr v190, v118  ; v118 = 32
+;; @0025                               trapnz v87, user2
+;;                                     v197 = ishl v82, v6  ; v6 = 3
+;; @0025                               v90 = uadd_overflow_trap v197, v7, user2  ; v7 = 32
+;; @0025                               v94 = uadd_overflow_trap v20, v90, user2
+;; @0025                               v95 = uextend.i64 v94
+;; @0025                               v97 = iadd v21, v95
 ;;                                     v215 = iconst.i32 48
-;; @0025                               v97 = isub v89, v215  ; v215 = 48
-;; @0025                               v98 = uextend.i64 v97
-;; @0025                               v99 = isub v96, v98
-;; @0025                               store user2 little region0 v4, v99
+;; @0025                               v98 = isub v90, v215  ; v215 = 48
+;; @0025                               v99 = uextend.i64 v98
+;; @0025                               v100 = isub v97, v99
+;; @0025                               store user2 little region0 v4, v100
 ;; @0029                               jump block1
 ;;
 ;;                                 block1:
-;; @0029                               return v19
+;; @0029                               return v20
 ;; }

--- a/tests/disas/gc/drc/array-new.wat
+++ b/tests/disas/gc/drc/array-new.wat
@@ -26,48 +26,48 @@
 ;; @0022                               v6 = uextend.i64 v3
 ;;                                     v73 = iconst.i64 3
 ;;                                     v74 = ishl v6, v73  ; v73 = 3
-;;                                     v71 = iconst.i64 32
-;; @0022                               v8 = ushr v74, v71  ; v71 = 32
-;; @0022                               trapnz v8, user18
+;;                                     v72 = iconst.i64 32
+;; @0022                               v9 = ushr v74, v72  ; v72 = 32
+;; @0022                               trapnz v9, user18
 ;; @0022                               v5 = iconst.i32 32
 ;;                                     v80 = iconst.i32 3
 ;;                                     v81 = ishl v3, v80  ; v80 = 3
-;; @0022                               v10 = uadd_overflow_trap v5, v81, user18  ; v5 = 32
-;; @0022                               v12 = iconst.i32 -1476395008
-;; @0022                               v14 = load.i64 notrap aligned readonly can_move v0+40
-;; @0022                               v15 = load.i32 notrap aligned readonly can_move v14
+;; @0022                               v11 = uadd_overflow_trap v5, v81, user18  ; v5 = 32
+;; @0022                               v13 = iconst.i32 -1476395008
+;; @0022                               v15 = load.i64 notrap aligned readonly can_move v0+40
+;; @0022                               v16 = load.i32 notrap aligned readonly can_move v15
 ;;                                     v78 = iconst.i32 8
-;; @0022                               v17 = call fn0(v0, v12, v15, v10, v78)  ; v12 = -1476395008, v78 = 8
-;; @0022                               v69 = load.i64 notrap aligned readonly can_move v0+8
-;; @0022                               v18 = load.i64 notrap aligned readonly can_move v69+32
-;; @0022                               v19 = uextend.i64 v17
-;; @0022                               v20 = iadd v18, v19
-;; @0022                               v21 = iconst.i64 24
-;; @0022                               v22 = iadd v20, v21  ; v21 = 24
-;; @0022                               store user2 region0 v3, v22
-;; @0022                               trapz v17, user16
-;; @0022                               v47 = load.i64 notrap aligned v69+40
-;; @0022                               v40 = iadd v20, v71  ; v71 = 32
-;; @0022                               v49 = uadd_overflow_trap v40, v74, user2
-;; @0022                               v48 = iadd v18, v47
-;; @0022                               v50 = icmp ugt v49, v48
-;; @0022                               trapnz v50, user2
+;; @0022                               v18 = call fn0(v0, v13, v16, v11, v78)  ; v13 = -1476395008, v78 = 8
+;; @0022                               v70 = load.i64 notrap aligned readonly can_move v0+8
+;; @0022                               v19 = load.i64 notrap aligned readonly can_move v70+32
+;; @0022                               v20 = uextend.i64 v18
+;; @0022                               v21 = iadd v19, v20
+;; @0022                               v22 = iconst.i64 24
+;; @0022                               v23 = iadd v21, v22  ; v22 = 24
+;; @0022                               store user2 region0 v3, v23
+;; @0022                               trapz v18, user16
+;; @0022                               v51 = load.i64 notrap aligned v70+40
+;; @0022                               v42 = iadd v21, v72  ; v72 = 32
+;; @0022                               v53 = uadd_overflow_trap v42, v74, user2
+;; @0022                               v52 = iadd v19, v51
+;; @0022                               v54 = icmp ugt v53, v52
+;; @0022                               trapnz v54, user2
 ;;                                     v84 = iconst.i64 0
-;; @0022                               v53 = icmp eq v6, v84  ; v84 = 0
-;;                                     v72 = iconst.i64 8
-;; @0022                               v51 = iadd v40, v74
-;; @0022                               brif v53, block3, block2(v40)
+;; @0022                               v57 = icmp eq v6, v84  ; v84 = 0
+;; @0022                               v7 = iconst.i64 8
+;; @0022                               v55 = iadd v42, v74
+;; @0022                               brif v57, block3, block2(v42)
 ;;
-;;                                 block2(v54: i64):
-;; @0022                               store.i64 user2 little region0 v2, v54
+;;                                 block2(v58: i64):
+;; @0022                               store.i64 user2 little region0 v2, v58
 ;;                                     v99 = iconst.i64 8
-;;                                     v100 = iadd v54, v99  ; v99 = 8
-;; @0022                               v57 = icmp eq v100, v51
-;; @0022                               brif v57, block3, block2(v100)
+;;                                     v100 = iadd v58, v99  ; v99 = 8
+;; @0022                               v61 = icmp eq v100, v55
+;; @0022                               brif v61, block3, block2(v100)
 ;;
 ;;                                 block3:
 ;; @0025                               jump block1
 ;;
 ;;                                 block1:
-;; @0025                               return v17
+;; @0025                               return v18
 ;; }

--- a/tests/disas/gc/null/array-fill.wat
+++ b/tests/disas/gc/null/array-fill.wat
@@ -31,32 +31,32 @@
 ;; @0027                               v11 = load.i32 user2 readonly region0 v10
 ;; @0027                               v13 = uextend.i64 v3
 ;; @0027                               v14 = uextend.i64 v5
-;; @0027                               v16 = iadd v13, v14
+;; @0027                               v17 = iadd v13, v14
 ;; @0027                               v12 = uextend.i64 v11
-;; @0027                               v17 = icmp ugt v16, v12
-;; @0027                               trapnz v17, user17
-;; @0027                               v29 = load.i64 notrap aligned v49+40
-;; @0027                               v21 = iconst.i64 16
-;; @0027                               v22 = iadd v8, v21  ; v21 = 16
+;; @0027                               v18 = icmp ugt v17, v12
+;; @0027                               trapnz v18, user17
+;; @0027                               v32 = load.i64 notrap aligned v49+40
+;; @0027                               v22 = iconst.i64 16
+;; @0027                               v23 = iadd v8, v22  ; v22 = 16
 ;;                                     v53 = iconst.i64 3
 ;;                                     v54 = ishl v13, v53  ; v53 = 3
-;; @0027                               v25 = iadd v22, v54
+;; @0027                               v27 = iadd v23, v54
 ;;                                     v56 = ishl v14, v53  ; v53 = 3
-;; @0027                               v31 = uadd_overflow_trap v25, v56, user2
-;; @0027                               v30 = iadd v7, v29
-;; @0027                               v32 = icmp ugt v31, v30
-;; @0027                               trapnz v32, user2
+;; @0027                               v34 = uadd_overflow_trap v27, v56, user2
+;; @0027                               v33 = iadd v7, v32
+;; @0027                               v35 = icmp ugt v34, v33
+;; @0027                               trapnz v35, user2
 ;;                                     v51 = iconst.i64 0
-;; @0027                               v35 = icmp eq v14, v51  ; v51 = 0
-;; @0027                               v33 = iadd v25, v56
-;; @0027                               brif v35, block3, block2(v25)
+;; @0027                               v38 = icmp eq v14, v51  ; v51 = 0
+;; @0027                               v36 = iadd v27, v56
+;; @0027                               brif v38, block3, block2(v27)
 ;;
-;;                                 block2(v36: i64):
-;; @0027                               store.i64 user2 little region0 v4, v36
+;;                                 block2(v39: i64):
+;; @0027                               store.i64 user2 little region0 v4, v39
 ;;                                     v58 = iconst.i64 8
-;;                                     v59 = iadd v36, v58  ; v58 = 8
-;; @0027                               v39 = icmp eq v59, v33
-;; @0027                               brif v39, block3, block2(v59)
+;;                                     v59 = iadd v39, v58  ; v58 = 8
+;; @0027                               v42 = icmp eq v59, v36
+;; @0027                               brif v42, block3, block2(v59)
 ;;
 ;;                                 block3:
 ;; @002a                               jump block1

--- a/tests/disas/gc/null/array-new-fixed-of-gc-refs.wat
+++ b/tests/disas/gc/null/array-new-fixed-of-gc-refs.wat
@@ -33,93 +33,93 @@
 ;;                                     store notrap v3, v144
 ;;                                     v143 = stack_addr.i64 ss0
 ;;                                     store notrap v4, v143
-;; @0025                               v17 = load.i64 notrap aligned readonly region0 v0+32
-;; @0025                               v18 = load.i32 user2 region1 v17
+;; @0025                               v18 = load.i64 notrap aligned readonly region0 v0+32
+;; @0025                               v19 = load.i32 user2 region1 v18
 ;;                                     v163 = iconst.i32 7
-;; @0025                               v21 = uadd_overflow_trap v18, v163, user18  ; v163 = 7
+;; @0025                               v22 = uadd_overflow_trap v19, v163, user18  ; v163 = 7
 ;;                                     v169 = iconst.i32 -8
-;; @0025                               v23 = band v21, v169  ; v169 = -8
+;; @0025                               v24 = band v22, v169  ; v169 = -8
 ;;                                     v156 = iconst.i32 24
-;; @0025                               v24 = uadd_overflow_trap v23, v156, user18  ; v156 = 24
-;; @0025                               v139 = load.i64 notrap aligned readonly can_move v0+8
-;; @0025                               v26 = load.i64 notrap aligned v139+40
-;; @0025                               v25 = uextend.i64 v24
-;; @0025                               v27 = icmp ule v25, v26
-;; @0025                               brif v27, block2, block3
+;; @0025                               v25 = uadd_overflow_trap v24, v156, user18  ; v156 = 24
+;; @0025                               v140 = load.i64 notrap aligned readonly can_move v0+8
+;; @0025                               v27 = load.i64 notrap aligned v140+40
+;; @0025                               v26 = uextend.i64 v25
+;; @0025                               v28 = icmp ule v26, v27
+;; @0025                               brif v28, block2, block3
 ;;
 ;;                                 block2:
 ;;                                     v170 = iconst.i32 -1476394984
-;; @0025                               v31 = load.i64 notrap aligned readonly can_move v139+32
-;;                                     v268 = band.i32 v21, v169  ; v169 = -8
+;; @0025                               v32 = load.i64 notrap aligned readonly can_move v140+32
+;;                                     v268 = band.i32 v22, v169  ; v169 = -8
 ;;                                     v269 = uextend.i64 v268
-;; @0025                               v33 = iadd v31, v269
-;; @0025                               store user2 region1 v170, v33  ; v170 = -1476394984
-;; @0025                               v37 = load.i64 notrap aligned readonly can_move v0+40
-;; @0025                               v38 = load.i32 notrap aligned readonly can_move v37
-;; @0025                               store user2 region1 v38, v33+4
-;; @0025                               store.i32 user2 region1 v24, v17
+;; @0025                               v34 = iadd v32, v269
+;; @0025                               store user2 region1 v170, v34  ; v170 = -1476394984
+;; @0025                               v38 = load.i64 notrap aligned readonly can_move v0+40
+;; @0025                               v39 = load.i32 notrap aligned readonly can_move v38
+;; @0025                               store user2 region1 v39, v34+4
+;; @0025                               store.i32 user2 region1 v25, v18
 ;; @0025                               v6 = iconst.i32 3
-;; @0025                               v39 = iconst.i64 8
-;; @0025                               v40 = iadd v33, v39  ; v39 = 8
-;; @0025                               store user2 region1 v6, v40  ; v6 = 3
+;; @0025                               v40 = iconst.i64 8
+;; @0025                               v41 = iadd v34, v40  ; v40 = 8
+;; @0025                               store user2 region1 v6, v41  ; v6 = 3
 ;; @0025                               trapz v268, user16
 ;;                                     v270 = iconst.i32 24
-;; @0025                               v59 = uadd_overflow_trap v268, v270, user2  ; v270 = 24
-;;                                     v118 = load.i32 notrap v145
-;; @0025                               v60 = uextend.i64 v59
-;; @0025                               v62 = iadd v31, v60
+;; @0025                               v60 = uadd_overflow_trap v268, v270, user2  ; v270 = 24
+;;                                     v119 = load.i32 notrap v145
+;; @0025                               v61 = uextend.i64 v60
+;; @0025                               v63 = iadd v32, v61
 ;;                                     v147 = iconst.i64 12
-;; @0025                               v65 = isub v62, v147  ; v147 = 12
-;; @0025                               store user2 little region1 v118, v65
-;; @0025                               v72 = load.i32 user2 readonly region1 v40
-;; @0025                               v66 = iconst.i32 1
-;;                                     v208 = icmp ugt v72, v66  ; v66 = 1
+;; @0025                               v66 = isub v63, v147  ; v147 = 12
+;; @0025                               store user2 little region1 v119, v66
+;; @0025                               v73 = load.i32 user2 readonly region1 v41
+;; @0025                               v67 = iconst.i32 1
+;;                                     v208 = icmp ugt v73, v67  ; v67 = 1
 ;; @0025                               trapz v208, user17
-;; @0025                               v75 = uextend.i64 v72
+;; @0025                               v76 = uextend.i64 v73
 ;;                                     v148 = iconst.i64 2
-;;                                     v210 = ishl v75, v148  ; v148 = 2
-;;                                     v141 = iconst.i64 32
-;; @0025                               v77 = ushr v210, v141  ; v141 = 32
-;; @0025                               trapnz v77, user2
+;;                                     v210 = ishl v76, v148  ; v148 = 2
+;;                                     v142 = iconst.i64 32
+;; @0025                               v78 = ushr v210, v142  ; v142 = 32
+;; @0025                               trapnz v78, user2
 ;;                                     v187 = iconst.i32 2
-;;                                     v217 = ishl v72, v187  ; v187 = 2
+;;                                     v217 = ishl v73, v187  ; v187 = 2
 ;; @0025                               v7 = iconst.i32 12
-;; @0025                               v80 = uadd_overflow_trap v217, v7, user2  ; v7 = 12
-;; @0025                               v84 = uadd_overflow_trap v268, v80, user2
-;;                                     v117 = load.i32 notrap v144
-;; @0025                               v85 = uextend.i64 v84
-;; @0025                               v87 = iadd v31, v85
+;; @0025                               v81 = uadd_overflow_trap v217, v7, user2  ; v7 = 12
+;; @0025                               v85 = uadd_overflow_trap v268, v81, user2
+;;                                     v118 = load.i32 notrap v144
+;; @0025                               v86 = uextend.i64 v85
+;; @0025                               v88 = iadd v32, v86
 ;;                                     v230 = iconst.i32 16
-;; @0025                               v88 = isub v80, v230  ; v230 = 16
-;; @0025                               v89 = uextend.i64 v88
-;; @0025                               v90 = isub v87, v89
-;; @0025                               store user2 little region1 v117, v90
-;; @0025                               v97 = load.i32 user2 readonly region1 v40
-;;                                     v236 = icmp ugt v97, v187  ; v187 = 2
+;; @0025                               v89 = isub v81, v230  ; v230 = 16
+;; @0025                               v90 = uextend.i64 v89
+;; @0025                               v91 = isub v88, v90
+;; @0025                               store user2 little region1 v118, v91
+;; @0025                               v98 = load.i32 user2 readonly region1 v41
+;;                                     v236 = icmp ugt v98, v187  ; v187 = 2
 ;; @0025                               trapz v236, user17
-;; @0025                               v100 = uextend.i64 v97
-;;                                     v238 = ishl v100, v148  ; v148 = 2
-;; @0025                               v102 = ushr v238, v141  ; v141 = 32
-;; @0025                               trapnz v102, user2
-;;                                     v245 = ishl v97, v187  ; v187 = 2
-;; @0025                               v105 = uadd_overflow_trap v245, v7, user2  ; v7 = 12
-;; @0025                               v109 = uadd_overflow_trap v268, v105, user2
-;;                                     v116 = load.i32 notrap v143
-;; @0025                               v110 = uextend.i64 v109
-;; @0025                               v112 = iadd v31, v110
+;; @0025                               v101 = uextend.i64 v98
+;;                                     v238 = ishl v101, v148  ; v148 = 2
+;; @0025                               v103 = ushr v238, v142  ; v142 = 32
+;; @0025                               trapnz v103, user2
+;;                                     v245 = ishl v98, v187  ; v187 = 2
+;; @0025                               v106 = uadd_overflow_trap v245, v7, user2  ; v7 = 12
+;; @0025                               v110 = uadd_overflow_trap v268, v106, user2
+;;                                     v117 = load.i32 notrap v143
+;; @0025                               v111 = uextend.i64 v110
+;; @0025                               v113 = iadd v32, v111
 ;;                                     v262 = iconst.i32 20
-;; @0025                               v113 = isub v105, v262  ; v262 = 20
-;; @0025                               v114 = uextend.i64 v113
-;; @0025                               v115 = isub v112, v114
-;; @0025                               store user2 little region1 v116, v115
+;; @0025                               v114 = isub v106, v262  ; v262 = 20
+;; @0025                               v115 = uextend.i64 v114
+;; @0025                               v116 = isub v113, v115
+;; @0025                               store user2 little region1 v117, v116
 ;; @0029                               jump block1
 ;;
 ;;                                 block3 cold:
-;; @0025                               v29 = isub.i64 v25, v26
-;; @0025                               v30 = call fn0(v0, v29), stack_map=[i32 @ ss2+0, i32 @ ss1+0, i32 @ ss0+0]
+;; @0025                               v30 = isub.i64 v26, v27
+;; @0025                               v31 = call fn0(v0, v30), stack_map=[i32 @ ss2+0, i32 @ ss1+0, i32 @ ss0+0]
 ;; @0025                               jump block2
 ;;
 ;;                                 block1:
-;;                                     v271 = band.i32 v21, v169  ; v169 = -8
+;;                                     v271 = band.i32 v22, v169  ; v169 = -8
 ;; @0029                               return v271
 ;; }

--- a/tests/disas/gc/null/array-new-fixed.wat
+++ b/tests/disas/gc/null/array-new-fixed.wat
@@ -24,90 +24,90 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i64, v4: i64):
-;; @0025                               v17 = load.i64 notrap aligned readonly region0 v0+32
-;; @0025                               v18 = load.i32 user2 region1 v17
+;; @0025                               v18 = load.i64 notrap aligned readonly region0 v0+32
+;; @0025                               v19 = load.i32 user2 region1 v18
 ;;                                     v154 = iconst.i32 7
-;; @0025                               v21 = uadd_overflow_trap v18, v154, user18  ; v154 = 7
+;; @0025                               v22 = uadd_overflow_trap v19, v154, user18  ; v154 = 7
 ;;                                     v160 = iconst.i32 -8
-;; @0025                               v23 = band v21, v160  ; v160 = -8
+;; @0025                               v24 = band v22, v160  ; v160 = -8
 ;;                                     v147 = iconst.i32 40
-;; @0025                               v24 = uadd_overflow_trap v23, v147, user18  ; v147 = 40
-;; @0025                               v133 = load.i64 notrap aligned readonly can_move v0+8
-;; @0025                               v26 = load.i64 notrap aligned v133+40
-;; @0025                               v25 = uextend.i64 v24
-;; @0025                               v27 = icmp ule v25, v26
-;; @0025                               brif v27, block2, block3
+;; @0025                               v25 = uadd_overflow_trap v24, v147, user18  ; v147 = 40
+;; @0025                               v134 = load.i64 notrap aligned readonly can_move v0+8
+;; @0025                               v27 = load.i64 notrap aligned v134+40
+;; @0025                               v26 = uextend.i64 v25
+;; @0025                               v28 = icmp ule v26, v27
+;; @0025                               brif v28, block2, block3
 ;;
 ;;                                 block2:
 ;;                                     v161 = iconst.i32 -1476394968
-;; @0025                               v31 = load.i64 notrap aligned readonly can_move v133+32
-;;                                     v256 = band.i32 v21, v160  ; v160 = -8
+;; @0025                               v32 = load.i64 notrap aligned readonly can_move v134+32
+;;                                     v256 = band.i32 v22, v160  ; v160 = -8
 ;;                                     v257 = uextend.i64 v256
-;; @0025                               v33 = iadd v31, v257
-;; @0025                               store user2 region1 v161, v33  ; v161 = -1476394968
-;; @0025                               v37 = load.i64 notrap aligned readonly can_move v0+40
-;; @0025                               v38 = load.i32 notrap aligned readonly can_move v37
-;; @0025                               store user2 region1 v38, v33+4
-;; @0025                               store.i32 user2 region1 v24, v17
+;; @0025                               v34 = iadd v32, v257
+;; @0025                               store user2 region1 v161, v34  ; v161 = -1476394968
+;; @0025                               v38 = load.i64 notrap aligned readonly can_move v0+40
+;; @0025                               v39 = load.i32 notrap aligned readonly can_move v38
+;; @0025                               store user2 region1 v39, v34+4
+;; @0025                               store.i32 user2 region1 v25, v18
 ;; @0025                               v6 = iconst.i32 3
-;;                                     v136 = iconst.i64 8
-;; @0025                               v40 = iadd v33, v136  ; v136 = 8
-;; @0025                               store user2 region1 v6, v40  ; v6 = 3
+;; @0025                               v9 = iconst.i64 8
+;; @0025                               v41 = iadd v34, v9  ; v9 = 8
+;; @0025                               store user2 region1 v6, v41  ; v6 = 3
 ;; @0025                               trapz v256, user16
 ;;                                     v258 = iconst.i32 40
-;; @0025                               v59 = uadd_overflow_trap v256, v258, user2  ; v258 = 40
-;; @0025                               v60 = uextend.i64 v59
-;; @0025                               v62 = iadd v31, v60
+;; @0025                               v60 = uadd_overflow_trap v256, v258, user2  ; v258 = 40
+;; @0025                               v61 = uextend.i64 v60
+;; @0025                               v63 = iadd v32, v61
 ;;                                     v138 = iconst.i64 24
-;; @0025                               v65 = isub v62, v138  ; v138 = 24
-;; @0025                               store.i64 user2 little region1 v2, v65
-;; @0025                               v72 = load.i32 user2 readonly region1 v40
-;; @0025                               v66 = iconst.i32 1
-;;                                     v197 = icmp ugt v72, v66  ; v66 = 1
+;; @0025                               v66 = isub v63, v138  ; v138 = 24
+;; @0025                               store.i64 user2 little region1 v2, v66
+;; @0025                               v73 = load.i32 user2 readonly region1 v41
+;; @0025                               v67 = iconst.i32 1
+;;                                     v197 = icmp ugt v73, v67  ; v67 = 1
 ;; @0025                               trapz v197, user17
-;; @0025                               v75 = uextend.i64 v72
+;; @0025                               v76 = uextend.i64 v73
 ;;                                     v137 = iconst.i64 3
-;;                                     v199 = ishl v75, v137  ; v137 = 3
-;;                                     v135 = iconst.i64 32
-;; @0025                               v77 = ushr v199, v135  ; v135 = 32
-;; @0025                               trapnz v77, user2
-;;                                     v206 = ishl v72, v6  ; v6 = 3
+;;                                     v199 = ishl v76, v137  ; v137 = 3
+;;                                     v136 = iconst.i64 32
+;; @0025                               v78 = ushr v199, v136  ; v136 = 32
+;; @0025                               trapnz v78, user2
+;;                                     v206 = ishl v73, v6  ; v6 = 3
 ;; @0025                               v7 = iconst.i32 16
-;; @0025                               v80 = uadd_overflow_trap v206, v7, user2  ; v7 = 16
-;; @0025                               v84 = uadd_overflow_trap v256, v80, user2
-;; @0025                               v85 = uextend.i64 v84
-;; @0025                               v87 = iadd v31, v85
+;; @0025                               v81 = uadd_overflow_trap v206, v7, user2  ; v7 = 16
+;; @0025                               v85 = uadd_overflow_trap v256, v81, user2
+;; @0025                               v86 = uextend.i64 v85
+;; @0025                               v88 = iadd v32, v86
 ;;                                     v146 = iconst.i32 24
-;; @0025                               v88 = isub v80, v146  ; v146 = 24
-;; @0025                               v89 = uextend.i64 v88
-;; @0025                               v90 = isub v87, v89
-;; @0025                               store.i64 user2 little region1 v3, v90
-;; @0025                               v97 = load.i32 user2 readonly region1 v40
-;; @0025                               v91 = iconst.i32 2
-;;                                     v224 = icmp ugt v97, v91  ; v91 = 2
+;; @0025                               v89 = isub v81, v146  ; v146 = 24
+;; @0025                               v90 = uextend.i64 v89
+;; @0025                               v91 = isub v88, v90
+;; @0025                               store.i64 user2 little region1 v3, v91
+;; @0025                               v98 = load.i32 user2 readonly region1 v41
+;; @0025                               v92 = iconst.i32 2
+;;                                     v224 = icmp ugt v98, v92  ; v92 = 2
 ;; @0025                               trapz v224, user17
-;; @0025                               v100 = uextend.i64 v97
-;;                                     v226 = ishl v100, v137  ; v137 = 3
-;; @0025                               v102 = ushr v226, v135  ; v135 = 32
-;; @0025                               trapnz v102, user2
-;;                                     v233 = ishl v97, v6  ; v6 = 3
-;; @0025                               v105 = uadd_overflow_trap v233, v7, user2  ; v7 = 16
-;; @0025                               v109 = uadd_overflow_trap v256, v105, user2
-;; @0025                               v110 = uextend.i64 v109
-;; @0025                               v112 = iadd v31, v110
+;; @0025                               v101 = uextend.i64 v98
+;;                                     v226 = ishl v101, v137  ; v137 = 3
+;; @0025                               v103 = ushr v226, v136  ; v136 = 32
+;; @0025                               trapnz v103, user2
+;;                                     v233 = ishl v98, v6  ; v6 = 3
+;; @0025                               v106 = uadd_overflow_trap v233, v7, user2  ; v7 = 16
+;; @0025                               v110 = uadd_overflow_trap v256, v106, user2
+;; @0025                               v111 = uextend.i64 v110
+;; @0025                               v113 = iadd v32, v111
 ;;                                     v250 = iconst.i32 32
-;; @0025                               v113 = isub v105, v250  ; v250 = 32
-;; @0025                               v114 = uextend.i64 v113
-;; @0025                               v115 = isub v112, v114
-;; @0025                               store.i64 user2 little region1 v4, v115
+;; @0025                               v114 = isub v106, v250  ; v250 = 32
+;; @0025                               v115 = uextend.i64 v114
+;; @0025                               v116 = isub v113, v115
+;; @0025                               store.i64 user2 little region1 v4, v116
 ;; @0029                               jump block1
 ;;
 ;;                                 block3 cold:
-;; @0025                               v29 = isub.i64 v25, v26
-;; @0025                               v30 = call fn0(v0, v29)
+;; @0025                               v30 = isub.i64 v26, v27
+;; @0025                               v31 = call fn0(v0, v30)
 ;; @0025                               jump block2
 ;;
 ;;                                 block1:
-;;                                     v259 = band.i32 v21, v160  ; v160 = -8
+;;                                     v259 = band.i32 v22, v160  ; v160 = -8
 ;; @0029                               return v259
 ;; }

--- a/tests/disas/gc/null/array-new.wat
+++ b/tests/disas/gc/null/array-new.wat
@@ -27,73 +27,73 @@
 ;; @0022                               v6 = uextend.i64 v3
 ;;                                     v91 = iconst.i64 3
 ;;                                     v92 = ishl v6, v91  ; v91 = 3
-;;                                     v89 = iconst.i64 32
-;; @0022                               v8 = ushr v92, v89  ; v89 = 32
-;; @0022                               trapnz v8, user18
+;;                                     v90 = iconst.i64 32
+;; @0022                               v9 = ushr v92, v90  ; v90 = 32
+;; @0022                               trapnz v9, user18
 ;; @0022                               v5 = iconst.i32 16
 ;;                                     v98 = iconst.i32 3
 ;;                                     v99 = ishl v3, v98  ; v98 = 3
-;; @0022                               v10 = uadd_overflow_trap v5, v99, user18  ; v5 = 16
-;; @0022                               v12 = iconst.i32 -67108864
-;; @0022                               v13 = band v10, v12  ; v12 = -67108864
-;; @0022                               trapnz v13, user18
-;; @0022                               v15 = load.i64 notrap aligned readonly region0 v0+32
-;; @0022                               v16 = load.i32 user2 region1 v15
+;; @0022                               v11 = uadd_overflow_trap v5, v99, user18  ; v5 = 16
+;; @0022                               v13 = iconst.i32 -67108864
+;; @0022                               v14 = band v11, v13  ; v13 = -67108864
+;; @0022                               trapnz v14, user18
+;; @0022                               v16 = load.i64 notrap aligned readonly region0 v0+32
+;; @0022                               v17 = load.i32 user2 region1 v16
 ;;                                     v102 = iconst.i32 7
-;; @0022                               v19 = uadd_overflow_trap v16, v102, user18  ; v102 = 7
+;; @0022                               v20 = uadd_overflow_trap v17, v102, user18  ; v102 = 7
 ;;                                     v108 = iconst.i32 -8
-;; @0022                               v21 = band v19, v108  ; v108 = -8
-;; @0022                               v22 = uadd_overflow_trap v21, v10, user18
-;; @0022                               v87 = load.i64 notrap aligned readonly can_move v0+8
-;; @0022                               v24 = load.i64 notrap aligned v87+40
-;; @0022                               v23 = uextend.i64 v22
-;; @0022                               v25 = icmp ule v23, v24
-;; @0022                               brif v25, block2, block3
+;; @0022                               v22 = band v20, v108  ; v108 = -8
+;; @0022                               v23 = uadd_overflow_trap v22, v11, user18
+;; @0022                               v88 = load.i64 notrap aligned readonly can_move v0+8
+;; @0022                               v25 = load.i64 notrap aligned v88+40
+;; @0022                               v24 = uextend.i64 v23
+;; @0022                               v26 = icmp ule v24, v25
+;; @0022                               brif v26, block2, block3
 ;;
 ;;                                 block2:
-;; @0022                               v32 = iconst.i32 -1476395008
-;;                                     v109 = bor.i32 v10, v32  ; v32 = -1476395008
-;; @0022                               v29 = load.i64 notrap aligned readonly can_move v87+32
-;;                                     v126 = band.i32 v19, v108  ; v108 = -8
+;; @0022                               v33 = iconst.i32 -1476395008
+;;                                     v109 = bor.i32 v11, v33  ; v33 = -1476395008
+;; @0022                               v30 = load.i64 notrap aligned readonly can_move v88+32
+;;                                     v126 = band.i32 v20, v108  ; v108 = -8
 ;;                                     v127 = uextend.i64 v126
-;; @0022                               v31 = iadd v29, v127
-;; @0022                               store user2 region1 v109, v31
-;; @0022                               v35 = load.i64 notrap aligned readonly can_move v0+40
-;; @0022                               v36 = load.i32 notrap aligned readonly can_move v35
-;; @0022                               store user2 region1 v36, v31+4
-;; @0022                               store.i32 user2 region1 v22, v15
-;;                                     v90 = iconst.i64 8
-;; @0022                               v38 = iadd v31, v90  ; v90 = 8
-;; @0022                               store.i32 user2 region1 v3, v38
+;; @0022                               v32 = iadd v30, v127
+;; @0022                               store user2 region1 v109, v32
+;; @0022                               v36 = load.i64 notrap aligned readonly can_move v0+40
+;; @0022                               v37 = load.i32 notrap aligned readonly can_move v36
+;; @0022                               store user2 region1 v37, v32+4
+;; @0022                               store.i32 user2 region1 v23, v16
+;; @0022                               v7 = iconst.i64 8
+;; @0022                               v39 = iadd v32, v7  ; v7 = 8
+;; @0022                               store.i32 user2 region1 v3, v39
 ;; @0022                               trapz v126, user16
-;; @0022                               v63 = load.i64 notrap aligned v87+40
-;; @0022                               v55 = iconst.i64 16
-;; @0022                               v56 = iadd v31, v55  ; v55 = 16
-;; @0022                               v65 = uadd_overflow_trap v56, v92, user2
-;; @0022                               v64 = iadd v29, v63
-;; @0022                               v66 = icmp ugt v65, v64
-;; @0022                               trapnz v66, user2
+;; @0022                               v67 = load.i64 notrap aligned v88+40
+;; @0022                               v57 = iconst.i64 16
+;; @0022                               v58 = iadd v32, v57  ; v57 = 16
+;; @0022                               v69 = uadd_overflow_trap v58, v92, user2
+;; @0022                               v68 = iadd v30, v67
+;; @0022                               v70 = icmp ugt v69, v68
+;; @0022                               trapnz v70, user2
 ;;                                     v111 = iconst.i64 0
-;; @0022                               v69 = icmp.i64 eq v6, v111  ; v111 = 0
-;; @0022                               v67 = iadd v56, v92
-;; @0022                               brif v69, block5, block4(v56)
+;; @0022                               v73 = icmp.i64 eq v6, v111  ; v111 = 0
+;; @0022                               v71 = iadd v58, v92
+;; @0022                               brif v73, block5, block4(v58)
 ;;
-;;                                 block4(v70: i64):
-;; @0022                               store.i64 user2 little region1 v2, v70
+;;                                 block4(v74: i64):
+;; @0022                               store.i64 user2 little region1 v2, v74
 ;;                                     v128 = iconst.i64 8
-;;                                     v129 = iadd v70, v128  ; v128 = 8
-;; @0022                               v73 = icmp eq v129, v67
-;; @0022                               brif v73, block5, block4(v129)
+;;                                     v129 = iadd v74, v128  ; v128 = 8
+;; @0022                               v77 = icmp eq v129, v71
+;; @0022                               brif v77, block5, block4(v129)
 ;;
 ;;                                 block5:
 ;; @0025                               jump block1
 ;;
 ;;                                 block3 cold:
-;; @0022                               v27 = isub.i64 v23, v24
-;; @0022                               v28 = call fn0(v0, v27)
+;; @0022                               v28 = isub.i64 v24, v25
+;; @0022                               v29 = call fn0(v0, v28)
 ;; @0022                               jump block2
 ;;
 ;;                                 block1:
-;;                                     v130 = band.i32 v19, v108  ; v108 = -8
+;;                                     v130 = band.i32 v20, v108  ; v108 = -8
 ;; @0025                               return v130
 ;; }

--- a/tests/disas/memory-copy-epochs.wat
+++ b/tests/disas/memory-copy-epochs.wat
@@ -34,63 +34,63 @@
 ;; @001e                               v12 = call fn0(v0)
 ;; @001e                               jump block2(v12)
 ;;
-;;                                 block2(v72: i64):
+;;                                 block2(v76: i64):
 ;; @0025                               v17 = load.i64 notrap aligned v0+64
 ;; @0025                               v18 = uextend.i64 v2
 ;; @0025                               v19 = uextend.i64 v4
-;; @0025                               v21 = iadd v18, v19
-;; @0025                               v22 = icmp ugt v21, v17
-;; @0025                               trapnz v22, heap_oob
-;; @0025                               v29 = uextend.i64 v3
-;; @0025                               v32 = iadd v29, v19
-;; @0025                               v33 = icmp ugt v32, v17
-;; @0025                               trapnz v33, heap_oob
-;; @0025                               v40 = iconst.i64 0x0800_0000
-;; @0025                               v41 = icmp ugt v19, v40  ; v40 = 0x0800_0000
-;; @0025                               v23 = load.i64 notrap aligned readonly can_move v0+56
-;; @0025                               v26 = iadd v23, v18
-;; @0025                               v37 = iadd v23, v29
-;; @0025                               brif v41, block4(v26, v37, v19, v72), block5(v26, v37, v19, v72)
+;; @0025                               v22 = iadd v18, v19
+;; @0025                               v23 = icmp ugt v22, v17
+;; @0025                               trapnz v23, heap_oob
+;; @0025                               v31 = uextend.i64 v3
+;; @0025                               v35 = iadd v31, v19
+;; @0025                               v36 = icmp ugt v35, v17
+;; @0025                               trapnz v36, heap_oob
+;; @0025                               v44 = iconst.i64 0x0800_0000
+;; @0025                               v45 = icmp ugt v19, v44  ; v44 = 0x0800_0000
+;; @0025                               v24 = load.i64 notrap aligned readonly can_move v0+56
+;; @0025                               v28 = iadd v24, v18
+;; @0025                               v41 = iadd v24, v31
+;; @0025                               brif v45, block4(v28, v41, v19, v76), block5(v28, v41, v19, v76)
 ;;
-;;                                 block4(v42: i64, v43: i64, v44: i64, v47: i64):
-;; @0025                               v46 = load.i64 notrap aligned v6
-;; @0025                               v48 = icmp uge v46, v47
-;; @0025                               brif v48, block7, block6(v47)
+;;                                 block4(v46: i64, v47: i64, v48: i64, v51: i64):
+;; @0025                               v50 = load.i64 notrap aligned v6
+;; @0025                               v52 = icmp uge v50, v51
+;; @0025                               brif v52, block7, block6(v51)
 ;;
-;;                                 block5(v58: i64, v59: i64, v60: i64, v63: i64):
-;; @0025                               v62 = load.i64 notrap aligned v6
-;; @0025                               v64 = icmp uge v62, v63
-;; @0025                               brif v64, block10, block9
+;;                                 block5(v62: i64, v63: i64, v64: i64, v67: i64):
+;; @0025                               v66 = load.i64 notrap aligned v6
+;; @0025                               v68 = icmp uge v66, v67
+;; @0025                               brif v68, block10, block9
 ;;
 ;;                                 block7 cold:
-;; @0025                               v50 = load.i64 notrap aligned v8+8
-;; @0025                               v51 = icmp.i64 uge v46, v50
-;; @0025                               brif v51, block8, block6(v50)
+;; @0025                               v54 = load.i64 notrap aligned v8+8
+;; @0025                               v55 = icmp.i64 uge v50, v54
+;; @0025                               brif v55, block8, block6(v54)
 ;;
 ;;                                 block8 cold:
-;; @0025                               v53 = call fn0(v0)
-;; @0025                               jump block6(v53)
+;; @0025                               v57 = call fn0(v0)
+;; @0025                               jump block6(v57)
 ;;
-;;                                 block6(v73: i64):
+;;                                 block6(v77: i64):
 ;;                                     v87 = iconst.i64 0x0800_0000
-;; @0025                               call fn1(v0, v42, v43, v87)  ; v87 = 0x0800_0000
-;;                                     v88 = isub.i64 v44, v87  ; v87 = 0x0800_0000
+;; @0025                               call fn1(v0, v46, v47, v87)  ; v87 = 0x0800_0000
+;;                                     v88 = isub.i64 v48, v87  ; v87 = 0x0800_0000
 ;;                                     v89 = icmp ugt v88, v87  ; v87 = 0x0800_0000
-;;                                     v90 = iadd.i64 v42, v87  ; v87 = 0x0800_0000
-;;                                     v91 = iadd.i64 v43, v87  ; v87 = 0x0800_0000
-;; @0025                               brif v89, block4(v90, v91, v88, v73), block5(v90, v91, v88, v73)
+;;                                     v90 = iadd.i64 v46, v87  ; v87 = 0x0800_0000
+;;                                     v91 = iadd.i64 v47, v87  ; v87 = 0x0800_0000
+;; @0025                               brif v89, block4(v90, v91, v88, v77), block5(v90, v91, v88, v77)
 ;;
 ;;                                 block10 cold:
-;; @0025                               v66 = load.i64 notrap aligned v8+8
-;; @0025                               v67 = icmp.i64 uge v62, v66
-;; @0025                               brif v67, block11, block9
+;; @0025                               v70 = load.i64 notrap aligned v8+8
+;; @0025                               v71 = icmp.i64 uge v66, v70
+;; @0025                               brif v71, block11, block9
 ;;
 ;;                                 block11 cold:
-;; @0025                               v69 = call fn0(v0)
+;; @0025                               v73 = call fn0(v0)
 ;; @0025                               jump block9
 ;;
 ;;                                 block9:
-;; @0025                               call fn1(v0, v58, v59, v60)
+;; @0025                               call fn1(v0, v62, v63, v64)
 ;; @0029                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/memory-copy-fuel.wat
+++ b/tests/disas/memory-copy-fuel.wat
@@ -38,65 +38,65 @@
 ;; @001e                               v15 = load.i64 notrap aligned v5
 ;; @001e                               jump block3(v15)
 ;;
-;;                                 block3(v43: i64):
+;;                                 block3(v47: i64):
 ;; @0025                               v20 = load.i64 notrap aligned v0+64
 ;; @0025                               v21 = uextend.i64 v2
 ;; @0025                               v22 = uextend.i64 v4
-;; @0025                               v24 = iadd v21, v22
-;; @0025                               v25 = icmp ugt v24, v20
-;; @0025                               trapnz v25, heap_oob
-;; @0025                               v32 = uextend.i64 v3
-;; @0025                               v35 = iadd v32, v22
-;; @0025                               v36 = icmp ugt v35, v20
-;; @0025                               trapnz v36, heap_oob
-;; @0025                               v46 = iconst.i64 0x0800_0000
-;; @0025                               v47 = icmp ugt v22, v46  ; v46 = 0x0800_0000
-;; @0025                               v26 = load.i64 notrap aligned readonly can_move v0+56
-;; @0025                               v29 = iadd v26, v21
-;; @0025                               v40 = iadd v26, v32
-;; @0025                               v44 = iconst.i64 4
-;; @0025                               v45 = iadd v43, v44  ; v44 = 4
-;; @0025                               brif v47, block4(v29, v40, v22, v45), block5(v29, v40, v22, v45)
+;; @0025                               v25 = iadd v21, v22
+;; @0025                               v26 = icmp ugt v25, v20
+;; @0025                               trapnz v26, heap_oob
+;; @0025                               v34 = uextend.i64 v3
+;; @0025                               v38 = iadd v34, v22
+;; @0025                               v39 = icmp ugt v38, v20
+;; @0025                               trapnz v39, heap_oob
+;; @0025                               v50 = iconst.i64 0x0800_0000
+;; @0025                               v51 = icmp ugt v22, v50  ; v50 = 0x0800_0000
+;; @0025                               v27 = load.i64 notrap aligned readonly can_move v0+56
+;; @0025                               v31 = iadd v27, v21
+;; @0025                               v44 = iadd v27, v34
+;; @0025                               v48 = iconst.i64 4
+;; @0025                               v49 = iadd v47, v48  ; v48 = 4
+;; @0025                               brif v51, block4(v31, v44, v22, v49), block5(v31, v44, v22, v49)
 ;;
-;;                                 block4(v48: i64, v49: i64, v50: i64, v51: i64):
+;;                                 block4(v52: i64, v53: i64, v54: i64, v55: i64):
 ;;                                     v97 = iconst.i64 0x0800_0000
-;;                                     v98 = iadd v51, v97  ; v97 = 0x0800_0000
+;;                                     v98 = iadd v55, v97  ; v97 = 0x0800_0000
 ;;                                     v99 = iconst.i64 0
 ;;                                     v100 = icmp sge v98, v99  ; v99 = 0
 ;; @0025                               brif v100, block6, block7(v98)
 ;;
-;;                                 block5(v64: i64, v65: i64, v66: i64, v67: i64):
-;; @0025                               v68 = iadd v67, v66
+;;                                 block5(v68: i64, v69: i64, v70: i64, v71: i64):
+;; @0025                               v72 = iadd v71, v70
 ;;                                     v106 = iconst.i64 0
-;;                                     v107 = icmp sge v68, v106  ; v106 = 0
-;; @0025                               brif v107, block8, block9(v68)
+;;                                     v107 = icmp sge v72, v106  ; v106 = 0
+;; @0025                               brif v107, block8, block9(v72)
 ;;
 ;;                                 block6:
 ;; @0025                               store.i64 notrap aligned v98, v5
-;; @0025                               v57 = call fn0(v0)
-;; @0025                               v59 = load.i64 notrap aligned v5
-;; @0025                               jump block7(v59)
+;; @0025                               v61 = call fn0(v0)
+;; @0025                               v63 = load.i64 notrap aligned v5
+;; @0025                               jump block7(v63)
 ;;
-;;                                 block7(v76: i64):
+;;                                 block7(v80: i64):
 ;;                                     v101 = iconst.i64 0x0800_0000
-;; @0025                               call fn1(v0, v48, v49, v101)  ; v101 = 0x0800_0000
-;;                                     v102 = isub.i64 v50, v101  ; v101 = 0x0800_0000
+;; @0025                               call fn1(v0, v52, v53, v101)  ; v101 = 0x0800_0000
+;;                                     v102 = isub.i64 v54, v101  ; v101 = 0x0800_0000
 ;;                                     v103 = icmp ugt v102, v101  ; v101 = 0x0800_0000
-;;                                     v104 = iadd.i64 v48, v101  ; v101 = 0x0800_0000
-;;                                     v105 = iadd.i64 v49, v101  ; v101 = 0x0800_0000
-;; @0025                               brif v103, block4(v104, v105, v102, v76), block5(v104, v105, v102, v76)
+;;                                     v104 = iadd.i64 v52, v101  ; v101 = 0x0800_0000
+;;                                     v105 = iadd.i64 v53, v101  ; v101 = 0x0800_0000
+;; @0025                               brif v103, block4(v104, v105, v102, v80), block5(v104, v105, v102, v80)
 ;;
 ;;                                 block8:
-;; @0025                               store.i64 notrap aligned v68, v5
-;; @0025                               v73 = call fn0(v0)
-;; @0025                               v75 = load.i64 notrap aligned v5
-;; @0025                               jump block9(v75)
+;; @0025                               store.i64 notrap aligned v72, v5
+;; @0025                               v77 = call fn0(v0)
+;; @0025                               v79 = load.i64 notrap aligned v5
+;; @0025                               jump block9(v79)
 ;;
-;;                                 block9(v78: i64):
-;; @0025                               call fn1(v0, v64, v65, v66)
+;;                                 block9(v82: i64):
+;; @0025                               call fn1(v0, v68, v69, v70)
 ;; @0029                               jump block1
 ;;
 ;;                                 block1:
-;; @0029                               store.i64 notrap aligned v78, v5
+;; @0029                               store.i64 notrap aligned v82, v5
 ;; @0029                               return
 ;; }

--- a/tests/disas/memory-copy-inline.wat
+++ b/tests/disas/memory-copy-inline.wat
@@ -24,18 +24,18 @@
 ;; @0024                               v6 = load.i64 notrap aligned v0+64
 ;; @0024                               v7 = uextend.i64 v2
 ;;                                     v35 = iconst.i64 16
-;; @0024                               v10 = iadd v7, v35  ; v35 = 16
-;; @0024                               v11 = icmp ugt v10, v6
-;; @0024                               trapnz v11, heap_oob
-;; @0024                               v18 = uextend.i64 v3
-;; @0024                               v21 = iadd v18, v35  ; v35 = 16
-;; @0024                               v22 = icmp ugt v21, v6
-;; @0024                               trapnz v22, heap_oob
-;; @0024                               v12 = load.i64 notrap aligned readonly can_move v0+56
-;; @0024                               v26 = iadd v12, v18
-;; @0024                               v28 = load.i8x16 notrap aligned little v26
-;; @0024                               v15 = iadd v12, v7
-;; @0024                               store notrap aligned little v28, v15
+;; @0024                               v11 = iadd v7, v35  ; v35 = 16
+;; @0024                               v12 = icmp ugt v11, v6
+;; @0024                               trapnz v12, heap_oob
+;; @0024                               v20 = uextend.i64 v3
+;; @0024                               v24 = iadd v20, v35  ; v35 = 16
+;; @0024                               v25 = icmp ugt v24, v6
+;; @0024                               trapnz v25, heap_oob
+;; @0024                               v13 = load.i64 notrap aligned readonly can_move v0+56
+;; @0024                               v30 = iadd v13, v20
+;; @0024                               v32 = load.i8x16 notrap aligned little v30
+;; @0024                               v17 = iadd v13, v7
+;; @0024                               store notrap aligned little v32, v17
 ;; @0028                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/memory_copy_host32.wat
+++ b/tests/disas/memory_copy_host32.wat
@@ -60,18 +60,18 @@
 ;; @0042                               v6 = load.i32 notrap aligned v0+44
 ;; @0042                               v7 = uextend.i64 v2
 ;; @0042                               v8 = uextend.i64 v4
-;; @0042                               v10 = iadd v7, v8
-;; @0042                               v11 = uextend.i64 v6
-;; @0042                               v12 = icmp ugt v10, v11
-;; @0042                               trapnz v12, heap_oob
-;; @0042                               v13 = load.i32 notrap aligned can_move v0+40
-;; @0042                               v18 = uextend.i64 v3
-;; @0042                               v21 = iadd v18, v8
-;; @0042                               v23 = icmp ugt v21, v11
-;; @0042                               trapnz v23, heap_oob
-;; @0042                               v15 = iadd v13, v2
-;; @0042                               v26 = iadd v13, v3
-;; @0042                               call fn0(v0, v15, v26, v4)
+;; @0042                               v11 = iadd v7, v8
+;; @0042                               v12 = uextend.i64 v6
+;; @0042                               v13 = icmp ugt v11, v12
+;; @0042                               trapnz v13, heap_oob
+;; @0042                               v14 = load.i32 notrap aligned can_move v0+40
+;; @0042                               v20 = uextend.i64 v3
+;; @0042                               v24 = iadd v20, v8
+;; @0042                               v26 = icmp ugt v24, v12
+;; @0042                               trapnz v26, heap_oob
+;; @0042                               v17 = iadd v14, v2
+;; @0042                               v30 = iadd v14, v3
+;; @0042                               call fn0(v0, v17, v30, v4)
 ;; @0046                               jump block1
 ;;
 ;;                                 block1:
@@ -91,21 +91,21 @@
 ;; @004f                               v6 = load.i32 notrap aligned v0+52
 ;; @004f                               v7 = uextend.i64 v2
 ;; @004f                               v8 = uextend.i64 v4
-;; @004f                               v10 = iadd v7, v8
-;; @004f                               v11 = uextend.i64 v6
-;; @004f                               v12 = icmp ugt v10, v11
-;; @004f                               trapnz v12, heap_oob
-;; @004f                               v13 = load.i32 notrap aligned can_move v0+48
-;; @004f                               v17 = load.i32 notrap aligned v0+44
-;; @004f                               v18 = uextend.i64 v3
-;; @004f                               v21 = iadd v18, v8
-;; @004f                               v22 = uextend.i64 v17
-;; @004f                               v23 = icmp ugt v21, v22
-;; @004f                               trapnz v23, heap_oob
-;; @004f                               v24 = load.i32 notrap aligned can_move v0+40
-;; @004f                               v15 = iadd v13, v2
-;; @004f                               v26 = iadd v24, v3
-;; @004f                               call fn0(v0, v15, v26, v4)
+;; @004f                               v11 = iadd v7, v8
+;; @004f                               v12 = uextend.i64 v6
+;; @004f                               v13 = icmp ugt v11, v12
+;; @004f                               trapnz v13, heap_oob
+;; @004f                               v14 = load.i32 notrap aligned can_move v0+48
+;; @004f                               v19 = load.i32 notrap aligned v0+44
+;; @004f                               v20 = uextend.i64 v3
+;; @004f                               v24 = iadd v20, v8
+;; @004f                               v25 = uextend.i64 v19
+;; @004f                               v26 = icmp ugt v24, v25
+;; @004f                               trapnz v26, heap_oob
+;; @004f                               v27 = load.i32 notrap aligned can_move v0+40
+;; @004f                               v17 = iadd v14, v2
+;; @004f                               v30 = iadd v27, v3
+;; @004f                               call fn0(v0, v17, v30, v4)
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:
@@ -129,17 +129,17 @@
 ;; @005c                               v10 = icmp ugt v8, v9
 ;; @005c                               trapnz v10, heap_oob
 ;; @005c                               v11 = load.i32 notrap aligned can_move v0+56
-;; @005c                               v16 = load.i32 notrap aligned v0+44
-;; @005c                               v17 = uextend.i64 v3
-;; @005c                               v20 = iadd v17, v5
-;; @005c                               v21 = uextend.i64 v16
-;; @005c                               v22 = icmp ugt v20, v21
-;; @005c                               trapnz v22, heap_oob
-;; @005c                               v23 = load.i32 notrap aligned can_move v0+40
+;; @005c                               v17 = load.i32 notrap aligned v0+44
+;; @005c                               v18 = uextend.i64 v3
+;; @005c                               v22 = iadd v18, v5
+;; @005c                               v23 = uextend.i64 v17
+;; @005c                               v24 = icmp ugt v22, v23
+;; @005c                               trapnz v24, heap_oob
+;; @005c                               v25 = load.i32 notrap aligned can_move v0+40
 ;; @005c                               v12 = ireduce.i32 v2
-;; @005c                               v14 = iadd v11, v12
-;; @005c                               v25 = iadd v23, v3
-;; @005c                               call fn0(v0, v14, v25, v4)
+;; @005c                               v15 = iadd v11, v12
+;; @005c                               v28 = iadd v25, v3
+;; @005c                               call fn0(v0, v15, v28, v4)
 ;; @0060                               jump block1
 ;;
 ;;                                 block1:
@@ -160,15 +160,15 @@
 ;; @0069                               v9 = icmp ugt v7, v8
 ;; @0069                               trapnz v9, heap_oob
 ;; @0069                               v10 = load.i32 notrap aligned can_move v0+56
-;; @0069                               v16 = uadd_overflow_trap v3, v4, heap_oob
-;; @0069                               v18 = icmp ugt v16, v8
-;; @0069                               trapnz v18, heap_oob
+;; @0069                               v17 = uadd_overflow_trap v3, v4, heap_oob
+;; @0069                               v19 = icmp ugt v17, v8
+;; @0069                               trapnz v19, heap_oob
 ;; @0069                               v11 = ireduce.i32 v2
-;; @0069                               v13 = iadd v10, v11
-;; @0069                               v20 = ireduce.i32 v3
-;; @0069                               v22 = iadd v10, v20
-;; @0069                               v23 = ireduce.i32 v4
-;; @0069                               call fn0(v0, v13, v22, v23)
+;; @0069                               v14 = iadd v10, v11
+;; @0069                               v21 = ireduce.i32 v3
+;; @0069                               v24 = iadd v10, v21
+;; @0069                               v25 = ireduce.i32 v4
+;; @0069                               call fn0(v0, v14, v24, v25)
 ;; @006d                               jump block1
 ;;
 ;;                                 block1:
@@ -191,18 +191,18 @@
 ;; @0076                               v9 = icmp ugt v7, v8
 ;; @0076                               trapnz v9, heap_oob
 ;; @0076                               v10 = load.i32 notrap aligned can_move v0+64
-;; @0076                               v15 = load.i32 notrap aligned v0+60
-;; @0076                               v16 = uadd_overflow_trap v3, v4, heap_oob
-;; @0076                               v17 = uextend.i64 v15
-;; @0076                               v18 = icmp ugt v16, v17
-;; @0076                               trapnz v18, heap_oob
-;; @0076                               v19 = load.i32 notrap aligned can_move v0+56
+;; @0076                               v16 = load.i32 notrap aligned v0+60
+;; @0076                               v17 = uadd_overflow_trap v3, v4, heap_oob
+;; @0076                               v18 = uextend.i64 v16
+;; @0076                               v19 = icmp ugt v17, v18
+;; @0076                               trapnz v19, heap_oob
+;; @0076                               v20 = load.i32 notrap aligned can_move v0+56
 ;; @0076                               v11 = ireduce.i32 v2
-;; @0076                               v13 = iadd v10, v11
-;; @0076                               v20 = ireduce.i32 v3
-;; @0076                               v22 = iadd v19, v20
-;; @0076                               v23 = ireduce.i32 v4
-;; @0076                               call fn0(v0, v13, v22, v23)
+;; @0076                               v14 = iadd v10, v11
+;; @0076                               v21 = ireduce.i32 v3
+;; @0076                               v24 = iadd v20, v21
+;; @0076                               v25 = ireduce.i32 v4
+;; @0076                               call fn0(v0, v14, v24, v25)
 ;; @007a                               jump block1
 ;;
 ;;                                 block1:
@@ -222,21 +222,21 @@
 ;; @0083                               v7 = load.i32 notrap aligned v0+44
 ;; @0083                               v8 = uextend.i64 v2
 ;; @0083                               v5 = uextend.i64 v4
-;; @0083                               v11 = iadd v8, v5
-;; @0083                               v12 = uextend.i64 v7
-;; @0083                               v13 = icmp ugt v11, v12
-;; @0083                               trapnz v13, heap_oob
-;; @0083                               v14 = load.i32 notrap aligned can_move v0+40
-;; @0083                               v18 = load.i32 notrap aligned v0+60
-;; @0083                               v19 = uadd_overflow_trap v3, v5, heap_oob
-;; @0083                               v20 = uextend.i64 v18
-;; @0083                               v21 = icmp ugt v19, v20
-;; @0083                               trapnz v21, heap_oob
-;; @0083                               v22 = load.i32 notrap aligned can_move v0+56
-;; @0083                               v16 = iadd v14, v2
-;; @0083                               v23 = ireduce.i32 v3
-;; @0083                               v25 = iadd v22, v23
-;; @0083                               call fn0(v0, v16, v25, v4)
+;; @0083                               v12 = iadd v8, v5
+;; @0083                               v13 = uextend.i64 v7
+;; @0083                               v14 = icmp ugt v12, v13
+;; @0083                               trapnz v14, heap_oob
+;; @0083                               v15 = load.i32 notrap aligned can_move v0+40
+;; @0083                               v20 = load.i32 notrap aligned v0+60
+;; @0083                               v21 = uadd_overflow_trap v3, v5, heap_oob
+;; @0083                               v22 = uextend.i64 v20
+;; @0083                               v23 = icmp ugt v21, v22
+;; @0083                               trapnz v23, heap_oob
+;; @0083                               v24 = load.i32 notrap aligned can_move v0+56
+;; @0083                               v18 = iadd v15, v2
+;; @0083                               v25 = ireduce.i32 v3
+;; @0083                               v28 = iadd v24, v25
+;; @0083                               call fn0(v0, v18, v28, v4)
 ;; @0087                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/memory_copy_host64.wat
+++ b/tests/disas/memory_copy_host64.wat
@@ -64,17 +64,17 @@
 ;; @0042                               v6 = load.i64 notrap aligned v0+88
 ;; @0042                               v7 = uextend.i64 v2
 ;; @0042                               v8 = uextend.i64 v4
-;; @0042                               v10 = iadd v7, v8
-;; @0042                               v11 = icmp ugt v10, v6
-;; @0042                               trapnz v11, heap_oob
-;; @0042                               v18 = uextend.i64 v3
-;; @0042                               v21 = iadd v18, v8
-;; @0042                               v22 = icmp ugt v21, v6
-;; @0042                               trapnz v22, heap_oob
-;; @0042                               v12 = load.i64 notrap aligned readonly can_move v0+80
-;; @0042                               v15 = iadd v12, v7
-;; @0042                               v26 = iadd v12, v18
-;; @0042                               call fn0(v0, v15, v26, v8)
+;; @0042                               v11 = iadd v7, v8
+;; @0042                               v12 = icmp ugt v11, v6
+;; @0042                               trapnz v12, heap_oob
+;; @0042                               v20 = uextend.i64 v3
+;; @0042                               v24 = iadd v20, v8
+;; @0042                               v25 = icmp ugt v24, v6
+;; @0042                               trapnz v25, heap_oob
+;; @0042                               v13 = load.i64 notrap aligned readonly can_move v0+80
+;; @0042                               v17 = iadd v13, v7
+;; @0042                               v30 = iadd v13, v20
+;; @0042                               call fn0(v0, v17, v30, v8)
 ;; @0046                               jump block1
 ;;
 ;;                                 block1:
@@ -98,19 +98,19 @@
 ;; @004f                               v6 = load.i64 notrap aligned v0+104
 ;; @004f                               v7 = uextend.i64 v2
 ;; @004f                               v8 = uextend.i64 v4
-;; @004f                               v10 = iadd v7, v8
-;; @004f                               v11 = icmp ugt v10, v6
-;; @004f                               trapnz v11, heap_oob
-;; @004f                               v17 = load.i64 notrap aligned v0+88
-;; @004f                               v18 = uextend.i64 v3
-;; @004f                               v21 = iadd v18, v8
-;; @004f                               v22 = icmp ugt v21, v17
-;; @004f                               trapnz v22, heap_oob
-;; @004f                               v12 = load.i64 notrap aligned readonly can_move v0+96
-;; @004f                               v15 = iadd v12, v7
-;; @004f                               v23 = load.i64 notrap aligned readonly can_move v0+80
-;; @004f                               v26 = iadd v23, v18
-;; @004f                               call fn0(v0, v15, v26, v8)
+;; @004f                               v11 = iadd v7, v8
+;; @004f                               v12 = icmp ugt v11, v6
+;; @004f                               trapnz v12, heap_oob
+;; @004f                               v19 = load.i64 notrap aligned v0+88
+;; @004f                               v20 = uextend.i64 v3
+;; @004f                               v24 = iadd v20, v8
+;; @004f                               v25 = icmp ugt v24, v19
+;; @004f                               trapnz v25, heap_oob
+;; @004f                               v13 = load.i64 notrap aligned readonly can_move v0+96
+;; @004f                               v17 = iadd v13, v7
+;; @004f                               v26 = load.i64 notrap aligned readonly can_move v0+80
+;; @004f                               v30 = iadd v26, v20
+;; @004f                               call fn0(v0, v17, v30, v8)
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:
@@ -137,15 +137,15 @@
 ;; @005c                               v9 = icmp ugt v8, v7
 ;; @005c                               trapnz v9, heap_oob
 ;; @005c                               v10 = load.i64 notrap aligned can_move v0+112
-;; @005c                               v14 = load.i64 notrap aligned v0+88
-;; @005c                               v15 = uextend.i64 v3
-;; @005c                               v18 = iadd v15, v5
-;; @005c                               v19 = icmp ugt v18, v14
-;; @005c                               trapnz v19, heap_oob
-;; @005c                               v12 = iadd v10, v2
-;; @005c                               v20 = load.i64 notrap aligned readonly can_move v0+80
-;; @005c                               v23 = iadd v20, v15
-;; @005c                               call fn0(v0, v12, v23, v5)
+;; @005c                               v15 = load.i64 notrap aligned v0+88
+;; @005c                               v16 = uextend.i64 v3
+;; @005c                               v20 = iadd v16, v5
+;; @005c                               v21 = icmp ugt v20, v15
+;; @005c                               trapnz v21, heap_oob
+;; @005c                               v13 = iadd v10, v2
+;; @005c                               v22 = load.i64 notrap aligned readonly can_move v0+80
+;; @005c                               v26 = iadd v22, v16
+;; @005c                               call fn0(v0, v13, v26, v5)
 ;; @0060                               jump block1
 ;;
 ;;                                 block1:
@@ -169,12 +169,12 @@
 ;; @0069                               v8 = icmp ugt v7, v6
 ;; @0069                               trapnz v8, heap_oob
 ;; @0069                               v9 = load.i64 notrap aligned can_move v0+112
-;; @0069                               v14 = uadd_overflow_trap v3, v4, heap_oob
-;; @0069                               v15 = icmp ugt v14, v6
-;; @0069                               trapnz v15, heap_oob
-;; @0069                               v11 = iadd v9, v2
-;; @0069                               v18 = iadd v9, v3
-;; @0069                               call fn0(v0, v11, v18, v4)
+;; @0069                               v15 = uadd_overflow_trap v3, v4, heap_oob
+;; @0069                               v16 = icmp ugt v15, v6
+;; @0069                               trapnz v16, heap_oob
+;; @0069                               v12 = iadd v9, v2
+;; @0069                               v20 = iadd v9, v3
+;; @0069                               call fn0(v0, v12, v20, v4)
 ;; @006d                               jump block1
 ;;
 ;;                                 block1:
@@ -200,14 +200,14 @@
 ;; @0076                               v8 = icmp ugt v7, v6
 ;; @0076                               trapnz v8, heap_oob
 ;; @0076                               v9 = load.i64 notrap aligned can_move v0+128
-;; @0076                               v13 = load.i64 notrap aligned v0+120
-;; @0076                               v14 = uadd_overflow_trap v3, v4, heap_oob
-;; @0076                               v15 = icmp ugt v14, v13
-;; @0076                               trapnz v15, heap_oob
-;; @0076                               v16 = load.i64 notrap aligned can_move v0+112
-;; @0076                               v11 = iadd v9, v2
-;; @0076                               v18 = iadd v16, v3
-;; @0076                               call fn0(v0, v11, v18, v4)
+;; @0076                               v14 = load.i64 notrap aligned v0+120
+;; @0076                               v15 = uadd_overflow_trap v3, v4, heap_oob
+;; @0076                               v16 = icmp ugt v15, v14
+;; @0076                               trapnz v16, heap_oob
+;; @0076                               v17 = load.i64 notrap aligned can_move v0+112
+;; @0076                               v12 = iadd v9, v2
+;; @0076                               v20 = iadd v17, v3
+;; @0076                               call fn0(v0, v12, v20, v4)
 ;; @007a                               jump block1
 ;;
 ;;                                 block1:
@@ -231,18 +231,18 @@
 ;; @0083                               v7 = load.i64 notrap aligned v0+88
 ;; @0083                               v8 = uextend.i64 v2
 ;; @0083                               v5 = uextend.i64 v4
-;; @0083                               v11 = iadd v8, v5
-;; @0083                               v12 = icmp ugt v11, v7
-;; @0083                               trapnz v12, heap_oob
-;; @0083                               v18 = load.i64 notrap aligned v0+120
-;; @0083                               v19 = uadd_overflow_trap v3, v5, heap_oob
-;; @0083                               v20 = icmp ugt v19, v18
-;; @0083                               trapnz v20, heap_oob
-;; @0083                               v21 = load.i64 notrap aligned can_move v0+112
-;; @0083                               v13 = load.i64 notrap aligned readonly can_move v0+80
-;; @0083                               v16 = iadd v13, v8
-;; @0083                               v23 = iadd v21, v3
-;; @0083                               call fn0(v0, v16, v23, v5)
+;; @0083                               v12 = iadd v8, v5
+;; @0083                               v13 = icmp ugt v12, v7
+;; @0083                               trapnz v13, heap_oob
+;; @0083                               v20 = load.i64 notrap aligned v0+120
+;; @0083                               v21 = uadd_overflow_trap v3, v5, heap_oob
+;; @0083                               v22 = icmp ugt v21, v20
+;; @0083                               trapnz v22, heap_oob
+;; @0083                               v23 = load.i64 notrap aligned can_move v0+112
+;; @0083                               v14 = load.i64 notrap aligned readonly can_move v0+80
+;; @0083                               v18 = iadd v14, v8
+;; @0083                               v26 = iadd v23, v3
+;; @0083                               call fn0(v0, v18, v26, v5)
 ;; @0087                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/memory_fill_host32.wat
+++ b/tests/disas/memory_fill_host32.wat
@@ -57,14 +57,14 @@
 ;; @003c                               v6 = load.i32 notrap aligned v0+48
 ;; @003c                               v7 = uextend.i64 v2
 ;; @003c                               v8 = uextend.i64 v3
-;; @003c                               v10 = iadd v7, v8
-;; @003c                               v11 = uextend.i64 v6
-;; @003c                               v12 = icmp ugt v10, v11
-;; @003c                               trapnz v12, heap_oob
-;; @003c                               v13 = load.i32 notrap aligned can_move v0+44
-;; @003c                               v15 = iadd v13, v2
+;; @003c                               v11 = iadd v7, v8
+;; @003c                               v12 = uextend.i64 v6
+;; @003c                               v13 = icmp ugt v11, v12
+;; @003c                               trapnz v13, heap_oob
+;; @003c                               v14 = load.i32 notrap aligned can_move v0+44
+;; @003c                               v17 = iadd v14, v2
 ;; @0038                               v4 = iconst.i32 0
-;; @003c                               call fn0(v0, v15, v4, v3)  ; v4 = 0
+;; @003c                               call fn0(v0, v17, v4, v3)  ; v4 = 0
 ;; @003f                               jump block1
 ;;
 ;;                                 block1:
@@ -86,10 +86,10 @@
 ;; @0048                               trapnz v9, heap_oob
 ;; @0048                               v10 = load.i32 notrap aligned can_move v0+52
 ;; @0048                               v11 = ireduce.i32 v2
-;; @0048                               v13 = iadd v10, v11
+;; @0048                               v14 = iadd v10, v11
 ;; @0044                               v4 = iconst.i32 0
-;; @0048                               v14 = ireduce.i32 v3
-;; @0048                               call fn0(v0, v13, v4, v14)  ; v4 = 0
+;; @0048                               v15 = ireduce.i32 v3
+;; @0048                               call fn0(v0, v14, v4, v15)  ; v4 = 0
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:
@@ -107,14 +107,14 @@
 ;; @0054                               v6 = load.i32 notrap aligned v0+64
 ;; @0054                               v7 = uextend.i64 v2
 ;; @0054                               v8 = uextend.i64 v3
-;; @0054                               v10 = iadd v7, v8
-;; @0054                               v11 = uextend.i64 v6
-;; @0054                               v12 = icmp ugt v10, v11
-;; @0054                               trapnz v12, heap_oob
-;; @0054                               v13 = load.i32 notrap aligned can_move v0+60
-;; @0054                               v15 = iadd v13, v2
+;; @0054                               v11 = iadd v7, v8
+;; @0054                               v12 = uextend.i64 v6
+;; @0054                               v13 = icmp ugt v11, v12
+;; @0054                               trapnz v13, heap_oob
+;; @0054                               v14 = load.i32 notrap aligned can_move v0+60
+;; @0054                               v17 = iadd v14, v2
 ;; @0050                               v4 = iconst.i32 0
-;; @0054                               call fn0(v0, v15, v4, v3)  ; v4 = 0
+;; @0054                               call fn0(v0, v17, v4, v3)  ; v4 = 0
 ;; @0057                               jump block1
 ;;
 ;;                                 block1:
@@ -136,10 +136,10 @@
 ;; @0060                               trapnz v9, heap_oob
 ;; @0060                               v10 = load.i32 notrap aligned can_move v0+68
 ;; @0060                               v11 = ireduce.i32 v2
-;; @0060                               v13 = iadd v10, v11
+;; @0060                               v14 = iadd v10, v11
 ;; @005c                               v4 = iconst.i32 0
-;; @0060                               v14 = ireduce.i32 v3
-;; @0060                               call fn0(v0, v13, v4, v14)  ; v4 = 0
+;; @0060                               v15 = ireduce.i32 v3
+;; @0060                               call fn0(v0, v14, v4, v15)  ; v4 = 0
 ;; @0063                               jump block1
 ;;
 ;;                                 block1:
@@ -157,14 +157,14 @@
 ;; @006c                               v6 = load.i32 notrap aligned v0+80
 ;; @006c                               v7 = uextend.i64 v2
 ;; @006c                               v8 = uextend.i64 v3
-;; @006c                               v10 = iadd v7, v8
-;; @006c                               v11 = uextend.i64 v6
-;; @006c                               v12 = icmp ugt v10, v11
-;; @006c                               trapnz v12, heap_oob
-;; @006c                               v13 = load.i32 notrap aligned readonly can_move v0+76
-;; @006c                               v15 = iadd v13, v2
+;; @006c                               v11 = iadd v7, v8
+;; @006c                               v12 = uextend.i64 v6
+;; @006c                               v13 = icmp ugt v11, v12
+;; @006c                               trapnz v13, heap_oob
+;; @006c                               v14 = load.i32 notrap aligned readonly can_move v0+76
+;; @006c                               v17 = iadd v14, v2
 ;; @0068                               v4 = iconst.i32 0
-;; @006c                               call fn0(v0, v15, v4, v3)  ; v4 = 0
+;; @006c                               call fn0(v0, v17, v4, v3)  ; v4 = 0
 ;; @006f                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/memory_fill_host64.wat
+++ b/tests/disas/memory_fill_host64.wat
@@ -58,13 +58,13 @@
 ;; @003c                               v6 = load.i64 notrap aligned v0+96
 ;; @003c                               v7 = uextend.i64 v2
 ;; @003c                               v8 = uextend.i64 v3
-;; @003c                               v10 = iadd v7, v8
-;; @003c                               v11 = icmp ugt v10, v6
-;; @003c                               trapnz v11, heap_oob
-;; @003c                               v12 = load.i64 notrap aligned readonly can_move v0+88
-;; @003c                               v15 = iadd v12, v7
+;; @003c                               v11 = iadd v7, v8
+;; @003c                               v12 = icmp ugt v11, v6
+;; @003c                               trapnz v12, heap_oob
+;; @003c                               v13 = load.i64 notrap aligned readonly can_move v0+88
+;; @003c                               v17 = iadd v13, v7
 ;; @0038                               v4 = iconst.i32 0
-;; @003c                               call fn0(v0, v15, v4, v8)  ; v4 = 0
+;; @003c                               call fn0(v0, v17, v4, v8)  ; v4 = 0
 ;; @003f                               jump block1
 ;;
 ;;                                 block1:
@@ -88,9 +88,9 @@
 ;; @0048                               v8 = icmp ugt v7, v6
 ;; @0048                               trapnz v8, heap_oob
 ;; @0048                               v9 = load.i64 notrap aligned can_move v0+104
-;; @0048                               v11 = iadd v9, v2
+;; @0048                               v12 = iadd v9, v2
 ;; @0044                               v4 = iconst.i32 0
-;; @0048                               call fn0(v0, v11, v4, v3)  ; v4 = 0
+;; @0048                               call fn0(v0, v12, v4, v3)  ; v4 = 0
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:
@@ -112,13 +112,13 @@
 ;; @0054                               v6 = load.i64 notrap aligned v0+128
 ;; @0054                               v7 = uextend.i64 v2
 ;; @0054                               v8 = uextend.i64 v3
-;; @0054                               v10 = iadd v7, v8
-;; @0054                               v11 = icmp ugt v10, v6
-;; @0054                               trapnz v11, heap_oob
-;; @0054                               v12 = load.i64 notrap aligned readonly can_move v0+120
-;; @0054                               v15 = iadd v12, v7
+;; @0054                               v11 = iadd v7, v8
+;; @0054                               v12 = icmp ugt v11, v6
+;; @0054                               trapnz v12, heap_oob
+;; @0054                               v13 = load.i64 notrap aligned readonly can_move v0+120
+;; @0054                               v17 = iadd v13, v7
 ;; @0050                               v4 = iconst.i32 0
-;; @0054                               call fn0(v0, v15, v4, v8)  ; v4 = 0
+;; @0054                               call fn0(v0, v17, v4, v8)  ; v4 = 0
 ;; @0057                               jump block1
 ;;
 ;;                                 block1:
@@ -142,9 +142,9 @@
 ;; @0060                               v8 = icmp ugt v7, v6
 ;; @0060                               trapnz v8, heap_oob
 ;; @0060                               v9 = load.i64 notrap aligned can_move v0+136
-;; @0060                               v11 = iadd v9, v2
+;; @0060                               v12 = iadd v9, v2
 ;; @005c                               v4 = iconst.i32 0
-;; @0060                               call fn0(v0, v11, v4, v3)  ; v4 = 0
+;; @0060                               call fn0(v0, v12, v4, v3)  ; v4 = 0
 ;; @0063                               jump block1
 ;;
 ;;                                 block1:
@@ -166,13 +166,13 @@
 ;; @006c                               v6 = load.i64 notrap aligned v0+160
 ;; @006c                               v7 = uextend.i64 v2
 ;; @006c                               v8 = uextend.i64 v3
-;; @006c                               v10 = iadd v7, v8
-;; @006c                               v11 = icmp ugt v10, v6
-;; @006c                               trapnz v11, heap_oob
-;; @006c                               v12 = load.i64 notrap aligned readonly can_move v0+152
-;; @006c                               v15 = iadd v12, v7
+;; @006c                               v11 = iadd v7, v8
+;; @006c                               v12 = icmp ugt v11, v6
+;; @006c                               trapnz v12, heap_oob
+;; @006c                               v13 = load.i64 notrap aligned readonly can_move v0+152
+;; @006c                               v17 = iadd v13, v7
 ;; @0068                               v4 = iconst.i32 0
-;; @006c                               call fn0(v0, v15, v4, v8)  ; v4 = 0
+;; @006c                               call fn0(v0, v17, v4, v8)  ; v4 = 0
 ;; @006f                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/passive-data.wat
+++ b/tests/disas/passive-data.wat
@@ -28,30 +28,30 @@
 ;; @003d                               v6 = load.i64 notrap aligned v0+64
 ;; @003d                               v7 = uextend.i64 v2
 ;; @003d                               v8 = uextend.i64 v4
-;;                                     v33 = iconst.i64 1
-;; @003d                               v9 = imul v8, v33  ; v33 = 1
-;; @003d                               v10 = iadd v7, v9
-;; @003d                               v11 = icmp ugt v10, v6
-;; @003d                               trapnz v11, heap_oob
-;; @003d                               v12 = load.i64 notrap aligned readonly can_move v0+56
-;; @003d                               v13 = uextend.i64 v2
-;;                                     v31 = iconst.i64 1
-;; @003d                               v14 = imul v13, v31  ; v31 = 1
-;; @003d                               v15 = iadd v12, v14
-;; @003d                               v17 = load.i32 notrap aligned v0+152
-;; @003d                               v18 = uextend.i64 v17
-;; @003d                               v19 = uextend.i64 v3
-;; @003d                               v20 = uextend.i64 v4
-;;                                     v30 = iconst.i64 1
-;; @003d                               v21 = imul v20, v30  ; v30 = 1
-;; @003d                               v22 = iadd v19, v21
-;; @003d                               v23 = icmp ugt v22, v18
-;; @003d                               trapnz v23, heap_oob
-;; @003d                               v25 = load.i64 notrap aligned v0+144
-;; @003d                               v26 = uextend.i64 v3
-;; @003d                               v27 = iadd v25, v26
-;; @003d                               v28 = uextend.i64 v4
-;; @003d                               call fn0(v0, v15, v27, v28)
+;; @003d                               v9 = iconst.i64 1
+;; @003d                               v10 = imul v8, v9  ; v9 = 1
+;; @003d                               v11 = iadd v7, v10
+;; @003d                               v12 = icmp ugt v11, v6
+;; @003d                               trapnz v12, heap_oob
+;; @003d                               v13 = load.i64 notrap aligned readonly can_move v0+56
+;; @003d                               v14 = uextend.i64 v2
+;; @003d                               v15 = iconst.i64 1
+;; @003d                               v16 = imul v14, v15  ; v15 = 1
+;; @003d                               v17 = iadd v13, v16
+;; @003d                               v19 = load.i32 notrap aligned v0+152
+;; @003d                               v20 = uextend.i64 v19
+;; @003d                               v21 = uextend.i64 v3
+;; @003d                               v22 = uextend.i64 v4
+;; @003d                               v23 = iconst.i64 1
+;; @003d                               v24 = imul v22, v23  ; v23 = 1
+;; @003d                               v25 = iadd v21, v24
+;; @003d                               v26 = icmp ugt v25, v20
+;; @003d                               trapnz v26, heap_oob
+;; @003d                               v28 = load.i64 notrap aligned v0+144
+;; @003d                               v29 = uextend.i64 v3
+;; @003d                               v30 = iadd v28, v29
+;; @003d                               v31 = uextend.i64 v4
+;; @003d                               call fn0(v0, v17, v30, v31)
 ;; @0041                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/stack-switching/resume-suspend-data-passing.wat
+++ b/tests/disas/stack-switching/resume-suspend-data-passing.wat
@@ -47,12 +47,12 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64):
 ;; @003c                               v3 = iconst.i32 10
-;; @0044                               v32 = iconst.i64 120
-;; @0044                               v35 = stack_addr.i64 ss0
-;; @0044                               v41 = iconst.i64 16
-;; @0044                               v38 = iconst.i64 0
-;; @0044                               v49 = iconst.i64 80
-;; @0044                               v52 = iconst.i64 -24
+;; @0044                               v33 = iconst.i64 120
+;; @0044                               v36 = stack_addr.i64 ss0
+;; @0044                               v42 = iconst.i64 16
+;; @0044                               v39 = iconst.i64 0
+;; @0044                               v50 = iconst.i64 80
+;; @0044                               v53 = iconst.i64 -24
 ;;                                     v70 = iconst.i64 0x0002_0000_0000
 ;; @0040                               jump block2(v3)  ; v3 = 10
 ;;
@@ -65,7 +65,7 @@
 ;; @003a                               v2 = iconst.i32 0
 ;; @0044                               jump block4(v10, v11, v4)
 ;;
-;;                                 block4(v12: i64, v13: i64, v62: i32):
+;;                                 block4(v12: i64, v13: i64, v63: i32):
 ;;                                     v73 = iconst.i64 1
 ;;                                     v74 = icmp eq v12, v73  ; v73 = 1
 ;; @0044                               trapnz v74, user22
@@ -82,21 +82,21 @@
 ;;                                     v67 = iconst.i32 3
 ;; @0044                               v6 = iconst.i64 48
 ;; @0044                               v7 = iadd.i64 v0, v6  ; v6 = 48
-;; @0044                               v30 = iconst.i32 1
+;; @0044                               v31 = iconst.i32 1
 ;; @0044                               jump block6(v77)  ; v77 = 0
 ;;
 ;;                                 block6(v23: i32):
 ;; @0044                               v24 = icmp ult v23, v21
-;; @0044                               brif v24, block7, block4(v16, v17, v62)
+;; @0044                               brif v24, block7, block4(v16, v17, v63)
 ;;
 ;;                                 block7:
 ;;                                     v78 = iconst.i32 3
 ;;                                     v79 = ishl.i32 v23, v78  ; v78 = 3
-;; @0044                               v26 = uextend.i64 v79
-;; @0044                               v27 = iadd.i64 v20, v26
-;; @0044                               v28 = load.i64 notrap aligned v27
+;; @0044                               v27 = uextend.i64 v79
+;; @0044                               v28 = iadd.i64 v20, v27
+;; @0044                               v29 = load.i64 notrap aligned v28
 ;;                                     v80 = iadd.i64 v0, v6  ; v6 = 48
-;;                                     v81 = icmp eq v28, v80
+;;                                     v81 = icmp eq v29, v80
 ;;                                     v82 = iconst.i32 1
 ;;                                     v83 = iadd.i32 v23, v82  ; v82 = 1
 ;; @0044                               brif v81, block8, block6(v83)
@@ -107,8 +107,8 @@
 ;;                                     v85 = iconst.i64 120
 ;;                                     v86 = iadd.i64 v11, v85  ; v85 = 120
 ;; @0044                               store notrap aligned v84, v86+4  ; v84 = 1
-;; @0044                               store.i64 notrap aligned v35, v86+8
-;; @0044                               store.i32 notrap aligned v4, v35
+;; @0044                               store.i64 notrap aligned v36, v86+8
+;; @0044                               store.i32 notrap aligned v4, v36
 ;; @0044                               store notrap aligned v84, v86  ; v84 = 1
 ;;                                     v87 = iconst.i32 3
 ;;                                     v88 = iconst.i64 16
@@ -119,19 +119,19 @@
 ;; @0044                               store notrap aligned v90, v13+56  ; v90 = 0
 ;;                                     v91 = iconst.i64 80
 ;;                                     v92 = iadd.i64 v13, v91  ; v91 = 80
-;; @0044                               v51 = load.i64 notrap aligned v92
+;; @0044                               v52 = load.i64 notrap aligned v92
 ;;                                     v93 = iconst.i64 -24
-;;                                     v94 = iadd v51, v93  ; v93 = -24
-;; @0044                               v47 = uextend.i64 v23
+;;                                     v94 = iadd v52, v93  ; v93 = -24
+;; @0044                               v48 = uextend.i64 v23
 ;;                                     v95 = iconst.i64 0x0002_0000_0000
-;;                                     v96 = bor v47, v95  ; v95 = 0x0002_0000_0000
-;; @0044                               v54 = stack_switch v94, v94, v96
-;; @0044                               v57 = load.i64 notrap aligned v86+8
+;;                                     v96 = bor v48, v95  ; v95 = 0x0002_0000_0000
+;; @0044                               v55 = stack_switch v94, v94, v96
+;; @0044                               v58 = load.i64 notrap aligned v86+8
 ;;                                     v97 = iconst.i32 0
 ;; @0044                               store notrap aligned v97, v86  ; v97 = 0
 ;; @0044                               store notrap aligned v97, v86+4  ; v97 = 0
 ;; @0044                               store notrap aligned v90, v86+8  ; v90 = 0
-;;                                     v98 = isub.i32 v62, v84  ; v84 = 1
+;;                                     v98 = isub.i32 v63, v84  ; v84 = 1
 ;; @004d                               brif v98, block2(v98), block10
 ;;
 ;;                                 block10:

--- a/tests/disas/stack-switching/resume-suspend.wat
+++ b/tests/disas/stack-switching/resume-suspend.wat
@@ -55,7 +55,7 @@
 ;;                                     v56 = iconst.i32 3
 ;; @003b                               v3 = iconst.i64 48
 ;; @003b                               v4 = iadd.i64 v0, v3  ; v3 = 48
-;; @003b                               v27 = iconst.i32 1
+;; @003b                               v28 = iconst.i32 1
 ;; @003b                               jump block4(v66)  ; v66 = 0
 ;;
 ;;                                 block4(v20: i32):
@@ -65,11 +65,11 @@
 ;;                                 block5:
 ;;                                     v67 = iconst.i32 3
 ;;                                     v68 = ishl.i32 v20, v67  ; v67 = 3
-;; @003b                               v23 = uextend.i64 v68
-;; @003b                               v24 = iadd.i64 v17, v23
-;; @003b                               v25 = load.i64 notrap aligned v24
+;; @003b                               v24 = uextend.i64 v68
+;; @003b                               v25 = iadd.i64 v17, v24
+;; @003b                               v26 = load.i64 notrap aligned v25
 ;;                                     v69 = iadd.i64 v0, v3  ; v3 = 48
-;;                                     v70 = icmp eq v25, v69
+;;                                     v70 = icmp eq v26, v69
 ;;                                     v71 = iconst.i32 1
 ;;                                     v72 = iadd.i32 v20, v71  ; v71 = 1
 ;; @003b                               brif v70, block6, block4(v72)
@@ -77,28 +77,28 @@
 ;;                                 block6:
 ;; @003b                               store.i64 notrap aligned v10, v8+64
 ;;                                     v73 = iconst.i32 3
-;; @003b                               v34 = iconst.i64 16
-;; @003b                               v35 = iadd.i64 v8, v34  ; v34 = 16
-;; @003b                               store notrap aligned v73, v35  ; v73 = 3
-;; @003b                               v31 = iconst.i64 0
-;; @003b                               store notrap aligned v31, v10+48  ; v31 = 0
-;; @003b                               store notrap aligned v31, v10+56  ; v31 = 0
-;; @003b                               v42 = iconst.i64 80
-;; @003b                               v43 = iadd.i64 v10, v42  ; v42 = 80
-;; @003b                               v44 = load.i64 notrap aligned v43
-;; @003b                               v45 = iconst.i64 -24
-;; @003b                               v46 = iadd v44, v45  ; v45 = -24
-;; @003b                               v40 = uextend.i64 v20
+;; @003b                               v35 = iconst.i64 16
+;; @003b                               v36 = iadd.i64 v8, v35  ; v35 = 16
+;; @003b                               store notrap aligned v73, v36  ; v73 = 3
+;; @003b                               v32 = iconst.i64 0
+;; @003b                               store notrap aligned v32, v10+48  ; v32 = 0
+;; @003b                               store notrap aligned v32, v10+56  ; v32 = 0
+;; @003b                               v43 = iconst.i64 80
+;; @003b                               v44 = iadd.i64 v10, v43  ; v43 = 80
+;; @003b                               v45 = load.i64 notrap aligned v44
+;; @003b                               v46 = iconst.i64 -24
+;; @003b                               v47 = iadd v45, v46  ; v46 = -24
+;; @003b                               v41 = uextend.i64 v20
 ;;                                     v59 = iconst.i64 0x0002_0000_0000
-;;                                     v60 = bor v40, v59  ; v59 = 0x0002_0000_0000
-;; @003b                               v47 = stack_switch v46, v46, v60
-;; @003b                               v29 = iconst.i64 120
-;; @003b                               v30 = iadd.i64 v8, v29  ; v29 = 120
-;; @003b                               v50 = load.i64 notrap aligned v30+8
+;;                                     v60 = bor v41, v59  ; v59 = 0x0002_0000_0000
+;; @003b                               v48 = stack_switch v47, v47, v60
+;; @003b                               v30 = iconst.i64 120
+;; @003b                               v31 = iadd.i64 v8, v30  ; v30 = 120
+;; @003b                               v51 = load.i64 notrap aligned v31+8
 ;;                                     v74 = iconst.i32 0
-;; @003b                               store notrap aligned v74, v30  ; v74 = 0
-;; @003b                               store notrap aligned v74, v30+4  ; v74 = 0
-;; @003b                               store notrap aligned v31, v30+8  ; v31 = 0
+;; @003b                               store notrap aligned v74, v31  ; v74 = 0
+;; @003b                               store notrap aligned v74, v31+4  ; v74 = 0
+;; @003b                               store notrap aligned v32, v31+8  ; v32 = 0
 ;; @003d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/stack-switching/symmetric-switch.wat
+++ b/tests/disas/stack-switching/symmetric-switch.wat
@@ -91,136 +91,136 @@
 ;; @003e                               brif v40, block5, block2(v32, v33)
 ;;
 ;;                                 block5:
-;;                                     v135 = iconst.i32 8
-;; @003e                               v41 = imul.i32 v39, v135  ; v135 = 8
-;; @003e                               v42 = uextend.i64 v41
-;; @003e                               v43 = iadd.i64 v36, v42
-;; @003e                               v44 = load.i64 notrap aligned v43
-;; @003e                               v45 = icmp eq v44, v24
-;; @003e                               v46 = iconst.i32 1
-;; @003e                               v47 = iadd.i32 v39, v46  ; v46 = 1
-;; @003e                               brif v45, block6, block4(v47)
+;; @003e                               v41 = iconst.i32 8
+;; @003e                               v42 = imul.i32 v39, v41  ; v41 = 8
+;; @003e                               v43 = uextend.i64 v42
+;; @003e                               v44 = iadd.i64 v36, v43
+;; @003e                               v45 = load.i64 notrap aligned v44
+;; @003e                               v46 = icmp eq v45, v24
+;; @003e                               v47 = iconst.i32 1
+;; @003e                               v48 = iadd.i32 v39, v47  ; v47 = 1
+;; @003e                               brif v46, block6, block4(v48)
 ;;
 ;;                                 block6:
 ;; @003e                               store.i64 notrap aligned v29, v27+64
-;; @003e                               v48 = iconst.i64 120
-;; @003e                               v49 = iadd.i64 v27, v48  ; v48 = 120
-;; @003e                               v50 = iconst.i64 0
-;; @003e                               v51 = iadd.i64 v27, v50  ; v50 = 0
-;; @003e                               v52 = iconst.i32 3
-;; @003e                               v53 = iconst.i64 16
-;; @003e                               v54 = iadd v51, v53  ; v53 = 16
-;; @003e                               store notrap aligned v52, v54  ; v52 = 3
-;; @003e                               v55 = iconst.i64 0
+;; @003e                               v49 = iconst.i64 120
+;; @003e                               v50 = iadd.i64 v27, v49  ; v49 = 120
+;; @003e                               v51 = iconst.i64 0
+;; @003e                               v52 = iadd.i64 v27, v51  ; v51 = 0
+;; @003e                               v53 = iconst.i32 3
+;; @003e                               v54 = iconst.i64 16
+;; @003e                               v55 = iadd v52, v54  ; v54 = 16
+;; @003e                               store notrap aligned v53, v55  ; v53 = 3
 ;; @003e                               v56 = iconst.i64 0
-;; @003e                               store notrap aligned v55, v29+48  ; v55 = 0
-;; @003e                               store notrap aligned v56, v29+56  ; v56 = 0
-;; @003e                               v57 = load.i64 notrap aligned readonly v0+8
-;; @003e                               v58 = iconst.i64 0
-;; @003e                               v59 = iadd v51, v58  ; v58 = 0
-;; @003e                               v60 = load.i64 notrap aligned v57+72
-;; @003e                               store notrap aligned v60, v59+8
-;; @003e                               v61 = load.i64 notrap aligned v27+72
-;; @003e                               v62 = uextend.i128 v27
-;; @003e                               v63 = uextend.i128 v61
-;;                                     v133 = iconst.i64 64
-;;                                     v134 = uextend.i128 v133  ; v133 = 64
-;; @003e                               v64 = ishl v63, v134
-;; @003e                               v65 = bor v64, v62
-;; @003e                               v67 = iconst.i64 0
-;; @003e                               v68 = iadd.i64 v15, v67  ; v67 = 0
-;; @003e                               v69 = iconst.i64 16
-;; @003e                               v70 = iadd v68, v69  ; v69 = 16
-;; @003e                               v71 = load.i32 notrap aligned v70
-;; @003e                               v72 = iconst.i32 0
-;; @003e                               v73 = icmp ne v71, v72  ; v72 = 0
-;; @003e                               brif v73, block9, block8
+;; @003e                               v57 = iconst.i64 0
+;; @003e                               store notrap aligned v56, v29+48  ; v56 = 0
+;; @003e                               store notrap aligned v57, v29+56  ; v57 = 0
+;; @003e                               v58 = load.i64 notrap aligned readonly v0+8
+;; @003e                               v59 = iconst.i64 0
+;; @003e                               v60 = iadd v52, v59  ; v59 = 0
+;; @003e                               v61 = load.i64 notrap aligned v58+72
+;; @003e                               store notrap aligned v61, v60+8
+;; @003e                               v62 = load.i64 notrap aligned v27+72
+;; @003e                               v63 = uextend.i128 v27
+;; @003e                               v64 = uextend.i128 v62
+;;                                     v134 = iconst.i64 64
+;;                                     v135 = uextend.i128 v134  ; v134 = 64
+;; @003e                               v65 = ishl v64, v135
+;; @003e                               v66 = bor v65, v63
+;; @003e                               v68 = iconst.i64 0
+;; @003e                               v69 = iadd.i64 v15, v68  ; v68 = 0
+;; @003e                               v70 = iconst.i64 16
+;; @003e                               v71 = iadd v69, v70  ; v70 = 16
+;; @003e                               v72 = load.i32 notrap aligned v71
+;; @003e                               v73 = iconst.i32 0
+;; @003e                               v74 = icmp ne v72, v73  ; v73 = 0
+;; @003e                               brif v74, block9, block8
 ;;
 ;;                                 block8:
-;; @003e                               v74 = iconst.i64 104
-;; @003e                               v75 = iadd.i64 v15, v74  ; v74 = 104
-;; @003e                               v76 = load.i64 notrap aligned v75+8
-;; @003e                               v77 = load.i32 notrap aligned v75
-;; @003e                               v78 = iconst.i32 1
-;; @003e                               v79 = iadd v77, v78  ; v78 = 1
-;; @003e                               store notrap aligned v79, v75
-;; @003e                               v80 = uextend.i64 v77
-;;                                     v132 = iconst.i64 16
-;; @003e                               v81 = imul v80, v132  ; v132 = 16
-;; @003e                               v82 = iadd v76, v81
-;; @003e                               jump block10(v82)
+;; @003e                               v75 = iconst.i64 104
+;; @003e                               v76 = iadd.i64 v15, v75  ; v75 = 104
+;; @003e                               v77 = load.i64 notrap aligned v76+8
+;; @003e                               v78 = load.i32 notrap aligned v76
+;; @003e                               v79 = iconst.i32 1
+;; @003e                               v80 = iadd v78, v79  ; v79 = 1
+;; @003e                               store notrap aligned v80, v76
+;; @003e                               v81 = uextend.i64 v78
+;; @003e                               v82 = iconst.i64 16
+;; @003e                               v83 = imul v81, v82  ; v82 = 16
+;; @003e                               v84 = iadd v77, v83
+;; @003e                               jump block10(v84)
 ;;
 ;;                                 block9:
-;; @003e                               v83 = iconst.i64 120
-;; @003e                               v84 = iadd.i64 v15, v83  ; v83 = 120
-;; @003e                               v85 = load.i64 notrap aligned v84+8
-;; @003e                               v86 = load.i32 notrap aligned v84
-;; @003e                               v87 = iconst.i32 1
-;; @003e                               v88 = iadd v86, v87  ; v87 = 1
-;; @003e                               store notrap aligned v88, v84
-;; @003e                               v89 = uextend.i64 v86
-;;                                     v131 = iconst.i64 16
-;; @003e                               v90 = imul v89, v131  ; v131 = 16
-;; @003e                               v91 = iadd v85, v90
-;; @003e                               jump block10(v91)
+;; @003e                               v85 = iconst.i64 120
+;; @003e                               v86 = iadd.i64 v15, v85  ; v85 = 120
+;; @003e                               v87 = load.i64 notrap aligned v86+8
+;; @003e                               v88 = load.i32 notrap aligned v86
+;; @003e                               v89 = iconst.i32 1
+;; @003e                               v90 = iadd v88, v89  ; v89 = 1
+;; @003e                               store notrap aligned v90, v86
+;; @003e                               v91 = uextend.i64 v88
+;; @003e                               v92 = iconst.i64 16
+;; @003e                               v93 = imul v91, v92  ; v92 = 16
+;; @003e                               v94 = iadd v87, v93
+;; @003e                               jump block10(v94)
 ;;
-;;                                 block10(v66: i64):
-;; @003e                               store.i128 notrap aligned v65, v66
-;; @003e                               v92 = iconst.i64 0
-;; @003e                               v93 = iadd.i64 v15, v92  ; v92 = 0
-;; @003e                               v94 = iconst.i32 1
-;; @003e                               v95 = iconst.i64 16
-;; @003e                               v96 = iadd v93, v95  ; v95 = 16
-;; @003e                               store notrap aligned v94, v96  ; v94 = 1
-;; @003e                               v97 = load.i64 notrap aligned v15+64
-;; @003e                               store.i64 notrap aligned v32, v97+48
-;; @003e                               store.i64 notrap aligned v33, v97+56
-;; @003e                               v98 = iconst.i64 2
-;; @003e                               v99 = load.i64 notrap aligned v0+8
-;; @003e                               store notrap aligned v98, v99+88  ; v98 = 2
-;; @003e                               store.i64 notrap aligned v15, v99+96
-;; @003e                               v100 = iconst.i64 0
-;; @003e                               v101 = iadd v93, v100  ; v100 = 0
-;; @003e                               v102 = load.i64 notrap aligned v101
-;; @003e                               store notrap aligned v102, v57+24
-;; @003e                               v103 = load.i64 notrap aligned v101+8
-;; @003e                               store notrap aligned v103, v57+72
-;; @003e                               v104 = iconst.i64 80
-;; @003e                               v105 = iadd.i64 v29, v104  ; v104 = 80
-;; @003e                               v106 = load.i64 notrap aligned v105
-;; @003e                               v107 = iconst.i64 -24
-;; @003e                               v108 = iadd v106, v107  ; v107 = -24
-;; @003e                               v109 = iconst.i64 80
-;; @003e                               v110 = iadd v97, v109  ; v109 = 80
-;; @003e                               v111 = load.i64 notrap aligned v110
-;; @003e                               v112 = iconst.i64 -24
-;; @003e                               v113 = iadd v111, v112  ; v112 = -24
-;; @003e                               v114 = stack_addr.i64 ss0
-;; @003e                               v115 = load.i64 notrap aligned v113
-;; @003e                               store notrap aligned v115, v114
-;; @003e                               v116 = load.i64 notrap aligned v108
-;; @003e                               store notrap aligned v116, v113
-;; @003e                               v117 = load.i64 notrap aligned v113+8
-;; @003e                               store notrap aligned v117, v114+8
-;; @003e                               v118 = load.i64 notrap aligned v108+8
-;; @003e                               store notrap aligned v118, v113+8
-;; @003e                               v119 = load.i64 notrap aligned v113+16
-;; @003e                               store notrap aligned v119, v114+16
-;; @003e                               v120 = load.i64 notrap aligned v108+16
-;; @003e                               store notrap aligned v120, v113+16
-;; @003e                               v121 = iconst.i64 3
-;;                                     v130 = iconst.i64 32
-;; @003e                               v122 = ishl v121, v130  ; v121 = 3, v130 = 32
-;; @003e                               v123 = stack_switch v108, v114, v122
-;; @003e                               v124 = iconst.i64 120
-;; @003e                               v125 = iadd.i64 v27, v124  ; v124 = 120
-;; @003e                               v126 = load.i64 notrap aligned v125+8
-;; @003e                               v127 = iconst.i32 0
-;; @003e                               store notrap aligned v127, v125  ; v127 = 0
-;; @003e                               v128 = iconst.i32 0
-;; @003e                               store notrap aligned v128, v125+4  ; v128 = 0
-;; @003e                               v129 = iconst.i64 0
-;; @003e                               store notrap aligned v129, v125+8  ; v129 = 0
+;;                                 block10(v67: i64):
+;; @003e                               store.i128 notrap aligned v66, v67
+;; @003e                               v95 = iconst.i64 0
+;; @003e                               v96 = iadd.i64 v15, v95  ; v95 = 0
+;; @003e                               v97 = iconst.i32 1
+;; @003e                               v98 = iconst.i64 16
+;; @003e                               v99 = iadd v96, v98  ; v98 = 16
+;; @003e                               store notrap aligned v97, v99  ; v97 = 1
+;; @003e                               v100 = load.i64 notrap aligned v15+64
+;; @003e                               store.i64 notrap aligned v32, v100+48
+;; @003e                               store.i64 notrap aligned v33, v100+56
+;; @003e                               v101 = iconst.i64 2
+;; @003e                               v102 = load.i64 notrap aligned v0+8
+;; @003e                               store notrap aligned v101, v102+88  ; v101 = 2
+;; @003e                               store.i64 notrap aligned v15, v102+96
+;; @003e                               v103 = iconst.i64 0
+;; @003e                               v104 = iadd v96, v103  ; v103 = 0
+;; @003e                               v105 = load.i64 notrap aligned v104
+;; @003e                               store notrap aligned v105, v58+24
+;; @003e                               v106 = load.i64 notrap aligned v104+8
+;; @003e                               store notrap aligned v106, v58+72
+;; @003e                               v107 = iconst.i64 80
+;; @003e                               v108 = iadd.i64 v29, v107  ; v107 = 80
+;; @003e                               v109 = load.i64 notrap aligned v108
+;; @003e                               v110 = iconst.i64 -24
+;; @003e                               v111 = iadd v109, v110  ; v110 = -24
+;; @003e                               v112 = iconst.i64 80
+;; @003e                               v113 = iadd v100, v112  ; v112 = 80
+;; @003e                               v114 = load.i64 notrap aligned v113
+;; @003e                               v115 = iconst.i64 -24
+;; @003e                               v116 = iadd v114, v115  ; v115 = -24
+;; @003e                               v117 = stack_addr.i64 ss0
+;; @003e                               v118 = load.i64 notrap aligned v116
+;; @003e                               store notrap aligned v118, v117
+;; @003e                               v119 = load.i64 notrap aligned v111
+;; @003e                               store notrap aligned v119, v116
+;; @003e                               v120 = load.i64 notrap aligned v116+8
+;; @003e                               store notrap aligned v120, v117+8
+;; @003e                               v121 = load.i64 notrap aligned v111+8
+;; @003e                               store notrap aligned v121, v116+8
+;; @003e                               v122 = load.i64 notrap aligned v116+16
+;; @003e                               store notrap aligned v122, v117+16
+;; @003e                               v123 = load.i64 notrap aligned v111+16
+;; @003e                               store notrap aligned v123, v116+16
+;; @003e                               v124 = iconst.i64 3
+;;                                     v133 = iconst.i64 32
+;; @003e                               v125 = ishl v124, v133  ; v124 = 3, v133 = 32
+;; @003e                               v126 = stack_switch v111, v117, v125
+;; @003e                               v127 = iconst.i64 120
+;; @003e                               v128 = iadd.i64 v27, v127  ; v127 = 120
+;; @003e                               v129 = load.i64 notrap aligned v128+8
+;; @003e                               v130 = iconst.i32 0
+;; @003e                               store notrap aligned v130, v128  ; v130 = 0
+;; @003e                               v131 = iconst.i32 0
+;; @003e                               store notrap aligned v131, v128+4  ; v131 = 0
+;; @003e                               v132 = iconst.i64 0
+;; @003e                               store notrap aligned v132, v128+8  ; v132 = 0
 ;; @0041                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/startup-data-active.wat
+++ b/tests/disas/startup-data-active.wat
@@ -51,10 +51,10 @@
 ;;     v8 = load.i32 notrap aligned v0+120
 ;;     v11 = load.i64 notrap aligned v0+64
 ;;     v13 = uextend.i64 v8
-;;     v16 = icmp ugt v13, v11
-;;     trapnz v16, heap_oob
-;;     v17 = load.i64 notrap aligned readonly can_move v0+56
-;;     call fn0(v0, v17, v3, v13)
+;;     v17 = icmp ugt v13, v11
+;;     trapnz v17, heap_oob
+;;     v18 = load.i64 notrap aligned readonly can_move v0+56
+;;     call fn0(v0, v18, v3, v13)
 ;;     jump block2
 ;;
 ;; block2:

--- a/tests/disas/startup-elem-active.wat
+++ b/tests/disas/startup-elem-active.wat
@@ -51,27 +51,27 @@
 ;;     v86 = iconst.i64 4
 ;;     v92 = icmp ult v6, v86  ; v86 = 4
 ;;     trapnz v92, user6
-;;     v12 = load.i64 notrap aligned v0+48
+;;     v13 = load.i64 notrap aligned v0+48
 ;;     v103 = iconst.i32 21
 ;;     v2 = iconst.i32 1
 ;;     v114 = icmp ule v5, v2  ; v2 = 1
 ;;     v79 = iconst.i64 0
-;;     v15 = iadd v12, v86  ; v86 = 4
-;;     v29 = select_spectre_guard v114, v79, v15  ; v79 = 0
-;;     store user6 aligned region0 v103, v29  ; v103 = 21
+;;     v17 = iadd v13, v86  ; v86 = 4
+;;     v31 = select_spectre_guard v114, v79, v17  ; v79 = 0
+;;     store user6 aligned region0 v103, v31  ; v103 = 21
 ;;     v117 = iconst.i32 23
 ;;     v123 = iconst.i32 2
 ;;     v129 = icmp ule v5, v123  ; v123 = 2
 ;;     v131 = iconst.i64 8
-;;     v41 = iadd v12, v131  ; v131 = 8
-;;     v43 = select_spectre_guard v129, v79, v41  ; v79 = 0
-;;     store user6 aligned region0 v117, v43  ; v117 = 23
+;;     v43 = iadd v13, v131  ; v131 = 8
+;;     v45 = select_spectre_guard v129, v79, v43  ; v79 = 0
+;;     store user6 aligned region0 v117, v45  ; v117 = 23
 ;;     v133 = iconst.i32 25
 ;;     v3 = iconst.i32 3
 ;;     v144 = icmp ule v5, v3  ; v3 = 3
 ;;     v146 = iconst.i64 12
-;;     v55 = iadd v12, v146  ; v146 = 12
-;;     v57 = select_spectre_guard v144, v79, v55  ; v79 = 0
-;;     store user6 aligned region0 v133, v57  ; v133 = 25
+;;     v57 = iadd v13, v146  ; v146 = 12
+;;     v59 = select_spectre_guard v144, v79, v57  ; v79 = 0
+;;     store user6 aligned region0 v133, v59  ; v133 = 25
 ;;     return
 ;; }

--- a/tests/disas/startup-table-initial-value.wat
+++ b/tests/disas/startup-table-initial-value.wat
@@ -44,20 +44,20 @@
 ;;     v41 = iconst.i64 10
 ;;     v53 = icmp ult v9, v41  ; v41 = 10
 ;;     trapnz v53, user6
-;;     v15 = load.i64 notrap aligned v0+48
+;;     v16 = load.i64 notrap aligned v0+48
 ;;     v34 = iconst.i32 1
 ;;     v83 = iconst.i64 36
-;;     v85 = iadd v15, v83  ; v83 = 36
-;;     v29 = iconst.i64 4
-;;     jump block1(v15)
+;;     v85 = iadd v16, v83  ; v83 = 36
+;;     v18 = iconst.i64 4
+;;     jump block1(v16)
 ;;
-;; block1(v24: i64):
+;; block1(v27: i64):
 ;;     v88 = iconst.i32 1
-;;     store notrap aligned v88, v24  ; v88 = 1
-;;     v89 = iadd.i64 v15, v83  ; v83 = 36
-;;     v90 = icmp eq v24, v89
+;;     store notrap aligned v88, v27  ; v88 = 1
+;;     v89 = iadd.i64 v16, v83  ; v83 = 36
+;;     v90 = icmp eq v27, v89
 ;;     v91 = iconst.i64 4
-;;     v92 = iadd v24, v91  ; v91 = 4
+;;     v92 = iadd v27, v91  ; v91 = 4
 ;;     brif v90, block2, block1(v92)
 ;;
 ;; block2:

--- a/tests/disas/table-copy.wat
+++ b/tests/disas/table-copy.wat
@@ -83,120 +83,120 @@
 ;; @0090                               v9 = uextend.i64 v8
 ;; @0090                               v10 = uextend.i64 v3
 ;; @0090                               v11 = uextend.i64 v5
-;;                                     v110 = iconst.i64 1
-;; @0090                               v12 = imul v11, v110  ; v110 = 1
-;; @0090                               v13 = iadd v10, v12
-;; @0090                               v14 = icmp ugt v13, v9
-;; @0090                               trapnz v14, user6
-;; @0090                               v108 = load.i64 notrap aligned readonly can_move v0+48
-;; @0090                               v15 = load.i64 notrap aligned v108
-;; @0090                               v16 = uextend.i64 v3
-;;                                     v107 = iconst.i64 8
-;; @0090                               v17 = imul v16, v107  ; v107 = 8
-;; @0090                               v18 = iadd v15, v17
-;; @0090                               v19 = iconst.i32 6
-;; @0090                               v20 = uextend.i64 v19  ; v19 = 6
-;; @0090                               v21 = uextend.i64 v4
-;; @0090                               v22 = uextend.i64 v5
-;;                                     v106 = iconst.i64 1
-;; @0090                               v23 = imul v22, v106  ; v106 = 1
-;; @0090                               v24 = iadd v21, v23
-;; @0090                               v25 = icmp ugt v24, v20
-;; @0090                               trapnz v25, user6
-;; @0090                               v26 = load.i64 notrap aligned readonly can_move v0+72
-;; @0090                               v27 = uextend.i64 v4
-;;                                     v104 = iconst.i64 8
-;; @0090                               v28 = imul v27, v104  ; v104 = 8
-;; @0090                               v29 = iadd v26, v28
-;; @0090                               v30 = uextend.i64 v5
-;;                                     v103 = iconst.i64 8
-;; @0090                               v31 = imul v30, v103  ; v103 = 8
-;;                                     v102 = iconst.i64 8
-;; @0090                               v32 = imul v30, v102  ; v102 = 8
-;; @0090                               brif v30, block2, block5
+;; @0090                               v12 = iconst.i64 1
+;; @0090                               v13 = imul v11, v12  ; v12 = 1
+;; @0090                               v14 = iadd v10, v13
+;; @0090                               v15 = icmp ugt v14, v9
+;; @0090                               trapnz v15, user6
+;; @0090                               v109 = load.i64 notrap aligned readonly can_move v0+48
+;; @0090                               v16 = load.i64 notrap aligned v109
+;; @0090                               v17 = uextend.i64 v3
+;; @0090                               v18 = iconst.i64 8
+;; @0090                               v19 = imul v17, v18  ; v18 = 8
+;; @0090                               v20 = iadd v16, v19
+;; @0090                               v21 = iconst.i32 6
+;; @0090                               v22 = uextend.i64 v21  ; v21 = 6
+;; @0090                               v23 = uextend.i64 v4
+;; @0090                               v24 = uextend.i64 v5
+;; @0090                               v25 = iconst.i64 1
+;; @0090                               v26 = imul v24, v25  ; v25 = 1
+;; @0090                               v27 = iadd v23, v26
+;; @0090                               v28 = icmp ugt v27, v22
+;; @0090                               trapnz v28, user6
+;; @0090                               v29 = load.i64 notrap aligned readonly can_move v0+72
+;; @0090                               v30 = uextend.i64 v4
+;; @0090                               v31 = iconst.i64 8
+;; @0090                               v32 = imul v30, v31  ; v31 = 8
+;; @0090                               v33 = iadd v29, v32
+;; @0090                               v34 = uextend.i64 v5
+;; @0090                               v35 = iconst.i64 8
+;; @0090                               v36 = imul v34, v35  ; v35 = 8
+;; @0090                               v37 = iconst.i64 8
+;; @0090                               v38 = imul v34, v37  ; v37 = 8
+;; @0090                               brif v34, block2, block5
 ;;
 ;;                                 block2:
-;; @0090                               v33 = icmp.i64 ult v18, v29
-;;                                     v101 = iconst.i64 8
-;; @0090                               v34 = imul.i64 v30, v101  ; v101 = 8
-;;                                     v100 = iconst.i64 8
-;; @0090                               v35 = imul.i64 v30, v100  ; v100 = 8
-;; @0090                               v36 = iadd.i64 v18, v34
-;; @0090                               v37 = iadd.i64 v29, v35
-;; @0090                               v38 = ireduce.i32 v30
-;; @0090                               v39 = iadd.i32 v4, v38
-;; @0090                               brif v33, block3(v18, v29, v4), block4(v36, v37, v39)
+;; @0090                               v39 = icmp.i64 ult v20, v33
+;; @0090                               v40 = iconst.i64 8
+;; @0090                               v41 = imul.i64 v34, v40  ; v40 = 8
+;; @0090                               v42 = iconst.i64 8
+;; @0090                               v43 = imul.i64 v34, v42  ; v42 = 8
+;; @0090                               v44 = iadd.i64 v20, v41
+;; @0090                               v45 = iadd.i64 v33, v43
+;; @0090                               v46 = ireduce.i32 v34
+;; @0090                               v47 = iadd.i32 v4, v46
+;; @0090                               brif v39, block3(v20, v33, v4), block4(v44, v45, v47)
 ;;
-;;                                 block3(v40: i64, v41: i64, v42: i32):
-;; @0090                               v43 = iconst.i32 6
-;; @0090                               v44 = icmp uge v42, v43  ; v43 = 6
-;; @0090                               v45 = uextend.i64 v42
-;; @0090                               v46 = load.i64 notrap aligned readonly can_move v0+72
-;;                                     v98 = iconst.i64 3
-;; @0090                               v47 = ishl v45, v98  ; v98 = 3
-;; @0090                               v48 = iadd v46, v47
-;; @0090                               v49 = iconst.i64 0
-;; @0090                               v50 = select_spectre_guard v44, v49, v48  ; v49 = 0
-;; @0090                               v51 = load.i64 user6 aligned region0 v50
-;;                                     v97 = iconst.i64 -2
-;; @0090                               v52 = band v51, v97  ; v97 = -2
-;; @0090                               brif v51, block7(v52), block6
+;;                                 block3(v48: i64, v49: i64, v50: i32):
+;; @0090                               v51 = iconst.i32 6
+;; @0090                               v52 = icmp uge v50, v51  ; v51 = 6
+;; @0090                               v53 = uextend.i64 v50
+;; @0090                               v54 = load.i64 notrap aligned readonly can_move v0+72
+;;                                     v106 = iconst.i64 3
+;; @0090                               v55 = ishl v53, v106  ; v106 = 3
+;; @0090                               v56 = iadd v54, v55
+;; @0090                               v57 = iconst.i64 0
+;; @0090                               v58 = select_spectre_guard v52, v57, v56  ; v57 = 0
+;; @0090                               v59 = load.i64 user6 aligned region0 v58
+;;                                     v105 = iconst.i64 -2
+;; @0090                               v60 = band v59, v105  ; v105 = -2
+;; @0090                               brif v59, block7(v60), block6
 ;;
-;;                                 block4(v66: i64, v67: i64, v68: i32):
-;; @0090                               v69 = iconst.i64 8
-;; @0090                               v70 = isub v66, v69  ; v69 = 8
-;; @0090                               v71 = iconst.i64 8
-;; @0090                               v72 = isub v67, v71  ; v71 = 8
-;; @0090                               v73 = iconst.i32 1
-;; @0090                               v74 = isub v68, v73  ; v73 = 1
-;; @0090                               v75 = iconst.i32 6
-;; @0090                               v76 = icmp uge v74, v75  ; v75 = 6
-;; @0090                               v77 = uextend.i64 v74
-;; @0090                               v78 = load.i64 notrap aligned readonly can_move v0+72
-;;                                     v95 = iconst.i64 3
-;; @0090                               v79 = ishl v77, v95  ; v95 = 3
-;; @0090                               v80 = iadd v78, v79
-;; @0090                               v81 = iconst.i64 0
-;; @0090                               v82 = select_spectre_guard v76, v81, v80  ; v81 = 0
-;; @0090                               v83 = load.i64 user6 aligned region0 v82
-;;                                     v94 = iconst.i64 -2
-;; @0090                               v84 = band v83, v94  ; v94 = -2
-;; @0090                               brif v83, block9(v84), block8
+;;                                 block4(v74: i64, v75: i64, v76: i32):
+;; @0090                               v77 = iconst.i64 8
+;; @0090                               v78 = isub v74, v77  ; v77 = 8
+;; @0090                               v79 = iconst.i64 8
+;; @0090                               v80 = isub v75, v79  ; v79 = 8
+;; @0090                               v81 = iconst.i32 1
+;; @0090                               v82 = isub v76, v81  ; v81 = 1
+;; @0090                               v83 = iconst.i32 6
+;; @0090                               v84 = icmp uge v82, v83  ; v83 = 6
+;; @0090                               v85 = uextend.i64 v82
+;; @0090                               v86 = load.i64 notrap aligned readonly can_move v0+72
+;;                                     v103 = iconst.i64 3
+;; @0090                               v87 = ishl v85, v103  ; v103 = 3
+;; @0090                               v88 = iadd v86, v87
+;; @0090                               v89 = iconst.i64 0
+;; @0090                               v90 = select_spectre_guard v84, v89, v88  ; v89 = 0
+;; @0090                               v91 = load.i64 user6 aligned region0 v90
+;;                                     v102 = iconst.i64 -2
+;; @0090                               v92 = band v91, v102  ; v102 = -2
+;; @0090                               brif v91, block9(v92), block8
 ;;
 ;;                                 block5:
 ;; @0094                               jump block1
 ;;
 ;;                                 block6 cold:
-;; @0090                               v54 = iconst.i32 1
-;; @0090                               v56 = uextend.i64 v42
-;; @0090                               v57 = call fn0(v0, v54, v56)  ; v54 = 1
-;; @0090                               jump block7(v57)
+;; @0090                               v62 = iconst.i32 1
+;; @0090                               v64 = uextend.i64 v50
+;; @0090                               v65 = call fn0(v0, v62, v64)  ; v62 = 1
+;; @0090                               jump block7(v65)
 ;;
-;;                                 block7(v53: i64):
-;;                                     v93 = iconst.i64 1
-;; @0090                               v58 = bor v53, v93  ; v93 = 1
-;; @0090                               store notrap aligned v58, v40
-;; @0090                               v59 = iconst.i64 8
-;; @0090                               v60 = iadd.i64 v40, v59  ; v59 = 8
-;; @0090                               v61 = iconst.i64 8
-;; @0090                               v62 = iadd.i64 v41, v61  ; v61 = 8
-;; @0090                               v63 = iconst.i32 1
-;; @0090                               v64 = iadd.i32 v42, v63  ; v63 = 1
-;; @0090                               v65 = icmp eq v62, v37
-;; @0090                               brif v65, block5, block3(v60, v62, v64)
+;;                                 block7(v61: i64):
+;;                                     v101 = iconst.i64 1
+;; @0090                               v66 = bor v61, v101  ; v101 = 1
+;; @0090                               store notrap aligned v66, v48
+;; @0090                               v67 = iconst.i64 8
+;; @0090                               v68 = iadd.i64 v48, v67  ; v67 = 8
+;; @0090                               v69 = iconst.i64 8
+;; @0090                               v70 = iadd.i64 v49, v69  ; v69 = 8
+;; @0090                               v71 = iconst.i32 1
+;; @0090                               v72 = iadd.i32 v50, v71  ; v71 = 1
+;; @0090                               v73 = icmp eq v70, v45
+;; @0090                               brif v73, block5, block3(v68, v70, v72)
 ;;
 ;;                                 block8 cold:
-;; @0090                               v86 = iconst.i32 1
-;; @0090                               v88 = uextend.i64 v74
-;; @0090                               v89 = call fn0(v0, v86, v88)  ; v86 = 1
-;; @0090                               jump block9(v89)
+;; @0090                               v94 = iconst.i32 1
+;; @0090                               v96 = uextend.i64 v82
+;; @0090                               v97 = call fn0(v0, v94, v96)  ; v94 = 1
+;; @0090                               jump block9(v97)
 ;;
-;;                                 block9(v85: i64):
-;;                                     v92 = iconst.i64 1
-;; @0090                               v90 = bor v85, v92  ; v92 = 1
-;; @0090                               store notrap aligned v90, v70
-;; @0090                               v91 = icmp.i64 eq v72, v29
-;; @0090                               brif v91, block5, block4(v70, v72, v74)
+;;                                 block9(v93: i64):
+;;                                     v100 = iconst.i64 1
+;; @0090                               v98 = bor v93, v100  ; v100 = 1
+;; @0090                               store notrap aligned v98, v78
+;; @0090                               v99 = icmp.i64 eq v80, v33
+;; @0090                               brif v99, block5, block4(v78, v80, v82)
 ;;
 ;;                                 block1:
 ;; @0094                               return v2
@@ -221,128 +221,128 @@
 ;; @009f                               v8 = uextend.i64 v7  ; v7 = 6
 ;; @009f                               v9 = uextend.i64 v3
 ;; @009f                               v10 = uextend.i64 v5
-;;                                     v120 = iconst.i64 1
-;; @009f                               v11 = imul v10, v120  ; v120 = 1
-;; @009f                               v12 = iadd v9, v11
-;; @009f                               v13 = icmp ugt v12, v8
-;; @009f                               trapnz v13, user6
-;; @009f                               v14 = load.i64 notrap aligned readonly can_move v0+72
-;; @009f                               v15 = uextend.i64 v3
-;;                                     v118 = iconst.i64 8
-;; @009f                               v16 = imul v15, v118  ; v118 = 8
-;; @009f                               v17 = iadd v14, v16
+;; @009f                               v11 = iconst.i64 1
+;; @009f                               v12 = imul v10, v11  ; v11 = 1
+;; @009f                               v13 = iadd v9, v12
+;; @009f                               v14 = icmp ugt v13, v8
+;; @009f                               trapnz v14, user6
+;; @009f                               v15 = load.i64 notrap aligned readonly can_move v0+72
+;; @009f                               v16 = uextend.i64 v3
+;; @009f                               v17 = iconst.i64 8
+;; @009f                               v18 = imul v16, v17  ; v17 = 8
+;; @009f                               v19 = iadd v15, v18
+;; @009f                               v118 = load.i64 notrap aligned readonly can_move v0+48
+;; @009f                               v20 = load.i64 notrap aligned v118+8
+;; @009f                               v21 = ireduce.i32 v20
+;; @009f                               v22 = uextend.i64 v21
+;; @009f                               v23 = uextend.i64 v4
+;; @009f                               v24 = uextend.i64 v5
+;; @009f                               v25 = iconst.i64 1
+;; @009f                               v26 = imul v24, v25  ; v25 = 1
+;; @009f                               v27 = iadd v23, v26
+;; @009f                               v28 = icmp ugt v27, v22
+;; @009f                               trapnz v28, user6
 ;; @009f                               v116 = load.i64 notrap aligned readonly can_move v0+48
-;; @009f                               v18 = load.i64 notrap aligned v116+8
-;; @009f                               v19 = ireduce.i32 v18
-;; @009f                               v20 = uextend.i64 v19
-;; @009f                               v21 = uextend.i64 v4
-;; @009f                               v22 = uextend.i64 v5
-;;                                     v115 = iconst.i64 1
-;; @009f                               v23 = imul v22, v115  ; v115 = 1
-;; @009f                               v24 = iadd v21, v23
-;; @009f                               v25 = icmp ugt v24, v20
-;; @009f                               trapnz v25, user6
-;; @009f                               v113 = load.i64 notrap aligned readonly can_move v0+48
-;; @009f                               v26 = load.i64 notrap aligned v113
-;; @009f                               v27 = uextend.i64 v4
-;;                                     v112 = iconst.i64 8
-;; @009f                               v28 = imul v27, v112  ; v112 = 8
-;; @009f                               v29 = iadd v26, v28
-;; @009f                               v30 = uextend.i64 v5
-;;                                     v111 = iconst.i64 8
-;; @009f                               v31 = imul v30, v111  ; v111 = 8
-;;                                     v110 = iconst.i64 8
-;; @009f                               v32 = imul v30, v110  ; v110 = 8
-;; @009f                               brif v30, block2, block5
+;; @009f                               v29 = load.i64 notrap aligned v116
+;; @009f                               v30 = uextend.i64 v4
+;; @009f                               v31 = iconst.i64 8
+;; @009f                               v32 = imul v30, v31  ; v31 = 8
+;; @009f                               v33 = iadd v29, v32
+;; @009f                               v34 = uextend.i64 v5
+;; @009f                               v35 = iconst.i64 8
+;; @009f                               v36 = imul v34, v35  ; v35 = 8
+;; @009f                               v37 = iconst.i64 8
+;; @009f                               v38 = imul v34, v37  ; v37 = 8
+;; @009f                               brif v34, block2, block5
 ;;
 ;;                                 block2:
-;; @009f                               v33 = icmp.i64 ult v17, v29
-;;                                     v109 = iconst.i64 8
-;; @009f                               v34 = imul.i64 v30, v109  ; v109 = 8
-;;                                     v108 = iconst.i64 8
-;; @009f                               v35 = imul.i64 v30, v108  ; v108 = 8
-;; @009f                               v36 = iadd.i64 v17, v34
-;; @009f                               v37 = iadd.i64 v29, v35
-;; @009f                               v38 = ireduce.i32 v30
-;; @009f                               v39 = iadd.i32 v4, v38
-;; @009f                               brif v33, block3(v17, v29, v4), block4(v36, v37, v39)
+;; @009f                               v39 = icmp.i64 ult v19, v33
+;; @009f                               v40 = iconst.i64 8
+;; @009f                               v41 = imul.i64 v34, v40  ; v40 = 8
+;; @009f                               v42 = iconst.i64 8
+;; @009f                               v43 = imul.i64 v34, v42  ; v42 = 8
+;; @009f                               v44 = iadd.i64 v19, v41
+;; @009f                               v45 = iadd.i64 v33, v43
+;; @009f                               v46 = ireduce.i32 v34
+;; @009f                               v47 = iadd.i32 v4, v46
+;; @009f                               brif v39, block3(v19, v33, v4), block4(v44, v45, v47)
 ;;
-;;                                 block3(v40: i64, v41: i64, v42: i32):
+;;                                 block3(v48: i64, v49: i64, v50: i32):
+;; @009f                               v114 = load.i64 notrap aligned readonly can_move v0+48
+;; @009f                               v51 = load.i64 notrap aligned v114+8
+;; @009f                               v52 = ireduce.i32 v51
+;; @009f                               v53 = icmp uge v50, v52
+;; @009f                               v54 = uextend.i64 v50
+;; @009f                               v112 = load.i64 notrap aligned readonly can_move v0+48
+;; @009f                               v55 = load.i64 notrap aligned v112
+;;                                     v111 = iconst.i64 3
+;; @009f                               v56 = ishl v54, v111  ; v111 = 3
+;; @009f                               v57 = iadd v55, v56
+;; @009f                               v58 = iconst.i64 0
+;; @009f                               v59 = select_spectre_guard v53, v58, v57  ; v58 = 0
+;; @009f                               v60 = load.i64 user6 aligned region0 v59
+;;                                     v110 = iconst.i64 -2
+;; @009f                               v61 = band v60, v110  ; v110 = -2
+;; @009f                               brif v60, block7(v61), block6
+;;
+;;                                 block4(v75: i64, v76: i64, v77: i32):
+;; @009f                               v78 = iconst.i64 8
+;; @009f                               v79 = isub v75, v78  ; v78 = 8
+;; @009f                               v80 = iconst.i64 8
+;; @009f                               v81 = isub v76, v80  ; v80 = 8
+;; @009f                               v82 = iconst.i32 1
+;; @009f                               v83 = isub v77, v82  ; v82 = 1
+;; @009f                               v108 = load.i64 notrap aligned readonly can_move v0+48
+;; @009f                               v84 = load.i64 notrap aligned v108+8
+;; @009f                               v85 = ireduce.i32 v84
+;; @009f                               v86 = icmp uge v83, v85
+;; @009f                               v87 = uextend.i64 v83
 ;; @009f                               v106 = load.i64 notrap aligned readonly can_move v0+48
-;; @009f                               v43 = load.i64 notrap aligned v106+8
-;; @009f                               v44 = ireduce.i32 v43
-;; @009f                               v45 = icmp uge v42, v44
-;; @009f                               v46 = uextend.i64 v42
-;; @009f                               v104 = load.i64 notrap aligned readonly can_move v0+48
-;; @009f                               v47 = load.i64 notrap aligned v104
-;;                                     v103 = iconst.i64 3
-;; @009f                               v48 = ishl v46, v103  ; v103 = 3
-;; @009f                               v49 = iadd v47, v48
-;; @009f                               v50 = iconst.i64 0
-;; @009f                               v51 = select_spectre_guard v45, v50, v49  ; v50 = 0
-;; @009f                               v52 = load.i64 user6 aligned region0 v51
-;;                                     v102 = iconst.i64 -2
-;; @009f                               v53 = band v52, v102  ; v102 = -2
-;; @009f                               brif v52, block7(v53), block6
-;;
-;;                                 block4(v67: i64, v68: i64, v69: i32):
-;; @009f                               v70 = iconst.i64 8
-;; @009f                               v71 = isub v67, v70  ; v70 = 8
-;; @009f                               v72 = iconst.i64 8
-;; @009f                               v73 = isub v68, v72  ; v72 = 8
-;; @009f                               v74 = iconst.i32 1
-;; @009f                               v75 = isub v69, v74  ; v74 = 1
-;; @009f                               v100 = load.i64 notrap aligned readonly can_move v0+48
-;; @009f                               v76 = load.i64 notrap aligned v100+8
-;; @009f                               v77 = ireduce.i32 v76
-;; @009f                               v78 = icmp uge v75, v77
-;; @009f                               v79 = uextend.i64 v75
-;; @009f                               v98 = load.i64 notrap aligned readonly can_move v0+48
-;; @009f                               v80 = load.i64 notrap aligned v98
-;;                                     v97 = iconst.i64 3
-;; @009f                               v81 = ishl v79, v97  ; v97 = 3
-;; @009f                               v82 = iadd v80, v81
-;; @009f                               v83 = iconst.i64 0
-;; @009f                               v84 = select_spectre_guard v78, v83, v82  ; v83 = 0
-;; @009f                               v85 = load.i64 user6 aligned region0 v84
-;;                                     v96 = iconst.i64 -2
-;; @009f                               v86 = band v85, v96  ; v96 = -2
-;; @009f                               brif v85, block9(v86), block8
+;; @009f                               v88 = load.i64 notrap aligned v106
+;;                                     v105 = iconst.i64 3
+;; @009f                               v89 = ishl v87, v105  ; v105 = 3
+;; @009f                               v90 = iadd v88, v89
+;; @009f                               v91 = iconst.i64 0
+;; @009f                               v92 = select_spectre_guard v86, v91, v90  ; v91 = 0
+;; @009f                               v93 = load.i64 user6 aligned region0 v92
+;;                                     v104 = iconst.i64 -2
+;; @009f                               v94 = band v93, v104  ; v104 = -2
+;; @009f                               brif v93, block9(v94), block8
 ;;
 ;;                                 block5:
 ;; @00a3                               jump block1
 ;;
 ;;                                 block6 cold:
-;; @009f                               v55 = iconst.i32 0
-;; @009f                               v57 = uextend.i64 v42
-;; @009f                               v58 = call fn0(v0, v55, v57)  ; v55 = 0
-;; @009f                               jump block7(v58)
+;; @009f                               v63 = iconst.i32 0
+;; @009f                               v65 = uextend.i64 v50
+;; @009f                               v66 = call fn0(v0, v63, v65)  ; v63 = 0
+;; @009f                               jump block7(v66)
 ;;
-;;                                 block7(v54: i64):
-;;                                     v95 = iconst.i64 1
-;; @009f                               v59 = bor v54, v95  ; v95 = 1
-;; @009f                               store notrap aligned v59, v40
-;; @009f                               v60 = iconst.i64 8
-;; @009f                               v61 = iadd.i64 v40, v60  ; v60 = 8
-;; @009f                               v62 = iconst.i64 8
-;; @009f                               v63 = iadd.i64 v41, v62  ; v62 = 8
-;; @009f                               v64 = iconst.i32 1
-;; @009f                               v65 = iadd.i32 v42, v64  ; v64 = 1
-;; @009f                               v66 = icmp eq v63, v37
-;; @009f                               brif v66, block5, block3(v61, v63, v65)
+;;                                 block7(v62: i64):
+;;                                     v103 = iconst.i64 1
+;; @009f                               v67 = bor v62, v103  ; v103 = 1
+;; @009f                               store notrap aligned v67, v48
+;; @009f                               v68 = iconst.i64 8
+;; @009f                               v69 = iadd.i64 v48, v68  ; v68 = 8
+;; @009f                               v70 = iconst.i64 8
+;; @009f                               v71 = iadd.i64 v49, v70  ; v70 = 8
+;; @009f                               v72 = iconst.i32 1
+;; @009f                               v73 = iadd.i32 v50, v72  ; v72 = 1
+;; @009f                               v74 = icmp eq v71, v45
+;; @009f                               brif v74, block5, block3(v69, v71, v73)
 ;;
 ;;                                 block8 cold:
-;; @009f                               v88 = iconst.i32 0
-;; @009f                               v90 = uextend.i64 v75
-;; @009f                               v91 = call fn0(v0, v88, v90)  ; v88 = 0
-;; @009f                               jump block9(v91)
+;; @009f                               v96 = iconst.i32 0
+;; @009f                               v98 = uextend.i64 v83
+;; @009f                               v99 = call fn0(v0, v96, v98)  ; v96 = 0
+;; @009f                               jump block9(v99)
 ;;
-;;                                 block9(v87: i64):
-;;                                     v94 = iconst.i64 1
-;; @009f                               v92 = bor v87, v94  ; v94 = 1
-;; @009f                               store notrap aligned v92, v71
-;; @009f                               v93 = icmp.i64 eq v73, v29
-;; @009f                               brif v93, block5, block4(v71, v73, v75)
+;;                                 block9(v95: i64):
+;;                                     v102 = iconst.i64 1
+;; @009f                               v100 = bor v95, v102  ; v102 = 1
+;; @009f                               store notrap aligned v100, v79
+;; @009f                               v101 = icmp.i64 eq v81, v33
+;; @009f                               brif v101, block5, block4(v79, v81, v83)
 ;;
 ;;                                 block1:
 ;; @00a3                               return v2


### PR DESCRIPTION
Again, small change but lots of filetest/disas expectation updates.