### PR TITLE
Reduce debugger-related duplication in wasmtime serve

### DIFF
--- a/crates/wasi-http/src/handler.rs
+++ b/crates/wasi-http/src/handler.rs
@@ -1192,7 +1192,8 @@ where
 ///
 /// Right now this is a bit gross since it has to type out a bunch of types by
 /// hand.
-enum Prepared<'a, T: 'static> {
+pub enum Prepared<'a, T: 'static> {
+    #[doc(hidden)]
     #[cfg(feature = "p2")]
     P2 {
         guest: &'a p2::bindings::Proxy,
@@ -1206,6 +1207,7 @@ enum Prepared<'a, T: 'static> {
         >,
         tx: Arc<Mutex<Option<oneshot::Sender<Result<Response, wasmtime::Error>>>>>,
     },
+    #[doc(hidden)]
     #[cfg(feature = "p3")]
     P3 {
         guest: &'a p3::bindings::Service,
@@ -1221,7 +1223,8 @@ enum Prepared<'a, T: 'static> {
 }
 
 impl<'a, T: Send> Prepared<'a, T> {
-    fn new(
+    /// Creates a new prepared request.
+    pub fn new(
         mut store: StoreContextMut<'_, T>,
         proxy: &'a Proxy,
         request: Request,
@@ -1299,7 +1302,8 @@ impl<'a, T: Send> Prepared<'a, T> {
         }
     }
 
-    async fn run(
+    /// Executes this request to completion.
+    pub async fn run(
         self,
         accessor: &Accessor<T>,
         expiration: impl Future<Output = ()>,

--- a/src/commands/serve.rs
+++ b/src/commands/serve.rs
@@ -2,8 +2,9 @@ use crate::common::{HttpHooks, Profile, RunCommon, RunTarget};
 use bytes::Bytes;
 use clap::Parser;
 use http::{HeaderMap, HeaderName, HeaderValue, Response, StatusCode};
-use http_body_util::BodyExt as _;
 use http_body_util::combinators::UnsyncBoxBody;
+use http_body_util::{BodyExt as _, Full};
+use hyper::server::conn::http1;
 use pin_project_lite::pin_project;
 use std::convert::Infallible;
 use std::ffi::OsString;
@@ -28,12 +29,12 @@ use wasmtime::{
 use wasmtime_cli_flags::opt::WasmtimeOptionValue;
 use wasmtime_wasi::p2::{StreamError, StreamResult};
 use wasmtime_wasi::{WasiCtx, WasiCtxBuilder, WasiCtxView, WasiView};
+use wasmtime_wasi_http::WasiHttpCtx;
 use wasmtime_wasi_http::handler::{
-    self, HandlerState, Instance, ProxyHandler, ProxyPre, ShouldAccept, ViewFn, WorkerExpiration,
-    WorkerState, WorkerStatus,
+    self, HandlerState, Instance, Prepared, Proxy, ProxyHandler, ProxyPre, ShouldAccept, ViewFn,
+    WorkerExpiration, WorkerState, WorkerStatus,
 };
 use wasmtime_wasi_http::io::TokioIo;
-use wasmtime_wasi_http::{WasiHttpCtx, p2::WasiHttpView};
 
 #[cfg(feature = "debug")]
 use crate::commands::run::RunCommand;
@@ -320,21 +321,16 @@ impl ServeCommand {
     /// sequentially, so the debugger can pause and inspect state.
     #[cfg(feature = "debug")]
     async fn serve_under_debugger(
-        &self,
+        self,
         mut debug_run: RunCommand,
-        engine: &Engine,
-        linker: &Linker<Host>,
-        component: &Component,
-        request_headers: RequestHeaders,
+        linker: Linker<Host>,
+        component: Component,
     ) -> Result<()> {
-        let instance_pre = linker.instantiate_pre(component)?;
-        let proxy_pre = wasmtime_wasi_http::p2::bindings::ProxyPre::new(instance_pre)?;
-
-        let mut debuggee_store = self.new_store(engine, None)?;
+        let mut debuggee_store = self.new_store(linker.engine(), None)?;
 
         // Pre-register component modules so the debugger can see
         // them and set breakpoints at the initial stop.
-        debuggee_store.debug_register_component(component)?;
+        debuggee_store.debug_register_component(&component)?;
 
         let debug_engine = debug_run.new_engine()?;
         let debug_main = debug_run.run.load_module(
@@ -356,21 +352,13 @@ impl ServeCommand {
         };
         debug_run.add_debugger_api(&mut debug_linker)?;
 
-        let addr = self.addr;
         debug_run
             .invoke_debugger(
                 &mut debug_store,
                 &debug_component,
                 &mut debug_linker,
                 debuggee_store,
-                move |store| {
-                    Box::pin(debug_serve_body(
-                        store,
-                        proxy_pre,
-                        addr,
-                        request_headers.clone(),
-                    ))
-                },
+                move |store| Box::pin(self.serve_maybe_debug(linker, component, Some(store))),
             )
             .await
     }
@@ -569,8 +557,6 @@ impl ServeCommand {
     }
 
     async fn serve(mut self) -> Result<()> {
-        use hyper::server::conn::http1;
-
         #[cfg(feature = "debug")]
         let debug_run = self.debugger_setup()?;
 
@@ -603,15 +589,25 @@ impl ServeCommand {
             RunTarget::Core(_) => bail!("The serve command currently requires a component"),
             RunTarget::Component(c) => c,
         };
-        let request_headers = RequestHeaders::parse(&self.headers)?;
 
         #[cfg(feature = "debug")]
         if let Some(debug_run) = debug_run {
             return self
-                .serve_under_debugger(debug_run, &engine, &linker, &component, request_headers)
+                .serve_under_debugger(debug_run, linker, component)
                 .await;
         }
 
+        self.serve_maybe_debug(linker, component, None).await
+    }
+
+    async fn serve_maybe_debug(
+        self,
+        linker: Linker<Host>,
+        component: Component,
+        mut debuggee_store: Option<&mut Store<Host>>,
+    ) -> Result<()> {
+        let engine = linker.engine();
+        let request_headers = RequestHeaders::parse(&self.headers)?;
         let instance = linker.instantiate_pre(&component)?;
         #[cfg(feature = "component-model-async")]
         let instance = match wasmtime_wasi_http::p3::bindings::ServicePre::new(instance.clone()) {
@@ -669,6 +665,8 @@ impl ServeCommand {
             Some(interval)
         } else if let Some(t) = self.run.common.wasm.timeout {
             Some(EPOCH_INTERRUPT_PERIOD.min(t))
+        } else if debuggee_store.is_some() {
+            Some(Duration::from_millis(1))
         } else {
             None
         };
@@ -688,14 +686,25 @@ impl ServeCommand {
         } else {
             1
         };
-        let sem_connections = Arc::new(Semaphore::new(
-            self.max_concurrent_connections.unwrap_or(1000),
-        ));
+
+        let max_concurrent_connections = self
+            .max_concurrent_connections
+            .unwrap_or(if debuggee_store.is_some() { 1 } else { 1000 });
+        let max_concurrent_requests = self
+            .max_concurrent_requests
+            .unwrap_or(if debuggee_store.is_some() { 1 } else { 1000 });
+        if debuggee_store.is_some() && max_concurrent_connections != 1 {
+            bail!("cannot have more than 1 max concurrent connections with a debugger");
+        }
+        if debuggee_store.is_some() && max_concurrent_requests != 1 {
+            bail!("cannot have more than 1 max concurrent requests with a debugger");
+        }
+
+        let sem_connections = Arc::new(Semaphore::new(max_concurrent_connections));
 
         let handler = ProxyHandler::new(HostHandlerState {
-            sem_requests: Semaphore::new(self.max_concurrent_requests.unwrap_or(1000)),
+            sem_requests: Semaphore::new(max_concurrent_requests),
             cmd: self,
-            engine,
             component,
             request_headers,
             max_instance_reuse_count,
@@ -728,61 +737,27 @@ impl ServeCommand {
             // TCP fragmentation.
             stream.set_nodelay(true)?;
 
-            let stream = TokioIo::new(stream);
-            let h = handler.clone();
-
             // In addition to the shutdown guard given to the handler above,
             // also give one to the tokio tasks doing HTTP I/O as well to ensure
             // it keeps them alive too.
             let shutdown_guard = shutdown.clone().increment();
-            tokio::task::spawn(async move {
-                if let Err(e) = http1::Builder::new()
-                    .keep_alive(true)
-                    .serve_connection(
-                        stream,
-                        hyper::service::service_fn(move |req| {
-                            let h = h.clone();
-                            async move {
-                                use http_body_util::{BodyExt, Full};
-                                match handle_request(h, req).await {
-                                    Ok(r) => Ok::<_, Infallible>(r),
-                                    Err(e) => {
-                                        eprintln!("error: {e:?}");
-                                        let error_html = "\
-<!doctype html>
-<html>
-<head>
-    <title>500 Internal Server Error</title>
-</head>
-<body>
-    <center>
-        <h1>500 Internal Server Error</h1>
-        <hr>
-        wasmtime
-    </center>
-</body>
-</html>";
-                                        Ok(Response::builder()
-                                            .status(StatusCode::INTERNAL_SERVER_ERROR)
-                                            .header("Content-Type", "text/html; charset=UTF-8")
-                                            .body(
-                                                Full::new(bytes::Bytes::from(error_html))
-                                                    .map_err(|_| unreachable!())
-                                                    .boxed_unsync(),
-                                            )
-                                            .unwrap())
-                                    }
-                                }
-                            }
-                        }),
-                    )
-                    .await
-                {
-                    eprintln!("error: {e:?}");
+
+            // When debugging, handle the client synchronously since
+            // concurrent requests can't be served. Otherwise though spawn a
+            // task to handle this client.
+            match &mut debuggee_store {
+                Some(store) => {
+                    handle_client(stream, &handler, Some(store)).await;
                 }
-                drop(shutdown_guard);
-                drop(connection_permit);
-            });
+                None => {
+                    let handler = handler.clone();
+                    tokio::task::spawn(async move {
+                        handle_client(stream, &handler, None).await;
+                        drop(shutdown_guard);
+                        drop(connection_permit);
+                    });
+                }
+            }
         }
 
         // Don't allow any further requests to get picked up.
@@ -896,7 +871,6 @@ impl WorkerState for HostWorkerState {
 
 struct HostHandlerState {
     cmd: ServeCommand,
-    engine: Engine,
     component: Component,
     request_headers: RequestHeaders,
     max_instance_reuse_count: usize,
@@ -908,6 +882,21 @@ struct HostHandlerState {
     _shutdown_guard: Box<dyn std::any::Any + Send + Sync>,
 }
 
+impl HostHandlerState {
+    async fn instantiate_into(&self, store: &mut Store<Host>) -> Result<Proxy> {
+        let write_profile = setup_epoch_handler(&self.cmd, &mut *store, self.component.clone())?;
+        store.data_mut().write_profile = Some(write_profile);
+        self.instance.instantiate_async(&mut *store).await
+    }
+
+    fn view(&self) -> ViewFn<Host> {
+        match &self.instance {
+            ProxyPre::P2(_) => ViewFn::P2(wasmtime_wasi_http::p2::WasiHttpView::http),
+            ProxyPre::P3(_) => ViewFn::P3(wasmtime_wasi_http::p3::WasiHttpView::http),
+        }
+    }
+}
+
 impl HandlerState for HostHandlerState {
     type StoreData = Host;
     type WorkerExpiration = HostWorkerExpiration;
@@ -917,21 +906,15 @@ impl HandlerState for HostHandlerState {
         &self,
     ) -> Result<Instance<Self::StoreData, Self::WorkerExpiration, Self::WorkerState>> {
         let instance_id = self.next_instance_id.fetch_add(1, Ordering::Relaxed);
-        let mut store = self.cmd.new_store(&self.engine, Some(instance_id))?;
-        let write_profile = setup_epoch_handler(&self.cmd, &mut store, self.component.clone())?;
-        store.data_mut().write_profile = Some(write_profile);
-
-        let proxy = self.instance.instantiate_async(&mut store).await?;
-
-        let view = match &self.instance {
-            ProxyPre::P2(_) => ViewFn::P2(wasmtime_wasi_http::p2::WasiHttpView::http),
-            ProxyPre::P3(_) => ViewFn::P3(wasmtime_wasi_http::p3::WasiHttpView::http),
-        };
+        let mut store = self
+            .cmd
+            .new_store(self.component.engine(), Some(instance_id))?;
+        let proxy = self.instantiate_into(&mut store).await?;
 
         Ok(Instance {
             store,
             proxy,
-            view,
+            view: self.view(),
             expiration: HostWorkerExpiration {
                 idle_timeout: self.cmd.idle_instance_timeout,
                 request_timeout: self.cmd.run.common.wasm.timeout.unwrap_or(Duration::MAX),
@@ -1053,7 +1036,7 @@ fn setup_epoch_handler(
     }
 
     // Profiling disabled but there's a global request timeout
-    if cmd.run.common.wasm.timeout.is_some() {
+    if cmd.run.common.wasm.timeout.is_some() || cmd.run.common.debug.debugger.is_some() {
         store.epoch_deadline_async_yield_and_update(1);
     }
 
@@ -1125,155 +1108,69 @@ fn setup_guest_profiler(
     Ok(write_profile)
 }
 
-/// Build a minimal error response with an empty body.
-fn error_response(status: StatusCode) -> hyper::Response<UnsyncBoxBody<Bytes, wasmtime::Error>> {
-    Response::builder()
-        .status(status)
-        .body(
-            http_body_util::Empty::new()
-                .map_err(|_| unreachable!())
-                .boxed_unsync(),
-        )
-        .unwrap()
-}
+type Request = hyper::Request<hyper::body::Incoming>;
 
-/// Debuggee body for `wasmtime serve -g`: instantiate the HTTP component
-/// once, then handle requests sequentially on a single store.
-#[cfg(feature = "debug")]
-async fn debug_serve_body(
-    store: &mut Store<Host>,
-    proxy_pre: wasmtime_wasi_http::p2::bindings::ProxyPre<Host>,
-    addr: SocketAddr,
-    request_headers: RequestHeaders,
-) -> Result<()> {
-    use hyper::server::conn::http1;
-    use wasmtime_wasi_http::p2::bindings::http::types::Scheme;
-    use wasmtime_wasi_http::p2::body::HyperOutgoingBody;
+async fn handle_client(
+    client: tokio::net::TcpStream,
+    handler: &ProxyHandler<HostHandlerState>,
+    debuggee_store: Option<&mut Store<Host>>,
+) {
+    // Hyper's `service_fn` takes an `Fn` closure, so to bridge the need to
+    // transfer a mutable store to each request for debugging a tokio mutex is
+    // used. The tokio mutex is required as the returned future must also be
+    // `Send`.
+    let lock = &debuggee_store.map(tokio::sync::Mutex::new);
 
-    type P2Response = std::result::Result<
-        hyper::Response<HyperOutgoingBody>,
-        wasmtime_wasi_http::p2::bindings::http::types::ErrorCode,
-    >;
-
-    let engine_clone = store.engine().clone();
-    let _epoch_thread = std::thread::spawn(move || {
-        loop {
-            std::thread::sleep(Duration::from_millis(1));
-            engine_clone.increment_epoch();
-        }
-    });
-
-    store.epoch_deadline_async_yield_and_update(1);
-
-    // Instantiate the HTTP component once.
-    let proxy = proxy_pre.instantiate_async(&mut *store).await?;
-
-    // Bind the TCP listener.
-    let socket = match addr {
-        SocketAddr::V4(_) => tokio::net::TcpSocket::new_v4()?,
-        SocketAddr::V6(_) => tokio::net::TcpSocket::new_v6()?,
-    };
-    socket.set_reuseaddr(!cfg!(windows))?;
-    socket.bind(addr)?;
-    let listener = socket.listen(100)?;
-    eprintln!("Serving HTTP on http://{}/", listener.local_addr()?);
-
-    // Accept loop: handle one connection at a time, requests sequentially.
-    loop {
-        let (stream, _) = listener.accept().await?;
-        stream.set_nodelay(true)?;
-        let stream = TokioIo::new(stream);
-
-        // Channel to bridge hyper's service_fn with our sequential
-        // request processing on the single store.
-        type RespBody = hyper::Response<UnsyncBoxBody<Bytes, wasmtime::Error>>;
-        let (req_tx, mut req_rx) = tokio::sync::mpsc::channel::<(
-            hyper::Request<hyper::body::Incoming>,
-            tokio::sync::oneshot::Sender<std::result::Result<RespBody, Infallible>>,
-        )>(1);
-
-        let serve_conn = http1::Builder::new().keep_alive(true).serve_connection(
-            stream,
-            hyper::service::service_fn(move |req| {
-                let req_tx = req_tx.clone();
-                async move {
-                    let (resp_tx, resp_rx) = tokio::sync::oneshot::channel();
-                    if req_tx.send((req, resp_tx)).await.is_err() {
-                        return Ok::<_, Infallible>(error_response(
-                            StatusCode::SERVICE_UNAVAILABLE,
-                        ));
+    if let Err(e) = http1::Builder::new()
+        .keep_alive(true)
+        .serve_connection(
+            TokioIo::new(client),
+            hyper::service::service_fn(move |req| async move {
+                let mut debuggee_store = match &lock {
+                    Some(store) => Some(store.lock().await),
+                    None => None,
+                };
+                let debuggee_store = debuggee_store.as_mut().map(|s| &mut ***s);
+                match handle_request(handler, debuggee_store, req).await {
+                    Ok(r) => Ok::<_, Infallible>(r),
+                    Err(e) => {
+                        eprintln!("error: {e:?}");
+                        let error_html = "\
+<!doctype html>
+<html>
+<head>
+    <title>500 Internal Server Error</title>
+</head>
+<body>
+    <center>
+        <h1>500 Internal Server Error</h1>
+        <hr>
+        wasmtime
+    </center>
+</body>
+</html>";
+                        Ok(Response::builder()
+                            .status(StatusCode::INTERNAL_SERVER_ERROR)
+                            .header("Content-Type", "text/html; charset=UTF-8")
+                            .body(
+                                Full::new(bytes::Bytes::from(error_html))
+                                    .map_err(|_| unreachable!())
+                                    .boxed_unsync(),
+                            )
+                            .unwrap())
                     }
-                    resp_rx
-                        .await
-                        .unwrap_or(Ok(error_response(StatusCode::SERVICE_UNAVAILABLE)))
                 }
             }),
-        );
-
-        tokio::pin!(serve_conn);
-
-        loop {
-            tokio::select! {
-                result = &mut serve_conn => {
-                    if let Err(e) = result {
-                        eprintln!("connection error: {e:?}");
-                    }
-                    break;
-                }
-                msg = req_rx.recv() => {
-                    let Some((req, resp_tx)) = msg else { break };
-                    let mut req = req;
-                    request_headers.apply(req.headers_mut());
-
-                    let (p2_tx, p2_rx) = tokio::sync::oneshot::channel::<P2Response>();
-                    let wasi_req = store
-                        .data_mut()
-                        .http()
-                        .new_incoming_request(Scheme::Http, req);
-                    let wasi_out = wasi_req.and_then(|_req| {
-                        let out = store.data_mut().http().new_response_outparam(p2_tx);
-                        out.map(|out| (_req, out))
-                    });
-                    let (wasi_req, wasi_out) = match wasi_out {
-                        Ok(pair) => pair,
-                        Err(e) => {
-                            eprintln!("error creating WASI request: {e:?}");
-                            let _ = resp_tx.send(Ok(error_response(
-                                StatusCode::INTERNAL_SERVER_ERROR,
-                            )));
-                            continue;
-                        }
-                    };
-
-                    if let Err(e) = proxy
-                        .wasi_http_incoming_handler()
-                        .call_handle(&mut *store, wasi_req, wasi_out)
-                        .await
-                    {
-                        eprintln!("handler error: {e:?}");
-                    }
-
-                    let resp = match p2_rx.await {
-                        Ok(Ok(resp)) => resp.map(|body| {
-                            body.map_err(|e| e.into()).boxed_unsync()
-                        }),
-                        Ok(Err(e)) => {
-                            eprintln!("component error: {e:?}");
-                            error_response(StatusCode::INTERNAL_SERVER_ERROR)
-                        }
-                        Err(_) => error_response(StatusCode::INTERNAL_SERVER_ERROR),
-                    };
-                    let _ = resp_tx.send(Ok(resp));
-                }
-            }
-        }
+        )
+        .await
+    {
+        eprintln!("error: {e:?}");
     }
 }
 
-type Request = hyper::Request<hyper::body::Incoming>;
-
 async fn handle_request(
-    handler: ProxyHandler<HostHandlerState>,
+    handler: &ProxyHandler<HostHandlerState>,
+    debuggee_store: Option<&mut Store<Host>>,
     mut req: Request,
 ) -> Result<hyper::Response<UnsyncBoxBody<Bytes, wasmtime::Error>>> {
     use wasmtime_wasi_http::p3::bindings::http::types::ErrorCode;
@@ -1294,16 +1191,36 @@ async fn handle_request(
         req.method(),
         req.uri()
     );
-    handler
-        .handle(
-            request_id,
-            req.map(|body| {
-                body.map_err(ErrorCode::from_hyper_request_error)
-                    .map_err(handler::ErrorCode::from)
-                    .boxed_unsync()
-            }),
-        )
-        .await
+
+    let req = req.map(|body| {
+        body.map_err(ErrorCode::from_hyper_request_error)
+            .map_err(handler::ErrorCode::from)
+            .boxed_unsync()
+    });
+
+    match debuggee_store {
+        // For debugging go ahead and synchronously execute the instance here
+        // in a single instance. This is debugging-specific to use the store
+        // passed in.
+        Some(store) => {
+            let instance = handler.state().instantiate_into(store).await?;
+            let (tx, rx) = futures::channel::oneshot::channel();
+            let prepared = Prepared::new(
+                store.as_context_mut(),
+                &instance,
+                req,
+                handler.state().view(),
+                tx,
+            )?;
+            store
+                .run_concurrent(async |store| prepared.run(store, std::future::pending()).await)
+                .await??;
+            rx.await?
+        }
+
+        // For when debugging is disabled delegate to the default handling path.
+        None => handler.handle(request_id, req).await,
+    }
 }
 
 #[derive(Clone, Default)]


### PR DESCRIPTION
When debugging was integrated into `wasmtime serve` it effectively
duplicated the entire process of handling the TCP socket, accepting
connections, dealing with Hyper, etc. This commit is targeted at
removing all of this duplication and using the same path for
debugging-and-not to ensure they don't diverge over time.

> **Note**: this is bulit on https://github.com/bytecodealliance/wasmtime/pull/13555 currently 