### PR TITLE
Use the imported alias region for exported memories/tables/globals

### DIFF
--- a/crates/cranelift/src/alias_region_key.rs
+++ b/crates/cranelift/src/alias_region_key.rs
@@ -30,8 +30,9 @@ pub(crate) enum AliasRegionKey {
         offset: u32,
     },
 
-    /// An imported memory access (shared across all imported memories).
-    ImportedMemory,
+    /// An imported or exported memory access (shared across all
+    /// imported/exported memories).
+    PublicMemory,
 
     /// A defined memory access.
     DefinedMemory {
@@ -41,8 +42,9 @@ pub(crate) enum AliasRegionKey {
         index: DefinedMemoryIndex,
     },
 
-    /// An imported table access (shared across all imported tables).
-    ImportedTable,
+    /// An imported or exported table access (shared across all
+    /// imported/exported tables).
+    PublicTable,
 
     /// A defined table access.
     DefinedTable {
@@ -52,8 +54,9 @@ pub(crate) enum AliasRegionKey {
         index: DefinedTableIndex,
     },
 
-    /// An imported global access (shared across all imported globals).
-    ImportedGlobal,
+    /// An imported or exported global access (shared across all
+    /// imported/exported globals).
+    PublicGlobal,
 
     /// A defined global access.
     DefinedGlobal {
@@ -111,7 +114,7 @@ impl AliasRegionKey {
                 debug_assert_eq!(offset & Self::KIND_MASK, 0);
                 Self::VM_STORE_CONTEXT_KIND | (offset & Self::OFFSET_MASK)
             }
-            AliasRegionKey::ImportedMemory => Self::IMPORTED_MEMORY_KIND,
+            AliasRegionKey::PublicMemory => Self::IMPORTED_MEMORY_KIND,
             AliasRegionKey::DefinedMemory { module, index } => {
                 debug_assert_eq!(
                     module.as_u32() & !Self::MODULE_MASK >> Self::MODULE_OFFSET,
@@ -122,7 +125,7 @@ impl AliasRegionKey {
                     | (module.as_u32() << Self::MODULE_OFFSET)
                     | index.as_u32()
             }
-            AliasRegionKey::ImportedTable => Self::IMPORTED_TABLE_KIND,
+            AliasRegionKey::PublicTable => Self::IMPORTED_TABLE_KIND,
             AliasRegionKey::DefinedTable { module, index } => {
                 debug_assert_eq!(
                     module.as_u32() & !Self::MODULE_MASK >> Self::MODULE_OFFSET,
@@ -131,7 +134,7 @@ impl AliasRegionKey {
                 debug_assert_eq!(index.as_u32() & !Self::INDEX_MASK, 0);
                 Self::DEFINED_TABLE_KIND | (module.as_u32() << Self::MODULE_OFFSET) | index.as_u32()
             }
-            AliasRegionKey::ImportedGlobal => Self::IMPORTED_GLOBAL_KIND,
+            AliasRegionKey::PublicGlobal => Self::IMPORTED_GLOBAL_KIND,
             AliasRegionKey::DefinedGlobal { module, index } => {
                 debug_assert_eq!(
                     module.as_u32() & !Self::MODULE_MASK >> Self::MODULE_OFFSET,
@@ -152,15 +155,15 @@ impl fmt::Debug for AliasRegionKey {
         match self {
             AliasRegionKey::VMContext { offset } => write!(f, "VMContext+{offset:#x}"),
             AliasRegionKey::VMStoreContext { offset } => write!(f, "VMStoreContext+{offset:#x}"),
-            AliasRegionKey::ImportedMemory => write!(f, "ImportedMemory"),
+            AliasRegionKey::PublicMemory => write!(f, "PublicMemory"),
             AliasRegionKey::DefinedMemory { module, index } => {
                 write!(f, "DefinedMemory({module:?}, {index:?})")
             }
-            AliasRegionKey::ImportedTable => write!(f, "ImportedTable"),
+            AliasRegionKey::PublicTable => write!(f, "PublicTable"),
             AliasRegionKey::DefinedTable { module, index } => {
                 write!(f, "DefinedTable({module:?}, {index:?})")
             }
-            AliasRegionKey::ImportedGlobal => write!(f, "ImportedGlobal"),
+            AliasRegionKey::PublicGlobal => write!(f, "PublicGlobal"),
             AliasRegionKey::DefinedGlobal { module, index } => {
                 write!(f, "DefinedGlobal({module:?}, {index:?})")
             }

--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -379,12 +379,28 @@ impl<'module_environment> FuncEnvironment<'module_environment> {
         func: &mut Function,
         memory: MemoryIndex,
     ) -> ir::AliasRegion {
-        let key = match self.module.defined_memory_index(memory) {
-            Some(def) => AliasRegionKey::DefinedMemory {
-                module: self.translation.module_index(),
-                index: def,
-            },
-            None => AliasRegionKey::ImportedMemory,
+        let key = if self
+            .module
+            .exports
+            .values()
+            .any(|entity| *entity == memory.into())
+        {
+            // A function that operates on an exported defined memory can be
+            // inlined into another module that imports that exported memory.
+            // That caller will access the memory with
+            // `AliasRegionKey::ImportedMemory`, so we must also conservatively
+            // do the same here, because memory accessed with two different
+            // alias regions must not actually alias, or else we will get
+            // miscompiles.
+            AliasRegionKey::ImportedMemory
+        } else {
+            match self.module.defined_memory_index(memory) {
+                Some(def) => AliasRegionKey::DefinedMemory {
+                    module: self.translation.module_index(),
+                    index: def,
+                },
+                None => AliasRegionKey::ImportedMemory,
+            }
         };
         self.alias_region(func, key)
     }
@@ -394,12 +410,22 @@ impl<'module_environment> FuncEnvironment<'module_environment> {
         func: &mut Function,
         table: TableIndex,
     ) -> ir::AliasRegion {
-        let key = match self.module.defined_table_index(table) {
-            Some(def) => AliasRegionKey::DefinedTable {
-                module: self.translation.module_index(),
-                index: def,
-            },
-            None => AliasRegionKey::ImportedTable,
+        let key = if self
+            .module
+            .exports
+            .values()
+            .any(|entity| *entity == table.into())
+        {
+            // See the comment in `memory_alias_region` for details.
+            AliasRegionKey::ImportedTable
+        } else {
+            match self.module.defined_table_index(table) {
+                Some(def) => AliasRegionKey::DefinedTable {
+                    module: self.translation.module_index(),
+                    index: def,
+                },
+                None => AliasRegionKey::ImportedTable,
+            }
         };
         self.alias_region(func, key)
     }
@@ -409,12 +435,22 @@ impl<'module_environment> FuncEnvironment<'module_environment> {
         func: &mut Function,
         global: GlobalIndex,
     ) -> ir::AliasRegion {
-        let key = match self.module.defined_global_index(global) {
-            Some(def) => AliasRegionKey::DefinedGlobal {
-                module: self.translation.module_index(),
-                index: def,
-            },
-            None => AliasRegionKey::ImportedGlobal,
+        let key = if self
+            .module
+            .exports
+            .values()
+            .any(|entity| *entity == global.into())
+        {
+            // See the comment in `memory_alias_region` for details.
+            AliasRegionKey::ImportedGlobal
+        } else {
+            match self.module.defined_global_index(global) {
+                Some(def) => AliasRegionKey::DefinedGlobal {
+                    module: self.translation.module_index(),
+                    index: def,
+                },
+                None => AliasRegionKey::ImportedGlobal,
+            }
         };
         self.alias_region(func, key)
     }

--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -379,27 +379,23 @@ impl<'module_environment> FuncEnvironment<'module_environment> {
         func: &mut Function,
         memory: MemoryIndex,
     ) -> ir::AliasRegion {
-        let key = if self
-            .module
-            .exports
-            .values()
-            .any(|entity| *entity == memory.into())
-        {
+        let key = if self.module.is_exported_memory(memory) {
             // A function that operates on an exported defined memory can be
-            // inlined into another module that imports that exported memory.
-            // That caller will access the memory with
-            // `AliasRegionKey::ImportedMemory`, so we must also conservatively
-            // do the same here, because memory accessed with two different
-            // alias regions must not actually alias, or else we will get
-            // miscompiles.
-            AliasRegionKey::ImportedMemory
+            // inlined into a different module caller, where that that caller's
+            // module also imports that exported memory. That caller will access
+            // the memory with `AliasRegionKey::PublicMemory`, so we must also
+            // conservatively do the same here, even though we potentially know
+            // the precise static module index and defined memory index, because
+            // memory accessed with two different alias regions must not
+            // actually alias, or else we will get miscompiles.
+            AliasRegionKey::PublicMemory
         } else {
             match self.module.defined_memory_index(memory) {
                 Some(def) => AliasRegionKey::DefinedMemory {
                     module: self.translation.module_index(),
                     index: def,
                 },
-                None => AliasRegionKey::ImportedMemory,
+                None => AliasRegionKey::PublicMemory,
             }
         };
         self.alias_region(func, key)
@@ -410,21 +406,16 @@ impl<'module_environment> FuncEnvironment<'module_environment> {
         func: &mut Function,
         table: TableIndex,
     ) -> ir::AliasRegion {
-        let key = if self
-            .module
-            .exports
-            .values()
-            .any(|entity| *entity == table.into())
-        {
+        let key = if self.module.is_exported_table(table) {
             // See the comment in `memory_alias_region` for details.
-            AliasRegionKey::ImportedTable
+            AliasRegionKey::PublicTable
         } else {
             match self.module.defined_table_index(table) {
                 Some(def) => AliasRegionKey::DefinedTable {
                     module: self.translation.module_index(),
                     index: def,
                 },
-                None => AliasRegionKey::ImportedTable,
+                None => AliasRegionKey::PublicTable,
             }
         };
         self.alias_region(func, key)
@@ -435,21 +426,16 @@ impl<'module_environment> FuncEnvironment<'module_environment> {
         func: &mut Function,
         global: GlobalIndex,
     ) -> ir::AliasRegion {
-        let key = if self
-            .module
-            .exports
-            .values()
-            .any(|entity| *entity == global.into())
-        {
+        let key = if self.module.is_exported_global(global) {
             // See the comment in `memory_alias_region` for details.
-            AliasRegionKey::ImportedGlobal
+            AliasRegionKey::PublicGlobal
         } else {
             match self.module.defined_global_index(global) {
                 Some(def) => AliasRegionKey::DefinedGlobal {
                     module: self.translation.module_index(),
                     index: def,
                 },
-                None => AliasRegionKey::ImportedGlobal,
+                None => AliasRegionKey::PublicGlobal,
             }
         };
         self.alias_region(func, key)

--- a/crates/environ/src/module.rs
+++ b/crates/environ/src/module.rs
@@ -370,6 +370,12 @@ impl Module {
         }
     }
 
+    /// Test whether the given table index is for an exported table.
+    #[inline]
+    pub fn is_exported_table(&self, index: TableIndex) -> bool {
+        self.exports.values().any(|entity| *entity == index.into())
+    }
+
     /// Test whether the given table index is for an imported table.
     #[inline]
     pub fn is_imported_table(&self, index: TableIndex) -> bool {
@@ -417,6 +423,12 @@ impl Module {
         OwnedMemoryIndex::new(owned_memory_index)
     }
 
+    /// Test whether the given memory index is for an exported memory.
+    #[inline]
+    pub fn is_exported_memory(&self, index: MemoryIndex) -> bool {
+        self.exports.values().any(|entity| *entity == index.into())
+    }
+
     /// Test whether the given memory index is for an imported memory.
     #[inline]
     pub fn is_imported_memory(&self, index: MemoryIndex) -> bool {
@@ -440,6 +452,12 @@ impl Module {
                 global.index() - self.num_imported_globals,
             ))
         }
+    }
+
+    /// Test whether the given global index is for an exported global.
+    #[inline]
+    pub fn is_exported_global(&self, index: GlobalIndex) -> bool {
+        self.exports.values().any(|entity| *entity == index.into())
     }
 
     /// Test whether the given global index is for an imported global.

--- a/tests/all/func.rs
+++ b/tests/all/func.rs
@@ -2353,3 +2353,141 @@ fn wasm_to_host_trampolines_and_subtyping(config: &mut Config) -> Result<()> {
 
     Ok(())
 }
+
+/// Run a component exporting a `g: func() -> u32` function both with and
+/// without inlining; check that it returns the expected value.
+fn assert_returns_regardless_of_inlining(
+    wat: &str,
+    expected: u32,
+    configure: impl Fn(&mut Config),
+) -> Result<()> {
+    for inlining in [wasmtime::Inlining::No, wasmtime::Inlining::Yes] {
+        let mut config = Config::new();
+        config.compiler_inlining(inlining);
+
+        // Make it so that function calls which *can* be inlined, *will* be
+        // inlined.
+        unsafe {
+            config.cranelift_flag_set(
+                "wasmtime_inlining_sum_size_threshold",
+                &u32::MAX.to_string(),
+            );
+        }
+
+        configure(&mut config);
+
+        let engine = Engine::new(&config)?;
+        let component = wasmtime::component::Component::new(&engine, wat)?;
+        let mut store = Store::new(&engine, ());
+        let instance =
+            wasmtime::component::Linker::new(&engine).instantiate(&mut store, &component)?;
+        let g = instance.get_typed_func::<(), (u32,)>(&mut store, "g")?;
+        let (result,) = g.call(&mut store, ())?;
+
+        assert_eq!(result, expected, "wrong result with {inlining:?}");
+    }
+    Ok(())
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn issue_13538_memories() -> Result<()> {
+    // `g` reads memory, has `writeit` store a new value into it, then reads the
+    // same location again and returns it: the second read must observe the
+    // store (`123`), not the stale value from the first read (`0`).
+    assert_returns_regardless_of_inlining(
+        r#"
+            (component
+              (core module $M
+                (memory (export "mem") 1)
+                (func (export "writeit") (param i32 i32)
+                  (i32.store (local.get 0) (local.get 1)))
+              )
+              (core instance $m (instantiate $M))
+              (core module $N
+                (import "" "mem" (memory 1))
+                (import "" "writeit" (func $writeit (param i32 i32)))
+                (func (export "g") (result i32)
+                  (i32.load (i32.const 0))
+                  drop
+                  (call $writeit (i32.const 0) (i32.const 123))
+                  (i32.load (i32.const 0)))
+              )
+              (core instance $n (instantiate $N
+                  (with "" (instance
+                    (export "mem" (memory $m "mem"))
+                    (export "writeit" (func $m "writeit"))))))
+              (func (export "g") (result u32) (canon lift (core func $n "g"))))
+        "#,
+        123,
+        |_| {},
+    )
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn issue_13538_globals() -> Result<()> {
+    // Same as `issue_13538_memories` but for globals.
+    assert_returns_regardless_of_inlining(
+        r#"
+            (component
+              (core module $M
+                (global (export "glob") (mut i32) (i32.const 0))
+                (func (export "writeit") (param i32)
+                  (global.set 0 (local.get 0)))
+              )
+              (core instance $m (instantiate $M))
+              (core module $N
+                (import "" "glob" (global $glob (mut i32)))
+                (import "" "writeit" (func $writeit (param i32)))
+                (func (export "g") (result i32)
+                  (global.get $glob)
+                  drop
+                  (call $writeit (i32.const 123))
+                  (global.get $glob))
+              )
+              (core instance $n (instantiate $N
+                  (with "" (instance
+                    (export "glob" (global $m "glob"))
+                    (export "writeit" (func $m "writeit"))))))
+              (func (export "g") (result u32) (canon lift (core func $n "g"))))
+        "#,
+        123,
+        |_| {},
+    )
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn issue_13538_tables() -> Result<()> {
+    // Same as `issue_13538_memories` but for tables.
+    assert_returns_regardless_of_inlining(
+        r#"
+            (component
+              (core module $M
+                (table (export "tab") 1 1 (ref i31) (ref.i31 (i32.const 0)))
+                (func (export "writeit") (param i32)
+                  (table.set (i32.const 0) (ref.i31 (local.get 0))))
+              )
+              (core instance $m (instantiate $M))
+              (core module $N
+                (import "" "tab" (table 1 1 (ref i31)))
+                (import "" "writeit" (func $writeit (param i32)))
+                (func (export "g") (result i32)
+                  (drop (table.get (i32.const 0)))
+                  (call $writeit (i32.const 123))
+                  (i31.get_u (table.get (i32.const 0))))
+              )
+              (core instance $n (instantiate $N
+                  (with "" (instance
+                    (export "tab" (table $m "tab"))
+                    (export "writeit" (func $m "writeit"))))))
+              (func (export "g") (result u32) (canon lift (core func $n "g"))))
+        "#,
+        123,
+        |config| {
+            config.wasm_function_references(true);
+            config.wasm_gc(true);
+        },
+    )
+}

--- a/tests/disas/alias-region-globals.wat
+++ b/tests/disas/alias-region-globals.wat
@@ -15,7 +15,7 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 1610612736 "ImportedGlobal"
+;;     region0 = 1610612736 "PublicGlobal"
 ;;     region1 = 1879048192 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8

--- a/tests/disas/alias-region-memories.wat
+++ b/tests/disas/alias-region-memories.wat
@@ -15,7 +15,7 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32) -> i32 tail {
-;;     region0 = 536870912 "ImportedMemory"
+;;     region0 = 536870912 "PublicMemory"
 ;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8

--- a/tests/disas/alias-region-tables.wat
+++ b/tests/disas/alias-region-tables.wat
@@ -16,7 +16,7 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32, i64) -> i32 tail {
-;;     region0 = 1073741824 "ImportedTable"
+;;     region0 = 1073741824 "PublicTable"
 ;;     region1 = 1342177280 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8

--- a/tests/disas/call-indirect.wat
+++ b/tests/disas/call-indirect.wat
@@ -8,7 +8,7 @@
 )
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) -> i32 tail {
-;;     region0 = 1073741824 "ImportedTable"
+;;     region0 = 1073741824 "PublicTable"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/call-indirect.wat
+++ b/tests/disas/call-indirect.wat
@@ -8,7 +8,7 @@
 )
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) -> i32 tail {
-;;     region0 = 1342177280 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
+;;     region0 = 1073741824 "ImportedTable"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/component-model/direct-adapter-calls-inlining.wat
+++ b/tests/disas/component-model/direct-adapter-calls-inlining.wat
@@ -55,7 +55,7 @@
 )
 
 ;; function u1:0(i64 vmctx, i64) -> i32 tail {
-;;     region0 = 1610612736 "ImportedGlobal"
+;;     region0 = 1610612736 "PublicGlobal"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/component-model/direct-adapter-calls.wat
+++ b/tests/disas/component-model/direct-adapter-calls.wat
@@ -92,7 +92,7 @@
 ;; }
 ;;
 ;; function u2:0(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 1610612736 "ImportedGlobal"
+;;     region0 = 1610612736 "PublicGlobal"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/duplicate-function-types.wat
+++ b/tests/disas/duplicate-function-types.wat
@@ -17,7 +17,7 @@
 )
 
 ;; function u0:0(i64 vmctx, i64, i32) -> i32, i32 tail {
-;;     region0 = 1073741824 "ImportedTable"
+;;     region0 = 1073741824 "PublicTable"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/duplicate-loads-dynamic-memory.wat
+++ b/tests/disas/duplicate-loads-dynamic-memory.wat
@@ -23,7 +23,7 @@
 )
 
 ;; function u0:0(i64 vmctx, i64, i32) -> i32, i32 tail {
-;;     region0 = 536870912 "ImportedMemory"
+;;     region0 = 536870912 "PublicMemory"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -48,7 +48,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32, i32 tail {
-;;     region0 = 536870912 "ImportedMemory"
+;;     region0 = 536870912 "PublicMemory"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/duplicate-loads-dynamic-memory.wat
+++ b/tests/disas/duplicate-loads-dynamic-memory.wat
@@ -23,7 +23,7 @@
 )
 
 ;; function u0:0(i64 vmctx, i64, i32) -> i32, i32 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 536870912 "ImportedMemory"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -48,7 +48,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32, i32 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 536870912 "ImportedMemory"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/duplicate-loads-static-memory.wat
+++ b/tests/disas/duplicate-loads-static-memory.wat
@@ -18,7 +18,7 @@
 )
 
 ;; function u0:0(i64 vmctx, i64, i32) -> i32, i32 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 536870912 "ImportedMemory"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -39,7 +39,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32, i32 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 536870912 "ImportedMemory"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/duplicate-loads-static-memory.wat
+++ b/tests/disas/duplicate-loads-static-memory.wat
@@ -18,7 +18,7 @@
 )
 
 ;; function u0:0(i64 vmctx, i64, i32) -> i32, i32 tail {
-;;     region0 = 536870912 "ImportedMemory"
+;;     region0 = 536870912 "PublicMemory"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -39,7 +39,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32, i32 tail {
-;;     region0 = 536870912 "ImportedMemory"
+;;     region0 = 536870912 "PublicMemory"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/dynamic-memory-no-spectre-access-same-index-different-offsets.wat
+++ b/tests/disas/dynamic-memory-no-spectre-access-same-index-different-offsets.wat
@@ -36,7 +36,7 @@
 )
 
 ;; function u0:0(i64 vmctx, i64, i32) -> i32, i32, i32 tail {
-;;     region0 = 536870912 "ImportedMemory"
+;;     region0 = 536870912 "PublicMemory"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -70,7 +70,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32, i32, i32, i32) tail {
-;;     region0 = 536870912 "ImportedMemory"
+;;     region0 = 536870912 "PublicMemory"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/dynamic-memory-no-spectre-access-same-index-different-offsets.wat
+++ b/tests/disas/dynamic-memory-no-spectre-access-same-index-different-offsets.wat
@@ -36,7 +36,7 @@
 )
 
 ;; function u0:0(i64 vmctx, i64, i32) -> i32, i32, i32 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 536870912 "ImportedMemory"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -70,7 +70,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32, i32, i32, i32) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 536870912 "ImportedMemory"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/dynamic-memory-yes-spectre-access-same-index-different-offsets.wat
+++ b/tests/disas/dynamic-memory-yes-spectre-access-same-index-different-offsets.wat
@@ -32,7 +32,7 @@
 )
 
 ;; function u0:0(i64 vmctx, i64, i32) -> i32, i32, i32 tail {
-;;     region0 = 536870912 "ImportedMemory"
+;;     region0 = 536870912 "PublicMemory"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -68,7 +68,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32, i32, i32, i32) tail {
-;;     region0 = 536870912 "ImportedMemory"
+;;     region0 = 536870912 "PublicMemory"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/dynamic-memory-yes-spectre-access-same-index-different-offsets.wat
+++ b/tests/disas/dynamic-memory-yes-spectre-access-same-index-different-offsets.wat
@@ -32,7 +32,7 @@
 )
 
 ;; function u0:0(i64 vmctx, i64, i32) -> i32, i32, i32 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 536870912 "ImportedMemory"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -68,7 +68,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32, i32, i32, i32) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 536870912 "ImportedMemory"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/foo.wat
+++ b/tests/disas/foo.wat
@@ -16,7 +16,7 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32) -> i32, i32 tail {
 ;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
-;;     region1 = 1073741824 "ImportedTable"
+;;     region1 = 1073741824 "PublicTable"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/global-get.wat
+++ b/tests/disas/global-get.wat
@@ -31,7 +31,7 @@
 )
 
 ;; function u0:0(i64 vmctx, i64) -> i32 tail {
-;;     region0 = 1610612736 "ImportedGlobal"
+;;     region0 = 1610612736 "PublicGlobal"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -49,7 +49,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64) -> i32 tail {
-;;     region0 = 1610612736 "ImportedGlobal"
+;;     region0 = 1610612736 "PublicGlobal"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/if-unreachable-else-params-2.wat
+++ b/tests/disas/if-unreachable-else-params-2.wat
@@ -20,7 +20,7 @@
   (export "memory" (memory 0)))
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) -> f64 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 536870912 "ImportedMemory"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/if-unreachable-else-params-2.wat
+++ b/tests/disas/if-unreachable-else-params-2.wat
@@ -20,7 +20,7 @@
   (export "memory" (memory 0)))
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) -> f64 tail {
-;;     region0 = 536870912 "ImportedMemory"
+;;     region0 = 536870912 "PublicMemory"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/if-unreachable-else-params.wat
+++ b/tests/disas/if-unreachable-else-params.wat
@@ -43,7 +43,7 @@
   (export "memory" (memory 0)))
 
 ;; function u0:0(i64 vmctx, i64, i32) tail {
-;;     region0 = 536870912 "ImportedMemory"
+;;     region0 = 536870912 "PublicMemory"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/if-unreachable-else-params.wat
+++ b/tests/disas/if-unreachable-else-params.wat
@@ -43,7 +43,7 @@
   (export "memory" (memory 0)))
 
 ;; function u0:0(i64 vmctx, i64, i32) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 536870912 "ImportedMemory"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/pr2303.wat
+++ b/tests/disas/pr2303.wat
@@ -17,7 +17,7 @@
 )
 
 ;; function u0:0(i64 vmctx, i64, i32) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 536870912 "ImportedMemory"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/pr2303.wat
+++ b/tests/disas/pr2303.wat
@@ -17,7 +17,7 @@
 )
 
 ;; function u0:0(i64 vmctx, i64, i32) tail {
-;;     region0 = 536870912 "ImportedMemory"
+;;     region0 = 536870912 "PublicMemory"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/ref-func-0.wat
+++ b/tests/disas/ref-func-0.wat
@@ -14,7 +14,7 @@
   (global (export "funcref-local") funcref (ref.func $local)))
 
 ;; function u0:0(i64 vmctx, i64) -> i32, i32, i64, i64 tail {
-;;     region0 = 1610612736 "ImportedGlobal"
+;;     region0 = 1610612736 "PublicGlobal"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/ref-func-0.wat
+++ b/tests/disas/ref-func-0.wat
@@ -14,8 +14,7 @@
   (global (export "funcref-local") funcref (ref.func $local)))
 
 ;; function u0:0(i64 vmctx, i64) -> i32, i32, i64, i64 tail {
-;;     region0 = 1879048194 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(2))"
-;;     region1 = 1879048195 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(3))"
+;;     region0 = 1610612736 "ImportedGlobal"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -30,7 +29,7 @@
 ;; @0091                               v12 = iadd v0, v11  ; v11 = 96
 ;; @0091                               v13 = load.i32 notrap aligned v12
 ;; @0093                               v15 = load.i64 notrap aligned region0 v0+112
-;; @0095                               v17 = load.i64 notrap aligned region1 v0+128
+;; @0095                               v17 = load.i64 notrap aligned region0 v0+128
 ;; @0097                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/table-copy.wat
+++ b/tests/disas/table-copy.wat
@@ -63,7 +63,7 @@
 ;; }
 ;;
 ;; function u0:3(i64 vmctx, i64, i32, i32, i32, i32) -> i32 tail {
-;;     region0 = 1342177280 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
+;;     region0 = 1073741824 "ImportedTable"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/table-copy.wat
+++ b/tests/disas/table-copy.wat
@@ -63,7 +63,7 @@
 ;; }
 ;;
 ;; function u0:3(i64 vmctx, i64, i32, i32, i32, i32) -> i32 tail {
-;;     region0 = 1073741824 "ImportedTable"
+;;     region0 = 1073741824 "PublicTable"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -203,7 +203,7 @@
 ;; }
 ;;
 ;; function u0:4(i64 vmctx, i64, i32, i32, i32, i32) -> i32 tail {
-;;     region0 = 1073741824 "ImportedTable"
+;;     region0 = 1073741824 "PublicTable"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/table-get-fixed-size.wat
+++ b/tests/disas/table-get-fixed-size.wat
@@ -16,7 +16,7 @@
     table.get 0))
 
 ;; function u0:0(i64 vmctx, i64) -> i32 tail {
-;;     region0 = 1073741824 "ImportedTable"
+;;     region0 = 1073741824 "PublicTable"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -43,7 +43,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 1073741824 "ImportedTable"
+;;     region0 = 1073741824 "PublicTable"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/table-get-fixed-size.wat
+++ b/tests/disas/table-get-fixed-size.wat
@@ -16,7 +16,7 @@
     table.get 0))
 
 ;; function u0:0(i64 vmctx, i64) -> i32 tail {
-;;     region0 = 1342177280 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
+;;     region0 = 1073741824 "ImportedTable"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -43,7 +43,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 1342177280 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
+;;     region0 = 1073741824 "ImportedTable"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/table-get.wat
+++ b/tests/disas/table-get.wat
@@ -15,7 +15,7 @@
     table.get 0))
 
 ;; function u0:0(i64 vmctx, i64) -> i32 tail {
-;;     region0 = 1073741824 "ImportedTable"
+;;     region0 = 1073741824 "PublicTable"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -44,7 +44,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 1073741824 "ImportedTable"
+;;     region0 = 1073741824 "PublicTable"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/table-get.wat
+++ b/tests/disas/table-get.wat
@@ -15,7 +15,7 @@
     table.get 0))
 
 ;; function u0:0(i64 vmctx, i64) -> i32 tail {
-;;     region0 = 1342177280 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
+;;     region0 = 1073741824 "ImportedTable"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -44,7 +44,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 1342177280 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
+;;     region0 = 1073741824 "ImportedTable"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/table-set-fixed-size.wat
+++ b/tests/disas/table-set-fixed-size.wat
@@ -17,7 +17,7 @@
     local.get 1
     table.set 0))
 ;; function u0:0(i64 vmctx, i64, i32) tail {
-;;     region0 = 1073741824 "ImportedTable"
+;;     region0 = 1073741824 "PublicTable"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -44,7 +44,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32, i32) tail {
-;;     region0 = 1073741824 "ImportedTable"
+;;     region0 = 1073741824 "PublicTable"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/table-set-fixed-size.wat
+++ b/tests/disas/table-set-fixed-size.wat
@@ -17,7 +17,7 @@
     local.get 1
     table.set 0))
 ;; function u0:0(i64 vmctx, i64, i32) tail {
-;;     region0 = 1342177280 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
+;;     region0 = 1073741824 "ImportedTable"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -44,7 +44,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32, i32) tail {
-;;     region0 = 1342177280 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
+;;     region0 = 1073741824 "ImportedTable"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/table-set.wat
+++ b/tests/disas/table-set.wat
@@ -17,7 +17,7 @@
     table.set 0))
 
 ;; function u0:0(i64 vmctx, i64, i32) tail {
-;;     region0 = 1342177280 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
+;;     region0 = 1073741824 "ImportedTable"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -46,7 +46,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32, i32) tail {
-;;     region0 = 1342177280 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
+;;     region0 = 1073741824 "ImportedTable"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24

--- a/tests/disas/table-set.wat
+++ b/tests/disas/table-set.wat
@@ -17,7 +17,7 @@
     table.set 0))
 
 ;; function u0:0(i64 vmctx, i64, i32) tail {
-;;     region0 = 1073741824 "ImportedTable"
+;;     region0 = 1073741824 "PublicTable"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -46,7 +46,7 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32, i32) tail {
-;;     region0 = 1073741824 "ImportedTable"
+;;     region0 = 1073741824 "PublicTable"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24


### PR DESCRIPTION
This is because a module can export a memory and a function that interacts with that memory, and then another module can import that memory and that function, and if its calls to that function get inlined, then the alias regions that the original module's access to the memory used and the second module's accesses use must match. Otherwise, we would get memory accesses that claim they cannot alias (by using different alias regions in their accesses) that actually can alias, which leads to miscompiles.

Fixes https://github.com/bytecodealliance/wasmtime/issues/13538

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
