### PR TITLE
Raise MSRV to 1.94.0

### DIFF
--- a/.github/actions/install-rust/action.yml
+++ b/.github/actions/install-rust/action.yml
@@ -32,7 +32,7 @@ runs:
         elif [ "${{ inputs.toolchain }}" = "msrv" ]; then
           echo "version=1.$msrv.0" >> "$GITHUB_OUTPUT"
         elif [ "${{ inputs.toolchain }}" = "wasmtime-ci-pinned-nightly" ]; then
-          echo "version=nightly-2026-04-16" >> "$GITHUB_OUTPUT"
+          echo "version=nightly-2026-06-03" >> "$GITHUB_OUTPUT"
         elif [ "${{ inputs.toolchain }}" = "wasmtime-ci-oss-fuzz-pin" ]; then
           # Do not change this number unless OSS-Fuzz has updated. If you update
           # this version and do not update OSS-Fuzz then you will break our

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -195,7 +195,7 @@ authors = ["The Wasmtime Project Developers"]
 edition = "2024"
 # Wasmtime's current policy is that this number can be no larger than the
 # current stable release of Rust minus 2.
-rust-version = "1.93.0"
+rust-version = "1.94.0"
 
 [workspace.lints.rust]
 # Turn on some lints which are otherwise allow-by-default in rustc.

--- a/cranelift/bforest/src/path.rs
+++ b/cranelift/bforest/src/path.rs
@@ -82,7 +82,7 @@ impl<F: Forest> Path<F> {
                         }
                     };
                 }
-                NodeData::Free { .. } => panic!("Free {} reached from {}", node, root),
+                NodeData::Free { .. } => panic!("Free {node} reached from {root}"),
             }
         }
         unreachable!();
@@ -98,7 +98,7 @@ impl<F: Forest> Path<F> {
             match pool[node] {
                 NodeData::Inner { tree, .. } => node = tree[0],
                 NodeData::Leaf { keys, vals, .. } => return (keys.borrow()[0], vals.borrow()[0]),
-                NodeData::Free { .. } => panic!("Free {} reached from {}", node, root),
+                NodeData::Free { .. } => panic!("Free {node} reached from {root}"),
             }
         }
         unreachable!();
@@ -216,7 +216,7 @@ impl<F: Forest> Path<F> {
                     self.size = l + 1;
                     break;
                 }
-                NodeData::Free { .. } => panic!("Free {} reached from {}", node, root),
+                NodeData::Free { .. } => panic!("Free {node} reached from {root}"),
             }
         }
         node

--- a/cranelift/bforest/src/pool.rs
+++ b/cranelift/bforest/src/pool.rs
@@ -38,7 +38,7 @@ impl<F: Forest> NodePool<F> {
                 // Remove this node from the free list.
                 match self.nodes[node] {
                     NodeData::Free { next } => self.freelist = next,
-                    _ => panic!("Invalid {} on free list", node),
+                    _ => panic!("Invalid {node} on free list"),
                 }
                 self.nodes[node] = data;
                 Ok(node)
@@ -200,7 +200,7 @@ impl<F: Forest> NodePool<F> {
                         lower = upper;
                     }
                 }
-                NodeData::Free { .. } => panic!("Free {} reached", node),
+                NodeData::Free { .. } => panic!("Free {node} reached"),
             }
         }
     }

