### PR TITLE
Remove the cap-net-ext dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -359,18 +359,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cap-net-ext"
-version = "4.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35e3ea603c5602ad8839d4cfcccbfb72bf494286a3dc4564b3b8f52d8f803a89"
-dependencies = [
- "cap-primitives",
- "cap-std",
- "rustix 1.1.4",
- "smallvec 1.15.1",
-]
-
-[[package]]
 name = "cap-primitives"
 version = "4.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5111,7 +5099,6 @@ dependencies = [
  "bitflags 2.11.1",
  "bytes",
  "cap-fs-ext",
- "cap-net-ext",
  "cap-std",
  "cfg-if",
  "env_logger 0.11.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -348,8 +348,6 @@ wasip1 = { version = "1.0.0", default-features = false }
 target-lexicon = "0.13.5"
 cap-std = "4.0.2"
 cap-fs-ext = "4.0.2"
-cap-net-ext = "4.0.2"
-cap-tempfile = "4.0.2"
 io-lifetimes = { version = "3.0.1", default-features = false }
 rustix = "1.1.4"
 # wit-bindgen:

--- a/crates/wasi/Cargo.toml
+++ b/crates/wasi/Cargo.toml
@@ -28,7 +28,6 @@ thiserror = { workspace = true }
 tracing = { workspace = true, features = ["std", "attributes"] }
 cap-std = { workspace = true }
 cap-fs-ext = { workspace = true }
-cap-net-ext = { workspace = true }
 io-lifetimes = { workspace = true }
 bitflags = { workspace = true }
 async-trait = { workspace = true }

--- a/crates/wasi/src/p2/host/network.rs
+++ b/crates/wasi/src/p2/host/network.rs
@@ -1,7 +1,6 @@
 use crate::p2::SocketError;
 use crate::p2::bindings::sockets::network::{
-    self, ErrorCode, IpAddress, IpAddressFamily, IpSocketAddress, Ipv4SocketAddress,
-    Ipv6SocketAddress,
+    self, ErrorCode, IpAddress, IpSocketAddress, Ipv4SocketAddress, Ipv6SocketAddress,
 };
 use crate::sockets::WasiSocketsCtxView;
 use crate::sockets::util::{from_ipv4_addr, from_ipv6_addr, to_ipv4_addr, to_ipv6_addr};
@@ -215,23 +214,5 @@ impl std::net::ToSocketAddrs for Ipv6SocketAddress {
 
     fn to_socket_addrs(&self) -> io::Result<Self::Iter> {
         std::net::SocketAddrV6::from(*self).to_socket_addrs()
-    }
-}
-
-impl From<IpAddressFamily> for cap_net_ext::AddressFamily {
-    fn from(family: IpAddressFamily) -> Self {
-        match family {
-            IpAddressFamily::Ipv4 => cap_net_ext::AddressFamily::Ipv4,
-            IpAddressFamily::Ipv6 => cap_net_ext::AddressFamily::Ipv6,
-        }
-    }
-}
-
-impl From<cap_net_ext::AddressFamily> for IpAddressFamily {
-    fn from(family: cap_net_ext::AddressFamily) -> Self {
-        match family {
-            cap_net_ext::AddressFamily::Ipv4 => IpAddressFamily::Ipv4,
-            cap_net_ext::AddressFamily::Ipv6 => IpAddressFamily::Ipv6,
-        }
     }
 }

--- a/crates/wasi/src/p3/sockets/conv.rs
+++ b/crates/wasi/src/p3/sockets/conv.rs
@@ -104,24 +104,6 @@ impl ToSocketAddrs for types::Ipv6SocketAddress {
     }
 }
 
