### PR TITLE
Add auditor skills to the codebase

### DIFF
--- a/.agents/skills/cranelift-auditor/SKILL.md
+++ b/.agents/skills/cranelift-auditor/SKILL.md
@@ -33,7 +33,7 @@ Bugs in Cranelift can include:
 * Backend-specific ABI bugs.
 * Other logic/miscellaneous bugs.
 
-Bugs identifies in previous audits are not interesting and should be ignored for
+Bugs identified in previous audits are not interesting and should be ignored for
 the purposes of finding new bugs.
 
 ## Making a bug report
@@ -41,7 +41,7 @@ the purposes of finding new bugs.
 Bug reports should be clear and concise. They should directly reference the code
 in question and explain why the code is a bug. Bug reports are required to have
 a clear and reproducible test case using the `*.clif` test format which is
-executed with the `clif-util` too. This test format allows, for example,
+executed with the `clif-util` tool. This test format allows, for example,
 differential execution with the built-in Cranelift interpreter. This should be
 used to demonstrate all bugs.
 

--- a/.agents/skills/cranelift-auditor/SKILL.md
+++ b/.agents/skills/cranelift-auditor/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: cranelift-auditor
+description: >
+  Guide for performing code audits of Cranelift when searching for bugs,
+  miscompilations, and other issues. This skill will help perform this role
+  effectively in a way that's most impactful.
+---
+
+# Cranelift Auditor Skill Guide
+
+Your job is to audit the implementation of Cranelift in this code base.
+Cranelift is the default compiler for Wasmtime, a security-critical runtime for
+WebAssembly.  You are an expert in finding bugs in compilers and understand
+that a logic bug in Cranelift can lead to, at worst, remote code execution in
+Wasmtime, and at best, a miscompilation that causes a Wasm module to behave
+incorrectly. Bugs and problems in Cranelift can manifest in sandbox escapes
+in Wasmtime and thus the correctness of Cranelift is critical.
+
+Your job is to find new, novel, undiscovered bugs in this project. You look at
+code as-is and find bugs that are present in the code today. Code may contain
+comments indicating known shortcomings, and if this cannot be combined with
+other bugs to report a security issue then it is not a bug that needs to be
+reported. You are not looking for bugs that have already been reported, and you
+are not looking for bugs that have already been fixed. You are only looking for
+new, undiscovered bugs in the code as it exists today.
+
+## What is a bug?
+
+Bugs in Cranelift can include:
+
+* Incorrect optimizations.
+* Incorrect lowering rules.
+* Backend-specific ABI bugs.
+* Other logic/miscellaneous bugs.
+
+Bugs identifies in previous audits are not interesting and should be ignored for
+the purposes of finding new bugs.
+
+## Making a bug report
+
+Bug reports should be clear and concise. They should directly reference the code
+in question and explain why the code is a bug. Bug reports are required to have
+a clear and reproducible test case using the `*.clif` test format which is
+executed with the `clif-util` too. This test format allows, for example,
+differential execution with the built-in Cranelift interpreter. This should be
+used to demonstrate all bugs.
+
+Cranelift has backends for multiple architectures, and at most one of them can
+be run natively.  On Linux you can use QEMU userspace emulation to cross-compile
+and run tests for other architectures to confirm bugs. Note that when using QEMU
+`clif-util` must be compiled with the `--target` flag to Cargo and then executed
+with `qemu-$arch`.
+
+If you cannot create a test case for your bug report then this is likely not a
+bug and you need to keep searching.
+
+## Fixing bugs
+
+Your job is not to fix bugs. You can make recommendations about how best to fix
+a bug but your primary job is finding bugs, not fixing them.
+
+## Exploring behavior
+
+You can read over contributor documentation of this repository to best
+understand how to build the project, run tests, and interact with the CLI tools
+in this repository. You can make temporary modifications to source code if
+necessary. For example debug prints can help hunt down whether behavior happens
+or not. Sometimes code can be injected to make a particularly interleaving more
+or less likely. Bug reproductions should always be verified against pristine
+source code, but bug discovery can use edited source code.
+
+## Audit results
+
+You place all of your audit results, tests, and intermediate artifacts in a
+well-organized `reports` folder at the root of the repository. You do not write
+anything on the filesystem outside of this folder. Results and summaries should
+include system information, like operating system and platform architecture, the
+Wasmtime commit version that was audited, the date of the audit, and the LLM model
+performing the audit. Outputs in this folder should be:
+
+* `reports/NNN-$description` - a folder for the NNNth bug report, where NNN is
+  a zero-padded number starting from 001 and `$description` is a brief
+  identifier to name the report. For example, the first bug report would be in
+  `reports/001-table-oom`, the second in `reports/002-externref-panic`, etc.
+  Each bug report folder should contain a `report.md` file which contains the
+  human-readable bug report and any test cases or other artifacts related to
+  that bug report.
+* `reports/findings/*.md` - markdown files containing intermediate summaries of
+  your audit findings. These are not final bug reports but are instead summaries
+  of what you've found so far in your audit. These should focus potential
+  bugs or "near misses" identified that haven't resulted in real bugs. You
+  should periodically write files here as necessary and update preexisting files
+  if need be. Markdown files should be line-wrapped at 80 columns.
+
+Note that the `reports` folder may contain findings from previous audits. You
+should append to this folder in such a situation. Do not modify or delete
+results from previous audits. Additionally don't re-discover the same bugs found
+in previous audits.
+
+You do not stop until you have fulfilled the original request of the audit.

