### PR TITLE
Optimize codegen for `call_indirect` of `final` super types with GC enabled

### DIFF
--- a/cranelift/codegen/src/egraph/mod.rs
+++ b/cranelift/codegen/src/egraph/mod.rs
@@ -663,10 +663,12 @@ where
                 }
                 // `ReplaceBranchCond` is unconditionally accepted — the
                 // opcode and successors don't change, so we can't use the
-                // cost-based ranking the other variants do. The first such
+                // cost-based ranking the other variants do (replacing the
+                // condition with a cheaper sub-expression keeps the same
+                // opcode/arity, hence the same skeleton cost). The first such
                 // candidate wins; ISLE rule ordering picks the form.
                 SkeletonInstSimplification::ReplaceBranchCond { cond } => {
-                    log::trace!(" -> simplify_skeleton: replace `brif` cond with {cond}");
+                    log::trace!(" -> simplify_skeleton: replace condition operand with {cond}");
                     return Some(SkeletonInstSimplification::ReplaceBranchCond { cond });
                 }
             };
@@ -995,12 +997,15 @@ impl<'a> EgraphPass<'a> {
             SkeletonInstSimplification::Replace { inst } => (inst, None),
             SkeletonInstSimplification::ReplaceWithVal { inst, val } => (inst, Some(val)),
             SkeletonInstSimplification::ReplaceBranchCond { cond } => {
-                // Swap the condition operand of the existing `brif` in
-                // place. Successors stay; CFG is preserved.
-                debug_assert_eq!(
+                // Swap the condition operand (argument 0) of the existing
+                // conditional skeleton instruction in place. The opcode and any
+                // successors stay the same, so the CFG is preserved. This
+                // applies to `brif` as well as the conditional traps `trapz` and
+                // `trapnz`, which all take the tested value as argument 0.
+                debug_assert!(matches!(
                     cursor.func.dfg.insts[old_inst].opcode(),
-                    crate::ir::Opcode::Brif,
-                );
+                    crate::ir::Opcode::Brif | crate::ir::Opcode::Trapz | crate::ir::Opcode::Trapnz,
+                ));
                 cursor.func.dfg.inst_args_mut(old_inst)[0] = cond;
                 return;
             }

--- a/cranelift/codegen/src/opts/skeleton.isle
+++ b/cranelift/codegen/src/opts/skeleton.isle
@@ -32,6 +32,18 @@
       (if-let dest (resolve_jump_table_entry jt idx))
       (jump dest))
 
+;; `brif`, `trapz`, and `trapnz` only test their condition for being zero
+;; vs. non-zero, so any truthiness-preserving operation can be stripped off.
+(rule (simplify_skeleton (brif c _ _))
+      (if-let x (truthy c))
+      (replace_branch_cond x))
+(rule (simplify_skeleton (trapz c _))
+      (if-let x (truthy c))
+      (replace_branch_cond x))
+(rule (simplify_skeleton (trapnz c _))
+      (if-let x (truthy c))
+      (replace_branch_cond x))
+
 ;; TODO: We can't simplify into unconditional traps yet. See the comment in
 ;; `simplify_skeleton_inst` for more details.
 ;;

--- a/cranelift/codegen/src/prelude_opt.isle
+++ b/cranelift/codegen/src/prelude_opt.isle
@@ -94,12 +94,15 @@
         ;; or types of results as the old instruction.
         (ReplaceWithVal (inst Inst) (val Value))
 
-        ;; Narrow rewrite: replace the condition operand of a `brif`
-        ;; (argument 0) with the given value. The opcode and successor
-        ;; blocks stay the same, so the CFG is preserved. Use this to
-        ;; rewrite branch conditions whose producer simplifies in
-        ;; boolean-test context (e.g. `(brif (ctz x))` → branch on the
-        ;; LSB of x).
+        ;; Narrow rewrite: replace the condition operand of a conditional
+        ;; skeleton instruction (i.e. `brif`, `trapz`, or `trapnz`) with the
+        ;; given value.
+        ;;
+        ;; The opcode and any successor blocks stay the same, so the CFG is
+        ;; preserved.
+        ;;
+        ;; Use this to rewrite conditions which simplify within a boolean-test
+        ;; context (e.g. `(brif (ctz x))` can be simplified to `(brif x)`).
         (ReplaceBranchCond (cond Value))))
 
 (decl pure inst_to_skeleton_inst_simplification (Inst) SkeletonInstSimplification)

--- a/cranelift/filetests/filetests/egraph/branch-trap-truthy.clif
+++ b/cranelift/filetests/filetests/egraph/branch-trap-truthy.clif
@@ -1,0 +1,115 @@
+test optimize precise-output
+set opt_level=speed
+target x86_64
+
+;; brif (bmask x) -> brif x
+function %brif_bmask(i32) -> i32 {
+block0(v0: i32):
+    v1 = bmask.i32 v0
+    brif v1, block1, block2
+
+block1:
+    v2 = iconst.i32 100
+    return v2
+
+block2:
+    v3 = iconst.i32 200
+    return v3
+}
+
+; function %brif_bmask(i32) -> i32 fast {
+; block0(v0: i32):
+;     brif v0, block1, block2
+;
+; block1:
+;     v2 = iconst.i32 100
+;     return v2  ; v2 = 100
+;
+; block2:
+;     v3 = iconst.i32 200
+;     return v3  ; v3 = 200
+; }
+
+;; brif (ineg x) -> brif x
+function %brif_ineg(i32) -> i32 {
+block0(v0: i32):
+    v1 = ineg.i32 v0
+    brif v1, block1, block2
+
+block1:
+    v2 = iconst.i32 100
+    return v2
+
+block2:
+    v3 = iconst.i32 200
+    return v3
+}
+
+; function %brif_ineg(i32) -> i32 fast {
+; block0(v0: i32):
+;     brif v0, block1, block2
+;
+; block1:
+;     v2 = iconst.i32 100
+;     return v2  ; v2 = 100
+;
+; block2:
+;     v3 = iconst.i32 200
+;     return v3  ; v3 = 200
+; }
+
+;; brif (sextend x) -> brif x
+function %brif_sextend(i8) -> i32 {
+block0(v0: i8):
+    v1 = sextend.i32 v0
+    brif v1, block1, block2
+
+block1:
+    v2 = iconst.i32 100
+    return v2
+
+block2:
+    v3 = iconst.i32 200
+    return v3
+}
+
+; function %brif_sextend(i8) -> i32 fast {
+; block0(v0: i8):
+;     brif v0, block1, block2
+;
+; block1:
+;     v2 = iconst.i32 100
+;     return v2  ; v2 = 100
+;
+; block2:
+;     v3 = iconst.i32 200
+;     return v3  ; v3 = 200
+; }
+
+;; trapz (uextend x) -> trapz x
+function %trapz_uextend(i8) -> i8 {
+block0(v0: i8):
+    v1 = uextend.i32 v0
+    trapz v1, user8
+    return v0
+}
+
+; function %trapz_uextend(i8) -> i8 fast {
+; block0(v0: i8):
+;     trapz v0, user8
+;     return v0
+; }
+
+;; trapnz (bmask x) -> trapnz x
+function %trapnz_bmask(i32) -> i32 {
+block0(v0: i32):
+    v1 = bmask.i32 v0
+    trapnz v1, user8
+    return v0
+}
+
+; function %trapnz_bmask(i32) -> i32 fast {
+; block0(v0: i32):
+;     trapnz v0, user8
+;     return v0
+; }

--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -2281,7 +2281,7 @@ impl<'a, 'func, 'module_env> Call<'a, 'func, 'module_env> {
         // full subtype check. Otherwise, we do a simple equality check.
         let matches = if features.gc() {
             self.env
-                .is_subtype(self.builder, callee_sig_id, caller_sig_id)
+                .is_subtype(self.builder, callee_sig_id, caller_sig_id, interned_ty)
         } else {
             self.builder
                 .ins()

--- a/crates/cranelift/src/func_environ/gc.rs
+++ b/crates/cranelift/src/func_environ/gc.rs
@@ -1247,7 +1247,12 @@ pub fn translate_ref_test(
                     .ins()
                     .load(ir::types::I32, gc_memflags.with_readonly(), ty_addr, 0);
 
-            func_env.is_subtype(builder, actual_shared_ty, expected_shared_ty)
+            func_env.is_subtype(
+                builder,
+                actual_shared_ty,
+                expected_shared_ty,
+                expected_interned_ty,
+            )
         }
 
         // Same as for concrete arrays and structs except that a `VMFuncRef`
@@ -1265,7 +1270,12 @@ pub fn translate_ref_test(
                 val,
             );
 
-            func_env.is_subtype(builder, actual_shared_ty, expected_shared_ty)
+            func_env.is_subtype(
+                builder,
+                actual_shared_ty,
+                expected_shared_ty,
+                expected_interned_ty,
+            )
         }
         WasmHeapType::ConcreteCont(_) => {
             // TODO(#10248) GC integration for stack switching
@@ -1648,22 +1658,35 @@ impl FuncEnvironment<'_> {
         }
     }
 