--- a/cranelift/codegen/src/isa/aarch64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/aarch64/lower/isle.rs
@@ -743,7 +743,7 @@ impl Context for IsleContext<'_, '_, MInst, AArch64Backend> {
     fn vec_extract_imm4_from_immediate(&mut self, imm: Immediate) -> Option<u8> {
         let bytes = self.lower_ctx.get_immediate_data(imm).as_slice();
 
-        if bytes.windows(2).all(|a| a[0] + 1 == a[1]) && bytes[0] < 16 {
+        if bytes.array_windows().all(|[a, b]| *a + 1 == *b) && bytes[0] < 16 {
             Some(bytes[0])
         } else {
             None

--- a/cranelift/codegen/src/isa/x64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/x64/lower/isle.rs
@@ -1664,7 +1664,7 @@ impl Context for IsleContext<'_, '_, MInst, X64Backend> {
     fn palignr_imm_from_immediate(&mut self, imm: Immediate) -> Option<u8> {
         let bytes = self.lower_ctx.get_immediate_data(imm).as_slice();
 
-        if bytes.windows(2).all(|a| a[0] + 1 == a[1]) {
+        if bytes.array_windows().all(|[a, b]| *a + 1 == *b) {
             Some(bytes[0])
         } else {
             None

--- a/cranelift/codegen/src/ranges.rs
+++ b/cranelift/codegen/src/ranges.rs
@@ -62,9 +62,9 @@ impl Ranges {
         &self,
     ) -> impl DoubleEndedIterator<Item = (usize, Range<usize>)> + ExactSizeIterator + '_ {
         self.ranges
-            .windows(2)
+            .array_windows()
             .enumerate()
-            .map(|(index, range)| (self.map_index(index), range[0] as usize..range[1] as usize))
+            .map(|(index, [lo, hi])| (self.map_index(index), *lo as usize..*hi as usize))
     }
 
     /// Reverse this list of ranges, so that the first range is at the

--- a/cranelift/isle/isle/src/serialize.rs
+++ b/cranelift/isle/isle/src/serialize.rs
@@ -829,8 +829,8 @@ fn group_by_mut<T: Eq>(
             None
         } else {
             let mid = xs
-                .windows(2)
-                .position(|w| !pred(&w[0], &w[1]))
+                .array_windows()
+                .position(|[a, b]| !pred(a, b))
                 .map_or(xs.len(), |x| x + 1);
             let slice = std::mem::take(&mut xs);
             let (group, rest) = slice.split_at_mut(mid);

--- a/crates/test-programs/src/bin/debugger_component.rs
+++ b/crates/test-programs/src/bin/debugger_component.rs
@@ -78,7 +78,7 @@ fn test_simple(d: &Debuggee) {
 
     // There should be five PCs and they should each be distinct from the previous.
     assert_eq!(pcs.len(), 5);
-    assert!(pcs.windows(2).all(|p| p[0] != p[1]));
+    assert!(pcs.array_windows().all(|[a, b]| a != b));
 
     eprintln!("OK");
 }

--- a/crates/wasmtime/src/compile.rs
+++ b/crates/wasmtime/src/compile.rs
@@ -641,11 +641,10 @@ the use case.
         if cfg!(debug_assertions) {
             let mut symbols: Vec<_> = raw_outputs.iter().map(|i| &i.symbol).collect();
             symbols.sort();
-            for w in symbols.windows(2) {
+            for [a, b] in symbols.array_windows() {
                 assert_ne!(
-                    w[0], w[1],
-                    "should never have duplicate symbols, but found two functions with the symbol `{}`",
-                    w[0]
+                    a, b,
+                    "should never have duplicate symbols, but found two functions with the symbol `{a}`",
                 );
             }
         }

--- a/crates/wizer/src/snapshot.rs
+++ b/crates/wizer/src/snapshot.rs
@@ -267,11 +267,11 @@ fn remove_excess_segments(merged_data_segments: &mut Vec<DataSegmentRange>) {
     // smallest gaps together. Because they are the smallest gaps, this will
     // bloat the size of our data segment the least.
     let mut smallest_gaps = Vec::with_capacity(merged_data_segments.len() - 1);
-    for (index, w) in merged_data_segments.windows(2).enumerate() {
-        if w[0].memory_index != w[1].memory_index {
+    for (index, [w1, w2]) in merged_data_segments.array_windows().enumerate() {
+        if w1.memory_index != w2.memory_index {
             continue;
         }
-        let gap = match u32::try_from(w[0].gap(&w[1])) {
+        let gap = match u32::try_from(w1.gap(&w2)) {
             Ok(gap) => gap,
             // If the gap is larger than 4G then don't consider these two data
             // segments for merging and assume there's enough other data

--- a/tests/all/threads.rs
+++ b/tests/all/threads.rs
@@ -260,7 +260,7 @@ fn test_grow_memory_in_multiple_threads() -> Result<()> {
 }
 
 fn is_sorted(data: &[u32]) -> bool {
-    data.windows(2).all(|d| d[0] <= d[1])
+    data.array_windows().all(|[a, b]| a <= b)
 }
 
 #[test]


### PR DESCRIPTION
Coupled with the release of Rust 1.96.0 last week. Use `array_windows` as a replacement for current calls to `windows`, and then additionally fix some warnings that are now cropping up.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