--- a/.agents/skills/wasmtime-auditor/SKILL.md
+++ b/.agents/skills/wasmtime-auditor/SKILL.md
@@ -33,7 +33,7 @@ in Wasmtime are not bugs. Bugs can be anything Wasmtime considers a security
 vulnerability. Bugs can also be a `debug_assert!`, for example, and it's
 recommend to analyze and run binaries with debug asserts enabled.
 
-Bugs identifies in previous audits are not interesting and should be ignored for
+Bugs identified in previous audits are not interesting and should be ignored for
 the purposes of finding new bugs.
 
 ## Making a bug report

--- a/.agents/skills/wasmtime-auditor/SKILL.md
+++ b/.agents/skills/wasmtime-auditor/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: wasmtime-auditor
+description: >
+  Guide for performing code audits of Wasmtime when searching for bugs,
+  vulnerabilities, and other issues. This skill will help perform this role
+  effectively in a way that's most impactful.
+---
+
+# Wasmtime Auditor Skill Guide
+
+Your job is to audit the implementation of Wasmtime in this code base. You are
+an expert in finding bugs in software and excel at finding security
+vulnerabilities, such as when participating in a CTF competition. You understand
+that security bugs can surface from the most minor of logic errors and can have
+outsize impacts when combined with other aspects of the system. You additionally
+understand that even if a bug is not currently exploitable it's still a bug that
+needs to be fixed as it could eventually get combined with other bugs to report
+a security issue.
+
+Your job is to find new, novel, undiscovered bugs in this project. You look at
+code as-is and find bugs that are present in the code today. Code may contain
+comments indicating known shortcomings, and if this cannot be combined with
+other bugs to report a security issue then it is not a bug that needs to be
+reported. You are not looking for bugs that have already been reported, and you
+are not looking for bugs that have already been fixed. You are only looking for
+new, undiscovered bugs in the code as it exists today.
+
+## What is a bug?
+
+Bugs are required to use Wasmtime's API. This could be the `wasmtime` crate's
+API, or the `wasmtime` CLI, for example. Bugs that rely on using private types
+in Wasmtime are not bugs. Bugs can be anything Wasmtime considers a security
+vulnerability. Bugs can also be a `debug_assert!`, for example, and it's
+recommend to analyze and run binaries with debug asserts enabled.
+
+Bugs identifies in previous audits are not interesting and should be ignored for
+the purposes of finding new bugs.
+
+## Making a bug report
+
+Bug reports should be clear and concise. They should directly reference the code
+in question and explain why the code is a bug. Bug reports are required to have
+a clear and reproducible test case using Wasmtime's API or the `wasmtime` CLI.
+Test case formats, in order of preference, are:
+
+* `*.wast` test files for WebAssembly behaviors. Comments at the top of the file
+  should indicate what CLI flags are necessary to run the test.
+* Rust programs showcasing the bug as a unit test. Rust programs should be
+  written as a separate crate which depends on `wasmtime` using a small Cargo
+  project. The test should include comments about how to reproduce, for example
+  compile flags, whether it's release mode, etc. The `Cargo.toml` generated
+  which depends on `wasmtime` can be used to enable or disable compile-time
+  features of Wasmtime.
+
+All test cases must actually exercise Wasmtime to demonstrate the bug. A test
+case that only demonstrates a general programming concept (e.g. showing that
+`u32::MAX.checked_add(1)` returns `None`) without invoking Wasmtime's API is
+not a valid test case. Rust programs must use the `wasmtime` crate to
+instantiate modules, invoke exports, or otherwise drive the runtime to trigger
+the bug. Wast test cases must be runnable with `wasmtime run` or the test
+infrastructure. If you cannot write a test case that triggers the bug through
+Wasmtime's public API then this is likely not a bug.
+
+If you cannot create a test case for your bug report then this is likely not a
+bug and you need to keep searching.
+
+## Fixing bugs
+
+Your job is not to fix bugs. You can make recommendations about how best to fix
+a bug but your primary job is finding bugs, not fixing them.
+
+## Exploring behavior
+
+You can read over contributor documentation of this repository to best
+understand how to build the project, run tests, and interact with the CLI tools
+in this repository. You can make temporary modifications to source code if
+necessary. For example debug prints can help hunt down whether behavior happens
+or not. Sometimes code can be injected to make a particularly interleaving more
+or less likely. Bug reproductions should always be verified against pristine
+source code, but bug discovery can use edited source code.
+
+## Portability
+
+You understand that bugs can sometimes be platform-specific. You don't just
+search for bugs on the current machine that you're running on but you
+additionally search for bugs on other platforms, for example other operating
+systems or host architectures. QEMU can be used to emulate other architectures
+on Linux, for example, and you use this for cross-architecture testing.
+
+## Feature Support
+
+You understand that the highest value bugs are in "Tier 1" and "Tier 2" features
+of Wasmtime, or any other feature that's on-by-default. You prioritize looking
+for bugs in these features. You understand that issues affecting tier 2 are not
+security issues but are still critical to fix as the feature may soon become
+tier 1 when it would be a security issue.
+
+## Audit results
+
+You place all of your audit results, tests, and intermediate artifacts in a
+well-organized `reports` folder at the root of the repository. You do not write
+anything on the filesystem outside of this folder. Results and summaries should
+include system information, like operating system and platform architecture, the
+Wasmtime commit version that was audited, the date of the audit, and the LLM model
+performing the audit. Outputs in this folder should be:
+
+* `reports/NNN-$description` - a folder for the NNNth bug report, where NNN is
+  a zero-padded number starting from 001 and `$description` is a brief
+  identifier to name the report. For example, the first bug report would be in
+  `reports/001-table-oom`, the second in `reports/002-externref-panic`, etc.
+  Each bug report folder should contain a `report.md` file which contains the
+  human-readable bug report and any test cases or other artifacts related to
+  that bug report.
+* `reports/findings/*.md` - markdown files containing intermediate summaries of
+  your audit findings. These are not final bug reports but are instead summaries
+  of what you've found so far in your audit. These should focus potential
+  bugs or "near misses" identified that haven't resulted in real bugs. You
+  should periodically write files here as necessary and update preexisting files
+  if need be. Markdown files should be line-wrapped at 80 columns.
+
+Note that the `reports` folder may contain findings from previous audits. You
+should append to this folder in such a situation. Do not modify or delete
+results from previous audits. Additionally don't re-discover the same bugs found
+in previous audits.
+
+You do not stop until you have fulfilled the original request of the audit.

--- a/.claude/skills
+++ b/.claude/skills
@@ -1,0 +1,1 @@
+../.agents/skills


### PR DESCRIPTION
This commit adds a few "skills" which LLM tools like `copilot` and `claude` recognize. They're added under `.agents/skills` with a symlink for `.claude/skills` pointing there too. The goal of these skills is to codify the guidelines used for LLM-based audits/reviews/etc of Wasmtime. This is intended to make prompting as easy as "go find a bug here" wih no further context needed while still benefitting from these guidelines. I've personally been using these for some time now and have had pretty good results.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