-    // Emit code to check whether `a <: b` for two `VMSharedTypeIndex`es.
+    /// Emit code to check whether `a <: b` for two `VMSharedTypeIndex`es.
     pub(crate) fn is_subtype(
         &mut self,
         builder: &mut FunctionBuilder<'_>,
         a: ir::Value,
         b: ir::Value,
+        b_ty: ModuleInternedTypeIndex,
     ) -> ir::Value {
         log::trace!("is_subtype({a:?}, {b:?})");
-
-        let diff_tys_block = builder.create_block();
-        let continue_block = builder.create_block();
 
         // Current block: fast path for when `a == b`.
         log::trace!("is_subtype: fast path check for exact same types");
         let same_ty = builder.ins().icmp(IntCC::Equal, a, b);
         let same_ty = builder.ins().uextend(ir::types::I32, same_ty);
+
+        // When `b` is final the equality check above is already a complete
+        // subtype check, so there is nothing more to do: a final type cannot be
+        // the supertype of any other type, so `a <: b` holds if and only if `a
+        // == b`; in that case we can avoid emitting the slow-path `is_subtype`
+        // libcall and its control flow entirely (the slow path would only ever
+        // return `false` here anyway).
+        let b_is_final = self.types[b_ty].is_final;
+        if b_is_final {
+            return same_ty;
+        }
+
+        let diff_tys_block = builder.create_block();
+        let continue_block = builder.create_block();
+
         builder.ins().brif(
             same_ty,
             continue_block,

--- a/tests/disas/array-copy-anyref.wat
+++ b/tests/disas/array-copy-anyref.wat
@@ -62,7 +62,7 @@
 ;; @002b                               v64 = uadd_overflow_trap v50, v124, user2
 ;; @002b                               v65 = icmp ugt v64, v58
 ;; @002b                               trapnz v65, user2
-;; @002b                               brif v15, block2, block5
+;; @002b                               brif v6, block2, block5
 ;;
 ;;                                 block2:
 ;; @002b                               v66 = icmp.i64 ult v28, v50

--- a/tests/disas/call-indirect-with-gc.wat
+++ b/tests/disas/call-indirect-with-gc.wat
@@ -19,9 +19,7 @@
 ;;     gv5 = load.i64 notrap aligned gv3+56
 ;;     sig0 = (i64 vmctx, i64, i32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i32, i64) -> i64 tail
-;;     sig2 = (i64 vmctx, i32, i32) -> i32 tail
 ;;     fn0 = colocated u805306368:7 sig1
-;;     fn1 = colocated u805306368:27 sig2
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -50,20 +48,12 @@
 ;; @0035                               v24 = load.i64 notrap aligned readonly can_move v0+40
 ;; @0035                               v25 = load.i32 notrap aligned readonly can_move v24+4
 ;; @0035                               v27 = icmp eq v26, v25
-;; @0035                               v28 = uextend.i32 v27
-;; @0035                               brif v27, block5(v28), block4
-;;
-;;                                 block4:
-;; @0035                               v30 = call fn1(v0, v26, v25)
-;; @0035                               jump block5(v30)
-;;
-;;                                 block5(v31: i32):
-;; @0035                               trapz v31, user8
-;; @0035                               v32 = load.i64 notrap aligned readonly v18+8
-;; @0035                               v33 = load.i64 notrap aligned readonly v18+24
-;; @0035                               v34 = call_indirect sig0, v32(v33, v0, v2)
+;; @0035                               trapz v27, user8
+;; @0035                               v29 = load.i64 notrap aligned readonly v18+8
+;; @0035                               v30 = load.i64 notrap aligned readonly v18+24
+;; @0035                               v31 = call_indirect sig0, v29(v30, v0, v2)
 ;; @0038                               jump block1
 ;;
 ;;                                 block1:
-;; @0038                               return v34
+;; @0038                               return v31
 ;; }

--- a/tests/disas/call-indirect-with-gc.wat
+++ b/tests/disas/call-indirect-with-gc.wat
@@ -51,7 +51,7 @@
 ;; @0035                               v25 = load.i32 notrap aligned readonly can_move v24+4
 ;; @0035                               v27 = icmp eq v26, v25
 ;; @0035                               v28 = uextend.i32 v27
-;; @0035                               brif v28, block5(v28), block4
+;; @0035                               brif v27, block5(v28), block4
 ;;
 ;;                                 block4:
 ;; @0035                               v30 = call fn1(v0, v26, v25)

--- a/tests/disas/call-indirect-with-gc.wat
+++ b/tests/disas/call-indirect-with-gc.wat
@@ -1,0 +1,69 @@
+;;! target = "x86_64"
+;;! flags = "-W function-references,gc"
+;;! test = "optimize"
+
+(module
+  (table (export "t") 0 100 funcref)
+  (func (export "f") (param i32 i32) (result i32)
+    (call_indirect (param i32) (result i32) (local.get 0) (local.get 1))
+  )
+)
+
+;; function u0:0(i64 vmctx, i64, i32, i32) -> i32 tail {
+;;     region0 = 1073741824 "PublicTable"
+;;     gv0 = vmctx
+;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv3 = vmctx
+;;     gv4 = load.i64 notrap aligned gv3+48
+;;     gv5 = load.i64 notrap aligned gv3+56
+;;     sig0 = (i64 vmctx, i64, i32) -> i32 tail
+;;     sig1 = (i64 vmctx, i32, i64) -> i64 tail
+;;     sig2 = (i64 vmctx, i32, i32) -> i32 tail
+;;     fn0 = colocated u805306368:7 sig1
+;;     fn1 = colocated u805306368:27 sig2
+;;     stack_limit = gv2
+;;
+;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
+;; @0035                               v5 = load.i64 notrap aligned v0+56
+;; @0035                               v9 = load.i64 notrap aligned v0+48
+;; @0035                               v6 = ireduce.i32 v5
+;; @0035                               v7 = icmp uge v3, v6
+;; @0035                               v13 = iconst.i64 0
+;; @0035                               v8 = uextend.i64 v3
+;; @0035                               v10 = iconst.i64 3
+;; @0035                               v11 = ishl v8, v10  ; v10 = 3
+;; @0035                               v12 = iadd v9, v11
+;; @0035                               v14 = select_spectre_guard v7, v13, v12  ; v13 = 0
+;; @0035                               v15 = load.i64 user6 aligned region0 v14
+;; @0035                               v16 = iconst.i64 -2
+;; @0035                               v17 = band v15, v16  ; v16 = -2
+;; @0035                               brif v15, block3(v17), block2
+;;
+;;                                 block2 cold:
+;; @0035                               v19 = iconst.i32 0
+;; @0035                               v22 = call fn0(v0, v19, v8)  ; v19 = 0
+;; @0035                               jump block3(v22)
+;;
+;;                                 block3(v18: i64):
+;; @0035                               v26 = load.i32 user7 aligned readonly v18+16
+;; @0035                               v24 = load.i64 notrap aligned readonly can_move v0+40
+;; @0035                               v25 = load.i32 notrap aligned readonly can_move v24+4
+;; @0035                               v27 = icmp eq v26, v25
+;; @0035                               v28 = uextend.i32 v27
+;; @0035                               brif v28, block5(v28), block4
+;;
+;;                                 block4:
+;; @0035                               v30 = call fn1(v0, v26, v25)
+;; @0035                               jump block5(v30)
+;;
+;;                                 block5(v31: i32):
+;; @0035                               trapz v31, user8
+;; @0035                               v32 = load.i64 notrap aligned readonly v18+8
+;; @0035                               v33 = load.i64 notrap aligned readonly v18+24
+;; @0035                               v34 = call_indirect sig0, v32(v33, v0, v2)
+;; @0038                               jump block1
+;;
+;;                                 block1:
+;; @0038                               return v34
+;; }

--- a/tests/disas/call-indirect-without-gc.wat
+++ b/tests/disas/call-indirect-without-gc.wat
@@ -1,4 +1,6 @@
 ;;! target = "x86_64"
+;;! flags = "-W function-references=n,gc=n"
+;;! test = "optimize"
 
 (module
   (table (export "t") 0 100 funcref)
@@ -22,14 +24,14 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0035                               v5 = load.i64 notrap aligned v0+56
+;; @0035                               v9 = load.i64 notrap aligned v0+48
 ;; @0035                               v6 = ireduce.i32 v5
 ;; @0035                               v7 = icmp uge v3, v6
+;; @0035                               v13 = iconst.i64 0
 ;; @0035                               v8 = uextend.i64 v3
-;; @0035                               v9 = load.i64 notrap aligned v0+48
 ;; @0035                               v10 = iconst.i64 3
 ;; @0035                               v11 = ishl v8, v10  ; v10 = 3
 ;; @0035                               v12 = iadd v9, v11
-;; @0035                               v13 = iconst.i64 0
 ;; @0035                               v14 = select_spectre_guard v7, v13, v12  ; v13 = 0
 ;; @0035                               v15 = load.i64 user6 aligned region0 v14
 ;; @0035                               v16 = iconst.i64 -2
@@ -38,14 +40,13 @@
 ;;
 ;;                                 block2 cold:
 ;; @0035                               v19 = iconst.i32 0
-;; @0035                               v21 = uextend.i64 v3
-;; @0035                               v22 = call fn0(v0, v19, v21)  ; v19 = 0
+;; @0035                               v22 = call fn0(v0, v19, v8)  ; v19 = 0
 ;; @0035                               jump block3(v22)
 ;;
 ;;                                 block3(v18: i64):
+;; @0035                               v26 = load.i32 user7 aligned readonly v18+16
 ;; @0035                               v24 = load.i64 notrap aligned readonly can_move v0+40
 ;; @0035                               v25 = load.i32 notrap aligned readonly can_move v24+4
-;; @0035                               v26 = load.i32 user7 aligned readonly v18+16
 ;; @0035                               v27 = icmp eq v26, v25
 ;; @0035                               trapz v27, user8
 ;; @0035                               v28 = load.i64 notrap aligned readonly v18+8

--- a/tests/disas/component-model/direct-adapter-calls-inlining.wat
+++ b/tests/disas/component-model/direct-adapter-calls-inlining.wat
@@ -87,8 +87,7 @@
 ;;                                     v15 = band v13, v14  ; v14 = 1
 ;;                                     v11 = iconst.i32 0
 ;;                                     v17 = icmp eq v15, v11  ; v11 = 0
-;;                                     v18 = uextend.i32 v17
-;;                                     brif v18, block4, block5
+;;                                     brif v17, block4, block5
 ;;
 ;;                                 block4:
 ;;                                     v21 = load.i64 notrap aligned readonly can_move v5+88

--- a/tests/disas/component-model/direct-adapter-calls.wat
+++ b/tests/disas/component-model/direct-adapter-calls.wat
@@ -111,8 +111,7 @@
 ;; @007b                               v8 = band v6, v7  ; v7 = 1
 ;; @0075                               v4 = iconst.i32 0
 ;; @007c                               v10 = icmp eq v8, v4  ; v4 = 0
-;; @007c                               v11 = uextend.i32 v10
-;; @007d                               brif v11, block2, block3
+;; @007d                               brif v10, block2, block3
 ;;
 ;;                                 block2:
 ;; @0081                               v15 = load.i64 notrap aligned readonly can_move v0+88

--- a/tests/disas/conditional-traps.wat
+++ b/tests/disas/conditional-traps.wat
@@ -47,8 +47,7 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0038                               v3 = iconst.i32 0
 ;; @0038                               v4 = icmp eq v2, v3  ; v3 = 0
-;; @0038                               v5 = uextend.i32 v4
-;; @003b                               trapnz v5, user12
+;; @003b                               trapnz v4, user12
 ;; @0039                               jump block3
 ;;
 ;;                                 block3:

--- a/tests/disas/gc/array-copy-with-fuel.wat
+++ b/tests/disas/gc/array-copy-with-fuel.wat
@@ -89,7 +89,7 @@
 ;; @002b                               trapnz v81, user2
 ;; @002b                               v83 = iconst.i64 6
 ;; @002b                               v84 = iadd v82, v83  ; v83 = 6
-;; @002b                               brif v31, block4, block7(v84)
+;; @002b                               brif.i32 v6, block4, block7(v84)
 ;;
 ;;                                 block4:
 ;;                                     v148 = load.i32 notrap v201

--- a/tests/disas/gc/call-indirect-final-type.wat
+++ b/tests/disas/gc/call-indirect-final-type.wat
@@ -1,0 +1,110 @@
+;;! target = "x86_64"
+;;! flags = "-W function-references,gc,tail-call"
+;;! test = "optimize"
+
+;; `call_indirect` / `return_call_indirect` whose expected type is `final`,
+;; which allows us to omit the slow-path for subtype checks.
+
+(module
+  (type $f (func (param i32) (result i32)))   ;; final by default
+  (table 0 100 funcref)
+
+  (func (param i32 i32) (result i32)
+    (call_indirect (type $f) (local.get 0) (local.get 1)))
+
+  (func (param i32 i32) (result i32)
+    (return_call_indirect (type $f) (local.get 0) (local.get 1)))
+)
+;; function u0:0(i64 vmctx, i64, i32, i32) -> i32 tail {
+;;     region0 = 1342177280 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
+;;     gv0 = vmctx
+;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv3 = vmctx
+;;     gv4 = load.i64 notrap aligned gv3+48
+;;     gv5 = load.i64 notrap aligned gv3+56
+;;     sig0 = (i64 vmctx, i64, i32) -> i32 tail
+;;     sig1 = (i64 vmctx, i32, i64) -> i64 tail
+;;     fn0 = colocated u805306368:7 sig1
+;;     stack_limit = gv2
+;;
+;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
+;; @002b                               v5 = load.i64 notrap aligned v0+56
+;; @002b                               v9 = load.i64 notrap aligned v0+48
+;; @002b                               v6 = ireduce.i32 v5
+;; @002b                               v7 = icmp uge v3, v6
+;; @002b                               v13 = iconst.i64 0
+;; @002b                               v8 = uextend.i64 v3
+;; @002b                               v10 = iconst.i64 3
+;; @002b                               v11 = ishl v8, v10  ; v10 = 3
+;; @002b                               v12 = iadd v9, v11
+;; @002b                               v14 = select_spectre_guard v7, v13, v12  ; v13 = 0
+;; @002b                               v15 = load.i64 user6 aligned region0 v14
+;; @002b                               v16 = iconst.i64 -2
+;; @002b                               v17 = band v15, v16  ; v16 = -2
+;; @002b                               brif v15, block3(v17), block2
+;;
+;;                                 block2 cold:
+;; @002b                               v19 = iconst.i32 0
+;; @002b                               v22 = call fn0(v0, v19, v8)  ; v19 = 0
+;; @002b                               jump block3(v22)
+;;
+;;                                 block3(v18: i64):
+;; @002b                               v26 = load.i32 user7 aligned readonly v18+16
+;; @002b                               v24 = load.i64 notrap aligned readonly can_move v0+40
+;; @002b                               v25 = load.i32 notrap aligned readonly can_move v24
+;; @002b                               v27 = icmp eq v26, v25
+;; @002b                               trapz v27, user8
+;; @002b                               v29 = load.i64 notrap aligned readonly v18+8
+;; @002b                               v30 = load.i64 notrap aligned readonly v18+24
+;; @002b                               v31 = call_indirect sig0, v29(v30, v0, v2)
+;; @002e                               jump block1
+;;
+;;                                 block1:
+;; @002e                               return v31
+;; }
+;;
+;; function u0:1(i64 vmctx, i64, i32, i32) -> i32 tail {
+;;     region0 = 1342177280 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
+;;     gv0 = vmctx
+;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv3 = vmctx
+;;     gv4 = load.i64 notrap aligned gv3+48
+;;     gv5 = load.i64 notrap aligned gv3+56
+;;     sig0 = (i64 vmctx, i64, i32) -> i32 tail
+;;     sig1 = (i64 vmctx, i32, i64) -> i64 tail
+;;     fn0 = colocated u805306368:7 sig1
+;;     stack_limit = gv2
+;;
+;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
+;; @0035                               v5 = load.i64 notrap aligned v0+56
+;; @0035                               v9 = load.i64 notrap aligned v0+48
+;; @0035                               v6 = ireduce.i32 v5
+;; @0035                               v7 = icmp uge v3, v6
+;; @0035                               v13 = iconst.i64 0
+;; @0035                               v8 = uextend.i64 v3
+;; @0035                               v10 = iconst.i64 3
+;; @0035                               v11 = ishl v8, v10  ; v10 = 3
+;; @0035                               v12 = iadd v9, v11
+;; @0035                               v14 = select_spectre_guard v7, v13, v12  ; v13 = 0
+;; @0035                               v15 = load.i64 user6 aligned region0 v14
+;; @0035                               v16 = iconst.i64 -2
+;; @0035                               v17 = band v15, v16  ; v16 = -2
+;; @0035                               brif v15, block3(v17), block2
+;;
+;;                                 block2 cold:
+;; @0035                               v19 = iconst.i32 0
+;; @0035                               v22 = call fn0(v0, v19, v8)  ; v19 = 0
+;; @0035                               jump block3(v22)
+;;
+;;                                 block3(v18: i64):
+;; @0035                               v26 = load.i32 user7 aligned readonly v18+16
+;; @0035                               v24 = load.i64 notrap aligned readonly can_move v0+40
+;; @0035                               v25 = load.i32 notrap aligned readonly can_move v24
+;; @0035                               v27 = icmp eq v26, v25
+;; @0035                               trapz v27, user8
+;; @0035                               v29 = load.i64 notrap aligned readonly v18+8
+;; @0035                               v30 = load.i64 notrap aligned readonly v18+24
+;; @0035                               return_call_indirect sig0, v29(v30, v0, v2)
+;; }

--- a/tests/disas/gc/copying/array-new-fixed-of-gc-refs.wat
+++ b/tests/disas/gc/copying/array-new-fixed-of-gc-refs.wat
@@ -83,9 +83,7 @@
 ;; @0025                               v53 = iadd v280, v51
 ;; @0025                               v55 = iadd v53, v48  ; v48 = 16
 ;; @0025                               v56 = load.i32 user2 readonly region1 v55
-;; @0025                               v50 = iconst.i32 0
-;;                                     v181 = icmp ne v56, v50  ; v50 = 0
-;; @0025                               trapz v181, user17
+;; @0025                               trapz v56, user17
 ;; @0025                               v59 = uextend.i64 v56
 ;;                                     v155 = iconst.i64 2
 ;;                                     v184 = ishl v59, v155  ; v155 = 2

--- a/tests/disas/gc/copying/array-new-fixed.wat
+++ b/tests/disas/gc/copying/array-new-fixed.wat
@@ -74,9 +74,7 @@
 ;; @0025                               v53 = iadd v268, v51
 ;; @0025                               v55 = iadd v53, v48  ; v48 = 16
 ;; @0025                               v56 = load.i32 user2 readonly region1 v55
-;; @0025                               v50 = iconst.i32 0
-;;                                     v171 = icmp ne v56, v50  ; v50 = 0
-;; @0025                               trapz v171, user17
+;; @0025                               trapz v56, user17
 ;; @0025                               v59 = uextend.i64 v56
 ;;                                     v144 = iconst.i64 3
 ;;                                     v174 = ishl v59, v144  ; v144 = 3

--- a/tests/disas/gc/copying/br-on-cast-fail.wat
+++ b/tests/disas/gc/copying/br-on-cast-fail.wat
@@ -35,8 +35,7 @@
 ;;                                     store notrap v2, v42
 ;; @002e                               v4 = iconst.i32 0
 ;; @002e                               v5 = icmp eq v2, v4  ; v4 = 0
-;; @002e                               v6 = uextend.i32 v5
-;; @002e                               brif v6, block5(v4), block3  ; v4 = 0
+;; @002e                               brif v5, block5(v4), block3  ; v4 = 0
 ;;
 ;;                                 block3:
 ;; @002e                               v8 = iconst.i32 1
@@ -56,7 +55,7 @@
 ;; @002e                               v13 = load.i32 notrap aligned readonly can_move v12
 ;; @002e                               v20 = icmp eq v19, v13
 ;; @002e                               v21 = uextend.i32 v20
-;; @002e                               brif v21, block7(v21), block6
+;; @002e                               brif v20, block7(v21), block6
 ;;
 ;;                                 block6:
 ;; @002e                               v23 = call fn0(v0, v19, v13), stack_map=[i32 @ ss0+0]

--- a/tests/disas/gc/copying/br-on-cast-fail.wat
+++ b/tests/disas/gc/copying/br-on-cast-fail.wat
@@ -16,7 +16,6 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32) tail {
-;;     ss0 = explicit_slot 4, align = 4
 ;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
@@ -25,14 +24,10 @@
 ;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
-;;     sig0 = (i64 vmctx, i32, i32) -> i32 tail
-;;     sig1 = (i64 vmctx, i64) tail
-;;     fn0 = colocated u805306368:27 sig0
+;;     sig0 = (i64 vmctx, i64) tail
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;;                                     v42 = stack_addr.i64 ss0
-;;                                     store notrap v2, v42
 ;; @002e                               v4 = iconst.i32 0
 ;; @002e                               v5 = icmp eq v2, v4  ; v4 = 0
 ;; @002e                               brif v5, block5(v4), block3  ; v4 = 0
@@ -40,12 +35,12 @@
 ;;                                 block3:
 ;; @002e                               v8 = iconst.i32 1
 ;; @002e                               v9 = band.i32 v2, v8  ; v8 = 1
-;;                                     v43 = iconst.i32 0
-;; @002e                               brif v9, block5(v43), block4  ; v43 = 0
+;;                                     v31 = iconst.i32 0
+;; @002e                               brif v9, block5(v31), block4  ; v31 = 0
 ;;
 ;;                                 block4:
-;; @002e                               v37 = load.i64 notrap aligned readonly can_move v0+8
-;; @002e                               v15 = load.i64 notrap aligned readonly can_move v37+32
+;; @002e                               v29 = load.i64 notrap aligned readonly can_move v0+8
+;; @002e                               v15 = load.i64 notrap aligned readonly can_move v29+32
 ;; @002e                               v14 = uextend.i64 v2
 ;; @002e                               v16 = iadd v15, v14
 ;; @002e                               v17 = iconst.i64 4
@@ -55,28 +50,20 @@
 ;; @002e                               v13 = load.i32 notrap aligned readonly can_move v12
 ;; @002e                               v20 = icmp eq v19, v13
 ;; @002e                               v21 = uextend.i32 v20
-;; @002e                               brif v20, block7(v21), block6
+;; @002e                               jump block5(v21)
+;;
+;;                                 block5(v22: i32):
+;; @002e                               brif v22, block6, block2
 ;;
 ;;                                 block6:
-;; @002e                               v23 = call fn0(v0, v19, v13), stack_map=[i32 @ ss0+0]
-;; @002e                               jump block7(v23)
-;;
-;;                                 block7(v24: i32):
-;; @002e                               jump block5(v24)
-;;
-;;                                 block5(v25: i32):
-;;                                     v32 = load.i32 notrap v42
-;; @002e                               brif v25, block8, block2
-;;
-;;                                 block8:
-;; @0034                               v28 = load.i64 notrap aligned readonly can_move v0+56
-;; @0034                               v27 = load.i64 notrap aligned readonly can_move v0+72
-;; @0034                               call_indirect sig1, v28(v27, v0)
+;; @0034                               v25 = load.i64 notrap aligned readonly can_move v0+56
+;; @0034                               v24 = load.i64 notrap aligned readonly can_move v0+72
+;; @0034                               call_indirect sig0, v25(v24, v0)
 ;; @0036                               return
 ;;
 ;;                                 block2:
-;; @0038                               v31 = load.i64 notrap aligned readonly can_move v0+88
-;; @0038                               v30 = load.i64 notrap aligned readonly can_move v0+104
-;; @0038                               call_indirect sig1, v31(v30, v0)
+;; @0038                               v28 = load.i64 notrap aligned readonly can_move v0+88
+;; @0038                               v27 = load.i64 notrap aligned readonly can_move v0+104
+;; @0038                               call_indirect sig0, v28(v27, v0)
 ;; @003a                               return
 ;; }

--- a/tests/disas/gc/copying/br-on-cast.wat
+++ b/tests/disas/gc/copying/br-on-cast.wat
@@ -16,7 +16,6 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32) tail {
-;;     ss0 = explicit_slot 4, align = 4
 ;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
@@ -25,14 +24,10 @@
 ;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
-;;     sig0 = (i64 vmctx, i32, i32) -> i32 tail
-;;     sig1 = (i64 vmctx, i64) tail
-;;     fn0 = colocated u805306368:27 sig0
+;;     sig0 = (i64 vmctx, i64) tail
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;;                                     v42 = stack_addr.i64 ss0
-;;                                     store notrap v2, v42
 ;; @002f                               v4 = iconst.i32 0
 ;; @002f                               v5 = icmp eq v2, v4  ; v4 = 0
 ;; @002f                               brif v5, block5(v4), block3  ; v4 = 0
@@ -40,12 +35,12 @@
 ;;                                 block3:
 ;; @002f                               v8 = iconst.i32 1
 ;; @002f                               v9 = band.i32 v2, v8  ; v8 = 1
-;;                                     v43 = iconst.i32 0
-;; @002f                               brif v9, block5(v43), block4  ; v43 = 0
+;;                                     v31 = iconst.i32 0
+;; @002f                               brif v9, block5(v31), block4  ; v31 = 0
 ;;
 ;;                                 block4:
-;; @002f                               v37 = load.i64 notrap aligned readonly can_move v0+8
-;; @002f                               v15 = load.i64 notrap aligned readonly can_move v37+32
+;; @002f                               v29 = load.i64 notrap aligned readonly can_move v0+8
+;; @002f                               v15 = load.i64 notrap aligned readonly can_move v29+32
 ;; @002f                               v14 = uextend.i64 v2
 ;; @002f                               v16 = iadd v15, v14
 ;; @002f                               v17 = iconst.i64 4
@@ -55,28 +50,20 @@
 ;; @002f                               v13 = load.i32 notrap aligned readonly can_move v12
 ;; @002f                               v20 = icmp eq v19, v13
 ;; @002f                               v21 = uextend.i32 v20
-;; @002f                               brif v20, block7(v21), block6
+;; @002f                               jump block5(v21)
+;;
+;;                                 block5(v22: i32):
+;; @002f                               brif v22, block2, block6
 ;;
 ;;                                 block6:
-;; @002f                               v23 = call fn0(v0, v19, v13), stack_map=[i32 @ ss0+0]
-;; @002f                               jump block7(v23)
-;;
-;;                                 block7(v24: i32):
-;; @002f                               jump block5(v24)
-;;
-;;                                 block5(v25: i32):
-;;                                     v32 = load.i32 notrap v42
-;; @002f                               brif v25, block2, block8
-;;
-;;                                 block8:
-;; @0035                               v28 = load.i64 notrap aligned readonly can_move v0+56
-;; @0035                               v27 = load.i64 notrap aligned readonly can_move v0+72
-;; @0035                               call_indirect sig1, v28(v27, v0)
+;; @0035                               v25 = load.i64 notrap aligned readonly can_move v0+56
+;; @0035                               v24 = load.i64 notrap aligned readonly can_move v0+72
+;; @0035                               call_indirect sig0, v25(v24, v0)
 ;; @0037                               return
 ;;
 ;;                                 block2:
-;; @0039                               v31 = load.i64 notrap aligned readonly can_move v0+88
-;; @0039                               v30 = load.i64 notrap aligned readonly can_move v0+104
-;; @0039                               call_indirect sig1, v31(v30, v0)
+;; @0039                               v28 = load.i64 notrap aligned readonly can_move v0+88
+;; @0039                               v27 = load.i64 notrap aligned readonly can_move v0+104
+;; @0039                               call_indirect sig0, v28(v27, v0)
 ;; @003b                               return
 ;; }

