### PR TITLE
Cranelift: remove the `sdiv_imm` instruction

### DIFF
--- a/cranelift/codegen/meta/src/shared/instructions.rs
+++ b/cranelift/codegen/meta/src/shared/instructions.rs
@@ -1947,7 +1947,8 @@ pub(crate) fn define(
         .operands_in(vec![Operand::new("x", iB), Operand::new("y", iB)])
         .operands_out(vec![Operand::new("a", iB)])
         .can_trap()
-        .side_effects_idempotent(),
+        .side_effects_idempotent()
+        .inst_builder_imm_method(true),
     );
 
     ig.push(
@@ -1980,24 +1981,6 @@ pub(crate) fn define(
         .operands_out(vec![Operand::new("a", iB)])
         .can_trap()
         .side_effects_idempotent(),
-    );
-
-    ig.push(
-        Inst::new(
-            "sdiv_imm",
-            r#"
-        Signed integer division by an immediate constant.
-
-        Same as `sdiv`, but one operand is a sign extended 64 bit immediate constant.
-
-        This operation traps if the divisor is zero, or if the result is not
-        representable in `B` bits two's complement. This only happens
-        when `x = -2^{B-1}, Y = -1`.
-        "#,
-            &formats.binary_imm64,
-        )
-        .operands_in(vec![Operand::new("x", iB), Operand::new("Y", &imm.imm64)])
-        .operands_out(vec![Operand::new("a", iB)]),
     );
 
     ig.push(

--- a/cranelift/codegen/src/ir/instructions.rs
+++ b/cranelift/codegen/src/ir/instructions.rs
@@ -647,7 +647,7 @@ impl InstructionData {
                 arg: _,
                 imm,
             } => {
-                if *opcode == Opcode::SdivImm || *opcode == Opcode::SremImm {
+                if *opcode == Opcode::SremImm {
                     *imm = imm.mask_to_width(bit_width);
                 }
             }

--- a/cranelift/codegen/src/legalizer/mod.rs
+++ b/cranelift/codegen/src/legalizer/mod.rs
@@ -204,7 +204,7 @@ fn expand_binary_imm64(
     pos.goto_inst(inst);
 
     let is_signed = match opcode {
-        ir::Opcode::IrsubImm | ir::Opcode::SdivImm | ir::Opcode::SremImm => true,
+        ir::Opcode::IrsubImm | ir::Opcode::SremImm => true,
         _ => false,
     };
 
@@ -242,9 +242,6 @@ fn expand_binary_imm64(
         ir::Opcode::IrsubImm => {
             // note: arg order reversed
             replace.isub(imm, arg);
-        }
-        ir::Opcode::SdivImm => {
-            replace.sdiv(arg, imm);
         }
         ir::Opcode::SremImm => {
             replace.srem(arg, imm);

--- a/cranelift/codegen/src/souper_harvest.rs
+++ b/cranelift/codegen/src/souper_harvest.rs
@@ -99,7 +99,6 @@ fn harvest_candidate_lhs(
                 | ir::Opcode::Imul
                 | ir::Opcode::Udiv
                 | ir::Opcode::Sdiv
-                | ir::Opcode::SdivImm
                 | ir::Opcode::Urem
                 | ir::Opcode::UremImm
                 | ir::Opcode::Srem
@@ -206,17 +205,6 @@ fn harvest_candidate_lhs(
                     (ir::Opcode::Sdiv, _) => {
                         let a = arg(allocs, 0);
                         let b = arg(allocs, 1);
-                        ast::Instruction::Sdiv { a, b }.into()
-                    }
-                    (ir::Opcode::SdivImm, ir::InstructionData::BinaryImm64 { imm, .. }) => {
-                        let a = arg(allocs, 0);
-                        let value: i64 = (*imm).into();
-                        let value: i128 = value.into();
-                        let b = ast::Constant {
-                            value,
-                            r#type: souper_type_of(&func.dfg, val),
-                        }
-                        .into();
                         ast::Instruction::Sdiv { a, b }.into()
                     }
                     (ir::Opcode::Urem, _) => {

--- a/cranelift/fuzzgen/src/function_generator.rs
+++ b/cranelift/fuzzgen/src/function_generator.rs
@@ -925,7 +925,6 @@ static OPCODE_SIGNATURES: LazyLock<Vec<OpcodeSignature>> = LazyLock::new(|| {
                 (Opcode::GetReturnAddress),
                 (Opcode::Blendv),
                 (Opcode::X86Pmulhrsw),
-                (Opcode::SdivImm),
                 (Opcode::UremImm),
                 (Opcode::SremImm),
                 (Opcode::IrsubImm),

--- a/cranelift/interpreter/src/interpreter.rs
+++ b/cranelift/interpreter/src/interpreter.rs
@@ -620,7 +620,8 @@ mod tests {
         let code = "function %test() -> i8 {
         block0:
             v0 = iconst.i32 -2147483648
-            v1 = sdiv_imm.i32 v0, -1
+            v2 = iconst.i32 -1
+            v1 = sdiv v0, v2
             return v1
         }";
 

--- a/cranelift/interpreter/src/step.rs
+++ b/cranelift/interpreter/src/step.rs
@@ -718,7 +718,6 @@ where
         Opcode::Sdiv => binary_can_trap(DataValueExt::sdiv, arg(0), arg(1))?,
         Opcode::Urem => binary_can_trap(DataValueExt::urem, arg(0), arg(1))?,
         Opcode::Srem => binary_can_trap(DataValueExt::srem, arg(0), arg(1))?,
-        Opcode::SdivImm => binary_can_trap(DataValueExt::sdiv, arg(0), imm_as_ctrl_ty()?)?,
         Opcode::UremImm => binary_can_trap(DataValueExt::urem, arg(0), imm_as_ctrl_ty()?)?,
         Opcode::SremImm => binary_can_trap(DataValueExt::srem, arg(0), imm_as_ctrl_ty()?)?,
         Opcode::IrsubImm => binary(DataValueExt::sub, imm_as_ctrl_ty()?, arg(0))?,


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