-impl From<types::IpAddressFamily> for cap_net_ext::AddressFamily {
-    fn from(family: types::IpAddressFamily) -> Self {
-        match family {
-            types::IpAddressFamily::Ipv4 => Self::Ipv4,
-            types::IpAddressFamily::Ipv6 => Self::Ipv6,
-        }
-    }
-}
-
-impl From<cap_net_ext::AddressFamily> for types::IpAddressFamily {
-    fn from(family: cap_net_ext::AddressFamily) -> Self {
-        match family {
-            cap_net_ext::AddressFamily::Ipv4 => Self::Ipv4,
-            cap_net_ext::AddressFamily::Ipv6 => Self::Ipv6,
-        }
-    }
-}
-
 impl From<SocketAddressFamily> for types::IpAddressFamily {
     fn from(family: SocketAddressFamily) -> Self {
         match family {

--- a/crates/wasi/src/sockets/udp.rs
+++ b/crates/wasi/src/sockets/udp.rs
@@ -5,7 +5,6 @@ use crate::sockets::util::{
     set_unicast_hop_limit, udp_bind, udp_connect, udp_disconnect, udp_socket,
 };
 use crate::sockets::{SocketAddrCheck, SocketAddressFamily, WasiSocketsCtx};
-use cap_net_ext::AddressFamily;
 use io_lifetimes::AsSocketlike as _;
 use io_lifetimes::raw::{FromRawSocketlike as _, IntoRawSocketlike as _};
 use rustix::io::Errno;
@@ -57,23 +56,14 @@ pub struct UdpSocket {
 
 impl UdpSocket {
     /// Create a new socket in the given family.
-    pub(crate) fn new(cx: &WasiSocketsCtx, family: AddressFamily) -> Result<Self, ErrorCode> {
+    pub(crate) fn new(cx: &WasiSocketsCtx, family: SocketAddressFamily) -> Result<Self, ErrorCode> {
         cx.allowed_network_uses.check_allowed_udp()?;
-
-        // Delegate socket creation to cap_net_ext. They handle a couple of things for us:
-        // - On Windows: call WSAStartup if not done before.
-        // - Set the NONBLOCK and CLOEXEC flags. Either immediately during socket creation,
-        //   or afterwards using ioctl or fcntl. Exact method depends on the platform.
 
         let fd = udp_socket(family)?;
 
-        let socket_address_family = match family {
-            AddressFamily::Ipv4 => SocketAddressFamily::Ipv4,
-            AddressFamily::Ipv6 => {
-                rustix::net::sockopt::set_ipv6_v6only(&fd, true)?;
-                SocketAddressFamily::Ipv6
-            }
-        };
+        if family == SocketAddressFamily::Ipv6 {
+            rustix::net::sockopt::set_ipv6_v6only(&fd, true)?;
+        }
 
         let socket = with_ambient_tokio_runtime(|| {
             tokio::net::UdpSocket::try_from(unsafe {
@@ -84,7 +74,7 @@ impl UdpSocket {
         Ok(Self {
             socket: Arc::new(socket),
             udp_state: UdpState::Default,
-            family: socket_address_family,
+            family,
             socket_addr_check: None,
         })
     }

--- a/crates/wasi/src/sockets/util.rs
+++ b/crates/wasi/src/sockets/util.rs
@@ -1,15 +1,12 @@
+use crate::sockets::SocketAddressFamily;
 use core::fmt;
 use core::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 use core::str::FromStr as _;
 use core::time::Duration;
-
-use cap_net_ext::{AddressFamily, Blocking, UdpSocketExt};
 use rustix::fd::AsFd;
 use rustix::io::Errno;
 use rustix::net::{bind, connect, connect_unspec, sockopt};
 use tracing::debug;
-
-use crate::sockets::SocketAddressFamily;
 
 #[derive(Debug)]
 pub enum ErrorCode {
@@ -368,13 +365,37 @@ pub fn tcp_bind(
         })
 }
 
-pub fn udp_socket(family: AddressFamily) -> std::io::Result<cap_std::net::UdpSocket> {
-    // Delegate socket creation to cap_net_ext. They handle a couple of things for us:
-    // - On Windows: call WSAStartup if not done before.
-    // - Set the NONBLOCK and CLOEXEC flags. Either immediately during socket creation,
-    //   or afterwards using ioctl or fcntl. Exact method depends on the platform.
+/// Creates a non-blocking/cloexec UDP socket.
+pub fn udp_socket(family: SocketAddressFamily) -> std::io::Result<rustix::fd::OwnedFd> {
+    // Let the standard library be responsible for handling `WSAStartup`.
+    #[cfg(windows)]
+    static INIT: std::sync::Once = std::sync::Once::new();
+    #[cfg(windows)]
+    INIT.call_once(|| {
+        let _ = std::net::TcpStream::connect(std::net::SocketAddrV4::new(
+            std::net::Ipv4Addr::UNSPECIFIED,
+            0,
+        ));
+    });
 
-    let socket = cap_std::net::UdpSocket::new(family, Blocking::No)?;
+    #[cfg(not(any(windows, target_vendor = "apple")))]
+    let flags = rustix::net::SocketFlags::CLOEXEC | rustix::net::SocketFlags::NONBLOCK;
+    #[cfg(any(windows, target_vendor = "apple"))]
+    let flags = rustix::net::SocketFlags::empty();
+
+    let socket = rustix::net::socket_with(
+        match family {
+            SocketAddressFamily::Ipv4 => rustix::net::AddressFamily::INET,
+            SocketAddressFamily::Ipv6 => rustix::net::AddressFamily::INET6,
+        },
+        rustix::net::SocketType::DGRAM,
+        flags,
+        None,
+    )?;
+    #[cfg(target_vendor = "apple")]
+    rustix::io::ioctl_fioclex(&socket)?;
+    #[cfg(any(windows, target_vendor = "apple"))]
+    rustix::io::ioctl_fionbio(&socket, true)?;
     Ok(socket)
 }
 


### PR DESCRIPTION
Similar to #13569 this is trying to keep `wasmtime-wasi` a bit leaner in terms of layers of abstraction to avoid needing to dig through many layers of crates to see what's going on.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