--- a/tests/disas/gc/copying/br-on-cast.wat
+++ b/tests/disas/gc/copying/br-on-cast.wat
@@ -35,8 +35,7 @@
 ;;                                     store notrap v2, v42
 ;; @002f                               v4 = iconst.i32 0
 ;; @002f                               v5 = icmp eq v2, v4  ; v4 = 0
-;; @002f                               v6 = uextend.i32 v5
-;; @002f                               brif v6, block5(v4), block3  ; v4 = 0
+;; @002f                               brif v5, block5(v4), block3  ; v4 = 0
 ;;
 ;;                                 block3:
 ;; @002f                               v8 = iconst.i32 1
@@ -56,7 +55,7 @@
 ;; @002f                               v13 = load.i32 notrap aligned readonly can_move v12
 ;; @002f                               v20 = icmp eq v19, v13
 ;; @002f                               v21 = uextend.i32 v20
-;; @002f                               brif v21, block7(v21), block6
+;; @002f                               brif v20, block7(v21), block6
 ;;
 ;;                                 block6:
 ;; @002f                               v23 = call fn0(v0, v19, v13), stack_map=[i32 @ ss0+0]

--- a/tests/disas/gc/copying/call-indirect-and-subtyping.wat
+++ b/tests/disas/gc/copying/call-indirect-and-subtyping.wat
@@ -55,7 +55,7 @@
 ;; @005c                               v22 = load.i32 notrap aligned readonly can_move v21
 ;; @005c                               v24 = icmp eq v23, v22
 ;; @005c                               v25 = uextend.i32 v24
-;; @005c                               brif v25, block5(v25), block4
+;; @005c                               brif v24, block5(v25), block4
 ;;
 ;;                                 block4:
 ;; @005c                               v27 = call fn1(v0, v23, v22)

--- a/tests/disas/gc/copying/ref-cast.wat
+++ b/tests/disas/gc/copying/ref-cast.wat
@@ -26,8 +26,7 @@
 ;;                                     store notrap v2, v36
 ;; @001e                               v4 = iconst.i32 0
 ;; @001e                               v5 = icmp eq v2, v4  ; v4 = 0
-;; @001e                               v6 = uextend.i32 v5
-;; @001e                               brif v6, block4(v4), block2  ; v4 = 0
+;; @001e                               brif v5, block4(v4), block2  ; v4 = 0
 ;;
 ;;                                 block2:
 ;; @001e                               v8 = iconst.i32 1
