### PR TITLE
Remove cap-time-ext dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,15 +68,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9d4ee0d472d1cd2e28c97dfa124b3d8d992e10eb0a035f33f5d12e3a177ba3b"
 
 [[package]]
-name = "android_system_properties"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -407,20 +398,6 @@ dependencies = [
  "io-extras",
  "io-lifetimes 3.0.1",
  "rustix 1.1.4",
-]
-
-[[package]]
-name = "cap-time-ext"
-version = "4.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15846d522ff80af20ebd2b690f56a0710f7e394911a85d76556d98e2264ae0d4"
-dependencies = [
- "ambient-authority",
- "cap-primitives",
- "iana-time-zone",
- "once_cell",
- "rustix 1.1.4",
- "winx",
 ]
 
 [[package]]
@@ -1911,29 +1888,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "iana-time-zone"
-version = "0.1.61"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "235e081f3925a06703c2d0117ea8b91f042756fd6e7a6e5d901e8ca1a996b220"
-dependencies = [
- "android_system_properties",
- "core-foundation-sys",
- "iana-time-zone-haiku",
- "js-sys",
- "wasm-bindgen",
- "windows-core",
-]
-
-[[package]]
-name = "iana-time-zone-haiku"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "icu_collections"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2233,16 +2187,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "js-sys"
-version = "0.3.74"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a865e038f7f6ed956f788f0d7d60c541fff74c7bd74272c5d4cf15c63743e705"
-dependencies = [
- "once_cell",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -4364,61 +4308,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-bindgen"
-version = "0.2.97"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d15e63b4482863c109d70a7b8706c1e364eb6ea449b201a76c5b89cedcec2d5c"
-dependencies = [
- "cfg-if",
- "once_cell",
- "wasm-bindgen-macro",
-]
-
-[[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.97"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d36ef12e3aaca16ddd3f67922bc63e48e953f126de60bd33ccc0101ef9998cd"
-dependencies = [
- "bumpalo",
- "log",
- "once_cell",
- "proc-macro2",
- "quote",
- "syn 2.0.106",
- "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-macro"
-version = "0.2.97"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "705440e08b42d3e4b36de7d66c944be628d579796b8090bfa3471478a2260051"
-dependencies = [
- "quote",
- "wasm-bindgen-macro-support",
-]
-
-[[package]]
-name = "wasm-bindgen-macro-support"
-version = "0.2.97"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98c9ae5a76e46f4deecd0f0255cc223cfa18dc9b261213b8aa0c7b36f61b3f1d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.106",
- "wasm-bindgen-backend",
- "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-shared"
-version = "0.2.97"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ee99da9c5ba11bd675621338ef6fa52296b76b83305e9b6e5c77d4c286d6d49"
-
-[[package]]
 name = "wasm-compose"
 version = "0.251.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5224,7 +5113,6 @@ dependencies = [
  "cap-fs-ext",
  "cap-net-ext",
  "cap-std",
- "cap-time-ext",
  "cfg-if",
  "env_logger 0.11.5",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -349,7 +349,6 @@ target-lexicon = "0.13.5"
 cap-std = "4.0.2"
 cap-fs-ext = "4.0.2"
 cap-net-ext = "4.0.2"
-cap-time-ext = "4.0.2"
 cap-tempfile = "4.0.2"
 io-lifetimes = { version = "3.0.1", default-features = false }
 rustix = "1.1.4"

--- a/crates/wasi/Cargo.toml
+++ b/crates/wasi/Cargo.toml
@@ -29,7 +29,6 @@ tracing = { workspace = true, features = ["std", "attributes"] }
 cap-std = { workspace = true }
 cap-fs-ext = { workspace = true }
 cap-net-ext = { workspace = true }
-cap-time-ext = { workspace = true }
 io-lifetimes = { workspace = true }
 bitflags = { workspace = true }
 async-trait = { workspace = true }
@@ -61,6 +60,7 @@ features = [
   "Win32_Foundation",
   "Win32_Storage_FileSystem",
   "Win32_System_IO",
+  "Win32_System_Performance",
 ]
 
 [features]

--- a/crates/wasi/src/clocks.rs
+++ b/crates/wasi/src/clocks.rs
@@ -1,6 +1,5 @@
 use cap_std::time::{Duration, Instant, SystemClock, SystemTime};
 use cap_std::{AmbientAuthority, ambient_authority};
-use cap_time_ext::{MonotonicClockExt as _, SystemClockExt as _};
 use std::error::Error;
 use std::fmt;
 use wasmtime::component::{HasData, ResourceTable};
@@ -103,7 +102,22 @@ impl WallClock {
 
 impl HostWallClock for WallClock {
     fn resolution(&self) -> Duration {
-        self.clock.resolution()
+        #[cfg(unix)]
+        {
+            let res = rustix::time::clock_getres(rustix::time::ClockId::Realtime);
+            Duration::new(
+                res.tv_sec.try_into().unwrap(),
+                res.tv_nsec.try_into().unwrap(),
+            )
+        }
+        #[cfg(windows)]
+        {
+            // According to [this blog post], the system timer resolution
+            // is 55ms or 10ms. Use the more conservative of the two.
+            //
+            // [this blog post]: https://devblogs.microsoft.com/oldnewthing/20170921-00/?p=97057
+            Duration::new(0, 55_000_000)
+        }
     }
 
     fn now(&self) -> Duration {
@@ -140,7 +154,26 @@ impl MonotonicClock {
 
 impl HostMonotonicClock for MonotonicClock {
     fn resolution(&self) -> u64 {
-        self.clock.resolution().as_nanos().try_into().unwrap()
+        #[cfg(unix)]
+        {
+            let res = rustix::time::clock_getres(rustix::time::ClockId::Monotonic);
+            u64::try_from(res.tv_sec).unwrap() * 1_000_000_000 + u64::try_from(res.tv_nsec).unwrap()
+        }
+        #[cfg(windows)]
+        {
+            use windows_sys::Win32::System::Performance::QueryPerformanceFrequency;
+
+            unsafe {
+                let mut frequency = 0;
+                if QueryPerformanceFrequency(&mut frequency) == 0 {
+                    panic!(
+                        "QueryPerformanceFrequency failed: {}",
+                        std::io::Error::last_os_error()
+                    );
+                }
+                1_000_000_000 / u64::try_from(frequency).unwrap()
+            }
+        }
     }
 
     fn now(&self) -> u64 {

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -832,13 +832,6 @@ user-id = 6825
 user-login = "sunfishcode"
 user-name = "Dan Gohman"
 
-[[publisher.cap-time-ext]]
-version = "4.0.2"
-when = "2026-02-15"
-user-id = 6825
-user-login = "sunfishcode"
-user-name = "Dan Gohman"
-
 [[publisher.cc]]
 version = "1.0.89"
 when = "2024-03-04"
@@ -1213,13 +1206,6 @@ user-name = "David Tolnay"
 [[publisher.jobserver]]
 version = "0.1.25"
 when = "2022-09-23"
-user-id = 1
-user-login = "alexcrichton"
-user-name = "Alex Crichton"
-
-[[publisher.js-sys]]
-version = "0.3.74"
-when = "2024-11-30"
 user-id = 1
 user-login = "alexcrichton"
 user-name = "Alex Crichton"
@@ -1672,41 +1658,6 @@ user-name = "Alex Crichton"
 [[publisher.wasip3]]
 version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 when = "2026-01-15"
-user-id = 1
-user-login = "alexcrichton"
-user-name = "Alex Crichton"
-
-[[publisher.wasm-bindgen]]
-version = "0.2.97"
-when = "2024-11-30"
-user-id = 1
-user-login = "alexcrichton"
-user-name = "Alex Crichton"
-
-[[publisher.wasm-bindgen-backend]]
-version = "0.2.97"
-when = "2024-11-30"
-user-id = 1
-user-login = "alexcrichton"
-user-name = "Alex Crichton"
-
-[[publisher.wasm-bindgen-macro]]
-version = "0.2.97"
-when = "2024-11-30"
-user-id = 1
-user-login = "alexcrichton"
-user-name = "Alex Crichton"
-
-[[publisher.wasm-bindgen-macro-support]]
-version = "0.2.97"
-when = "2024-11-30"
-user-id = 1
-user-login = "alexcrichton"
-user-name = "Alex Crichton"
-
-[[publisher.wasm-bindgen-shared]]
-version = "0.2.97"
-when = "2024-11-30"
 user-id = 1
 user-login = "alexcrichton"
 user-name = "Alex Crichton"


### PR DESCRIPTION
Removes an extra dependency of `wasmtime-wasi` by inlining the necessary implementations within the crate itself. This helps remove layers of abstraction in `wasmtime-wasi` and helps prune from our lock file as well.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
