### PR TITLE
Move the type parameters on `*WithStore` traits

### DIFF
--- a/crates/component-macro/tests/expanded/char.rs
+++ b/crates/component-macro/tests/expanded/char.rs
@@ -171,7 +171,7 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: foo::foo::chars::HostWithStore,
+            D: foo::foo::chars::HostWithStore<T>,
             for<'a> D::Data<'a>: foo::foo::chars::Host,
             T: 'static,
         {
@@ -189,10 +189,10 @@ pub mod foo {
         pub mod chars {
             #[allow(unused_imports)]
             use wasmtime::component::__internal::Box;
-            pub trait HostWithStore: wasmtime::component::HasData {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<T>: wasmtime::component::HasData {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData,
+                H: wasmtime::component::HasData,
             {}
             pub trait Host {
                 /// A function that accepts a character
@@ -215,7 +215,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {
@@ -245,7 +245,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {

--- a/crates/component-macro/tests/expanded/char_async.rs
+++ b/crates/component-macro/tests/expanded/char_async.rs
@@ -171,7 +171,7 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: foo::foo::chars::HostWithStore + Send,
+            D: foo::foo::chars::HostWithStore<T> + Send,
             for<'a> D::Data<'a>: foo::foo::chars::Host + Send,
             T: 'static + Send,
         {
@@ -189,10 +189,10 @@ pub mod foo {
         pub mod chars {
             #[allow(unused_imports)]
             use wasmtime::component::__internal::Box;
-            pub trait HostWithStore: wasmtime::component::HasData + Send {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<T>: wasmtime::component::HasData + Send {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData + Send,
+                H: wasmtime::component::HasData + Send,
             {}
             pub trait Host: Send {
                 /// A function that accepts a character
@@ -225,7 +225,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
@@ -259,7 +259,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {

--- a/crates/component-macro/tests/expanded/char_concurrent.rs
+++ b/crates/component-macro/tests/expanded/char_concurrent.rs
@@ -171,7 +171,7 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: foo::foo::chars::HostWithStore + Send,
+            D: foo::foo::chars::HostWithStore<T> + Send,
             for<'a> D::Data<'a>: foo::foo::chars::Host + Send,
             T: 'static + Send,
         {
@@ -189,14 +189,14 @@ pub mod foo {
         pub mod chars {
             #[allow(unused_imports)]
             use wasmtime::component::__internal::Box;
-            pub trait HostWithStore: wasmtime::component::HasData + Send {
+            pub trait HostWithStore<T>: wasmtime::component::HasData + Send {
                 /// A function that accepts a character
-                fn take_char<T: Send>(
+                fn take_char(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     x: char,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
                 /// A function that returns a character
-                fn return_char<T: Send>(
+                fn return_char(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = char> + Send;
             }
@@ -207,7 +207,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
@@ -216,7 +216,7 @@ pub mod foo {
                     move |caller: &wasmtime::component::Accessor<T>, (arg0,): (char,)| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::take_char(host, arg0).await;
+                            let r = <D as HostWithStore<T>>::take_char(host, arg0).await;
                             Ok(r)
                         })
                     },
@@ -226,7 +226,7 @@ pub mod foo {
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::return_char(host).await;
+                            let r = <D as HostWithStore<T>>::return_char(host).await;
                             Ok((r,))
                         })
                     },
@@ -238,7 +238,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {

--- a/crates/component-macro/tests/expanded/char_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/char_tracing_async.rs
@@ -171,7 +171,7 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: foo::foo::chars::HostWithStore + Send,
+            D: foo::foo::chars::HostWithStore<T> + Send,
             for<'a> D::Data<'a>: foo::foo::chars::Host + Send,
             T: 'static + Send,
         {
@@ -189,10 +189,10 @@ pub mod foo {
         pub mod chars {
             #[allow(unused_imports)]
             use wasmtime::component::__internal::Box;
-            pub trait HostWithStore: wasmtime::component::HasData + Send {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<T>: wasmtime::component::HasData + Send {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData + Send,
+                H: wasmtime::component::HasData + Send,
             {}
             pub trait Host: Send {
                 /// A function that accepts a character
@@ -225,7 +225,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
@@ -288,7 +288,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {

--- a/crates/component-macro/tests/expanded/conventions.rs
+++ b/crates/component-macro/tests/expanded/conventions.rs
@@ -173,7 +173,7 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: foo::foo::conventions::HostWithStore,
+            D: foo::foo::conventions::HostWithStore<T>,
             for<'a> D::Data<'a>: foo::foo::conventions::Host,
             T: 'static,
         {
@@ -223,10 +223,10 @@ pub mod foo {
                     >::ALIGN32
                 );
             };
-            pub trait HostWithStore: wasmtime::component::HasData {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<T>: wasmtime::component::HasData {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData,
+                H: wasmtime::component::HasData,
             {}
             pub trait Host {
                 fn kebab_case(&mut self) -> ();
@@ -297,7 +297,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {
@@ -407,7 +407,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {

--- a/crates/component-macro/tests/expanded/conventions_async.rs
+++ b/crates/component-macro/tests/expanded/conventions_async.rs
@@ -173,7 +173,7 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: foo::foo::conventions::HostWithStore + Send,
+            D: foo::foo::conventions::HostWithStore<T> + Send,
             for<'a> D::Data<'a>: foo::foo::conventions::Host + Send,
             T: 'static + Send,
         {
@@ -223,10 +223,10 @@ pub mod foo {
                     >::ALIGN32
                 );
             };
-            pub trait HostWithStore: wasmtime::component::HasData + Send {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<T>: wasmtime::component::HasData + Send {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData + Send,
+                H: wasmtime::component::HasData + Send,
             {}
             pub trait Host: Send {
                 fn kebab_case(
@@ -331,7 +331,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
@@ -465,7 +465,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {

--- a/crates/component-macro/tests/expanded/conventions_concurrent.rs
+++ b/crates/component-macro/tests/expanded/conventions_concurrent.rs
@@ -173,7 +173,7 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: foo::foo::conventions::HostWithStore + Send,
+            D: foo::foo::conventions::HostWithStore<T> + Send,
             for<'a> D::Data<'a>: foo::foo::conventions::Host + Send,
             T: 'static + Send,
         {
@@ -223,30 +223,30 @@ pub mod foo {
                     >::ALIGN32
                 );
             };
-            pub trait HostWithStore: wasmtime::component::HasData + Send {
-                fn kebab_case<T: Send>(
+            pub trait HostWithStore<T>: wasmtime::component::HasData + Send {
+                fn kebab_case(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
-                fn foo<T: Send>(
+                fn foo(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     x: LudicrousSpeed,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
-                fn function_with_dashes<T: Send>(
+                fn function_with_dashes(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
-                fn function_with_no_weird_characters<T: Send>(
+                fn function_with_no_weird_characters(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
-                fn apple<T: Send>(
+                fn apple(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
-                fn apple_pear<T: Send>(
+                fn apple_pear(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
-                fn apple_pear_grape<T: Send>(
+                fn apple_pear_grape(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
-                fn a0<T: Send>(
+                fn a0(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
                 /// Comment out identifiers that collide when mapped to snake_case, for now; see
@@ -254,17 +254,17 @@ pub mod foo {
                 /// APPLE: func()
                 /// APPLE-pear-GRAPE: func()
                 /// apple-PEAR-grape: func()
-                fn is_xml<T: Send>(
+                fn is_xml(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
-                fn explicit<T: Send>(
+                fn explicit(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
-                fn explicit_kebab<T: Send>(
+                fn explicit_kebab(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
                 /// Identifiers with the same name as keywords are quoted.
-                fn bool<T: Send>(
+                fn bool(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
             }
@@ -275,7 +275,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
@@ -284,7 +284,7 @@ pub mod foo {
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::kebab_case(host).await;
+                            let r = <D as HostWithStore<T>>::kebab_case(host).await;
                             Ok(r)
                         })
                     },
@@ -297,7 +297,7 @@ pub mod foo {
                     {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::foo(host, arg0).await;
+                            let r = <D as HostWithStore<T>>::foo(host, arg0).await;
                             Ok(r)
                         })
                     },
@@ -307,7 +307,7 @@ pub mod foo {
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::function_with_dashes(host)
+                            let r = <D as HostWithStore<T>>::function_with_dashes(host)
                                 .await;
                             Ok(r)
                         })
@@ -318,9 +318,9 @@ pub mod foo {
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::function_with_no_weird_characters(
-                                    host,
-                                )
+                            let r = <D as HostWithStore<
+                                T,
+                            >>::function_with_no_weird_characters(host)
                                 .await;
                             Ok(r)
                         })
@@ -331,7 +331,7 @@ pub mod foo {
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::apple(host).await;
+                            let r = <D as HostWithStore<T>>::apple(host).await;
                             Ok(r)
                         })
                     },
@@ -341,7 +341,7 @@ pub mod foo {
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::apple_pear(host).await;
+                            let r = <D as HostWithStore<T>>::apple_pear(host).await;
                             Ok(r)
                         })
                     },
@@ -351,7 +351,8 @@ pub mod foo {
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::apple_pear_grape(host).await;
+                            let r = <D as HostWithStore<T>>::apple_pear_grape(host)
+                                .await;
                             Ok(r)
                         })
                     },
@@ -361,7 +362,7 @@ pub mod foo {
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::a0(host).await;
+                            let r = <D as HostWithStore<T>>::a0(host).await;
                             Ok(r)
                         })
                     },
@@ -371,7 +372,7 @@ pub mod foo {
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::is_xml(host).await;
+                            let r = <D as HostWithStore<T>>::is_xml(host).await;
                             Ok(r)
                         })
                     },
@@ -381,7 +382,7 @@ pub mod foo {
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::explicit(host).await;
+                            let r = <D as HostWithStore<T>>::explicit(host).await;
                             Ok(r)
                         })
                     },
@@ -391,7 +392,7 @@ pub mod foo {
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::explicit_kebab(host).await;
+                            let r = <D as HostWithStore<T>>::explicit_kebab(host).await;
                             Ok(r)
                         })
                     },
@@ -401,7 +402,7 @@ pub mod foo {
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::bool(host).await;
+                            let r = <D as HostWithStore<T>>::bool(host).await;
                             Ok(r)
                         })
                     },
@@ -413,7 +414,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {

--- a/crates/component-macro/tests/expanded/conventions_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/conventions_tracing_async.rs
@@ -173,7 +173,7 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: foo::foo::conventions::HostWithStore + Send,
+            D: foo::foo::conventions::HostWithStore<T> + Send,
             for<'a> D::Data<'a>: foo::foo::conventions::Host + Send,
             T: 'static + Send,
         {
@@ -223,10 +223,10 @@ pub mod foo {
                     >::ALIGN32
                 );
             };
-            pub trait HostWithStore: wasmtime::component::HasData + Send {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<T>: wasmtime::component::HasData + Send {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData + Send,
+                H: wasmtime::component::HasData + Send,
             {}
             pub trait Host: Send {
                 fn kebab_case(
@@ -331,7 +331,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
@@ -625,7 +625,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {

--- a/crates/component-macro/tests/expanded/dead-code.rs
+++ b/crates/component-macro/tests/expanded/dead-code.rs
@@ -165,8 +165,8 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: a::b::interface_with_live_type::HostWithStore
-                + a::b::interface_with_dead_type::HostWithStore,
+            D: a::b::interface_with_live_type::HostWithStore<T>
+                + a::b::interface_with_dead_type::HostWithStore<T>,
             for<'a> D::Data<
                 'a,
             >: a::b::interface_with_live_type::Host
@@ -205,10 +205,10 @@ pub mod a {
                     4 == < LiveType as wasmtime::component::ComponentType >::ALIGN32
                 );
             };
-            pub trait HostWithStore: wasmtime::component::HasData {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<T>: wasmtime::component::HasData {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData,
+                H: wasmtime::component::HasData,
             {}
             pub trait Host {
                 fn f(&mut self) -> LiveType;
@@ -223,7 +223,7 @@ pub mod a {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {
@@ -242,7 +242,7 @@ pub mod a {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {
@@ -304,10 +304,10 @@ pub mod a {
                 assert!(8 == < V as wasmtime::component::ComponentType >::SIZE32);
                 assert!(4 == < V as wasmtime::component::ComponentType >::ALIGN32);
             };
-            pub trait HostWithStore: wasmtime::component::HasData {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<T>: wasmtime::component::HasData {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData,
+                H: wasmtime::component::HasData,
             {}
             pub trait Host {}
             impl<_T: Host + ?Sized> Host for &mut _T {}
@@ -316,7 +316,7 @@ pub mod a {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {
@@ -327,7 +327,7 @@ pub mod a {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {

--- a/crates/component-macro/tests/expanded/dead-code_async.rs
+++ b/crates/component-macro/tests/expanded/dead-code_async.rs
@@ -165,8 +165,8 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: a::b::interface_with_live_type::HostWithStore
-                + a::b::interface_with_dead_type::HostWithStore + Send,
+            D: a::b::interface_with_live_type::HostWithStore<T>
+                + a::b::interface_with_dead_type::HostWithStore<T> + Send,
             for<'a> D::Data<
                 'a,
             >: a::b::interface_with_live_type::Host
@@ -205,10 +205,10 @@ pub mod a {
                     4 == < LiveType as wasmtime::component::ComponentType >::ALIGN32
                 );
             };
-            pub trait HostWithStore: wasmtime::component::HasData + Send {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<T>: wasmtime::component::HasData + Send {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData + Send,
+                H: wasmtime::component::HasData + Send,
             {}
             pub trait Host: Send {
                 fn f(&mut self) -> impl ::core::future::Future<Output = LiveType> + Send;
@@ -225,7 +225,7 @@ pub mod a {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
@@ -246,7 +246,7 @@ pub mod a {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
@@ -308,10 +308,10 @@ pub mod a {
                 assert!(8 == < V as wasmtime::component::ComponentType >::SIZE32);
                 assert!(4 == < V as wasmtime::component::ComponentType >::ALIGN32);
             };
-            pub trait HostWithStore: wasmtime::component::HasData {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<T>: wasmtime::component::HasData {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData,
+                H: wasmtime::component::HasData,
             {}
             pub trait Host {}
             impl<_T: Host + ?Sized> Host for &mut _T {}
@@ -320,7 +320,7 @@ pub mod a {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {
@@ -331,7 +331,7 @@ pub mod a {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {

--- a/crates/component-macro/tests/expanded/dead-code_concurrent.rs
+++ b/crates/component-macro/tests/expanded/dead-code_concurrent.rs
@@ -165,8 +165,8 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: a::b::interface_with_live_type::HostWithStore
-                + a::b::interface_with_dead_type::HostWithStore + Send,
+            D: a::b::interface_with_live_type::HostWithStore<T>
+                + a::b::interface_with_dead_type::HostWithStore<T> + Send,
             for<'a> D::Data<
                 'a,
             >: a::b::interface_with_live_type::Host
@@ -205,8 +205,8 @@ pub mod a {
                     4 == < LiveType as wasmtime::component::ComponentType >::ALIGN32
                 );
             };
-            pub trait HostWithStore: wasmtime::component::HasData + Send {
-                fn f<T: Send>(
+            pub trait HostWithStore<T>: wasmtime::component::HasData + Send {
+                fn f(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = LiveType> + Send;
             }
@@ -217,7 +217,7 @@ pub mod a {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
@@ -226,7 +226,7 @@ pub mod a {
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::f(host).await;
+                            let r = <D as HostWithStore<T>>::f(host).await;
                             Ok((r,))
                         })
                     },
@@ -238,7 +238,7 @@ pub mod a {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
@@ -300,10 +300,10 @@ pub mod a {
                 assert!(8 == < V as wasmtime::component::ComponentType >::SIZE32);
                 assert!(4 == < V as wasmtime::component::ComponentType >::ALIGN32);
             };
-            pub trait HostWithStore: wasmtime::component::HasData {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<T>: wasmtime::component::HasData {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData,
+                H: wasmtime::component::HasData,
             {}
             pub trait Host {}
             impl<_T: Host + ?Sized> Host for &mut _T {}
@@ -312,7 +312,7 @@ pub mod a {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {
@@ -323,7 +323,7 @@ pub mod a {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {

--- a/crates/component-macro/tests/expanded/dead-code_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/dead-code_tracing_async.rs
@@ -165,8 +165,8 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: a::b::interface_with_live_type::HostWithStore
-                + a::b::interface_with_dead_type::HostWithStore + Send,
+            D: a::b::interface_with_live_type::HostWithStore<T>
+                + a::b::interface_with_dead_type::HostWithStore<T> + Send,
             for<'a> D::Data<
                 'a,
             >: a::b::interface_with_live_type::Host
@@ -205,10 +205,10 @@ pub mod a {
                     4 == < LiveType as wasmtime::component::ComponentType >::ALIGN32
                 );
             };
-            pub trait HostWithStore: wasmtime::component::HasData + Send {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<T>: wasmtime::component::HasData + Send {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData + Send,
+                H: wasmtime::component::HasData + Send,
             {}
             pub trait Host: Send {
                 fn f(&mut self) -> impl ::core::future::Future<Output = LiveType> + Send;
@@ -225,7 +225,7 @@ pub mod a {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
@@ -259,7 +259,7 @@ pub mod a {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
@@ -321,10 +321,10 @@ pub mod a {
                 assert!(8 == < V as wasmtime::component::ComponentType >::SIZE32);
                 assert!(4 == < V as wasmtime::component::ComponentType >::ALIGN32);
             };
-            pub trait HostWithStore: wasmtime::component::HasData {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<T>: wasmtime::component::HasData {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData,
+                H: wasmtime::component::HasData,
             {}
             pub trait Host {}
             impl<_T: Host + ?Sized> Host for &mut _T {}
@@ -333,7 +333,7 @@ pub mod a {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {
@@ -344,7 +344,7 @@ pub mod a {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {

--- a/crates/component-macro/tests/expanded/direct-import.rs
+++ b/crates/component-macro/tests/expanded/direct-import.rs
@@ -98,10 +98,10 @@ pub struct FooIndices {}
 /// [`Component`]: wasmtime::component::Component
 /// [`Linker`]: wasmtime::component::Linker
 pub struct Foo {}
-pub trait FooImportsWithStore: wasmtime::component::HasData {}
-impl<_T: ?Sized> FooImportsWithStore for _T
+pub trait FooImportsWithStore<T>: wasmtime::component::HasData {}
+impl<H: ?Sized, T> FooImportsWithStore<T> for H
 where
-    _T: wasmtime::component::HasData,
+    H: wasmtime::component::HasData,
 {}
 pub trait FooImports {
     fn foo(&mut self) -> ();
@@ -178,7 +178,7 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: FooImportsWithStore,
+            D: FooImportsWithStore<T>,
             for<'a> D::Data<'a>: FooImports,
             T: 'static,
         {
@@ -199,7 +199,7 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: FooImportsWithStore,
+            D: FooImportsWithStore<T>,
             for<'a> D::Data<'a>: FooImports,
             T: 'static,
         {

--- a/crates/component-macro/tests/expanded/direct-import_async.rs
+++ b/crates/component-macro/tests/expanded/direct-import_async.rs
@@ -98,10 +98,10 @@ pub struct FooIndices {}
 /// [`Component`]: wasmtime::component::Component
 /// [`Linker`]: wasmtime::component::Linker
 pub struct Foo {}
-pub trait FooImportsWithStore: wasmtime::component::HasData + Send {}
-impl<_T: ?Sized> FooImportsWithStore for _T
+pub trait FooImportsWithStore<T>: wasmtime::component::HasData + Send {}
+impl<H: ?Sized, T> FooImportsWithStore<T> for H
 where
-    _T: wasmtime::component::HasData + Send,
+    H: wasmtime::component::HasData + Send,
 {}
 pub trait FooImports: Send {
     fn foo(&mut self) -> impl ::core::future::Future<Output = ()> + Send;
@@ -178,7 +178,7 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: FooImportsWithStore,
+            D: FooImportsWithStore<T>,
             for<'a> D::Data<'a>: FooImports,
             T: 'static + Send,
         {
@@ -201,7 +201,7 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: FooImportsWithStore + Send,
+            D: FooImportsWithStore<T> + Send,
             for<'a> D::Data<'a>: FooImports + Send,
             T: 'static + Send,
         {

--- a/crates/component-macro/tests/expanded/direct-import_concurrent.rs
+++ b/crates/component-macro/tests/expanded/direct-import_concurrent.rs
@@ -98,8 +98,8 @@ pub struct FooIndices {}
 /// [`Component`]: wasmtime::component::Component
 /// [`Linker`]: wasmtime::component::Linker
 pub struct Foo {}
-pub trait FooImportsWithStore: wasmtime::component::HasData + Send {
-    fn foo<T: Send>(
+pub trait FooImportsWithStore<T>: wasmtime::component::HasData + Send {
+    fn foo(
         accessor: &wasmtime::component::Accessor<T, Self>,
     ) -> impl ::core::future::Future<Output = ()> + Send;
 }
@@ -172,7 +172,7 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: FooImportsWithStore,
+            D: FooImportsWithStore<T>,
             for<'a> D::Data<'a>: FooImports,
             T: 'static + Send,
         {
@@ -183,7 +183,7 @@ const _: () = {
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as FooImportsWithStore>::foo(host).await;
+                            let r = <D as FooImportsWithStore<T>>::foo(host).await;
                             Ok(r)
                         })
                     },
@@ -195,7 +195,7 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: FooImportsWithStore + Send,
+            D: FooImportsWithStore<T> + Send,
             for<'a> D::Data<'a>: FooImports + Send,
             T: 'static + Send,
         {

--- a/crates/component-macro/tests/expanded/direct-import_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/direct-import_tracing_async.rs
@@ -98,10 +98,10 @@ pub struct FooIndices {}
 /// [`Component`]: wasmtime::component::Component
 /// [`Linker`]: wasmtime::component::Linker
 pub struct Foo {}
-pub trait FooImportsWithStore: wasmtime::component::HasData + Send {}
-impl<_T: ?Sized> FooImportsWithStore for _T
+pub trait FooImportsWithStore<T>: wasmtime::component::HasData + Send {}
+impl<H: ?Sized, T> FooImportsWithStore<T> for H
 where
-    _T: wasmtime::component::HasData + Send,
+    H: wasmtime::component::HasData + Send,
 {}
 pub trait FooImports: Send {
     fn foo(&mut self) -> impl ::core::future::Future<Output = ()> + Send;
@@ -178,7 +178,7 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: FooImportsWithStore,
+            D: FooImportsWithStore<T>,
             for<'a> D::Data<'a>: FooImports,
             T: 'static + Send,
         {
@@ -214,7 +214,7 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: FooImportsWithStore + Send,
+            D: FooImportsWithStore<T> + Send,
             for<'a> D::Data<'a>: FooImports + Send,
             T: 'static + Send,
         {

--- a/crates/component-macro/tests/expanded/flags.rs
+++ b/crates/component-macro/tests/expanded/flags.rs
@@ -171,7 +171,7 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: foo::foo::flegs::HostWithStore,
+            D: foo::foo::flegs::HostWithStore<T>,
             for<'a> D::Data<'a>: foo::foo::flegs::Host,
             T: 'static,
         {
@@ -303,10 +303,10 @@ pub mod foo {
                 assert!(8 == < Flag64 as wasmtime::component::ComponentType >::SIZE32);
                 assert!(4 == < Flag64 as wasmtime::component::ComponentType >::ALIGN32);
             };
-            pub trait HostWithStore: wasmtime::component::HasData {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<T>: wasmtime::component::HasData {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData,
+                H: wasmtime::component::HasData,
             {}
             pub trait Host {
                 fn roundtrip_flag1(&mut self, x: Flag1) -> Flag1;
@@ -345,7 +345,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {
@@ -433,7 +433,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {

--- a/crates/component-macro/tests/expanded/flags_async.rs
+++ b/crates/component-macro/tests/expanded/flags_async.rs
@@ -171,7 +171,7 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: foo::foo::flegs::HostWithStore + Send,
+            D: foo::foo::flegs::HostWithStore<T> + Send,
             for<'a> D::Data<'a>: foo::foo::flegs::Host + Send,
             T: 'static + Send,
         {
@@ -303,10 +303,10 @@ pub mod foo {
                 assert!(8 == < Flag64 as wasmtime::component::ComponentType >::SIZE32);
                 assert!(4 == < Flag64 as wasmtime::component::ComponentType >::ALIGN32);
             };
-            pub trait HostWithStore: wasmtime::component::HasData + Send {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<T>: wasmtime::component::HasData + Send {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData + Send,
+                H: wasmtime::component::HasData + Send,
             {}
             pub trait Host: Send {
                 fn roundtrip_flag1(
@@ -387,7 +387,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
@@ -489,7 +489,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {

--- a/crates/component-macro/tests/expanded/flags_concurrent.rs
+++ b/crates/component-macro/tests/expanded/flags_concurrent.rs
@@ -171,7 +171,7 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: foo::foo::flegs::HostWithStore + Send,
+            D: foo::foo::flegs::HostWithStore<T> + Send,
             for<'a> D::Data<'a>: foo::foo::flegs::Host + Send,
             T: 'static + Send,
         {
@@ -303,32 +303,32 @@ pub mod foo {
                 assert!(8 == < Flag64 as wasmtime::component::ComponentType >::SIZE32);
                 assert!(4 == < Flag64 as wasmtime::component::ComponentType >::ALIGN32);
             };
-            pub trait HostWithStore: wasmtime::component::HasData + Send {
-                fn roundtrip_flag1<T: Send>(
+            pub trait HostWithStore<T>: wasmtime::component::HasData + Send {
+                fn roundtrip_flag1(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     x: Flag1,
                 ) -> impl ::core::future::Future<Output = Flag1> + Send;
-                fn roundtrip_flag2<T: Send>(
+                fn roundtrip_flag2(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     x: Flag2,
                 ) -> impl ::core::future::Future<Output = Flag2> + Send;
-                fn roundtrip_flag4<T: Send>(
+                fn roundtrip_flag4(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     x: Flag4,
                 ) -> impl ::core::future::Future<Output = Flag4> + Send;
-                fn roundtrip_flag8<T: Send>(
+                fn roundtrip_flag8(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     x: Flag8,
                 ) -> impl ::core::future::Future<Output = Flag8> + Send;
-                fn roundtrip_flag16<T: Send>(
+                fn roundtrip_flag16(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     x: Flag16,
                 ) -> impl ::core::future::Future<Output = Flag16> + Send;
-                fn roundtrip_flag32<T: Send>(
+                fn roundtrip_flag32(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     x: Flag32,
                 ) -> impl ::core::future::Future<Output = Flag32> + Send;
-                fn roundtrip_flag64<T: Send>(
+                fn roundtrip_flag64(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     x: Flag64,
                 ) -> impl ::core::future::Future<Output = Flag64> + Send;
@@ -340,7 +340,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
@@ -349,7 +349,7 @@ pub mod foo {
                     move |caller: &wasmtime::component::Accessor<T>, (arg0,): (Flag1,)| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::roundtrip_flag1(host, arg0)
+                            let r = <D as HostWithStore<T>>::roundtrip_flag1(host, arg0)
                                 .await;
                             Ok((r,))
                         })
@@ -360,7 +360,7 @@ pub mod foo {
                     move |caller: &wasmtime::component::Accessor<T>, (arg0,): (Flag2,)| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::roundtrip_flag2(host, arg0)
+                            let r = <D as HostWithStore<T>>::roundtrip_flag2(host, arg0)
                                 .await;
                             Ok((r,))
                         })
@@ -371,7 +371,7 @@ pub mod foo {
                     move |caller: &wasmtime::component::Accessor<T>, (arg0,): (Flag4,)| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::roundtrip_flag4(host, arg0)
+                            let r = <D as HostWithStore<T>>::roundtrip_flag4(host, arg0)
                                 .await;
                             Ok((r,))
                         })
@@ -382,7 +382,7 @@ pub mod foo {
                     move |caller: &wasmtime::component::Accessor<T>, (arg0,): (Flag8,)| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::roundtrip_flag8(host, arg0)
+                            let r = <D as HostWithStore<T>>::roundtrip_flag8(host, arg0)
                                 .await;
                             Ok((r,))
                         })
@@ -393,7 +393,7 @@ pub mod foo {
                     move |caller: &wasmtime::component::Accessor<T>, (arg0,): (Flag16,)| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::roundtrip_flag16(host, arg0)
+                            let r = <D as HostWithStore<T>>::roundtrip_flag16(host, arg0)
                                 .await;
                             Ok((r,))
                         })
@@ -404,7 +404,7 @@ pub mod foo {
                     move |caller: &wasmtime::component::Accessor<T>, (arg0,): (Flag32,)| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::roundtrip_flag32(host, arg0)
+                            let r = <D as HostWithStore<T>>::roundtrip_flag32(host, arg0)
                                 .await;
                             Ok((r,))
                         })
@@ -415,7 +415,7 @@ pub mod foo {
                     move |caller: &wasmtime::component::Accessor<T>, (arg0,): (Flag64,)| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::roundtrip_flag64(host, arg0)
+                            let r = <D as HostWithStore<T>>::roundtrip_flag64(host, arg0)
                                 .await;
                             Ok((r,))
                         })
@@ -428,7 +428,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {

--- a/crates/component-macro/tests/expanded/flags_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/flags_tracing_async.rs
@@ -171,7 +171,7 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: foo::foo::flegs::HostWithStore + Send,
+            D: foo::foo::flegs::HostWithStore<T> + Send,
             for<'a> D::Data<'a>: foo::foo::flegs::Host + Send,
             T: 'static + Send,
         {
@@ -303,10 +303,10 @@ pub mod foo {
                 assert!(8 == < Flag64 as wasmtime::component::ComponentType >::SIZE32);
                 assert!(4 == < Flag64 as wasmtime::component::ComponentType >::ALIGN32);
             };
-            pub trait HostWithStore: wasmtime::component::HasData + Send {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<T>: wasmtime::component::HasData + Send {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData + Send,
+                H: wasmtime::component::HasData + Send,
             {}
             pub trait Host: Send {
                 fn roundtrip_flag1(
@@ -387,7 +387,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
@@ -601,7 +601,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {

--- a/crates/component-macro/tests/expanded/floats.rs
+++ b/crates/component-macro/tests/expanded/floats.rs
@@ -173,7 +173,7 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: foo::foo::floats::HostWithStore,
+            D: foo::foo::floats::HostWithStore<T>,
             for<'a> D::Data<'a>: foo::foo::floats::Host,
             T: 'static,
         {
@@ -191,10 +191,10 @@ pub mod foo {
         pub mod floats {
             #[allow(unused_imports)]
             use wasmtime::component::__internal::Box;
-            pub trait HostWithStore: wasmtime::component::HasData {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<T>: wasmtime::component::HasData {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData,
+                H: wasmtime::component::HasData,
             {}
             pub trait Host {
                 fn f32_param(&mut self, x: f32) -> ();
@@ -221,7 +221,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {
@@ -264,7 +264,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {

--- a/crates/component-macro/tests/expanded/floats_async.rs
+++ b/crates/component-macro/tests/expanded/floats_async.rs
@@ -173,7 +173,7 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: foo::foo::floats::HostWithStore + Send,
+            D: foo::foo::floats::HostWithStore<T> + Send,
             for<'a> D::Data<'a>: foo::foo::floats::Host + Send,
             T: 'static + Send,
         {
@@ -191,10 +191,10 @@ pub mod foo {
         pub mod floats {
             #[allow(unused_imports)]
             use wasmtime::component::__internal::Box;
-            pub trait HostWithStore: wasmtime::component::HasData + Send {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<T>: wasmtime::component::HasData + Send {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData + Send,
+                H: wasmtime::component::HasData + Send,
             {}
             pub trait Host: Send {
                 fn f32_param(
@@ -241,7 +241,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
@@ -292,7 +292,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {

--- a/crates/component-macro/tests/expanded/floats_concurrent.rs
+++ b/crates/component-macro/tests/expanded/floats_concurrent.rs
@@ -173,7 +173,7 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: foo::foo::floats::HostWithStore + Send,
+            D: foo::foo::floats::HostWithStore<T> + Send,
             for<'a> D::Data<'a>: foo::foo::floats::Host + Send,
             T: 'static + Send,
         {
@@ -191,19 +191,19 @@ pub mod foo {
         pub mod floats {
             #[allow(unused_imports)]
             use wasmtime::component::__internal::Box;
-            pub trait HostWithStore: wasmtime::component::HasData + Send {
-                fn f32_param<T: Send>(
+            pub trait HostWithStore<T>: wasmtime::component::HasData + Send {
+                fn f32_param(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     x: f32,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
-                fn f64_param<T: Send>(
+                fn f64_param(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     x: f64,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
-                fn f32_result<T: Send>(
+                fn f32_result(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = f32> + Send;
-                fn f64_result<T: Send>(
+                fn f64_result(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = f64> + Send;
             }
@@ -214,7 +214,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
@@ -223,7 +223,7 @@ pub mod foo {
                     move |caller: &wasmtime::component::Accessor<T>, (arg0,): (f32,)| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::f32_param(host, arg0).await;
+                            let r = <D as HostWithStore<T>>::f32_param(host, arg0).await;
                             Ok(r)
                         })
                     },
@@ -233,7 +233,7 @@ pub mod foo {
                     move |caller: &wasmtime::component::Accessor<T>, (arg0,): (f64,)| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::f64_param(host, arg0).await;
+                            let r = <D as HostWithStore<T>>::f64_param(host, arg0).await;
                             Ok(r)
                         })
                     },
@@ -243,7 +243,7 @@ pub mod foo {
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::f32_result(host).await;
+                            let r = <D as HostWithStore<T>>::f32_result(host).await;
                             Ok((r,))
                         })
                     },
@@ -253,7 +253,7 @@ pub mod foo {
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::f64_result(host).await;
+                            let r = <D as HostWithStore<T>>::f64_result(host).await;
                             Ok((r,))
                         })
                     },
@@ -265,7 +265,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {

--- a/crates/component-macro/tests/expanded/floats_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/floats_tracing_async.rs
@@ -173,7 +173,7 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: foo::foo::floats::HostWithStore + Send,
+            D: foo::foo::floats::HostWithStore<T> + Send,
             for<'a> D::Data<'a>: foo::foo::floats::Host + Send,
             T: 'static + Send,
         {
@@ -191,10 +191,10 @@ pub mod foo {
         pub mod floats {
             #[allow(unused_imports)]
             use wasmtime::component::__internal::Box;
-            pub trait HostWithStore: wasmtime::component::HasData + Send {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<T>: wasmtime::component::HasData + Send {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData + Send,
+                H: wasmtime::component::HasData + Send,
             {}
             pub trait Host: Send {
                 fn f32_param(
@@ -241,7 +241,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
@@ -350,7 +350,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {

--- a/crates/component-macro/tests/expanded/host-world.rs
+++ b/crates/component-macro/tests/expanded/host-world.rs
@@ -98,10 +98,10 @@ pub struct Host_Indices {}
 /// [`Component`]: wasmtime::component::Component
 /// [`Linker`]: wasmtime::component::Linker
 pub struct Host_ {}
-pub trait Host_ImportsWithStore: wasmtime::component::HasData {}
-impl<_T: ?Sized> Host_ImportsWithStore for _T
+pub trait Host_ImportsWithStore<T>: wasmtime::component::HasData {}
+impl<H: ?Sized, T> Host_ImportsWithStore<T> for H
 where
-    _T: wasmtime::component::HasData,
+    H: wasmtime::component::HasData,
 {}
 pub trait Host_Imports {
     fn foo(&mut self) -> ();
@@ -178,7 +178,7 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: Host_ImportsWithStore,
+            D: Host_ImportsWithStore<T>,
             for<'a> D::Data<'a>: Host_Imports,
             T: 'static,
         {
@@ -199,7 +199,7 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: Host_ImportsWithStore,
+            D: Host_ImportsWithStore<T>,
             for<'a> D::Data<'a>: Host_Imports,
             T: 'static,
         {

--- a/crates/component-macro/tests/expanded/host-world_async.rs
+++ b/crates/component-macro/tests/expanded/host-world_async.rs
@@ -98,10 +98,10 @@ pub struct Host_Indices {}
 /// [`Component`]: wasmtime::component::Component
 /// [`Linker`]: wasmtime::component::Linker
 pub struct Host_ {}
-pub trait Host_ImportsWithStore: wasmtime::component::HasData + Send {}
-impl<_T: ?Sized> Host_ImportsWithStore for _T
+pub trait Host_ImportsWithStore<T>: wasmtime::component::HasData + Send {}
+impl<H: ?Sized, T> Host_ImportsWithStore<T> for H
 where
-    _T: wasmtime::component::HasData + Send,
+    H: wasmtime::component::HasData + Send,
 {}
 pub trait Host_Imports: Send {
     fn foo(&mut self) -> impl ::core::future::Future<Output = ()> + Send;
@@ -178,7 +178,7 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: Host_ImportsWithStore,
+            D: Host_ImportsWithStore<T>,
             for<'a> D::Data<'a>: Host_Imports,
             T: 'static + Send,
         {
@@ -201,7 +201,7 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: Host_ImportsWithStore + Send,
+            D: Host_ImportsWithStore<T> + Send,
             for<'a> D::Data<'a>: Host_Imports + Send,
             T: 'static + Send,
         {

--- a/crates/component-macro/tests/expanded/host-world_concurrent.rs
+++ b/crates/component-macro/tests/expanded/host-world_concurrent.rs
@@ -98,8 +98,8 @@ pub struct Host_Indices {}
 /// [`Component`]: wasmtime::component::Component
 /// [`Linker`]: wasmtime::component::Linker
 pub struct Host_ {}
-pub trait Host_ImportsWithStore: wasmtime::component::HasData + Send {
-    fn foo<T: Send>(
+pub trait Host_ImportsWithStore<T>: wasmtime::component::HasData + Send {
+    fn foo(
         accessor: &wasmtime::component::Accessor<T, Self>,
     ) -> impl ::core::future::Future<Output = ()> + Send;
 }
@@ -172,7 +172,7 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: Host_ImportsWithStore,
+            D: Host_ImportsWithStore<T>,
             for<'a> D::Data<'a>: Host_Imports,
             T: 'static + Send,
         {
@@ -183,7 +183,7 @@ const _: () = {
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as Host_ImportsWithStore>::foo(host).await;
+                            let r = <D as Host_ImportsWithStore<T>>::foo(host).await;
                             Ok(r)
                         })
                     },
@@ -195,7 +195,7 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: Host_ImportsWithStore + Send,
+            D: Host_ImportsWithStore<T> + Send,
             for<'a> D::Data<'a>: Host_Imports + Send,
             T: 'static + Send,
         {

--- a/crates/component-macro/tests/expanded/host-world_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/host-world_tracing_async.rs
@@ -98,10 +98,10 @@ pub struct Host_Indices {}
 /// [`Component`]: wasmtime::component::Component
 /// [`Linker`]: wasmtime::component::Linker
 pub struct Host_ {}
-pub trait Host_ImportsWithStore: wasmtime::component::HasData + Send {}
-impl<_T: ?Sized> Host_ImportsWithStore for _T
+pub trait Host_ImportsWithStore<T>: wasmtime::component::HasData + Send {}
+impl<H: ?Sized, T> Host_ImportsWithStore<T> for H
 where
-    _T: wasmtime::component::HasData + Send,
+    H: wasmtime::component::HasData + Send,
 {}
 pub trait Host_Imports: Send {
     fn foo(&mut self) -> impl ::core::future::Future<Output = ()> + Send;
@@ -178,7 +178,7 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: Host_ImportsWithStore,
+            D: Host_ImportsWithStore<T>,
             for<'a> D::Data<'a>: Host_Imports,
             T: 'static + Send,
         {
@@ -214,7 +214,7 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: Host_ImportsWithStore + Send,
+            D: Host_ImportsWithStore<T> + Send,
             for<'a> D::Data<'a>: Host_Imports + Send,
             T: 'static + Send,
         {

--- a/crates/component-macro/tests/expanded/implements.rs
+++ b/crates/component-macro/tests/expanded/implements.rs
@@ -165,7 +165,7 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: foo::foo::store::HostWithStore + foo::foo::store::HostWithStore,
+            D: foo::foo::store::HostWithStore<T> + foo::foo::store::HostWithStore<T>,
             for<'a> D::Data<'a>: foo::foo::store::Host + foo::foo::store::Host,
             T: 'static,
         {
@@ -187,10 +187,10 @@ pub mod foo {
         pub mod store {
             #[allow(unused_imports)]
             use wasmtime::component::__internal::Box;
-            pub trait HostWithStore: wasmtime::component::HasData {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<T>: wasmtime::component::HasData {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData,
+                H: wasmtime::component::HasData,
             {}
             pub trait Host {
                 fn get(
@@ -223,7 +223,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {
@@ -262,7 +262,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {

--- a/crates/component-macro/tests/expanded/implements_async.rs
+++ b/crates/component-macro/tests/expanded/implements_async.rs
@@ -165,7 +165,8 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: foo::foo::store::HostWithStore + foo::foo::store::HostWithStore + Send,
+            D: foo::foo::store::HostWithStore<T> + foo::foo::store::HostWithStore<T>
+                + Send,
             for<'a> D::Data<'a>: foo::foo::store::Host + foo::foo::store::Host + Send,
             T: 'static + Send,
         {
@@ -187,10 +188,10 @@ pub mod foo {
         pub mod store {
             #[allow(unused_imports)]
             use wasmtime::component::__internal::Box;
-            pub trait HostWithStore: wasmtime::component::HasData + Send {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<T>: wasmtime::component::HasData + Send {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData + Send,
+                H: wasmtime::component::HasData + Send,
             {}
             pub trait Host: Send {
                 fn get(
@@ -227,7 +228,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
@@ -270,7 +271,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {

--- a/crates/component-macro/tests/expanded/implements_concurrent.rs
+++ b/crates/component-macro/tests/expanded/implements_concurrent.rs
@@ -165,7 +165,8 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: foo::foo::store::HostWithStore + foo::foo::store::HostWithStore + Send,
+            D: foo::foo::store::HostWithStore<T> + foo::foo::store::HostWithStore<T>
+                + Send,
             for<'a> D::Data<'a>: foo::foo::store::Host + foo::foo::store::Host + Send,
             T: 'static + Send,
         {
@@ -187,14 +188,14 @@ pub mod foo {
         pub mod store {
             #[allow(unused_imports)]
             use wasmtime::component::__internal::Box;
-            pub trait HostWithStore: wasmtime::component::HasData + Send {
-                fn get<T: Send>(
+            pub trait HostWithStore<T>: wasmtime::component::HasData + Send {
+                fn get(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     key: wasmtime::component::__internal::String,
                 ) -> impl ::core::future::Future<
                     Output = Option<wasmtime::component::__internal::String>,
                 > + Send;
-                fn set<T: Send>(
+                fn set(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     key: wasmtime::component::__internal::String,
                     value: wasmtime::component::__internal::String,
@@ -207,7 +208,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
@@ -219,7 +220,7 @@ pub mod foo {
                     {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::get(host, arg0).await;
+                            let r = <D as HostWithStore<T>>::get(host, arg0).await;
                             Ok((r,))
                         })
                     },
@@ -238,7 +239,7 @@ pub mod foo {
                     {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::set(host, arg0, arg1).await;
+                            let r = <D as HostWithStore<T>>::set(host, arg0, arg1).await;
                             Ok(r)
                         })
                     },
@@ -250,7 +251,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {

--- a/crates/component-macro/tests/expanded/implements_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/implements_tracing_async.rs
@@ -165,7 +165,8 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: foo::foo::store::HostWithStore + foo::foo::store::HostWithStore + Send,
+            D: foo::foo::store::HostWithStore<T> + foo::foo::store::HostWithStore<T>
+                + Send,
             for<'a> D::Data<'a>: foo::foo::store::Host + foo::foo::store::Host + Send,
             T: 'static + Send,
         {
@@ -187,10 +188,10 @@ pub mod foo {
         pub mod store {
             #[allow(unused_imports)]
             use wasmtime::component::__internal::Box;
-            pub trait HostWithStore: wasmtime::component::HasData + Send {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<T>: wasmtime::component::HasData + Send {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData + Send,
+                H: wasmtime::component::HasData + Send,
             {}
             pub trait Host: Send {
                 fn get(
@@ -227,7 +228,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
@@ -302,7 +303,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {

--- a/crates/component-macro/tests/expanded/integers.rs
+++ b/crates/component-macro/tests/expanded/integers.rs
@@ -173,7 +173,7 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: foo::foo::integers::HostWithStore,
+            D: foo::foo::integers::HostWithStore<T>,
             for<'a> D::Data<'a>: foo::foo::integers::Host,
             T: 'static,
         {
@@ -191,10 +191,10 @@ pub mod foo {
         pub mod integers {
             #[allow(unused_imports)]
             use wasmtime::component::__internal::Box;
-            pub trait HostWithStore: wasmtime::component::HasData {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<T>: wasmtime::component::HasData {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData,
+                H: wasmtime::component::HasData,
             {}
             pub trait Host {
                 fn a1(&mut self, x: u8) -> ();
@@ -297,7 +297,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {
@@ -474,7 +474,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {

--- a/crates/component-macro/tests/expanded/integers_async.rs
+++ b/crates/component-macro/tests/expanded/integers_async.rs
@@ -173,7 +173,7 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: foo::foo::integers::HostWithStore + Send,
+            D: foo::foo::integers::HostWithStore<T> + Send,
             for<'a> D::Data<'a>: foo::foo::integers::Host + Send,
             T: 'static + Send,
         {
@@ -191,10 +191,10 @@ pub mod foo {
         pub mod integers {
             #[allow(unused_imports)]
             use wasmtime::component::__internal::Box;
-            pub trait HostWithStore: wasmtime::component::HasData + Send {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<T>: wasmtime::component::HasData + Send {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData + Send,
+                H: wasmtime::component::HasData + Send,
             {}
             pub trait Host: Send {
                 fn a1(
@@ -349,7 +349,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
@@ -563,7 +563,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {

--- a/crates/component-macro/tests/expanded/integers_concurrent.rs
+++ b/crates/component-macro/tests/expanded/integers_concurrent.rs
@@ -173,7 +173,7 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: foo::foo::integers::HostWithStore + Send,
+            D: foo::foo::integers::HostWithStore<T> + Send,
             for<'a> D::Data<'a>: foo::foo::integers::Host + Send,
             T: 'static + Send,
         {
@@ -191,40 +191,40 @@ pub mod foo {
         pub mod integers {
             #[allow(unused_imports)]
             use wasmtime::component::__internal::Box;
-            pub trait HostWithStore: wasmtime::component::HasData + Send {
-                fn a1<T: Send>(
+            pub trait HostWithStore<T>: wasmtime::component::HasData + Send {
+                fn a1(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     x: u8,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
-                fn a2<T: Send>(
+                fn a2(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     x: i8,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
-                fn a3<T: Send>(
+                fn a3(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     x: u16,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
-                fn a4<T: Send>(
+                fn a4(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     x: i16,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
-                fn a5<T: Send>(
+                fn a5(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     x: u32,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
-                fn a6<T: Send>(
+                fn a6(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     x: i32,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
-                fn a7<T: Send>(
+                fn a7(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     x: u64,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
-                fn a8<T: Send>(
+                fn a8(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     x: i64,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
-                fn a9<T: Send>(
+                fn a9(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     p1: u8,
                     p2: i8,
@@ -235,31 +235,31 @@ pub mod foo {
                     p7: u64,
                     p8: i64,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
-                fn r1<T: Send>(
+                fn r1(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = u8> + Send;
-                fn r2<T: Send>(
+                fn r2(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = i8> + Send;
-                fn r3<T: Send>(
+                fn r3(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = u16> + Send;
-                fn r4<T: Send>(
+                fn r4(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = i16> + Send;
-                fn r5<T: Send>(
+                fn r5(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = u32> + Send;
-                fn r6<T: Send>(
+                fn r6(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = i32> + Send;
-                fn r7<T: Send>(
+                fn r7(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = u64> + Send;
-                fn r8<T: Send>(
+                fn r8(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = i64> + Send;
-                fn pair_ret<T: Send>(
+                fn pair_ret(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = (i64, u8)> + Send;
             }
@@ -270,7 +270,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
@@ -279,7 +279,7 @@ pub mod foo {
                     move |caller: &wasmtime::component::Accessor<T>, (arg0,): (u8,)| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::a1(host, arg0).await;
+                            let r = <D as HostWithStore<T>>::a1(host, arg0).await;
                             Ok(r)
                         })
                     },
@@ -289,7 +289,7 @@ pub mod foo {
                     move |caller: &wasmtime::component::Accessor<T>, (arg0,): (i8,)| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::a2(host, arg0).await;
+                            let r = <D as HostWithStore<T>>::a2(host, arg0).await;
                             Ok(r)
                         })
                     },
@@ -299,7 +299,7 @@ pub mod foo {
                     move |caller: &wasmtime::component::Accessor<T>, (arg0,): (u16,)| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::a3(host, arg0).await;
+                            let r = <D as HostWithStore<T>>::a3(host, arg0).await;
                             Ok(r)
                         })
                     },
@@ -309,7 +309,7 @@ pub mod foo {
                     move |caller: &wasmtime::component::Accessor<T>, (arg0,): (i16,)| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::a4(host, arg0).await;
+                            let r = <D as HostWithStore<T>>::a4(host, arg0).await;
                             Ok(r)
                         })
                     },
@@ -319,7 +319,7 @@ pub mod foo {
                     move |caller: &wasmtime::component::Accessor<T>, (arg0,): (u32,)| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::a5(host, arg0).await;
+                            let r = <D as HostWithStore<T>>::a5(host, arg0).await;
                             Ok(r)
                         })
                     },
@@ -329,7 +329,7 @@ pub mod foo {
                     move |caller: &wasmtime::component::Accessor<T>, (arg0,): (i32,)| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::a6(host, arg0).await;
+                            let r = <D as HostWithStore<T>>::a6(host, arg0).await;
                             Ok(r)
                         })
                     },
@@ -339,7 +339,7 @@ pub mod foo {
                     move |caller: &wasmtime::component::Accessor<T>, (arg0,): (u64,)| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::a7(host, arg0).await;
+                            let r = <D as HostWithStore<T>>::a7(host, arg0).await;
                             Ok(r)
                         })
                     },
@@ -349,7 +349,7 @@ pub mod foo {
                     move |caller: &wasmtime::component::Accessor<T>, (arg0,): (i64,)| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::a8(host, arg0).await;
+                            let r = <D as HostWithStore<T>>::a8(host, arg0).await;
                             Ok(r)
                         })
                     },
@@ -371,17 +371,9 @@ pub mod foo {
                     {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::a9(
-                                    host,
-                                    arg0,
-                                    arg1,
-                                    arg2,
-                                    arg3,
-                                    arg4,
-                                    arg5,
-                                    arg6,
-                                    arg7,
-                                )
+                            let r = <D as HostWithStore<
+                                T,
+                            >>::a9(host, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)
                                 .await;
                             Ok(r)
                         })
@@ -392,7 +384,7 @@ pub mod foo {
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::r1(host).await;
+                            let r = <D as HostWithStore<T>>::r1(host).await;
                             Ok((r,))
                         })
                     },
@@ -402,7 +394,7 @@ pub mod foo {
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::r2(host).await;
+                            let r = <D as HostWithStore<T>>::r2(host).await;
                             Ok((r,))
                         })
                     },
@@ -412,7 +404,7 @@ pub mod foo {
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::r3(host).await;
+                            let r = <D as HostWithStore<T>>::r3(host).await;
                             Ok((r,))
                         })
                     },
@@ -422,7 +414,7 @@ pub mod foo {
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::r4(host).await;
+                            let r = <D as HostWithStore<T>>::r4(host).await;
                             Ok((r,))
                         })
                     },
@@ -432,7 +424,7 @@ pub mod foo {
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::r5(host).await;
+                            let r = <D as HostWithStore<T>>::r5(host).await;
                             Ok((r,))
                         })
                     },
@@ -442,7 +434,7 @@ pub mod foo {
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::r6(host).await;
+                            let r = <D as HostWithStore<T>>::r6(host).await;
                             Ok((r,))
                         })
                     },
@@ -452,7 +444,7 @@ pub mod foo {
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::r7(host).await;
+                            let r = <D as HostWithStore<T>>::r7(host).await;
                             Ok((r,))
                         })
                     },
@@ -462,7 +454,7 @@ pub mod foo {
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::r8(host).await;
+                            let r = <D as HostWithStore<T>>::r8(host).await;
                             Ok((r,))
                         })
                     },
@@ -472,7 +464,7 @@ pub mod foo {
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::pair_ret(host).await;
+                            let r = <D as HostWithStore<T>>::pair_ret(host).await;
                             Ok((r,))
                         })
                     },
@@ -484,7 +476,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {

--- a/crates/component-macro/tests/expanded/integers_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/integers_tracing_async.rs
@@ -173,7 +173,7 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: foo::foo::integers::HostWithStore + Send,
+            D: foo::foo::integers::HostWithStore<T> + Send,
             for<'a> D::Data<'a>: foo::foo::integers::Host + Send,
             T: 'static + Send,
         {
@@ -191,10 +191,10 @@ pub mod foo {
         pub mod integers {
             #[allow(unused_imports)]
             use wasmtime::component::__internal::Box;
-            pub trait HostWithStore: wasmtime::component::HasData + Send {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<T>: wasmtime::component::HasData + Send {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData + Send,
+                H: wasmtime::component::HasData + Send,
             {}
             pub trait Host: Send {
                 fn a1(
@@ -349,7 +349,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
@@ -828,7 +828,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {

--- a/crates/component-macro/tests/expanded/lists.rs
+++ b/crates/component-macro/tests/expanded/lists.rs
@@ -171,7 +171,7 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: foo::foo::lists::HostWithStore,
+            D: foo::foo::lists::HostWithStore<T>,
             for<'a> D::Data<'a>: foo::foo::lists::Host,
             T: 'static,
         {
@@ -369,10 +369,10 @@ pub mod foo {
                     >::ALIGN32
                 );
             };
-            pub trait HostWithStore: wasmtime::component::HasData {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<T>: wasmtime::component::HasData {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData,
+                H: wasmtime::component::HasData,
             {}
             pub trait Host {
                 fn list_u8_param(
@@ -635,7 +635,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {
@@ -950,7 +950,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {

--- a/crates/component-macro/tests/expanded/lists_async.rs
+++ b/crates/component-macro/tests/expanded/lists_async.rs
@@ -171,7 +171,7 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: foo::foo::lists::HostWithStore + Send,
+            D: foo::foo::lists::HostWithStore<T> + Send,
             for<'a> D::Data<'a>: foo::foo::lists::Host + Send,
             T: 'static + Send,
         {
@@ -369,10 +369,10 @@ pub mod foo {
                     >::ALIGN32
                 );
             };
-            pub trait HostWithStore: wasmtime::component::HasData + Send {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<T>: wasmtime::component::HasData + Send {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData + Send,
+                H: wasmtime::component::HasData + Send,
             {}
             pub trait Host: Send {
                 fn list_u8_param(
@@ -743,7 +743,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
@@ -1116,7 +1116,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {

--- a/crates/component-macro/tests/expanded/lists_concurrent.rs
+++ b/crates/component-macro/tests/expanded/lists_concurrent.rs
@@ -171,7 +171,7 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: foo::foo::lists::HostWithStore + Send,
+            D: foo::foo::lists::HostWithStore<T> + Send,
             for<'a> D::Data<'a>: foo::foo::lists::Host + Send,
             T: 'static + Send,
         {
@@ -369,117 +369,117 @@ pub mod foo {
                     >::ALIGN32
                 );
             };
-            pub trait HostWithStore: wasmtime::component::HasData + Send {
-                fn list_u8_param<T: Send>(
+            pub trait HostWithStore<T>: wasmtime::component::HasData + Send {
+                fn list_u8_param(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     x: wasmtime::component::__internal::Vec<u8>,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
-                fn list_u16_param<T: Send>(
+                fn list_u16_param(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     x: wasmtime::component::__internal::Vec<u16>,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
-                fn list_u32_param<T: Send>(
+                fn list_u32_param(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     x: wasmtime::component::__internal::Vec<u32>,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
-                fn list_u64_param<T: Send>(
+                fn list_u64_param(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     x: wasmtime::component::__internal::Vec<u64>,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
-                fn list_s8_param<T: Send>(
+                fn list_s8_param(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     x: wasmtime::component::__internal::Vec<i8>,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
-                fn list_s16_param<T: Send>(
+                fn list_s16_param(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     x: wasmtime::component::__internal::Vec<i16>,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
-                fn list_s32_param<T: Send>(
+                fn list_s32_param(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     x: wasmtime::component::__internal::Vec<i32>,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
-                fn list_s64_param<T: Send>(
+                fn list_s64_param(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     x: wasmtime::component::__internal::Vec<i64>,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
-                fn list_f32_param<T: Send>(
+                fn list_f32_param(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     x: wasmtime::component::__internal::Vec<f32>,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
-                fn list_f64_param<T: Send>(
+                fn list_f64_param(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     x: wasmtime::component::__internal::Vec<f64>,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
-                fn list_u8_ret<T: Send>(
+                fn list_u8_ret(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<
                     Output = wasmtime::component::__internal::Vec<u8>,
                 > + Send;
-                fn list_u16_ret<T: Send>(
+                fn list_u16_ret(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<
                     Output = wasmtime::component::__internal::Vec<u16>,
                 > + Send;
-                fn list_u32_ret<T: Send>(
+                fn list_u32_ret(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<
                     Output = wasmtime::component::__internal::Vec<u32>,
                 > + Send;
-                fn list_u64_ret<T: Send>(
+                fn list_u64_ret(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<
                     Output = wasmtime::component::__internal::Vec<u64>,
                 > + Send;
-                fn list_s8_ret<T: Send>(
+                fn list_s8_ret(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<
                     Output = wasmtime::component::__internal::Vec<i8>,
                 > + Send;
-                fn list_s16_ret<T: Send>(
+                fn list_s16_ret(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<
                     Output = wasmtime::component::__internal::Vec<i16>,
                 > + Send;
-                fn list_s32_ret<T: Send>(
+                fn list_s32_ret(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<
                     Output = wasmtime::component::__internal::Vec<i32>,
                 > + Send;
-                fn list_s64_ret<T: Send>(
+                fn list_s64_ret(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<
                     Output = wasmtime::component::__internal::Vec<i64>,
                 > + Send;
-                fn list_f32_ret<T: Send>(
+                fn list_f32_ret(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<
                     Output = wasmtime::component::__internal::Vec<f32>,
                 > + Send;
-                fn list_f64_ret<T: Send>(
+                fn list_f64_ret(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<
                     Output = wasmtime::component::__internal::Vec<f64>,
                 > + Send;
-                fn tuple_list<T: Send>(
+                fn tuple_list(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     x: wasmtime::component::__internal::Vec<(u8, i8)>,
                 ) -> impl ::core::future::Future<
                     Output = wasmtime::component::__internal::Vec<(i64, u32)>,
                 > + Send;
-                fn string_list_arg<T: Send>(
+                fn string_list_arg(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     a: wasmtime::component::__internal::Vec<
                         wasmtime::component::__internal::String,
                     >,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
-                fn string_list_ret<T: Send>(
+                fn string_list_ret(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<
                     Output = wasmtime::component::__internal::Vec<
                         wasmtime::component::__internal::String,
                     >,
                 > + Send;
-                fn tuple_string_list<T: Send>(
+                fn tuple_string_list(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     x: wasmtime::component::__internal::Vec<
                         (u8, wasmtime::component::__internal::String),
@@ -489,7 +489,7 @@ pub mod foo {
                         (wasmtime::component::__internal::String, u8),
                     >,
                 > + Send;
-                fn string_list<T: Send>(
+                fn string_list(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     x: wasmtime::component::__internal::Vec<
                         wasmtime::component::__internal::String,
@@ -499,25 +499,25 @@ pub mod foo {
                         wasmtime::component::__internal::String,
                     >,
                 > + Send;
-                fn record_list<T: Send>(
+                fn record_list(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     x: wasmtime::component::__internal::Vec<SomeRecord>,
                 ) -> impl ::core::future::Future<
                     Output = wasmtime::component::__internal::Vec<OtherRecord>,
                 > + Send;
-                fn record_list_reverse<T: Send>(
+                fn record_list_reverse(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     x: wasmtime::component::__internal::Vec<OtherRecord>,
                 ) -> impl ::core::future::Future<
                     Output = wasmtime::component::__internal::Vec<SomeRecord>,
                 > + Send;
-                fn variant_list<T: Send>(
+                fn variant_list(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     x: wasmtime::component::__internal::Vec<SomeVariant>,
                 ) -> impl ::core::future::Future<
                     Output = wasmtime::component::__internal::Vec<OtherVariant>,
                 > + Send;
-                fn load_store_everything<T: Send>(
+                fn load_store_everything(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     a: LoadStoreAllSizes,
                 ) -> impl ::core::future::Future<Output = LoadStoreAllSizes> + Send;
@@ -529,7 +529,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
@@ -541,7 +541,7 @@ pub mod foo {
                     {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::list_u8_param(host, arg0)
+                            let r = <D as HostWithStore<T>>::list_u8_param(host, arg0)
                                 .await;
                             Ok(r)
                         })
@@ -555,7 +555,7 @@ pub mod foo {
                     {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::list_u16_param(host, arg0)
+                            let r = <D as HostWithStore<T>>::list_u16_param(host, arg0)
                                 .await;
                             Ok(r)
                         })
@@ -569,7 +569,7 @@ pub mod foo {
                     {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::list_u32_param(host, arg0)
+                            let r = <D as HostWithStore<T>>::list_u32_param(host, arg0)
                                 .await;
                             Ok(r)
                         })
@@ -583,7 +583,7 @@ pub mod foo {
                     {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::list_u64_param(host, arg0)
+                            let r = <D as HostWithStore<T>>::list_u64_param(host, arg0)
                                 .await;
                             Ok(r)
                         })
@@ -597,7 +597,7 @@ pub mod foo {
                     {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::list_s8_param(host, arg0)
+                            let r = <D as HostWithStore<T>>::list_s8_param(host, arg0)
                                 .await;
                             Ok(r)
                         })
@@ -611,7 +611,7 @@ pub mod foo {
                     {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::list_s16_param(host, arg0)
+                            let r = <D as HostWithStore<T>>::list_s16_param(host, arg0)
                                 .await;
                             Ok(r)
                         })
@@ -625,7 +625,7 @@ pub mod foo {
                     {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::list_s32_param(host, arg0)
+                            let r = <D as HostWithStore<T>>::list_s32_param(host, arg0)
                                 .await;
                             Ok(r)
                         })
@@ -639,7 +639,7 @@ pub mod foo {
                     {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::list_s64_param(host, arg0)
+                            let r = <D as HostWithStore<T>>::list_s64_param(host, arg0)
                                 .await;
                             Ok(r)
                         })
@@ -653,7 +653,7 @@ pub mod foo {
                     {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::list_f32_param(host, arg0)
+                            let r = <D as HostWithStore<T>>::list_f32_param(host, arg0)
                                 .await;
                             Ok(r)
                         })
@@ -667,7 +667,7 @@ pub mod foo {
                     {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::list_f64_param(host, arg0)
+                            let r = <D as HostWithStore<T>>::list_f64_param(host, arg0)
                                 .await;
                             Ok(r)
                         })
@@ -678,7 +678,7 @@ pub mod foo {
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::list_u8_ret(host).await;
+                            let r = <D as HostWithStore<T>>::list_u8_ret(host).await;
                             Ok((r,))
                         })
                     },
@@ -688,7 +688,7 @@ pub mod foo {
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::list_u16_ret(host).await;
+                            let r = <D as HostWithStore<T>>::list_u16_ret(host).await;
                             Ok((r,))
                         })
                     },
@@ -698,7 +698,7 @@ pub mod foo {
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::list_u32_ret(host).await;
+                            let r = <D as HostWithStore<T>>::list_u32_ret(host).await;
                             Ok((r,))
                         })
                     },
@@ -708,7 +708,7 @@ pub mod foo {
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::list_u64_ret(host).await;
+                            let r = <D as HostWithStore<T>>::list_u64_ret(host).await;
                             Ok((r,))
                         })
                     },
@@ -718,7 +718,7 @@ pub mod foo {
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::list_s8_ret(host).await;
+                            let r = <D as HostWithStore<T>>::list_s8_ret(host).await;
                             Ok((r,))
                         })
                     },
@@ -728,7 +728,7 @@ pub mod foo {
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::list_s16_ret(host).await;
+                            let r = <D as HostWithStore<T>>::list_s16_ret(host).await;
                             Ok((r,))
                         })
                     },
@@ -738,7 +738,7 @@ pub mod foo {
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::list_s32_ret(host).await;
+                            let r = <D as HostWithStore<T>>::list_s32_ret(host).await;
                             Ok((r,))
                         })
                     },
@@ -748,7 +748,7 @@ pub mod foo {
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::list_s64_ret(host).await;
+                            let r = <D as HostWithStore<T>>::list_s64_ret(host).await;
                             Ok((r,))
                         })
                     },
@@ -758,7 +758,7 @@ pub mod foo {
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::list_f32_ret(host).await;
+                            let r = <D as HostWithStore<T>>::list_f32_ret(host).await;
                             Ok((r,))
                         })
                     },
@@ -768,7 +768,7 @@ pub mod foo {
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::list_f64_ret(host).await;
+                            let r = <D as HostWithStore<T>>::list_f64_ret(host).await;
                             Ok((r,))
                         })
                     },
@@ -781,7 +781,8 @@ pub mod foo {
                     {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::tuple_list(host, arg0).await;
+                            let r = <D as HostWithStore<T>>::tuple_list(host, arg0)
+                                .await;
                             Ok((r,))
                         })
                     },
@@ -800,7 +801,7 @@ pub mod foo {
                     {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::string_list_arg(host, arg0)
+                            let r = <D as HostWithStore<T>>::string_list_arg(host, arg0)
                                 .await;
                             Ok(r)
                         })
@@ -811,7 +812,7 @@ pub mod foo {
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::string_list_ret(host).await;
+                            let r = <D as HostWithStore<T>>::string_list_ret(host).await;
                             Ok((r,))
                         })
                     },
@@ -830,7 +831,9 @@ pub mod foo {
                     {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::tuple_string_list(host, arg0)
+                            let r = <D as HostWithStore<
+                                T,
+                            >>::tuple_string_list(host, arg0)
                                 .await;
                             Ok((r,))
                         })
@@ -850,7 +853,8 @@ pub mod foo {
                     {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::string_list(host, arg0).await;
+                            let r = <D as HostWithStore<T>>::string_list(host, arg0)
+                                .await;
                             Ok((r,))
                         })
                     },
@@ -863,7 +867,8 @@ pub mod foo {
                     {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::record_list(host, arg0).await;
+                            let r = <D as HostWithStore<T>>::record_list(host, arg0)
+                                .await;
                             Ok((r,))
                         })
                     },
@@ -876,7 +881,9 @@ pub mod foo {
                     {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::record_list_reverse(host, arg0)
+                            let r = <D as HostWithStore<
+                                T,
+                            >>::record_list_reverse(host, arg0)
                                 .await;
                             Ok((r,))
                         })
@@ -890,7 +897,8 @@ pub mod foo {
                     {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::variant_list(host, arg0).await;
+                            let r = <D as HostWithStore<T>>::variant_list(host, arg0)
+                                .await;
                             Ok((r,))
                         })
                     },
@@ -903,10 +911,9 @@ pub mod foo {
                     {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::load_store_everything(
-                                    host,
-                                    arg0,
-                                )
+                            let r = <D as HostWithStore<
+                                T,
+                            >>::load_store_everything(host, arg0)
                                 .await;
                             Ok((r,))
                         })
@@ -919,7 +926,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {

--- a/crates/component-macro/tests/expanded/lists_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/lists_tracing_async.rs
@@ -171,7 +171,7 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: foo::foo::lists::HostWithStore + Send,
+            D: foo::foo::lists::HostWithStore<T> + Send,
             for<'a> D::Data<'a>: foo::foo::lists::Host + Send,
             T: 'static + Send,
         {
@@ -369,10 +369,10 @@ pub mod foo {
                     >::ALIGN32
                 );
             };
-            pub trait HostWithStore: wasmtime::component::HasData + Send {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<T>: wasmtime::component::HasData + Send {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData + Send,
+                H: wasmtime::component::HasData + Send,
             {}
             pub trait Host: Send {
                 fn list_u8_param(
@@ -743,7 +743,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
@@ -1547,7 +1547,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {

--- a/crates/component-macro/tests/expanded/many-arguments.rs
+++ b/crates/component-macro/tests/expanded/many-arguments.rs
@@ -173,7 +173,7 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: foo::foo::manyarg::HostWithStore,
+            D: foo::foo::manyarg::HostWithStore<T>,
             for<'a> D::Data<'a>: foo::foo::manyarg::Host,
             T: 'static,
         {
@@ -272,10 +272,10 @@ pub mod foo {
                     4 == < BigStruct as wasmtime::component::ComponentType >::ALIGN32
                 );
             };
-            pub trait HostWithStore: wasmtime::component::HasData {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<T>: wasmtime::component::HasData {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData,
+                H: wasmtime::component::HasData,
             {}
             pub trait Host {
                 fn many_args(
@@ -348,7 +348,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {
@@ -433,7 +433,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {

--- a/crates/component-macro/tests/expanded/many-arguments_async.rs
+++ b/crates/component-macro/tests/expanded/many-arguments_async.rs
@@ -173,7 +173,7 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: foo::foo::manyarg::HostWithStore + Send,
+            D: foo::foo::manyarg::HostWithStore<T> + Send,
             for<'a> D::Data<'a>: foo::foo::manyarg::Host + Send,
             T: 'static + Send,
         {
@@ -272,10 +272,10 @@ pub mod foo {
                     4 == < BigStruct as wasmtime::component::ComponentType >::ALIGN32
                 );
             };
-            pub trait HostWithStore: wasmtime::component::HasData + Send {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<T>: wasmtime::component::HasData + Send {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData + Send,
+                H: wasmtime::component::HasData + Send,
             {}
             pub trait Host: Send {
                 fn many_args(
@@ -357,7 +357,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
@@ -447,7 +447,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {

--- a/crates/component-macro/tests/expanded/many-arguments_concurrent.rs
+++ b/crates/component-macro/tests/expanded/many-arguments_concurrent.rs
@@ -173,7 +173,7 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: foo::foo::manyarg::HostWithStore + Send,
+            D: foo::foo::manyarg::HostWithStore<T> + Send,
             for<'a> D::Data<'a>: foo::foo::manyarg::Host + Send,
             T: 'static + Send,
         {
@@ -272,8 +272,8 @@ pub mod foo {
                     4 == < BigStruct as wasmtime::component::ComponentType >::ALIGN32
                 );
             };
-            pub trait HostWithStore: wasmtime::component::HasData + Send {
-                fn many_args<T: Send>(
+            pub trait HostWithStore<T>: wasmtime::component::HasData + Send {
+                fn many_args(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     a1: u64,
                     a2: u64,
@@ -292,7 +292,7 @@ pub mod foo {
                     a15: u64,
                     a16: u64,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
-                fn big_argument<T: Send>(
+                fn big_argument(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     x: BigStruct,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
@@ -304,7 +304,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
@@ -350,7 +350,9 @@ pub mod foo {
                     {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::many_args(
+                            let r = <D as HostWithStore<
+                                T,
+                            >>::many_args(
                                     host,
                                     arg0,
                                     arg1,
@@ -382,7 +384,8 @@ pub mod foo {
                     {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::big_argument(host, arg0).await;
+                            let r = <D as HostWithStore<T>>::big_argument(host, arg0)
+                                .await;
                             Ok(r)
                         })
                     },
@@ -394,7 +397,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {

--- a/crates/component-macro/tests/expanded/many-arguments_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/many-arguments_tracing_async.rs
@@ -173,7 +173,7 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: foo::foo::manyarg::HostWithStore + Send,
+            D: foo::foo::manyarg::HostWithStore<T> + Send,
             for<'a> D::Data<'a>: foo::foo::manyarg::Host + Send,
             T: 'static + Send,
         {
@@ -272,10 +272,10 @@ pub mod foo {
                     4 == < BigStruct as wasmtime::component::ComponentType >::ALIGN32
                 );
             };
-            pub trait HostWithStore: wasmtime::component::HasData + Send {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<T>: wasmtime::component::HasData + Send {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData + Send,
+                H: wasmtime::component::HasData + Send,
             {}
             pub trait Host: Send {
                 fn many_args(
@@ -357,7 +357,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
@@ -490,7 +490,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {

--- a/crates/component-macro/tests/expanded/multiversion.rs
+++ b/crates/component-macro/tests/expanded/multiversion.rs
@@ -178,7 +178,7 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: my::dep0_1_0::a::HostWithStore + my::dep0_2_0::a::HostWithStore,
+            D: my::dep0_1_0::a::HostWithStore<T> + my::dep0_2_0::a::HostWithStore<T>,
             for<'a> D::Data<'a>: my::dep0_1_0::a::Host + my::dep0_2_0::a::Host,
             T: 'static,
         {
@@ -200,10 +200,10 @@ pub mod my {
         pub mod a {
             #[allow(unused_imports)]
             use wasmtime::component::__internal::Box;
-            pub trait HostWithStore: wasmtime::component::HasData {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<T>: wasmtime::component::HasData {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData,
+                H: wasmtime::component::HasData,
             {}
             pub trait Host {
                 fn x(&mut self) -> ();
@@ -218,7 +218,7 @@ pub mod my {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {
@@ -237,7 +237,7 @@ pub mod my {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {
@@ -251,10 +251,10 @@ pub mod my {
         pub mod a {
             #[allow(unused_imports)]
             use wasmtime::component::__internal::Box;
-            pub trait HostWithStore: wasmtime::component::HasData {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<T>: wasmtime::component::HasData {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData,
+                H: wasmtime::component::HasData,
             {}
             pub trait Host {
                 fn x(&mut self) -> ();
@@ -269,7 +269,7 @@ pub mod my {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {
@@ -288,7 +288,7 @@ pub mod my {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {

--- a/crates/component-macro/tests/expanded/multiversion_async.rs
+++ b/crates/component-macro/tests/expanded/multiversion_async.rs
@@ -178,7 +178,8 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: my::dep0_1_0::a::HostWithStore + my::dep0_2_0::a::HostWithStore + Send,
+            D: my::dep0_1_0::a::HostWithStore<T> + my::dep0_2_0::a::HostWithStore<T>
+                + Send,
             for<'a> D::Data<'a>: my::dep0_1_0::a::Host + my::dep0_2_0::a::Host + Send,
             T: 'static + Send,
         {
@@ -200,10 +201,10 @@ pub mod my {
         pub mod a {
             #[allow(unused_imports)]
             use wasmtime::component::__internal::Box;
-            pub trait HostWithStore: wasmtime::component::HasData + Send {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<T>: wasmtime::component::HasData + Send {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData + Send,
+                H: wasmtime::component::HasData + Send,
             {}
             pub trait Host: Send {
                 fn x(&mut self) -> impl ::core::future::Future<Output = ()> + Send;
@@ -218,7 +219,7 @@ pub mod my {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
@@ -239,7 +240,7 @@ pub mod my {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
@@ -253,10 +254,10 @@ pub mod my {
         pub mod a {
             #[allow(unused_imports)]
             use wasmtime::component::__internal::Box;
-            pub trait HostWithStore: wasmtime::component::HasData + Send {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<T>: wasmtime::component::HasData + Send {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData + Send,
+                H: wasmtime::component::HasData + Send,
             {}
             pub trait Host: Send {
                 fn x(&mut self) -> impl ::core::future::Future<Output = ()> + Send;
@@ -271,7 +272,7 @@ pub mod my {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
@@ -292,7 +293,7 @@ pub mod my {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {

--- a/crates/component-macro/tests/expanded/multiversion_concurrent.rs
+++ b/crates/component-macro/tests/expanded/multiversion_concurrent.rs
@@ -178,7 +178,8 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: my::dep0_1_0::a::HostWithStore + my::dep0_2_0::a::HostWithStore + Send,
+            D: my::dep0_1_0::a::HostWithStore<T> + my::dep0_2_0::a::HostWithStore<T>
+                + Send,
             for<'a> D::Data<'a>: my::dep0_1_0::a::Host + my::dep0_2_0::a::Host + Send,
             T: 'static + Send,
         {
@@ -200,8 +201,8 @@ pub mod my {
         pub mod a {
             #[allow(unused_imports)]
             use wasmtime::component::__internal::Box;
-            pub trait HostWithStore: wasmtime::component::HasData + Send {
-                fn x<T: Send>(
+            pub trait HostWithStore<T>: wasmtime::component::HasData + Send {
+                fn x(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
             }
@@ -212,7 +213,7 @@ pub mod my {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
@@ -221,7 +222,7 @@ pub mod my {
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::x(host).await;
+                            let r = <D as HostWithStore<T>>::x(host).await;
                             Ok(r)
                         })
                     },
@@ -233,7 +234,7 @@ pub mod my {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
@@ -247,8 +248,8 @@ pub mod my {
         pub mod a {
             #[allow(unused_imports)]
             use wasmtime::component::__internal::Box;
-            pub trait HostWithStore: wasmtime::component::HasData + Send {
-                fn x<T: Send>(
+            pub trait HostWithStore<T>: wasmtime::component::HasData + Send {
+                fn x(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
             }
@@ -259,7 +260,7 @@ pub mod my {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
@@ -268,7 +269,7 @@ pub mod my {
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::x(host).await;
+                            let r = <D as HostWithStore<T>>::x(host).await;
                             Ok(r)
                         })
                     },
@@ -280,7 +281,7 @@ pub mod my {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {

--- a/crates/component-macro/tests/expanded/multiversion_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/multiversion_tracing_async.rs
@@ -178,7 +178,8 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: my::dep0_1_0::a::HostWithStore + my::dep0_2_0::a::HostWithStore + Send,
+            D: my::dep0_1_0::a::HostWithStore<T> + my::dep0_2_0::a::HostWithStore<T>
+                + Send,
             for<'a> D::Data<'a>: my::dep0_1_0::a::Host + my::dep0_2_0::a::Host + Send,
             T: 'static + Send,
         {
@@ -200,10 +201,10 @@ pub mod my {
         pub mod a {
             #[allow(unused_imports)]
             use wasmtime::component::__internal::Box;
-            pub trait HostWithStore: wasmtime::component::HasData + Send {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<T>: wasmtime::component::HasData + Send {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData + Send,
+                H: wasmtime::component::HasData + Send,
             {}
             pub trait Host: Send {
                 fn x(&mut self) -> impl ::core::future::Future<Output = ()> + Send;
@@ -218,7 +219,7 @@ pub mod my {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
@@ -252,7 +253,7 @@ pub mod my {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
@@ -266,10 +267,10 @@ pub mod my {
         pub mod a {
             #[allow(unused_imports)]
             use wasmtime::component::__internal::Box;
-            pub trait HostWithStore: wasmtime::component::HasData + Send {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<T>: wasmtime::component::HasData + Send {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData + Send,
+                H: wasmtime::component::HasData + Send,
             {}
             pub trait Host: Send {
                 fn x(&mut self) -> impl ::core::future::Future<Output = ()> + Send;
@@ -284,7 +285,7 @@ pub mod my {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
@@ -318,7 +319,7 @@ pub mod my {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {

--- a/crates/component-macro/tests/expanded/path1.rs
+++ b/crates/component-macro/tests/expanded/path1.rs
@@ -165,7 +165,7 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: paths::path1::test::HostWithStore,
+            D: paths::path1::test::HostWithStore<T>,
             for<'a> D::Data<'a>: paths::path1::test::Host,
             T: 'static,
         {
@@ -180,10 +180,10 @@ pub mod paths {
         pub mod test {
             #[allow(unused_imports)]
             use wasmtime::component::__internal::Box;
-            pub trait HostWithStore: wasmtime::component::HasData {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<T>: wasmtime::component::HasData {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData,
+                H: wasmtime::component::HasData,
             {}
             pub trait Host {}
             impl<_T: Host + ?Sized> Host for &mut _T {}
@@ -192,7 +192,7 @@ pub mod paths {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {
@@ -203,7 +203,7 @@ pub mod paths {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {

--- a/crates/component-macro/tests/expanded/path1_async.rs
+++ b/crates/component-macro/tests/expanded/path1_async.rs
@@ -165,7 +165,7 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: paths::path1::test::HostWithStore,
+            D: paths::path1::test::HostWithStore<T>,
             for<'a> D::Data<'a>: paths::path1::test::Host,
             T: 'static + Send,
         {
@@ -180,10 +180,10 @@ pub mod paths {
         pub mod test {
             #[allow(unused_imports)]
             use wasmtime::component::__internal::Box;
-            pub trait HostWithStore: wasmtime::component::HasData {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<T>: wasmtime::component::HasData {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData,
+                H: wasmtime::component::HasData,
             {}
             pub trait Host {}
             impl<_T: Host + ?Sized> Host for &mut _T {}
@@ -192,7 +192,7 @@ pub mod paths {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {
@@ -203,7 +203,7 @@ pub mod paths {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {

--- a/crates/component-macro/tests/expanded/path1_concurrent.rs
+++ b/crates/component-macro/tests/expanded/path1_concurrent.rs
@@ -165,7 +165,7 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: paths::path1::test::HostWithStore,
+            D: paths::path1::test::HostWithStore<T>,
             for<'a> D::Data<'a>: paths::path1::test::Host,
             T: 'static + Send,
         {
@@ -180,10 +180,10 @@ pub mod paths {
         pub mod test {
             #[allow(unused_imports)]
             use wasmtime::component::__internal::Box;
-            pub trait HostWithStore: wasmtime::component::HasData {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<T>: wasmtime::component::HasData {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData,
+                H: wasmtime::component::HasData,
             {}
             pub trait Host {}
             impl<_T: Host + ?Sized> Host for &mut _T {}
@@ -192,7 +192,7 @@ pub mod paths {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {
@@ -203,7 +203,7 @@ pub mod paths {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {

--- a/crates/component-macro/tests/expanded/path1_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/path1_tracing_async.rs
@@ -165,7 +165,7 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: paths::path1::test::HostWithStore,
+            D: paths::path1::test::HostWithStore<T>,
             for<'a> D::Data<'a>: paths::path1::test::Host,
             T: 'static + Send,
         {
@@ -180,10 +180,10 @@ pub mod paths {
         pub mod test {
             #[allow(unused_imports)]
             use wasmtime::component::__internal::Box;
-            pub trait HostWithStore: wasmtime::component::HasData {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<T>: wasmtime::component::HasData {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData,
+                H: wasmtime::component::HasData,
             {}
             pub trait Host {}
             impl<_T: Host + ?Sized> Host for &mut _T {}
@@ -192,7 +192,7 @@ pub mod paths {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {
@@ -203,7 +203,7 @@ pub mod paths {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {

--- a/crates/component-macro/tests/expanded/path2.rs
+++ b/crates/component-macro/tests/expanded/path2.rs
@@ -165,7 +165,7 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: paths::path2::test::HostWithStore,
+            D: paths::path2::test::HostWithStore<T>,
             for<'a> D::Data<'a>: paths::path2::test::Host,
             T: 'static,
         {
@@ -180,10 +180,10 @@ pub mod paths {
         pub mod test {
             #[allow(unused_imports)]
             use wasmtime::component::__internal::Box;
-            pub trait HostWithStore: wasmtime::component::HasData {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<T>: wasmtime::component::HasData {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData,
+                H: wasmtime::component::HasData,
             {}
             pub trait Host {}
             impl<_T: Host + ?Sized> Host for &mut _T {}
@@ -192,7 +192,7 @@ pub mod paths {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {
@@ -203,7 +203,7 @@ pub mod paths {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {

--- a/crates/component-macro/tests/expanded/path2_async.rs
+++ b/crates/component-macro/tests/expanded/path2_async.rs
@@ -165,7 +165,7 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: paths::path2::test::HostWithStore,
+            D: paths::path2::test::HostWithStore<T>,
             for<'a> D::Data<'a>: paths::path2::test::Host,
             T: 'static + Send,
         {
@@ -180,10 +180,10 @@ pub mod paths {
         pub mod test {
             #[allow(unused_imports)]
             use wasmtime::component::__internal::Box;
-            pub trait HostWithStore: wasmtime::component::HasData {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<T>: wasmtime::component::HasData {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData,
+                H: wasmtime::component::HasData,
             {}
             pub trait Host {}
             impl<_T: Host + ?Sized> Host for &mut _T {}
@@ -192,7 +192,7 @@ pub mod paths {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {
@@ -203,7 +203,7 @@ pub mod paths {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {

--- a/crates/component-macro/tests/expanded/path2_concurrent.rs
+++ b/crates/component-macro/tests/expanded/path2_concurrent.rs
@@ -165,7 +165,7 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: paths::path2::test::HostWithStore,
+            D: paths::path2::test::HostWithStore<T>,
             for<'a> D::Data<'a>: paths::path2::test::Host,
             T: 'static + Send,
         {
@@ -180,10 +180,10 @@ pub mod paths {
         pub mod test {
             #[allow(unused_imports)]
             use wasmtime::component::__internal::Box;
-            pub trait HostWithStore: wasmtime::component::HasData {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<T>: wasmtime::component::HasData {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData,
+                H: wasmtime::component::HasData,
             {}
             pub trait Host {}
             impl<_T: Host + ?Sized> Host for &mut _T {}
@@ -192,7 +192,7 @@ pub mod paths {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {
@@ -203,7 +203,7 @@ pub mod paths {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {

--- a/crates/component-macro/tests/expanded/path2_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/path2_tracing_async.rs
@@ -165,7 +165,7 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: paths::path2::test::HostWithStore,
+            D: paths::path2::test::HostWithStore<T>,
             for<'a> D::Data<'a>: paths::path2::test::Host,
             T: 'static + Send,
         {
@@ -180,10 +180,10 @@ pub mod paths {
         pub mod test {
             #[allow(unused_imports)]
             use wasmtime::component::__internal::Box;
-            pub trait HostWithStore: wasmtime::component::HasData {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<T>: wasmtime::component::HasData {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData,
+                H: wasmtime::component::HasData,
             {}
             pub trait Host {}
             impl<_T: Host + ?Sized> Host for &mut _T {}
@@ -192,7 +192,7 @@ pub mod paths {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {
@@ -203,7 +203,7 @@ pub mod paths {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {

--- a/crates/component-macro/tests/expanded/records.rs
+++ b/crates/component-macro/tests/expanded/records.rs
@@ -173,7 +173,7 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: foo::foo::records::HostWithStore,
+            D: foo::foo::records::HostWithStore<T>,
             for<'a> D::Data<'a>: foo::foo::records::Host,
             T: 'static,
         {
@@ -388,10 +388,10 @@ pub mod foo {
                     >::ALIGN32
                 );
             };
-            pub trait HostWithStore: wasmtime::component::HasData {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<T>: wasmtime::component::HasData {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData,
+                H: wasmtime::component::HasData,
             {}
             pub trait Host {
                 fn tuple_arg(&mut self, x: (char, u32)) -> ();
@@ -446,7 +446,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {
@@ -563,7 +563,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {

--- a/crates/component-macro/tests/expanded/records_async.rs
+++ b/crates/component-macro/tests/expanded/records_async.rs
@@ -173,7 +173,7 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: foo::foo::records::HostWithStore + Send,
+            D: foo::foo::records::HostWithStore<T> + Send,
             for<'a> D::Data<'a>: foo::foo::records::Host + Send,
             T: 'static + Send,
         {
@@ -388,10 +388,10 @@ pub mod foo {
                     >::ALIGN32
                 );
             };
-            pub trait HostWithStore: wasmtime::component::HasData + Send {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<T>: wasmtime::component::HasData + Send {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData + Send,
+                H: wasmtime::component::HasData + Send,
             {}
             pub trait Host: Send {
                 fn tuple_arg(
@@ -502,7 +502,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
@@ -641,7 +641,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {

--- a/crates/component-macro/tests/expanded/records_concurrent.rs
+++ b/crates/component-macro/tests/expanded/records_concurrent.rs
@@ -173,7 +173,7 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: foo::foo::records::HostWithStore + Send,
+            D: foo::foo::records::HostWithStore<T> + Send,
             for<'a> D::Data<'a>: foo::foo::records::Host + Send,
             T: 'static + Send,
         {
@@ -388,43 +388,43 @@ pub mod foo {
                     >::ALIGN32
                 );
             };
-            pub trait HostWithStore: wasmtime::component::HasData + Send {
-                fn tuple_arg<T: Send>(
+            pub trait HostWithStore<T>: wasmtime::component::HasData + Send {
+                fn tuple_arg(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     x: (char, u32),
                 ) -> impl ::core::future::Future<Output = ()> + Send;
-                fn tuple_result<T: Send>(
+                fn tuple_result(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = (char, u32)> + Send;
-                fn empty_arg<T: Send>(
+                fn empty_arg(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     x: Empty,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
-                fn empty_result<T: Send>(
+                fn empty_result(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = Empty> + Send;
-                fn scalar_arg<T: Send>(
+                fn scalar_arg(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     x: Scalars,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
-                fn scalar_result<T: Send>(
+                fn scalar_result(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = Scalars> + Send;
-                fn flags_arg<T: Send>(
+                fn flags_arg(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     x: ReallyFlags,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
-                fn flags_result<T: Send>(
+                fn flags_result(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = ReallyFlags> + Send;
-                fn aggregate_arg<T: Send>(
+                fn aggregate_arg(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     x: Aggregates,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
-                fn aggregate_result<T: Send>(
+                fn aggregate_result(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = Aggregates> + Send;
-                fn typedef_inout<T: Send>(
+                fn typedef_inout(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     e: TupleTypedef2,
                 ) -> impl ::core::future::Future<Output = i32> + Send;
@@ -436,7 +436,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
@@ -448,7 +448,7 @@ pub mod foo {
                     {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::tuple_arg(host, arg0).await;
+                            let r = <D as HostWithStore<T>>::tuple_arg(host, arg0).await;
                             Ok(r)
                         })
                     },
@@ -458,7 +458,7 @@ pub mod foo {
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::tuple_result(host).await;
+                            let r = <D as HostWithStore<T>>::tuple_result(host).await;
                             Ok((r,))
                         })
                     },
@@ -468,7 +468,7 @@ pub mod foo {
                     move |caller: &wasmtime::component::Accessor<T>, (arg0,): (Empty,)| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::empty_arg(host, arg0).await;
+                            let r = <D as HostWithStore<T>>::empty_arg(host, arg0).await;
                             Ok(r)
                         })
                     },
@@ -478,7 +478,7 @@ pub mod foo {
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::empty_result(host).await;
+                            let r = <D as HostWithStore<T>>::empty_result(host).await;
                             Ok((r,))
                         })
                     },
@@ -491,7 +491,8 @@ pub mod foo {
                     {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::scalar_arg(host, arg0).await;
+                            let r = <D as HostWithStore<T>>::scalar_arg(host, arg0)
+                                .await;
                             Ok(r)
                         })
                     },
@@ -501,7 +502,7 @@ pub mod foo {
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::scalar_result(host).await;
+                            let r = <D as HostWithStore<T>>::scalar_result(host).await;
                             Ok((r,))
                         })
                     },
@@ -514,7 +515,7 @@ pub mod foo {
                     {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::flags_arg(host, arg0).await;
+                            let r = <D as HostWithStore<T>>::flags_arg(host, arg0).await;
                             Ok(r)
                         })
                     },
@@ -524,7 +525,7 @@ pub mod foo {
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::flags_result(host).await;
+                            let r = <D as HostWithStore<T>>::flags_result(host).await;
                             Ok((r,))
                         })
                     },
@@ -537,7 +538,7 @@ pub mod foo {
                     {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::aggregate_arg(host, arg0)
+                            let r = <D as HostWithStore<T>>::aggregate_arg(host, arg0)
                                 .await;
                             Ok(r)
                         })
@@ -548,7 +549,8 @@ pub mod foo {
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::aggregate_result(host).await;
+                            let r = <D as HostWithStore<T>>::aggregate_result(host)
+                                .await;
                             Ok((r,))
                         })
                     },
@@ -561,7 +563,7 @@ pub mod foo {
                     {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::typedef_inout(host, arg0)
+                            let r = <D as HostWithStore<T>>::typedef_inout(host, arg0)
                                 .await;
                             Ok((r,))
                         })
@@ -574,7 +576,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {

--- a/crates/component-macro/tests/expanded/records_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/records_tracing_async.rs
@@ -173,7 +173,7 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: foo::foo::records::HostWithStore + Send,
+            D: foo::foo::records::HostWithStore<T> + Send,
             for<'a> D::Data<'a>: foo::foo::records::Host + Send,
             T: 'static + Send,
         {
@@ -388,10 +388,10 @@ pub mod foo {
                     >::ALIGN32
                 );
             };
-            pub trait HostWithStore: wasmtime::component::HasData + Send {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<T>: wasmtime::component::HasData + Send {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData + Send,
+                H: wasmtime::component::HasData + Send,
             {}
             pub trait Host: Send {
                 fn tuple_arg(
@@ -502,7 +502,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
@@ -802,7 +802,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {

--- a/crates/component-macro/tests/expanded/rename.rs
+++ b/crates/component-macro/tests/expanded/rename.rs
@@ -165,7 +165,7 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: foo::foo::green::HostWithStore + foo::foo::red::HostWithStore,
+            D: foo::foo::green::HostWithStore<T> + foo::foo::red::HostWithStore<T>,
             for<'a> D::Data<'a>: foo::foo::green::Host + foo::foo::red::Host,
             T: 'static,
         {
@@ -186,10 +186,10 @@ pub mod foo {
                 assert!(4 == < Thing as wasmtime::component::ComponentType >::SIZE32);
                 assert!(4 == < Thing as wasmtime::component::ComponentType >::ALIGN32);
             };
-            pub trait HostWithStore: wasmtime::component::HasData {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<T>: wasmtime::component::HasData {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData,
+                H: wasmtime::component::HasData,
             {}
             pub trait Host {}
             impl<_T: Host + ?Sized> Host for &mut _T {}
@@ -198,7 +198,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {
@@ -209,7 +209,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {
@@ -226,10 +226,10 @@ pub mod foo {
                 assert!(4 == < Thing as wasmtime::component::ComponentType >::SIZE32);
                 assert!(4 == < Thing as wasmtime::component::ComponentType >::ALIGN32);
             };
-            pub trait HostWithStore: wasmtime::component::HasData {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<T>: wasmtime::component::HasData {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData,
+                H: wasmtime::component::HasData,
             {}
             pub trait Host {
                 fn foo(&mut self) -> Thing;
@@ -244,7 +244,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {
@@ -263,7 +263,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {

--- a/crates/component-macro/tests/expanded/rename_async.rs
+++ b/crates/component-macro/tests/expanded/rename_async.rs
@@ -165,7 +165,8 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: foo::foo::green::HostWithStore + foo::foo::red::HostWithStore + Send,
+            D: foo::foo::green::HostWithStore<T> + foo::foo::red::HostWithStore<T>
+                + Send,
             for<'a> D::Data<'a>: foo::foo::green::Host + foo::foo::red::Host + Send,
             T: 'static + Send,
         {
@@ -186,10 +187,10 @@ pub mod foo {
                 assert!(4 == < Thing as wasmtime::component::ComponentType >::SIZE32);
                 assert!(4 == < Thing as wasmtime::component::ComponentType >::ALIGN32);
             };
-            pub trait HostWithStore: wasmtime::component::HasData {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<T>: wasmtime::component::HasData {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData,
+                H: wasmtime::component::HasData,
             {}
             pub trait Host {}
             impl<_T: Host + ?Sized> Host for &mut _T {}
@@ -198,7 +199,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {
@@ -209,7 +210,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {
@@ -226,10 +227,10 @@ pub mod foo {
                 assert!(4 == < Thing as wasmtime::component::ComponentType >::SIZE32);
                 assert!(4 == < Thing as wasmtime::component::ComponentType >::ALIGN32);
             };
-            pub trait HostWithStore: wasmtime::component::HasData + Send {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<T>: wasmtime::component::HasData + Send {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData + Send,
+                H: wasmtime::component::HasData + Send,
             {}
             pub trait Host: Send {
                 fn foo(&mut self) -> impl ::core::future::Future<Output = Thing> + Send;
@@ -244,7 +245,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
@@ -265,7 +266,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {

--- a/crates/component-macro/tests/expanded/rename_concurrent.rs
+++ b/crates/component-macro/tests/expanded/rename_concurrent.rs
@@ -165,7 +165,8 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: foo::foo::green::HostWithStore + foo::foo::red::HostWithStore + Send,
+            D: foo::foo::green::HostWithStore<T> + foo::foo::red::HostWithStore<T>
+                + Send,
             for<'a> D::Data<'a>: foo::foo::green::Host + foo::foo::red::Host + Send,
             T: 'static + Send,
         {
@@ -186,10 +187,10 @@ pub mod foo {
                 assert!(4 == < Thing as wasmtime::component::ComponentType >::SIZE32);
                 assert!(4 == < Thing as wasmtime::component::ComponentType >::ALIGN32);
             };
-            pub trait HostWithStore: wasmtime::component::HasData {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<T>: wasmtime::component::HasData {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData,
+                H: wasmtime::component::HasData,
             {}
             pub trait Host {}
             impl<_T: Host + ?Sized> Host for &mut _T {}
@@ -198,7 +199,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {
@@ -209,7 +210,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {
@@ -226,8 +227,8 @@ pub mod foo {
                 assert!(4 == < Thing as wasmtime::component::ComponentType >::SIZE32);
                 assert!(4 == < Thing as wasmtime::component::ComponentType >::ALIGN32);
             };
-            pub trait HostWithStore: wasmtime::component::HasData + Send {
-                fn foo<T: Send>(
+            pub trait HostWithStore<T>: wasmtime::component::HasData + Send {
+                fn foo(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = Thing> + Send;
             }
@@ -238,7 +239,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
@@ -247,7 +248,7 @@ pub mod foo {
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::foo(host).await;
+                            let r = <D as HostWithStore<T>>::foo(host).await;
                             Ok((r,))
                         })
                     },
@@ -259,7 +260,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {

--- a/crates/component-macro/tests/expanded/rename_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/rename_tracing_async.rs
@@ -165,7 +165,8 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: foo::foo::green::HostWithStore + foo::foo::red::HostWithStore + Send,
+            D: foo::foo::green::HostWithStore<T> + foo::foo::red::HostWithStore<T>
+                + Send,
             for<'a> D::Data<'a>: foo::foo::green::Host + foo::foo::red::Host + Send,
             T: 'static + Send,
         {
@@ -186,10 +187,10 @@ pub mod foo {
                 assert!(4 == < Thing as wasmtime::component::ComponentType >::SIZE32);
                 assert!(4 == < Thing as wasmtime::component::ComponentType >::ALIGN32);
             };
-            pub trait HostWithStore: wasmtime::component::HasData {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<T>: wasmtime::component::HasData {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData,
+                H: wasmtime::component::HasData,
             {}
             pub trait Host {}
             impl<_T: Host + ?Sized> Host for &mut _T {}
@@ -198,7 +199,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {
@@ -209,7 +210,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {
@@ -226,10 +227,10 @@ pub mod foo {
                 assert!(4 == < Thing as wasmtime::component::ComponentType >::SIZE32);
                 assert!(4 == < Thing as wasmtime::component::ComponentType >::ALIGN32);
             };
-            pub trait HostWithStore: wasmtime::component::HasData + Send {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<T>: wasmtime::component::HasData + Send {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData + Send,
+                H: wasmtime::component::HasData + Send,
             {}
             pub trait Host: Send {
                 fn foo(&mut self) -> impl ::core::future::Future<Output = Thing> + Send;
@@ -244,7 +245,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
@@ -278,7 +279,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {

--- a/crates/component-macro/tests/expanded/resources-export.rs
+++ b/crates/component-macro/tests/expanded/resources-export.rs
@@ -201,7 +201,7 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: foo::foo::transitive_import::HostWithStore,
+            D: foo::foo::transitive_import::HostWithStore<T>,
             for<'a> D::Data<'a>: foo::foo::transitive_import::Host,
             T: 'static,
         {
@@ -235,10 +235,10 @@ pub mod foo {
             #[allow(unused_imports)]
             use wasmtime::component::__internal::Box;
             pub enum Y {}
-            pub trait HostYWithStore: wasmtime::component::HasData {}
-            impl<_T: ?Sized> HostYWithStore for _T
+            pub trait HostYWithStore<T>: wasmtime::component::HasData {}
+            impl<H: ?Sized, T> HostYWithStore<T> for H
             where
-                _T: wasmtime::component::HasData,
+                H: wasmtime::component::HasData,
             {}
             pub trait HostY {
                 fn drop(
@@ -254,10 +254,12 @@ pub mod foo {
                     HostY::drop(*self, rep)
                 }
             }
-            pub trait HostWithStore: wasmtime::component::HasData + HostYWithStore {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<
+                T,
+            >: wasmtime::component::HasData + HostYWithStore<T> {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData + HostYWithStore,
+                H: wasmtime::component::HasData + HostYWithStore<T>,
             {}
             pub trait Host: HostY {}
             impl<_T: Host + ?Sized> Host for &mut _T {}
@@ -266,7 +268,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {
@@ -287,7 +289,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {

--- a/crates/component-macro/tests/expanded/resources-export_async.rs
+++ b/crates/component-macro/tests/expanded/resources-export_async.rs
@@ -201,7 +201,7 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: foo::foo::transitive_import::HostWithStore + Send,
+            D: foo::foo::transitive_import::HostWithStore<T> + Send,
             for<'a> D::Data<'a>: foo::foo::transitive_import::Host + Send,
             T: 'static + Send,
         {
@@ -235,10 +235,10 @@ pub mod foo {
             #[allow(unused_imports)]
             use wasmtime::component::__internal::Box;
             pub enum Y {}
-            pub trait HostYWithStore: wasmtime::component::HasData {}
-            impl<_T: ?Sized> HostYWithStore for _T
+            pub trait HostYWithStore<T>: wasmtime::component::HasData {}
+            impl<H: ?Sized, T> HostYWithStore<T> for H
             where
-                _T: wasmtime::component::HasData,
+                H: wasmtime::component::HasData,
             {}
             pub trait HostY {
                 fn drop(
@@ -254,10 +254,12 @@ pub mod foo {
                     HostY::drop(*self, rep).await
                 }
             }
-            pub trait HostWithStore: wasmtime::component::HasData + HostYWithStore + Send {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<
+                T,
+            >: wasmtime::component::HasData + HostYWithStore<T> + Send {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData + HostYWithStore + Send,
+                H: wasmtime::component::HasData + HostYWithStore<T> + Send,
             {}
             pub trait Host: HostY + Send {}
             impl<_T: Host + ?Sized + Send> Host for &mut _T {}
@@ -266,7 +268,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
@@ -292,7 +294,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {

--- a/crates/component-macro/tests/expanded/resources-export_concurrent.rs
+++ b/crates/component-macro/tests/expanded/resources-export_concurrent.rs
@@ -201,7 +201,7 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: foo::foo::transitive_import::HostWithStore + Send,
+            D: foo::foo::transitive_import::HostWithStore<T> + Send,
             for<'a> D::Data<'a>: foo::foo::transitive_import::Host + Send,
             T: 'static + Send,
         {
@@ -235,8 +235,8 @@ pub mod foo {
             #[allow(unused_imports)]
             use wasmtime::component::__internal::Box;
             pub enum Y {}
-            pub trait HostYWithStore: wasmtime::component::HasData {
-                fn drop<T>(
+            pub trait HostYWithStore<T>: wasmtime::component::HasData {
+                fn drop(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     rep: wasmtime::component::Resource<Y>,
                 ) -> impl ::core::future::Future<Output = wasmtime::Result<()>> + Send
@@ -245,10 +245,12 @@ pub mod foo {
             }
             pub trait HostY {}
             impl<_T: HostY + ?Sized + Send> HostY for &mut _T {}
-            pub trait HostWithStore: wasmtime::component::HasData + HostYWithStore + Send {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<
+                T,
+            >: wasmtime::component::HasData + HostYWithStore<T> + Send {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData + HostYWithStore + Send,
+                H: wasmtime::component::HasData + HostYWithStore<T> + Send,
             {}
             pub trait Host: HostY + Send {}
             impl<_T: Host + ?Sized + Send> Host for &mut _T {}
@@ -257,7 +259,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
@@ -268,7 +270,9 @@ pub mod foo {
                         wasmtime::component::__internal::Box::pin(async move {
                             let accessor = &caller.with_getter(host_getter);
                             wasmtime::ToWasmtimeResult::to_wasmtime_result(
-                                HostYWithStore::drop(
+                                HostYWithStore::<
+                                    T,
+                                >::drop(
                                         accessor,
                                         wasmtime::component::Resource::new_own(rep),
                                     )
@@ -284,7 +288,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {

--- a/crates/component-macro/tests/expanded/resources-export_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/resources-export_tracing_async.rs
@@ -201,7 +201,7 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: foo::foo::transitive_import::HostWithStore + Send,
+            D: foo::foo::transitive_import::HostWithStore<T> + Send,
             for<'a> D::Data<'a>: foo::foo::transitive_import::Host + Send,
             T: 'static + Send,
         {
@@ -235,10 +235,10 @@ pub mod foo {
             #[allow(unused_imports)]
             use wasmtime::component::__internal::Box;
             pub enum Y {}
-            pub trait HostYWithStore: wasmtime::component::HasData {}
-            impl<_T: ?Sized> HostYWithStore for _T
+            pub trait HostYWithStore<T>: wasmtime::component::HasData {}
+            impl<H: ?Sized, T> HostYWithStore<T> for H
             where
-                _T: wasmtime::component::HasData,
+                H: wasmtime::component::HasData,
             {}
             pub trait HostY {
                 fn drop(
@@ -254,10 +254,12 @@ pub mod foo {
                     HostY::drop(*self, rep).await
                 }
             }
-            pub trait HostWithStore: wasmtime::component::HasData + HostYWithStore + Send {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<
+                T,
+            >: wasmtime::component::HasData + HostYWithStore<T> + Send {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData + HostYWithStore + Send,
+                H: wasmtime::component::HasData + HostYWithStore<T> + Send,
             {}
             pub trait Host: HostY + Send {}
             impl<_T: Host + ?Sized + Send> Host for &mut _T {}
@@ -266,7 +268,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
@@ -292,7 +294,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {

--- a/crates/component-macro/tests/expanded/resources-import.rs
+++ b/crates/component-macro/tests/expanded/resources-import.rs
@@ -1,8 +1,8 @@
 pub enum WorldResource {}
-pub trait HostWorldResourceWithStore: wasmtime::component::HasData {}
-impl<_T: ?Sized> HostWorldResourceWithStore for _T
+pub trait HostWorldResourceWithStore<T>: wasmtime::component::HasData {}
+impl<H: ?Sized, T> HostWorldResourceWithStore<T> for H
 where
-    _T: wasmtime::component::HasData,
+    H: wasmtime::component::HasData,
 {}
 pub trait HostWorldResource {
     fn new(&mut self) -> wasmtime::component::Resource<WorldResource>;
@@ -136,10 +136,12 @@ pub struct TheWorld {
     interface1: exports::foo::foo::uses_resource_transitively::Guest,
     some_world_func2: wasmtime::component::Func,
 }
-pub trait TheWorldImportsWithStore: wasmtime::component::HasData + HostWorldResourceWithStore {}
-impl<_T: ?Sized> TheWorldImportsWithStore for _T
+pub trait TheWorldImportsWithStore<
+    T,
+>: wasmtime::component::HasData + HostWorldResourceWithStore<T> {}
+impl<H: ?Sized, T> TheWorldImportsWithStore<T> for H
 where
-    _T: wasmtime::component::HasData + HostWorldResourceWithStore,
+    H: wasmtime::component::HasData + HostWorldResourceWithStore<T>,
 {}
 pub trait TheWorldImports: HostWorldResource {
     fn some_world_func(&mut self) -> wasmtime::component::Resource<WorldResource>;
@@ -259,7 +261,7 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: TheWorldImportsWithStore,
+            D: TheWorldImportsWithStore<T>,
             for<'a> D::Data<'a>: TheWorldImports,
             T: 'static,
         {
@@ -324,13 +326,13 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: foo::foo::resources::HostWithStore
-                + foo::foo::long_use_chain1::HostWithStore
-                + foo::foo::long_use_chain2::HostWithStore
-                + foo::foo::long_use_chain3::HostWithStore
-                + foo::foo::long_use_chain4::HostWithStore
-                + foo::foo::transitive_interface_with_resource::HostWithStore
-                + TheWorldImportsWithStore,
+            D: foo::foo::resources::HostWithStore<T>
+                + foo::foo::long_use_chain1::HostWithStore<T>
+                + foo::foo::long_use_chain2::HostWithStore<T>
+                + foo::foo::long_use_chain3::HostWithStore<T>
+                + foo::foo::long_use_chain4::HostWithStore<T>
+                + foo::foo::transitive_interface_with_resource::HostWithStore<T>
+                + TheWorldImportsWithStore<T>,
             for<'a> D::Data<
                 'a,
             >: foo::foo::resources::Host + foo::foo::long_use_chain1::Host
@@ -378,10 +380,10 @@ pub mod foo {
             #[allow(unused_imports)]
             use wasmtime::component::__internal::Box;
             pub enum Bar {}
-            pub trait HostBarWithStore: wasmtime::component::HasData {}
-            impl<_T: ?Sized> HostBarWithStore for _T
+            pub trait HostBarWithStore<T>: wasmtime::component::HasData {}
+            impl<H: ?Sized, T> HostBarWithStore<T> for H
             where
-                _T: wasmtime::component::HasData,
+                H: wasmtime::component::HasData,
             {}
             pub trait HostBar {
                 fn new(&mut self) -> wasmtime::component::Resource<Bar>;
@@ -468,10 +470,10 @@ pub mod foo {
                 );
             };
             pub enum Fallible {}
-            pub trait HostFallibleWithStore: wasmtime::component::HasData {}
-            impl<_T: ?Sized> HostFallibleWithStore for _T
+            pub trait HostFallibleWithStore<T>: wasmtime::component::HasData {}
+            impl<H: ?Sized, T> HostFallibleWithStore<T> for H
             where
-                _T: wasmtime::component::HasData,
+                H: wasmtime::component::HasData,
             {}
             pub trait HostFallible {
                 fn new(
@@ -501,11 +503,15 @@ pub mod foo {
                     HostFallible::drop(*self, rep)
                 }
             }
-            pub trait HostWithStore: wasmtime::component::HasData + HostBarWithStore + HostFallibleWithStore {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<
+                T,
+            >: wasmtime::component::HasData + HostBarWithStore<
+                    T,
+                > + HostFallibleWithStore<T> {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData + HostBarWithStore
-                    + HostFallibleWithStore,
+                H: wasmtime::component::HasData + HostBarWithStore<T>
+                    + HostFallibleWithStore<T>,
             {}
             pub trait Host: HostBar + HostFallible {
                 fn bar_own_arg(&mut self, x: wasmtime::component::Resource<Bar>) -> ();
@@ -670,7 +676,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {
@@ -942,7 +948,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {
@@ -955,10 +961,10 @@ pub mod foo {
             #[allow(unused_imports)]
             use wasmtime::component::__internal::Box;
             pub enum A {}
-            pub trait HostAWithStore: wasmtime::component::HasData {}
-            impl<_T: ?Sized> HostAWithStore for _T
+            pub trait HostAWithStore<T>: wasmtime::component::HasData {}
+            impl<H: ?Sized, T> HostAWithStore<T> for H
             where
-                _T: wasmtime::component::HasData,
+                H: wasmtime::component::HasData,
             {}
             pub trait HostA {
                 fn drop(
@@ -974,10 +980,12 @@ pub mod foo {
                     HostA::drop(*self, rep)
                 }
             }
-            pub trait HostWithStore: wasmtime::component::HasData + HostAWithStore {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<
+                T,
+            >: wasmtime::component::HasData + HostAWithStore<T> {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData + HostAWithStore,
+                H: wasmtime::component::HasData + HostAWithStore<T>,
             {}
             pub trait Host: HostA {}
             impl<_T: Host + ?Sized> Host for &mut _T {}
@@ -986,7 +994,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {
@@ -1007,7 +1015,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {
@@ -1020,10 +1028,10 @@ pub mod foo {
             #[allow(unused_imports)]
             use wasmtime::component::__internal::Box;
             pub type A = super::super::super::foo::foo::long_use_chain1::A;
-            pub trait HostWithStore: wasmtime::component::HasData {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<T>: wasmtime::component::HasData {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData,
+                H: wasmtime::component::HasData,
             {}
             pub trait Host {}
             impl<_T: Host + ?Sized> Host for &mut _T {}
@@ -1032,7 +1040,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {
@@ -1043,7 +1051,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {
@@ -1056,10 +1064,10 @@ pub mod foo {
             #[allow(unused_imports)]
             use wasmtime::component::__internal::Box;
             pub type A = super::super::super::foo::foo::long_use_chain2::A;
-            pub trait HostWithStore: wasmtime::component::HasData {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<T>: wasmtime::component::HasData {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData,
+                H: wasmtime::component::HasData,
             {}
             pub trait Host {}
             impl<_T: Host + ?Sized> Host for &mut _T {}
@@ -1068,7 +1076,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {
@@ -1079,7 +1087,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {
@@ -1092,10 +1100,10 @@ pub mod foo {
             #[allow(unused_imports)]
             use wasmtime::component::__internal::Box;
             pub type A = super::super::super::foo::foo::long_use_chain3::A;
-            pub trait HostWithStore: wasmtime::component::HasData {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<T>: wasmtime::component::HasData {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData,
+                H: wasmtime::component::HasData,
             {}
             pub trait Host {
                 fn foo(&mut self) -> wasmtime::component::Resource<A>;
@@ -1110,7 +1118,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {
@@ -1129,7 +1137,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {
@@ -1142,10 +1150,10 @@ pub mod foo {
             #[allow(unused_imports)]
             use wasmtime::component::__internal::Box;
             pub enum Foo {}
-            pub trait HostFooWithStore: wasmtime::component::HasData {}
-            impl<_T: ?Sized> HostFooWithStore for _T
+            pub trait HostFooWithStore<T>: wasmtime::component::HasData {}
+            impl<H: ?Sized, T> HostFooWithStore<T> for H
             where
-                _T: wasmtime::component::HasData,
+                H: wasmtime::component::HasData,
             {}
             pub trait HostFoo {
                 fn drop(
@@ -1161,10 +1169,12 @@ pub mod foo {
                     HostFoo::drop(*self, rep)
                 }
             }
-            pub trait HostWithStore: wasmtime::component::HasData + HostFooWithStore {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<
+                T,
+            >: wasmtime::component::HasData + HostFooWithStore<T> {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData + HostFooWithStore,
+                H: wasmtime::component::HasData + HostFooWithStore<T>,
             {}
             pub trait Host: HostFoo {}
             impl<_T: Host + ?Sized> Host for &mut _T {}
@@ -1173,7 +1183,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {
@@ -1194,7 +1204,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {

--- a/crates/component-macro/tests/expanded/resources-import_async.rs
+++ b/crates/component-macro/tests/expanded/resources-import_async.rs
@@ -1,8 +1,8 @@
 pub enum WorldResource {}
-pub trait HostWorldResourceWithStore: wasmtime::component::HasData + Send {}
-impl<_T: ?Sized> HostWorldResourceWithStore for _T
+pub trait HostWorldResourceWithStore<T>: wasmtime::component::HasData + Send {}
+impl<H: ?Sized, T> HostWorldResourceWithStore<T> for H
 where
-    _T: wasmtime::component::HasData + Send,
+    H: wasmtime::component::HasData + Send,
 {}
 pub trait HostWorldResource: Send {
     fn new(
@@ -150,10 +150,12 @@ pub struct TheWorld {
     interface1: exports::foo::foo::uses_resource_transitively::Guest,
     some_world_func2: wasmtime::component::Func,
 }
-pub trait TheWorldImportsWithStore: wasmtime::component::HasData + HostWorldResourceWithStore + Send {}
-impl<_T: ?Sized> TheWorldImportsWithStore for _T
+pub trait TheWorldImportsWithStore<
+    T,
+>: wasmtime::component::HasData + HostWorldResourceWithStore<T> + Send {}
+impl<H: ?Sized, T> TheWorldImportsWithStore<T> for H
 where
-    _T: wasmtime::component::HasData + HostWorldResourceWithStore + Send,
+    H: wasmtime::component::HasData + HostWorldResourceWithStore<T> + Send,
 {}
 pub trait TheWorldImports: HostWorldResource + Send {
     fn some_world_func(
@@ -281,7 +283,7 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: TheWorldImportsWithStore,
+            D: TheWorldImportsWithStore<T>,
             for<'a> D::Data<'a>: TheWorldImports,
             T: 'static + Send,
         {
@@ -356,13 +358,13 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: foo::foo::resources::HostWithStore
-                + foo::foo::long_use_chain1::HostWithStore
-                + foo::foo::long_use_chain2::HostWithStore
-                + foo::foo::long_use_chain3::HostWithStore
-                + foo::foo::long_use_chain4::HostWithStore
-                + foo::foo::transitive_interface_with_resource::HostWithStore
-                + TheWorldImportsWithStore + Send,
+            D: foo::foo::resources::HostWithStore<T>
+                + foo::foo::long_use_chain1::HostWithStore<T>
+                + foo::foo::long_use_chain2::HostWithStore<T>
+                + foo::foo::long_use_chain3::HostWithStore<T>
+                + foo::foo::long_use_chain4::HostWithStore<T>
+                + foo::foo::transitive_interface_with_resource::HostWithStore<T>
+                + TheWorldImportsWithStore<T> + Send,
             for<'a> D::Data<
                 'a,
             >: foo::foo::resources::Host + foo::foo::long_use_chain1::Host
@@ -414,10 +416,10 @@ pub mod foo {
             #[allow(unused_imports)]
             use wasmtime::component::__internal::Box;
             pub enum Bar {}
-            pub trait HostBarWithStore: wasmtime::component::HasData + Send {}
-            impl<_T: ?Sized> HostBarWithStore for _T
+            pub trait HostBarWithStore<T>: wasmtime::component::HasData + Send {}
+            impl<H: ?Sized, T> HostBarWithStore<T> for H
             where
-                _T: wasmtime::component::HasData + Send,
+                H: wasmtime::component::HasData + Send,
             {}
             pub trait HostBar: Send {
                 fn new(
@@ -519,10 +521,10 @@ pub mod foo {
                 );
             };
             pub enum Fallible {}
-            pub trait HostFallibleWithStore: wasmtime::component::HasData + Send {}
-            impl<_T: ?Sized> HostFallibleWithStore for _T
+            pub trait HostFallibleWithStore<T>: wasmtime::component::HasData + Send {}
+            impl<H: ?Sized, T> HostFallibleWithStore<T> for H
             where
-                _T: wasmtime::component::HasData + Send,
+                H: wasmtime::component::HasData + Send,
             {}
             pub trait HostFallible: Send {
                 fn new(
@@ -556,11 +558,15 @@ pub mod foo {
                     HostFallible::drop(*self, rep).await
                 }
             }
-            pub trait HostWithStore: wasmtime::component::HasData + HostBarWithStore + HostFallibleWithStore + Send {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<
+                T,
+            >: wasmtime::component::HasData + HostBarWithStore<
+                    T,
+                > + HostFallibleWithStore<T> + Send {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData + HostBarWithStore
-                    + HostFallibleWithStore + Send,
+                H: wasmtime::component::HasData + HostBarWithStore<T>
+                    + HostFallibleWithStore<T> + Send,
             {}
             pub trait Host: HostBar + HostFallible + Send {
                 fn bar_own_arg(
@@ -781,7 +787,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
@@ -1106,7 +1112,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
@@ -1119,10 +1125,10 @@ pub mod foo {
             #[allow(unused_imports)]
             use wasmtime::component::__internal::Box;
             pub enum A {}
-            pub trait HostAWithStore: wasmtime::component::HasData {}
-            impl<_T: ?Sized> HostAWithStore for _T
+            pub trait HostAWithStore<T>: wasmtime::component::HasData {}
+            impl<H: ?Sized, T> HostAWithStore<T> for H
             where
-                _T: wasmtime::component::HasData,
+                H: wasmtime::component::HasData,
             {}
             pub trait HostA {
                 fn drop(
@@ -1138,10 +1144,12 @@ pub mod foo {
                     HostA::drop(*self, rep).await
                 }
             }
-            pub trait HostWithStore: wasmtime::component::HasData + HostAWithStore + Send {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<
+                T,
+            >: wasmtime::component::HasData + HostAWithStore<T> + Send {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData + HostAWithStore + Send,
+                H: wasmtime::component::HasData + HostAWithStore<T> + Send,
             {}
             pub trait Host: HostA + Send {}
             impl<_T: Host + ?Sized + Send> Host for &mut _T {}
@@ -1150,7 +1158,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
@@ -1176,7 +1184,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
@@ -1189,10 +1197,10 @@ pub mod foo {
             #[allow(unused_imports)]
             use wasmtime::component::__internal::Box;
             pub type A = super::super::super::foo::foo::long_use_chain1::A;
-            pub trait HostWithStore: wasmtime::component::HasData {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<T>: wasmtime::component::HasData {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData,
+                H: wasmtime::component::HasData,
             {}
             pub trait Host {}
             impl<_T: Host + ?Sized> Host for &mut _T {}
@@ -1201,7 +1209,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {
@@ -1212,7 +1220,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {
@@ -1225,10 +1233,10 @@ pub mod foo {
             #[allow(unused_imports)]
             use wasmtime::component::__internal::Box;
             pub type A = super::super::super::foo::foo::long_use_chain2::A;
-            pub trait HostWithStore: wasmtime::component::HasData {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<T>: wasmtime::component::HasData {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData,
+                H: wasmtime::component::HasData,
             {}
             pub trait Host {}
             impl<_T: Host + ?Sized> Host for &mut _T {}
@@ -1237,7 +1245,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {
@@ -1248,7 +1256,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {
@@ -1261,10 +1269,10 @@ pub mod foo {
             #[allow(unused_imports)]
             use wasmtime::component::__internal::Box;
             pub type A = super::super::super::foo::foo::long_use_chain3::A;
-            pub trait HostWithStore: wasmtime::component::HasData + Send {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<T>: wasmtime::component::HasData + Send {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData + Send,
+                H: wasmtime::component::HasData + Send,
             {}
             pub trait Host: Send {
                 fn foo(
@@ -1287,7 +1295,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
@@ -1308,7 +1316,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
@@ -1321,10 +1329,10 @@ pub mod foo {
             #[allow(unused_imports)]
             use wasmtime::component::__internal::Box;
             pub enum Foo {}
-            pub trait HostFooWithStore: wasmtime::component::HasData {}
-            impl<_T: ?Sized> HostFooWithStore for _T
+            pub trait HostFooWithStore<T>: wasmtime::component::HasData {}
+            impl<H: ?Sized, T> HostFooWithStore<T> for H
             where
-                _T: wasmtime::component::HasData,
+                H: wasmtime::component::HasData,
             {}
             pub trait HostFoo {
                 fn drop(
@@ -1340,10 +1348,12 @@ pub mod foo {
                     HostFoo::drop(*self, rep).await
                 }
             }
-            pub trait HostWithStore: wasmtime::component::HasData + HostFooWithStore + Send {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<
+                T,
+            >: wasmtime::component::HasData + HostFooWithStore<T> + Send {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData + HostFooWithStore + Send,
+                H: wasmtime::component::HasData + HostFooWithStore<T> + Send,
             {}
             pub trait Host: HostFoo + Send {}
             impl<_T: Host + ?Sized + Send> Host for &mut _T {}
@@ -1352,7 +1362,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
@@ -1378,7 +1388,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {

--- a/crates/component-macro/tests/expanded/resources-import_concurrent.rs
+++ b/crates/component-macro/tests/expanded/resources-import_concurrent.rs
@@ -1,21 +1,21 @@
 pub enum WorldResource {}
-pub trait HostWorldResourceWithStore: wasmtime::component::HasData + Send {
-    fn drop<T>(
+pub trait HostWorldResourceWithStore<T>: wasmtime::component::HasData + Send {
+    fn drop(
         accessor: &wasmtime::component::Accessor<T, Self>,
         rep: wasmtime::component::Resource<WorldResource>,
     ) -> impl ::core::future::Future<Output = wasmtime::Result<()>> + Send
     where
         Self: Sized;
-    fn new<T: Send>(
+    fn new(
         accessor: &wasmtime::component::Accessor<T, Self>,
     ) -> impl ::core::future::Future<
         Output = wasmtime::component::Resource<WorldResource>,
     > + Send;
-    fn foo<T: Send>(
+    fn foo(
         accessor: &wasmtime::component::Accessor<T, Self>,
         self_: wasmtime::component::Resource<WorldResource>,
     ) -> impl ::core::future::Future<Output = ()> + Send;
-    fn static_foo<T: Send>(
+    fn static_foo(
         accessor: &wasmtime::component::Accessor<T, Self>,
     ) -> impl ::core::future::Future<Output = ()> + Send;
 }
@@ -127,8 +127,10 @@ pub struct TheWorld {
     interface1: exports::foo::foo::uses_resource_transitively::Guest,
     some_world_func2: wasmtime::component::Func,
 }
-pub trait TheWorldImportsWithStore: wasmtime::component::HasData + HostWorldResourceWithStore + Send {
-    fn some_world_func<T: Send>(
+pub trait TheWorldImportsWithStore<
+    T,
+>: wasmtime::component::HasData + HostWorldResourceWithStore<T> + Send {
+    fn some_world_func(
         accessor: &wasmtime::component::Accessor<T, Self>,
     ) -> impl ::core::future::Future<
         Output = wasmtime::component::Resource<WorldResource>,
@@ -246,7 +248,7 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: TheWorldImportsWithStore,
+            D: TheWorldImportsWithStore<T>,
             for<'a> D::Data<'a>: TheWorldImports,
             T: 'static + Send,
         {
@@ -259,7 +261,9 @@ const _: () = {
                         wasmtime::component::__internal::Box::pin(async move {
                             let accessor = &caller.with_getter(host_getter);
                             wasmtime::ToWasmtimeResult::to_wasmtime_result(
-                                HostWorldResourceWithStore::drop(
+                                HostWorldResourceWithStore::<
+                                    T,
+                                >::drop(
                                         accessor,
                                         wasmtime::component::Resource::new_own(rep),
                                     )
@@ -274,9 +278,9 @@ const _: () = {
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as TheWorldImportsWithStore>::some_world_func(
-                                    host,
-                                )
+                            let r = <D as TheWorldImportsWithStore<
+                                T,
+                            >>::some_world_func(host)
                                 .await;
                             Ok((r,))
                         })
@@ -288,7 +292,8 @@ const _: () = {
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWorldResourceWithStore>::new(host).await;
+                            let r = <D as HostWorldResourceWithStore<T>>::new(host)
+                                .await;
                             Ok((r,))
                         })
                     },
@@ -302,7 +307,7 @@ const _: () = {
                     {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWorldResourceWithStore>::foo(host, arg0)
+                            let r = <D as HostWorldResourceWithStore<T>>::foo(host, arg0)
                                 .await;
                             Ok(r)
                         })
@@ -314,7 +319,9 @@ const _: () = {
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWorldResourceWithStore>::static_foo(host)
+                            let r = <D as HostWorldResourceWithStore<
+                                T,
+                            >>::static_foo(host)
                                 .await;
                             Ok(r)
                         })
@@ -327,13 +334,13 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: foo::foo::resources::HostWithStore
-                + foo::foo::long_use_chain1::HostWithStore
-                + foo::foo::long_use_chain2::HostWithStore
-                + foo::foo::long_use_chain3::HostWithStore
-                + foo::foo::long_use_chain4::HostWithStore
-                + foo::foo::transitive_interface_with_resource::HostWithStore
-                + TheWorldImportsWithStore + Send,
+            D: foo::foo::resources::HostWithStore<T>
+                + foo::foo::long_use_chain1::HostWithStore<T>
+                + foo::foo::long_use_chain2::HostWithStore<T>
+                + foo::foo::long_use_chain3::HostWithStore<T>
+                + foo::foo::long_use_chain4::HostWithStore<T>
+                + foo::foo::transitive_interface_with_resource::HostWithStore<T>
+                + TheWorldImportsWithStore<T> + Send,
             for<'a> D::Data<
                 'a,
             >: foo::foo::resources::Host + foo::foo::long_use_chain1::Host
@@ -386,22 +393,22 @@ pub mod foo {
             #[allow(unused_imports)]
             use wasmtime::component::__internal::Box;
             pub enum Bar {}
-            pub trait HostBarWithStore: wasmtime::component::HasData + Send {
-                fn drop<T>(
+            pub trait HostBarWithStore<T>: wasmtime::component::HasData + Send {
+                fn drop(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     rep: wasmtime::component::Resource<Bar>,
                 ) -> impl ::core::future::Future<Output = wasmtime::Result<()>> + Send
                 where
                     Self: Sized;
-                fn new<T: Send>(
+                fn new(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<
                     Output = wasmtime::component::Resource<Bar>,
                 > + Send;
-                fn static_a<T: Send>(
+                fn static_a(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = u32> + Send;
-                fn method_a<T: Send>(
+                fn method_a(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     self_: wasmtime::component::Resource<Bar>,
                 ) -> impl ::core::future::Future<Output = u32> + Send;
@@ -464,14 +471,14 @@ pub mod foo {
                 );
             };
             pub enum Fallible {}
-            pub trait HostFallibleWithStore: wasmtime::component::HasData + Send {
-                fn drop<T>(
+            pub trait HostFallibleWithStore<T>: wasmtime::component::HasData + Send {
+                fn drop(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     rep: wasmtime::component::Resource<Fallible>,
                 ) -> impl ::core::future::Future<Output = wasmtime::Result<()>> + Send
                 where
                     Self: Sized;
-                fn new<T: Send>(
+                fn new(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<
                     Output = Result<
@@ -482,90 +489,94 @@ pub mod foo {
             }
             pub trait HostFallible: Send {}
             impl<_T: HostFallible + ?Sized + Send> HostFallible for &mut _T {}
-            pub trait HostWithStore: wasmtime::component::HasData + HostBarWithStore + HostFallibleWithStore + Send {
-                fn bar_own_arg<T: Send>(
+            pub trait HostWithStore<
+                T,
+            >: wasmtime::component::HasData + HostBarWithStore<
+                    T,
+                > + HostFallibleWithStore<T> + Send {
+                fn bar_own_arg(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     x: wasmtime::component::Resource<Bar>,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
-                fn bar_borrow_arg<T: Send>(
+                fn bar_borrow_arg(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     x: wasmtime::component::Resource<Bar>,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
-                fn bar_result<T: Send>(
+                fn bar_result(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<
                     Output = wasmtime::component::Resource<Bar>,
                 > + Send;
-                fn tuple_own_arg<T: Send>(
+                fn tuple_own_arg(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     x: (wasmtime::component::Resource<Bar>, u32),
                 ) -> impl ::core::future::Future<Output = ()> + Send;
-                fn tuple_borrow_arg<T: Send>(
+                fn tuple_borrow_arg(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     x: (wasmtime::component::Resource<Bar>, u32),
                 ) -> impl ::core::future::Future<Output = ()> + Send;
-                fn tuple_result<T: Send>(
+                fn tuple_result(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<
                     Output = (wasmtime::component::Resource<Bar>, u32),
                 > + Send;
-                fn option_own_arg<T: Send>(
+                fn option_own_arg(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     x: Option<wasmtime::component::Resource<Bar>>,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
-                fn option_borrow_arg<T: Send>(
+                fn option_borrow_arg(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     x: Option<wasmtime::component::Resource<Bar>>,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
-                fn option_result<T: Send>(
+                fn option_result(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<
                     Output = Option<wasmtime::component::Resource<Bar>>,
                 > + Send;
-                fn result_own_arg<T: Send>(
+                fn result_own_arg(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     x: Result<wasmtime::component::Resource<Bar>, ()>,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
-                fn result_borrow_arg<T: Send>(
+                fn result_borrow_arg(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     x: Result<wasmtime::component::Resource<Bar>, ()>,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
-                fn result_result<T: Send>(
+                fn result_result(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<
                     Output = Result<wasmtime::component::Resource<Bar>, ()>,
                 > + Send;
-                fn list_own_arg<T: Send>(
+                fn list_own_arg(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     x: wasmtime::component::__internal::Vec<
                         wasmtime::component::Resource<Bar>,
                     >,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
-                fn list_borrow_arg<T: Send>(
+                fn list_borrow_arg(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     x: wasmtime::component::__internal::Vec<
                         wasmtime::component::Resource<Bar>,
                     >,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
-                fn list_result<T: Send>(
+                fn list_result(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<
                     Output = wasmtime::component::__internal::Vec<
                         wasmtime::component::Resource<Bar>,
                     >,
                 > + Send;
-                fn record_own_arg<T: Send>(
+                fn record_own_arg(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     x: NestedOwn,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
-                fn record_borrow_arg<T: Send>(
+                fn record_borrow_arg(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     x: NestedBorrow,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
-                fn record_result<T: Send>(
+                fn record_result(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = NestedOwn> + Send;
-                fn func_with_handle_typedef<T: Send>(
+                fn func_with_handle_typedef(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     x: SomeHandle,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
@@ -577,7 +588,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
@@ -588,7 +599,9 @@ pub mod foo {
                         wasmtime::component::__internal::Box::pin(async move {
                             let accessor = &caller.with_getter(host_getter);
                             wasmtime::ToWasmtimeResult::to_wasmtime_result(
-                                HostBarWithStore::drop(
+                                HostBarWithStore::<
+                                    T,
+                                >::drop(
                                         accessor,
                                         wasmtime::component::Resource::new_own(rep),
                                     )
@@ -604,7 +617,9 @@ pub mod foo {
                         wasmtime::component::__internal::Box::pin(async move {
                             let accessor = &caller.with_getter(host_getter);
                             wasmtime::ToWasmtimeResult::to_wasmtime_result(
-                                HostFallibleWithStore::drop(
+                                HostFallibleWithStore::<
+                                    T,
+                                >::drop(
                                         accessor,
                                         wasmtime::component::Resource::new_own(rep),
                                     )
@@ -618,7 +633,7 @@ pub mod foo {
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostBarWithStore>::new(host).await;
+                            let r = <D as HostBarWithStore<T>>::new(host).await;
                             Ok((r,))
                         })
                     },
@@ -628,7 +643,7 @@ pub mod foo {
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostBarWithStore>::static_a(host).await;
+                            let r = <D as HostBarWithStore<T>>::static_a(host).await;
                             Ok((r,))
                         })
                     },
@@ -641,7 +656,8 @@ pub mod foo {
                     {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostBarWithStore>::method_a(host, arg0).await;
+                            let r = <D as HostBarWithStore<T>>::method_a(host, arg0)
+                                .await;
                             Ok((r,))
                         })
                     },
@@ -654,7 +670,8 @@ pub mod foo {
                     {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::bar_own_arg(host, arg0).await;
+                            let r = <D as HostWithStore<T>>::bar_own_arg(host, arg0)
+                                .await;
                             Ok(r)
                         })
                     },
@@ -667,7 +684,7 @@ pub mod foo {
                     {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::bar_borrow_arg(host, arg0)
+                            let r = <D as HostWithStore<T>>::bar_borrow_arg(host, arg0)
                                 .await;
                             Ok(r)
                         })
@@ -678,7 +695,7 @@ pub mod foo {
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::bar_result(host).await;
+                            let r = <D as HostWithStore<T>>::bar_result(host).await;
                             Ok((r,))
                         })
                     },
@@ -691,7 +708,7 @@ pub mod foo {
                     {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::tuple_own_arg(host, arg0)
+                            let r = <D as HostWithStore<T>>::tuple_own_arg(host, arg0)
                                 .await;
                             Ok(r)
                         })
@@ -705,7 +722,7 @@ pub mod foo {
                     {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::tuple_borrow_arg(host, arg0)
+                            let r = <D as HostWithStore<T>>::tuple_borrow_arg(host, arg0)
                                 .await;
                             Ok(r)
                         })
@@ -716,7 +733,7 @@ pub mod foo {
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::tuple_result(host).await;
+                            let r = <D as HostWithStore<T>>::tuple_result(host).await;
                             Ok((r,))
                         })
                     },
@@ -729,7 +746,7 @@ pub mod foo {
                     {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::option_own_arg(host, arg0)
+                            let r = <D as HostWithStore<T>>::option_own_arg(host, arg0)
                                 .await;
                             Ok(r)
                         })
@@ -743,7 +760,9 @@ pub mod foo {
                     {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::option_borrow_arg(host, arg0)
+                            let r = <D as HostWithStore<
+                                T,
+                            >>::option_borrow_arg(host, arg0)
                                 .await;
                             Ok(r)
                         })
@@ -754,7 +773,7 @@ pub mod foo {
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::option_result(host).await;
+                            let r = <D as HostWithStore<T>>::option_result(host).await;
                             Ok((r,))
                         })
                     },
@@ -767,7 +786,7 @@ pub mod foo {
                     {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::result_own_arg(host, arg0)
+                            let r = <D as HostWithStore<T>>::result_own_arg(host, arg0)
                                 .await;
                             Ok(r)
                         })
@@ -781,7 +800,9 @@ pub mod foo {
                     {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::result_borrow_arg(host, arg0)
+                            let r = <D as HostWithStore<
+                                T,
+                            >>::result_borrow_arg(host, arg0)
                                 .await;
                             Ok(r)
                         })
@@ -792,7 +813,7 @@ pub mod foo {
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::result_result(host).await;
+                            let r = <D as HostWithStore<T>>::result_result(host).await;
                             Ok((r,))
                         })
                     },
@@ -811,7 +832,8 @@ pub mod foo {
                     {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::list_own_arg(host, arg0).await;
+                            let r = <D as HostWithStore<T>>::list_own_arg(host, arg0)
+                                .await;
                             Ok(r)
                         })
                     },
@@ -830,7 +852,7 @@ pub mod foo {
                     {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::list_borrow_arg(host, arg0)
+                            let r = <D as HostWithStore<T>>::list_borrow_arg(host, arg0)
                                 .await;
                             Ok(r)
                         })
@@ -841,7 +863,7 @@ pub mod foo {
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::list_result(host).await;
+                            let r = <D as HostWithStore<T>>::list_result(host).await;
                             Ok((r,))
                         })
                     },
@@ -854,7 +876,7 @@ pub mod foo {
                     {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::record_own_arg(host, arg0)
+                            let r = <D as HostWithStore<T>>::record_own_arg(host, arg0)
                                 .await;
                             Ok(r)
                         })
@@ -868,7 +890,9 @@ pub mod foo {
                     {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::record_borrow_arg(host, arg0)
+                            let r = <D as HostWithStore<
+                                T,
+                            >>::record_borrow_arg(host, arg0)
                                 .await;
                             Ok(r)
                         })
@@ -879,7 +903,7 @@ pub mod foo {
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::record_result(host).await;
+                            let r = <D as HostWithStore<T>>::record_result(host).await;
                             Ok((r,))
                         })
                     },
@@ -892,10 +916,9 @@ pub mod foo {
                     {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::func_with_handle_typedef(
-                                    host,
-                                    arg0,
-                                )
+                            let r = <D as HostWithStore<
+                                T,
+                            >>::func_with_handle_typedef(host, arg0)
                                 .await;
                             Ok(r)
                         })
@@ -906,7 +929,7 @@ pub mod foo {
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostFallibleWithStore>::new(host).await;
+                            let r = <D as HostFallibleWithStore<T>>::new(host).await;
                             Ok((r,))
                         })
                     },
@@ -918,7 +941,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
@@ -931,8 +954,8 @@ pub mod foo {
             #[allow(unused_imports)]
             use wasmtime::component::__internal::Box;
             pub enum A {}
-            pub trait HostAWithStore: wasmtime::component::HasData {
-                fn drop<T>(
+            pub trait HostAWithStore<T>: wasmtime::component::HasData {
+                fn drop(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     rep: wasmtime::component::Resource<A>,
                 ) -> impl ::core::future::Future<Output = wasmtime::Result<()>> + Send
@@ -941,10 +964,12 @@ pub mod foo {
             }
             pub trait HostA {}
             impl<_T: HostA + ?Sized + Send> HostA for &mut _T {}
-            pub trait HostWithStore: wasmtime::component::HasData + HostAWithStore + Send {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<
+                T,
+            >: wasmtime::component::HasData + HostAWithStore<T> + Send {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData + HostAWithStore + Send,
+                H: wasmtime::component::HasData + HostAWithStore<T> + Send,
             {}
             pub trait Host: HostA + Send {}
             impl<_T: Host + ?Sized + Send> Host for &mut _T {}
@@ -953,7 +978,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
@@ -964,7 +989,9 @@ pub mod foo {
                         wasmtime::component::__internal::Box::pin(async move {
                             let accessor = &caller.with_getter(host_getter);
                             wasmtime::ToWasmtimeResult::to_wasmtime_result(
-                                HostAWithStore::drop(
+                                HostAWithStore::<
+                                    T,
+                                >::drop(
                                         accessor,
                                         wasmtime::component::Resource::new_own(rep),
                                     )
@@ -980,7 +1007,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
@@ -993,10 +1020,10 @@ pub mod foo {
             #[allow(unused_imports)]
             use wasmtime::component::__internal::Box;
             pub type A = super::super::super::foo::foo::long_use_chain1::A;
-            pub trait HostWithStore: wasmtime::component::HasData {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<T>: wasmtime::component::HasData {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData,
+                H: wasmtime::component::HasData,
             {}
             pub trait Host {}
             impl<_T: Host + ?Sized> Host for &mut _T {}
@@ -1005,7 +1032,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {
@@ -1016,7 +1043,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {
@@ -1029,10 +1056,10 @@ pub mod foo {
             #[allow(unused_imports)]
             use wasmtime::component::__internal::Box;
             pub type A = super::super::super::foo::foo::long_use_chain2::A;
-            pub trait HostWithStore: wasmtime::component::HasData {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<T>: wasmtime::component::HasData {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData,
+                H: wasmtime::component::HasData,
             {}
             pub trait Host {}
             impl<_T: Host + ?Sized> Host for &mut _T {}
@@ -1041,7 +1068,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {
@@ -1052,7 +1079,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {
@@ -1065,8 +1092,8 @@ pub mod foo {
             #[allow(unused_imports)]
             use wasmtime::component::__internal::Box;
             pub type A = super::super::super::foo::foo::long_use_chain3::A;
-            pub trait HostWithStore: wasmtime::component::HasData + Send {
-                fn foo<T: Send>(
+            pub trait HostWithStore<T>: wasmtime::component::HasData + Send {
+                fn foo(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<
                     Output = wasmtime::component::Resource<A>,
@@ -1079,7 +1106,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
@@ -1088,7 +1115,7 @@ pub mod foo {
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::foo(host).await;
+                            let r = <D as HostWithStore<T>>::foo(host).await;
                             Ok((r,))
                         })
                     },
@@ -1100,7 +1127,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
@@ -1113,8 +1140,8 @@ pub mod foo {
             #[allow(unused_imports)]
             use wasmtime::component::__internal::Box;
             pub enum Foo {}
-            pub trait HostFooWithStore: wasmtime::component::HasData {
-                fn drop<T>(
+            pub trait HostFooWithStore<T>: wasmtime::component::HasData {
+                fn drop(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     rep: wasmtime::component::Resource<Foo>,
                 ) -> impl ::core::future::Future<Output = wasmtime::Result<()>> + Send
@@ -1123,10 +1150,12 @@ pub mod foo {
             }
             pub trait HostFoo {}
             impl<_T: HostFoo + ?Sized + Send> HostFoo for &mut _T {}
-            pub trait HostWithStore: wasmtime::component::HasData + HostFooWithStore + Send {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<
+                T,
+            >: wasmtime::component::HasData + HostFooWithStore<T> + Send {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData + HostFooWithStore + Send,
+                H: wasmtime::component::HasData + HostFooWithStore<T> + Send,
             {}
             pub trait Host: HostFoo + Send {}
             impl<_T: Host + ?Sized + Send> Host for &mut _T {}
@@ -1135,7 +1164,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
@@ -1146,7 +1175,9 @@ pub mod foo {
                         wasmtime::component::__internal::Box::pin(async move {
                             let accessor = &caller.with_getter(host_getter);
                             wasmtime::ToWasmtimeResult::to_wasmtime_result(
-                                HostFooWithStore::drop(
+                                HostFooWithStore::<
+                                    T,
+                                >::drop(
                                         accessor,
                                         wasmtime::component::Resource::new_own(rep),
                                     )
@@ -1162,7 +1193,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {

--- a/crates/component-macro/tests/expanded/resources-import_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/resources-import_tracing_async.rs
@@ -1,8 +1,8 @@
 pub enum WorldResource {}
-pub trait HostWorldResourceWithStore: wasmtime::component::HasData + Send {}
-impl<_T: ?Sized> HostWorldResourceWithStore for _T
+pub trait HostWorldResourceWithStore<T>: wasmtime::component::HasData + Send {}
+impl<H: ?Sized, T> HostWorldResourceWithStore<T> for H
 where
-    _T: wasmtime::component::HasData + Send,
+    H: wasmtime::component::HasData + Send,
 {}
 pub trait HostWorldResource: Send {
     fn new(
@@ -150,10 +150,12 @@ pub struct TheWorld {
     interface1: exports::foo::foo::uses_resource_transitively::Guest,
     some_world_func2: wasmtime::component::Func,
 }
-pub trait TheWorldImportsWithStore: wasmtime::component::HasData + HostWorldResourceWithStore + Send {}
-impl<_T: ?Sized> TheWorldImportsWithStore for _T
+pub trait TheWorldImportsWithStore<
+    T,
+>: wasmtime::component::HasData + HostWorldResourceWithStore<T> + Send {}
+impl<H: ?Sized, T> TheWorldImportsWithStore<T> for H
 where
-    _T: wasmtime::component::HasData + HostWorldResourceWithStore + Send,
+    H: wasmtime::component::HasData + HostWorldResourceWithStore<T> + Send,
 {}
 pub trait TheWorldImports: HostWorldResource + Send {
     fn some_world_func(
@@ -281,7 +283,7 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: TheWorldImportsWithStore,
+            D: TheWorldImportsWithStore<T>,
             for<'a> D::Data<'a>: TheWorldImports,
             T: 'static + Send,
         {
@@ -411,13 +413,13 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: foo::foo::resources::HostWithStore
-                + foo::foo::long_use_chain1::HostWithStore
-                + foo::foo::long_use_chain2::HostWithStore
-                + foo::foo::long_use_chain3::HostWithStore
-                + foo::foo::long_use_chain4::HostWithStore
-                + foo::foo::transitive_interface_with_resource::HostWithStore
-                + TheWorldImportsWithStore + Send,
+            D: foo::foo::resources::HostWithStore<T>
+                + foo::foo::long_use_chain1::HostWithStore<T>
+                + foo::foo::long_use_chain2::HostWithStore<T>
+                + foo::foo::long_use_chain3::HostWithStore<T>
+                + foo::foo::long_use_chain4::HostWithStore<T>
+                + foo::foo::transitive_interface_with_resource::HostWithStore<T>
+                + TheWorldImportsWithStore<T> + Send,
             for<'a> D::Data<
                 'a,
             >: foo::foo::resources::Host + foo::foo::long_use_chain1::Host
@@ -477,10 +479,10 @@ pub mod foo {
             #[allow(unused_imports)]
             use wasmtime::component::__internal::Box;
             pub enum Bar {}
-            pub trait HostBarWithStore: wasmtime::component::HasData + Send {}
-            impl<_T: ?Sized> HostBarWithStore for _T
+            pub trait HostBarWithStore<T>: wasmtime::component::HasData + Send {}
+            impl<H: ?Sized, T> HostBarWithStore<T> for H
             where
-                _T: wasmtime::component::HasData + Send,
+                H: wasmtime::component::HasData + Send,
             {}
             pub trait HostBar: Send {
                 fn new(
@@ -582,10 +584,10 @@ pub mod foo {
                 );
             };
             pub enum Fallible {}
-            pub trait HostFallibleWithStore: wasmtime::component::HasData + Send {}
-            impl<_T: ?Sized> HostFallibleWithStore for _T
+            pub trait HostFallibleWithStore<T>: wasmtime::component::HasData + Send {}
+            impl<H: ?Sized, T> HostFallibleWithStore<T> for H
             where
-                _T: wasmtime::component::HasData + Send,
+                H: wasmtime::component::HasData + Send,
             {}
             pub trait HostFallible: Send {
                 fn new(
@@ -619,11 +621,15 @@ pub mod foo {
                     HostFallible::drop(*self, rep).await
                 }
             }
-            pub trait HostWithStore: wasmtime::component::HasData + HostBarWithStore + HostFallibleWithStore + Send {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<
+                T,
+            >: wasmtime::component::HasData + HostBarWithStore<
+                    T,
+                > + HostFallibleWithStore<T> + Send {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData + HostBarWithStore
-                    + HostFallibleWithStore + Send,
+                H: wasmtime::component::HasData + HostBarWithStore<T>
+                    + HostFallibleWithStore<T> + Send,
             {}
             pub trait Host: HostBar + HostFallible + Send {
                 fn bar_own_arg(
@@ -844,7 +850,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
@@ -1510,7 +1516,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
@@ -1523,10 +1529,10 @@ pub mod foo {
             #[allow(unused_imports)]
             use wasmtime::component::__internal::Box;
             pub enum A {}
-            pub trait HostAWithStore: wasmtime::component::HasData {}
-            impl<_T: ?Sized> HostAWithStore for _T
+            pub trait HostAWithStore<T>: wasmtime::component::HasData {}
+            impl<H: ?Sized, T> HostAWithStore<T> for H
             where
-                _T: wasmtime::component::HasData,
+                H: wasmtime::component::HasData,
             {}
             pub trait HostA {
                 fn drop(
@@ -1542,10 +1548,12 @@ pub mod foo {
                     HostA::drop(*self, rep).await
                 }
             }
-            pub trait HostWithStore: wasmtime::component::HasData + HostAWithStore + Send {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<
+                T,
+            >: wasmtime::component::HasData + HostAWithStore<T> + Send {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData + HostAWithStore + Send,
+                H: wasmtime::component::HasData + HostAWithStore<T> + Send,
             {}
             pub trait Host: HostA + Send {}
             impl<_T: Host + ?Sized + Send> Host for &mut _T {}
@@ -1554,7 +1562,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
@@ -1580,7 +1588,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
@@ -1593,10 +1601,10 @@ pub mod foo {
             #[allow(unused_imports)]
             use wasmtime::component::__internal::Box;
             pub type A = super::super::super::foo::foo::long_use_chain1::A;
-            pub trait HostWithStore: wasmtime::component::HasData {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<T>: wasmtime::component::HasData {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData,
+                H: wasmtime::component::HasData,
             {}
             pub trait Host {}
             impl<_T: Host + ?Sized> Host for &mut _T {}
@@ -1605,7 +1613,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {
@@ -1616,7 +1624,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {
@@ -1629,10 +1637,10 @@ pub mod foo {
             #[allow(unused_imports)]
             use wasmtime::component::__internal::Box;
             pub type A = super::super::super::foo::foo::long_use_chain2::A;
-            pub trait HostWithStore: wasmtime::component::HasData {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<T>: wasmtime::component::HasData {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData,
+                H: wasmtime::component::HasData,
             {}
             pub trait Host {}
             impl<_T: Host + ?Sized> Host for &mut _T {}
@@ -1641,7 +1649,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {
@@ -1652,7 +1660,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {
@@ -1665,10 +1673,10 @@ pub mod foo {
             #[allow(unused_imports)]
             use wasmtime::component::__internal::Box;
             pub type A = super::super::super::foo::foo::long_use_chain3::A;
-            pub trait HostWithStore: wasmtime::component::HasData + Send {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<T>: wasmtime::component::HasData + Send {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData + Send,
+                H: wasmtime::component::HasData + Send,
             {}
             pub trait Host: Send {
                 fn foo(
@@ -1691,7 +1699,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
@@ -1725,7 +1733,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
@@ -1738,10 +1746,10 @@ pub mod foo {
             #[allow(unused_imports)]
             use wasmtime::component::__internal::Box;
             pub enum Foo {}
-            pub trait HostFooWithStore: wasmtime::component::HasData {}
-            impl<_T: ?Sized> HostFooWithStore for _T
+            pub trait HostFooWithStore<T>: wasmtime::component::HasData {}
+            impl<H: ?Sized, T> HostFooWithStore<T> for H
             where
-                _T: wasmtime::component::HasData,
+                H: wasmtime::component::HasData,
             {}
             pub trait HostFoo {
                 fn drop(
@@ -1757,10 +1765,12 @@ pub mod foo {
                     HostFoo::drop(*self, rep).await
                 }
             }
-            pub trait HostWithStore: wasmtime::component::HasData + HostFooWithStore + Send {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<
+                T,
+            >: wasmtime::component::HasData + HostFooWithStore<T> + Send {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData + HostFooWithStore + Send,
+                H: wasmtime::component::HasData + HostFooWithStore<T> + Send,
             {}
             pub trait Host: HostFoo + Send {}
             impl<_T: Host + ?Sized + Send> Host for &mut _T {}
@@ -1769,7 +1779,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
@@ -1795,7 +1805,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {

--- a/crates/component-macro/tests/expanded/share-types.rs
+++ b/crates/component-macro/tests/expanded/share-types.rs
@@ -171,7 +171,7 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: foo::foo::http_types::HostWithStore + http_fetch::HostWithStore,
+            D: foo::foo::http_types::HostWithStore<T> + http_fetch::HostWithStore<T>,
             for<'a> D::Data<'a>: foo::foo::http_types::Host + http_fetch::Host,
             T: 'static,
         {
@@ -228,10 +228,10 @@ pub mod foo {
                     4 == < Response as wasmtime::component::ComponentType >::ALIGN32
                 );
             };
-            pub trait HostWithStore: wasmtime::component::HasData {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<T>: wasmtime::component::HasData {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData,
+                H: wasmtime::component::HasData,
             {}
             pub trait Host {}
             impl<_T: Host + ?Sized> Host for &mut _T {}
@@ -240,7 +240,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {
@@ -251,7 +251,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {
@@ -275,10 +275,10 @@ pub mod http_fetch {
         assert!(8 == < Response as wasmtime::component::ComponentType >::SIZE32);
         assert!(4 == < Response as wasmtime::component::ComponentType >::ALIGN32);
     };
-    pub trait HostWithStore: wasmtime::component::HasData {}
-    impl<_T: ?Sized> HostWithStore for _T
+    pub trait HostWithStore<T>: wasmtime::component::HasData {}
+    impl<H: ?Sized, T> HostWithStore<T> for H
     where
-        _T: wasmtime::component::HasData,
+        H: wasmtime::component::HasData,
     {}
     pub trait Host {
         fn fetch_request(&mut self, request: Request) -> Response;
@@ -293,7 +293,7 @@ pub mod http_fetch {
         host_getter: fn(&mut T) -> D::Data<'_>,
     ) -> wasmtime::Result<()>
     where
-        D: HostWithStore,
+        D: HostWithStore<T>,
         for<'a> D::Data<'a>: Host,
         T: 'static,
     {
@@ -312,7 +312,7 @@ pub mod http_fetch {
         host_getter: fn(&mut T) -> D::Data<'_>,
     ) -> wasmtime::Result<()>
     where
-        D: HostWithStore,
+        D: HostWithStore<T>,
         for<'a> D::Data<'a>: Host,
         T: 'static,
     {

--- a/crates/component-macro/tests/expanded/share-types_async.rs
+++ b/crates/component-macro/tests/expanded/share-types_async.rs
@@ -171,7 +171,8 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: foo::foo::http_types::HostWithStore + http_fetch::HostWithStore + Send,
+            D: foo::foo::http_types::HostWithStore<T> + http_fetch::HostWithStore<T>
+                + Send,
             for<'a> D::Data<'a>: foo::foo::http_types::Host + http_fetch::Host + Send,
             T: 'static + Send,
         {
@@ -228,10 +229,10 @@ pub mod foo {
                     4 == < Response as wasmtime::component::ComponentType >::ALIGN32
                 );
             };
-            pub trait HostWithStore: wasmtime::component::HasData {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<T>: wasmtime::component::HasData {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData,
+                H: wasmtime::component::HasData,
             {}
             pub trait Host {}
             impl<_T: Host + ?Sized> Host for &mut _T {}
@@ -240,7 +241,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {
@@ -251,7 +252,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {
@@ -275,10 +276,10 @@ pub mod http_fetch {
         assert!(8 == < Response as wasmtime::component::ComponentType >::SIZE32);
         assert!(4 == < Response as wasmtime::component::ComponentType >::ALIGN32);
     };
-    pub trait HostWithStore: wasmtime::component::HasData + Send {}
-    impl<_T: ?Sized> HostWithStore for _T
+    pub trait HostWithStore<T>: wasmtime::component::HasData + Send {}
+    impl<H: ?Sized, T> HostWithStore<T> for H
     where
-        _T: wasmtime::component::HasData + Send,
+        H: wasmtime::component::HasData + Send,
     {}
     pub trait Host: Send {
         fn fetch_request(
@@ -299,7 +300,7 @@ pub mod http_fetch {
         host_getter: fn(&mut T) -> D::Data<'_>,
     ) -> wasmtime::Result<()>
     where
-        D: HostWithStore,
+        D: HostWithStore<T>,
         for<'a> D::Data<'a>: Host,
         T: 'static + Send,
     {
@@ -320,7 +321,7 @@ pub mod http_fetch {
         host_getter: fn(&mut T) -> D::Data<'_>,
     ) -> wasmtime::Result<()>
     where
-        D: HostWithStore,
+        D: HostWithStore<T>,
         for<'a> D::Data<'a>: Host,
         T: 'static + Send,
     {

--- a/crates/component-macro/tests/expanded/share-types_concurrent.rs
+++ b/crates/component-macro/tests/expanded/share-types_concurrent.rs
@@ -171,7 +171,8 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: foo::foo::http_types::HostWithStore + http_fetch::HostWithStore + Send,
+            D: foo::foo::http_types::HostWithStore<T> + http_fetch::HostWithStore<T>
+                + Send,
             for<'a> D::Data<'a>: foo::foo::http_types::Host + http_fetch::Host + Send,
             T: 'static + Send,
         {
@@ -228,10 +229,10 @@ pub mod foo {
                     4 == < Response as wasmtime::component::ComponentType >::ALIGN32
                 );
             };
-            pub trait HostWithStore: wasmtime::component::HasData {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<T>: wasmtime::component::HasData {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData,
+                H: wasmtime::component::HasData,
             {}
             pub trait Host {}
             impl<_T: Host + ?Sized> Host for &mut _T {}
@@ -240,7 +241,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {
@@ -251,7 +252,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {
@@ -275,8 +276,8 @@ pub mod http_fetch {
         assert!(8 == < Response as wasmtime::component::ComponentType >::SIZE32);
         assert!(4 == < Response as wasmtime::component::ComponentType >::ALIGN32);
     };
-    pub trait HostWithStore: wasmtime::component::HasData + Send {
-        fn fetch_request<T: Send>(
+    pub trait HostWithStore<T>: wasmtime::component::HasData + Send {
+        fn fetch_request(
             accessor: &wasmtime::component::Accessor<T, Self>,
             request: Request,
         ) -> impl ::core::future::Future<Output = Response> + Send;
@@ -288,7 +289,7 @@ pub mod http_fetch {
         host_getter: fn(&mut T) -> D::Data<'_>,
     ) -> wasmtime::Result<()>
     where
-        D: HostWithStore,
+        D: HostWithStore<T>,
         for<'a> D::Data<'a>: Host,
         T: 'static + Send,
     {
@@ -297,7 +298,7 @@ pub mod http_fetch {
             move |caller: &wasmtime::component::Accessor<T>, (arg0,): (Request,)| {
                 wasmtime::component::__internal::Box::pin(async move {
                     let host = &caller.with_getter(host_getter);
-                    let r = <D as HostWithStore>::fetch_request(host, arg0).await;
+                    let r = <D as HostWithStore<T>>::fetch_request(host, arg0).await;
                     Ok((r,))
                 })
             },
@@ -309,7 +310,7 @@ pub mod http_fetch {
         host_getter: fn(&mut T) -> D::Data<'_>,
     ) -> wasmtime::Result<()>
     where
-        D: HostWithStore,
+        D: HostWithStore<T>,
         for<'a> D::Data<'a>: Host,
         T: 'static + Send,
     {

--- a/crates/component-macro/tests/expanded/share-types_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/share-types_tracing_async.rs
@@ -171,7 +171,8 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: foo::foo::http_types::HostWithStore + http_fetch::HostWithStore + Send,
+            D: foo::foo::http_types::HostWithStore<T> + http_fetch::HostWithStore<T>
+                + Send,
             for<'a> D::Data<'a>: foo::foo::http_types::Host + http_fetch::Host + Send,
             T: 'static + Send,
         {
@@ -228,10 +229,10 @@ pub mod foo {
                     4 == < Response as wasmtime::component::ComponentType >::ALIGN32
                 );
             };
-            pub trait HostWithStore: wasmtime::component::HasData {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<T>: wasmtime::component::HasData {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData,
+                H: wasmtime::component::HasData,
             {}
             pub trait Host {}
             impl<_T: Host + ?Sized> Host for &mut _T {}
@@ -240,7 +241,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {
@@ -251,7 +252,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {
@@ -275,10 +276,10 @@ pub mod http_fetch {
         assert!(8 == < Response as wasmtime::component::ComponentType >::SIZE32);
         assert!(4 == < Response as wasmtime::component::ComponentType >::ALIGN32);
     };
-    pub trait HostWithStore: wasmtime::component::HasData + Send {}
-    impl<_T: ?Sized> HostWithStore for _T
+    pub trait HostWithStore<T>: wasmtime::component::HasData + Send {}
+    impl<H: ?Sized, T> HostWithStore<T> for H
     where
-        _T: wasmtime::component::HasData + Send,
+        H: wasmtime::component::HasData + Send,
     {}
     pub trait Host: Send {
         fn fetch_request(
@@ -299,7 +300,7 @@ pub mod http_fetch {
         host_getter: fn(&mut T) -> D::Data<'_>,
     ) -> wasmtime::Result<()>
     where
-        D: HostWithStore,
+        D: HostWithStore<T>,
         for<'a> D::Data<'a>: Host,
         T: 'static + Send,
     {
@@ -336,7 +337,7 @@ pub mod http_fetch {
         host_getter: fn(&mut T) -> D::Data<'_>,
     ) -> wasmtime::Result<()>
     where
-        D: HostWithStore,
+        D: HostWithStore<T>,
         for<'a> D::Data<'a>: Host,
         T: 'static + Send,
     {

--- a/crates/component-macro/tests/expanded/simple-functions.rs
+++ b/crates/component-macro/tests/expanded/simple-functions.rs
@@ -173,7 +173,7 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: foo::foo::simple::HostWithStore,
+            D: foo::foo::simple::HostWithStore<T>,
             for<'a> D::Data<'a>: foo::foo::simple::Host,
             T: 'static,
         {
@@ -191,10 +191,10 @@ pub mod foo {
         pub mod simple {
             #[allow(unused_imports)]
             use wasmtime::component::__internal::Box;
-            pub trait HostWithStore: wasmtime::component::HasData {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<T>: wasmtime::component::HasData {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData,
+                H: wasmtime::component::HasData,
             {}
             pub trait Host {
                 fn f1(&mut self) -> ();
@@ -229,7 +229,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {
@@ -294,7 +294,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {

--- a/crates/component-macro/tests/expanded/simple-functions_async.rs
+++ b/crates/component-macro/tests/expanded/simple-functions_async.rs
@@ -173,7 +173,7 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: foo::foo::simple::HostWithStore + Send,
+            D: foo::foo::simple::HostWithStore<T> + Send,
             for<'a> D::Data<'a>: foo::foo::simple::Host + Send,
             T: 'static + Send,
         {
@@ -191,10 +191,10 @@ pub mod foo {
         pub mod simple {
             #[allow(unused_imports)]
             use wasmtime::component::__internal::Box;
-            pub trait HostWithStore: wasmtime::component::HasData + Send {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<T>: wasmtime::component::HasData + Send {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData + Send,
+                H: wasmtime::component::HasData + Send,
             {}
             pub trait Host: Send {
                 fn f1(&mut self) -> impl ::core::future::Future<Output = ()> + Send;
@@ -257,7 +257,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
@@ -334,7 +334,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {

--- a/crates/component-macro/tests/expanded/simple-functions_concurrent.rs
+++ b/crates/component-macro/tests/expanded/simple-functions_concurrent.rs
@@ -173,7 +173,7 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: foo::foo::simple::HostWithStore + Send,
+            D: foo::foo::simple::HostWithStore<T> + Send,
             for<'a> D::Data<'a>: foo::foo::simple::Host + Send,
             T: 'static + Send,
         {
@@ -191,26 +191,26 @@ pub mod foo {
         pub mod simple {
             #[allow(unused_imports)]
             use wasmtime::component::__internal::Box;
-            pub trait HostWithStore: wasmtime::component::HasData + Send {
-                fn f1<T: Send>(
+            pub trait HostWithStore<T>: wasmtime::component::HasData + Send {
+                fn f1(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
-                fn f2<T: Send>(
+                fn f2(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     a: u32,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
-                fn f3<T: Send>(
+                fn f3(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     a: u32,
                     b: u32,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
-                fn f4<T: Send>(
+                fn f4(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = u32> + Send;
-                fn f5<T: Send>(
+                fn f5(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = (u32, u32)> + Send;
-                fn f6<T: Send>(
+                fn f6(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     a: u32,
                     b: u32,
@@ -224,7 +224,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
@@ -233,7 +233,7 @@ pub mod foo {
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::f1(host).await;
+                            let r = <D as HostWithStore<T>>::f1(host).await;
                             Ok(r)
                         })
                     },
@@ -243,7 +243,7 @@ pub mod foo {
                     move |caller: &wasmtime::component::Accessor<T>, (arg0,): (u32,)| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::f2(host, arg0).await;
+                            let r = <D as HostWithStore<T>>::f2(host, arg0).await;
                             Ok(r)
                         })
                     },
@@ -256,7 +256,7 @@ pub mod foo {
                     {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::f3(host, arg0, arg1).await;
+                            let r = <D as HostWithStore<T>>::f3(host, arg0, arg1).await;
                             Ok(r)
                         })
                     },
@@ -266,7 +266,7 @@ pub mod foo {
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::f4(host).await;
+                            let r = <D as HostWithStore<T>>::f4(host).await;
                             Ok((r,))
                         })
                     },
@@ -276,7 +276,7 @@ pub mod foo {
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::f5(host).await;
+                            let r = <D as HostWithStore<T>>::f5(host).await;
                             Ok((r,))
                         })
                     },
@@ -289,7 +289,7 @@ pub mod foo {
                     {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::f6(host, arg0, arg1, arg2)
+                            let r = <D as HostWithStore<T>>::f6(host, arg0, arg1, arg2)
                                 .await;
                             Ok((r,))
                         })
@@ -302,7 +302,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {

--- a/crates/component-macro/tests/expanded/simple-functions_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/simple-functions_tracing_async.rs
@@ -173,7 +173,7 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: foo::foo::simple::HostWithStore + Send,
+            D: foo::foo::simple::HostWithStore<T> + Send,
             for<'a> D::Data<'a>: foo::foo::simple::Host + Send,
             T: 'static + Send,
         {
@@ -191,10 +191,10 @@ pub mod foo {
         pub mod simple {
             #[allow(unused_imports)]
             use wasmtime::component::__internal::Box;
-            pub trait HostWithStore: wasmtime::component::HasData + Send {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<T>: wasmtime::component::HasData + Send {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData + Send,
+                H: wasmtime::component::HasData + Send,
             {}
             pub trait Host: Send {
                 fn f1(&mut self) -> impl ::core::future::Future<Output = ()> + Send;
@@ -257,7 +257,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
@@ -422,7 +422,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {

--- a/crates/component-macro/tests/expanded/simple-lists.rs
+++ b/crates/component-macro/tests/expanded/simple-lists.rs
@@ -173,7 +173,7 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: foo::foo::simple_lists::HostWithStore,
+            D: foo::foo::simple_lists::HostWithStore<T>,
             for<'a> D::Data<'a>: foo::foo::simple_lists::Host,
             T: 'static,
         {
@@ -191,10 +191,10 @@ pub mod foo {
         pub mod simple_lists {
             #[allow(unused_imports)]
             use wasmtime::component::__internal::Box;
-            pub trait HostWithStore: wasmtime::component::HasData {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<T>: wasmtime::component::HasData {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData,
+                H: wasmtime::component::HasData,
             {}
             pub trait Host {
                 fn simple_list1(
@@ -255,7 +255,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {
@@ -319,7 +319,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {

--- a/crates/component-macro/tests/expanded/simple-lists_async.rs
+++ b/crates/component-macro/tests/expanded/simple-lists_async.rs
@@ -173,7 +173,7 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: foo::foo::simple_lists::HostWithStore + Send,
+            D: foo::foo::simple_lists::HostWithStore<T> + Send,
             for<'a> D::Data<'a>: foo::foo::simple_lists::Host + Send,
             T: 'static + Send,
         {
@@ -191,10 +191,10 @@ pub mod foo {
         pub mod simple_lists {
             #[allow(unused_imports)]
             use wasmtime::component::__internal::Box;
-            pub trait HostWithStore: wasmtime::component::HasData + Send {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<T>: wasmtime::component::HasData + Send {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData + Send,
+                H: wasmtime::component::HasData + Send,
             {}
             pub trait Host: Send {
                 fn simple_list1(
@@ -271,7 +271,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
@@ -343,7 +343,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {

--- a/crates/component-macro/tests/expanded/simple-lists_concurrent.rs
+++ b/crates/component-macro/tests/expanded/simple-lists_concurrent.rs
@@ -173,7 +173,7 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: foo::foo::simple_lists::HostWithStore + Send,
+            D: foo::foo::simple_lists::HostWithStore<T> + Send,
             for<'a> D::Data<'a>: foo::foo::simple_lists::Host + Send,
             T: 'static + Send,
         {
@@ -191,17 +191,17 @@ pub mod foo {
         pub mod simple_lists {
             #[allow(unused_imports)]
             use wasmtime::component::__internal::Box;
-            pub trait HostWithStore: wasmtime::component::HasData + Send {
-                fn simple_list1<T: Send>(
+            pub trait HostWithStore<T>: wasmtime::component::HasData + Send {
+                fn simple_list1(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     l: wasmtime::component::__internal::Vec<u32>,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
-                fn simple_list2<T: Send>(
+                fn simple_list2(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<
                     Output = wasmtime::component::__internal::Vec<u32>,
                 > + Send;
-                fn simple_list3<T: Send>(
+                fn simple_list3(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     a: wasmtime::component::__internal::Vec<u32>,
                     b: wasmtime::component::__internal::Vec<u32>,
@@ -211,7 +211,7 @@ pub mod foo {
                         wasmtime::component::__internal::Vec<u32>,
                     ),
                 > + Send;
-                fn simple_list4<T: Send>(
+                fn simple_list4(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     l: wasmtime::component::__internal::Vec<
                         wasmtime::component::__internal::Vec<u32>,
@@ -229,7 +229,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
@@ -241,7 +241,8 @@ pub mod foo {
                     {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::simple_list1(host, arg0).await;
+                            let r = <D as HostWithStore<T>>::simple_list1(host, arg0)
+                                .await;
                             Ok(r)
                         })
                     },
@@ -251,7 +252,7 @@ pub mod foo {
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::simple_list2(host).await;
+                            let r = <D as HostWithStore<T>>::simple_list2(host).await;
                             Ok((r,))
                         })
                     },
@@ -270,7 +271,9 @@ pub mod foo {
                     {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::simple_list3(host, arg0, arg1)
+                            let r = <D as HostWithStore<
+                                T,
+                            >>::simple_list3(host, arg0, arg1)
                                 .await;
                             Ok((r,))
                         })
@@ -290,7 +293,8 @@ pub mod foo {
                     {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::simple_list4(host, arg0).await;
+                            let r = <D as HostWithStore<T>>::simple_list4(host, arg0)
+                                .await;
                             Ok((r,))
                         })
                     },
@@ -302,7 +306,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {

--- a/crates/component-macro/tests/expanded/simple-lists_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/simple-lists_tracing_async.rs
@@ -173,7 +173,7 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: foo::foo::simple_lists::HostWithStore + Send,
+            D: foo::foo::simple_lists::HostWithStore<T> + Send,
             for<'a> D::Data<'a>: foo::foo::simple_lists::Host + Send,
             T: 'static + Send,
         {
@@ -191,10 +191,10 @@ pub mod foo {
         pub mod simple_lists {
             #[allow(unused_imports)]
             use wasmtime::component::__internal::Box;
-            pub trait HostWithStore: wasmtime::component::HasData + Send {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<T>: wasmtime::component::HasData + Send {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData + Send,
+                H: wasmtime::component::HasData + Send,
             {}
             pub trait Host: Send {
                 fn simple_list1(
@@ -271,7 +271,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
@@ -404,7 +404,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {

--- a/crates/component-macro/tests/expanded/simple-wasi.rs
+++ b/crates/component-macro/tests/expanded/simple-wasi.rs
@@ -165,8 +165,8 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: foo::foo::wasi_filesystem::HostWithStore
-                + foo::foo::wall_clock::HostWithStore,
+            D: foo::foo::wasi_filesystem::HostWithStore<T>
+                + foo::foo::wall_clock::HostWithStore<T>,
             for<'a> D::Data<
                 'a,
             >: foo::foo::wasi_filesystem::Host + foo::foo::wall_clock::Host,
@@ -245,10 +245,10 @@ pub mod foo {
                 assert!(1 == < Errno as wasmtime::component::ComponentType >::SIZE32);
                 assert!(1 == < Errno as wasmtime::component::ComponentType >::ALIGN32);
             };
-            pub trait HostWithStore: wasmtime::component::HasData {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<T>: wasmtime::component::HasData {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData,
+                H: wasmtime::component::HasData,
             {}
             pub trait Host {
                 fn create_directory_at(&mut self) -> Result<(), Errno>;
@@ -267,7 +267,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {
@@ -294,7 +294,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {
@@ -325,10 +325,10 @@ pub mod foo {
                     1 == < WallClock as wasmtime::component::ComponentType >::ALIGN32
                 );
             };
-            pub trait HostWithStore: wasmtime::component::HasData {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<T>: wasmtime::component::HasData {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData,
+                H: wasmtime::component::HasData,
             {}
             pub trait Host {}
             impl<_T: Host + ?Sized> Host for &mut _T {}
@@ -337,7 +337,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {
@@ -348,7 +348,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {

--- a/crates/component-macro/tests/expanded/simple-wasi_async.rs
+++ b/crates/component-macro/tests/expanded/simple-wasi_async.rs
@@ -165,8 +165,8 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: foo::foo::wasi_filesystem::HostWithStore
-                + foo::foo::wall_clock::HostWithStore + Send,
+            D: foo::foo::wasi_filesystem::HostWithStore<T>
+                + foo::foo::wall_clock::HostWithStore<T> + Send,
             for<'a> D::Data<
                 'a,
             >: foo::foo::wasi_filesystem::Host + foo::foo::wall_clock::Host + Send,
@@ -245,10 +245,10 @@ pub mod foo {
                 assert!(1 == < Errno as wasmtime::component::ComponentType >::SIZE32);
                 assert!(1 == < Errno as wasmtime::component::ComponentType >::ALIGN32);
             };
-            pub trait HostWithStore: wasmtime::component::HasData + Send {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<T>: wasmtime::component::HasData + Send {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData + Send,
+                H: wasmtime::component::HasData + Send,
             {}
             pub trait Host: Send {
                 fn create_directory_at(
@@ -279,7 +279,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
@@ -310,7 +310,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
@@ -341,10 +341,10 @@ pub mod foo {
                     1 == < WallClock as wasmtime::component::ComponentType >::ALIGN32
                 );
             };
-            pub trait HostWithStore: wasmtime::component::HasData {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<T>: wasmtime::component::HasData {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData,
+                H: wasmtime::component::HasData,
             {}
             pub trait Host {}
             impl<_T: Host + ?Sized> Host for &mut _T {}
@@ -353,7 +353,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {
@@ -364,7 +364,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {

--- a/crates/component-macro/tests/expanded/simple-wasi_concurrent.rs
+++ b/crates/component-macro/tests/expanded/simple-wasi_concurrent.rs
@@ -165,8 +165,8 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: foo::foo::wasi_filesystem::HostWithStore
-                + foo::foo::wall_clock::HostWithStore + Send,
+            D: foo::foo::wasi_filesystem::HostWithStore<T>
+                + foo::foo::wall_clock::HostWithStore<T> + Send,
             for<'a> D::Data<
                 'a,
             >: foo::foo::wasi_filesystem::Host + foo::foo::wall_clock::Host + Send,
@@ -245,11 +245,11 @@ pub mod foo {
                 assert!(1 == < Errno as wasmtime::component::ComponentType >::SIZE32);
                 assert!(1 == < Errno as wasmtime::component::ComponentType >::ALIGN32);
             };
-            pub trait HostWithStore: wasmtime::component::HasData + Send {
-                fn create_directory_at<T: Send>(
+            pub trait HostWithStore<T>: wasmtime::component::HasData + Send {
+                fn create_directory_at(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = Result<(), Errno>> + Send;
-                fn stat<T: Send>(
+                fn stat(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<
                     Output = Result<DescriptorStat, Errno>,
@@ -262,7 +262,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
@@ -271,7 +271,7 @@ pub mod foo {
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::create_directory_at(host)
+                            let r = <D as HostWithStore<T>>::create_directory_at(host)
                                 .await;
                             Ok((r,))
                         })
@@ -282,7 +282,7 @@ pub mod foo {
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::stat(host).await;
+                            let r = <D as HostWithStore<T>>::stat(host).await;
                             Ok((r,))
                         })
                     },
@@ -294,7 +294,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
@@ -325,10 +325,10 @@ pub mod foo {
                     1 == < WallClock as wasmtime::component::ComponentType >::ALIGN32
                 );
             };
-            pub trait HostWithStore: wasmtime::component::HasData {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<T>: wasmtime::component::HasData {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData,
+                H: wasmtime::component::HasData,
             {}
             pub trait Host {}
             impl<_T: Host + ?Sized> Host for &mut _T {}
@@ -337,7 +337,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {
@@ -348,7 +348,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {

--- a/crates/component-macro/tests/expanded/simple-wasi_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/simple-wasi_tracing_async.rs
@@ -165,8 +165,8 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: foo::foo::wasi_filesystem::HostWithStore
-                + foo::foo::wall_clock::HostWithStore + Send,
+            D: foo::foo::wasi_filesystem::HostWithStore<T>
+                + foo::foo::wall_clock::HostWithStore<T> + Send,
             for<'a> D::Data<
                 'a,
             >: foo::foo::wasi_filesystem::Host + foo::foo::wall_clock::Host + Send,
@@ -245,10 +245,10 @@ pub mod foo {
                 assert!(1 == < Errno as wasmtime::component::ComponentType >::SIZE32);
                 assert!(1 == < Errno as wasmtime::component::ComponentType >::ALIGN32);
             };
-            pub trait HostWithStore: wasmtime::component::HasData + Send {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<T>: wasmtime::component::HasData + Send {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData + Send,
+                H: wasmtime::component::HasData + Send,
             {}
             pub trait Host: Send {
                 fn create_directory_at(
@@ -279,7 +279,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
@@ -336,7 +336,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
@@ -367,10 +367,10 @@ pub mod foo {
                     1 == < WallClock as wasmtime::component::ComponentType >::ALIGN32
                 );
             };
-            pub trait HostWithStore: wasmtime::component::HasData {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<T>: wasmtime::component::HasData {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData,
+                H: wasmtime::component::HasData,
             {}
             pub trait Host {}
             impl<_T: Host + ?Sized> Host for &mut _T {}
@@ -379,7 +379,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {
@@ -390,7 +390,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {

--- a/crates/component-macro/tests/expanded/small-anonymous.rs
+++ b/crates/component-macro/tests/expanded/small-anonymous.rs
@@ -171,7 +171,7 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: foo::foo::anon::HostWithStore,
+            D: foo::foo::anon::HostWithStore<T>,
             for<'a> D::Data<'a>: foo::foo::anon::Host,
             T: 'static,
         {
@@ -234,10 +234,10 @@ pub mod foo {
                 assert!(1 == < Error as wasmtime::component::ComponentType >::SIZE32);
                 assert!(1 == < Error as wasmtime::component::ComponentType >::ALIGN32);
             };
-            pub trait HostWithStore: wasmtime::component::HasData {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<T>: wasmtime::component::HasData {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData,
+                H: wasmtime::component::HasData,
             {}
             pub trait Host {
                 fn option_test(
@@ -256,7 +256,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {
@@ -275,7 +275,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {

--- a/crates/component-macro/tests/expanded/small-anonymous_async.rs
+++ b/crates/component-macro/tests/expanded/small-anonymous_async.rs
@@ -171,7 +171,7 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: foo::foo::anon::HostWithStore + Send,
+            D: foo::foo::anon::HostWithStore<T> + Send,
             for<'a> D::Data<'a>: foo::foo::anon::Host + Send,
             T: 'static + Send,
         {
@@ -234,10 +234,10 @@ pub mod foo {
                 assert!(1 == < Error as wasmtime::component::ComponentType >::SIZE32);
                 assert!(1 == < Error as wasmtime::component::ComponentType >::ALIGN32);
             };
-            pub trait HostWithStore: wasmtime::component::HasData + Send {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<T>: wasmtime::component::HasData + Send {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData + Send,
+                H: wasmtime::component::HasData + Send,
             {}
             pub trait Host: Send {
                 fn option_test(
@@ -266,7 +266,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
@@ -287,7 +287,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {

--- a/crates/component-macro/tests/expanded/small-anonymous_concurrent.rs
+++ b/crates/component-macro/tests/expanded/small-anonymous_concurrent.rs
@@ -171,7 +171,7 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: foo::foo::anon::HostWithStore + Send,
+            D: foo::foo::anon::HostWithStore<T> + Send,
             for<'a> D::Data<'a>: foo::foo::anon::Host + Send,
             T: 'static + Send,
         {
@@ -234,8 +234,8 @@ pub mod foo {
                 assert!(1 == < Error as wasmtime::component::ComponentType >::SIZE32);
                 assert!(1 == < Error as wasmtime::component::ComponentType >::ALIGN32);
             };
-            pub trait HostWithStore: wasmtime::component::HasData + Send {
-                fn option_test<T: Send>(
+            pub trait HostWithStore<T>: wasmtime::component::HasData + Send {
+                fn option_test(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<
                     Output = Result<
@@ -251,7 +251,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
@@ -260,7 +260,7 @@ pub mod foo {
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::option_test(host).await;
+                            let r = <D as HostWithStore<T>>::option_test(host).await;
                             Ok((r,))
                         })
                     },
@@ -272,7 +272,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {

--- a/crates/component-macro/tests/expanded/small-anonymous_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/small-anonymous_tracing_async.rs
@@ -171,7 +171,7 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: foo::foo::anon::HostWithStore + Send,
+            D: foo::foo::anon::HostWithStore<T> + Send,
             for<'a> D::Data<'a>: foo::foo::anon::Host + Send,
             T: 'static + Send,
         {
@@ -234,10 +234,10 @@ pub mod foo {
                 assert!(1 == < Error as wasmtime::component::ComponentType >::SIZE32);
                 assert!(1 == < Error as wasmtime::component::ComponentType >::ALIGN32);
             };
-            pub trait HostWithStore: wasmtime::component::HasData + Send {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<T>: wasmtime::component::HasData + Send {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData + Send,
+                H: wasmtime::component::HasData + Send,
             {}
             pub trait Host: Send {
                 fn option_test(
@@ -266,7 +266,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
@@ -300,7 +300,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {

--- a/crates/component-macro/tests/expanded/smoke.rs
+++ b/crates/component-macro/tests/expanded/smoke.rs
@@ -165,7 +165,7 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: imports::HostWithStore,
+            D: imports::HostWithStore<T>,
             for<'a> D::Data<'a>: imports::Host,
             T: 'static,
         {
@@ -178,10 +178,10 @@ const _: () = {
 pub mod imports {
     #[allow(unused_imports)]
     use wasmtime::component::__internal::Box;
-    pub trait HostWithStore: wasmtime::component::HasData {}
-    impl<_T: ?Sized> HostWithStore for _T
+    pub trait HostWithStore<T>: wasmtime::component::HasData {}
+    impl<H: ?Sized, T> HostWithStore<T> for H
     where
-        _T: wasmtime::component::HasData,
+        H: wasmtime::component::HasData,
     {}
     pub trait Host {
         fn y(&mut self) -> ();
@@ -196,7 +196,7 @@ pub mod imports {
         host_getter: fn(&mut T) -> D::Data<'_>,
     ) -> wasmtime::Result<()>
     where
-        D: HostWithStore,
+        D: HostWithStore<T>,
         for<'a> D::Data<'a>: Host,
         T: 'static,
     {
@@ -215,7 +215,7 @@ pub mod imports {
         host_getter: fn(&mut T) -> D::Data<'_>,
     ) -> wasmtime::Result<()>
     where
-        D: HostWithStore,
+        D: HostWithStore<T>,
         for<'a> D::Data<'a>: Host,
         T: 'static,
     {

--- a/crates/component-macro/tests/expanded/smoke_async.rs
+++ b/crates/component-macro/tests/expanded/smoke_async.rs
@@ -165,7 +165,7 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: imports::HostWithStore + Send,
+            D: imports::HostWithStore<T> + Send,
             for<'a> D::Data<'a>: imports::Host + Send,
             T: 'static + Send,
         {
@@ -178,10 +178,10 @@ const _: () = {
 pub mod imports {
     #[allow(unused_imports)]
     use wasmtime::component::__internal::Box;
-    pub trait HostWithStore: wasmtime::component::HasData + Send {}
-    impl<_T: ?Sized> HostWithStore for _T
+    pub trait HostWithStore<T>: wasmtime::component::HasData + Send {}
+    impl<H: ?Sized, T> HostWithStore<T> for H
     where
-        _T: wasmtime::component::HasData + Send,
+        H: wasmtime::component::HasData + Send,
     {}
     pub trait Host: Send {
         fn y(&mut self) -> impl ::core::future::Future<Output = ()> + Send;
@@ -196,7 +196,7 @@ pub mod imports {
         host_getter: fn(&mut T) -> D::Data<'_>,
     ) -> wasmtime::Result<()>
     where
-        D: HostWithStore,
+        D: HostWithStore<T>,
         for<'a> D::Data<'a>: Host,
         T: 'static + Send,
     {
@@ -217,7 +217,7 @@ pub mod imports {
         host_getter: fn(&mut T) -> D::Data<'_>,
     ) -> wasmtime::Result<()>
     where
-        D: HostWithStore,
+        D: HostWithStore<T>,
         for<'a> D::Data<'a>: Host,
         T: 'static + Send,
     {

--- a/crates/component-macro/tests/expanded/smoke_concurrent.rs
+++ b/crates/component-macro/tests/expanded/smoke_concurrent.rs
@@ -165,7 +165,7 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: imports::HostWithStore + Send,
+            D: imports::HostWithStore<T> + Send,
             for<'a> D::Data<'a>: imports::Host + Send,
             T: 'static + Send,
         {
@@ -178,8 +178,8 @@ const _: () = {
 pub mod imports {
     #[allow(unused_imports)]
     use wasmtime::component::__internal::Box;
-    pub trait HostWithStore: wasmtime::component::HasData + Send {
-        fn y<T: Send>(
+    pub trait HostWithStore<T>: wasmtime::component::HasData + Send {
+        fn y(
             accessor: &wasmtime::component::Accessor<T, Self>,
         ) -> impl ::core::future::Future<Output = ()> + Send;
     }
@@ -190,7 +190,7 @@ pub mod imports {
         host_getter: fn(&mut T) -> D::Data<'_>,
     ) -> wasmtime::Result<()>
     where
-        D: HostWithStore,
+        D: HostWithStore<T>,
         for<'a> D::Data<'a>: Host,
         T: 'static + Send,
     {
@@ -199,7 +199,7 @@ pub mod imports {
             move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                 wasmtime::component::__internal::Box::pin(async move {
                     let host = &caller.with_getter(host_getter);
-                    let r = <D as HostWithStore>::y(host).await;
+                    let r = <D as HostWithStore<T>>::y(host).await;
                     Ok(r)
                 })
             },
@@ -211,7 +211,7 @@ pub mod imports {
         host_getter: fn(&mut T) -> D::Data<'_>,
     ) -> wasmtime::Result<()>
     where
-        D: HostWithStore,
+        D: HostWithStore<T>,
         for<'a> D::Data<'a>: Host,
         T: 'static + Send,
     {

--- a/crates/component-macro/tests/expanded/smoke_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/smoke_tracing_async.rs
@@ -165,7 +165,7 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: imports::HostWithStore + Send,
+            D: imports::HostWithStore<T> + Send,
             for<'a> D::Data<'a>: imports::Host + Send,
             T: 'static + Send,
         {
@@ -178,10 +178,10 @@ const _: () = {
 pub mod imports {
     #[allow(unused_imports)]
     use wasmtime::component::__internal::Box;
-    pub trait HostWithStore: wasmtime::component::HasData + Send {}
-    impl<_T: ?Sized> HostWithStore for _T
+    pub trait HostWithStore<T>: wasmtime::component::HasData + Send {}
+    impl<H: ?Sized, T> HostWithStore<T> for H
     where
-        _T: wasmtime::component::HasData + Send,
+        H: wasmtime::component::HasData + Send,
     {}
     pub trait Host: Send {
         fn y(&mut self) -> impl ::core::future::Future<Output = ()> + Send;
@@ -196,7 +196,7 @@ pub mod imports {
         host_getter: fn(&mut T) -> D::Data<'_>,
     ) -> wasmtime::Result<()>
     where
-        D: HostWithStore,
+        D: HostWithStore<T>,
         for<'a> D::Data<'a>: Host,
         T: 'static + Send,
     {
@@ -230,7 +230,7 @@ pub mod imports {
         host_getter: fn(&mut T) -> D::Data<'_>,
     ) -> wasmtime::Result<()>
     where
-        D: HostWithStore,
+        D: HostWithStore<T>,
         for<'a> D::Data<'a>: Host,
         T: 'static + Send,
     {

--- a/crates/component-macro/tests/expanded/strings.rs
+++ b/crates/component-macro/tests/expanded/strings.rs
@@ -173,7 +173,7 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: foo::foo::strings::HostWithStore,
+            D: foo::foo::strings::HostWithStore<T>,
             for<'a> D::Data<'a>: foo::foo::strings::Host,
             T: 'static,
         {
@@ -191,10 +191,10 @@ pub mod foo {
         pub mod strings {
             #[allow(unused_imports)]
             use wasmtime::component::__internal::Box;
-            pub trait HostWithStore: wasmtime::component::HasData {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<T>: wasmtime::component::HasData {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData,
+                H: wasmtime::component::HasData,
             {}
             pub trait Host {
                 fn a(&mut self, x: wasmtime::component::__internal::String) -> ();
@@ -225,7 +225,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {
@@ -272,7 +272,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {

--- a/crates/component-macro/tests/expanded/strings_async.rs
+++ b/crates/component-macro/tests/expanded/strings_async.rs
@@ -173,7 +173,7 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: foo::foo::strings::HostWithStore + Send,
+            D: foo::foo::strings::HostWithStore<T> + Send,
             for<'a> D::Data<'a>: foo::foo::strings::Host + Send,
             T: 'static + Send,
         {
@@ -191,10 +191,10 @@ pub mod foo {
         pub mod strings {
             #[allow(unused_imports)]
             use wasmtime::component::__internal::Box;
-            pub trait HostWithStore: wasmtime::component::HasData + Send {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<T>: wasmtime::component::HasData + Send {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData + Send,
+                H: wasmtime::component::HasData + Send,
             {}
             pub trait Host: Send {
                 fn a(
@@ -243,7 +243,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
@@ -296,7 +296,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {

--- a/crates/component-macro/tests/expanded/strings_concurrent.rs
+++ b/crates/component-macro/tests/expanded/strings_concurrent.rs
@@ -173,7 +173,7 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: foo::foo::strings::HostWithStore + Send,
+            D: foo::foo::strings::HostWithStore<T> + Send,
             for<'a> D::Data<'a>: foo::foo::strings::Host + Send,
             T: 'static + Send,
         {
@@ -191,17 +191,17 @@ pub mod foo {
         pub mod strings {
             #[allow(unused_imports)]
             use wasmtime::component::__internal::Box;
-            pub trait HostWithStore: wasmtime::component::HasData + Send {
-                fn a<T: Send>(
+            pub trait HostWithStore<T>: wasmtime::component::HasData + Send {
+                fn a(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     x: wasmtime::component::__internal::String,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
-                fn b<T: Send>(
+                fn b(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<
                     Output = wasmtime::component::__internal::String,
                 > + Send;
-                fn c<T: Send>(
+                fn c(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     a: wasmtime::component::__internal::String,
                     b: wasmtime::component::__internal::String,
@@ -216,7 +216,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
@@ -228,7 +228,7 @@ pub mod foo {
                     {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::a(host, arg0).await;
+                            let r = <D as HostWithStore<T>>::a(host, arg0).await;
                             Ok(r)
                         })
                     },
@@ -238,7 +238,7 @@ pub mod foo {
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::b(host).await;
+                            let r = <D as HostWithStore<T>>::b(host).await;
                             Ok((r,))
                         })
                     },
@@ -257,7 +257,7 @@ pub mod foo {
                     {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::c(host, arg0, arg1).await;
+                            let r = <D as HostWithStore<T>>::c(host, arg0, arg1).await;
                             Ok((r,))
                         })
                     },
@@ -269,7 +269,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {

--- a/crates/component-macro/tests/expanded/strings_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/strings_tracing_async.rs
@@ -173,7 +173,7 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: foo::foo::strings::HostWithStore + Send,
+            D: foo::foo::strings::HostWithStore<T> + Send,
             for<'a> D::Data<'a>: foo::foo::strings::Host + Send,
             T: 'static + Send,
         {
@@ -191,10 +191,10 @@ pub mod foo {
         pub mod strings {
             #[allow(unused_imports)]
             use wasmtime::component::__internal::Box;
-            pub trait HostWithStore: wasmtime::component::HasData + Send {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<T>: wasmtime::component::HasData + Send {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData + Send,
+                H: wasmtime::component::HasData + Send,
             {}
             pub trait Host: Send {
                 fn a(
@@ -243,7 +243,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
@@ -341,7 +341,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {

--- a/crates/component-macro/tests/expanded/unstable-features.rs
+++ b/crates/component-macro/tests/expanded/unstable-features.rs
@@ -79,10 +79,10 @@ impl core::convert::From<&LinkOptions> for foo::foo::the_interface::LinkOptions 
     }
 }
 pub enum Baz {}
-pub trait HostBazWithStore: wasmtime::component::HasData {}
-impl<_T: ?Sized> HostBazWithStore for _T
+pub trait HostBazWithStore<T>: wasmtime::component::HasData {}
+impl<H: ?Sized, T> HostBazWithStore<T> for H
 where
-    _T: wasmtime::component::HasData,
+    H: wasmtime::component::HasData,
 {}
 pub trait HostBaz {
     fn foo(&mut self, self_: wasmtime::component::Resource<Baz>) -> ();
@@ -196,10 +196,12 @@ pub struct TheWorldIndices {}
 /// [`Component`]: wasmtime::component::Component
 /// [`Linker`]: wasmtime::component::Linker
 pub struct TheWorld {}
-pub trait TheWorldImportsWithStore: wasmtime::component::HasData + HostBazWithStore {}
-impl<_T: ?Sized> TheWorldImportsWithStore for _T
+pub trait TheWorldImportsWithStore<
+    T,
+>: wasmtime::component::HasData + HostBazWithStore<T> {}
+impl<H: ?Sized, T> TheWorldImportsWithStore<T> for H
 where
-    _T: wasmtime::component::HasData + HostBazWithStore,
+    H: wasmtime::component::HasData + HostBazWithStore<T>,
 {}
 pub trait TheWorldImports: HostBaz {
     fn foo(&mut self) -> ();
@@ -277,7 +279,7 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: TheWorldImportsWithStore,
+            D: TheWorldImportsWithStore<T>,
             for<'a> D::Data<'a>: TheWorldImports,
             T: 'static,
         {
@@ -330,7 +332,7 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: foo::foo::the_interface::HostWithStore + TheWorldImportsWithStore,
+            D: foo::foo::the_interface::HostWithStore<T> + TheWorldImportsWithStore<T>,
             for<'a> D::Data<'a>: foo::foo::the_interface::Host + TheWorldImports,
             T: 'static,
         {
@@ -393,10 +395,10 @@ pub mod foo {
                 }
             }
             pub enum Bar {}
-            pub trait HostBarWithStore: wasmtime::component::HasData {}
-            impl<_T: ?Sized> HostBarWithStore for _T
+            pub trait HostBarWithStore<T>: wasmtime::component::HasData {}
+            impl<H: ?Sized, T> HostBarWithStore<T> for H
             where
-                _T: wasmtime::component::HasData,
+                H: wasmtime::component::HasData,
             {}
             pub trait HostBar {
                 fn foo(&mut self, self_: wasmtime::component::Resource<Bar>) -> ();
@@ -416,10 +418,12 @@ pub mod foo {
                     HostBar::drop(*self, rep)
                 }
             }
-            pub trait HostWithStore: wasmtime::component::HasData + HostBarWithStore {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<
+                T,
+            >: wasmtime::component::HasData + HostBarWithStore<T> {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData + HostBarWithStore,
+                H: wasmtime::component::HasData + HostBarWithStore<T>,
             {}
             pub trait Host: HostBar {
                 fn foo(&mut self) -> ();
@@ -435,7 +439,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {
@@ -484,7 +488,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {

--- a/crates/component-macro/tests/expanded/unstable-features_async.rs
+++ b/crates/component-macro/tests/expanded/unstable-features_async.rs
@@ -79,10 +79,10 @@ impl core::convert::From<&LinkOptions> for foo::foo::the_interface::LinkOptions 
     }
 }
 pub enum Baz {}
-pub trait HostBazWithStore: wasmtime::component::HasData + Send {}
-impl<_T: ?Sized> HostBazWithStore for _T
+pub trait HostBazWithStore<T>: wasmtime::component::HasData + Send {}
+impl<H: ?Sized, T> HostBazWithStore<T> for H
 where
-    _T: wasmtime::component::HasData + Send,
+    H: wasmtime::component::HasData + Send,
 {}
 pub trait HostBaz: Send {
     fn foo(
@@ -208,10 +208,12 @@ pub struct TheWorldIndices {}
 /// [`Component`]: wasmtime::component::Component
 /// [`Linker`]: wasmtime::component::Linker
 pub struct TheWorld {}
-pub trait TheWorldImportsWithStore: wasmtime::component::HasData + HostBazWithStore + Send {}
-impl<_T: ?Sized> TheWorldImportsWithStore for _T
+pub trait TheWorldImportsWithStore<
+    T,
+>: wasmtime::component::HasData + HostBazWithStore<T> + Send {}
+impl<H: ?Sized, T> TheWorldImportsWithStore<T> for H
 where
-    _T: wasmtime::component::HasData + HostBazWithStore + Send,
+    H: wasmtime::component::HasData + HostBazWithStore<T> + Send,
 {}
 pub trait TheWorldImports: HostBaz + Send {
     fn foo(&mut self) -> impl ::core::future::Future<Output = ()> + Send;
@@ -289,7 +291,7 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: TheWorldImportsWithStore,
+            D: TheWorldImportsWithStore<T>,
             for<'a> D::Data<'a>: TheWorldImports,
             T: 'static + Send,
         {
@@ -351,7 +353,8 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: foo::foo::the_interface::HostWithStore + TheWorldImportsWithStore + Send,
+            D: foo::foo::the_interface::HostWithStore<T> + TheWorldImportsWithStore<T>
+                + Send,
             for<'a> D::Data<'a>: foo::foo::the_interface::Host + TheWorldImports + Send,
             T: 'static + Send,
         {
@@ -414,10 +417,10 @@ pub mod foo {
                 }
             }
             pub enum Bar {}
-            pub trait HostBarWithStore: wasmtime::component::HasData + Send {}
-            impl<_T: ?Sized> HostBarWithStore for _T
+            pub trait HostBarWithStore<T>: wasmtime::component::HasData + Send {}
+            impl<H: ?Sized, T> HostBarWithStore<T> for H
             where
-                _T: wasmtime::component::HasData + Send,
+                H: wasmtime::component::HasData + Send,
             {}
             pub trait HostBar: Send {
                 fn foo(
@@ -443,10 +446,12 @@ pub mod foo {
                     HostBar::drop(*self, rep).await
                 }
             }
-            pub trait HostWithStore: wasmtime::component::HasData + HostBarWithStore + Send {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<
+                T,
+            >: wasmtime::component::HasData + HostBarWithStore<T> + Send {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData + HostBarWithStore + Send,
+                H: wasmtime::component::HasData + HostBarWithStore<T> + Send,
             {}
             pub trait Host: HostBar + Send {
                 fn foo(&mut self) -> impl ::core::future::Future<Output = ()> + Send;
@@ -462,7 +467,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
@@ -520,7 +525,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {

--- a/crates/component-macro/tests/expanded/unstable-features_concurrent.rs
+++ b/crates/component-macro/tests/expanded/unstable-features_concurrent.rs
@@ -79,14 +79,14 @@ impl core::convert::From<&LinkOptions> for foo::foo::the_interface::LinkOptions 
     }
 }
 pub enum Baz {}
-pub trait HostBazWithStore: wasmtime::component::HasData + Send {
-    fn drop<T>(
+pub trait HostBazWithStore<T>: wasmtime::component::HasData + Send {
+    fn drop(
         accessor: &wasmtime::component::Accessor<T, Self>,
         rep: wasmtime::component::Resource<Baz>,
     ) -> impl ::core::future::Future<Output = wasmtime::Result<()>> + Send
     where
         Self: Sized;
-    fn foo<T: Send>(
+    fn foo(
         accessor: &wasmtime::component::Accessor<T, Self>,
         self_: wasmtime::component::Resource<Baz>,
     ) -> impl ::core::future::Future<Output = ()> + Send;
@@ -193,8 +193,10 @@ pub struct TheWorldIndices {}
 /// [`Component`]: wasmtime::component::Component
 /// [`Linker`]: wasmtime::component::Linker
 pub struct TheWorld {}
-pub trait TheWorldImportsWithStore: wasmtime::component::HasData + HostBazWithStore + Send {
-    fn foo<T: Send>(
+pub trait TheWorldImportsWithStore<
+    T,
+>: wasmtime::component::HasData + HostBazWithStore<T> + Send {
+    fn foo(
         accessor: &wasmtime::component::Accessor<T, Self>,
     ) -> impl ::core::future::Future<Output = ()> + Send;
 }
@@ -268,7 +270,7 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: TheWorldImportsWithStore,
+            D: TheWorldImportsWithStore<T>,
             for<'a> D::Data<'a>: TheWorldImports,
             T: 'static + Send,
         {
@@ -283,7 +285,9 @@ const _: () = {
                                 wasmtime::component::__internal::Box::pin(async move {
                                     let accessor = &caller.with_getter(host_getter);
                                     wasmtime::ToWasmtimeResult::to_wasmtime_result(
-                                        HostBazWithStore::drop(
+                                        HostBazWithStore::<
+                                            T,
+                                        >::drop(
                                                 accessor,
                                                 wasmtime::component::Resource::new_own(rep),
                                             )
@@ -300,7 +304,7 @@ const _: () = {
                             move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                                 wasmtime::component::__internal::Box::pin(async move {
                                     let host = &caller.with_getter(host_getter);
-                                    let r = <D as TheWorldImportsWithStore>::foo(host).await;
+                                    let r = <D as TheWorldImportsWithStore<T>>::foo(host).await;
                                     Ok(r)
                                 })
                             },
@@ -316,7 +320,7 @@ const _: () = {
                             {
                                 wasmtime::component::__internal::Box::pin(async move {
                                     let host = &caller.with_getter(host_getter);
-                                    let r = <D as HostBazWithStore>::foo(host, arg0).await;
+                                    let r = <D as HostBazWithStore<T>>::foo(host, arg0).await;
                                     Ok(r)
                                 })
                             },
@@ -331,7 +335,8 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: foo::foo::the_interface::HostWithStore + TheWorldImportsWithStore + Send,
+            D: foo::foo::the_interface::HostWithStore<T> + TheWorldImportsWithStore<T>
+                + Send,
             for<'a> D::Data<'a>: foo::foo::the_interface::Host + TheWorldImports + Send,
             T: 'static + Send,
         {
@@ -394,22 +399,24 @@ pub mod foo {
                 }
             }
             pub enum Bar {}
-            pub trait HostBarWithStore: wasmtime::component::HasData + Send {
-                fn drop<T>(
+            pub trait HostBarWithStore<T>: wasmtime::component::HasData + Send {
+                fn drop(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     rep: wasmtime::component::Resource<Bar>,
                 ) -> impl ::core::future::Future<Output = wasmtime::Result<()>> + Send
                 where
                     Self: Sized;
-                fn foo<T: Send>(
+                fn foo(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     self_: wasmtime::component::Resource<Bar>,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
             }
             pub trait HostBar: Send {}
             impl<_T: HostBar + ?Sized + Send> HostBar for &mut _T {}
-            pub trait HostWithStore: wasmtime::component::HasData + HostBarWithStore + Send {
-                fn foo<T: Send>(
+            pub trait HostWithStore<
+                T,
+            >: wasmtime::component::HasData + HostBarWithStore<T> + Send {
+                fn foo(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
             }
@@ -421,7 +428,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
@@ -434,7 +441,9 @@ pub mod foo {
                                 wasmtime::component::__internal::Box::pin(async move {
                                     let accessor = &caller.with_getter(host_getter);
                                     wasmtime::ToWasmtimeResult::to_wasmtime_result(
-                                        HostBarWithStore::drop(
+                                        HostBarWithStore::<
+                                            T,
+                                        >::drop(
                                                 accessor,
                                                 wasmtime::component::Resource::new_own(rep),
                                             )
@@ -450,7 +459,7 @@ pub mod foo {
                             move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                                 wasmtime::component::__internal::Box::pin(async move {
                                     let host = &caller.with_getter(host_getter);
-                                    let r = <D as HostWithStore>::foo(host).await;
+                                    let r = <D as HostWithStore<T>>::foo(host).await;
                                     Ok(r)
                                 })
                             },
@@ -465,7 +474,7 @@ pub mod foo {
                             {
                                 wasmtime::component::__internal::Box::pin(async move {
                                     let host = &caller.with_getter(host_getter);
-                                    let r = <D as HostBarWithStore>::foo(host, arg0).await;
+                                    let r = <D as HostBarWithStore<T>>::foo(host, arg0).await;
                                     Ok(r)
                                 })
                             },
@@ -480,7 +489,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {

--- a/crates/component-macro/tests/expanded/unstable-features_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/unstable-features_tracing_async.rs
@@ -79,10 +79,10 @@ impl core::convert::From<&LinkOptions> for foo::foo::the_interface::LinkOptions 
     }
 }
 pub enum Baz {}
-pub trait HostBazWithStore: wasmtime::component::HasData + Send {}
-impl<_T: ?Sized> HostBazWithStore for _T
+pub trait HostBazWithStore<T>: wasmtime::component::HasData + Send {}
+impl<H: ?Sized, T> HostBazWithStore<T> for H
 where
-    _T: wasmtime::component::HasData + Send,
+    H: wasmtime::component::HasData + Send,
 {}
 pub trait HostBaz: Send {
     fn foo(
@@ -208,10 +208,12 @@ pub struct TheWorldIndices {}
 /// [`Component`]: wasmtime::component::Component
 /// [`Linker`]: wasmtime::component::Linker
 pub struct TheWorld {}
-pub trait TheWorldImportsWithStore: wasmtime::component::HasData + HostBazWithStore + Send {}
-impl<_T: ?Sized> TheWorldImportsWithStore for _T
+pub trait TheWorldImportsWithStore<
+    T,
+>: wasmtime::component::HasData + HostBazWithStore<T> + Send {}
+impl<H: ?Sized, T> TheWorldImportsWithStore<T> for H
 where
-    _T: wasmtime::component::HasData + HostBazWithStore + Send,
+    H: wasmtime::component::HasData + HostBazWithStore<T> + Send,
 {}
 pub trait TheWorldImports: HostBaz + Send {
     fn foo(&mut self) -> impl ::core::future::Future<Output = ()> + Send;
@@ -289,7 +291,7 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: TheWorldImportsWithStore,
+            D: TheWorldImportsWithStore<T>,
             for<'a> D::Data<'a>: TheWorldImports,
             T: 'static + Send,
         {
@@ -380,7 +382,8 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: foo::foo::the_interface::HostWithStore + TheWorldImportsWithStore + Send,
+            D: foo::foo::the_interface::HostWithStore<T> + TheWorldImportsWithStore<T>
+                + Send,
             for<'a> D::Data<'a>: foo::foo::the_interface::Host + TheWorldImports + Send,
             T: 'static + Send,
         {
@@ -443,10 +446,10 @@ pub mod foo {
                 }
             }
             pub enum Bar {}
-            pub trait HostBarWithStore: wasmtime::component::HasData + Send {}
-            impl<_T: ?Sized> HostBarWithStore for _T
+            pub trait HostBarWithStore<T>: wasmtime::component::HasData + Send {}
+            impl<H: ?Sized, T> HostBarWithStore<T> for H
             where
-                _T: wasmtime::component::HasData + Send,
+                H: wasmtime::component::HasData + Send,
             {}
             pub trait HostBar: Send {
                 fn foo(
@@ -472,10 +475,12 @@ pub mod foo {
                     HostBar::drop(*self, rep).await
                 }
             }
-            pub trait HostWithStore: wasmtime::component::HasData + HostBarWithStore + Send {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<
+                T,
+            >: wasmtime::component::HasData + HostBarWithStore<T> + Send {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData + HostBarWithStore + Send,
+                H: wasmtime::component::HasData + HostBarWithStore<T> + Send,
             {}
             pub trait Host: HostBar + Send {
                 fn foo(&mut self) -> impl ::core::future::Future<Output = ()> + Send;
@@ -491,7 +496,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
@@ -578,7 +583,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {

--- a/crates/component-macro/tests/expanded/unversioned-foo.rs
+++ b/crates/component-macro/tests/expanded/unversioned-foo.rs
@@ -165,7 +165,7 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: foo::foo::a::HostWithStore,
+            D: foo::foo::a::HostWithStore<T>,
             for<'a> D::Data<'a>: foo::foo::a::Host,
             T: 'static,
         {
@@ -208,10 +208,10 @@ pub mod foo {
                 assert!(12 == < Error as wasmtime::component::ComponentType >::SIZE32);
                 assert!(4 == < Error as wasmtime::component::ComponentType >::ALIGN32);
             };
-            pub trait HostWithStore: wasmtime::component::HasData {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<T>: wasmtime::component::HasData {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData,
+                H: wasmtime::component::HasData,
             {}
             pub trait Host {
                 fn g(&mut self) -> Result<(), Error>;
@@ -226,7 +226,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {
@@ -245,7 +245,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {

--- a/crates/component-macro/tests/expanded/unversioned-foo_async.rs
+++ b/crates/component-macro/tests/expanded/unversioned-foo_async.rs
@@ -165,7 +165,7 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: foo::foo::a::HostWithStore + Send,
+            D: foo::foo::a::HostWithStore<T> + Send,
             for<'a> D::Data<'a>: foo::foo::a::Host + Send,
             T: 'static + Send,
         {
@@ -208,10 +208,10 @@ pub mod foo {
                 assert!(12 == < Error as wasmtime::component::ComponentType >::SIZE32);
                 assert!(4 == < Error as wasmtime::component::ComponentType >::ALIGN32);
             };
-            pub trait HostWithStore: wasmtime::component::HasData + Send {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<T>: wasmtime::component::HasData + Send {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData + Send,
+                H: wasmtime::component::HasData + Send,
             {}
             pub trait Host: Send {
                 fn g(
@@ -230,7 +230,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
@@ -251,7 +251,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {

--- a/crates/component-macro/tests/expanded/unversioned-foo_concurrent.rs
+++ b/crates/component-macro/tests/expanded/unversioned-foo_concurrent.rs
@@ -165,7 +165,7 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: foo::foo::a::HostWithStore + Send,
+            D: foo::foo::a::HostWithStore<T> + Send,
             for<'a> D::Data<'a>: foo::foo::a::Host + Send,
             T: 'static + Send,
         {
@@ -208,8 +208,8 @@ pub mod foo {
                 assert!(12 == < Error as wasmtime::component::ComponentType >::SIZE32);
                 assert!(4 == < Error as wasmtime::component::ComponentType >::ALIGN32);
             };
-            pub trait HostWithStore: wasmtime::component::HasData + Send {
-                fn g<T: Send>(
+            pub trait HostWithStore<T>: wasmtime::component::HasData + Send {
+                fn g(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = Result<(), Error>> + Send;
             }
@@ -220,7 +220,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
@@ -229,7 +229,7 @@ pub mod foo {
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::g(host).await;
+                            let r = <D as HostWithStore<T>>::g(host).await;
                             Ok((r,))
                         })
                     },
@@ -241,7 +241,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {

--- a/crates/component-macro/tests/expanded/unversioned-foo_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/unversioned-foo_tracing_async.rs
@@ -165,7 +165,7 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: foo::foo::a::HostWithStore + Send,
+            D: foo::foo::a::HostWithStore<T> + Send,
             for<'a> D::Data<'a>: foo::foo::a::Host + Send,
             T: 'static + Send,
         {
@@ -208,10 +208,10 @@ pub mod foo {
                 assert!(12 == < Error as wasmtime::component::ComponentType >::SIZE32);
                 assert!(4 == < Error as wasmtime::component::ComponentType >::ALIGN32);
             };
-            pub trait HostWithStore: wasmtime::component::HasData + Send {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<T>: wasmtime::component::HasData + Send {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData + Send,
+                H: wasmtime::component::HasData + Send,
             {}
             pub trait Host: Send {
                 fn g(
@@ -230,7 +230,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
@@ -264,7 +264,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {

--- a/crates/component-macro/tests/expanded/use-paths.rs
+++ b/crates/component-macro/tests/expanded/use-paths.rs
@@ -165,8 +165,8 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: foo::foo::a::HostWithStore + foo::foo::b::HostWithStore
-                + foo::foo::c::HostWithStore + d::HostWithStore,
+            D: foo::foo::a::HostWithStore<T> + foo::foo::b::HostWithStore<T>
+                + foo::foo::c::HostWithStore<T> + d::HostWithStore<T>,
             for<'a> D::Data<
                 'a,
             >: foo::foo::a::Host + foo::foo::b::Host + foo::foo::c::Host + d::Host,
@@ -201,10 +201,10 @@ pub mod foo {
                 assert!(0 == < Foo as wasmtime::component::ComponentType >::SIZE32);
                 assert!(1 == < Foo as wasmtime::component::ComponentType >::ALIGN32);
             };
-            pub trait HostWithStore: wasmtime::component::HasData {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<T>: wasmtime::component::HasData {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData,
+                H: wasmtime::component::HasData,
             {}
             pub trait Host {
                 fn a(&mut self) -> Foo;
@@ -219,7 +219,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {
@@ -238,7 +238,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {
@@ -255,10 +255,10 @@ pub mod foo {
                 assert!(0 == < Foo as wasmtime::component::ComponentType >::SIZE32);
                 assert!(1 == < Foo as wasmtime::component::ComponentType >::ALIGN32);
             };
-            pub trait HostWithStore: wasmtime::component::HasData {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<T>: wasmtime::component::HasData {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData,
+                H: wasmtime::component::HasData,
             {}
             pub trait Host {
                 fn a(&mut self) -> Foo;
@@ -273,7 +273,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {
@@ -292,7 +292,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {
@@ -309,10 +309,10 @@ pub mod foo {
                 assert!(0 == < Foo as wasmtime::component::ComponentType >::SIZE32);
                 assert!(1 == < Foo as wasmtime::component::ComponentType >::ALIGN32);
             };
-            pub trait HostWithStore: wasmtime::component::HasData {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<T>: wasmtime::component::HasData {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData,
+                H: wasmtime::component::HasData,
             {}
             pub trait Host {
                 fn a(&mut self) -> Foo;
@@ -327,7 +327,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {
@@ -346,7 +346,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {
@@ -365,10 +365,10 @@ pub mod d {
         assert!(0 == < Foo as wasmtime::component::ComponentType >::SIZE32);
         assert!(1 == < Foo as wasmtime::component::ComponentType >::ALIGN32);
     };
-    pub trait HostWithStore: wasmtime::component::HasData {}
-    impl<_T: ?Sized> HostWithStore for _T
+    pub trait HostWithStore<T>: wasmtime::component::HasData {}
+    impl<H: ?Sized, T> HostWithStore<T> for H
     where
-        _T: wasmtime::component::HasData,
+        H: wasmtime::component::HasData,
     {}
     pub trait Host {
         fn b(&mut self) -> Foo;
@@ -383,7 +383,7 @@ pub mod d {
         host_getter: fn(&mut T) -> D::Data<'_>,
     ) -> wasmtime::Result<()>
     where
-        D: HostWithStore,
+        D: HostWithStore<T>,
         for<'a> D::Data<'a>: Host,
         T: 'static,
     {
@@ -402,7 +402,7 @@ pub mod d {
         host_getter: fn(&mut T) -> D::Data<'_>,
     ) -> wasmtime::Result<()>
     where
-        D: HostWithStore,
+        D: HostWithStore<T>,
         for<'a> D::Data<'a>: Host,
         T: 'static,
     {

--- a/crates/component-macro/tests/expanded/use-paths_async.rs
+++ b/crates/component-macro/tests/expanded/use-paths_async.rs
@@ -165,8 +165,8 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: foo::foo::a::HostWithStore + foo::foo::b::HostWithStore
-                + foo::foo::c::HostWithStore + d::HostWithStore + Send,
+            D: foo::foo::a::HostWithStore<T> + foo::foo::b::HostWithStore<T>
+                + foo::foo::c::HostWithStore<T> + d::HostWithStore<T> + Send,
             for<'a> D::Data<
                 'a,
             >: foo::foo::a::Host + foo::foo::b::Host + foo::foo::c::Host + d::Host
@@ -202,10 +202,10 @@ pub mod foo {
                 assert!(0 == < Foo as wasmtime::component::ComponentType >::SIZE32);
                 assert!(1 == < Foo as wasmtime::component::ComponentType >::ALIGN32);
             };
-            pub trait HostWithStore: wasmtime::component::HasData + Send {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<T>: wasmtime::component::HasData + Send {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData + Send,
+                H: wasmtime::component::HasData + Send,
             {}
             pub trait Host: Send {
                 fn a(&mut self) -> impl ::core::future::Future<Output = Foo> + Send;
@@ -220,7 +220,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
@@ -241,7 +241,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
@@ -258,10 +258,10 @@ pub mod foo {
                 assert!(0 == < Foo as wasmtime::component::ComponentType >::SIZE32);
                 assert!(1 == < Foo as wasmtime::component::ComponentType >::ALIGN32);
             };
-            pub trait HostWithStore: wasmtime::component::HasData + Send {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<T>: wasmtime::component::HasData + Send {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData + Send,
+                H: wasmtime::component::HasData + Send,
             {}
             pub trait Host: Send {
                 fn a(&mut self) -> impl ::core::future::Future<Output = Foo> + Send;
@@ -276,7 +276,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
@@ -297,7 +297,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
@@ -314,10 +314,10 @@ pub mod foo {
                 assert!(0 == < Foo as wasmtime::component::ComponentType >::SIZE32);
                 assert!(1 == < Foo as wasmtime::component::ComponentType >::ALIGN32);
             };
-            pub trait HostWithStore: wasmtime::component::HasData + Send {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<T>: wasmtime::component::HasData + Send {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData + Send,
+                H: wasmtime::component::HasData + Send,
             {}
             pub trait Host: Send {
                 fn a(&mut self) -> impl ::core::future::Future<Output = Foo> + Send;
@@ -332,7 +332,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
@@ -353,7 +353,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
@@ -372,10 +372,10 @@ pub mod d {
         assert!(0 == < Foo as wasmtime::component::ComponentType >::SIZE32);
         assert!(1 == < Foo as wasmtime::component::ComponentType >::ALIGN32);
     };
-    pub trait HostWithStore: wasmtime::component::HasData + Send {}
-    impl<_T: ?Sized> HostWithStore for _T
+    pub trait HostWithStore<T>: wasmtime::component::HasData + Send {}
+    impl<H: ?Sized, T> HostWithStore<T> for H
     where
-        _T: wasmtime::component::HasData + Send,
+        H: wasmtime::component::HasData + Send,
     {}
     pub trait Host: Send {
         fn b(&mut self) -> impl ::core::future::Future<Output = Foo> + Send;
@@ -390,7 +390,7 @@ pub mod d {
         host_getter: fn(&mut T) -> D::Data<'_>,
     ) -> wasmtime::Result<()>
     where
-        D: HostWithStore,
+        D: HostWithStore<T>,
         for<'a> D::Data<'a>: Host,
         T: 'static + Send,
     {
@@ -411,7 +411,7 @@ pub mod d {
         host_getter: fn(&mut T) -> D::Data<'_>,
     ) -> wasmtime::Result<()>
     where
-        D: HostWithStore,
+        D: HostWithStore<T>,
         for<'a> D::Data<'a>: Host,
         T: 'static + Send,
     {

--- a/crates/component-macro/tests/expanded/use-paths_concurrent.rs
+++ b/crates/component-macro/tests/expanded/use-paths_concurrent.rs
@@ -165,8 +165,8 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: foo::foo::a::HostWithStore + foo::foo::b::HostWithStore
-                + foo::foo::c::HostWithStore + d::HostWithStore + Send,
+            D: foo::foo::a::HostWithStore<T> + foo::foo::b::HostWithStore<T>
+                + foo::foo::c::HostWithStore<T> + d::HostWithStore<T> + Send,
             for<'a> D::Data<
                 'a,
             >: foo::foo::a::Host + foo::foo::b::Host + foo::foo::c::Host + d::Host
@@ -202,8 +202,8 @@ pub mod foo {
                 assert!(0 == < Foo as wasmtime::component::ComponentType >::SIZE32);
                 assert!(1 == < Foo as wasmtime::component::ComponentType >::ALIGN32);
             };
-            pub trait HostWithStore: wasmtime::component::HasData + Send {
-                fn a<T: Send>(
+            pub trait HostWithStore<T>: wasmtime::component::HasData + Send {
+                fn a(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = Foo> + Send;
             }
@@ -214,7 +214,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
@@ -223,7 +223,7 @@ pub mod foo {
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::a(host).await;
+                            let r = <D as HostWithStore<T>>::a(host).await;
                             Ok((r,))
                         })
                     },
@@ -235,7 +235,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
@@ -252,8 +252,8 @@ pub mod foo {
                 assert!(0 == < Foo as wasmtime::component::ComponentType >::SIZE32);
                 assert!(1 == < Foo as wasmtime::component::ComponentType >::ALIGN32);
             };
-            pub trait HostWithStore: wasmtime::component::HasData + Send {
-                fn a<T: Send>(
+            pub trait HostWithStore<T>: wasmtime::component::HasData + Send {
+                fn a(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = Foo> + Send;
             }
@@ -264,7 +264,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
@@ -273,7 +273,7 @@ pub mod foo {
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::a(host).await;
+                            let r = <D as HostWithStore<T>>::a(host).await;
                             Ok((r,))
                         })
                     },
@@ -285,7 +285,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
@@ -302,8 +302,8 @@ pub mod foo {
                 assert!(0 == < Foo as wasmtime::component::ComponentType >::SIZE32);
                 assert!(1 == < Foo as wasmtime::component::ComponentType >::ALIGN32);
             };
-            pub trait HostWithStore: wasmtime::component::HasData + Send {
-                fn a<T: Send>(
+            pub trait HostWithStore<T>: wasmtime::component::HasData + Send {
+                fn a(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = Foo> + Send;
             }
@@ -314,7 +314,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
@@ -323,7 +323,7 @@ pub mod foo {
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::a(host).await;
+                            let r = <D as HostWithStore<T>>::a(host).await;
                             Ok((r,))
                         })
                     },
@@ -335,7 +335,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
@@ -354,8 +354,8 @@ pub mod d {
         assert!(0 == < Foo as wasmtime::component::ComponentType >::SIZE32);
         assert!(1 == < Foo as wasmtime::component::ComponentType >::ALIGN32);
     };
-    pub trait HostWithStore: wasmtime::component::HasData + Send {
-        fn b<T: Send>(
+    pub trait HostWithStore<T>: wasmtime::component::HasData + Send {
+        fn b(
             accessor: &wasmtime::component::Accessor<T, Self>,
         ) -> impl ::core::future::Future<Output = Foo> + Send;
     }
@@ -366,7 +366,7 @@ pub mod d {
         host_getter: fn(&mut T) -> D::Data<'_>,
     ) -> wasmtime::Result<()>
     where
-        D: HostWithStore,
+        D: HostWithStore<T>,
         for<'a> D::Data<'a>: Host,
         T: 'static + Send,
     {
@@ -375,7 +375,7 @@ pub mod d {
             move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                 wasmtime::component::__internal::Box::pin(async move {
                     let host = &caller.with_getter(host_getter);
-                    let r = <D as HostWithStore>::b(host).await;
+                    let r = <D as HostWithStore<T>>::b(host).await;
                     Ok((r,))
                 })
             },
@@ -387,7 +387,7 @@ pub mod d {
         host_getter: fn(&mut T) -> D::Data<'_>,
     ) -> wasmtime::Result<()>
     where
-        D: HostWithStore,
+        D: HostWithStore<T>,
         for<'a> D::Data<'a>: Host,
         T: 'static + Send,
     {

--- a/crates/component-macro/tests/expanded/use-paths_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/use-paths_tracing_async.rs
@@ -165,8 +165,8 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: foo::foo::a::HostWithStore + foo::foo::b::HostWithStore
-                + foo::foo::c::HostWithStore + d::HostWithStore + Send,
+            D: foo::foo::a::HostWithStore<T> + foo::foo::b::HostWithStore<T>
+                + foo::foo::c::HostWithStore<T> + d::HostWithStore<T> + Send,
             for<'a> D::Data<
                 'a,
             >: foo::foo::a::Host + foo::foo::b::Host + foo::foo::c::Host + d::Host
@@ -202,10 +202,10 @@ pub mod foo {
                 assert!(0 == < Foo as wasmtime::component::ComponentType >::SIZE32);
                 assert!(1 == < Foo as wasmtime::component::ComponentType >::ALIGN32);
             };
-            pub trait HostWithStore: wasmtime::component::HasData + Send {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<T>: wasmtime::component::HasData + Send {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData + Send,
+                H: wasmtime::component::HasData + Send,
             {}
             pub trait Host: Send {
                 fn a(&mut self) -> impl ::core::future::Future<Output = Foo> + Send;
@@ -220,7 +220,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
@@ -254,7 +254,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
@@ -271,10 +271,10 @@ pub mod foo {
                 assert!(0 == < Foo as wasmtime::component::ComponentType >::SIZE32);
                 assert!(1 == < Foo as wasmtime::component::ComponentType >::ALIGN32);
             };
-            pub trait HostWithStore: wasmtime::component::HasData + Send {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<T>: wasmtime::component::HasData + Send {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData + Send,
+                H: wasmtime::component::HasData + Send,
             {}
             pub trait Host: Send {
                 fn a(&mut self) -> impl ::core::future::Future<Output = Foo> + Send;
@@ -289,7 +289,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
@@ -323,7 +323,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
@@ -340,10 +340,10 @@ pub mod foo {
                 assert!(0 == < Foo as wasmtime::component::ComponentType >::SIZE32);
                 assert!(1 == < Foo as wasmtime::component::ComponentType >::ALIGN32);
             };
-            pub trait HostWithStore: wasmtime::component::HasData + Send {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<T>: wasmtime::component::HasData + Send {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData + Send,
+                H: wasmtime::component::HasData + Send,
             {}
             pub trait Host: Send {
                 fn a(&mut self) -> impl ::core::future::Future<Output = Foo> + Send;
@@ -358,7 +358,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
@@ -392,7 +392,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
@@ -411,10 +411,10 @@ pub mod d {
         assert!(0 == < Foo as wasmtime::component::ComponentType >::SIZE32);
         assert!(1 == < Foo as wasmtime::component::ComponentType >::ALIGN32);
     };
-    pub trait HostWithStore: wasmtime::component::HasData + Send {}
-    impl<_T: ?Sized> HostWithStore for _T
+    pub trait HostWithStore<T>: wasmtime::component::HasData + Send {}
+    impl<H: ?Sized, T> HostWithStore<T> for H
     where
-        _T: wasmtime::component::HasData + Send,
+        H: wasmtime::component::HasData + Send,
     {}
     pub trait Host: Send {
         fn b(&mut self) -> impl ::core::future::Future<Output = Foo> + Send;
@@ -429,7 +429,7 @@ pub mod d {
         host_getter: fn(&mut T) -> D::Data<'_>,
     ) -> wasmtime::Result<()>
     where
-        D: HostWithStore,
+        D: HostWithStore<T>,
         for<'a> D::Data<'a>: Host,
         T: 'static + Send,
     {
@@ -463,7 +463,7 @@ pub mod d {
         host_getter: fn(&mut T) -> D::Data<'_>,
     ) -> wasmtime::Result<()>
     where
-        D: HostWithStore,
+        D: HostWithStore<T>,
         for<'a> D::Data<'a>: Host,
         T: 'static + Send,
     {

--- a/crates/component-macro/tests/expanded/variants.rs
+++ b/crates/component-macro/tests/expanded/variants.rs
@@ -173,7 +173,7 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: foo::foo::variants::HostWithStore,
+            D: foo::foo::variants::HostWithStore<T>,
             for<'a> D::Data<'a>: foo::foo::variants::Host,
             T: 'static,
         {
@@ -463,10 +463,10 @@ pub mod foo {
                 assert!(12 == < IsClone as wasmtime::component::ComponentType >::SIZE32);
                 assert!(4 == < IsClone as wasmtime::component::ComponentType >::ALIGN32);
             };
-            pub trait HostWithStore: wasmtime::component::HasData {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<T>: wasmtime::component::HasData {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData,
+                H: wasmtime::component::HasData,
             {}
             pub trait Host {
                 fn e1_arg(&mut self, x: E1) -> ();
@@ -653,7 +653,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {
@@ -893,7 +893,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {

--- a/crates/component-macro/tests/expanded/variants_async.rs
+++ b/crates/component-macro/tests/expanded/variants_async.rs
@@ -173,7 +173,7 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: foo::foo::variants::HostWithStore + Send,
+            D: foo::foo::variants::HostWithStore<T> + Send,
             for<'a> D::Data<'a>: foo::foo::variants::Host + Send,
             T: 'static + Send,
         {
@@ -463,10 +463,10 @@ pub mod foo {
                 assert!(12 == < IsClone as wasmtime::component::ComponentType >::SIZE32);
                 assert!(4 == < IsClone as wasmtime::component::ComponentType >::ALIGN32);
             };
-            pub trait HostWithStore: wasmtime::component::HasData + Send {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<T>: wasmtime::component::HasData + Send {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData + Send,
+                H: wasmtime::component::HasData + Send,
             {}
             pub trait Host: Send {
                 fn e1_arg(
@@ -741,7 +741,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
@@ -1024,7 +1024,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {

--- a/crates/component-macro/tests/expanded/variants_concurrent.rs
+++ b/crates/component-macro/tests/expanded/variants_concurrent.rs
@@ -173,7 +173,7 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: foo::foo::variants::HostWithStore + Send,
+            D: foo::foo::variants::HostWithStore<T> + Send,
             for<'a> D::Data<'a>: foo::foo::variants::Host + Send,
             T: 'static + Send,
         {
@@ -463,29 +463,29 @@ pub mod foo {
                 assert!(12 == < IsClone as wasmtime::component::ComponentType >::SIZE32);
                 assert!(4 == < IsClone as wasmtime::component::ComponentType >::ALIGN32);
             };
-            pub trait HostWithStore: wasmtime::component::HasData + Send {
-                fn e1_arg<T: Send>(
+            pub trait HostWithStore<T>: wasmtime::component::HasData + Send {
+                fn e1_arg(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     x: E1,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
-                fn e1_result<T: Send>(
+                fn e1_result(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = E1> + Send;
-                fn v1_arg<T: Send>(
+                fn v1_arg(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     x: V1,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
-                fn v1_result<T: Send>(
+                fn v1_result(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = V1> + Send;
-                fn bool_arg<T: Send>(
+                fn bool_arg(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     x: bool,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
-                fn bool_result<T: Send>(
+                fn bool_result(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = bool> + Send;
-                fn option_arg<T: Send>(
+                fn option_arg(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     a: Option<bool>,
                     b: Option<()>,
@@ -494,7 +494,7 @@ pub mod foo {
                     e: Option<f32>,
                     g: Option<Option<bool>>,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
-                fn option_result<T: Send>(
+                fn option_result(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<
                     Output = (
@@ -506,7 +506,7 @@ pub mod foo {
                         Option<Option<bool>>,
                     ),
                 > + Send;
-                fn casts<T: Send>(
+                fn casts(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     a: Casts1,
                     b: Casts2,
@@ -517,7 +517,7 @@ pub mod foo {
                 ) -> impl ::core::future::Future<
                     Output = (Casts1, Casts2, Casts3, Casts4, Casts5, Casts6),
                 > + Send;
-                fn result_arg<T: Send>(
+                fn result_arg(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     a: Result<(), ()>,
                     b: Result<(), E1>,
@@ -529,7 +529,7 @@ pub mod foo {
                         wasmtime::component::__internal::Vec<u8>,
                     >,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
-                fn result_result<T: Send>(
+                fn result_result(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<
                     Output = (
@@ -544,36 +544,36 @@ pub mod foo {
                         >,
                     ),
                 > + Send;
-                fn return_result_sugar<T: Send>(
+                fn return_result_sugar(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = Result<i32, MyErrno>> + Send;
-                fn return_result_sugar2<T: Send>(
+                fn return_result_sugar2(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = Result<(), MyErrno>> + Send;
-                fn return_result_sugar3<T: Send>(
+                fn return_result_sugar3(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<
                     Output = Result<MyErrno, MyErrno>,
                 > + Send;
-                fn return_result_sugar4<T: Send>(
+                fn return_result_sugar4(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<
                     Output = Result<(i32, u32), MyErrno>,
                 > + Send;
-                fn return_option_sugar<T: Send>(
+                fn return_option_sugar(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = Option<i32>> + Send;
-                fn return_option_sugar2<T: Send>(
+                fn return_option_sugar2(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = Option<MyErrno>> + Send;
-                fn result_simple<T: Send>(
+                fn result_simple(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = Result<u32, i32>> + Send;
-                fn is_clone_arg<T: Send>(
+                fn is_clone_arg(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     a: IsClone,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
-                fn is_clone_return<T: Send>(
+                fn is_clone_return(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = IsClone> + Send;
             }
@@ -584,7 +584,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
@@ -593,7 +593,7 @@ pub mod foo {
                     move |caller: &wasmtime::component::Accessor<T>, (arg0,): (E1,)| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::e1_arg(host, arg0).await;
+                            let r = <D as HostWithStore<T>>::e1_arg(host, arg0).await;
                             Ok(r)
                         })
                     },
@@ -603,7 +603,7 @@ pub mod foo {
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::e1_result(host).await;
+                            let r = <D as HostWithStore<T>>::e1_result(host).await;
                             Ok((r,))
                         })
                     },
@@ -613,7 +613,7 @@ pub mod foo {
                     move |caller: &wasmtime::component::Accessor<T>, (arg0,): (V1,)| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::v1_arg(host, arg0).await;
+                            let r = <D as HostWithStore<T>>::v1_arg(host, arg0).await;
                             Ok(r)
                         })
                     },
@@ -623,7 +623,7 @@ pub mod foo {
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::v1_result(host).await;
+                            let r = <D as HostWithStore<T>>::v1_result(host).await;
                             Ok((r,))
                         })
                     },
@@ -633,7 +633,7 @@ pub mod foo {
                     move |caller: &wasmtime::component::Accessor<T>, (arg0,): (bool,)| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::bool_arg(host, arg0).await;
+                            let r = <D as HostWithStore<T>>::bool_arg(host, arg0).await;
                             Ok(r)
                         })
                     },
@@ -643,7 +643,7 @@ pub mod foo {
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::bool_result(host).await;
+                            let r = <D as HostWithStore<T>>::bool_result(host).await;
                             Ok((r,))
                         })
                     },
@@ -670,15 +670,9 @@ pub mod foo {
                     {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::option_arg(
-                                    host,
-                                    arg0,
-                                    arg1,
-                                    arg2,
-                                    arg3,
-                                    arg4,
-                                    arg5,
-                                )
+                            let r = <D as HostWithStore<
+                                T,
+                            >>::option_arg(host, arg0, arg1, arg2, arg3, arg4, arg5)
                                 .await;
                             Ok(r)
                         })
@@ -689,7 +683,7 @@ pub mod foo {
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::option_result(host).await;
+                            let r = <D as HostWithStore<T>>::option_result(host).await;
                             Ok((r,))
                         })
                     },
@@ -709,15 +703,9 @@ pub mod foo {
                     {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::casts(
-                                    host,
-                                    arg0,
-                                    arg1,
-                                    arg2,
-                                    arg3,
-                                    arg4,
-                                    arg5,
-                                )
+                            let r = <D as HostWithStore<
+                                T,
+                            >>::casts(host, arg0, arg1, arg2, arg3, arg4, arg5)
                                 .await;
                             Ok((r,))
                         })
@@ -748,15 +736,9 @@ pub mod foo {
                     {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::result_arg(
-                                    host,
-                                    arg0,
-                                    arg1,
-                                    arg2,
-                                    arg3,
-                                    arg4,
-                                    arg5,
-                                )
+                            let r = <D as HostWithStore<
+                                T,
+                            >>::result_arg(host, arg0, arg1, arg2, arg3, arg4, arg5)
                                 .await;
                             Ok(r)
                         })
@@ -767,7 +749,7 @@ pub mod foo {
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::result_result(host).await;
+                            let r = <D as HostWithStore<T>>::result_result(host).await;
                             Ok((r,))
                         })
                     },
@@ -777,7 +759,7 @@ pub mod foo {
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::return_result_sugar(host)
+                            let r = <D as HostWithStore<T>>::return_result_sugar(host)
                                 .await;
                             Ok((r,))
                         })
@@ -788,7 +770,7 @@ pub mod foo {
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::return_result_sugar2(host)
+                            let r = <D as HostWithStore<T>>::return_result_sugar2(host)
                                 .await;
                             Ok((r,))
                         })
@@ -799,7 +781,7 @@ pub mod foo {
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::return_result_sugar3(host)
+                            let r = <D as HostWithStore<T>>::return_result_sugar3(host)
                                 .await;
                             Ok((r,))
                         })
@@ -810,7 +792,7 @@ pub mod foo {
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::return_result_sugar4(host)
+                            let r = <D as HostWithStore<T>>::return_result_sugar4(host)
                                 .await;
                             Ok((r,))
                         })
@@ -821,7 +803,7 @@ pub mod foo {
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::return_option_sugar(host)
+                            let r = <D as HostWithStore<T>>::return_option_sugar(host)
                                 .await;
                             Ok((r,))
                         })
@@ -832,7 +814,7 @@ pub mod foo {
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::return_option_sugar2(host)
+                            let r = <D as HostWithStore<T>>::return_option_sugar2(host)
                                 .await;
                             Ok((r,))
                         })
@@ -843,7 +825,7 @@ pub mod foo {
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::result_simple(host).await;
+                            let r = <D as HostWithStore<T>>::result_simple(host).await;
                             Ok((r,))
                         })
                     },
@@ -856,7 +838,8 @@ pub mod foo {
                     {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::is_clone_arg(host, arg0).await;
+                            let r = <D as HostWithStore<T>>::is_clone_arg(host, arg0)
+                                .await;
                             Ok(r)
                         })
                     },
@@ -866,7 +849,7 @@ pub mod foo {
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let host = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::is_clone_return(host).await;
+                            let r = <D as HostWithStore<T>>::is_clone_return(host).await;
                             Ok((r,))
                         })
                     },
@@ -878,7 +861,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {

--- a/crates/component-macro/tests/expanded/variants_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/variants_tracing_async.rs
@@ -173,7 +173,7 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: foo::foo::variants::HostWithStore + Send,
+            D: foo::foo::variants::HostWithStore<T> + Send,
             for<'a> D::Data<'a>: foo::foo::variants::Host + Send,
             T: 'static + Send,
         {
@@ -463,10 +463,10 @@ pub mod foo {
                 assert!(12 == < IsClone as wasmtime::component::ComponentType >::SIZE32);
                 assert!(4 == < IsClone as wasmtime::component::ComponentType >::ALIGN32);
             };
-            pub trait HostWithStore: wasmtime::component::HasData + Send {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<T>: wasmtime::component::HasData + Send {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData + Send,
+                H: wasmtime::component::HasData + Send,
             {}
             pub trait Host: Send {
                 fn e1_arg(
@@ -741,7 +741,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
@@ -1322,7 +1322,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {

--- a/crates/component-macro/tests/expanded/worlds-with-types.rs
+++ b/crates/component-macro/tests/expanded/worlds-with-types.rs
@@ -212,7 +212,7 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: foo::foo::i::HostWithStore,
+            D: foo::foo::i::HostWithStore<T>,
             for<'a> D::Data<'a>: foo::foo::i::Host,
             T: 'static,
         {
@@ -242,10 +242,10 @@ pub mod foo {
                 assert!(2 == < T as wasmtime::component::ComponentType >::SIZE32);
                 assert!(2 == < T as wasmtime::component::ComponentType >::ALIGN32);
             };
-            pub trait HostWithStore: wasmtime::component::HasData {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<T>: wasmtime::component::HasData {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData,
+                H: wasmtime::component::HasData,
             {}
             pub trait Host {}
             impl<_T: Host + ?Sized> Host for &mut _T {}
@@ -254,7 +254,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {
@@ -265,7 +265,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {

--- a/crates/component-macro/tests/expanded/worlds-with-types_async.rs
+++ b/crates/component-macro/tests/expanded/worlds-with-types_async.rs
@@ -212,7 +212,7 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: foo::foo::i::HostWithStore,
+            D: foo::foo::i::HostWithStore<T>,
             for<'a> D::Data<'a>: foo::foo::i::Host,
             T: 'static + Send,
         {
@@ -245,10 +245,10 @@ pub mod foo {
                 assert!(2 == < T as wasmtime::component::ComponentType >::SIZE32);
                 assert!(2 == < T as wasmtime::component::ComponentType >::ALIGN32);
             };
-            pub trait HostWithStore: wasmtime::component::HasData {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<T>: wasmtime::component::HasData {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData,
+                H: wasmtime::component::HasData,
             {}
             pub trait Host {}
             impl<_T: Host + ?Sized> Host for &mut _T {}
@@ -257,7 +257,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {
@@ -268,7 +268,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {

--- a/crates/component-macro/tests/expanded/worlds-with-types_concurrent.rs
+++ b/crates/component-macro/tests/expanded/worlds-with-types_concurrent.rs
@@ -212,7 +212,7 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: foo::foo::i::HostWithStore,
+            D: foo::foo::i::HostWithStore<T>,
             for<'a> D::Data<'a>: foo::foo::i::Host,
             T: 'static + Send,
         {
@@ -246,10 +246,10 @@ pub mod foo {
                 assert!(2 == < T as wasmtime::component::ComponentType >::SIZE32);
                 assert!(2 == < T as wasmtime::component::ComponentType >::ALIGN32);
             };
-            pub trait HostWithStore: wasmtime::component::HasData {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<T>: wasmtime::component::HasData {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData,
+                H: wasmtime::component::HasData,
             {}
             pub trait Host {}
             impl<_T: Host + ?Sized> Host for &mut _T {}
@@ -258,7 +258,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {
@@ -269,7 +269,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {

--- a/crates/component-macro/tests/expanded/worlds-with-types_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/worlds-with-types_tracing_async.rs
@@ -212,7 +212,7 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: foo::foo::i::HostWithStore,
+            D: foo::foo::i::HostWithStore<T>,
             for<'a> D::Data<'a>: foo::foo::i::Host,
             T: 'static + Send,
         {
@@ -253,10 +253,10 @@ pub mod foo {
                 assert!(2 == < T as wasmtime::component::ComponentType >::SIZE32);
                 assert!(2 == < T as wasmtime::component::ComponentType >::ALIGN32);
             };
-            pub trait HostWithStore: wasmtime::component::HasData {}
-            impl<_T: ?Sized> HostWithStore for _T
+            pub trait HostWithStore<T>: wasmtime::component::HasData {}
+            impl<H: ?Sized, T> HostWithStore<T> for H
             where
-                _T: wasmtime::component::HasData,
+                H: wasmtime::component::HasData,
             {}
             pub trait Host {}
             impl<_T: Host + ?Sized> Host for &mut _T {}
@@ -265,7 +265,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {
@@ -276,7 +276,7 @@ pub mod foo {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: HostWithStore,
+                D: HostWithStore<T>,
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {

--- a/crates/misc/component-async-tests/src/resource_stream.rs
+++ b/crates/misc/component-async-tests/src/resource_stream.rs
@@ -33,8 +33,8 @@ impl bindings::local::local::resource_stream::HostX for Ctx {
     }
 }
 
-impl bindings::local::local::resource_stream::HostWithStore for Ctx {
-    async fn foo<T: 'static>(
+impl<T> bindings::local::local::resource_stream::HostWithStore<T> for Ctx {
+    async fn foo(
         accessor: &Accessor<T, Self>,
         count: u32,
     ) -> wasmtime::Result<StreamReader<Resource<ResourceStreamX>>> {

--- a/crates/misc/component-async-tests/src/round_trip.rs
+++ b/crates/misc/component-async-tests/src/round_trip.rs
@@ -18,8 +18,8 @@ pub mod non_concurrent_export_bindings {
     });
 }
 
-impl bindings::local::local::baz::HostWithStore for Ctx {
-    async fn foo<T>(_: &Accessor<T, Self>, s: String) -> wasmtime::Result<String> {
+impl<T> bindings::local::local::baz::HostWithStore<T> for Ctx {
+    async fn foo(_: &Accessor<T, Self>, s: String) -> wasmtime::Result<String> {
         yield_times(10).await;
         Ok(format!("{s} - entered host - exited host"))
     }

--- a/crates/misc/component-async-tests/src/round_trip_direct.rs
+++ b/crates/misc/component-async-tests/src/round_trip_direct.rs
@@ -9,8 +9,8 @@ pub mod bindings {
     });
 }
 
-impl bindings::RoundTripDirectImportsWithStore for Ctx {
-    async fn foo<T>(_: &Accessor<T, Self>, s: String) -> String {
+impl<T> bindings::RoundTripDirectImportsWithStore<T> for Ctx {
+    async fn foo(_: &Accessor<T, Self>, s: String) -> String {
         yield_times(5).await;
         format!("{s} - entered host - exited host")
     }

--- a/crates/misc/component-async-tests/src/round_trip_many.rs
+++ b/crates/misc/component-async-tests/src/round_trip_many.rs
@@ -22,8 +22,8 @@ pub mod non_concurrent_export_bindings {
 
 use bindings::local::local::many::Stuff;
 
-impl bindings::local::local::many::HostWithStore for Ctx {
-    async fn foo<T>(
+impl<T> bindings::local::local::many::HostWithStore<T> for Ctx {
+    async fn foo(
         _: &Accessor<T, Self>,
         a: String,
         b: u32,

--- a/crates/misc/component-async-tests/src/yield_.rs
+++ b/crates/misc/component-async-tests/src/yield_.rs
@@ -6,8 +6,8 @@ wasmtime::component::bindgen!({
     world: "yield-host",
 });
 
-impl local::local::yield_::HostWithStore for Ctx {
-    async fn yield_times<T>(_: &Accessor<T, Self>, times: u64) {
+impl<T> local::local::yield_::HostWithStore<T> for Ctx {
+    async fn yield_times(_: &Accessor<T, Self>, times: u64) {
         crate::util::yield_times(times.try_into().unwrap()).await;
     }
 }

--- a/crates/misc/component-async-tests/src/yield_runner.rs
+++ b/crates/misc/component-async-tests/src/yield_runner.rs
@@ -58,8 +58,8 @@ impl bindings::local::local::ready::HostThing for Ctx {
     }
 }
 
-impl bindings::local::local::ready::HostThingWithStore for Ctx {
-    async fn when_ready<T>(
+impl<T> bindings::local::local::ready::HostThingWithStore<T> for Ctx {
+    async fn when_ready(
         accessor: &Accessor<T, Self>,
         thing: Resource<Thing>,
     ) -> wasmtime::Result<()> {

--- a/crates/misc/component-async-tests/tests/scenario/round_trip.rs
+++ b/crates/misc/component-async-tests/tests/scenario/round_trip.rs
@@ -267,8 +267,10 @@ async fn test_round_trip_recurse(component: &str, same_instance: bool) -> Result
         type Data<'a> = &'a mut Self;
     }
 
-    impl component_async_tests::round_trip::bindings::local::local::baz::HostWithStore for MyCtx {
-        async fn foo<T: Send>(accessor: &Accessor<T, Self>, s: String) -> wasmtime::Result<String> {
+    impl<T: Send> component_async_tests::round_trip::bindings::local::local::baz::HostWithStore<T>
+        for MyCtx
+    {
+        async fn foo(accessor: &Accessor<T, Self>, s: String) -> wasmtime::Result<String> {
             if let Some(instance) = accessor.with(|mut access| access.get().instance.take()) {
                 run(accessor, &instance).await?;
                 accessor.with(|mut access| access.get().instance = Some(instance));

--- a/crates/wasi-http/src/p3/host/handler.rs
+++ b/crates/wasi-http/src/p3/host/handler.rs
@@ -34,8 +34,8 @@ async fn io_task_result(
     io_result_rx.await.unwrap_or(Ok(()))
 }
 
-impl HostWithStore for WasiHttp {
-    async fn send<T>(
+impl<T> HostWithStore<T> for WasiHttp {
+    async fn send(
         store: &Accessor<T, Self>,
         req: Resource<Request>,
     ) -> HttpResult<Resource<Response>> {

--- a/crates/wasi-http/src/p3/host/types.rs
+++ b/crates/wasi-http/src/p3/host/types.rs
@@ -306,8 +306,8 @@ impl HostFields for WasiHttpCtxView<'_> {
     }
 }
 
-impl HostRequestWithStore for WasiHttp {
-    fn new<T>(
+impl<T> HostRequestWithStore<T> for WasiHttp {
+    fn new(
         mut store: Access<T, Self>,
         headers: Resource<Headers>,
         contents: Option<StreamReader<u8>>,
@@ -354,7 +354,7 @@ impl HostRequestWithStore for WasiHttp {
         ))
     }
 
-    fn consume_body<T>(
+    fn consume_body(
         mut store: Access<T, Self>,
         req: Resource<Request>,
         fut: FutureReader<Result<(), ErrorCode>>,
@@ -371,7 +371,7 @@ impl HostRequestWithStore for WasiHttp {
         body.consume(store, fut, getter)
     }
 
-    fn drop<T>(mut store: Access<'_, T, Self>, req: Resource<Request>) -> wasmtime::Result<()> {
+    fn drop(mut store: Access<'_, T, Self>, req: Resource<Request>) -> wasmtime::Result<()> {
         let Request { body, .. } = store
             .get()
             .table
@@ -589,8 +589,8 @@ impl HostRequestOptions for WasiHttpCtxView<'_> {
     }
 }
 
-impl HostResponseWithStore for WasiHttp {
-    fn new<T>(
+impl<T> HostResponseWithStore<T> for WasiHttp {
+    fn new(
         mut store: Access<T, Self>,
         headers: Resource<Headers>,
         contents: Option<StreamReader<u8>>,
@@ -631,7 +631,7 @@ impl HostResponseWithStore for WasiHttp {
         ))
     }
 
-    fn consume_body<T>(
+    fn consume_body(
         mut store: Access<T, Self>,
         res: Resource<Response>,
         fut: FutureReader<Result<(), ErrorCode>>,
@@ -648,7 +648,7 @@ impl HostResponseWithStore for WasiHttp {
         body.consume(store, fut, getter)
     }
 
-    fn drop<T>(mut store: Access<'_, T, Self>, res: Resource<Response>) -> wasmtime::Result<()> {
+    fn drop(mut store: Access<'_, T, Self>, res: Resource<Response>) -> wasmtime::Result<()> {
         let Response { body, .. } = store
             .get()
             .table

--- a/crates/wasi-tls/src/p3/host.rs
+++ b/crates/wasi-tls/src/p3/host.rs
@@ -47,8 +47,8 @@ impl<'a> bindings::tls::client::HostConnector for WasiTlsCtxView<'a> {
     }
 }
 
-impl bindings::tls::client::HostConnectorWithStore for WasiTls {
-    fn send<T: 'static>(
+impl<T> bindings::tls::client::HostConnectorWithStore<T> for WasiTls {
+    fn send(
         mut store: Access<'_, T, Self>,
         this: Resource<Connector>,
         mut cleartext: StreamReader<u8>,
@@ -110,7 +110,7 @@ impl bindings::tls::client::HostConnectorWithStore for WasiTls {
         ))
     }
 
-    fn receive<T: 'static>(
+    fn receive(
         mut store: Access<'_, T, Self>,
         this: Resource<Connector>,
         mut ciphertext: StreamReader<u8>,
@@ -176,7 +176,7 @@ impl bindings::tls::client::HostConnectorWithStore for WasiTls {
         ))
     }
 
-    async fn connect<T: Send>(
+    async fn connect(
         accessor: &Accessor<T, Self>,
         this: Resource<Connector>,
         server_name: String,

--- a/crates/wasi/src/p3/cli/host.rs
+++ b/crates/wasi/src/p3/cli/host.rs
@@ -191,8 +191,8 @@ impl terminal_stderr::Host for WasiCliCtxView<'_> {
     }
 }
 
-impl stdin::HostWithStore for WasiCli {
-    fn read_via_stream<U>(
+impl<U> stdin::HostWithStore<U> for WasiCli {
+    fn read_via_stream(
         mut store: Access<U, Self>,
     ) -> wasmtime::Result<(StreamReader<u8>, FutureReader<Result<(), ErrorCode>>)> {
         let rx = store.get().ctx.stdin.async_stream();
@@ -216,8 +216,8 @@ impl stdin::HostWithStore for WasiCli {
 
 impl stdin::Host for WasiCliCtxView<'_> {}
 
-impl stdout::HostWithStore for WasiCli {
-    fn write_via_stream<U>(
+impl<U> stdout::HostWithStore<U> for WasiCli {
+    fn write_via_stream(
         mut store: Access<'_, U, Self>,
         data: StreamReader<u8>,
     ) -> wasmtime::Result<FutureReader<Result<(), ErrorCode>>> {
@@ -241,8 +241,8 @@ impl stdout::HostWithStore for WasiCli {
 
 impl stdout::Host for WasiCliCtxView<'_> {}
 
-impl stderr::HostWithStore for WasiCli {
-    fn write_via_stream<U>(
+impl<U> stderr::HostWithStore<U> for WasiCli {
+    fn write_via_stream(
         mut store: Access<'_, U, Self>,
         data: StreamReader<u8>,
     ) -> wasmtime::Result<FutureReader<Result<(), ErrorCode>>> {

--- a/crates/wasi/src/p3/clocks/host.rs
+++ b/crates/wasi/src/p3/clocks/host.rs
@@ -22,8 +22,8 @@ impl system_clock::Host for WasiClocksCtxView<'_> {
     }
 }
 
-impl monotonic_clock::HostWithStore for WasiClocks {
-    async fn wait_until<U>(
+impl<U> monotonic_clock::HostWithStore<U> for WasiClocks {
+    async fn wait_until(
         store: &Accessor<U, Self>,
         when: monotonic_clock::Mark,
     ) -> wasmtime::Result<()> {
@@ -34,7 +34,7 @@ impl monotonic_clock::HostWithStore for WasiClocks {
         Ok(())
     }
 
-    async fn wait_for<U>(
+    async fn wait_for(
         _store: &Accessor<U, Self>,
         duration: types::Duration,
     ) -> wasmtime::Result<()> {

--- a/crates/wasi/src/p3/filesystem/host.rs
+++ b/crates/wasi/src/p3/filesystem/host.rs
@@ -519,8 +519,8 @@ impl types::Host for WasiFilesystemCtxView<'_> {
     }
 }
 
-impl types::HostDescriptorWithStore for WasiFilesystem {
-    fn read_via_stream<U>(
+impl<U> types::HostDescriptorWithStore<U> for WasiFilesystem {
+    fn read_via_stream(
         mut store: Access<U, Self>,
         fd: Resource<Descriptor>,
         offset: Filesize,
@@ -551,7 +551,7 @@ impl types::HostDescriptorWithStore for WasiFilesystem {
         ))
     }
 
-    fn write_via_stream<U>(
+    fn write_via_stream(
         mut store: Access<'_, U, Self>,
         fd: Resource<Descriptor>,
         mut data: StreamReader<u8>,
@@ -579,7 +579,7 @@ impl types::HostDescriptorWithStore for WasiFilesystem {
         FutureReader::new(&mut store, result_rx)
     }
 
-    fn append_via_stream<U>(
+    fn append_via_stream(
         mut store: Access<'_, U, Self>,
         fd: Resource<Descriptor>,
         mut data: StreamReader<u8>,
@@ -603,7 +603,7 @@ impl types::HostDescriptorWithStore for WasiFilesystem {
         FutureReader::new(&mut store, result_rx)
     }
 
-    async fn advise<U>(
+    async fn advise(
         store: &Accessor<U, Self>,
         fd: Resource<Descriptor>,
         offset: Filesize,
@@ -615,7 +615,7 @@ impl types::HostDescriptorWithStore for WasiFilesystem {
         Ok(())
     }
 
-    async fn sync_data<U>(
+    async fn sync_data(
         store: &Accessor<U, Self>,
         fd: Resource<Descriptor>,
     ) -> FilesystemResult<()> {
@@ -624,7 +624,7 @@ impl types::HostDescriptorWithStore for WasiFilesystem {
         Ok(())
     }
 
-    async fn get_flags<U>(
+    async fn get_flags(
         store: &Accessor<U, Self>,
         fd: Resource<Descriptor>,
     ) -> FilesystemResult<DescriptorFlags> {
@@ -633,7 +633,7 @@ impl types::HostDescriptorWithStore for WasiFilesystem {
         Ok(flags.into())
     }
 
-    async fn get_type<U>(
+    async fn get_type(
         store: &Accessor<U, Self>,
         fd: Resource<Descriptor>,
     ) -> FilesystemResult<DescriptorType> {
@@ -642,7 +642,7 @@ impl types::HostDescriptorWithStore for WasiFilesystem {
         Ok(ty.into())
     }
 
-    async fn set_size<U>(
+    async fn set_size(
         store: &Accessor<U, Self>,
         fd: Resource<Descriptor>,
         size: Filesize,
@@ -652,7 +652,7 @@ impl types::HostDescriptorWithStore for WasiFilesystem {
         Ok(())
     }
 
-    async fn set_times<U>(
+    async fn set_times(
         store: &Accessor<U, Self>,
         fd: Resource<Descriptor>,
         data_access_timestamp: NewTimestamp,
@@ -665,7 +665,7 @@ impl types::HostDescriptorWithStore for WasiFilesystem {
         Ok(())
     }
 
-    fn read_directory<U>(
+    fn read_directory(
         mut store: Access<'_, U, Self>,
         fd: Resource<Descriptor>,
     ) -> wasmtime::Result<(
@@ -709,13 +709,13 @@ impl types::HostDescriptorWithStore for WasiFilesystem {
         Ok((stream, FutureReader::new(&mut store, result_rx)?))
     }
 
-    async fn sync<U>(store: &Accessor<U, Self>, fd: Resource<Descriptor>) -> FilesystemResult<()> {
+    async fn sync(store: &Accessor<U, Self>, fd: Resource<Descriptor>) -> FilesystemResult<()> {
         let fd = store.get_descriptor(&fd)?;
         fd.sync().await?;
         Ok(())
     }
 
-    async fn create_directory_at<U>(
+    async fn create_directory_at(
         store: &Accessor<U, Self>,
         fd: Resource<Descriptor>,
         path: String,
@@ -725,7 +725,7 @@ impl types::HostDescriptorWithStore for WasiFilesystem {
         Ok(())
     }
 
-    async fn stat<U>(
+    async fn stat(
         store: &Accessor<U, Self>,
         fd: Resource<Descriptor>,
     ) -> FilesystemResult<DescriptorStat> {
@@ -734,7 +734,7 @@ impl types::HostDescriptorWithStore for WasiFilesystem {
         Ok(stat.into())
     }
 
-    async fn stat_at<U>(
+    async fn stat_at(
         store: &Accessor<U, Self>,
         fd: Resource<Descriptor>,
         path_flags: PathFlags,
@@ -745,7 +745,7 @@ impl types::HostDescriptorWithStore for WasiFilesystem {
         Ok(stat.into())
     }
 
-    async fn set_times_at<U>(
+    async fn set_times_at(
         store: &Accessor<U, Self>,
         fd: Resource<Descriptor>,
         path_flags: PathFlags,
@@ -761,7 +761,7 @@ impl types::HostDescriptorWithStore for WasiFilesystem {
         Ok(())
     }
 
-    async fn link_at<U>(
+    async fn link_at(
         store: &Accessor<U, Self>,
         fd: Resource<Descriptor>,
         old_path_flags: PathFlags,
@@ -776,7 +776,7 @@ impl types::HostDescriptorWithStore for WasiFilesystem {
         Ok(())
     }
 
-    async fn open_at<U>(
+    async fn open_at(
         store: &Accessor<U, Self>,
         fd: Resource<Descriptor>,
         path_flags: PathFlags,
@@ -802,7 +802,7 @@ impl types::HostDescriptorWithStore for WasiFilesystem {
         Ok(fd)
     }
 
-    async fn readlink_at<U>(
+    async fn readlink_at(
         store: &Accessor<U, Self>,
         fd: Resource<Descriptor>,
         path: String,
@@ -812,7 +812,7 @@ impl types::HostDescriptorWithStore for WasiFilesystem {
         Ok(path)
     }
 
-    async fn remove_directory_at<U>(
+    async fn remove_directory_at(
         store: &Accessor<U, Self>,
         fd: Resource<Descriptor>,
         path: String,
@@ -822,7 +822,7 @@ impl types::HostDescriptorWithStore for WasiFilesystem {
         Ok(())
     }
 
-    async fn rename_at<U>(
+    async fn rename_at(
         store: &Accessor<U, Self>,
         fd: Resource<Descriptor>,
         old_path: String,
@@ -834,7 +834,7 @@ impl types::HostDescriptorWithStore for WasiFilesystem {
         Ok(())
     }
 
-    async fn symlink_at<U>(
+    async fn symlink_at(
         store: &Accessor<U, Self>,
         fd: Resource<Descriptor>,
         old_path: String,
@@ -845,7 +845,7 @@ impl types::HostDescriptorWithStore for WasiFilesystem {
         Ok(())
     }
 
-    async fn unlink_file_at<U>(
+    async fn unlink_file_at(
         store: &Accessor<U, Self>,
         fd: Resource<Descriptor>,
         path: String,
@@ -855,7 +855,7 @@ impl types::HostDescriptorWithStore for WasiFilesystem {
         Ok(())
     }
 
-    async fn is_same_object<U>(
+    async fn is_same_object(
         store: &Accessor<U, Self>,
         fd: Resource<Descriptor>,
         other: Resource<Descriptor>,
@@ -869,7 +869,7 @@ impl types::HostDescriptorWithStore for WasiFilesystem {
         fd.is_same_object(&other).await
     }
 
-    async fn metadata_hash<U>(
+    async fn metadata_hash(
         store: &Accessor<U, Self>,
         fd: Resource<Descriptor>,
     ) -> FilesystemResult<MetadataHashValue> {
@@ -878,7 +878,7 @@ impl types::HostDescriptorWithStore for WasiFilesystem {
         Ok(meta.into())
     }
 
-    async fn metadata_hash_at<U>(
+    async fn metadata_hash_at(
         store: &Accessor<U, Self>,
         fd: Resource<Descriptor>,
         path_flags: PathFlags,

--- a/crates/wasi/src/p3/sockets/host/ip_name_lookup.rs
+++ b/crates/wasi/src/p3/sockets/host/ip_name_lookup.rs
@@ -7,8 +7,8 @@ use crate::p3::sockets::WasiSockets;
 use crate::sockets::WasiSocketsCtxView;
 use crate::sockets::util::{from_ipv4_addr, from_ipv6_addr, parse_host};
 
-impl HostWithStore for WasiSockets {
-    async fn resolve_addresses<U>(
+impl<U> HostWithStore<U> for WasiSockets {
+    async fn resolve_addresses(
         store: &Accessor<U, Self>,
         name: String,
     ) -> wasmtime::Result<Result<Vec<types::IpAddress>, ErrorCode>> {

--- a/crates/wasi/src/p3/sockets/host/types/tcp.rs
+++ b/crates/wasi/src/p3/sockets/host/types/tcp.rs
@@ -241,8 +241,8 @@ impl<D> StreamConsumer<D> for SendStreamConsumer {
     }
 }
 
-impl HostTcpSocketWithStore for WasiSockets {
-    async fn connect<T>(
+impl<T> HostTcpSocketWithStore<T> for WasiSockets {
+    async fn connect(
         store: &Accessor<T, Self>,
         socket: Resource<TcpSocket>,
         remote_address: IpSocketAddress,
@@ -267,7 +267,7 @@ impl HostTcpSocketWithStore for WasiSockets {
         })
     }
 
-    fn listen<T: 'static>(
+    fn listen(
         mut store: Access<'_, T, Self>,
         socket: Resource<TcpSocket>,
     ) -> SocketResult<StreamReader<Resource<TcpSocket>>> {
@@ -290,7 +290,7 @@ impl HostTcpSocketWithStore for WasiSockets {
         Ok(ret)
     }
 
-    fn send<T: 'static>(
+    fn send(
         mut store: Access<'_, T, Self>,
         socket: Resource<TcpSocket>,
         mut data: StreamReader<u8>,
@@ -315,7 +315,7 @@ impl HostTcpSocketWithStore for WasiSockets {
         }
     }
 
-    fn receive<T: 'static>(
+    fn receive(
         mut store: Access<T, Self>,
         socket: Resource<TcpSocket>,
     ) -> wasmtime::Result<(StreamReader<u8>, FutureReader<Result<(), ErrorCode>>)> {

--- a/crates/wasi/src/p3/sockets/host/types/udp.rs
+++ b/crates/wasi/src/p3/sockets/host/types/udp.rs
@@ -29,8 +29,8 @@ fn get_socket_mut<'a>(
         .map_err(TrappableError::trap)
 }
 
-impl HostUdpSocketWithStore for WasiSockets {
-    async fn send<T>(
+impl<T> HostUdpSocketWithStore<T> for WasiSockets {
+    async fn send(
         store: &Accessor<T, Self>,
         socket: Resource<UdpSocket>,
         data: Vec<u8>,
@@ -54,7 +54,7 @@ impl HostUdpSocketWithStore for WasiSockets {
         Ok(())
     }
 
-    async fn receive<T>(
+    async fn receive(
         store: &Accessor<T, Self>,
         socket: Resource<UdpSocket>,
     ) -> SocketResult<(Vec<u8>, IpSocketAddress)> {

--- a/crates/wit-bindgen/src/lib.rs
+++ b/crates/wit-bindgen/src/lib.rs
@@ -1485,7 +1485,7 @@ impl Wasmtime {
             // don't necessarily know whether the other bindings generation
             // specified this flag or not. To handle that always assume that a
             // `HostWithStore` bound is needed.
-            with_store.push(format!("{path}::HostWithStore"));
+            with_store.push(format!("{path}::HostWithStore<T>"));
             with_store_async = with_store_async || flags.contains(FunctionFlags::ASYNC);
         }
         if let Some(world_trait) = world_trait {
@@ -1686,7 +1686,7 @@ impl Wasmtime {
                             {wt}::component::__internal::Box::pin(async move {{
                                 let accessor = &caller.with_getter(host_getter);
                                 {wt}::ToWasmtimeResult::to_wasmtime_result(
-                                    Host{camel}WithStore::drop(accessor, {wt}::component::Resource::new_own(rep)).await
+                                    Host{camel}WithStore::<T>::drop(accessor, {wt}::component::Resource::new_own(rep)).await
                                 )
                             }})
                         }},
@@ -1712,7 +1712,7 @@ impl Wasmtime {
             let (first_arg, trait_suffix) = if flags.contains(FunctionFlags::STORE) {
                 (
                     format!("{wt}::component::Access::new(store, host_getter)"),
-                    "WithStore",
+                    "WithStore::<T>",
                 )
             } else {
                 ("&mut host_getter(store.data_mut())".to_string(), "")
@@ -2540,7 +2540,7 @@ impl<'a> InterfaceGenerator<'a> {
                     host_getter: fn(&mut T) -> D::Data<'_>,
                 ) -> {wt}::Result<()>
                     where
-                        D: HostWithStore,
+                        D: HostWithStore<T>,
                         for<'a> D::Data<'a>: {sync_bounds},
                         T: 'static {opt_t_send_bound},
                 {{
@@ -2580,7 +2580,7 @@ pub fn add_to_linker<T, D>(
     host_getter: fn(&mut T) -> D::Data<'_>,
 ) -> {wt}::Result<()>
     where
-        D: HostWithStore,
+        D: HostWithStore<T>,
         for<'a> D::Data<'a>: {sync_bounds},
         T: 'static {opt_t_send_bound},
 {{
@@ -2619,7 +2619,7 @@ pub fn add_to_linker<T, D>(
     host_getter: fn(&mut T) -> D::Data<'_>,
 ) -> {wt}::Result<()>
     where
-        D: HostWithStore,
+        D: HostWithStore<T>,
         for<'a> D::Data<'a>: {sync_bounds},
         T: 'static {opt_t_send_bound},
 {{
@@ -2808,7 +2808,7 @@ pub fn add_to_linker<T, D>(
         if flags.contains(FunctionFlags::STORE) {
             uwrite!(
                 self.src,
-                "let r = <D as {host_trait}WithStore>::{func_name}(host, "
+                "let r = <D as {host_trait}WithStore<T>>::{func_name}(host, "
             );
         } else {
             uwrite!(self.src, "let r = {host_trait}::{func_name}(host, ");
@@ -2897,12 +2897,9 @@ pub fn add_to_linker<T, D>(
         self.push_str("fn ");
         self.push_str(&rust_function_name(func));
         if flags.contains(FunctionFlags::STORE | FunctionFlags::ASYNC) {
-            uwrite!(
-                self.src,
-                "<T: Send>(accessor: &{wt}::component::Accessor<T, Self>, "
-            );
+            uwrite!(self.src, "(accessor: &{wt}::component::Accessor<T, Self>, ");
         } else if flags.contains(FunctionFlags::STORE) {
-            uwrite!(self.src, "<T>(host: {wt}::component::Access<T, Self>, ");
+            uwrite!(self.src, "(host: {wt}::component::Access<T, Self>, ");
         } else {
             self.push_str("(&mut self, ");
         }
@@ -3190,7 +3187,7 @@ pub fn add_to_linker<T, D>(
                 ret.all_func_flags |= *flags;
             }
             ret.all_func_flags |= self.import_resource_drop_flags(name);
-            with_store_supertraits.push(format!("Host{camel}WithStore"));
+            with_store_supertraits.push(format!("Host{camel}WithStore<T>"));
         }
         if ret.all_func_flags.contains(FunctionFlags::ASYNC) {
             with_store_supertraits.push("Send".to_string());
@@ -3199,10 +3196,10 @@ pub fn add_to_linker<T, D>(
 
         uwriteln!(
             self.src,
-            "pub trait {trait_name}WithStore: {} {{",
+            "pub trait {trait_name}WithStore<T>: {} {{",
             with_store_supertraits.join(" + "),
         );
-        ret.with_store_name = Some(format!("{trait_name}WithStore"));
+        ret.with_store_name = Some(format!("{trait_name}WithStore<T>"));
 
         let mut extra_with_store_function = false;
         for extra in extra_functions {
@@ -3218,7 +3215,7 @@ pub fn add_to_linker<T, D>(
                         uwrite!(
                             self.src,
                             "
-fn drop<T>(accessor: &{wt}::component::Accessor<T, Self>, rep: {wt}::component::Resource<{camel}>)
+fn drop(accessor: &{wt}::component::Accessor<T, Self>, rep: {wt}::component::Resource<{camel}>)
     -> impl ::core::future::Future<Output =
 "
                         );
@@ -3228,7 +3225,7 @@ fn drop<T>(accessor: &{wt}::component::Accessor<T, Self>, rep: {wt}::component::
                         uwrite!(
                             self.src,
                             "
-fn drop<T>(accessor: {wt}::component::Access<T, Self>, rep: {wt}::component::Resource<{camel}>)
+fn drop(accessor: {wt}::component::Access<T, Self>, rep: {wt}::component::Resource<{camel}>)
     ->
 "
                         );
@@ -3251,12 +3248,11 @@ fn drop<T>(accessor: {wt}::component::Access<T, Self>, rep: {wt}::component::Res
         // If `*WithStore` is empty, generate a blanket impl for the trait since
         // it's otherwise not necessary to implement it manually.
         if partition.with_store.is_empty() && !extra_with_store_function {
-            uwriteln!(self.src, "impl<_T: ?Sized> {trait_name}WithStore for _T");
             uwriteln!(
                 self.src,
-                " where _T: {}",
-                with_store_supertraits.join(" + ")
+                "impl<H: ?Sized, T> {trait_name}WithStore<T> for H"
             );
+            uwriteln!(self.src, " where H: {}", with_store_supertraits.join(" + "));
 
             uwriteln!(self.src, "{{}}");
         }

--- a/tests/all/component_model/bindgen.rs
+++ b/tests/all/component_model/bindgen.rs
@@ -272,8 +272,8 @@ mod one_import_concurrent {
             type Data<'a> = &'a mut MyImports;
         }
 
-        impl foo::HostWithStore for MyImports {
-            async fn foo<T>(accessor: &Accessor<T, Self>) {
+        impl<T> foo::HostWithStore<T> for MyImports {
+            async fn foo(accessor: &Accessor<T, Self>) {
                 accessor.with(|mut view| view.get().hit = true);
             }
         }


### PR DESCRIPTION
This commit lifts the `<T>` type parameter on all methods of `*WithStore` traits up to the trait level instead of on each method. This is functionally equivalent, more ergonomic, and exposes `T` to be used in `Self` types if so desired.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