@@ -47,7 +46,7 @@
 ;; @001e                               v13 = load.i32 notrap aligned readonly can_move v12
 ;; @001e                               v20 = icmp eq v19, v13
 ;; @001e                               v21 = uextend.i32 v20
-;; @001e                               brif v21, block6(v21), block5
+;; @001e                               brif v20, block6(v21), block5
 ;;
 ;;                                 block5:
 ;; @001e                               v23 = call fn0(v0, v19, v13), stack_map=[i32 @ ss0+0]

--- a/tests/disas/gc/copying/ref-cast.wat
+++ b/tests/disas/gc/copying/ref-cast.wat
@@ -8,7 +8,6 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
-;;     ss0 = explicit_slot 4, align = 4
 ;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
@@ -17,13 +16,9 @@
 ;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
-;;     sig0 = (i64 vmctx, i32, i32) -> i32 tail
-;;     fn0 = colocated u805306368:27 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;;                                     v36 = stack_addr.i64 ss0
-;;                                     store notrap v2, v36
 ;; @001e                               v4 = iconst.i32 0
 ;; @001e                               v5 = icmp eq v2, v4  ; v4 = 0
 ;; @001e                               brif v5, block4(v4), block2  ; v4 = 0
@@ -31,12 +26,12 @@
 ;;                                 block2:
 ;; @001e                               v8 = iconst.i32 1
 ;; @001e                               v9 = band.i32 v2, v8  ; v8 = 1
-;;                                     v37 = iconst.i32 0
-;; @001e                               brif v9, block4(v37), block3  ; v37 = 0
+;;                                     v25 = iconst.i32 0
+;; @001e                               brif v9, block4(v25), block3  ; v25 = 0
 ;;
 ;;                                 block3:
-;; @001e                               v31 = load.i64 notrap aligned readonly can_move v0+8
-;; @001e                               v15 = load.i64 notrap aligned readonly can_move v31+32
+;; @001e                               v23 = load.i64 notrap aligned readonly can_move v0+8
+;; @001e                               v15 = load.i64 notrap aligned readonly can_move v23+32
 ;; @001e                               v14 = uextend.i64 v2
 ;; @001e                               v16 = iadd v15, v14
 ;; @001e                               v17 = iconst.i64 4
@@ -46,20 +41,12 @@
 ;; @001e                               v13 = load.i32 notrap aligned readonly can_move v12
 ;; @001e                               v20 = icmp eq v19, v13
 ;; @001e                               v21 = uextend.i32 v20
-;; @001e                               brif v20, block6(v21), block5
+;; @001e                               jump block4(v21)
 ;;
-;;                                 block5:
-;; @001e                               v23 = call fn0(v0, v19, v13), stack_map=[i32 @ ss0+0]
-;; @001e                               jump block6(v23)
-;;
-;;                                 block6(v24: i32):
-;; @001e                               jump block4(v24)
-;;
-;;                                 block4(v25: i32):
-;; @001e                               trapz v25, user19
-;;                                     v26 = load.i32 notrap v36
+;;                                 block4(v22: i32):
+;; @001e                               trapz v22, user19
 ;; @0021                               jump block1
 ;;
 ;;                                 block1:
-;; @0021                               return v26
+;; @0021                               return v2
 ;; }

--- a/tests/disas/gc/copying/ref-test-array.wat
+++ b/tests/disas/gc/copying/ref-test-array.wat
@@ -20,8 +20,7 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @001b                               v4 = iconst.i32 0
 ;; @001b                               v5 = icmp eq v2, v4  ; v4 = 0
-;; @001b                               v6 = uextend.i32 v5
-;; @001b                               brif v6, block4(v4), block2  ; v4 = 0
+;; @001b                               brif v5, block4(v4), block2  ; v4 = 0
 ;;
 ;;                                 block2:
 ;; @001b                               v8 = iconst.i32 1

--- a/tests/disas/gc/copying/ref-test-concrete-func-type.wat
+++ b/tests/disas/gc/copying/ref-test-concrete-func-type.wat
@@ -13,8 +13,6 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     sig0 = (i64 vmctx, i32, i32) -> i32 tail
-;;     fn0 = colocated u805306368:27 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
@@ -32,17 +30,10 @@
 ;; @0020                               v10 = load.i32 notrap aligned readonly can_move v9
 ;; @0020                               v12 = icmp eq v11, v10
 ;; @0020                               v13 = uextend.i32 v12
-;; @0020                               brif v12, block6(v13), block5
+;; @0020                               jump block4(v13)
 ;;
-;;                                 block5:
-;; @0020                               v15 = call fn0(v0, v11, v10)
-;; @0020                               jump block6(v15)
-;;
-;;                                 block6(v16: i32):
-;; @0020                               jump block4(v16)
-;;
-;;                                 block4(v17: i32):
-;; @0023                               jump block1(v17)
+;;                                 block4(v14: i32):
+;; @0023                               jump block1(v14)
 ;;
 ;;                                 block1(v3: i32):
 ;; @0023                               return v3

--- a/tests/disas/gc/copying/ref-test-concrete-func-type.wat
+++ b/tests/disas/gc/copying/ref-test-concrete-func-type.wat
@@ -20,9 +20,8 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @0020                               v4 = iconst.i64 0
 ;; @0020                               v5 = icmp eq v2, v4  ; v4 = 0
-;; @0020                               v6 = uextend.i32 v5
 ;; @0020                               v7 = iconst.i32 0
-;; @0020                               brif v6, block4(v7), block2  ; v7 = 0
+;; @0020                               brif v5, block4(v7), block2  ; v7 = 0
 ;;
 ;;                                 block2:
 ;; @0020                               jump block3
@@ -33,7 +32,7 @@
 ;; @0020                               v10 = load.i32 notrap aligned readonly can_move v9
 ;; @0020                               v12 = icmp eq v11, v10
 ;; @0020                               v13 = uextend.i32 v12
-;; @0020                               brif v13, block6(v13), block5
+;; @0020                               brif v12, block6(v13), block5
 ;;
 ;;                                 block5:
 ;; @0020                               v15 = call fn0(v0, v11, v10)

--- a/tests/disas/gc/copying/ref-test-concrete-type.wat
+++ b/tests/disas/gc/copying/ref-test-concrete-type.wat
@@ -16,8 +16,6 @@
 ;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
-;;     sig0 = (i64 vmctx, i32, i32) -> i32 tail
-;;     fn0 = colocated u805306368:27 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -28,12 +26,12 @@
 ;;                                 block2:
 ;; @001d                               v8 = iconst.i32 1
 ;; @001d                               v9 = band.i32 v2, v8  ; v8 = 1
-;;                                     v28 = iconst.i32 0
-;; @001d                               brif v9, block4(v28), block3  ; v28 = 0
+;;                                     v25 = iconst.i32 0
+;; @001d                               brif v9, block4(v25), block3  ; v25 = 0
 ;;
 ;;                                 block3:
-;; @001d                               v26 = load.i64 notrap aligned readonly can_move v0+8
-;; @001d                               v15 = load.i64 notrap aligned readonly can_move v26+32
+;; @001d                               v23 = load.i64 notrap aligned readonly can_move v0+8
+;; @001d                               v15 = load.i64 notrap aligned readonly can_move v23+32
 ;; @001d                               v14 = uextend.i64 v2
 ;; @001d                               v16 = iadd v15, v14
 ;; @001d                               v17 = iconst.i64 4
@@ -43,17 +41,10 @@
 ;; @001d                               v13 = load.i32 notrap aligned readonly can_move v12
 ;; @001d                               v20 = icmp eq v19, v13
 ;; @001d                               v21 = uextend.i32 v20
-;; @001d                               brif v20, block6(v21), block5
+;; @001d                               jump block4(v21)
 ;;
-;;                                 block5:
-;; @001d                               v23 = call fn0(v0, v19, v13)
-;; @001d                               jump block6(v23)
-;;
-;;                                 block6(v24: i32):
-;; @001d                               jump block4(v24)
-;;
-;;                                 block4(v25: i32):
-;; @0020                               jump block1(v25)
+;;                                 block4(v22: i32):
+;; @0020                               jump block1(v22)
 ;;
 ;;                                 block1(v3: i32):
 ;; @0020                               return v3

--- a/tests/disas/gc/copying/ref-test-concrete-type.wat
+++ b/tests/disas/gc/copying/ref-test-concrete-type.wat
@@ -23,8 +23,7 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @001d                               v4 = iconst.i32 0
 ;; @001d                               v5 = icmp eq v2, v4  ; v4 = 0
-;; @001d                               v6 = uextend.i32 v5
-;; @001d                               brif v6, block4(v4), block2  ; v4 = 0
+;; @001d                               brif v5, block4(v4), block2  ; v4 = 0
 ;;
 ;;                                 block2:
 ;; @001d                               v8 = iconst.i32 1
@@ -44,7 +43,7 @@
 ;; @001d                               v13 = load.i32 notrap aligned readonly can_move v12
 ;; @001d                               v20 = icmp eq v19, v13
 ;; @001d                               v21 = uextend.i32 v20
-;; @001d                               brif v21, block6(v21), block5
+;; @001d                               brif v20, block6(v21), block5
 ;;
 ;;                                 block5:
 ;; @001d                               v23 = call fn0(v0, v19, v13)

--- a/tests/disas/gc/copying/ref-test-eq.wat
+++ b/tests/disas/gc/copying/ref-test-eq.wat
@@ -20,8 +20,7 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @001b                               v4 = iconst.i32 0
 ;; @001b                               v5 = icmp eq v2, v4  ; v4 = 0
-;; @001b                               v6 = uextend.i32 v5
-;; @001b                               brif v6, block4(v4), block2  ; v4 = 0
+;; @001b                               brif v5, block4(v4), block2  ; v4 = 0
 ;;
 ;;                                 block2:
 ;; @001b                               v8 = iconst.i32 1

--- a/tests/disas/gc/copying/ref-test-struct.wat
+++ b/tests/disas/gc/copying/ref-test-struct.wat
@@ -20,8 +20,7 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @001b                               v4 = iconst.i32 0
 ;; @001b                               v5 = icmp eq v2, v4  ; v4 = 0
-;; @001b                               v6 = uextend.i32 v5
-;; @001b                               brif v6, block4(v4), block2  ; v4 = 0
+;; @001b                               brif v5, block4(v4), block2  ; v4 = 0
 ;;
 ;;                                 block2:
 ;; @001b                               v8 = iconst.i32 1

--- a/tests/disas/gc/drc/br-on-cast-fail.wat
+++ b/tests/disas/gc/drc/br-on-cast-fail.wat
@@ -36,8 +36,7 @@
 ;;                                     store notrap v2, v42
 ;; @002e                               v4 = iconst.i32 0
 ;; @002e                               v5 = icmp eq v2, v4  ; v4 = 0
-;; @002e                               v6 = uextend.i32 v5
-;; @002e                               brif v6, block5(v4), block3  ; v4 = 0
+;; @002e                               brif v5, block5(v4), block3  ; v4 = 0
 ;;
 ;;                                 block3:
 ;; @002e                               v8 = iconst.i32 1
@@ -57,7 +56,7 @@
 ;; @002e                               v13 = load.i32 notrap aligned readonly can_move v12
 ;; @002e                               v20 = icmp eq v19, v13
 ;; @002e                               v21 = uextend.i32 v20
-;; @002e                               brif v21, block7(v21), block6
+;; @002e                               brif v20, block7(v21), block6
 ;;
 ;;                                 block6:
 ;; @002e                               v23 = call fn0(v0, v19, v13), stack_map=[i32 @ ss0+0]

