### PR TITLE
Remove direct dependency on `fs-set-times`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5294,7 +5294,6 @@ dependencies = [
  "cap-time-ext",
  "cfg-if",
  "env_logger 0.11.5",
- "fs-set-times",
  "futures",
  "io-extras",
  "io-lifetimes",

--- a/crates/wasi/Cargo.toml
+++ b/crates/wasi/Cargo.toml
@@ -31,7 +31,6 @@ cap-fs-ext = { workspace = true }
 cap-net-ext = { workspace = true }
 cap-time-ext = { workspace = true }
 io-lifetimes = { workspace = true }
-fs-set-times = { workspace = true }
 bitflags = { workspace = true }
 async-trait = { workspace = true }
 futures = { workspace = true }

--- a/crates/wasi/src/filesystem.rs
+++ b/crates/wasi/src/filesystem.rs
@@ -1,9 +1,10 @@
 use crate::clocks::Datetime;
 use crate::runtime::{AbortOnDropJoinHandle, spawn_blocking};
-use cap_fs_ext::{FileTypeExt as _, MetadataExt as _};
-use fs_set_times::SystemTimeSpec;
+use cap_fs_ext::{FileTypeExt as _, MetadataExt as _, SystemTimeSpec};
+use io_lifetimes::AsFilelike;
 use std::collections::hash_map;
 use std::sync::Arc;
+use std::time::SystemTime;
 use tracing::debug;
 use wasmtime::component::{HasData, Resource, ResourceTable};
 use wasmtime::error::Context as _;
@@ -564,23 +565,31 @@ impl Descriptor {
 
     pub(crate) async fn set_times(
         &self,
-        atim: Option<SystemTimeSpec>,
-        mtim: Option<SystemTimeSpec>,
+        atim: Option<SystemTime>,
+        mtim: Option<SystemTime>,
     ) -> Result<(), ErrorCode> {
-        use fs_set_times::SetTimes as _;
+        let mut times = std::fs::FileTimes::new();
+        if let Some(atim) = atim {
+            times = times.set_accessed(atim);
+        }
+        if let Some(mtim) = mtim {
+            times = times.set_modified(mtim);
+        }
         match self {
             Self::File(f) => {
                 if !f.perms.contains(FilePerms::WRITE) {
                     return Err(ErrorCode::NotPermitted);
                 }
-                f.run_blocking(|f| f.set_times(atim, mtim)).await?;
+                f.run_blocking(move |f| f.as_filelike_view::<std::fs::File>().set_times(times))
+                    .await?;
                 Ok(())
             }
             Self::Dir(d) => {
                 if !d.perms.contains(DirPerms::MUTATE) {
                     return Err(ErrorCode::NotPermitted);
                 }
-                d.run_blocking(|d| d.set_times(atim, mtim)).await?;
+                d.run_blocking(move |d| d.as_filelike_view::<std::fs::File>().set_times(times))
+                    .await?;
                 Ok(())
             }
         }
@@ -870,32 +879,22 @@ impl Dir {
         &self,
         path_flags: PathFlags,
         path: String,
-        atim: Option<SystemTimeSpec>,
-        mtim: Option<SystemTimeSpec>,
+        atim: Option<SystemTime>,
+        mtim: Option<SystemTime>,
     ) -> Result<(), ErrorCode> {
         use cap_fs_ext::DirExt as _;
 
         if !self.perms.contains(DirPerms::MUTATE) {
             return Err(ErrorCode::NotPermitted);
         }
+        let atim = atim.map(|t| SystemTimeSpec::Absolute(cap_std::time::SystemTime::from_std(t)));
+        let mtim = mtim.map(|t| SystemTimeSpec::Absolute(cap_std::time::SystemTime::from_std(t)));
         if path_flags.contains(PathFlags::SYMLINK_FOLLOW) {
-            self.run_blocking(move |d| {
-                d.set_times(
-                    &path,
-                    atim.map(cap_fs_ext::SystemTimeSpec::from_std),
-                    mtim.map(cap_fs_ext::SystemTimeSpec::from_std),
-                )
-            })
-            .await?;
+            self.run_blocking(move |d| d.set_times(&path, atim, mtim))
+                .await?;
         } else {
-            self.run_blocking(move |d| {
-                d.set_symlink_times(
-                    &path,
-                    atim.map(cap_fs_ext::SystemTimeSpec::from_std),
-                    mtim.map(cap_fs_ext::SystemTimeSpec::from_std),
-                )
-            })
-            .await?;
+            self.run_blocking(move |d| d.set_symlink_times(&path, atim, mtim))
+                .await?;
         }
         Ok(())
     }

--- a/crates/wasi/src/p2/host/filesystem.rs
+++ b/crates/wasi/src/p2/host/filesystem.rs
@@ -8,6 +8,7 @@ use crate::p2::bindings::filesystem::types::{
 use crate::p2::filesystem::{FileInputStream, FileOutputStream, ReaddirIterator};
 use crate::p2::{FsError, FsResult};
 use crate::{DirPerms, FilePerms};
+use std::time::SystemTime;
 use wasmtime::component::Resource;
 use wasmtime_wasi_io::streams::{DynInputStream, DynOutputStream};
 
@@ -741,16 +742,13 @@ fn systemtime_from(t: wall_clock::Datetime) -> Result<std::time::SystemTime, Err
         .ok_or(ErrorCode::Overflow)
 }
 
-fn systemtimespec_from(
-    t: types::NewTimestamp,
-) -> Result<Option<fs_set_times::SystemTimeSpec>, ErrorCode> {
-    use fs_set_times::SystemTimeSpec;
+fn systemtimespec_from(t: types::NewTimestamp) -> Result<Option<SystemTime>, ErrorCode> {
     match t {
         types::NewTimestamp::NoChange => Ok(None),
-        types::NewTimestamp::Now => Ok(Some(SystemTimeSpec::SymbolicNow)),
+        types::NewTimestamp::Now => Ok(Some(SystemTime::now())),
         types::NewTimestamp::Timestamp(st) => {
             let st = systemtime_from(st)?;
-            Ok(Some(SystemTimeSpec::Absolute(st)))
+            Ok(Some(st))
         }
     }
 }

--- a/crates/wasi/src/p3/filesystem/host.rs
+++ b/crates/wasi/src/p3/filesystem/host.rs
@@ -14,6 +14,7 @@ use core::task::{Context, Poll, ready};
 use core::{iter, mem};
 use std::io;
 use std::sync::Arc;
+use std::time::SystemTime;
 use tokio::sync::{mpsc, oneshot};
 use tokio::task::{JoinHandle, spawn_blocking};
 use wasmtime::StoreContextMut;
@@ -111,15 +112,11 @@ fn systemtime_from(t: system_clock::Instant) -> Result<std::time::SystemTime, Er
     }
 }
 
-fn systemtimespec_from(t: NewTimestamp) -> Result<Option<fs_set_times::SystemTimeSpec>, ErrorCode> {
-    use fs_set_times::SystemTimeSpec;
+fn systemtimespec_from(t: NewTimestamp) -> Result<Option<SystemTime>, ErrorCode> {
     match t {
         NewTimestamp::NoChange => Ok(None),
-        NewTimestamp::Now => Ok(Some(SystemTimeSpec::SymbolicNow)),
-        NewTimestamp::Timestamp(st) => {
-            let st = systemtime_from(st)?;
-            Ok(Some(SystemTimeSpec::Absolute(st)))
-        }
+        NewTimestamp::Now => Ok(Some(SystemTime::now())),
+        NewTimestamp::Timestamp(st) => Ok(Some(systemtime_from(st)?)),
     }
 }
 


### PR DESCRIPTION
Trying to tidy up dependencies...

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
