### PR TITLE
Fix subtraction order in `poll_oneoff`

### DIFF
--- a/crates/wasi/src/p1.rs
+++ b/crates/wasi/src/p1.rs
@@ -2384,22 +2384,8 @@ impl wasi_snapshot_preview1::WasiSnapshotPreview1 for WasiP1Ctx {
                             let now = wall_clock::Host::now(&mut temp.ctx.clocks())
                                 .context("failed to call `wall_clock::now`")
                                 .map_err(types::Error::trap)?;
-
-                            // Convert `timeout` to `Datetime` format.
-                            let seconds = timeout / 1_000_000_000;
-                            let nanoseconds = timeout % 1_000_000_000;
-
-                            let timeout = if now.seconds < seconds
-                                || now.seconds == seconds
-                                    && u64::from(now.nanoseconds) < nanoseconds
-                            {
-                                // `now` is less than `timeout`, which is expressible as u64,
-                                // subtract the nanosecond counts directly
-                                now.seconds * 1_000_000_000 + u64::from(now.nanoseconds) - timeout
-                            } else {
-                                0
-                            };
-                            (timeout, false)
+                            let now = now.seconds * 1_000_000_000 + u64::from(now.nanoseconds);
+                            (timeout.saturating_sub(now), false)
                         }
                         _ => return Err(types::Errno::Inval.into()),
                     };


### PR DESCRIPTION
For the WASIp1 implementation of `poll_oneoff` witha  "realtime" clock specified in an absolute value the implementation had a typo where the order of subtraction was reversed by accident. This can lead to a subtraction overflow in debug mode and a sleep-too-long in release mode. This requires an extremely long sleep to trigger, however, so it's either really long sleep A or really long sleep B. Regardless seems good to fix, but not easy to test.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