--- a/tests/disas/gc/drc/br-on-cast-fail.wat
+++ b/tests/disas/gc/drc/br-on-cast-fail.wat
@@ -17,7 +17,6 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32) tail {
-;;     ss0 = explicit_slot 4, align = 4
 ;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
@@ -26,14 +25,10 @@
 ;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
-;;     sig0 = (i64 vmctx, i32, i32) -> i32 tail
-;;     sig1 = (i64 vmctx, i64) tail
-;;     fn0 = colocated u805306368:27 sig0
+;;     sig0 = (i64 vmctx, i64) tail
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;;                                     v42 = stack_addr.i64 ss0
-;;                                     store notrap v2, v42
 ;; @002e                               v4 = iconst.i32 0
 ;; @002e                               v5 = icmp eq v2, v4  ; v4 = 0
 ;; @002e                               brif v5, block5(v4), block3  ; v4 = 0
@@ -41,12 +36,12 @@
 ;;                                 block3:
 ;; @002e                               v8 = iconst.i32 1
 ;; @002e                               v9 = band.i32 v2, v8  ; v8 = 1
-;;                                     v43 = iconst.i32 0
-;; @002e                               brif v9, block5(v43), block4  ; v43 = 0
+;;                                     v31 = iconst.i32 0
+;; @002e                               brif v9, block5(v31), block4  ; v31 = 0
 ;;
 ;;                                 block4:
-;; @002e                               v37 = load.i64 notrap aligned readonly can_move v0+8
-;; @002e                               v15 = load.i64 notrap aligned readonly can_move v37+32
+;; @002e                               v29 = load.i64 notrap aligned readonly can_move v0+8
+;; @002e                               v15 = load.i64 notrap aligned readonly can_move v29+32
 ;; @002e                               v14 = uextend.i64 v2
 ;; @002e                               v16 = iadd v15, v14
 ;; @002e                               v17 = iconst.i64 4
@@ -56,28 +51,20 @@
 ;; @002e                               v13 = load.i32 notrap aligned readonly can_move v12
 ;; @002e                               v20 = icmp eq v19, v13
 ;; @002e                               v21 = uextend.i32 v20
-;; @002e                               brif v20, block7(v21), block6
+;; @002e                               jump block5(v21)
+;;
+;;                                 block5(v22: i32):
+;; @002e                               brif v22, block6, block2
 ;;
 ;;                                 block6:
-;; @002e                               v23 = call fn0(v0, v19, v13), stack_map=[i32 @ ss0+0]
-;; @002e                               jump block7(v23)
-;;
-;;                                 block7(v24: i32):
-;; @002e                               jump block5(v24)
-;;
-;;                                 block5(v25: i32):
-;;                                     v32 = load.i32 notrap v42
-;; @002e                               brif v25, block8, block2
-;;
-;;                                 block8:
-;; @0034                               v28 = load.i64 notrap aligned readonly can_move v0+56
-;; @0034                               v27 = load.i64 notrap aligned readonly can_move v0+72
-;; @0034                               call_indirect sig1, v28(v27, v0)
+;; @0034                               v25 = load.i64 notrap aligned readonly can_move v0+56
+;; @0034                               v24 = load.i64 notrap aligned readonly can_move v0+72
+;; @0034                               call_indirect sig0, v25(v24, v0)
 ;; @0036                               return
 ;;
 ;;                                 block2:
-;; @0038                               v31 = load.i64 notrap aligned readonly can_move v0+88
-;; @0038                               v30 = load.i64 notrap aligned readonly can_move v0+104
-;; @0038                               call_indirect sig1, v31(v30, v0)
+;; @0038                               v28 = load.i64 notrap aligned readonly can_move v0+88
+;; @0038                               v27 = load.i64 notrap aligned readonly can_move v0+104
+;; @0038                               call_indirect sig0, v28(v27, v0)
 ;; @003a                               return
 ;; }

--- a/tests/disas/gc/drc/br-on-cast.wat
+++ b/tests/disas/gc/drc/br-on-cast.wat
@@ -17,7 +17,6 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32) tail {
-;;     ss0 = explicit_slot 4, align = 4
 ;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
@@ -26,14 +25,10 @@
 ;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
-;;     sig0 = (i64 vmctx, i32, i32) -> i32 tail
-;;     sig1 = (i64 vmctx, i64) tail
-;;     fn0 = colocated u805306368:27 sig0
+;;     sig0 = (i64 vmctx, i64) tail
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;;                                     v42 = stack_addr.i64 ss0
-;;                                     store notrap v2, v42
 ;; @002f                               v4 = iconst.i32 0
 ;; @002f                               v5 = icmp eq v2, v4  ; v4 = 0
 ;; @002f                               brif v5, block5(v4), block3  ; v4 = 0
@@ -41,12 +36,12 @@
 ;;                                 block3:
 ;; @002f                               v8 = iconst.i32 1
 ;; @002f                               v9 = band.i32 v2, v8  ; v8 = 1
-;;                                     v43 = iconst.i32 0
-;; @002f                               brif v9, block5(v43), block4  ; v43 = 0
+;;                                     v31 = iconst.i32 0
+;; @002f                               brif v9, block5(v31), block4  ; v31 = 0
 ;;
 ;;                                 block4:
-;; @002f                               v37 = load.i64 notrap aligned readonly can_move v0+8
-;; @002f                               v15 = load.i64 notrap aligned readonly can_move v37+32
+;; @002f                               v29 = load.i64 notrap aligned readonly can_move v0+8
+;; @002f                               v15 = load.i64 notrap aligned readonly can_move v29+32
 ;; @002f                               v14 = uextend.i64 v2
 ;; @002f                               v16 = iadd v15, v14
 ;; @002f                               v17 = iconst.i64 4
@@ -56,28 +51,20 @@
 ;; @002f                               v13 = load.i32 notrap aligned readonly can_move v12
 ;; @002f                               v20 = icmp eq v19, v13
 ;; @002f                               v21 = uextend.i32 v20
-;; @002f                               brif v20, block7(v21), block6
+;; @002f                               jump block5(v21)
+;;
+;;                                 block5(v22: i32):
+;; @002f                               brif v22, block2, block6
 ;;
 ;;                                 block6:
-;; @002f                               v23 = call fn0(v0, v19, v13), stack_map=[i32 @ ss0+0]
-;; @002f                               jump block7(v23)
-;;
-;;                                 block7(v24: i32):
-;; @002f                               jump block5(v24)
-;;
-;;                                 block5(v25: i32):
-;;                                     v32 = load.i32 notrap v42
-;; @002f                               brif v25, block2, block8
-;;
-;;                                 block8:
-;; @0035                               v28 = load.i64 notrap aligned readonly can_move v0+56
-;; @0035                               v27 = load.i64 notrap aligned readonly can_move v0+72
-;; @0035                               call_indirect sig1, v28(v27, v0)
+;; @0035                               v25 = load.i64 notrap aligned readonly can_move v0+56
+;; @0035                               v24 = load.i64 notrap aligned readonly can_move v0+72
+;; @0035                               call_indirect sig0, v25(v24, v0)
 ;; @0037                               return
 ;;
 ;;                                 block2:
-;; @0039                               v31 = load.i64 notrap aligned readonly can_move v0+88
-;; @0039                               v30 = load.i64 notrap aligned readonly can_move v0+104
-;; @0039                               call_indirect sig1, v31(v30, v0)
+;; @0039                               v28 = load.i64 notrap aligned readonly can_move v0+88
+;; @0039                               v27 = load.i64 notrap aligned readonly can_move v0+104
+;; @0039                               call_indirect sig0, v28(v27, v0)
 ;; @003b                               return
 ;; }

--- a/tests/disas/gc/drc/br-on-cast.wat
+++ b/tests/disas/gc/drc/br-on-cast.wat
@@ -36,8 +36,7 @@
 ;;                                     store notrap v2, v42
 ;; @002f                               v4 = iconst.i32 0
 ;; @002f                               v5 = icmp eq v2, v4  ; v4 = 0
-;; @002f                               v6 = uextend.i32 v5
-;; @002f                               brif v6, block5(v4), block3  ; v4 = 0
+;; @002f                               brif v5, block5(v4), block3  ; v4 = 0
 ;;
 ;;                                 block3:
 ;; @002f                               v8 = iconst.i32 1
@@ -57,7 +56,7 @@
 ;; @002f                               v13 = load.i32 notrap aligned readonly can_move v12
 ;; @002f                               v20 = icmp eq v19, v13
 ;; @002f                               v21 = uextend.i32 v20
-;; @002f                               brif v21, block7(v21), block6
+;; @002f                               brif v20, block7(v21), block6
 ;;
 ;;                                 block6:
 ;; @002f                               v23 = call fn0(v0, v19, v13), stack_map=[i32 @ ss0+0]

--- a/tests/disas/gc/drc/call-indirect-and-subtyping.wat
+++ b/tests/disas/gc/drc/call-indirect-and-subtyping.wat
@@ -56,7 +56,7 @@
 ;; @005c                               v22 = load.i32 notrap aligned readonly can_move v21
 ;; @005c                               v24 = icmp eq v23, v22
 ;; @005c                               v25 = uextend.i32 v24
-;; @005c                               brif v25, block5(v25), block4
+;; @005c                               brif v24, block5(v25), block4
 ;;
 ;;                                 block4:
 ;; @005c                               v27 = call fn1(v0, v23, v22)

--- a/tests/disas/gc/drc/ref-cast.wat
+++ b/tests/disas/gc/drc/ref-cast.wat
@@ -9,7 +9,6 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
-;;     ss0 = explicit_slot 4, align = 4
 ;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
@@ -18,13 +17,9 @@
 ;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
-;;     sig0 = (i64 vmctx, i32, i32) -> i32 tail
-;;     fn0 = colocated u805306368:27 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;;                                     v36 = stack_addr.i64 ss0
-;;                                     store notrap v2, v36
 ;; @001e                               v4 = iconst.i32 0
 ;; @001e                               v5 = icmp eq v2, v4  ; v4 = 0
 ;; @001e                               brif v5, block4(v4), block2  ; v4 = 0
@@ -32,12 +27,12 @@
 ;;                                 block2:
 ;; @001e                               v8 = iconst.i32 1
 ;; @001e                               v9 = band.i32 v2, v8  ; v8 = 1
-;;                                     v37 = iconst.i32 0
-;; @001e                               brif v9, block4(v37), block3  ; v37 = 0
+;;                                     v25 = iconst.i32 0
+;; @001e                               brif v9, block4(v25), block3  ; v25 = 0
 ;;
 ;;                                 block3:
-;; @001e                               v31 = load.i64 notrap aligned readonly can_move v0+8
-;; @001e                               v15 = load.i64 notrap aligned readonly can_move v31+32
+;; @001e                               v23 = load.i64 notrap aligned readonly can_move v0+8
+;; @001e                               v15 = load.i64 notrap aligned readonly can_move v23+32
 ;; @001e                               v14 = uextend.i64 v2
 ;; @001e                               v16 = iadd v15, v14
 ;; @001e                               v17 = iconst.i64 4
@@ -47,20 +42,12 @@
 ;; @001e                               v13 = load.i32 notrap aligned readonly can_move v12
 ;; @001e                               v20 = icmp eq v19, v13
 ;; @001e                               v21 = uextend.i32 v20
-;; @001e                               brif v20, block6(v21), block5
+;; @001e                               jump block4(v21)
 ;;
-;;                                 block5:
-;; @001e                               v23 = call fn0(v0, v19, v13), stack_map=[i32 @ ss0+0]
-;; @001e                               jump block6(v23)
-;;
-;;                                 block6(v24: i32):
-;; @001e                               jump block4(v24)
-;;
-;;                                 block4(v25: i32):
-;; @001e                               trapz v25, user19
-;;                                     v26 = load.i32 notrap v36
+;;                                 block4(v22: i32):
+;; @001e                               trapz v22, user19
 ;; @0021                               jump block1
 ;;
 ;;                                 block1:
-;; @0021                               return v26
+;; @0021                               return v2
 ;; }

--- a/tests/disas/gc/drc/ref-cast.wat
+++ b/tests/disas/gc/drc/ref-cast.wat
@@ -27,8 +27,7 @@
 ;;                                     store notrap v2, v36
 ;; @001e                               v4 = iconst.i32 0
 ;; @001e                               v5 = icmp eq v2, v4  ; v4 = 0
-;; @001e                               v6 = uextend.i32 v5
-;; @001e                               brif v6, block4(v4), block2  ; v4 = 0
+;; @001e                               brif v5, block4(v4), block2  ; v4 = 0
 ;;
 ;;                                 block2:
 ;; @001e                               v8 = iconst.i32 1
@@ -48,7 +47,7 @@
 ;; @001e                               v13 = load.i32 notrap aligned readonly can_move v12
 ;; @001e                               v20 = icmp eq v19, v13
 ;; @001e                               v21 = uextend.i32 v20
-;; @001e                               brif v21, block6(v21), block5
+;; @001e                               brif v20, block6(v21), block5
 ;;
 ;;                                 block5:
 ;; @001e                               v23 = call fn0(v0, v19, v13), stack_map=[i32 @ ss0+0]

--- a/tests/disas/gc/drc/ref-test-array.wat
+++ b/tests/disas/gc/drc/ref-test-array.wat
@@ -21,8 +21,7 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @001b                               v4 = iconst.i32 0
 ;; @001b                               v5 = icmp eq v2, v4  ; v4 = 0
-;; @001b                               v6 = uextend.i32 v5
-;; @001b                               brif v6, block4(v4), block2  ; v4 = 0
+;; @001b                               brif v5, block4(v4), block2  ; v4 = 0
 ;;
 ;;                                 block2:
 ;; @001b                               v8 = iconst.i32 1

--- a/tests/disas/gc/drc/ref-test-concrete-func-type.wat
+++ b/tests/disas/gc/drc/ref-test-concrete-func-type.wat
@@ -14,8 +14,6 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     sig0 = (i64 vmctx, i32, i32) -> i32 tail
-;;     fn0 = colocated u805306368:27 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
@@ -33,17 +31,10 @@
 ;; @0020                               v10 = load.i32 notrap aligned readonly can_move v9
 ;; @0020                               v12 = icmp eq v11, v10
 ;; @0020                               v13 = uextend.i32 v12
-;; @0020                               brif v12, block6(v13), block5
+;; @0020                               jump block4(v13)
 ;;
-;;                                 block5:
-;; @0020                               v15 = call fn0(v0, v11, v10)
-;; @0020                               jump block6(v15)
-;;
-;;                                 block6(v16: i32):
-;; @0020                               jump block4(v16)
-;;
-;;                                 block4(v17: i32):
-;; @0023                               jump block1(v17)
+;;                                 block4(v14: i32):
+;; @0023                               jump block1(v14)
 ;;
 ;;                                 block1(v3: i32):
 ;; @0023                               return v3

--- a/tests/disas/gc/drc/ref-test-concrete-func-type.wat
+++ b/tests/disas/gc/drc/ref-test-concrete-func-type.wat
@@ -21,9 +21,8 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @0020                               v4 = iconst.i64 0
 ;; @0020                               v5 = icmp eq v2, v4  ; v4 = 0
-;; @0020                               v6 = uextend.i32 v5
 ;; @0020                               v7 = iconst.i32 0
-;; @0020                               brif v6, block4(v7), block2  ; v7 = 0
+;; @0020                               brif v5, block4(v7), block2  ; v7 = 0
 ;;
 ;;                                 block2:
 ;; @0020                               jump block3
@@ -34,7 +33,7 @@
 ;; @0020                               v10 = load.i32 notrap aligned readonly can_move v9
 ;; @0020                               v12 = icmp eq v11, v10
 ;; @0020                               v13 = uextend.i32 v12
-;; @0020                               brif v13, block6(v13), block5
+;; @0020                               brif v12, block6(v13), block5
 ;;
 ;;                                 block5:
 ;; @0020                               v15 = call fn0(v0, v11, v10)

--- a/tests/disas/gc/drc/ref-test-concrete-type.wat
+++ b/tests/disas/gc/drc/ref-test-concrete-type.wat
@@ -24,8 +24,7 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @001d                               v4 = iconst.i32 0
 ;; @001d                               v5 = icmp eq v2, v4  ; v4 = 0
-;; @001d                               v6 = uextend.i32 v5
-;; @001d                               brif v6, block4(v4), block2  ; v4 = 0
+;; @001d                               brif v5, block4(v4), block2  ; v4 = 0
 ;;
 ;;                                 block2:
 ;; @001d                               v8 = iconst.i32 1
@@ -45,7 +44,7 @@
 ;; @001d                               v13 = load.i32 notrap aligned readonly can_move v12
 ;; @001d                               v20 = icmp eq v19, v13
 ;; @001d                               v21 = uextend.i32 v20
-;; @001d                               brif v21, block6(v21), block5
+;; @001d                               brif v20, block6(v21), block5
 ;;
 ;;                                 block5:
 ;; @001d                               v23 = call fn0(v0, v19, v13)

--- a/tests/disas/gc/drc/ref-test-concrete-type.wat
+++ b/tests/disas/gc/drc/ref-test-concrete-type.wat
@@ -17,8 +17,6 @@
 ;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
-;;     sig0 = (i64 vmctx, i32, i32) -> i32 tail
-;;     fn0 = colocated u805306368:27 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -29,12 +27,12 @@
 ;;                                 block2:
 ;; @001d                               v8 = iconst.i32 1
 ;; @001d                               v9 = band.i32 v2, v8  ; v8 = 1
-;;                                     v28 = iconst.i32 0
-;; @001d                               brif v9, block4(v28), block3  ; v28 = 0
+;;                                     v25 = iconst.i32 0
+;; @001d                               brif v9, block4(v25), block3  ; v25 = 0
 ;;
 ;;                                 block3:
-;; @001d                               v26 = load.i64 notrap aligned readonly can_move v0+8
-;; @001d                               v15 = load.i64 notrap aligned readonly can_move v26+32
+;; @001d                               v23 = load.i64 notrap aligned readonly can_move v0+8
+;; @001d                               v15 = load.i64 notrap aligned readonly can_move v23+32
 ;; @001d                               v14 = uextend.i64 v2
 ;; @001d                               v16 = iadd v15, v14
 ;; @001d                               v17 = iconst.i64 4
@@ -44,17 +42,10 @@
 ;; @001d                               v13 = load.i32 notrap aligned readonly can_move v12
 ;; @001d                               v20 = icmp eq v19, v13
 ;; @001d                               v21 = uextend.i32 v20
-;; @001d                               brif v20, block6(v21), block5
+;; @001d                               jump block4(v21)
 ;;
-;;                                 block5:
-;; @001d                               v23 = call fn0(v0, v19, v13)
-;; @001d                               jump block6(v23)
-;;
-;;                                 block6(v24: i32):
-;; @001d                               jump block4(v24)
-;;
-;;                                 block4(v25: i32):
-;; @0020                               jump block1(v25)
+;;                                 block4(v22: i32):
+;; @0020                               jump block1(v22)
 ;;
 ;;                                 block1(v3: i32):
 ;; @0020                               return v3

--- a/tests/disas/gc/drc/ref-test-eq.wat
+++ b/tests/disas/gc/drc/ref-test-eq.wat
@@ -21,8 +21,7 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @001b                               v4 = iconst.i32 0
 ;; @001b                               v5 = icmp eq v2, v4  ; v4 = 0
-;; @001b                               v6 = uextend.i32 v5
-;; @001b                               brif v6, block4(v4), block2  ; v4 = 0
+;; @001b                               brif v5, block4(v4), block2  ; v4 = 0
 ;;
 ;;                                 block2:
 ;; @001b                               v8 = iconst.i32 1

--- a/tests/disas/gc/drc/ref-test-struct.wat
+++ b/tests/disas/gc/drc/ref-test-struct.wat
@@ -21,8 +21,7 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @001b                               v4 = iconst.i32 0
 ;; @001b                               v5 = icmp eq v2, v4  ; v4 = 0
-;; @001b                               v6 = uextend.i32 v5
-;; @001b                               brif v6, block4(v4), block2  ; v4 = 0
+;; @001b                               brif v5, block4(v4), block2  ; v4 = 0
 ;;
 ;;                                 block2:
 ;; @001b                               v8 = iconst.i32 1

--- a/tests/disas/gc/null/br-on-cast-fail.wat
+++ b/tests/disas/gc/null/br-on-cast-fail.wat
@@ -36,8 +36,7 @@
 ;;                                     store notrap v2, v42
 ;; @002e                               v4 = iconst.i32 0
 ;; @002e                               v5 = icmp eq v2, v4  ; v4 = 0
-;; @002e                               v6 = uextend.i32 v5
-;; @002e                               brif v6, block5(v4), block3  ; v4 = 0
+;; @002e                               brif v5, block5(v4), block3  ; v4 = 0
 ;;
 ;;                                 block3:
 ;; @002e                               v8 = iconst.i32 1
@@ -57,7 +56,7 @@
 ;; @002e                               v13 = load.i32 notrap aligned readonly can_move v12
 ;; @002e                               v20 = icmp eq v19, v13
 ;; @002e                               v21 = uextend.i32 v20
-;; @002e                               brif v21, block7(v21), block6
+;; @002e                               brif v20, block7(v21), block6
 ;;
 ;;                                 block6:
 ;; @002e                               v23 = call fn0(v0, v19, v13), stack_map=[i32 @ ss0+0]

--- a/tests/disas/gc/null/br-on-cast-fail.wat
+++ b/tests/disas/gc/null/br-on-cast-fail.wat
@@ -17,7 +17,6 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32) tail {
-;;     ss0 = explicit_slot 4, align = 4
 ;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
@@ -26,14 +25,10 @@
 ;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
-;;     sig0 = (i64 vmctx, i32, i32) -> i32 tail
-;;     sig1 = (i64 vmctx, i64) tail
-;;     fn0 = colocated u805306368:27 sig0
+;;     sig0 = (i64 vmctx, i64) tail
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;;                                     v42 = stack_addr.i64 ss0
-;;                                     store notrap v2, v42
 ;; @002e                               v4 = iconst.i32 0
 ;; @002e                               v5 = icmp eq v2, v4  ; v4 = 0
 ;; @002e                               brif v5, block5(v4), block3  ; v4 = 0
@@ -41,12 +36,12 @@
 ;;                                 block3:
 ;; @002e                               v8 = iconst.i32 1
 ;; @002e                               v9 = band.i32 v2, v8  ; v8 = 1
-;;                                     v43 = iconst.i32 0
-;; @002e                               brif v9, block5(v43), block4  ; v43 = 0
+;;                                     v31 = iconst.i32 0
+;; @002e                               brif v9, block5(v31), block4  ; v31 = 0
 ;;
 ;;                                 block4:
-;; @002e                               v37 = load.i64 notrap aligned readonly can_move v0+8
-;; @002e                               v15 = load.i64 notrap aligned readonly can_move v37+32
+;; @002e                               v29 = load.i64 notrap aligned readonly can_move v0+8
+;; @002e                               v15 = load.i64 notrap aligned readonly can_move v29+32
 ;; @002e                               v14 = uextend.i64 v2
 ;; @002e                               v16 = iadd v15, v14
 ;; @002e                               v17 = iconst.i64 4
@@ -56,28 +51,20 @@
 ;; @002e                               v13 = load.i32 notrap aligned readonly can_move v12
 ;; @002e                               v20 = icmp eq v19, v13
 ;; @002e                               v21 = uextend.i32 v20
-;; @002e                               brif v20, block7(v21), block6
+;; @002e                               jump block5(v21)
+;;
+;;                                 block5(v22: i32):
+;; @002e                               brif v22, block6, block2
 ;;
 ;;                                 block6:
-;; @002e                               v23 = call fn0(v0, v19, v13), stack_map=[i32 @ ss0+0]
-;; @002e                               jump block7(v23)
-;;
-;;                                 block7(v24: i32):
-;; @002e                               jump block5(v24)
-;;
-;;                                 block5(v25: i32):
-;;                                     v32 = load.i32 notrap v42
-;; @002e                               brif v25, block8, block2
-;;
-;;                                 block8:
-;; @0034                               v28 = load.i64 notrap aligned readonly can_move v0+56
-;; @0034                               v27 = load.i64 notrap aligned readonly can_move v0+72
-;; @0034                               call_indirect sig1, v28(v27, v0)
+;; @0034                               v25 = load.i64 notrap aligned readonly can_move v0+56
+;; @0034                               v24 = load.i64 notrap aligned readonly can_move v0+72
+;; @0034                               call_indirect sig0, v25(v24, v0)
 ;; @0036                               return
 ;;
 ;;                                 block2:
-;; @0038                               v31 = load.i64 notrap aligned readonly can_move v0+88
-;; @0038                               v30 = load.i64 notrap aligned readonly can_move v0+104
-;; @0038                               call_indirect sig1, v31(v30, v0)
+;; @0038                               v28 = load.i64 notrap aligned readonly can_move v0+88
+;; @0038                               v27 = load.i64 notrap aligned readonly can_move v0+104
+;; @0038                               call_indirect sig0, v28(v27, v0)
 ;; @003a                               return
 ;; }

--- a/tests/disas/gc/null/br-on-cast.wat
+++ b/tests/disas/gc/null/br-on-cast.wat
@@ -17,7 +17,6 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32) tail {
-;;     ss0 = explicit_slot 4, align = 4
 ;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
@@ -26,14 +25,10 @@
 ;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
-;;     sig0 = (i64 vmctx, i32, i32) -> i32 tail
-;;     sig1 = (i64 vmctx, i64) tail
-;;     fn0 = colocated u805306368:27 sig0
+;;     sig0 = (i64 vmctx, i64) tail
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;;                                     v42 = stack_addr.i64 ss0
-;;                                     store notrap v2, v42
 ;; @002f                               v4 = iconst.i32 0
 ;; @002f                               v5 = icmp eq v2, v4  ; v4 = 0
 ;; @002f                               brif v5, block5(v4), block3  ; v4 = 0
@@ -41,12 +36,12 @@
 ;;                                 block3:
 ;; @002f                               v8 = iconst.i32 1
 ;; @002f                               v9 = band.i32 v2, v8  ; v8 = 1
-;;                                     v43 = iconst.i32 0
-;; @002f                               brif v9, block5(v43), block4  ; v43 = 0
+;;                                     v31 = iconst.i32 0
+;; @002f                               brif v9, block5(v31), block4  ; v31 = 0
 ;;
 ;;                                 block4:
-;; @002f                               v37 = load.i64 notrap aligned readonly can_move v0+8
-;; @002f                               v15 = load.i64 notrap aligned readonly can_move v37+32
+;; @002f                               v29 = load.i64 notrap aligned readonly can_move v0+8
+;; @002f                               v15 = load.i64 notrap aligned readonly can_move v29+32
 ;; @002f                               v14 = uextend.i64 v2
 ;; @002f                               v16 = iadd v15, v14
 ;; @002f                               v17 = iconst.i64 4
@@ -56,28 +51,20 @@
 ;; @002f                               v13 = load.i32 notrap aligned readonly can_move v12
 ;; @002f                               v20 = icmp eq v19, v13
 ;; @002f                               v21 = uextend.i32 v20
-;; @002f                               brif v20, block7(v21), block6
+;; @002f                               jump block5(v21)
+;;
+;;                                 block5(v22: i32):
+;; @002f                               brif v22, block2, block6
 ;;
 ;;                                 block6:
-;; @002f                               v23 = call fn0(v0, v19, v13), stack_map=[i32 @ ss0+0]
-;; @002f                               jump block7(v23)
-;;
-;;                                 block7(v24: i32):
-;; @002f                               jump block5(v24)
-;;
-;;                                 block5(v25: i32):
-;;                                     v32 = load.i32 notrap v42
-;; @002f                               brif v25, block2, block8
-;;
-;;                                 block8:
-;; @0035                               v28 = load.i64 notrap aligned readonly can_move v0+56
-;; @0035                               v27 = load.i64 notrap aligned readonly can_move v0+72
-;; @0035                               call_indirect sig1, v28(v27, v0)
+;; @0035                               v25 = load.i64 notrap aligned readonly can_move v0+56
+;; @0035                               v24 = load.i64 notrap aligned readonly can_move v0+72
+;; @0035                               call_indirect sig0, v25(v24, v0)
 ;; @0037                               return
 ;;
 ;;                                 block2:
-;; @0039                               v31 = load.i64 notrap aligned readonly can_move v0+88
-;; @0039                               v30 = load.i64 notrap aligned readonly can_move v0+104
-;; @0039                               call_indirect sig1, v31(v30, v0)
+;; @0039                               v28 = load.i64 notrap aligned readonly can_move v0+88
+;; @0039                               v27 = load.i64 notrap aligned readonly can_move v0+104
+;; @0039                               call_indirect sig0, v28(v27, v0)
 ;; @003b                               return
 ;; }

--- a/tests/disas/gc/null/br-on-cast.wat
+++ b/tests/disas/gc/null/br-on-cast.wat
@@ -36,8 +36,7 @@
 ;;                                     store notrap v2, v42
 ;; @002f                               v4 = iconst.i32 0
 ;; @002f                               v5 = icmp eq v2, v4  ; v4 = 0
-;; @002f                               v6 = uextend.i32 v5
-;; @002f                               brif v6, block5(v4), block3  ; v4 = 0
+;; @002f                               brif v5, block5(v4), block3  ; v4 = 0
 ;;
 ;;                                 block3:
 ;; @002f                               v8 = iconst.i32 1
@@ -57,7 +56,7 @@
 ;; @002f                               v13 = load.i32 notrap aligned readonly can_move v12
 ;; @002f                               v20 = icmp eq v19, v13
 ;; @002f                               v21 = uextend.i32 v20
-;; @002f                               brif v21, block7(v21), block6
+;; @002f                               brif v20, block7(v21), block6
 ;;
 ;;                                 block6:
 ;; @002f                               v23 = call fn0(v0, v19, v13), stack_map=[i32 @ ss0+0]

--- a/tests/disas/gc/null/call-indirect-and-subtyping.wat
+++ b/tests/disas/gc/null/call-indirect-and-subtyping.wat
@@ -56,7 +56,7 @@
 ;; @005c                               v22 = load.i32 notrap aligned readonly can_move v21
 ;; @005c                               v24 = icmp eq v23, v22
 ;; @005c                               v25 = uextend.i32 v24
-;; @005c                               brif v25, block5(v25), block4
+;; @005c                               brif v24, block5(v25), block4
 ;;
 ;;                                 block4:
 ;; @005c                               v27 = call fn1(v0, v23, v22)

--- a/tests/disas/gc/null/ref-cast.wat
+++ b/tests/disas/gc/null/ref-cast.wat
@@ -9,7 +9,6 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
-;;     ss0 = explicit_slot 4, align = 4
 ;;     region0 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
@@ -18,13 +17,9 @@
 ;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
-;;     sig0 = (i64 vmctx, i32, i32) -> i32 tail
-;;     fn0 = colocated u805306368:27 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;;                                     v36 = stack_addr.i64 ss0
-;;                                     store notrap v2, v36
 ;; @001e                               v4 = iconst.i32 0
 ;; @001e                               v5 = icmp eq v2, v4  ; v4 = 0
 ;; @001e                               brif v5, block4(v4), block2  ; v4 = 0
@@ -32,12 +27,12 @@
 ;;                                 block2:
 ;; @001e                               v8 = iconst.i32 1
 ;; @001e                               v9 = band.i32 v2, v8  ; v8 = 1
-;;                                     v37 = iconst.i32 0
-;; @001e                               brif v9, block4(v37), block3  ; v37 = 0
+;;                                     v25 = iconst.i32 0
+;; @001e                               brif v9, block4(v25), block3  ; v25 = 0
 ;;
 ;;                                 block3:
-;; @001e                               v31 = load.i64 notrap aligned readonly can_move v0+8
-;; @001e                               v15 = load.i64 notrap aligned readonly can_move v31+32
+;; @001e                               v23 = load.i64 notrap aligned readonly can_move v0+8
+;; @001e                               v15 = load.i64 notrap aligned readonly can_move v23+32
 ;; @001e                               v14 = uextend.i64 v2
 ;; @001e                               v16 = iadd v15, v14
 ;; @001e                               v17 = iconst.i64 4
@@ -47,20 +42,12 @@
 ;; @001e                               v13 = load.i32 notrap aligned readonly can_move v12
 ;; @001e                               v20 = icmp eq v19, v13
 ;; @001e                               v21 = uextend.i32 v20
-;; @001e                               brif v20, block6(v21), block5
+;; @001e                               jump block4(v21)
 ;;
-;;                                 block5:
-;; @001e                               v23 = call fn0(v0, v19, v13), stack_map=[i32 @ ss0+0]
-;; @001e                               jump block6(v23)
-;;
-;;                                 block6(v24: i32):
-;; @001e                               jump block4(v24)
-;;
-;;                                 block4(v25: i32):
-;; @001e                               trapz v25, user19
-;;                                     v26 = load.i32 notrap v36
+;;                                 block4(v22: i32):
+;; @001e                               trapz v22, user19
 ;; @0021                               jump block1
 ;;
 ;;                                 block1:
-;; @0021                               return v26
+;; @0021                               return v2
 ;; }

--- a/tests/disas/gc/null/ref-cast.wat
+++ b/tests/disas/gc/null/ref-cast.wat
@@ -27,8 +27,7 @@
 ;;                                     store notrap v2, v36
 ;; @001e                               v4 = iconst.i32 0
 ;; @001e                               v5 = icmp eq v2, v4  ; v4 = 0
-;; @001e                               v6 = uextend.i32 v5
-;; @001e                               brif v6, block4(v4), block2  ; v4 = 0
+;; @001e                               brif v5, block4(v4), block2  ; v4 = 0
 ;;
 ;;                                 block2:
 ;; @001e                               v8 = iconst.i32 1
@@ -48,7 +47,7 @@
 ;; @001e                               v13 = load.i32 notrap aligned readonly can_move v12
 ;; @001e                               v20 = icmp eq v19, v13
 ;; @001e                               v21 = uextend.i32 v20
-;; @001e                               brif v21, block6(v21), block5
+;; @001e                               brif v20, block6(v21), block5
 ;;
 ;;                                 block5:
 ;; @001e                               v23 = call fn0(v0, v19, v13), stack_map=[i32 @ ss0+0]

--- a/tests/disas/gc/null/ref-test-array.wat
+++ b/tests/disas/gc/null/ref-test-array.wat
@@ -21,8 +21,7 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @001b                               v4 = iconst.i32 0
 ;; @001b                               v5 = icmp eq v2, v4  ; v4 = 0
-;; @001b                               v6 = uextend.i32 v5
-;; @001b                               brif v6, block4(v4), block2  ; v4 = 0
+;; @001b                               brif v5, block4(v4), block2  ; v4 = 0
 ;;
 ;;                                 block2:
 ;; @001b                               v8 = iconst.i32 1

--- a/tests/disas/gc/null/ref-test-concrete-func-type.wat
+++ b/tests/disas/gc/null/ref-test-concrete-func-type.wat
@@ -14,8 +14,6 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     sig0 = (i64 vmctx, i32, i32) -> i32 tail
-;;     fn0 = colocated u805306368:27 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
@@ -33,17 +31,10 @@
 ;; @0020                               v10 = load.i32 notrap aligned readonly can_move v9
 ;; @0020                               v12 = icmp eq v11, v10
 ;; @0020                               v13 = uextend.i32 v12
-;; @0020                               brif v12, block6(v13), block5
+;; @0020                               jump block4(v13)
 ;;
-;;                                 block5:
-;; @0020                               v15 = call fn0(v0, v11, v10)
-;; @0020                               jump block6(v15)
-;;
-;;                                 block6(v16: i32):
-;; @0020                               jump block4(v16)
-;;
-;;                                 block4(v17: i32):
-;; @0023                               jump block1(v17)
+;;                                 block4(v14: i32):
+;; @0023                               jump block1(v14)
 ;;
 ;;                                 block1(v3: i32):
 ;; @0023                               return v3

--- a/tests/disas/gc/null/ref-test-concrete-func-type.wat
+++ b/tests/disas/gc/null/ref-test-concrete-func-type.wat
@@ -21,9 +21,8 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @0020                               v4 = iconst.i64 0
 ;; @0020                               v5 = icmp eq v2, v4  ; v4 = 0
-;; @0020                               v6 = uextend.i32 v5
 ;; @0020                               v7 = iconst.i32 0
-;; @0020                               brif v6, block4(v7), block2  ; v7 = 0
+;; @0020                               brif v5, block4(v7), block2  ; v7 = 0
 ;;
 ;;                                 block2:
 ;; @0020                               jump block3
@@ -34,7 +33,7 @@
 ;; @0020                               v10 = load.i32 notrap aligned readonly can_move v9
 ;; @0020                               v12 = icmp eq v11, v10
 ;; @0020                               v13 = uextend.i32 v12
-;; @0020                               brif v13, block6(v13), block5
+;; @0020                               brif v12, block6(v13), block5
 ;;
 ;;                                 block5:
 ;; @0020                               v15 = call fn0(v0, v11, v10)

--- a/tests/disas/gc/null/ref-test-concrete-type.wat
+++ b/tests/disas/gc/null/ref-test-concrete-type.wat
@@ -24,8 +24,7 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @001d                               v4 = iconst.i32 0
 ;; @001d                               v5 = icmp eq v2, v4  ; v4 = 0
-;; @001d                               v6 = uextend.i32 v5
-;; @001d                               brif v6, block4(v4), block2  ; v4 = 0
+;; @001d                               brif v5, block4(v4), block2  ; v4 = 0
 ;;
 ;;                                 block2:
 ;; @001d                               v8 = iconst.i32 1
@@ -45,7 +44,7 @@
 ;; @001d                               v13 = load.i32 notrap aligned readonly can_move v12
 ;; @001d                               v20 = icmp eq v19, v13
 ;; @001d                               v21 = uextend.i32 v20
-;; @001d                               brif v21, block6(v21), block5
+;; @001d                               brif v20, block6(v21), block5
 ;;
 ;;                                 block5:
 ;; @001d                               v23 = call fn0(v0, v19, v13)

--- a/tests/disas/gc/null/ref-test-concrete-type.wat
+++ b/tests/disas/gc/null/ref-test-concrete-type.wat
@@ -17,8 +17,6 @@
 ;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
-;;     sig0 = (i64 vmctx, i32, i32) -> i32 tail
-;;     fn0 = colocated u805306368:27 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -29,12 +27,12 @@
 ;;                                 block2:
 ;; @001d                               v8 = iconst.i32 1
 ;; @001d                               v9 = band.i32 v2, v8  ; v8 = 1
-;;                                     v28 = iconst.i32 0
-;; @001d                               brif v9, block4(v28), block3  ; v28 = 0
+;;                                     v25 = iconst.i32 0
+;; @001d                               brif v9, block4(v25), block3  ; v25 = 0
 ;;
 ;;                                 block3:
-;; @001d                               v26 = load.i64 notrap aligned readonly can_move v0+8
-;; @001d                               v15 = load.i64 notrap aligned readonly can_move v26+32
+;; @001d                               v23 = load.i64 notrap aligned readonly can_move v0+8
+;; @001d                               v15 = load.i64 notrap aligned readonly can_move v23+32
 ;; @001d                               v14 = uextend.i64 v2
 ;; @001d                               v16 = iadd v15, v14
 ;; @001d                               v17 = iconst.i64 4
@@ -44,17 +42,10 @@
 ;; @001d                               v13 = load.i32 notrap aligned readonly can_move v12
 ;; @001d                               v20 = icmp eq v19, v13
 ;; @001d                               v21 = uextend.i32 v20
-;; @001d                               brif v20, block6(v21), block5
+;; @001d                               jump block4(v21)
 ;;
-;;                                 block5:
-;; @001d                               v23 = call fn0(v0, v19, v13)
-;; @001d                               jump block6(v23)
-;;
-;;                                 block6(v24: i32):
-;; @001d                               jump block4(v24)
-;;
-;;                                 block4(v25: i32):
-;; @0020                               jump block1(v25)
+;;                                 block4(v22: i32):
+;; @0020                               jump block1(v22)
 ;;
 ;;                                 block1(v3: i32):
 ;; @0020                               return v3

--- a/tests/disas/gc/null/ref-test-eq.wat
+++ b/tests/disas/gc/null/ref-test-eq.wat
@@ -21,8 +21,7 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @001b                               v4 = iconst.i32 0
 ;; @001b                               v5 = icmp eq v2, v4  ; v4 = 0
-;; @001b                               v6 = uextend.i32 v5
-;; @001b                               brif v6, block4(v4), block2  ; v4 = 0
+;; @001b                               brif v5, block4(v4), block2  ; v4 = 0
 ;;
 ;;                                 block2:
 ;; @001b                               v8 = iconst.i32 1

--- a/tests/disas/gc/null/ref-test-struct.wat
+++ b/tests/disas/gc/null/ref-test-struct.wat
@@ -21,8 +21,7 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @001b                               v4 = iconst.i32 0
 ;; @001b                               v5 = icmp eq v2, v4  ; v4 = 0
-;; @001b                               v6 = uextend.i32 v5
-;; @001b                               brif v6, block4(v4), block2  ; v4 = 0
+;; @001b                               brif v5, block4(v4), block2  ; v4 = 0
 ;;
 ;;                                 block2:
 ;; @001b                               v8 = iconst.i32 1

--- a/tests/disas/gc/ref-test-cast-final-type.wat
+++ b/tests/disas/gc/ref-test-cast-final-type.wat
@@ -1,0 +1,102 @@
+;;! target = "x86_64"
+;;! flags = "-W function-references,gc -C collector=drc"
+;;! test = "optimize"
+
+;; `ref.test` / `ref.cast` against a `final` concrete type, which allows us to
+;; omit the slow-path from the subtype check.
+
+(module
+  (type $s (struct))   ;; final by default
+
+  (func (param anyref) (result i32)
+    (ref.test (ref $s) (local.get 0)))
+
+  (func (param anyref) (result (ref $s))
+    (ref.cast (ref $s) (local.get 0)))
+)
+;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
+;;     region0 = 2147483648 "GcHeap"
+;;     gv0 = vmctx
+;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv3 = vmctx
+;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
+;;     gv6 = load.i64 notrap aligned gv4+40
+;;     stack_limit = gv2
+;;
+;;                                 block0(v0: i64, v1: i64, v2: i32):
+;; @0024                               v4 = iconst.i32 0
+;; @0024                               v5 = icmp eq v2, v4  ; v4 = 0
+;; @0024                               brif v5, block4(v4), block2  ; v4 = 0
+;;
+;;                                 block2:
+;; @0024                               v8 = iconst.i32 1
+;; @0024                               v9 = band.i32 v2, v8  ; v8 = 1
+;;                                     v25 = iconst.i32 0
+;; @0024                               brif v9, block4(v25), block3  ; v25 = 0
+;;
+;;                                 block3:
+;; @0024                               v23 = load.i64 notrap aligned readonly can_move v0+8
+;; @0024                               v15 = load.i64 notrap aligned readonly can_move v23+32
+;; @0024                               v14 = uextend.i64 v2
+;; @0024                               v16 = iadd v15, v14
+;; @0024                               v17 = iconst.i64 4
+;; @0024                               v18 = iadd v16, v17  ; v17 = 4
+;; @0024                               v19 = load.i32 user2 readonly region0 v18
+;; @0024                               v12 = load.i64 notrap aligned readonly can_move v0+40
+;; @0024                               v13 = load.i32 notrap aligned readonly can_move v12
+;; @0024                               v20 = icmp eq v19, v13
+;; @0024                               v21 = uextend.i32 v20
+;; @0024                               jump block4(v21)
+;;
+;;                                 block4(v22: i32):
+;; @0027                               jump block1(v22)
+;;
+;;                                 block1(v3: i32):
+;; @0027                               return v3
+;; }
+;;
+;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
+;;     region0 = 2147483648 "GcHeap"
+;;     gv0 = vmctx
+;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv3 = vmctx
+;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
+;;     gv6 = load.i64 notrap aligned gv4+40
+;;     stack_limit = gv2
+;;
+;;                                 block0(v0: i64, v1: i64, v2: i32):
+;; @002c                               v4 = iconst.i32 0
+;; @002c                               v5 = icmp eq v2, v4  ; v4 = 0
+;; @002c                               brif v5, block4(v4), block2  ; v4 = 0
+;;
+;;                                 block2:
+;; @002c                               v8 = iconst.i32 1
+;; @002c                               v9 = band.i32 v2, v8  ; v8 = 1
+;;                                     v25 = iconst.i32 0
+;; @002c                               brif v9, block4(v25), block3  ; v25 = 0
+;;
+;;                                 block3:
+;; @002c                               v23 = load.i64 notrap aligned readonly can_move v0+8
+;; @002c                               v15 = load.i64 notrap aligned readonly can_move v23+32
+;; @002c                               v14 = uextend.i64 v2
+;; @002c                               v16 = iadd v15, v14
+;; @002c                               v17 = iconst.i64 4
+;; @002c                               v18 = iadd v16, v17  ; v17 = 4
+;; @002c                               v19 = load.i32 user2 readonly region0 v18
+;; @002c                               v12 = load.i64 notrap aligned readonly can_move v0+40
+;; @002c                               v13 = load.i32 notrap aligned readonly can_move v12
+;; @002c                               v20 = icmp eq v19, v13
+;; @002c                               v21 = uextend.i32 v20
+;; @002c                               jump block4(v21)
+;;
+;;                                 block4(v22: i32):
+;; @002c                               trapz v22, user19
+;; @002f                               jump block1
+;;
+;;                                 block1:
+;; @002f                               return v2
+;; }

--- a/tests/disas/x64/call-indirect-with-gc.wat
+++ b/tests/disas/x64/call-indirect-with-gc.wat
@@ -14,13 +14,12 @@
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r10
 ;;       movq    0x18(%r10), %r10
-;;       addq    $0x30, %r10
+;;       addq    $0x20, %r10
 ;;       cmpq    %rsp, %r10
-;;       ja      0xc7
-;;   19: subq    $0x20, %rsp
+;;       ja      0x9d
+;;   19: subq    $0x10, %rsp
 ;;       movq    %rbx, (%rsp)
 ;;       movq    %r12, 8(%rsp)
-;;       movq    %r13, 0x10(%rsp)
 ;;       movq    %rdx, %r12
 ;;       movq    0x38(%rdi), %rax
 ;;       movq    0x30(%rdi), %r8
@@ -34,38 +33,27 @@
 ;;       movq    %rcx, %rax
 ;;       andq    $0xfffffffffffffffe, %rax
 ;;       testq   %rcx, %rcx
-;;       je      0xb5
-;;   5b: movq    %r9, %rbx
-;;       movl    0x10(%rax), %esi
-;;       movq    %rax, %r13
-;;       movq    0x28(%rbx), %rax
-;;       movl    4(%rax), %edx
-;;       cmpl    %edx, %esi
-;;       sete    %al
-;;       movzbl  %al, %eax
-;;       cmpl    %edx, %esi
-;;       je      0x83
-;;   7b: movq    %rbx, %rdi
-;;       callq   0x26e
-;;       testl   %eax, %eax
-;;       je      0xc9
-;;   8b: movq    %r13, %rcx
-;;       movq    8(%rcx), %rax
-;;       movq    0x18(%rcx), %rdi
+;;       je      0x8b
+;;   56: movq    %r9, %rbx
+;;       movl    0x10(%rax), %ecx
+;;       movq    0x28(%rbx), %rdx
+;;       cmpl    4(%rdx), %ecx
+;;       jne     0x9f
+;;   69: movq    8(%rax), %rcx
+;;       movq    0x18(%rax), %rdi
 ;;       movq    %r12, %rdx
 ;;       movq    %rbx, %rsi
-;;       callq   *%rax
+;;       callq   *%rcx
 ;;       movq    (%rsp), %rbx
 ;;       movq    8(%rsp), %r12
-;;       movq    0x10(%rsp), %r13
-;;       addq    $0x20, %rsp
+;;       addq    $0x10, %rsp
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   b5: xorl    %esi, %esi
-;;   b7: movq    %r9, %rbx
-;;   ba: movq    %rbx, %rdi
-;;   bd: callq   0x243
-;;   c2: jmp     0x5e
-;;   c7: ud2
-;;   c9: ud2
+;;   8b: xorl    %esi, %esi
+;;   8d: movq    %r9, %rbx
+;;   90: movq    %rbx, %rdi
+;;   93: callq   0x219
+;;   98: jmp     0x59
+;;   9d: ud2
+;;   9f: ud2

--- a/tests/disas/x64/call-indirect-with-gc.wat
+++ b/tests/disas/x64/call-indirect-with-gc.wat
@@ -1,0 +1,71 @@
+;;! target = "x86_64"
+;;! flags = "-W function-references,gc"
+;;! test = "compile"
+
+(module
+  (table (export "t") 0 100 funcref)
+  (func (export "f") (param i32 i32) (result i32)
+    (call_indirect (param i32) (result i32) (local.get 0) (local.get 1))
+  )
+)
+
+;; wasm[0]::function[0]:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       movq    8(%rdi), %r10
+;;       movq    0x18(%r10), %r10
+;;       addq    $0x30, %r10
+;;       cmpq    %rsp, %r10
+;;       ja      0xc7
+;;   19: subq    $0x20, %rsp
+;;       movq    %rbx, (%rsp)
+;;       movq    %r12, 8(%rsp)
+;;       movq    %r13, 0x10(%rsp)
+;;       movq    %rdx, %r12
+;;       movq    0x38(%rdi), %rax
+;;       movq    0x30(%rdi), %r8
+;;       movq    %rdi, %r9
+;;       xorq    %rsi, %rsi
+;;       movl    %ecx, %edx
+;;       leaq    (%r8, %rdx, 8), %rdi
+;;       cmpl    %eax, %ecx
+;;       cmovaeq %rsi, %rdi
+;;       movq    (%rdi), %rcx
+;;       movq    %rcx, %rax
+;;       andq    $0xfffffffffffffffe, %rax
+;;       testq   %rcx, %rcx
+;;       je      0xb5
+;;   5b: movq    %r9, %rbx
+;;       movl    0x10(%rax), %esi
+;;       movq    %rax, %r13
+;;       movq    0x28(%rbx), %rax
+;;       movl    4(%rax), %edx
+;;       cmpl    %edx, %esi
+;;       sete    %al
+;;       movzbl  %al, %eax
+;;       cmpl    %edx, %esi
+;;       je      0x83
+;;   7b: movq    %rbx, %rdi
+;;       callq   0x26e
+;;       testl   %eax, %eax
+;;       je      0xc9
+;;   8b: movq    %r13, %rcx
+;;       movq    8(%rcx), %rax
+;;       movq    0x18(%rcx), %rdi
+;;       movq    %r12, %rdx
+;;       movq    %rbx, %rsi
+;;       callq   *%rax
+;;       movq    (%rsp), %rbx
+;;       movq    8(%rsp), %r12
+;;       movq    0x10(%rsp), %r13
+;;       addq    $0x20, %rsp
+;;       movq    %rbp, %rsp
+;;       popq    %rbp
+;;       retq
+;;   b5: xorl    %esi, %esi
+;;   b7: movq    %r9, %rbx
+;;   ba: movq    %rbx, %rdi
+;;   bd: callq   0x243
+;;   c2: jmp     0x5e
+;;   c7: ud2
+;;   c9: ud2

--- a/tests/disas/x64/call-indirect-without-gc.wat
+++ b/tests/disas/x64/call-indirect-without-gc.wat
@@ -1,0 +1,59 @@
+;;! target = "x86_64"
+;;! flags = "-W function-references=n,gc=n"
+;;! test = "compile"
+
+(module
+  (table (export "t") 0 100 funcref)
+  (func (export "f") (param i32 i32) (result i32)
+    (call_indirect (param i32) (result i32) (local.get 0) (local.get 1))
+  )
+)
+
+;; wasm[0]::function[0]:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       movq    8(%rdi), %r10
+;;       movq    0x18(%r10), %r10
+;;       addq    $0x20, %r10
+;;       cmpq    %rsp, %r10
+;;       ja      0x9d
+;;   19: subq    $0x10, %rsp
+;;       movq    %rbx, (%rsp)
+;;       movq    %r12, 8(%rsp)
+;;       movq    %rdx, %r12
+;;       movq    0x38(%rdi), %rax
+;;       movq    0x30(%rdi), %r8
+;;       movq    %rdi, %r9
+;;       xorq    %rsi, %rsi
+;;       movl    %ecx, %edx
+;;       leaq    (%r8, %rdx, 8), %rdi
+;;       cmpl    %eax, %ecx
+;;       cmovaeq %rsi, %rdi
+;;       movq    (%rdi), %rcx
+;;       movq    %rcx, %rax
+;;       andq    $0xfffffffffffffffe, %rax
+;;       testq   %rcx, %rcx
+;;       je      0x8b
+;;   56: movq    %r9, %rbx
+;;       movl    0x10(%rax), %ecx
+;;       movq    0x28(%rbx), %rdx
+;;       cmpl    4(%rdx), %ecx
+;;       jne     0x9f
+;;   69: movq    8(%rax), %rcx
+;;       movq    0x18(%rax), %rdi
+;;       movq    %r12, %rdx
+;;       movq    %rbx, %rsi
+;;       callq   *%rcx
+;;       movq    (%rsp), %rbx
+;;       movq    8(%rsp), %r12
+;;       addq    $0x10, %rsp
+;;       movq    %rbp, %rsp
+;;       popq    %rbp
+;;       retq
+;;   8b: xorl    %esi, %esi
+;;   8d: movq    %r9, %rbx
+;;   90: movq    %rbx, %rdi
+;;   93: callq   0x219
+;;   98: jmp     0x59
+;;   9d: ud2
+;;   9f: ud2


### PR DESCRIPTION
See each commit for details.