### PR TITLE
Cranelift: Remove the `stack_{load,store}` instructions

### DIFF
--- a/cranelift/codegen/meta/src/gen_inst.rs
+++ b/cranelift/codegen/meta/src/gen_inst.rs
@@ -1481,6 +1481,90 @@ fn gen_one_imm_inst_builder(
     });
 }
 
+/// Emit the `stack_load`, `stack_store`, `dynamic_stack_load`, and
+/// `dynamic_stack_store` `InstBuilder` backwards-compat/convenience methods.
+///
+/// These are equivalent to a `[dynamic_]stack_addr` followed by a normal
+/// `load`/`store`.
+fn gen_stack_access_builders(fmt: &mut Formatter) {
+    // `stack_load` => `stack_addr` + `load`.
+    fmt.doc_comment(
+        "Load a value from a stack slot at the constant offset.\n\n\
+         This emits a `stack_addr` followed by a `load`.",
+    );
+    fmt.line("#[allow(non_snake_case, reason = \"generated code\")]");
+    fmt.add_block(
+        "fn stack_load<T1: Into<ir::immediates::Offset32>>(mut self, pointer_type: crate::ir::Type, Mem: crate::ir::Type, SS: ir::StackSlot, Offset: T1) -> Value",
+        |fmt| {
+            fmt.line("let Offset = Offset.into();");
+            fmt.line("let addr = self.build_aux_inst(InstructionData::StackAddr { opcode: Opcode::StackAddr, stack_slot: SS, offset: Offset }, pointer_type);");
+            fmt.line("let addr = self.data_flow_graph().first_result(addr);");
+            fmt.line("// Stack slots are required to be accessible, but we can't");
+            fmt.line("// currently ensure that they are aligned.");
+            fmt.line("let mut flags = ir::MemFlagsData::new();");
+            fmt.line("flags.set_notrap();");
+            fmt.line("self.load(Mem, flags, addr, 0)");
+        },
+    );
+    fmt.empty_line();
+
+    // `stack_store` => `stack_addr` + `store`.
+    fmt.doc_comment(
+        "Store a value to a stack slot at a constant offset.\n\n\
+         This emits a `stack_addr` followed by a `store`.",
+    );
+    fmt.line("#[allow(non_snake_case, reason = \"generated code\")]");
+    fmt.add_block(
+        "fn stack_store<T1: Into<ir::immediates::Offset32>>(mut self, pointer_type: crate::ir::Type, x: ir::Value, SS: ir::StackSlot, Offset: T1) -> Inst",
+        |fmt| {
+            fmt.line("let Offset = Offset.into();");
+            fmt.line("let addr = self.build_aux_inst(InstructionData::StackAddr { opcode: Opcode::StackAddr, stack_slot: SS, offset: Offset }, pointer_type);");
+            fmt.line("let addr = self.data_flow_graph().first_result(addr);");
+            fmt.line("// Stack slots are required to be accessible, but we can't");
+            fmt.line("// currently ensure that they are aligned.");
+            fmt.line("let mut flags = ir::MemFlagsData::new();");
+            fmt.line("flags.set_notrap();");
+            fmt.line("self.store(flags, x, addr, 0)");
+        },
+    );
+    fmt.empty_line();
+
+    // `dynamic_stack_load` => `dynamic_stack_addr` + `load`.
+    fmt.doc_comment(
+        "Load a value from a dynamic stack slot.\n\n\
+         This emits a `dynamic_stack_addr` followed by a `load`.",
+    );
+    fmt.line("#[allow(non_snake_case, reason = \"generated code\")]");
+    fmt.add_block(
+        "fn dynamic_stack_load(mut self, pointer_type: crate::ir::Type, Mem: crate::ir::Type, DSS: ir::DynamicStackSlot) -> Value",
+        |fmt| {
+            fmt.line("let addr = self.build_aux_inst(InstructionData::DynamicStackAddr { opcode: Opcode::DynamicStackAddr, dynamic_stack_slot: DSS }, pointer_type);");
+            fmt.line("let addr = self.data_flow_graph().first_result(addr);");
+            fmt.line("// Dynamic stack slots are required to be accessible and aligned.");
+            fmt.line("let flags = ir::MemFlagsData::trusted();");
+            fmt.line("self.load(Mem, flags, addr, 0)");
+        },
+    );
+    fmt.empty_line();
+
+    // `dynamic_stack_store` => `dynamic_stack_addr` + `store`.
+    fmt.doc_comment(
+        "Store a value to a dynamic stack slot.\n\n\
+         This emits a `dynamic_stack_addr` followed by a `store`.",
+    );
+    fmt.line("#[allow(non_snake_case, reason = \"generated code\")]");
+    fmt.add_block(
+        "fn dynamic_stack_store(mut self, pointer_type: crate::ir::Type, x: ir::Value, DSS: ir::DynamicStackSlot) -> Inst",
+        |fmt| {
+            fmt.line("let addr = self.build_aux_inst(InstructionData::DynamicStackAddr { opcode: Opcode::DynamicStackAddr, dynamic_stack_slot: DSS }, pointer_type);");
+            fmt.line("let addr = self.data_flow_graph().first_result(addr);");
+            fmt.line("// Dynamic stack slots are required to be accessible and aligned.");
+            fmt.line("let flags = ir::MemFlagsData::trusted();");
+            fmt.line("self.store(flags, x, addr, 0)");
+        },
+    );
+}
+
 /// Generate a Builder trait with methods for all instructions.
 fn gen_builder(
     instructions: &AllInstructions,
@@ -1516,6 +1600,8 @@ fn gen_builder(
                 fmt.empty_line();
             }
         }
+        gen_stack_access_builders(fmt);
+        fmt.empty_line();
         for (i, format) in formats.iter().enumerate() {
             gen_format_constructor(format, fmt);
             if i + 1 != formats.len() {

--- a/cranelift/codegen/meta/src/shared/formats.rs
+++ b/cranelift/codegen/meta/src/shared/formats.rs
@@ -24,10 +24,8 @@ pub(crate) struct Formats {
     pub(crate) multiary: Rc<InstructionFormat>,
     pub(crate) nullary: Rc<InstructionFormat>,
     pub(crate) shuffle: Rc<InstructionFormat>,
-    pub(crate) stack_load: Rc<InstructionFormat>,
-    pub(crate) stack_store: Rc<InstructionFormat>,
-    pub(crate) dynamic_stack_load: Rc<InstructionFormat>,
-    pub(crate) dynamic_stack_store: Rc<InstructionFormat>,
+    pub(crate) stack_addr: Rc<InstructionFormat>,
+    pub(crate) dynamic_stack_addr: Rc<InstructionFormat>,
     pub(crate) store: Rc<InstructionFormat>,
     pub(crate) store_no_offset: Rc<InstructionFormat>,
     pub(crate) ternary: Rc<InstructionFormat>,
@@ -181,23 +179,12 @@ impl Formats {
                 .value()
                 .build(),
 
-            stack_load: Builder::new("StackLoad")
+            stack_addr: Builder::new("StackAddr")
                 .imm(&entities.stack_slot)
                 .imm(&imm.offset32)
                 .build(),
 
-            stack_store: Builder::new("StackStore")
-                .value()
-                .imm(&entities.stack_slot)
-                .imm(&imm.offset32)
-                .build(),
-
-            dynamic_stack_load: Builder::new("DynamicStackLoad")
-                .imm(&entities.dynamic_stack_slot)
-                .build(),
-
-            dynamic_stack_store: Builder::new("DynamicStackStore")
-                .value()
+            dynamic_stack_addr: Builder::new("DynamicStackAddr")
                 .imm(&entities.dynamic_stack_slot)
                 .build(),
 

--- a/cranelift/codegen/meta/src/shared/instructions.rs
+++ b/cranelift/codegen/meta/src/shared/instructions.rs
@@ -1189,52 +1189,6 @@ pub(crate) fn define(
 
     ig.push(
         Inst::new(
-            "stack_load",
-            r#"
-        Load a value from a stack slot at the constant offset.
-
-        This is a polymorphic instruction that can load any value type which
-        has a memory representation.
-
-        The offset is an immediate constant, not an SSA value. The memory
-        access cannot go out of bounds, i.e.
-        `sizeof(a) + Offset <= sizeof(SS)`.
-        "#,
-            &formats.stack_load,
-        )
-        .operands_in(vec![
-            Operand::new("SS", &entities.stack_slot),
-            Operand::new("Offset", &imm.offset32).with_doc("In-bounds offset into stack slot"),
-        ])
-        .operands_out(vec![Operand::new("a", Mem).with_doc("Value loaded")])
-        .can_load(),
-    );
-
-    ig.push(
-        Inst::new(
-            "stack_store",
-            r#"
-        Store a value to a stack slot at a constant offset.
-
-        This is a polymorphic instruction that can store any value type with a
-        memory representation.
-
-        The offset is an immediate constant, not an SSA value. The memory
-        access cannot go out of bounds, i.e.
-        `sizeof(a) + Offset <= sizeof(SS)`.
-        "#,
-            &formats.stack_store,
-        )
-        .operands_in(vec![
-            Operand::new("x", Mem).with_doc("Value to be stored"),
-            Operand::new("SS", &entities.stack_slot),
-            Operand::new("Offset", &imm.offset32).with_doc("In-bounds offset into stack slot"),
-        ])
-        .can_store(),
-    );
-
-    ig.push(
-        Inst::new(
             "stack_addr",
             r#"
         Get the address of a stack slot.
@@ -1243,7 +1197,7 @@ pub(crate) fn define(
         refer to a byte inside the stack slot:
         `0 <= Offset < sizeof(SS)`.
         "#,
-            &formats.stack_load,
+            &formats.stack_addr,
         )
         .operands_in(vec![
             Operand::new("SS", &entities.stack_slot),
@@ -1254,47 +1208,13 @@ pub(crate) fn define(
 
     ig.push(
         Inst::new(
-            "dynamic_stack_load",
-            r#"
-        Load a value from a dynamic stack slot.
-
-        This is a polymorphic instruction that can load any value type which
-        has a memory representation.
-        "#,
-            &formats.dynamic_stack_load,
-        )
-        .operands_in(vec![Operand::new("DSS", &entities.dynamic_stack_slot)])
-        .operands_out(vec![Operand::new("a", Mem).with_doc("Value loaded")])
-        .can_load(),
-    );
-
-    ig.push(
-        Inst::new(
-            "dynamic_stack_store",
-            r#"
-        Store a value to a dynamic stack slot.
-
-        This is a polymorphic instruction that can store any dynamic value type with a
-        memory representation.
-        "#,
-            &formats.dynamic_stack_store,
-        )
-        .operands_in(vec![
-            Operand::new("x", Mem).with_doc("Value to be stored"),
-            Operand::new("DSS", &entities.dynamic_stack_slot),
-        ])
-        .can_store(),
-    );
-
-    ig.push(
-        Inst::new(
             "dynamic_stack_addr",
             r#"
         Get the address of a dynamic stack slot.
 
         Compute the absolute address of the first byte of a dynamic stack slot.
         "#,
-            &formats.dynamic_stack_load,
+            &formats.dynamic_stack_addr,
         )
         .operands_in(vec![Operand::new("DSS", &entities.dynamic_stack_slot)])
         .operands_out(vec![Operand::new("addr", iAddr)]),

--- a/cranelift/codegen/src/inst_predicates.rs
+++ b/cranelift/codegen/src/inst_predicates.rs
@@ -27,7 +27,6 @@ fn is_load_with_defined_trapping(
         return false;
     }
     match *data {
-        InstructionData::StackLoad { .. } => false,
         InstructionData::Load { flags, .. } => !dfg.mem_flags[flags].notrap(),
         _ => true,
     }

--- a/cranelift/codegen/src/ir/function.rs
+++ b/cranelift/codegen/src/ir/function.rs
@@ -235,14 +235,14 @@ impl FunctionStencil {
         self.dfg.jump_tables.push(data)
     }
 
-    /// Creates a sized stack slot in the function, to be used by `stack_load`, `stack_store`
-    /// and `stack_addr` instructions.
+    /// Creates a sized stack slot in the function, to be used by the `stack_addr`
+    /// instruction.
     pub fn create_sized_stack_slot(&mut self, data: StackSlotData) -> StackSlot {
         self.sized_stack_slots.push(data)
     }
 
-    /// Creates a dynamic stack slot in the function, to be used by `dynamic_stack_load`,
-    /// `dynamic_stack_store` and `dynamic_stack_addr` instructions.
+    /// Creates a dynamic stack slot in the function, to be used by the
+    /// `dynamic_stack_addr` instruction.
     pub fn create_dynamic_stack_slot(&mut self, data: DynamicStackSlotData) -> DynamicStackSlot {
         self.dynamic_stack_slots.push(data)
     }

--- a/cranelift/codegen/src/ir/instructions.rs
+++ b/cranelift/codegen/src/ir/instructions.rs
@@ -548,9 +548,8 @@ impl InstructionData {
     pub fn load_store_offset(&self) -> Option<i32> {
         match self {
             &InstructionData::Load { offset, .. }
-            | &InstructionData::StackLoad { offset, .. }
-            | &InstructionData::Store { offset, .. }
-            | &InstructionData::StackStore { offset, .. } => Some(offset.into()),
+            | &InstructionData::StackAddr { offset, .. }
+            | &InstructionData::Store { offset, .. } => Some(offset.into()),
             _ => None,
         }
     }
@@ -577,8 +576,7 @@ impl InstructionData {
     /// If this instruction references a stack slot, return it
     pub fn stack_slot(&self) -> Option<StackSlot> {
         match self {
-            &InstructionData::StackStore { stack_slot, .. }
-            | &InstructionData::StackLoad { stack_slot, .. } => Some(stack_slot),
+            &InstructionData::StackAddr { stack_slot, .. } => Some(stack_slot),
             _ => None,
         }
     }
@@ -1485,13 +1483,13 @@ mod tests {
 
         // Mapping `StackSlot`s.
         assert_eq!(
-            map(InstructionData::StackLoad {
-                opcode: Opcode::StackLoad,
+            map(InstructionData::StackAddr {
+                opcode: Opcode::StackAddr,
                 stack_slot: StackSlot::from_u32(0),
                 offset: 0.into()
             }),
-            InstructionData::StackLoad {
-                opcode: Opcode::StackLoad,
+            InstructionData::StackAddr {
+                opcode: Opcode::StackAddr,
                 stack_slot: StackSlot::from_u32(1),
                 offset: 0.into()
             },
@@ -1499,12 +1497,12 @@ mod tests {
 
         // Mapping `DynamicStackSlot`s.
         assert_eq!(
-            map(InstructionData::DynamicStackLoad {
-                opcode: Opcode::DynamicStackLoad,
+            map(InstructionData::DynamicStackAddr {
+                opcode: Opcode::DynamicStackAddr,
                 dynamic_stack_slot: DynamicStackSlot::from_u32(0),
             }),
-            InstructionData::DynamicStackLoad {
-                opcode: Opcode::DynamicStackLoad,
+            InstructionData::DynamicStackAddr {
+                opcode: Opcode::DynamicStackAddr,
                 dynamic_stack_slot: DynamicStackSlot::from_u32(1),
             },
         );

--- a/cranelift/codegen/src/ir/stackslot.rs
+++ b/cranelift/codegen/src/ir/stackslot.rs
@@ -23,11 +23,11 @@ pub type StackSize = u32;
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
 pub enum StackSlotKind {
-    /// An explicit stack slot. This is a chunk of stack memory for use by the `stack_load`
-    /// and `stack_store` instructions.
+    /// An explicit stack slot. This is a chunk of stack memory for use by the
+    /// `stack_addr` instruction.
     ExplicitSlot,
-    /// An explicit stack slot for dynamic vector types. This is a chunk of stack memory
-    /// for use by the `dynamic_stack_load` and `dynamic_stack_store` instructions.
+    /// An explicit stack slot for dynamic vector types. This is a chunk of
+    /// stack memory for use by the `dynamic_stack_addr` instruction.
     ExplicitDynamicSlot,
 }
 

--- a/cranelift/codegen/src/legalizer/mod.rs
+++ b/cranelift/codegen/src/legalizer/mod.rs
@@ -14,7 +14,7 @@
 //! from the encoding recipes, and solved later by the register allocator.
 
 use crate::cursor::{Cursor, FuncCursor};
-use crate::ir::{self, InstBuilder, InstructionData, MemFlagsData, Value};
+use crate::ir::{self, InstBuilder, InstructionData};
 use crate::isa::TargetIsa;
 use crate::trace;
 use cranelift_entity::EntitySet;
@@ -98,30 +98,6 @@ pub fn simple_legalize(func: &mut ir::Function, isa: &dyn TargetIsa) {
             global_value,
         } => expand_global_value(inst, func, isa, global_value),
 
-        InstructionData::StackLoad {
-            opcode: ir::Opcode::StackLoad,
-            stack_slot,
-            offset,
-        } => expand_stack_load(isa, func, inst, stack_slot, offset),
-
-        InstructionData::StackStore {
-            opcode: ir::Opcode::StackStore,
-            arg,
-            stack_slot,
-            offset,
-        } => expand_stack_store(isa, func, inst, arg, stack_slot, offset),
-
-        InstructionData::DynamicStackLoad {
-            opcode: ir::Opcode::DynamicStackLoad,
-            dynamic_stack_slot,
-        } => expand_dynamic_stack_load(isa, func, inst, dynamic_stack_slot),
-
-        InstructionData::DynamicStackStore {
-            opcode: ir::Opcode::DynamicStackStore,
-            arg,
-            dynamic_stack_slot,
-        } => expand_dynamic_stack_store(isa, func, inst, arg, dynamic_stack_slot),
-
         InstructionData::Binary { opcode, args } => expand_binary(func, inst, opcode, args),
 
         _ => WalkCommand::Continue,
@@ -158,105 +134,6 @@ fn expand_binary(
         }
         _ => {}
     }
-
-    WalkCommand::Continue
-}
-
-fn expand_dynamic_stack_store(
-    isa: &dyn TargetIsa,
-    func: &mut ir::Function,
-    inst: ir::Inst,
-    arg: Value,
-    dynamic_stack_slot: ir::DynamicStackSlot,
-) -> WalkCommand {
-    let mut pos = FuncCursor::new(func);
-    pos.goto_inst(inst);
-    pos.use_srcloc(inst);
-
-    let vector_ty = pos.func.dfg.value_type(arg);
-    assert!(vector_ty.is_dynamic_vector());
-
-    let addr_ty = isa.pointer_type();
-    let addr = pos.ins().dynamic_stack_addr(addr_ty, dynamic_stack_slot);
-
-    let mut mflags = MemFlagsData::new();
-    // Stack slots are required to be accessible and aligned.
-    mflags.set_notrap();
-    mflags.set_aligned();
-
-    pos.func.replace(inst).store(mflags, arg, addr, 0);
-
-    WalkCommand::Continue
-}
-
-fn expand_dynamic_stack_load(
-    isa: &dyn TargetIsa,
-    func: &mut ir::Function,
-    inst: ir::Inst,
-    dynamic_stack_slot: ir::DynamicStackSlot,
-) -> WalkCommand {
-    let mut pos = FuncCursor::new(func).at_inst(inst);
-    pos.use_srcloc(inst);
-
-    let ty = pos.func.dfg.value_type(pos.func.dfg.first_result(inst));
-    assert!(ty.is_dynamic_vector());
-
-    let addr_ty = isa.pointer_type();
-    let addr = pos.ins().dynamic_stack_addr(addr_ty, dynamic_stack_slot);
-
-    // Stack slots are required to be accessible and aligned.
-    let mflags = MemFlagsData::trusted();
-
-    pos.func.replace(inst).load(ty, mflags, addr, 0);
-
-    WalkCommand::Continue
-}
-
-fn expand_stack_store(
-    isa: &dyn TargetIsa,
-    func: &mut ir::Function,
-    inst: ir::Inst,
-    arg: ir::Value,
-    stack_slot: ir::StackSlot,
-    offset: ir::immediates::Offset32,
-) -> WalkCommand {
-    let mut pos = FuncCursor::new(func).at_inst(inst);
-    pos.use_srcloc(inst);
-
-    let addr_ty = isa.pointer_type();
-    let addr = pos.ins().stack_addr(addr_ty, stack_slot, offset);
-
-    // Stack slots are required to be accessible.
-    // We can't currently ensure that they are aligned.
-    let mut mflags = MemFlagsData::new();
-    mflags.set_notrap();
-
-    pos.func.replace(inst).store(mflags, arg, addr, 0);
-
-    WalkCommand::Continue
-}
-
-fn expand_stack_load(
-    isa: &dyn TargetIsa,
-    func: &mut ir::Function,
-    inst: ir::Inst,
-    stack_slot: ir::StackSlot,
-    offset: ir::immediates::Offset32,
-) -> WalkCommand {
-    let mut pos = FuncCursor::new(func).at_inst(inst);
-    pos.use_srcloc(inst);
-
-    let ty = pos.func.dfg.value_type(pos.func.dfg.first_result(inst));
-    let addr_ty = isa.pointer_type();
-
-    let addr = pos.ins().stack_addr(addr_ty, stack_slot, offset);
-
-    // Stack slots are required to be accessible.
-    // We can't currently ensure that they are aligned.
-    let mut mflags = MemFlagsData::new();
-    mflags.set_notrap();
-
-    pos.func.replace(inst).load(ty, mflags, addr, 0);
 
     WalkCommand::Continue
 }

--- a/cranelift/codegen/src/verifier/mod.rs
+++ b/cranelift/codegen/src/verifier/mod.rs
@@ -617,13 +617,10 @@ impl<'a> Verifier<'a> {
             FuncAddr { func_ref, .. } => {
                 self.verify_func_ref(inst, func_ref, errors)?;
             }
-            StackLoad { stack_slot, .. } | StackStore { stack_slot, .. } => {
+            StackAddr { stack_slot, .. } => {
                 self.verify_stack_slot(inst, stack_slot, errors)?;
             }
-            DynamicStackLoad {
-                dynamic_stack_slot, ..
-            }
-            | DynamicStackStore {
+            DynamicStackAddr {
                 dynamic_stack_slot, ..
             } => {
                 self.verify_dynamic_stack_slot(inst, dynamic_stack_slot, errors)?;

--- a/cranelift/codegen/src/write.rs
+++ b/cranelift/codegen/src/write.rs
@@ -500,23 +500,12 @@ pub fn write_operands(w: &mut dyn Write, dfg: &DataFlowGraph, inst: Inst) -> fmt
             write_user_stack_map_entries(w, dfg, inst)
         }
         FuncAddr { func_ref, .. } => write!(w, " {func_ref}"),
-        StackLoad {
+        StackAddr {
             stack_slot, offset, ..
         } => write!(w, " {stack_slot}{offset}"),
-        StackStore {
-            arg,
-            stack_slot,
-            offset,
-            ..
-        } => write!(w, " {arg}, {stack_slot}{offset}"),
-        DynamicStackLoad {
+        DynamicStackAddr {
             dynamic_stack_slot, ..
         } => write!(w, " {dynamic_stack_slot}"),
-        DynamicStackStore {
-            arg,
-            dynamic_stack_slot,
-            ..
-        } => write!(w, " {arg}, {dynamic_stack_slot}"),
         Load {
             flags, arg, offset, ..
         } => write!(w, "{} {arg}{offset}", dfg.mem_flags[flags]),

--- a/cranelift/filetests/filetests/egraph/issue-5716.clif
+++ b/cranelift/filetests/filetests/egraph/issue-5716.clif
@@ -35,6 +35,7 @@ block37:
 block38:
   v98 = load.i8 notrap v97
   v99 = fcvt_from_uint.f64 v98
-  stack_store v99, ss0
+  v240 = stack_addr.i64 ss0
+  store notrap v99, v240
   trap user1
 }

--- a/cranelift/filetests/filetests/egraph/misc.clif
+++ b/cranelift/filetests/filetests/egraph/misc.clif
@@ -6,15 +6,17 @@ function %stack_load(i64) -> i64 {
   ss0 = explicit_slot 8
 
 block0(v0: i64):
-  stack_store.i64 v0, ss0
-  v1 = stack_load.i64 ss0
+  v2 = stack_addr.i64 ss0
+  store.i64 notrap v0, v2
+  v3 = stack_addr.i64 ss0
+  v1 = load.i64 notrap v3
   return v1
 }
 
 ; check: function %stack_load(i64) -> i64 fast {
 ; nextln:    ss0 = explicit_slot 8
 ; check:  block0(v0: i64):
-; nextln:     v3 = stack_addr.i64 ss0
-; nextln:     store notrap v0, v3
+; nextln:     v2 = stack_addr.i64 ss0
+; nextln:     store notrap v0, v2
 ; nextln:     return v0
 ; nextln: }

--- a/cranelift/filetests/filetests/inline/dynamic-stack-slots.clif
+++ b/cranelift/filetests/filetests/inline/dynamic-stack-slots.clif
@@ -7,7 +7,8 @@ function %f0(i32) {
     dss0 = explicit_dynamic_slot dt0
 block0(v0: i32):
     v1 = splat.dt0 v0
-    dynamic_stack_store.dt0 v1, dss0
+    v2 = dynamic_stack_addr.i64 dss0
+    store.dt0 notrap aligned v1, v2
     return
 }
 
@@ -21,7 +22,8 @@ function %f1() {
 block0:
     v0 = iconst.i64 99
     v1 = splat.dt0 v0
-    dynamic_stack_store.dt0 v1, dss0
+    v3 = dynamic_stack_addr.i64 dss0
+    store.dt0 notrap aligned v1, v3
     v2 = iconst.i32 1
     call fn0(v2)
     return

--- a/cranelift/filetests/filetests/inline/stack-maps-opt.clif
+++ b/cranelift/filetests/filetests/inline/stack-maps-opt.clif
@@ -17,9 +17,11 @@ function %f1(i32) -> i32 {
     ss0 = explicit_slot 4
     fn0 = %f0() -> i32
 block0(v0: i32):
-    stack_store v0, ss0
+    v5 = stack_addr.i64 ss0
+    store notrap v0, v5
     v1 = call fn0(), stack_map=[i32 @ ss0+0]
-    v2 = stack_load.i32 ss0
+    v4 = stack_addr.i64 ss0
+    v2 = load.i32 notrap v4
     v3 = iadd v2, v1
     return v3
 }

--- a/cranelift/filetests/filetests/inline/stack-maps.clif
+++ b/cranelift/filetests/filetests/inline/stack-maps.clif
@@ -8,9 +8,11 @@ function %f0(i64) -> i64 tail {
     ss0 = explicit_slot 16
     fn0 = %whatever(i64)
 block0(v0: i64):
-    stack_store v0, ss0+8
+    v3 = stack_addr.i64 ss0+8
+    store notrap v0, v3
     call fn0(v0), stack_map=[i64 @ ss0+8]
-    v1 = stack_load.i64 ss0+8
+    v2 = stack_addr.i64 ss0+8
+    v1 = load.i64 notrap v2
     return v1
 }
 
@@ -64,9 +66,11 @@ function %f3(i64) -> i64 tail {
     ss0 = explicit_slot 16
     fn0 = %f2(i64) -> i64 tail
 block0(v0: i64):
-    stack_store v0, ss0+8
+    v5 = stack_addr.i64 ss0+8
+    store notrap v0, v5
     v1 = call fn0(v0), stack_map=[i64 @ ss0+8]
-    v2 = stack_load.i64 ss0+8
+    v4 = stack_addr.i64 ss0+8
+    v2 = load.i64 notrap v4
     v3 = iadd v1, v2
     return v3
 }
@@ -102,9 +106,11 @@ function %f4(i64) -> i64 tail {
     ss0 = explicit_slot 8
     fn0 = %whatever(i64)
 block0(v0: i64):
-    stack_store v0, ss0
+    v3 = stack_addr.i64 ss0
+    store notrap v0, v3
     call fn0(v0), stack_map=[i64 @ ss0+0]
-    v1 = stack_load.i64 ss0
+    v2 = stack_addr.i64 ss0
+    v1 = load.i64 notrap v2
     return v1
 }
 
@@ -114,9 +120,11 @@ function %f5(i64) -> i64 tail {
     ss0 = explicit_slot 16
     fn0 = %f4(i64) -> i64 tail
 block0(v0: i64):
-    stack_store v0, ss0+8
+    v5 = stack_addr.i64 ss0+8
+    store notrap v0, v5
     v1 = call fn0(v0), stack_map=[i64 @ ss0+8]
-    v2 = stack_load.i64 ss0+8
+    v4 = stack_addr.i64 ss0+8
+    v2 = load.i64 notrap v4
     v3 = iadd v1, v2
     return v3
 }
@@ -166,9 +174,11 @@ function %f7(i64) -> i64 tail {
     ss0 = explicit_slot 16
     fn0 = %f6(i64) -> i64 tail
 block0(v0: i64):
-    stack_store v0, ss0+8
+    v5 = stack_addr.i64 ss0+8
+    store notrap v0, v5
     v1 = call fn0(v0), stack_map=[i64 @ ss0+8]
-    v2 = stack_load.i64 ss0+8
+    v4 = stack_addr.i64 ss0+8
+    v2 = load.i64 notrap v4
     v3 = iadd v1, v2
     return v3
 }
@@ -213,9 +223,11 @@ function %f9(i64, i64) -> i64 tail {
     ss0 = explicit_slot 16
     fn0 = %f8(i64, i64) -> i64 tail
 block0(v0: i64, v1: i64):
-    stack_store v0, ss0+8
+    v6 = stack_addr.i64 ss0+8
+    store notrap v0, v6
     v2 = call fn0(v0, v1), stack_map=[i64 @ ss0+8]
-    v3 = stack_load.i64 ss0+8
+    v5 = stack_addr.i64 ss0+8
+    v3 = load.i64 notrap v5
     v4 = iadd v2, v3
     return v4
 }

--- a/cranelift/filetests/filetests/inline/stack-slots.clif
+++ b/cranelift/filetests/filetests/inline/stack-slots.clif
@@ -4,8 +4,10 @@ target x86_64
 function %f0(i64) -> i64 tail {
     ss0 = explicit_slot 8
 block0(v0: i64):
-    stack_store v0, ss0
-    v1 = stack_load.i64 ss0
+    v3 = stack_addr.i64 ss0
+    store notrap v0, v3
+    v2 = stack_addr.i64 ss0
+    v1 = load.i64 notrap v2
     return v1
 }
 

--- a/cranelift/filetests/filetests/isa/aarch64/dynamic-slot.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/dynamic-slot.clif
@@ -7,7 +7,8 @@ function %store_scale() {
 
 block0:
   v0 = global_value.i64 gv0
-  stack_store.i64 v0, ss0
+  v1 = stack_addr.i64 ss0
+  store.i64 notrap v0, v1
   return
 }
 
@@ -40,7 +41,8 @@ function %store_scale_lt_128() {
 
 block0:
   v0 = global_value.i64 gv0
-  stack_store.i64 v0, ss0
+  v1 = stack_addr.i64 ss0
+  store.i64 notrap v0, v1
   return
 }
 
@@ -74,7 +76,8 @@ function %store_explicit(i32) {
 
 block0(v0: i32):
   v1 = splat.dt0 v0
-  dynamic_stack_store.dt0 v1, dss0
+  v2 = dynamic_stack_addr.i64 dss0
+  store.dt0 notrap aligned v1, v2
   return
 }
 
@@ -109,7 +112,8 @@ function %load_explicit() -> i32x4 {
   dss0 = explicit_dynamic_slot dt0
 
 block0:
-  v0 = dynamic_stack_load.dt0 dss0
+  v2 = dynamic_stack_addr.i64 dss0
+  v0 = load.dt0 notrap aligned v2
   v1 = extract_vector.dt0 v0, 0
   return v1
 }
@@ -144,7 +148,8 @@ function %store_implicit(i32) {
 
 block0(v0: i32):
   v1 = splat.dt0 v0
-  dynamic_stack_store v1, dss0
+  v2 = dynamic_stack_addr.i64 dss0
+  store notrap aligned v1, v2
   return
 }
 

--- a/cranelift/filetests/filetests/isa/aarch64/stack.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/stack.clif
@@ -73,7 +73,8 @@ function %stack_load_small() -> i64 {
 ss0 = explicit_slot 8
 
 block0:
-  v0 = stack_load.i64 ss0
+  v1 = stack_addr.i64 ss0
+  v0 = load.i64 notrap v1
   return v0
 }
 
@@ -103,7 +104,8 @@ ss0 = explicit_slot 100000
 ss1 = explicit_slot 8
 
 block0:
-  v0 = stack_load.i64 ss0
+  v1 = stack_addr.i64 ss0
+  v0 = load.i64 notrap v1
   return v0
 }
 
@@ -140,7 +142,8 @@ function %stack_store_small(i64) {
 ss0 = explicit_slot 8
 
 block0(v0: i64):
-  stack_store.i64 v0, ss0
+  v1 = stack_addr.i64 ss0
+  store.i64 notrap v0, v1
   return
 }
 
@@ -170,7 +173,8 @@ ss0 = explicit_slot 100000
 ss1 = explicit_slot 8
 
 block0(v0: i64):
-  stack_store.i64 v0, ss0
+  v1 = stack_addr.i64 ss0
+  store.i64 notrap v0, v1
   return
 }
 
@@ -713,7 +717,8 @@ function %i128_stack_store(i128) {
 ss0 = explicit_slot 16
 
 block0(v0: i128):
-  stack_store.i128 v0, ss0
+  v1 = stack_addr.i64 ss0
+  store.i128 notrap v0, v1
   return
 }
 
@@ -745,7 +750,8 @@ ss0 = explicit_slot 16
 ss1 = explicit_slot 16
 
 block0(v0: i128):
-  stack_store.i128 v0, ss1+16
+  v1 = stack_addr.i64 ss1+16
+  store.i128 notrap v0, v1
   return
 }
 
@@ -777,7 +783,8 @@ ss0 = explicit_slot 100000
 ss1 = explicit_slot 8
 
 block0(v0: i128):
-  stack_store.i128 v0, ss0
+  v1 = stack_addr.i64 ss0
+  store.i128 notrap v0, v1
   return
 }
 
@@ -816,7 +823,8 @@ function %i128_stack_load() -> i128 {
 ss0 = explicit_slot 16
 
 block0:
-  v0 = stack_load.i128 ss0
+  v1 = stack_addr.i64 ss0
+  v0 = load.i128 notrap v1
   return v0
 }
 
@@ -848,7 +856,8 @@ ss0 = explicit_slot 16
 ss1 = explicit_slot 16
 
 block0:
-  v0 = stack_load.i128 ss1+16
+  v1 = stack_addr.i64 ss1+16
+  v0 = load.i128 notrap v1
   return v0
 }
 
@@ -880,7 +889,8 @@ ss0 = explicit_slot 100000
 ss1 = explicit_slot 8
 
 block0:
-  v0 = stack_load.i128 ss0
+  v1 = stack_addr.i64 ss0
+  v0 = load.i128 notrap v1
   return v0
 }
 

--- a/cranelift/filetests/filetests/isa/aarch64/stackslot.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/stackslot.clif
@@ -6,16 +6,26 @@ function %f1(i32, i64, f32, f64, i8x16) -> i32, i64, f32, f64, i8x16 {
   ss0 = explicit_slot 40
 
 block0(v0: i32, v1: i64, v2: f32, v3: f64, v4: i8x16):
-  stack_store v0, ss0+0
-  stack_store v1, ss0+4
-  stack_store v2, ss0+12
-  stack_store v3, ss0+16
-  stack_store v4, ss0+24
-  v5 = stack_load.i32 ss0+0
-  v6 = stack_load.i64 ss0+4
-  v7 = stack_load.f32 ss0+12
-  v8 = stack_load.f64 ss0+16
-  v9 = stack_load.i8x16 ss0+24
+  v15 = stack_addr.i64 ss0+0
+  store notrap v0, v15
+  v16 = stack_addr.i64 ss0+4
+  store notrap v1, v16
+  v17 = stack_addr.i64 ss0+12
+  store notrap v2, v17
+  v18 = stack_addr.i64 ss0+16
+  store notrap v3, v18
+  v19 = stack_addr.i64 ss0+24
+  store notrap v4, v19
+  v10 = stack_addr.i64 ss0+0
+  v5 = load.i32 notrap v10
+  v11 = stack_addr.i64 ss0+4
+  v6 = load.i64 notrap v11
+  v12 = stack_addr.i64 ss0+12
+  v7 = load.f32 notrap v12
+  v13 = stack_addr.i64 ss0+16
+  v8 = load.f64 notrap v13
+  v14 = stack_addr.i64 ss0+24
+  v9 = load.i8x16 notrap v14
   return v5, v6, v7, v8, v9
 }
 

--- a/cranelift/filetests/filetests/isa/aarch64/user_stack_maps.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/user_stack_maps.clif
@@ -14,16 +14,22 @@ block0:
     v2 = iconst.i32 2
     v3 = iconst.i32 3
 
-    stack_store v0, ss0
-    stack_store v1, ss0+4
-    stack_store v2, ss0+8
+    v4 = stack_addr.i64 ss0
+    store notrap v0, v4
+    v5 = stack_addr.i64 ss0+4
+    store notrap v1, v5
+    v6 = stack_addr.i64 ss0+8
+    store notrap v2, v6
     call fn0(v0), stack_map=[i32 @ ss0+0, i32 @ ss0+4, i32 @ ss0+8]
 
-    stack_store v1, ss0
-    stack_store v2, ss0+4
+    v7 = stack_addr.i64 ss0
+    store notrap v1, v7
+    v8 = stack_addr.i64 ss0+4
+    store notrap v2, v8
     call fn0(v0), stack_map=[i32 @ ss0+0, i32 @ ss0+4]
 
-    stack_store v2, ss0
+    v9 = stack_addr.i64 ss0
+    store notrap v2, v9
     call fn0(v1), stack_map=[i32 @ ss0+0]
 
     call fn0(v2)
@@ -105,12 +111,18 @@ function %different_types(i8, i16, i32, i64, f32, f64) -> i8, i16, i32, i64, f32
     fn0 = colocated u0:0 sig0
 
 block0(v0: i8, v1: i16, v2: i32, v3: i64, v4: f32, v5: f64):
-    stack_store v0, ss0
-    stack_store v1, ss1
-    stack_store v2, ss2
-    stack_store v4, ss2+4
-    stack_store v3, ss3
-    stack_store v5, ss3+8
+    v6 = stack_addr.i64 ss0
+    store notrap v0, v6
+    v7 = stack_addr.i64 ss1
+    store notrap v1, v7
+    v8 = stack_addr.i64 ss2
+    store notrap v2, v8
+    v9 = stack_addr.i64 ss2+4
+    store notrap v4, v9
+    v10 = stack_addr.i64 ss3
+    store notrap v3, v10
+    v11 = stack_addr.i64 ss3+8
+    store notrap v5, v11
     call fn0(), stack_map=[i8 @ ss0+0, i16 @ ss1+0, i32 @ ss2+0, f32 @ ss2+4, i64 @ ss3+0, f64 @ ss3+8]
     return v0, v1, v2, v3, v4, v5
 }

--- a/cranelift/filetests/filetests/isa/riscv64/f16-memory.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/f16-memory.clif
@@ -5,9 +5,11 @@ function %f16_load(i16) -> f16 {
     ss0 = explicit_slot 4
 
 block0(v0: i16):
-    stack_store.i16 v0, ss0+2
+    v2 = stack_addr.i64 ss0+2
+    store.i16 notrap v0, v2
     
-    v1 = stack_load.f16 ss0+2
+    v3 = stack_addr.i64 ss0+2
+    v1 = load.f16 notrap v3
     return v1
 }
 
@@ -46,9 +48,11 @@ function %f16_store(f16) -> i16 {
     ss0 = explicit_slot 4
 
 block0(v0: f16):
-    stack_store.f16 v0, ss0+2
+    v2 = stack_addr.i64 ss0+2
+    store.f16 notrap v0, v2
     
-    v1 = stack_load.i16 ss0+2
+    v3 = stack_addr.i64 ss0+2
+    v1 = load.i16 notrap v3
     return v1
 }
 
@@ -87,8 +91,10 @@ function %f16_roundtrip(f16) -> f16 {
     ss0 = explicit_slot 2
 
 block0(v0: f16):
-    stack_store.f16 v0, ss0
-    v1 = stack_load.f16 ss0
+    v2 = stack_addr.i64 ss0
+    store.f16 notrap v0, v2
+    v3 = stack_addr.i64 ss0
+    v1 = load.f16 notrap v3
     return v1
 }
 

--- a/cranelift/filetests/filetests/isa/riscv64/issue-6954.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/issue-6954.clif
@@ -14,36 +14,66 @@ block0(v0: i16, v1: f32, v2: f64x2, v3: i32, v4: i8, v5: i64x2, v6: i8, v7: f32x
     v13 = iconst.i32 0
     v14 = iconst.i64 0
     v15 = uextend.i128 v14
-    stack_store v15, ss0
-    stack_store v15, ss0+16
-    stack_store v15, ss0+32
-    stack_store v15, ss0+48
-    stack_store v15, ss0+64
-    stack_store v15, ss0+80
-    stack_store v15, ss0+96
-    stack_store v14, ss0+112
-    stack_store v13, ss0+120
-    stack_store v12, ss0+124
-    stack_store v15, ss1
-    stack_store v15, ss1+16
-    stack_store v15, ss1+32
-    stack_store v15, ss1+48
-    stack_store v15, ss1+64
-    stack_store v15, ss1+80
-    stack_store v15, ss1+96
-    stack_store v14, ss1+112
-    stack_store v13, ss1+120
-    stack_store v12, ss1+124
-    stack_store v15, ss2
-    stack_store v15, ss2+16
-    stack_store v15, ss2+32
-    stack_store v15, ss2+48
-    stack_store v15, ss2+64
-    stack_store v15, ss2+80
-    stack_store v15, ss2+96
-    stack_store v14, ss2+112
-    stack_store v13, ss2+120
-    stack_store v12, ss2+124
+    v88 = stack_addr.i64 ss0
+    store notrap v15, v88
+    v89 = stack_addr.i64 ss0+16
+    store notrap v15, v89
+    v90 = stack_addr.i64 ss0+32
+    store notrap v15, v90
+    v91 = stack_addr.i64 ss0+48
+    store notrap v15, v91
+    v92 = stack_addr.i64 ss0+64
+    store notrap v15, v92
+    v93 = stack_addr.i64 ss0+80
+    store notrap v15, v93
+    v94 = stack_addr.i64 ss0+96
+    store notrap v15, v94
+    v95 = stack_addr.i64 ss0+112
+    store notrap v14, v95
+    v96 = stack_addr.i64 ss0+120
+    store notrap v13, v96
+    v97 = stack_addr.i64 ss0+124
+    store notrap v12, v97
+    v98 = stack_addr.i64 ss1
+    store notrap v15, v98
+    v99 = stack_addr.i64 ss1+16
+    store notrap v15, v99
+    v100 = stack_addr.i64 ss1+32
+    store notrap v15, v100
+    v101 = stack_addr.i64 ss1+48
+    store notrap v15, v101
+    v102 = stack_addr.i64 ss1+64
+    store notrap v15, v102
+    v103 = stack_addr.i64 ss1+80
+    store notrap v15, v103
+    v104 = stack_addr.i64 ss1+96
+    store notrap v15, v104
+    v105 = stack_addr.i64 ss1+112
+    store notrap v14, v105
+    v106 = stack_addr.i64 ss1+120
+    store notrap v13, v106
+    v107 = stack_addr.i64 ss1+124
+    store notrap v12, v107
+    v108 = stack_addr.i64 ss2
+    store notrap v15, v108
+    v109 = stack_addr.i64 ss2+16
+    store notrap v15, v109
+    v110 = stack_addr.i64 ss2+32
+    store notrap v15, v110
+    v111 = stack_addr.i64 ss2+48
+    store notrap v15, v111
+    v112 = stack_addr.i64 ss2+64
+    store notrap v15, v112
+    v113 = stack_addr.i64 ss2+80
+    store notrap v15, v113
+    v114 = stack_addr.i64 ss2+96
+    store notrap v15, v114
+    v115 = stack_addr.i64 ss2+112
+    store notrap v14, v115
+    v116 = stack_addr.i64 ss2+120
+    store notrap v13, v116
+    v117 = stack_addr.i64 ss2+124
+    store notrap v12, v117
     v16 = select v3, v8, v8
     v17 = select v3, v16, v16
     v18 = select v3, v17, v17
@@ -90,7 +120,8 @@ block0(v0: i16, v1: f32, v2: f64x2, v3: i32, v4: i8, v5: i64x2, v6: i8, v7: f32x
     v48 = select v30, v47, v47
     v49 = select v30, v48, v48
     v50 = select v30, v49, v49
-    stack_store v37, ss0+33
+    v118 = stack_addr.i64 ss0+33
+    store notrap v37, v118
     v51 = select v30, v50, v50
     v52 = select v30, v51, v51
     v53 = select v30, v52, v52

--- a/cranelift/filetests/filetests/isa/riscv64/stack.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/stack.clif
@@ -97,7 +97,8 @@ function %stack_load_small() -> i64 {
 ss0 = explicit_slot 8
 
 block0:
-  v0 = stack_load.i64 ss0
+  v1 = stack_addr.i64 ss0
+  v0 = load.i64 notrap v1
   return v0
 }
 
@@ -135,7 +136,8 @@ ss0 = explicit_slot 100000
 ss1 = explicit_slot 8
 
 block0:
-  v0 = stack_load.i64 ss0
+  v1 = stack_addr.i64 ss0
+  v0 = load.i64 notrap v1
   return v0
 }
 
@@ -187,7 +189,8 @@ function %stack_store_small(i64) {
 ss0 = explicit_slot 8
 
 block0(v0: i64):
-  stack_store.i64 v0, ss0
+  v1 = stack_addr.i64 ss0
+  store.i64 notrap v0, v1
   return
 }
 
@@ -225,7 +228,8 @@ ss0 = explicit_slot 100000
 ss1 = explicit_slot 8
 
 block0(v0: i64):
-  stack_store.i64 v0, ss0
+  v1 = stack_addr.i64 ss0
+  store.i64 notrap v0, v1
   return
 }
 
@@ -839,7 +843,8 @@ function %i128_stack_store(i128) {
 ss0 = explicit_slot 16
 
 block0(v0: i128):
-  stack_store.i128 v0, ss0
+  v1 = stack_addr.i64 ss0
+  store.i128 notrap v0, v1
   return
 }
 
@@ -879,7 +884,8 @@ ss0 = explicit_slot 16
 ss1 = explicit_slot 16
 
 block0(v0: i128):
-  stack_store.i128 v0, ss1+16
+  v1 = stack_addr.i64 ss1+16
+  store.i128 notrap v0, v1
   return
 }
 
@@ -919,7 +925,8 @@ ss0 = explicit_slot 100000
 ss1 = explicit_slot 8
 
 block0(v0: i128):
-  stack_store.i128 v0, ss0
+  v1 = stack_addr.i64 ss0
+  store.i128 notrap v0, v1
   return
 }
 
@@ -973,7 +980,8 @@ function %i128_stack_load() -> i128 {
 ss0 = explicit_slot 16
 
 block0:
-  v0 = stack_load.i128 ss0
+  v1 = stack_addr.i64 ss0
+  v0 = load.i128 notrap v1
   return v0
 }
 
@@ -1013,7 +1021,8 @@ ss0 = explicit_slot 16
 ss1 = explicit_slot 16
 
 block0:
-  v0 = stack_load.i128 ss1+16
+  v1 = stack_addr.i64 ss1+16
+  v0 = load.i128 notrap v1
   return v0
 }
 
@@ -1053,7 +1062,8 @@ ss0 = explicit_slot 100000
 ss1 = explicit_slot 8
 
 block0:
-  v0 = stack_load.i128 ss0
+  v1 = stack_addr.i64 ss0
+  v0 = load.i128 notrap v1
   return v0
 }
 

--- a/cranelift/filetests/filetests/isa/riscv64/user_stack_maps.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/user_stack_maps.clif
@@ -15,16 +15,22 @@ block0:
     v2 = iconst.i32 2
     v3 = iconst.i32 3
 
-    stack_store v0, ss0
-    stack_store v1, ss0+4
-    stack_store v2, ss0+8
+    v4 = stack_addr.i64 ss0
+    store notrap v0, v4
+    v5 = stack_addr.i64 ss0+4
+    store notrap v1, v5
+    v6 = stack_addr.i64 ss0+8
+    store notrap v2, v6
     call fn0(v0), stack_map=[i32 @ ss0+0, i32 @ ss0+4, i32 @ ss0+8]
 
-    stack_store v1, ss0
-    stack_store v2, ss0+4
+    v7 = stack_addr.i64 ss0
+    store notrap v1, v7
+    v8 = stack_addr.i64 ss0+4
+    store notrap v2, v8
     call fn0(v0), stack_map=[i32 @ ss0+0, i32 @ ss0+4]
 
-    stack_store v2, ss0
+    v9 = stack_addr.i64 ss0
+    store notrap v2, v9
     call fn0(v1), stack_map=[i32 @ ss0+0]
 
     call fn0(v2)
@@ -122,12 +128,18 @@ function %different_types(i8, i16, i32, i64, f32, f64) -> i8, i16, i32, i64, f32
     fn0 = colocated u0:0 sig0
 
 block0(v0: i8, v1: i16, v2: i32, v3: i64, v4: f32, v5: f64):
-    stack_store v0, ss0
-    stack_store v1, ss1
-    stack_store v2, ss2
-    stack_store v4, ss2+4
-    stack_store v3, ss3
-    stack_store v5, ss3+8
+    v6 = stack_addr.i64 ss0
+    store notrap v0, v6
+    v7 = stack_addr.i64 ss1
+    store notrap v1, v7
+    v8 = stack_addr.i64 ss2
+    store notrap v2, v8
+    v9 = stack_addr.i64 ss2+4
+    store notrap v4, v9
+    v10 = stack_addr.i64 ss3
+    store notrap v3, v10
+    v11 = stack_addr.i64 ss3+8
+    store notrap v5, v11
     call fn0(), stack_map=[i8 @ ss0+0, i16 @ ss1+0, i32 @ ss2+0, f32 @ ss2+4, i64 @ ss3+0, f64 @ ss3+8]
     return v0, v1, v2, v3, v4, v5
 }

--- a/cranelift/filetests/filetests/isa/riscv64/zca.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/zca.clif
@@ -697,7 +697,8 @@ function %c_lwsp() -> i32 {
   ss0 = explicit_slot 16
 
 block0:
-  v0 = stack_load.i32 ss0+12
+  v1 = stack_addr.i64 ss0+12
+  v0 = load.i32 notrap v1
   return v0
 }
 
@@ -734,7 +735,8 @@ function %c_ldsp() -> i64 {
   ss0 = explicit_slot 128
 
 block0:
-  v0 = stack_load.i64 ss0+64
+  v1 = stack_addr.i64 ss0+64
+  v0 = load.i64 notrap v1
   return v0
 }
 
@@ -771,7 +773,8 @@ function %c_swsp(i32) {
   ss0 = explicit_slot 16
 
 block0(v0: i32):
-  stack_store.i32 v0, ss0+12
+  v1 = stack_addr.i64 ss0+12
+  store.i32 notrap v0, v1
   return
 }
 
@@ -808,7 +811,8 @@ function %c_sdsp(i64) {
   ss0 = explicit_slot 128
 
 block0(v0: i64):
-  stack_store.i64 v0, ss0+64
+  v1 = stack_addr.i64 ss0+64
+  store.i64 notrap v0, v1
   return
 }
 

--- a/cranelift/filetests/filetests/isa/riscv64/zcb.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/zcb.clif
@@ -238,27 +238,33 @@ function %no_compress_store_zero(i64) {
 block0(v0: i64):
   v1 = iconst.i8 0
   store.i8 notrap v1, v0
-  stack_store.i8 v1, ss1
+  v7 = stack_addr.i64 ss1
+  store.i8 notrap v1, v7
 
   v2 = iconst.i16 0
   store.i16 notrap v2, v0
-  stack_store.i16 v2, ss2
+  v8 = stack_addr.i64 ss2
+  store.i16 notrap v2, v8
 
   v3 = iconst.i32 0
   store.i32 notrap v3, v0
-  stack_store.i32 v3, ss4
+  v9 = stack_addr.i64 ss4
+  store.i32 notrap v3, v9
 
   v4 = iconst.i64 0
   store.i64 notrap v4, v0
-  stack_store.i64 v4, ss8
+  v10 = stack_addr.i64 ss8
+  store.i64 notrap v4, v10
 
   v5 = f32const 0.0
   store.f32 notrap v5, v0
-  stack_store.f32 v5, ss4
+  v11 = stack_addr.i64 ss4
+  store.f32 notrap v5, v11
 
   v6 = f64const 0.0
   store.f64 notrap v6, v0
-  stack_store.f64 v6, ss8
+  v12 = stack_addr.i64 ss8
+  store.f64 notrap v6, v12
 
   return
 }

--- a/cranelift/filetests/filetests/isa/riscv64/zcd.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/zcd.clif
@@ -6,7 +6,8 @@ function %c_fldsp() -> f64 {
   ss0 = explicit_slot 16
 
 block0:
-  v0 = stack_load.f64 ss0+8
+  v1 = stack_addr.i64 ss0+8
+  v0 = load.f64 notrap v1
   return v0
 }
 
@@ -43,7 +44,8 @@ function %c_fsdsp(f64) {
   ss0 = explicit_slot 128
 
 block0(v0: f64):
-  stack_store.f64 v0, ss0+64
+  v1 = stack_addr.i64 ss0+64
+  store.f64 notrap v0, v1
   return
 }
 

--- a/cranelift/filetests/filetests/isa/s390x/stack.clif
+++ b/cranelift/filetests/filetests/isa/s390x/stack.clif
@@ -54,7 +54,8 @@ function %stack_load_small() -> i64 {
 ss0 = explicit_slot 8
 
 block0:
-  v0 = stack_load.i64 ss0
+  v1 = stack_addr.i64 ss0
+  v0 = load.i64 notrap v1
   return v0
 }
 
@@ -80,7 +81,8 @@ ss0 = explicit_slot 100000
 ss1 = explicit_slot 8
 
 block0:
-  v0 = stack_load.i64 ss0
+  v1 = stack_addr.i64 ss0
+  v0 = load.i64 notrap v1
   return v0
 }
 
@@ -105,7 +107,8 @@ function %stack_store_small(i64) {
 ss0 = explicit_slot 8
 
 block0(v0: i64):
-  stack_store.i64 v0, ss0
+  v1 = stack_addr.i64 ss0
+  store.i64 notrap v0, v1
   return
 }
 
@@ -131,7 +134,8 @@ ss0 = explicit_slot 100000
 ss1 = explicit_slot 8
 
 block0(v0: i64):
-  stack_store.i64 v0, ss0
+  v1 = stack_addr.i64 ss0
+  store.i64 notrap v0, v1
   return
 }
 

--- a/cranelift/filetests/filetests/isa/s390x/user_stack_maps.clif
+++ b/cranelift/filetests/filetests/isa/s390x/user_stack_maps.clif
@@ -14,16 +14,22 @@ block0:
     v2 = iconst.i32 2
     v3 = iconst.i32 3
 
-    stack_store v0, ss0
-    stack_store v1, ss0+4
-    stack_store v2, ss0+8
+    v4 = stack_addr.i64 ss0
+    store notrap v0, v4
+    v5 = stack_addr.i64 ss0+4
+    store notrap v1, v5
+    v6 = stack_addr.i64 ss0+8
+    store notrap v2, v6
     call fn0(v0), stack_map=[i32 @ ss0+0, i32 @ ss0+4, i32 @ ss0+8]
 
-    stack_store v1, ss0
-    stack_store v2, ss0+4
+    v7 = stack_addr.i64 ss0
+    store notrap v1, v7
+    v8 = stack_addr.i64 ss0+4
+    store notrap v2, v8
     call fn0(v0), stack_map=[i32 @ ss0+0, i32 @ ss0+4]
 
-    stack_store v2, ss0
+    v9 = stack_addr.i64 ss0
+    store notrap v2, v9
     call fn0(v1), stack_map=[i32 @ ss0+0]
 
     call fn0(v2)
@@ -105,12 +111,18 @@ function %different_types(i8, i16, i32, i64, f32, f64) -> i8, i16, i32, i64, f32
     fn0 = colocated u0:0 sig0
 
 block0(v0: i8, v1: i16, v2: i32, v3: i64, v4: f32, v5: f64):
-    stack_store v0, ss0
-    stack_store v1, ss1
-    stack_store v2, ss2
-    stack_store v4, ss2+4
-    stack_store v3, ss3
-    stack_store v5, ss3+8
+    v6 = stack_addr.i64 ss0
+    store notrap v0, v6
+    v7 = stack_addr.i64 ss1
+    store notrap v1, v7
+    v8 = stack_addr.i64 ss2
+    store notrap v2, v8
+    v9 = stack_addr.i64 ss2+4
+    store notrap v4, v9
+    v10 = stack_addr.i64 ss3
+    store notrap v3, v10
+    v11 = stack_addr.i64 ss3+8
+    store notrap v5, v11
     call fn0(), stack_map=[i8 @ ss0+0, i16 @ ss1+0, i32 @ ss2+0, f32 @ ss2+4, i64 @ ss3+0, f64 @ ss3+8]
     return v0, v1, v2, v3, v4, v5
 }

--- a/cranelift/filetests/filetests/isa/x64/atomic-cas-bug.clif
+++ b/cranelift/filetests/filetests/isa/x64/atomic-cas-bug.clif
@@ -63,20 +63,31 @@ function u0:31(i64, i32, i32, i8, i8) -> i32, i32 system_v {
                                     v72 -> v2
                                     v78 -> v2
                                     v84 -> v2
-                                    stack_store v3, ss1
-                                    stack_store v4, ss2
+                                    v120 = stack_addr.i64 ss1
+                                    store notrap v3, v120
+                                    v121 = stack_addr.i64 ss2
+                                    store notrap v4, v121
                                     jump block1
 
                                 block1:
-@0002                               v5 = stack_load.i8 ss1
-@0002                               stack_store v5, ss4
-@0003                               v6 = stack_load.i8 ss2
-@0003                               stack_store v6, ss5
-@0001                               v7 = stack_load.i8 ss4
-@0001                               stack_store v7, ss3
-@0001                               v8 = stack_load.i8 ss5
-@0001                               stack_store v8, ss3+1
-@0001                               v9 = stack_load.i8 ss3
+@0002                               v122 = stack_addr.i64 ss1
+@0002                               v5 = load.i8 notrap v122
+@0002                               v123 = stack_addr.i64 ss4
+@0002                               store notrap v5, v123
+@0003                               v124 = stack_addr.i64 ss2
+@0003                               v6 = load.i8 notrap v124
+@0003                               v125 = stack_addr.i64 ss5
+@0003                               store notrap v6, v125
+@0001                               v126 = stack_addr.i64 ss4
+@0001                               v7 = load.i8 notrap v126
+@0001                               v127 = stack_addr.i64 ss3
+@0001                               store notrap v7, v127
+@0001                               v128 = stack_addr.i64 ss5
+@0001                               v8 = load.i8 notrap v128
+@0001                               v129 = stack_addr.i64 ss3+1
+@0001                               store notrap v8, v129
+@0001                               v130 = stack_addr.i64 ss3
+@0001                               v9 = load.i8 notrap v130
 @0001                               v10 = uextend.i32 v9
 @0005                               jump block37
 
@@ -84,12 +95,14 @@ function u0:31(i64, i32, i32, i8, i8) -> i32, i32 system_v {
 @0005                               br_table v10, block36, [block2, block4, block5, block6, block7]
 
                                 block2:
-@0001                               v11 = stack_load.i8 ss3+1
+@0001                               v131 = stack_addr.i64 ss3+1
+@0001                               v11 = load.i8 notrap v131
 @0001                               v12 = uextend.i64 v11
 @0005                               brif v12, block3, block15
 
                                 block3:
-@0001                               v13 = stack_load.i8 ss3+1
+@0001                               v132 = stack_addr.i64 ss3+1
+@0001                               v13 = load.i8 notrap v132
 @0001                               v14 = uextend.i64 v13
 @0005                               v114 = iconst.i64 3
 @0005                               v15 = icmp eq v14, v114
@@ -101,12 +114,14 @@ function u0:31(i64, i32, i32, i8, i8) -> i32, i32 system_v {
 @0005                               brif v16, block29, block8
 
                                 block4:
-@0001                               v17 = stack_load.i8 ss3+1
+@0001                               v133 = stack_addr.i64 ss3+1
+@0001                               v17 = load.i8 notrap v133
 @0001                               v18 = uextend.i64 v17
 @0005                               brif v18, block3, block11
 
                                 block5:
-@0001                               v19 = stack_load.i8 ss3+1
+@0001                               v134 = stack_addr.i64 ss3+1
+@0001                               v19 = load.i8 notrap v134
 @0001                               v20 = uextend.i64 v19
 @0005                               v116 = iconst.i64 2
 @0005                               v21 = icmp eq v20, v116
@@ -116,7 +131,8 @@ function u0:31(i64, i32, i32, i8, i8) -> i32, i32 system_v {
 @0005                               brif.i64 v20, block3, block19
 
                                 block6:
-@0001                               v22 = stack_load.i8 ss3+1
+@0001                               v135 = stack_addr.i64 ss3+1
+@0001                               v22 = load.i8 notrap v135
 @0001                               v23 = uextend.i64 v22
 @0005                               v117 = iconst.i64 2
 @0005                               v24 = icmp eq v23, v117
@@ -126,7 +142,8 @@ function u0:31(i64, i32, i32, i8, i8) -> i32, i32 system_v {
 @0005                               brif.i64 v23, block3, block21
 
                                 block7:
-@0001                               v25 = stack_load.i8 ss3+1
+@0001                               v136 = stack_addr.i64 ss3+1
+@0001                               v25 = load.i8 notrap v136
 @0001                               v26 = uextend.i64 v25
 @0005                               v118 = iconst.i64 4
 @0005                               v27 = icmp eq v26, v118
@@ -263,19 +280,27 @@ function u0:31(i64, i32, i32, i8, i8) -> i32, i32 system_v {
 @0045                               brif v105, block33, block34
 
                                 block33:
-@0048                               stack_store.i32 v106, ss0+4
+@0048                               v137 = stack_addr.i64 ss0+4
+@0048                               store.i32 notrap v106, v137
 @0048                               v107 = iconst.i32 0
-@0048                               stack_store v107, ss0
-@004a                               v108 = stack_load.i32 ss0
-@004a                               v109 = stack_load.i32 ss0+4
+@0048                               v138 = stack_addr.i64 ss0
+@0048                               store notrap v107, v138
+@004a                               v139 = stack_addr.i64 ss0
+@004a                               v108 = load.i32 notrap v139
+@004a                               v140 = stack_addr.i64 ss0+4
+@004a                               v109 = load.i32 notrap v140
 @004a                               return v108, v109
 
                                 block34:
-@004c                               stack_store.i32 v110, ss0+4
+@004c                               v141 = stack_addr.i64 ss0+4
+@004c                               store.i32 notrap v110, v141
 @004c                               v111 = iconst.i32 1
-@004c                               stack_store v111, ss0
-@004a                               v112 = stack_load.i32 ss0
-@004a                               v113 = stack_load.i32 ss0+4
+@004c                               v142 = stack_addr.i64 ss0
+@004c                               store notrap v111, v142
+@004a                               v143 = stack_addr.i64 ss0
+@004a                               v112 = load.i32 notrap v143
+@004a                               v144 = stack_addr.i64 ss0+4
+@004a                               v113 = load.i32 notrap v144
 @004a                               return v112, v113
 
                                 block36:

--- a/cranelift/filetests/filetests/isa/x64/stackslot.clif
+++ b/cranelift/filetests/filetests/isa/x64/stackslot.clif
@@ -64,16 +64,26 @@ function %f1(i32, i64, f32, f64, i8x16) -> i32, i64, f32, f64, i8x16 {
   ss0 = explicit_slot 40
 
 block0(v0: i32, v1: i64, v2: f32, v3: f64, v4: i8x16):
-  stack_store v0, ss0+0
-  stack_store v1, ss0+4
-  stack_store v2, ss0+12
-  stack_store v3, ss0+16
-  stack_store v4, ss0+24
-  v5 = stack_load.i32 ss0+0
-  v6 = stack_load.i64 ss0+4
-  v7 = stack_load.f32 ss0+12
-  v8 = stack_load.f64 ss0+16
-  v9 = stack_load.i8x16 ss0+24
+  v15 = stack_addr.i64 ss0+0
+  store notrap v0, v15
+  v16 = stack_addr.i64 ss0+4
+  store notrap v1, v16
+  v17 = stack_addr.i64 ss0+12
+  store notrap v2, v17
+  v18 = stack_addr.i64 ss0+16
+  store notrap v3, v18
+  v19 = stack_addr.i64 ss0+24
+  store notrap v4, v19
+  v10 = stack_addr.i64 ss0+0
+  v5 = load.i32 notrap v10
+  v11 = stack_addr.i64 ss0+4
+  v6 = load.i64 notrap v11
+  v12 = stack_addr.i64 ss0+12
+  v7 = load.f32 notrap v12
+  v13 = stack_addr.i64 ss0+16
+  v8 = load.f64 notrap v13
+  v14 = stack_addr.i64 ss0+24
+  v9 = load.i8x16 notrap v14
   return v5, v6, v7, v8, v9
 }
 

--- a/cranelift/filetests/filetests/isa/x64/user_stack_maps.clif
+++ b/cranelift/filetests/filetests/isa/x64/user_stack_maps.clif
@@ -15,16 +15,22 @@ block0:
     v2 = iconst.i32 2
     v3 = iconst.i32 3
 
-    stack_store v0, ss0
-    stack_store v1, ss0+4
-    stack_store v2, ss0+8
+    v4 = stack_addr.i64 ss0
+    store notrap v0, v4
+    v5 = stack_addr.i64 ss0+4
+    store notrap v1, v5
+    v6 = stack_addr.i64 ss0+8
+    store notrap v2, v6
     call fn0(v0), stack_map=[i32 @ ss0+0, i32 @ ss0+4, i32 @ ss0+8]
 
-    stack_store v1, ss0
-    stack_store v2, ss0+4
+    v7 = stack_addr.i64 ss0
+    store notrap v1, v7
+    v8 = stack_addr.i64 ss0+4
+    store notrap v2, v8
     call fn0(v0), stack_map=[i32 @ ss0+0, i32 @ ss0+4]
 
-    stack_store v2, ss0
+    v9 = stack_addr.i64 ss0
+    store notrap v2, v9
     call fn0(v1), stack_map=[i32 @ ss0+0]
 
     call fn0(v2)
@@ -113,12 +119,18 @@ function %different_types(i8, i16, i32, i64, f32, f64) -> i8, i16, i32, i64, f32
     fn0 = colocated u0:0 sig0
 
 block0(v0: i8, v1: i16, v2: i32, v3: i64, v4: f32, v5: f64):
-    stack_store v0, ss0
-    stack_store v1, ss1
-    stack_store v2, ss2
-    stack_store v4, ss2+4
-    stack_store v3, ss3
-    stack_store v5, ss3+8
+    v6 = stack_addr.i64 ss0
+    store notrap v0, v6
+    v7 = stack_addr.i64 ss1
+    store notrap v1, v7
+    v8 = stack_addr.i64 ss2
+    store notrap v2, v8
+    v9 = stack_addr.i64 ss2+4
+    store notrap v4, v9
+    v10 = stack_addr.i64 ss3
+    store notrap v3, v10
+    v11 = stack_addr.i64 ss3+8
+    store notrap v5, v11
     call fn0(), stack_map=[i8 @ ss0+0, i16 @ ss1+0, i32 @ ss2+0, f32 @ ss2+4, i64 @ ss3+0, f64 @ ss3+8]
     return v0, v1, v2, v3, v4, v5
 }

--- a/cranelift/filetests/filetests/parser/tiny.clif
+++ b/cranelift/filetests/filetests/parser/tiny.clif
@@ -143,20 +143,28 @@ function %stack() {
     ss2 = explicit_slot 4
 
 block0:
-    v1 = stack_load.i32 ss10
-    v2 = stack_load.i32 ss10+4
-    stack_store v1, ss10+2
-    stack_store v2, ss2
+    v3 = stack_addr.i64 ss10
+    v1 = load.i32 notrap v3
+    v4 = stack_addr.i64 ss10+4
+    v2 = load.i32 notrap v4
+    v5 = stack_addr.i64 ss10+2
+    store notrap v1, v5
+    v6 = stack_addr.i64 ss2
+    store notrap v2, v6
 }
 ; sameln: function %stack() fast {
 ; check:     ss2 = explicit_slot 4
 ; check:     ss10 = explicit_slot 8
 
 ; check: block0:
-; nextln: v1 = stack_load.i32 ss10
-; nextln: v2 = stack_load.i32 ss10+4
-; nextln: stack_store v1, ss10+2
-; nextln: stack_store v2, ss2
+; nextln: v3 = stack_addr.i64 ss10
+; nextln: v1 = load.i32 notrap v3
+; nextln: v4 = stack_addr.i64 ss10+4
+; nextln: v2 = load.i32 notrap v4
+; nextln: v5 = stack_addr.i64 ss10+2
+; nextln: store notrap v1, v5
+; nextln: v6 = stack_addr.i64 ss2
+; nextln: store notrap v2, v6
 
 ; Memory access instructions.
 function %memory(i32) {

--- a/cranelift/filetests/filetests/parser/user_stack_maps.clif
+++ b/cranelift/filetests/filetests/parser/user_stack_maps.clif
@@ -13,18 +13,24 @@ block0:
     v2 = iconst.i32 2
     v3 = iconst.i32 3
 
-    stack_store v0, ss0
-    stack_store v1, ss0+4
-    stack_store v2, ss0+8
+    v4 = stack_addr.i64 ss0
+    store notrap v0, v4
+    v5 = stack_addr.i64 ss0+4
+    store notrap v1, v5
+    v6 = stack_addr.i64 ss0+8
+    store notrap v2, v6
     call fn0(v0), stack_map=[i32 @ ss0+0, i32 @ ss0+4, i32 @ ss0+8]
 ; check: call fn0(v0), stack_map=[i32 @ ss0+0, i32 @ ss0+4, i32 @ ss0+8]
 
-    stack_store v1, ss0
-    stack_store v2, ss0+4
+    v7 = stack_addr.i64 ss0
+    store notrap v1, v7
+    v8 = stack_addr.i64 ss0+4
+    store notrap v2, v8
     call fn0(v0), stack_map=[i32 @ ss0+0, i32 @ ss0+4]
 ; check: call fn0(v0), stack_map=[i32 @ ss0+0, i32 @ ss0+4]
 
-    stack_store v2, ss0
+    v9 = stack_addr.i64 ss0
+    store notrap v2, v9
     call fn0(v1), stack_map=[i32 @ ss0+0]
 ; check: call fn0(v1), stack_map=[i32 @ ss0+0]
 

--- a/cranelift/filetests/filetests/runtests/atomic-128.clif
+++ b/cranelift/filetests/filetests/runtests/atomic-128.clif
@@ -8,7 +8,8 @@ function %atomic_load(i128) -> i128 {
     ss0 = explicit_slot 16
 
 block0(v0: i128):
-    stack_store.i128 v0, ss0
+    v3 = stack_addr.i64 ss0
+    store.i128 notrap v0, v3
     v1 = stack_addr.i64 ss0
     v2 = atomic_load.i128 v1
     return v2
@@ -28,7 +29,8 @@ function %atomic_store(i128) -> i128 {
 block0(v0: i128):
     v1 = stack_addr.i64 ss0
     atomic_store.i128 v0, v1
-    v2 = stack_load.i128 ss0
+    v3 = stack_addr.i64 ss0
+    v2 = load.i128 notrap v3
     return v2
 }
 ; run: %atomic_store(0) == 0
@@ -44,10 +46,12 @@ function %atomic_cas(i128, i128, i128) -> i128, i128 {
     ss0 = explicit_slot 16
 
 block0(v0: i128, v1: i128, v2: i128):
-    stack_store.i128 v0, ss0
+    v6 = stack_addr.i64 ss0
+    store.i128 notrap v0, v6
     v3 = stack_addr.i64 ss0
     v4 = atomic_cas.i128 v3, v1, v2
-    v5 = stack_load.i128 ss0
+    v7 = stack_addr.i64 ss0
+    v5 = load.i128 notrap v7
     return v5, v4
 }
 
@@ -62,10 +66,12 @@ function %atomic_add(i128, i128) -> i128, i128 {
     ss0 = explicit_slot 16
 
 block0(v0: i128, v1: i128):
-    stack_store.i128 v0, ss0
+    v5 = stack_addr.i64 ss0
+    store.i128 notrap v0, v5
     v2 = stack_addr.i64 ss0
     v3 = atomic_rmw.i128 add v2, v1
-    v4 = stack_load.i128 ss0
+    v6 = stack_addr.i64 ss0
+    v4 = load.i128 notrap v6
     return v4, v3
 }
 
@@ -81,10 +87,12 @@ function %atomic_sub(i128, i128) -> i128, i128 {
     ss0 = explicit_slot 16
 
 block0(v0: i128, v1: i128):
-    stack_store.i128 v0, ss0
+    v5 = stack_addr.i64 ss0
+    store.i128 notrap v0, v5
     v2 = stack_addr.i64 ss0
     v3 = atomic_rmw.i128 sub v2, v1
-    v4 = stack_load.i128 ss0
+    v6 = stack_addr.i64 ss0
+    v4 = load.i128 notrap v6
     return v4, v3
 }
 
@@ -100,10 +108,12 @@ function %atomic_and(i128, i128) -> i128, i128 {
     ss0 = explicit_slot 16
 
 block0(v0: i128, v1: i128):
-    stack_store.i128 v0, ss0
+    v5 = stack_addr.i64 ss0
+    store.i128 notrap v0, v5
     v2 = stack_addr.i64 ss0
     v3 = atomic_rmw.i128 and v2, v1
-    v4 = stack_load.i128 ss0
+    v6 = stack_addr.i64 ss0
+    v4 = load.i128 notrap v6
     return v4, v3
 }
 
@@ -119,10 +129,12 @@ function %atomic_nand(i128, i128) -> i128, i128 {
     ss0 = explicit_slot 16
 
 block0(v0: i128, v1: i128):
-    stack_store.i128 v0, ss0
+    v5 = stack_addr.i64 ss0
+    store.i128 notrap v0, v5
     v2 = stack_addr.i64 ss0
     v3 = atomic_rmw.i128 nand v2, v1
-    v4 = stack_load.i128 ss0
+    v6 = stack_addr.i64 ss0
+    v4 = load.i128 notrap v6
     return v4, v3
 }
 
@@ -138,10 +150,12 @@ function %atomic_or(i128, i128) -> i128, i128 {
     ss0 = explicit_slot 16
 
 block0(v0: i128, v1: i128):
-    stack_store.i128 v0, ss0
+    v5 = stack_addr.i64 ss0
+    store.i128 notrap v0, v5
     v2 = stack_addr.i64 ss0
     v3 = atomic_rmw.i128 or v2, v1
-    v4 = stack_load.i128 ss0
+    v6 = stack_addr.i64 ss0
+    v4 = load.i128 notrap v6
     return v4, v3
 }
 
@@ -157,10 +171,12 @@ function %atomic_xor(i128, i128) -> i128, i128 {
     ss0 = explicit_slot 16
 
 block0(v0: i128, v1: i128):
-    stack_store.i128 v0, ss0
+    v5 = stack_addr.i64 ss0
+    store.i128 notrap v0, v5
     v2 = stack_addr.i64 ss0
     v3 = atomic_rmw.i128 xor v2, v1
-    v4 = stack_load.i128 ss0
+    v6 = stack_addr.i64 ss0
+    v4 = load.i128 notrap v6
     return v4, v3
 }
 
@@ -176,10 +192,12 @@ function %atomic_xchg(i128, i128) -> i128, i128 {
     ss0 = explicit_slot 16
 
 block0(v0: i128, v1: i128):
-    stack_store.i128 v0, ss0
+    v5 = stack_addr.i64 ss0
+    store.i128 notrap v0, v5
     v2 = stack_addr.i64 ss0
     v3 = atomic_rmw.i128 xchg v2, v1
-    v4 = stack_load.i128 ss0
+    v6 = stack_addr.i64 ss0
+    v4 = load.i128 notrap v6
     return v4, v3
 }
 
@@ -195,10 +213,12 @@ function %atomic_umin(i128, i128) -> i128, i128 {
     ss0 = explicit_slot 16
 
 block0(v0: i128, v1: i128):
-    stack_store.i128 v0, ss0
+    v5 = stack_addr.i64 ss0
+    store.i128 notrap v0, v5
     v2 = stack_addr.i64 ss0
     v3 = atomic_rmw.i128 umin v2, v1
-    v4 = stack_load.i128 ss0
+    v6 = stack_addr.i64 ss0
+    v4 = load.i128 notrap v6
     return v4, v3
 }
 
@@ -216,10 +236,12 @@ function %atomic_umax(i128, i128) -> i128, i128 {
     ss0 = explicit_slot 16
 
 block0(v0: i128, v1: i128):
-    stack_store.i128 v0, ss0
+    v5 = stack_addr.i64 ss0
+    store.i128 notrap v0, v5
     v2 = stack_addr.i64 ss0
     v3 = atomic_rmw.i128 umax v2, v1
-    v4 = stack_load.i128 ss0
+    v6 = stack_addr.i64 ss0
+    v4 = load.i128 notrap v6
     return v4, v3
 }
 
@@ -237,10 +259,12 @@ function %atomic_smin(i128, i128) -> i128, i128 {
     ss0 = explicit_slot 16
 
 block0(v0: i128, v1: i128):
-    stack_store.i128 v0, ss0
+    v5 = stack_addr.i64 ss0
+    store.i128 notrap v0, v5
     v2 = stack_addr.i64 ss0
     v3 = atomic_rmw.i128 smin v2, v1
-    v4 = stack_load.i128 ss0
+    v6 = stack_addr.i64 ss0
+    v4 = load.i128 notrap v6
     return v4, v3
 }
 
@@ -258,10 +282,12 @@ function %atomic_smax(i128, i128) -> i128, i128 {
     ss0 = explicit_slot 16
 
 block0(v0: i128, v1: i128):
-    stack_store.i128 v0, ss0
+    v5 = stack_addr.i64 ss0
+    store.i128 notrap v0, v5
     v2 = stack_addr.i64 ss0
     v3 = atomic_rmw.i128 smax v2, v1
-    v4 = stack_load.i128 ss0
+    v6 = stack_addr.i64 ss0
+    v4 = load.i128 notrap v6
     return v4, v3
 }
 

--- a/cranelift/filetests/filetests/runtests/atomic-cas.clif
+++ b/cranelift/filetests/filetests/runtests/atomic-cas.clif
@@ -13,12 +13,14 @@ function %atomic_cas_i64(i64, i64, i64) -> i64 {
     ss0 = explicit_slot 8
 
 block0(v0: i64, v1: i64, v2: i64):
-    stack_store.i64 v0, ss0
+    v6 = stack_addr.i64 ss0
+    store.i64 notrap v0, v6
 
     v3 = stack_addr.i64 ss0
     v4 = atomic_cas.i64 v3, v1, v2
 
-    v5 = stack_load.i64 ss0
+    v7 = stack_addr.i64 ss0
+    v5 = load.i64 notrap v7
     return v5
 }
 ; run: %atomic_cas_i64(0, 0, 2) == 2
@@ -30,12 +32,14 @@ function %atomic_cas_i32(i32, i32, i32) -> i32 {
     ss0 = explicit_slot 4
 
 block0(v0: i32, v1: i32, v2: i32):
-    stack_store.i32 v0, ss0
+    v6 = stack_addr.i64 ss0
+    store.i32 notrap v0, v6
 
     v3 = stack_addr.i64 ss0
     v4 = atomic_cas.i32 v3, v1, v2
 
-    v5 = stack_load.i32 ss0
+    v7 = stack_addr.i64 ss0
+    v5 = load.i32 notrap v7
     return v5
 }
 ; run: %atomic_cas_i32(0, 0, 2) == 2

--- a/cranelift/filetests/filetests/runtests/f16-memory.clif
+++ b/cranelift/filetests/filetests/runtests/f16-memory.clif
@@ -12,9 +12,11 @@ function %f16_load(i16) -> f16 {
     ss0 = explicit_slot 4
 
 block0(v0: i16):
-    stack_store.i16 v0, ss0+2
+    v2 = stack_addr.i64 ss0+2
+    store.i16 notrap v0, v2
     
-    v1 = stack_load.f16 ss0+2
+    v3 = stack_addr.i64 ss0+2
+    v1 = load.f16 notrap v3
     return v1
 }
 ; run: %f16_load(0) == 0x0.0
@@ -27,9 +29,11 @@ function %f16_store(f16) -> i16 {
     ss0 = explicit_slot 4
 
 block0(v0: f16):
-    stack_store.f16 v0, ss0+2
+    v2 = stack_addr.i64 ss0+2
+    store.f16 notrap v0, v2
     
-    v1 = stack_load.i16 ss0+2
+    v3 = stack_addr.i64 ss0+2
+    v1 = load.i16 notrap v3
     return v1
 }
 ; run: %f16_store(0x0.0) == 0
@@ -42,8 +46,10 @@ function %f16_roundtrip(f16) -> f16 {
     ss0 = explicit_slot 2
 
 block0(v0: f16):
-    stack_store.f16 v0, ss0
-    v1 = stack_load.f16 ss0
+    v2 = stack_addr.i64 ss0
+    store.f16 notrap v0, v2
+    v3 = stack_addr.i64 ss0
+    v1 = load.f16 notrap v3
     return v1
 }
 ; run: %f16_roundtrip(0x0.0) == 0x0.0

--- a/cranelift/filetests/filetests/runtests/fma.clif
+++ b/cranelift/filetests/filetests/runtests/fma.clif
@@ -145,8 +145,10 @@ function %fma_load_f32(f32, f32, f32) -> f32 {
     ss0 = explicit_slot 4
 
 block0(v0: f32, v1: f32, v2: f32):
-    stack_store.f32 v2, ss0
-    v3 = stack_load.f32 ss0
+    v5 = stack_addr.i64 ss0
+    store.f32 notrap v2, v5
+    v6 = stack_addr.i64 ss0
+    v3 = load.f32 notrap v6
     v4 = fma v0, v1, v3
     return v4
 }

--- a/cranelift/filetests/filetests/runtests/global_value.clif
+++ b/cranelift/filetests/filetests/runtests/global_value.clif
@@ -33,7 +33,8 @@ function %vm_state() -> i64 {
 block0:
     ;; Store a 1 in the vmctx struct
     v1 = iconst.i64 1
-    stack_store.i64 v1, ss1
+    v4 = stack_addr.i64 ss1
+    store.i64 notrap v1, v4
 
     ;; Call %load_at_0_and_add with vmctx
     v2 = stack_addr.i64 ss1

--- a/cranelift/filetests/filetests/runtests/i128-load-store.clif
+++ b/cranelift/filetests/filetests/runtests/i128-load-store.clif
@@ -12,8 +12,10 @@ function %i128_stack_store_load(i128) -> i8 {
     ss0 = explicit_slot 16
 
 block0(v0: i128):
-    stack_store.i128 v0, ss0
-    v1 = stack_load.i128 ss0
+    v3 = stack_addr.i64 ss0
+    store.i128 notrap v0, v3
+    v4 = stack_addr.i64 ss0
+    v1 = load.i128 notrap v4
 
     v2 = icmp.i128 eq v0, v1
     return v2
@@ -33,8 +35,10 @@ function %i128_stack_store_load_inst_offset(i128) -> i8 {
     ss2 = explicit_slot 16
 
 block0(v0: i128):
-    stack_store.i128 v0, ss1+16
-    v1 = stack_load.i128 ss1+16
+    v3 = stack_addr.i64 ss1+16
+    store.i128 notrap v0, v3
+    v4 = stack_addr.i64 ss1+16
+    v1 = load.i128 notrap v4
 
     v2 = icmp.i128 eq v0, v1
     return v2
@@ -55,8 +59,10 @@ function %i128_stack_store_load_big_offset(i128) -> i8 {
     ss1 = explicit_slot 8
 
 block0(v0: i128):
-    stack_store.i128 v0, ss0
-    v1 = stack_load.i128 ss0
+    v3 = stack_addr.i64 ss0
+    store.i128 notrap v0, v3
+    v4 = stack_addr.i64 ss0
+    v1 = load.i128 notrap v4
 
     v2 = icmp.i128 eq v0, v1
     return v2

--- a/cranelift/filetests/filetests/runtests/inline-probestack.clif
+++ b/cranelift/filetests/filetests/runtests/inline-probestack.clif
@@ -25,8 +25,10 @@ function %probe_loop(i64) -> i64 {
     ss0 = explicit_slot 1048576
 
 block0(v0: i64):
-    stack_store.i64 v0, ss0
-    v1 = stack_load.i64 ss0
+    v2 = stack_addr.i64 ss0
+    store.i64 notrap v0, v2
+    v3 = stack_addr.i64 ss0
+    v1 = load.i64 notrap v3
     return v1
 }
 ; run: %probe_loop(1) == 1
@@ -37,8 +39,10 @@ function %probe_unroll(i64) -> i64 {
     ss0 = explicit_slot 9000
 
 block0(v0: i64):
-    stack_store.i64 v0, ss0
-    v1 = stack_load.i64 ss0
+    v2 = stack_addr.i64 ss0
+    store.i64 notrap v0, v2
+    v3 = stack_addr.i64 ss0
+    v1 = load.i64 notrap v3
     return v1
 }
 ; run: %probe_unroll(1) == 1

--- a/cranelift/filetests/filetests/runtests/issue-6954.clif
+++ b/cranelift/filetests/filetests/runtests/issue-6954.clif
@@ -17,36 +17,66 @@ block0(v0: i16, v1: f32, v2: f64x2, v3: i32, v4: i8, v5: i64x2, v6: i8, v7: f32x
     v13 = iconst.i32 0
     v14 = iconst.i64 0
     v15 = uextend.i128 v14  ; v14 = 0
-    stack_store v15, ss0
-    stack_store v15, ss0+16
-    stack_store v15, ss0+32
-    stack_store v15, ss0+48
-    stack_store v15, ss0+64
-    stack_store v15, ss0+80
-    stack_store v15, ss0+96
-    stack_store v14, ss0+112  ; v14 = 0
-    stack_store v13, ss0+120  ; v13 = 0
-    stack_store v12, ss0+124  ; v12 = 0
-    stack_store v15, ss1
-    stack_store v15, ss1+16
-    stack_store v15, ss1+32
-    stack_store v15, ss1+48
-    stack_store v15, ss1+64
-    stack_store v15, ss1+80
-    stack_store v15, ss1+96
-    stack_store v14, ss1+112  ; v14 = 0
-    stack_store v13, ss1+120  ; v13 = 0
-    stack_store v12, ss1+124  ; v12 = 0
-    stack_store v15, ss2
-    stack_store v15, ss2+16
-    stack_store v15, ss2+32
-    stack_store v15, ss2+48
-    stack_store v15, ss2+64
-    stack_store v15, ss2+80
-    stack_store v15, ss2+96
-    stack_store v14, ss2+112  ; v14 = 0
-    stack_store v13, ss2+120  ; v13 = 0
-    stack_store v12, ss2+124  ; v12 = 0
+    v88 = stack_addr.i64 ss0
+    store notrap v15, v88
+    v89 = stack_addr.i64 ss0+16
+    store notrap v15, v89
+    v90 = stack_addr.i64 ss0+32
+    store notrap v15, v90
+    v91 = stack_addr.i64 ss0+48
+    store notrap v15, v91
+    v92 = stack_addr.i64 ss0+64
+    store notrap v15, v92
+    v93 = stack_addr.i64 ss0+80
+    store notrap v15, v93
+    v94 = stack_addr.i64 ss0+96
+    store notrap v15, v94
+    v95 = stack_addr.i64 ss0+112
+    store notrap v14, v95  ; v14 = 0
+    v96 = stack_addr.i64 ss0+120
+    store notrap v13, v96  ; v13 = 0
+    v97 = stack_addr.i64 ss0+124
+    store notrap v12, v97  ; v12 = 0
+    v98 = stack_addr.i64 ss1
+    store notrap v15, v98
+    v99 = stack_addr.i64 ss1+16
+    store notrap v15, v99
+    v100 = stack_addr.i64 ss1+32
+    store notrap v15, v100
+    v101 = stack_addr.i64 ss1+48
+    store notrap v15, v101
+    v102 = stack_addr.i64 ss1+64
+    store notrap v15, v102
+    v103 = stack_addr.i64 ss1+80
+    store notrap v15, v103
+    v104 = stack_addr.i64 ss1+96
+    store notrap v15, v104
+    v105 = stack_addr.i64 ss1+112
+    store notrap v14, v105  ; v14 = 0
+    v106 = stack_addr.i64 ss1+120
+    store notrap v13, v106  ; v13 = 0
+    v107 = stack_addr.i64 ss1+124
+    store notrap v12, v107  ; v12 = 0
+    v108 = stack_addr.i64 ss2
+    store notrap v15, v108
+    v109 = stack_addr.i64 ss2+16
+    store notrap v15, v109
+    v110 = stack_addr.i64 ss2+32
+    store notrap v15, v110
+    v111 = stack_addr.i64 ss2+48
+    store notrap v15, v111
+    v112 = stack_addr.i64 ss2+64
+    store notrap v15, v112
+    v113 = stack_addr.i64 ss2+80
+    store notrap v15, v113
+    v114 = stack_addr.i64 ss2+96
+    store notrap v15, v114
+    v115 = stack_addr.i64 ss2+112
+    store notrap v14, v115  ; v14 = 0
+    v116 = stack_addr.i64 ss2+120
+    store notrap v13, v116  ; v13 = 0
+    v117 = stack_addr.i64 ss2+124
+    store notrap v12, v117  ; v12 = 0
     v16 = select v3, v8, v8
     v17 = select v3, v16, v16
     v18 = select v3, v17, v17
@@ -93,7 +123,8 @@ block0(v0: i16, v1: f32, v2: f64x2, v3: i32, v4: i8, v5: i64x2, v6: i8, v7: f32x
     v48 = select v30, v47, v47
     v49 = select v30, v48, v48
     v50 = select v30, v49, v49
-    stack_store v37, ss0+33
+    v118 = stack_addr.i64 ss0+33
+    store notrap v37, v118
     v51 = select v30, v50, v50
     v52 = select v30, v51, v51
     v53 = select v30, v52, v52

--- a/cranelift/filetests/filetests/runtests/issue5526.clif
+++ b/cranelift/filetests/filetests/runtests/issue5526.clif
@@ -21,74 +21,142 @@ block0(v0: i128, v1: i8, v2: i8, v3: i8, v4: i16, v5: i32, v6: i8, v7: i8, v8: i
     v14 = iconst.i32 0
     v15 = iconst.i64 0
     v16 = uextend.i128 v15  ; v15 = 0
-    stack_store v16, ss0
-    stack_store v16, ss0+16
-    stack_store v16, ss0+32
-    stack_store v16, ss0+48
-    stack_store v16, ss0+64
-    stack_store v15, ss0+80  ; v15 = 0
-    stack_store v13, ss0+88  ; v13 = 0
-    stack_store v16, ss1
-    stack_store v16, ss1+16
-    stack_store v16, ss1+32
-    stack_store v16, ss1+48
-    stack_store v16, ss1+64
-    stack_store v15, ss1+80  ; v15 = 0
-    stack_store v13, ss1+88  ; v13 = 0
-    stack_store v16, ss2
-    stack_store v16, ss2+16
-    stack_store v16, ss2+32
-    stack_store v16, ss2+48
-    stack_store v16, ss2+64
-    stack_store v15, ss2+80  ; v15 = 0
-    stack_store v13, ss2+88  ; v13 = 0
-    stack_store v16, ss3
-    stack_store v16, ss3+16
-    stack_store v16, ss3+32
-    stack_store v16, ss3+48
-    stack_store v16, ss3+64
-    stack_store v15, ss3+80  ; v15 = 0
-    stack_store v13, ss3+88  ; v13 = 0
-    stack_store v16, ss4
-    stack_store v16, ss4+16
-    stack_store v16, ss4+32
-    stack_store v16, ss4+48
-    stack_store v16, ss4+64
-    stack_store v16, ss4+80
-    stack_store v16, ss4+96
-    stack_store v15, ss4+112  ; v15 = 0
-    stack_store v14, ss4+120  ; v14 = 0
-    stack_store v13, ss4+124  ; v13 = 0
-    stack_store v16, ss5
-    stack_store v16, ss5+16
-    stack_store v16, ss5+32
-    stack_store v16, ss5+48
-    stack_store v16, ss5+64
-    stack_store v16, ss5+80
-    stack_store v16, ss5+96
-    stack_store v15, ss5+112  ; v15 = 0
-    stack_store v14, ss5+120  ; v14 = 0
-    stack_store v13, ss5+124  ; v13 = 0
-    stack_store v16, ss6
-    stack_store v16, ss6+16
-    stack_store v16, ss6+32
-    stack_store v16, ss6+48
-    stack_store v16, ss6+64
-    stack_store v16, ss6+80
-    stack_store v16, ss6+96
-    stack_store v15, ss6+112  ; v15 = 0
-    stack_store v14, ss6+120  ; v14 = 0
-    stack_store v13, ss6+124  ; v13 = 0
-    stack_store v16, ss7
-    stack_store v16, ss7+16
-    stack_store v16, ss7+32
-    stack_store v16, ss7+48
-    stack_store v16, ss7+64
-    stack_store v16, ss7+80
-    stack_store v16, ss7+96
-    stack_store v15, ss7+112  ; v15 = 0
-    stack_store v14, ss7+120  ; v14 = 0
-    stack_store v13, ss7+124  ; v13 = 0
+    v19 = stack_addr.i64 ss0
+    store notrap v16, v19
+    v20 = stack_addr.i64 ss0+16
+    store notrap v16, v20
+    v21 = stack_addr.i64 ss0+32
+    store notrap v16, v21
+    v22 = stack_addr.i64 ss0+48
+    store notrap v16, v22
+    v23 = stack_addr.i64 ss0+64
+    store notrap v16, v23
+    v24 = stack_addr.i64 ss0+80
+    store notrap v15, v24  ; v15 = 0
+    v25 = stack_addr.i64 ss0+88
+    store notrap v13, v25  ; v13 = 0
+    v26 = stack_addr.i64 ss1
+    store notrap v16, v26
+    v27 = stack_addr.i64 ss1+16
+    store notrap v16, v27
+    v28 = stack_addr.i64 ss1+32
+    store notrap v16, v28
+    v29 = stack_addr.i64 ss1+48
+    store notrap v16, v29
+    v30 = stack_addr.i64 ss1+64
+    store notrap v16, v30
+    v31 = stack_addr.i64 ss1+80
+    store notrap v15, v31  ; v15 = 0
+    v32 = stack_addr.i64 ss1+88
+    store notrap v13, v32  ; v13 = 0
+    v33 = stack_addr.i64 ss2
+    store notrap v16, v33
+    v34 = stack_addr.i64 ss2+16
+    store notrap v16, v34
+    v35 = stack_addr.i64 ss2+32
+    store notrap v16, v35
+    v36 = stack_addr.i64 ss2+48
+    store notrap v16, v36
+    v37 = stack_addr.i64 ss2+64
+    store notrap v16, v37
+    v38 = stack_addr.i64 ss2+80
+    store notrap v15, v38  ; v15 = 0
+    v39 = stack_addr.i64 ss2+88
+    store notrap v13, v39  ; v13 = 0
+    v40 = stack_addr.i64 ss3
+    store notrap v16, v40
+    v41 = stack_addr.i64 ss3+16
+    store notrap v16, v41
+    v42 = stack_addr.i64 ss3+32
+    store notrap v16, v42
+    v43 = stack_addr.i64 ss3+48
+    store notrap v16, v43
+    v44 = stack_addr.i64 ss3+64
+    store notrap v16, v44
+    v45 = stack_addr.i64 ss3+80
+    store notrap v15, v45  ; v15 = 0
+    v46 = stack_addr.i64 ss3+88
+    store notrap v13, v46  ; v13 = 0
+    v47 = stack_addr.i64 ss4
+    store notrap v16, v47
+    v48 = stack_addr.i64 ss4+16
+    store notrap v16, v48
+    v49 = stack_addr.i64 ss4+32
+    store notrap v16, v49
+    v50 = stack_addr.i64 ss4+48
+    store notrap v16, v50
+    v51 = stack_addr.i64 ss4+64
+    store notrap v16, v51
+    v52 = stack_addr.i64 ss4+80
+    store notrap v16, v52
+    v53 = stack_addr.i64 ss4+96
+    store notrap v16, v53
+    v54 = stack_addr.i64 ss4+112
+    store notrap v15, v54  ; v15 = 0
+    v55 = stack_addr.i64 ss4+120
+    store notrap v14, v55  ; v14 = 0
+    v56 = stack_addr.i64 ss4+124
+    store notrap v13, v56  ; v13 = 0
+    v57 = stack_addr.i64 ss5
+    store notrap v16, v57
+    v58 = stack_addr.i64 ss5+16
+    store notrap v16, v58
+    v59 = stack_addr.i64 ss5+32
+    store notrap v16, v59
+    v60 = stack_addr.i64 ss5+48
+    store notrap v16, v60
+    v61 = stack_addr.i64 ss5+64
+    store notrap v16, v61
+    v62 = stack_addr.i64 ss5+80
+    store notrap v16, v62
+    v63 = stack_addr.i64 ss5+96
+    store notrap v16, v63
+    v64 = stack_addr.i64 ss5+112
+    store notrap v15, v64  ; v15 = 0
+    v65 = stack_addr.i64 ss5+120
+    store notrap v14, v65  ; v14 = 0
+    v66 = stack_addr.i64 ss5+124
+    store notrap v13, v66  ; v13 = 0
+    v67 = stack_addr.i64 ss6
+    store notrap v16, v67
+    v68 = stack_addr.i64 ss6+16
+    store notrap v16, v68
+    v69 = stack_addr.i64 ss6+32
+    store notrap v16, v69
+    v70 = stack_addr.i64 ss6+48
+    store notrap v16, v70
+    v71 = stack_addr.i64 ss6+64
+    store notrap v16, v71
+    v72 = stack_addr.i64 ss6+80
+    store notrap v16, v72
+    v73 = stack_addr.i64 ss6+96
+    store notrap v16, v73
+    v74 = stack_addr.i64 ss6+112
+    store notrap v15, v74  ; v15 = 0
+    v75 = stack_addr.i64 ss6+120
+    store notrap v14, v75  ; v14 = 0
+    v76 = stack_addr.i64 ss6+124
+    store notrap v13, v76  ; v13 = 0
+    v77 = stack_addr.i64 ss7
+    store notrap v16, v77
+    v78 = stack_addr.i64 ss7+16
+    store notrap v16, v78
+    v79 = stack_addr.i64 ss7+32
+    store notrap v16, v79
+    v80 = stack_addr.i64 ss7+48
+    store notrap v16, v80
+    v81 = stack_addr.i64 ss7+64
+    store notrap v16, v81
+    v82 = stack_addr.i64 ss7+80
+    store notrap v16, v82
+    v83 = stack_addr.i64 ss7+96
+    store notrap v16, v83
+    v84 = stack_addr.i64 ss7+112
+    store notrap v15, v84  ; v15 = 0
+    v85 = stack_addr.i64 ss7+120
+    store notrap v14, v85  ; v14 = 0
+    v86 = stack_addr.i64 ss7+124
+    store notrap v13, v86  ; v13 = 0
 
 
     v17 = select_spectre_guard v8, v0, v0

--- a/cranelift/filetests/filetests/runtests/issue5569.clif
+++ b/cranelift/filetests/filetests/runtests/issue5569.clif
@@ -11,8 +11,10 @@ block0(v0: i16, v1: f64, v2: i32, v3: i64, v4: i16, v5: i128, v6: f32):
     v10 = iconst.i32 0
     v11 = iconst.i64 0
     v12 = uextend.i128 v11  ; v11 = 0
-    stack_store v12, ss0
-    stack_store v11, ss0+16  ; v11 = 0
+    v835 = stack_addr.i64 ss0
+    store notrap v12, v835
+    v836 = stack_addr.i64 ss0+16
+    store notrap v11, v836  ; v11 = 0
     v55 = iconst.i32 0
     v56 = iconst.i32 1
     v57 = icmp eq v2, v55  ; v55 = 0
@@ -111,7 +113,8 @@ block0(v0: i16, v1: f64, v2: i32, v3: i64, v4: i16, v5: i128, v6: f32):
     v133 = bor v127, v132
     v134 = select v133, v126, v20  ; v126 = 1
     v21 = sdiv v20, v134
-    stack_store v16, ss0+4
+    v837 = stack_addr.i64 ss0+4
+    store notrap v16, v837
     v135 = iconst.i32 0
     v136 = iconst.i32 1
     v137 = icmp eq v21, v135  ; v135 = 0
@@ -298,7 +301,8 @@ block0(v0: i16, v1: f64, v2: i32, v3: i64, v4: i16, v5: i128, v6: f32):
     v283 = bor v277, v282
     v284 = select v283, v276, v37  ; v276 = 1
     v38 = sdiv v37, v284
-    stack_store v16, ss0+4
+    v838 = stack_addr.i64 ss0+4
+    store notrap v16, v838
     v285 = iconst.i32 0
     v286 = iconst.i32 1
     v287 = icmp eq v38, v285  ; v285 = 0

--- a/cranelift/filetests/filetests/runtests/riscv64-vstate.clif
+++ b/cranelift/filetests/filetests/runtests/riscv64-vstate.clif
@@ -17,12 +17,18 @@ function u1:1(i64) -> i64 fast {
 block0(v2: i64):
     v1 = iconst.i64 -5608073308517523622
     v3 = vconst.f32x4 const0
-    stack_store v1, ss0
-    stack_store v1, ss0+8
-    stack_store v1, ss0+16
-    stack_store v1, ss0+24
-    stack_store v3, ss1
-    stack_store v3, ss1+16
+    v4 = stack_addr.i64 ss0
+    store notrap v1, v4
+    v5 = stack_addr.i64 ss0+8
+    store notrap v1, v5
+    v6 = stack_addr.i64 ss0+16
+    store notrap v1, v6
+    v7 = stack_addr.i64 ss0+24
+    store notrap v1, v7
+    v8 = stack_addr.i64 ss1
+    store notrap v3, v8
+    v9 = stack_addr.i64 ss1+16
+    store notrap v3, v9
     return v2
 }
 

--- a/cranelift/filetests/filetests/runtests/simd-extractlane-32.clif
+++ b/cranelift/filetests/filetests/runtests/simd-extractlane-32.clif
@@ -1,16 +1,8 @@
 test interpret
 test run
-target aarch64
-target s390x
-target x86_64
-target x86_64 sse41
-target x86_64 sse42
-target x86_64 sse42 has_avx
 set enable_multi_ret_implicit_sret
-target riscv64 has_v
-target riscv64 has_v has_c has_zcb
-target pulley64
-target pulley64be
+target pulley32
+target pulley32be
 
 function %extractlane_4(i8x16) -> i8 {
 block0(v0: i8x16):
@@ -47,14 +39,14 @@ function %unaligned_extractlane() -> f64 {
 
 block0:
     v0 = iconst.i64 0
-    v3 = stack_addr.i64 ss0+0
+    v3 = stack_addr.i32 ss0+0
     store.i64 notrap v0, v3
-    v4 = stack_addr.i64 ss0+8
+    v4 = stack_addr.i32 ss0+8
     store.i64 notrap v0, v4
-    v5 = stack_addr.i64 ss0+16
+    v5 = stack_addr.i32 ss0+16
     store.i64 notrap v0, v5
 
-    v6 = stack_addr.i64 ss0+1
+    v6 = stack_addr.i32 ss0+1
     v1 = load.f64x2 notrap v6
     v2 = extractlane v1, 1
     return v2

--- a/cranelift/filetests/filetests/runtests/simd-small.clif
+++ b/cranelift/filetests/filetests/runtests/simd-small.clif
@@ -42,8 +42,10 @@ block0(v0: f64):
 function %store_i32x2(i32x2) -> i64 {
     ss0 = explicit_slot 8
 block0(v0: i32x2):
-    stack_store.i32x2 v0, ss0
-    v1 = stack_load.i64 ss0
+    v2 = stack_addr.i64 ss0
+    store.i32x2 notrap v0, v2
+    v3 = stack_addr.i64 ss0
+    v1 = load.i64 notrap v3
     return v1
 }
 ; run: %store_i32x2([0xBEEF 0xC0FFEE]) == 0x00c0ffee_0000beef
@@ -52,8 +54,10 @@ block0(v0: i32x2):
 function %load_i32x2(i64) -> i32x2 {
     ss0 = explicit_slot 8
 block0(v0: i64):
-    stack_store.i64 v0, ss0
-    v1 = stack_load.i32x2 ss0
+    v2 = stack_addr.i64 ss0
+    store.i64 notrap v0, v2
+    v3 = stack_addr.i64 ss0
+    v1 = load.i32x2 notrap v3
     return v1
 }
 ; run: %bitcast_i64_to_i32x2(0x00c0ffee_0000beef) == [0xBEEF 0xC0FFEE]
@@ -96,8 +100,10 @@ block0(v0: f32):
 function %store_i16x2(i16x2) -> i32 {
     ss0 = explicit_slot 4
 block0(v0: i16x2):
-    stack_store.i16x2 v0, ss0
-    v1 = stack_load.i32 ss0
+    v2 = stack_addr.i64 ss0
+    store.i16x2 notrap v0, v2
+    v3 = stack_addr.i64 ss0
+    v1 = load.i32 notrap v3
     return v1
 }
 ; run: %store_i16x2([0xBEEF 0xC0FE]) == 0xc0fe_beef
@@ -106,8 +112,10 @@ block0(v0: i16x2):
 function %load_i16x2(i32) -> i16x2 {
     ss0 = explicit_slot 4
 block0(v0: i32):
-    stack_store.i32 v0, ss0
-    v1 = stack_load.i16x2 ss0
+    v2 = stack_addr.i64 ss0
+    store.i32 notrap v0, v2
+    v3 = stack_addr.i64 ss0
+    v1 = load.i16x2 notrap v3
     return v1
 }
 ; run: %bitcast_i32_to_i16x2(0xc0fe_beef) == [0xBEEF 0xC0FE]
@@ -150,8 +158,10 @@ block0(v0: f16):
 function %store_i8x2(i8x2) -> i16 {
     ss0 = explicit_slot 2
 block0(v0: i8x2):
-    stack_store.i8x2 v0, ss0
-    v1 = stack_load.i16 ss0
+    v2 = stack_addr.i64 ss0
+    store.i8x2 notrap v0, v2
+    v3 = stack_addr.i64 ss0
+    v1 = load.i16 notrap v3
     return v1
 }
 ; run: %store_i8x2([0xFE 0xC0]) == 0xc0fe
@@ -160,8 +170,10 @@ block0(v0: i8x2):
 function %load_i8x2(i16) -> i8x2 {
     ss0 = explicit_slot 2
 block0(v0: i16):
-    stack_store.i16 v0, ss0
-    v1 = stack_load.i8x2 ss0
+    v2 = stack_addr.i64 ss0
+    store.i16 notrap v0, v2
+    v3 = stack_addr.i64 ss0
+    v1 = load.i8x2 notrap v3
     return v1
 }
 ; run: %bitcast_i16_to_i8x2(0xc0fe) == [0xFE 0xC0]

--- a/cranelift/filetests/filetests/runtests/simd-splat-32.clif
+++ b/cranelift/filetests/filetests/runtests/simd-splat-32.clif
@@ -1,17 +1,8 @@
 ; test interpret TODO: Not yet implemented
 test run
-target aarch64
-target s390x
-target x86_64
-target x86_64 ssse3
-target x86_64 sse41
-target x86_64 sse41 has_avx
-target x86_64 sse41 has_avx has_avx2
 set enable_multi_ret_implicit_sret
-target riscv64 has_v
-target riscv64 has_v has_c has_zcb
-target pulley64
-target pulley64be
+target pulley32
+target pulley32be
 
 function %splat_i8x16(i8) -> i8x16 {
 block0(v0: i8):
@@ -137,9 +128,9 @@ function %load_splat_i8x16(i8) -> i8x16 {
     ss0 = explicit_slot 8
 
 block0(v0: i8):
-    v3 = stack_addr.i64 ss0
+    v3 = stack_addr.i32 ss0
     store.i8 notrap v0, v3
-    v4 = stack_addr.i64 ss0
+    v4 = stack_addr.i32 ss0
     v1 = load.i8 notrap v4
     v2 = splat.i8x16 v1
     return v2
@@ -152,9 +143,9 @@ function %load_splat_i16x8(i16) -> i16x8 {
     ss0 = explicit_slot 8
 
 block0(v0: i16):
-    v3 = stack_addr.i64 ss0
+    v3 = stack_addr.i32 ss0
     store.i16 notrap v0, v3
-    v4 = stack_addr.i64 ss0
+    v4 = stack_addr.i32 ss0
     v1 = load.i16 notrap v4
     v2 = splat.i16x8 v1
     return v2
@@ -167,9 +158,9 @@ function %load_splat_i32x4(i32) -> i32x4 {
     ss0 = explicit_slot 8
 
 block0(v0: i32):
-    v3 = stack_addr.i64 ss0
+    v3 = stack_addr.i32 ss0
     store.i32 notrap v0, v3
-    v4 = stack_addr.i64 ss0
+    v4 = stack_addr.i32 ss0
     v1 = load.i32 notrap v4
     v2 = splat.i32x4 v1
     return v2
@@ -182,9 +173,9 @@ function %load_splat_i64x2(i64) -> i64x2 {
     ss0 = explicit_slot 8
 
 block0(v0: i64):
-    v3 = stack_addr.i64 ss0
+    v3 = stack_addr.i32 ss0
     store.i64 notrap v0, v3
-    v4 = stack_addr.i64 ss0
+    v4 = stack_addr.i32 ss0
     v1 = load.i64 notrap v4
     v2 = splat.i64x2 v1
     return v2
@@ -197,9 +188,9 @@ function %load_splat_f32x4(f32) -> f32x4 {
     ss0 = explicit_slot 8
 
 block0(v0: f32):
-    v3 = stack_addr.i64 ss0
+    v3 = stack_addr.i32 ss0
     store.f32 notrap v0, v3
-    v4 = stack_addr.i64 ss0
+    v4 = stack_addr.i32 ss0
     v1 = load.f32 notrap v4
     v2 = splat.f32x4 v1
     return v2
@@ -212,9 +203,9 @@ function %load_splat_f64x2(f64) -> f64x2 {
     ss0 = explicit_slot 8
 
 block0(v0: f64):
-    v3 = stack_addr.i64 ss0
+    v3 = stack_addr.i32 ss0
     store.f64 notrap v0, v3
-    v4 = stack_addr.i64 ss0
+    v4 = stack_addr.i32 ss0
     v1 = load.f64 notrap v4
     v2 = splat.f64x2 v1
     return v2

--- a/cranelift/filetests/filetests/runtests/stack-32.clif
+++ b/cranelift/filetests/filetests/runtests/stack-32.clif
@@ -2,21 +2,16 @@ test interpret
 test run
 ; Disable stack probes since these tests don't require them
 set enable_probestack=false
-target x86_64
-target s390x
-target aarch64
-target riscv64
-target riscv64 has_c has_zcb
-target pulley64
-target pulley64be
+target pulley32
+target pulley32be
 
 function %stack_simple(i64) -> i64 {
     ss0 = explicit_slot 8
 
 block0(v0: i64):
-    v2 = stack_addr.i64 ss0
+    v2 = stack_addr.i32 ss0
     store.i64 notrap v0, v2
-    v3 = stack_addr.i64 ss0
+    v3 = stack_addr.i32 ss0
     v1 = load.i64 notrap v3
     return v1
 }
@@ -29,9 +24,9 @@ function %stack_offset(i64) -> i64 {
     ss0 = explicit_slot 16
 
 block0(v0: i64):
-    v2 = stack_addr.i64 ss0+8
+    v2 = stack_addr.i32 ss0+8
     store.i64 notrap v0, v2
-    v3 = stack_addr.i64 ss0+8
+    v3 = stack_addr.i32 ss0+8
     v1 = load.i64 notrap v3
     return v1
 }
@@ -44,9 +39,9 @@ function %offset_unaligned(i64) -> i64 {
     ss0 = explicit_slot 11
 
 block0(v0: i64):
-    v2 = stack_addr.i64 ss0+3
+    v2 = stack_addr.i32 ss0+3
     store.i64 notrap v0, v2
-    v3 = stack_addr.i64 ss0+3
+    v3 = stack_addr.i32 ss0+3
     v1 = load.i64 notrap v3
     return v1
 }
@@ -61,13 +56,13 @@ function %multi_slot_stack(i64, i64) -> i64 {
     ss1 = explicit_slot 8
 
 block0(v0: i64, v1: i64):
-    v5 = stack_addr.i64 ss0
+    v5 = stack_addr.i32 ss0
     store.i64 notrap v0, v5
-    v6 = stack_addr.i64 ss1
+    v6 = stack_addr.i32 ss1
     store.i64 notrap v1, v6
-    v7 = stack_addr.i64 ss0
+    v7 = stack_addr.i32 ss0
     v2 = load.i64 notrap v7
-    v8 = stack_addr.i64 ss1
+    v8 = stack_addr.i32 ss1
     v3 = load.i64 notrap v8
     v4 = iadd.i64 v2, v3
     return v4
@@ -82,13 +77,13 @@ function %multi_slot_out_of_bounds_writes(i8, i64) -> i8, i64 {
     ss1 = explicit_slot 8
 
 block0(v0: i8, v1: i64):
-    v4 = stack_addr.i64 ss0
+    v4 = stack_addr.i32 ss0
     store.i8 notrap v0, v4
-    v5 = stack_addr.i64 ss1
+    v5 = stack_addr.i32 ss1
     store.i64 notrap v1, v5
-    v6 = stack_addr.i64 ss0
+    v6 = stack_addr.i32 ss0
     v2 = load.i8 notrap v6
-    v7 = stack_addr.i64 ss1
+    v7 = stack_addr.i32 ss1
     v3 = load.i64 notrap v7
     return v2, v3
 }
@@ -101,13 +96,13 @@ function %multi_slot_offset_writes(i8, i64) -> i8, i64 {
     ss1 = explicit_slot 8
 
 block0(v0: i8, v1: i64):
-    v4 = stack_addr.i64 ss0
+    v4 = stack_addr.i32 ss0
     store.i8 notrap v0, v4
-    v5 = stack_addr.i64 ss1
+    v5 = stack_addr.i32 ss1
     store.i64 notrap v1, v5
-    v6 = stack_addr.i64 ss0
+    v6 = stack_addr.i32 ss0
     v2 = load.i8 notrap v6
-    v7 = stack_addr.i64 ss1
+    v7 = stack_addr.i32 ss1
     v3 = load.i64 notrap v7
     return v2, v3
 }
@@ -118,9 +113,9 @@ function %huge_slots(i64) -> i64 {
     ss0 = explicit_slot 1048576 ; 1MB Slot
 
 block0(v0: i64):
-    v2 = stack_addr.i64 ss0+1048568
+    v2 = stack_addr.i32 ss0+1048568
     store.i64 notrap v0, v2 ; Store at 1MB - 8bytes
-    v3 = stack_addr.i64 ss0+1048568
+    v3 = stack_addr.i32 ss0+1048568
     v1 = load.i64 notrap v3
     return v1
 }

--- a/cranelift/filetests/filetests/runtests/stack-addr-32.clif
+++ b/cranelift/filetests/filetests/runtests/stack-addr-32.clif
@@ -10,13 +10,15 @@ block0(v0: i64):
     v10 = iconst.i32 8
     v2 = iadd v1, v10
 
-    stack_store.i64 v0, ss0+8
+    v12 = stack_addr.i32 ss0+8
+    store.i64 notrap v0, v12
     v3 = load.i64 v2
 
     v11 = iconst.i64 20
     v5 = iadd v0, v11
     store.i64 v5, v2
-    v6 = stack_load.i64 ss0+8
+    v13 = stack_addr.i32 ss0+8
+    v6 = load.i64 notrap v13
 
     v7 = icmp eq v0, v3
     v8 = icmp eq v5, v6
@@ -33,13 +35,15 @@ function %stack_addr_32(i64) -> i8 {
 
 block0(v0: i64):
     v1 = stack_addr.i32 ss0
-    stack_store.i64 v0, ss0
+    v12 = stack_addr.i32 ss0
+    store.i64 notrap v0, v12
     v2 = load.i64 v1
     v3 = icmp eq v0, v2
 
     v4 = stack_addr.i32 ss0+8
     store.i64 v0, v4
-    v5 = stack_load.i64 ss0+8
+    v13 = stack_addr.i32 ss0+8
+    v5 = load.i64 notrap v13
     v6 = icmp eq v0, v5
 
     v7 = stack_addr.i32 ss0+16

--- a/cranelift/filetests/filetests/runtests/stack-addr-64.clif
+++ b/cranelift/filetests/filetests/runtests/stack-addr-64.clif
@@ -16,13 +16,15 @@ block0(v0: i64):
     v10 = iconst.i64 8
     v2 = iadd v1, v10
 
-    stack_store.i64 v0, ss0+8
+    v12 = stack_addr.i64 ss0+8
+    store.i64 notrap v0, v12
     v3 = load.i64 v2
 
     v11 = iconst.i64 20
     v5 = iadd v0, v11
     store.i64 v5, v2
-    v6 = stack_load.i64 ss0+8
+    v13 = stack_addr.i64 ss0+8
+    v6 = load.i64 notrap v13
 
     v7 = icmp eq v0, v3
     v8 = icmp eq v5, v6
@@ -38,13 +40,15 @@ function %stack_addr_64(i64) -> i8 {
 
 block0(v0: i64):
     v1 = stack_addr.i64 ss0
-    stack_store.i64 v0, ss0
+    v12 = stack_addr.i64 ss0
+    store.i64 notrap v0, v12
     v2 = load.i64 v1
     v3 = icmp eq v0, v2
 
     v4 = stack_addr.i64 ss0+8
     store.i64 v0, v4
-    v5 = stack_load.i64 ss0+8
+    v13 = stack_addr.i64 ss0+8
+    v5 = load.i64 notrap v13
     v6 = icmp eq v0, v5
 
     v7 = stack_addr.i64 ss0+16

--- a/cranelift/filetests/filetests/runtests/tail-stack-limit.clif
+++ b/cranelift/filetests/filetests/runtests/tail-stack-limit.clif
@@ -28,7 +28,8 @@ function %b(i8, i8, i8, i8, i8, i8, i8, i128) -> i128 tail {
 block0(v1: i8, v2: i8, v3: i8, v4: i8, v5: i8, v6: i8, v7: i8, v8: i128):
     ;; Store a 0 in the vmctx struct.
     v9 = iconst.i64 0
-    stack_store.i64 v9, ss0
+    v11 = stack_addr.i64 ss0
+    store.i64 notrap v9, v11
 
     ;; Call %a with our vmctx.
     v10 = stack_addr.i64 ss0

--- a/cranelift/filetests/filetests/verifier/pointer_width_32.clif
+++ b/cranelift/filetests/filetests/verifier/pointer_width_32.clif
@@ -29,10 +29,12 @@ function %error_atomic_cas(i128, i128, i128) -> i128, i128 {
     ss0 = explicit_slot 16
 
 block0(v0: i128, v1: i128, v2: i128):
-    stack_store.i128 v0, ss0
+    v6 = stack_addr.i32 ss0
+    store.i128 notrap v0, v6
     v3 = stack_addr.i64 ss0
     v4 = atomic_cas.i128 v3, v1, v2; error: invalid pointer width (got 64, expected 32) encountered v3
-    v5 = stack_load.i128 ss0
+    v7 = stack_addr.i32 ss0
+    v5 = load.i128 notrap v7
     return v5, v4
 }
 

--- a/cranelift/filetests/filetests/verifier/pointer_width_64.clif
+++ b/cranelift/filetests/filetests/verifier/pointer_width_64.clif
@@ -29,10 +29,12 @@ function %error_atomic_cas(i128, i128, i128) -> i128, i128 {
     ss0 = explicit_slot 16
 
 block0(v0: i128, v1: i128, v2: i128):
-    stack_store.i128 v0, ss0
+    v6 = stack_addr.i64 ss0
+    store.i128 notrap v0, v6
     v3 = stack_addr.i32 ss0
     v4 = atomic_cas.i128 v3, v1, v2; error: invalid pointer width (got 32, expected 64) encountered v3
-    v5 = stack_load.i128 ss0
+    v7 = stack_addr.i64 ss0
+    v5 = load.i128 notrap v7
     return v5, v4
 }
 

--- a/cranelift/filetests/src/function_runner.rs
+++ b/cranelift/filetests/src/function_runner.rs
@@ -611,7 +611,7 @@ fn make_trampoline(name: UserFuncName, signature: &ir::Signature, isa: &dyn Targ
     }
 
     builder.ins().return_(&[]);
-    builder.finalize();
+    builder.finalize(isa.frontend_config());
 
     func
 }

--- a/cranelift/frontend/src/frontend.rs
+++ b/cranelift/frontend/src/frontend.rs
@@ -681,7 +681,7 @@ impl<'a> FunctionBuilder<'a> {
     ///
     /// This resets the state of the [`FunctionBuilderContext`] in preparation to
     /// be used for another function.
-    pub fn finalize(mut self) {
+    pub fn finalize(mut self, frontend_config: TargetFrontendConfig) {
         // Check that all the `Block`s are filled and sealed.
         #[cfg(debug_assertions)]
         {
@@ -715,9 +715,11 @@ impl<'a> FunctionBuilder<'a> {
         // to run our pass to spill those values to the stack at safepoints and
         // generate stack maps.
         if !self.func_ctx.ssa.stack_map_values().is_empty() {
-            self.func_ctx
-                .safepoints
-                .run(&mut self.func, self.func_ctx.ssa.stack_map_values());
+            self.func_ctx.safepoints.run(
+                &mut self.func,
+                self.func_ctx.ssa.stack_map_values(),
+                frontend_config.pointer_type(),
+            );
         }
 
         // Clear the state (but preserve the allocated buffers) in preparation
@@ -1295,7 +1297,7 @@ mod tests {
                 builder.seal_all_blocks();
             }
 
-            builder.finalize();
+            builder.finalize(systemv_frontend_config());
         }
 
         let flags = settings::Flags::new(settings::builder());
@@ -1361,7 +1363,7 @@ mod tests {
             builder.ins().return_(&[size]);
 
             builder.seal_all_blocks();
-            builder.finalize();
+            builder.finalize(systemv_frontend_config());
         }
 
         check(
@@ -1416,7 +1418,7 @@ block0:
             builder.ins().return_(&[dest]);
 
             builder.seal_all_blocks();
-            builder.finalize();
+            builder.finalize(systemv_frontend_config());
         }
 
         check(
@@ -1468,7 +1470,7 @@ block0:
             builder.ins().return_(&[dest]);
 
             builder.seal_all_blocks();
-            builder.finalize();
+            builder.finalize(systemv_frontend_config());
         }
 
         check(
@@ -1512,7 +1514,7 @@ block0:
             builder.ins().return_(&[dest]);
 
             builder.seal_all_blocks();
-            builder.finalize();
+            builder.finalize(systemv_frontend_config());
         }
 
         check(
@@ -1551,7 +1553,7 @@ block0:
             builder.ins().return_(&[dest]);
 
             builder.seal_all_blocks();
-            builder.finalize();
+            builder.finalize(systemv_frontend_config());
         }
 
         check(
@@ -1612,7 +1614,7 @@ block0:
             builder.ins().return_(&[cmp]);
 
             builder.seal_all_blocks();
-            builder.finalize();
+            builder.finalize(systemv_frontend_config());
         }
 
         check(
@@ -1821,7 +1823,7 @@ block0:
             builder.ins().return_(&[ret]);
 
             builder.seal_all_blocks();
-            builder.finalize();
+            builder.finalize(systemv_frontend_config());
         }
 
         check(
@@ -1854,7 +1856,7 @@ block0:
             builder.ins().return_(&[a, b, c]);
 
             builder.seal_all_blocks();
-            builder.finalize();
+            builder.finalize(systemv_frontend_config());
         }
 
         check(
@@ -1927,7 +1929,7 @@ block0:
         builder.ins().return_(&[]);
 
         builder.seal_all_blocks();
-        builder.finalize();
+        builder.finalize(systemv_frontend_config());
 
         let flags = cranelift_codegen::settings::Flags::new(cranelift_codegen::settings::builder());
         let ctx = cranelift_codegen::Context::for_function(func);
@@ -2002,7 +2004,7 @@ block0:
         builder.ins().return_(&[ret_val]);
 
         builder.seal_all_blocks();
-        builder.finalize();
+        builder.finalize(systemv_frontend_config());
 
         let flags = cranelift_codegen::settings::Flags::new(cranelift_codegen::settings::builder());
         let ctx = cranelift_codegen::Context::for_function(func);

--- a/cranelift/frontend/src/frontend/safepoints.rs
+++ b/cranelift/frontend/src/frontend/safepoints.rs
@@ -623,7 +623,12 @@ impl SafepointSpiller {
     /// Identify needs-stack-map values that are live across safepoints, and
     /// rewrite the function's instructions to spill and reload them as
     /// necessary.
-    pub fn run(&mut self, func: &mut Function, stack_map_values: &EntitySet<ir::Value>) {
+    pub fn run(
+        &mut self,
+        func: &mut Function,
+        stack_map_values: &EntitySet<ir::Value>,
+        pointer_type: ir::Type,
+    ) {
         log::trace!("values needing inclusion in stack maps: {stack_map_values:?}");
         log::trace!(
             "before inserting safepoint spills and reloads:\n{}",
@@ -632,7 +637,7 @@ impl SafepointSpiller {
 
         self.clear();
         self.liveness.run(func, stack_map_values);
-        self.rewrite(func);
+        self.rewrite(func, pointer_type);
 
         log::trace!(
             "after inserting safepoint spills and reloads:\n{}",
@@ -644,10 +649,10 @@ impl SafepointSpiller {
     /// included in stack maps and is live across any safepoints.
     ///
     /// The given cursor must point just after this value's definition.
-    fn rewrite_def(&mut self, pos: &mut FuncCursor<'_>, val: ir::Value) {
+    fn rewrite_def(&mut self, pos: &mut FuncCursor<'_>, val: ir::Value, pointer_type: ir::Type) {
         debug_assert!(!pos.func.dfg.value_is_alias(val));
         if let Some(slot) = self.stack_slots.get(val) {
-            let i = pos.ins().stack_store(val, slot, 0);
+            let i = pos.ins().stack_store(pointer_type, val, slot, 0);
             log::trace!(
                 "rewriting:   spilling {val:?} to {slot:?}: {}",
                 pos.func.dfg.display_inst(i)
@@ -708,7 +713,12 @@ impl SafepointSpiller {
     ///
     /// The given cursor must point just before the use of the value that we are
     /// replacing.
-    fn rewrite_use(&mut self, pos: &mut FuncCursor<'_>, val: &mut ir::Value) -> bool {
+    fn rewrite_use(
+        &mut self,
+        pos: &mut FuncCursor<'_>,
+        val: &mut ir::Value,
+        pointer_type: ir::Type,
+    ) -> bool {
         debug_assert!(!pos.func.dfg.value_is_alias(*val));
         if !self.liveness.live_across_any_safepoint.contains(*val) {
             return false;
@@ -719,7 +729,7 @@ impl SafepointSpiller {
 
         let ty = pos.func.dfg.value_type(*val);
         let slot = self.stack_slots.get_or_create_stack_slot(pos.func, *val);
-        *val = pos.ins().stack_load(ty, slot, 0);
+        *val = pos.ins().stack_load(pointer_type, ty, slot, 0);
 
         log::trace!(
             "rewriting:     reloading {old_val:?}: {}",
@@ -743,7 +753,7 @@ impl SafepointSpiller {
     ///
     /// 3. Uses of needs-stack-map values that have been spilled to a stack slot
     ///    need to be replaced with reloads from the slot.
-    fn rewrite(&mut self, func: &mut Function) {
+    fn rewrite(&mut self, func: &mut Function, pointer_type: ir::Type) {
         // Shared temporary storage for operand and result lists.
         let mut vals: SmallVec<[_; 8]> = Default::default();
 
@@ -781,7 +791,7 @@ impl SafepointSpiller {
                 let mut pos = FuncCursor::new(func).after_inst(inst);
                 vals.extend_from_slice(pos.func.dfg.inst_results(inst));
                 for val in vals.drain(..) {
-                    self.rewrite_def(&mut pos, val);
+                    self.rewrite_def(&mut pos, val, pointer_type);
                 }
 
                 // If this instruction is a safepoint, then we must add stack
@@ -798,7 +808,7 @@ impl SafepointSpiller {
                 let mut replaced_any = false;
                 for val in &mut vals {
                     *val = pos.func.dfg.resolve_aliases(*val);
-                    replaced_any |= self.rewrite_use(&mut pos, val);
+                    replaced_any |= self.rewrite_use(&mut pos, val, pointer_type);
                 }
                 if replaced_any {
                     pos.func.dfg.overwrite_inst_values(inst, vals.drain(..));
@@ -820,7 +830,7 @@ impl SafepointSpiller {
             vals.clear();
             vals.extend_from_slice(pos.func.dfg.block_params(block));
             for val in vals.drain(..) {
-                self.rewrite_def(&mut pos, val);
+                self.rewrite_def(&mut pos, val, pointer_type);
             }
         }
     }
@@ -831,7 +841,15 @@ mod tests {
     use super::*;
     use alloc::string::ToString;
     use cranelift_codegen::ir::{BlockCall, ExceptionTableData};
-    use cranelift_codegen::isa::CallConv;
+    use cranelift_codegen::isa::{CallConv, TargetFrontendConfig};
+
+    fn systemv_frontend_config() -> TargetFrontendConfig {
+        TargetFrontendConfig {
+            default_call_conv: CallConv::SystemV,
+            pointer_width: target_lexicon::PointerWidth::U64,
+            page_size_align_log2: 12,
+        }
+    }
 
     #[test]
     fn needs_stack_map_and_loop() {
@@ -876,7 +894,7 @@ mod tests {
         builder.ins().call(func_ref, &[a]);
         builder.ins().jump(block0, &[a.into(), b.into()]);
         builder.seal_all_blocks();
-        builder.finalize();
+        builder.finalize(systemv_frontend_config());
 
         assert_eq_output!(
             func.display().to_string(),
@@ -888,13 +906,18 @@ function %sample(i32, i32) system_v {
     fn0 = colocated u0:0 sig0
 
 block0(v0: i32, v1: i32):
-    stack_store v0, ss0
-    stack_store v1, ss1
-    v4 = stack_load.i32 ss0
-    call fn0(v4), stack_map=[i32 @ ss0+0, i32 @ ss1+0]
-    v2 = stack_load.i32 ss0
-    v3 = stack_load.i32 ss1
-    jump block0(v2, v3)
+    v8 = stack_addr.i64 ss0
+    store notrap v0, v8
+    v9 = stack_addr.i64 ss1
+    store notrap v1, v9
+    v6 = stack_addr.i64 ss0
+    v7 = load.i32 notrap v6
+    call fn0(v7), stack_map=[i32 @ ss0+0, i32 @ ss1+0]
+    v2 = stack_addr.i64 ss0
+    v3 = load.i32 notrap v2
+    v4 = stack_addr.i64 ss1
+    v5 = load.i32 notrap v4
+    jump block0(v3, v5)
 }
             "#
         );
@@ -961,7 +984,7 @@ block0(v0: i32, v1: i32):
         builder.ins().call(func_ref, &[v2]);
         builder.ins().return_(&[]);
         builder.seal_all_blocks();
-        builder.finalize();
+        builder.finalize(systemv_frontend_config());
 
         assert_eq_output!(
             func.display().to_string(),
@@ -975,19 +998,25 @@ function %sample() system_v {
 
 block0:
     v0 = iconst.i32 0
-    stack_store v0, ss2  ; v0 = 0
+    v12 = stack_addr.i64 ss2
+    store notrap v0, v12  ; v0 = 0
     v1 = iconst.i32 1
-    stack_store v1, ss1  ; v1 = 1
+    v11 = stack_addr.i64 ss1
+    store notrap v1, v11  ; v1 = 1
     v2 = iconst.i32 2
-    stack_store v2, ss0  ; v2 = 2
+    v10 = stack_addr.i64 ss0
+    store notrap v2, v10  ; v2 = 2
     v3 = iconst.i32 3
     call fn0(v3), stack_map=[i32 @ ss2+0, i32 @ ss1+0, i32 @ ss0+0]  ; v3 = 3
-    v6 = stack_load.i32 ss2
-    call fn0(v6), stack_map=[i32 @ ss1+0, i32 @ ss0+0]
-    v5 = stack_load.i32 ss1
-    call fn0(v5), stack_map=[i32 @ ss0+0]
-    v4 = stack_load.i32 ss0
-    call fn0(v4)
+    v8 = stack_addr.i64 ss2
+    v9 = load.i32 notrap v8
+    call fn0(v9), stack_map=[i32 @ ss1+0, i32 @ ss0+0]
+    v6 = stack_addr.i64 ss1
+    v7 = load.i32 notrap v6
+    call fn0(v7), stack_map=[i32 @ ss0+0]
+    v4 = stack_addr.i64 ss0
+    v5 = load.i32 notrap v4
+    call fn0(v5)
     return
 }
             "#
@@ -1069,7 +1098,7 @@ block0:
         builder.ins().return_(&[]);
 
         builder.seal_all_blocks();
-        builder.finalize();
+        builder.finalize(systemv_frontend_config());
 
         assert_eq_output!(
             func.display().to_string(),
@@ -1161,7 +1190,7 @@ block3:
         builder.ins().return_(&[]);
 
         builder.seal_all_blocks();
-        builder.finalize();
+        builder.finalize(systemv_frontend_config());
 
         assert_eq_output!(
             func.display().to_string(),
@@ -1234,7 +1263,7 @@ block2:
         builder.ins().return_(&[]);
 
         builder.seal_all_blocks();
-        builder.finalize();
+        builder.finalize(systemv_frontend_config());
 
         assert_eq_output!(
             func.display().to_string(),
@@ -1322,7 +1351,7 @@ block2:
         builder.ins().return_(&[]);
 
         builder.seal_all_blocks();
-        builder.finalize();
+        builder.finalize(systemv_frontend_config());
 
         assert_eq_output!(
             func.display().to_string(),
@@ -1393,7 +1422,7 @@ block2:
         builder.ins().return_call(func_ref, &[]);
 
         builder.seal_all_blocks();
-        builder.finalize();
+        builder.finalize(systemv_frontend_config());
 
         assert_eq_output!(
             func.display().to_string(),
@@ -1502,7 +1531,7 @@ block2:
         builder.ins().return_(&[]);
 
         builder.seal_all_blocks();
-        builder.finalize();
+        builder.finalize(systemv_frontend_config());
 
         assert_eq_output!(
             func.display().to_string(),
@@ -1518,28 +1547,36 @@ block0(v0: i32):
 
 block1:
     v1 = iconst.i64 1
-    stack_store v1, ss0  ; v1 = 1
+    v16 = stack_addr.i64 ss0
+    store notrap v1, v16  ; v1 = 1
     v2 = iconst.i64 2
-    stack_store v2, ss1  ; v2 = 2
+    v15 = stack_addr.i64 ss1
+    store notrap v2, v15  ; v2 = 2
     call fn0(), stack_map=[i64 @ ss0+0, i64 @ ss1+0]
-    v10 = stack_load.i64 ss0
-    v11 = stack_load.i64 ss1
-    jump block3(v10, v11)
+    v11 = stack_addr.i64 ss0
+    v12 = load.i64 notrap v11
+    v13 = stack_addr.i64 ss1
+    v14 = load.i64 notrap v13
+    jump block3(v12, v14)
 
 block2:
     v3 = iconst.i64 3
-    stack_store v3, ss0  ; v3 = 3
+    v21 = stack_addr.i64 ss0
+    store notrap v3, v21  ; v3 = 3
     v4 = iconst.i64 4
     call fn0(), stack_map=[i64 @ ss0+0, i64 @ ss0+0]
-    v12 = stack_load.i64 ss0
-    v13 = stack_load.i64 ss0
-    jump block3(v12, v13)
+    v17 = stack_addr.i64 ss0
+    v18 = load.i64 notrap v17
+    v19 = stack_addr.i64 ss0
+    v20 = load.i64 notrap v19
+    jump block3(v18, v20)
 
 block3(v5: i64, v6: i64):
     call fn0(), stack_map=[i64 @ ss0+0]
     v7 = iconst.i64 0
-    v9 = stack_load.i64 ss0
-    v8 = iadd v9, v7  ; v7 = 0
+    v9 = stack_addr.i64 ss0
+    v10 = load.i64 notrap v9
+    v8 = iadd v10, v7  ; v7 = 0
     return
 }
             "#
@@ -1604,7 +1641,7 @@ block3(v5: i64, v6: i64):
         builder.ins().return_(&params);
 
         builder.seal_all_blocks();
-        builder.finalize();
+        builder.finalize(systemv_frontend_config());
 
         assert_eq_output!(
             func.display().to_string(),
@@ -1623,26 +1660,44 @@ function %sample(i8, i16, i32, i64, i128, f32, f64, i8x16, i16x8) -> i8, i16, i3
     fn0 = colocated u0:0 sig0
 
 block0(v0: i8, v1: i16, v2: i32, v3: i64, v4: i128, v5: f32, v6: f64, v7: i8x16, v8: i16x8):
-    stack_store v0, ss0
-    stack_store v1, ss1
-    stack_store v2, ss2
-    stack_store v3, ss3
-    stack_store v4, ss4
-    stack_store v5, ss5
-    stack_store v6, ss6
-    stack_store v7, ss7
-    stack_store v8, ss8
+    v27 = stack_addr.i64 ss0
+    store notrap v0, v27
+    v28 = stack_addr.i64 ss1
+    store notrap v1, v28
+    v29 = stack_addr.i64 ss2
+    store notrap v2, v29
+    v30 = stack_addr.i64 ss3
+    store notrap v3, v30
+    v31 = stack_addr.i64 ss4
+    store notrap v4, v31
+    v32 = stack_addr.i64 ss5
+    store notrap v5, v32
+    v33 = stack_addr.i64 ss6
+    store notrap v6, v33
+    v34 = stack_addr.i64 ss7
+    store notrap v7, v34
+    v35 = stack_addr.i64 ss8
+    store notrap v8, v35
     call fn0(), stack_map=[i8 @ ss0+0, i16 @ ss1+0, i32 @ ss2+0, i64 @ ss3+0, i128 @ ss4+0, f32 @ ss5+0, f64 @ ss6+0, i8x16 @ ss7+0, i16x8 @ ss8+0]
-    v9 = stack_load.i8 ss0
-    v10 = stack_load.i16 ss1
-    v11 = stack_load.i32 ss2
-    v12 = stack_load.i64 ss3
-    v13 = stack_load.i128 ss4
-    v14 = stack_load.f32 ss5
-    v15 = stack_load.f64 ss6
-    v16 = stack_load.i8x16 ss7
-    v17 = stack_load.i16x8 ss8
-    return v9, v10, v11, v12, v13, v14, v15, v16, v17
+    v9 = stack_addr.i64 ss0
+    v10 = load.i8 notrap v9
+    v11 = stack_addr.i64 ss1
+    v12 = load.i16 notrap v11
+    v13 = stack_addr.i64 ss2
+    v14 = load.i32 notrap v13
+    v15 = stack_addr.i64 ss3
+    v16 = load.i64 notrap v15
+    v17 = stack_addr.i64 ss4
+    v18 = load.i128 notrap v17
+    v19 = stack_addr.i64 ss5
+    v20 = load.f32 notrap v19
+    v21 = stack_addr.i64 ss6
+    v22 = load.f64 notrap v21
+    v23 = stack_addr.i64 ss7
+    v24 = load.i8x16 notrap v23
+    v25 = stack_addr.i64 ss8
+    v26 = load.i16x8 notrap v25
+    return v10, v12, v14, v16, v18, v20, v22, v24, v26
 }
             "#
         );
@@ -1727,7 +1782,7 @@ block0(v0: i8, v1: i16, v2: i32, v3: i64, v4: i128, v5: f32, v6: f64, v7: i8x16,
         builder.ins().call(consume_func_ref, &[v3]);
         builder.ins().return_(&[]);
         builder.seal_all_blocks();
-        builder.finalize();
+        builder.finalize(systemv_frontend_config());
 
         assert_eq_output!(
             func.display().to_string(),
@@ -1741,25 +1796,33 @@ function %sample() system_v {
 
 block0:
     v0 = iconst.i32 0
-    stack_store v0, ss0  ; v0 = 0
+    v15 = stack_addr.i64 ss0
+    store notrap v0, v15  ; v0 = 0
     call fn0(), stack_map=[i32 @ ss0+0]
-    v7 = stack_load.i32 ss0
-    call fn1(v7)
+    v13 = stack_addr.i64 ss0
+    v14 = load.i32 notrap v13
+    call fn1(v14)
     v1 = iconst.i32 1
-    stack_store v1, ss0  ; v1 = 1
+    v12 = stack_addr.i64 ss0
+    store notrap v1, v12  ; v1 = 1
     call fn0(), stack_map=[i32 @ ss0+0]
-    v6 = stack_load.i32 ss0
-    call fn1(v6)
+    v10 = stack_addr.i64 ss0
+    v11 = load.i32 notrap v10
+    call fn1(v11)
     v2 = iconst.i32 2
-    stack_store v2, ss0  ; v2 = 2
+    v9 = stack_addr.i64 ss0
+    store notrap v2, v9  ; v2 = 2
     call fn0(), stack_map=[i32 @ ss0+0]
-    v5 = stack_load.i32 ss0
-    call fn1(v5)
+    v7 = stack_addr.i64 ss0
+    v8 = load.i32 notrap v7
+    call fn1(v8)
     v3 = iconst.i32 3
-    stack_store v3, ss0  ; v3 = 3
+    v6 = stack_addr.i64 ss0
+    store notrap v3, v6  ; v3 = 3
     call fn0(), stack_map=[i32 @ ss0+0]
-    v4 = stack_load.i32 ss0
-    call fn1(v4)
+    v4 = stack_addr.i64 ss0
+    v5 = load.i32 notrap v4
+    call fn1(v5)
     return
 }
             "#
@@ -1871,7 +1934,7 @@ block0:
         builder.ins().return_(&[x]);
 
         builder.seal_all_blocks();
-        builder.finalize();
+        builder.finalize(systemv_frontend_config());
 
         assert_eq_output!(
             func.display().to_string(),
@@ -1886,41 +1949,56 @@ block0(v0: i32):
     v1 = iconst.i32 42
     v2 -> v1
     v4 -> v1
-    stack_store v1, ss0  ; v1 = 42
-    v17 = stack_load.i32 ss0
-    call fn0(v17), stack_map=[i32 @ ss0+0]
+    v32 = stack_addr.i64 ss0
+    store notrap v1, v32  ; v1 = 42
+    v30 = stack_addr.i64 ss0
+    v31 = load.i32 notrap v30
+    call fn0(v31), stack_map=[i32 @ ss0+0]
     brif v0, block1, block2
 
 block1:
-    v12 = stack_load.i32 ss0
-    call fn0(v12), stack_map=[i32 @ ss0+0]
-    v11 = stack_load.i32 ss0
-    call fn0(v11)
+    v19 = stack_addr.i64 ss0
+    v20 = load.i32 notrap v19
+    call fn0(v20), stack_map=[i32 @ ss0+0]
+    v17 = stack_addr.i64 ss0
+    v18 = load.i32 notrap v17
+    call fn0(v18)
     v3 = iconst.i32 36
-    stack_store v3, ss0  ; v3 = 36
-    v10 = stack_load.i32 ss0
-    call fn0(v10), stack_map=[i32 @ ss0+0]
-    v9 = stack_load.i32 ss0
-    jump block3(v9)
-
-block2:
-    v16 = stack_load.i32 ss0
-    call fn0(v16), stack_map=[i32 @ ss0+0]
-    v15 = stack_load.i32 ss0
-    call fn0(v15)
-    v5 = iconst.i32 36
-    stack_store v5, ss1  ; v5 = 36
-    v14 = stack_load.i32 ss1
-    call fn0(v14), stack_map=[i32 @ ss1+0]
-    v13 = stack_load.i32 ss1
+    v16 = stack_addr.i64 ss0
+    store notrap v3, v16  ; v3 = 36
+    v14 = stack_addr.i64 ss0
+    v15 = load.i32 notrap v14
+    call fn0(v15), stack_map=[i32 @ ss0+0]
+    v12 = stack_addr.i64 ss0
+    v13 = load.i32 notrap v12
     jump block3(v13)
 
+block2:
+    v28 = stack_addr.i64 ss0
+    v29 = load.i32 notrap v28
+    call fn0(v29), stack_map=[i32 @ ss0+0]
+    v26 = stack_addr.i64 ss0
+    v27 = load.i32 notrap v26
+    call fn0(v27)
+    v5 = iconst.i32 36
+    v25 = stack_addr.i64 ss1
+    store notrap v5, v25  ; v5 = 36
+    v23 = stack_addr.i64 ss1
+    v24 = load.i32 notrap v23
+    call fn0(v24), stack_map=[i32 @ ss1+0]
+    v21 = stack_addr.i64 ss1
+    v22 = load.i32 notrap v21
+    jump block3(v22)
+
 block3(v6: i32):
-    stack_store v6, ss0
-    v8 = stack_load.i32 ss0
-    call fn0(v8), stack_map=[i32 @ ss0+0]
-    v7 = stack_load.i32 ss0
-    return v7
+    v11 = stack_addr.i64 ss0
+    store notrap v6, v11
+    v9 = stack_addr.i64 ss0
+    v10 = load.i32 notrap v9
+    call fn0(v10), stack_map=[i32 @ ss0+0]
+    v7 = stack_addr.i64 ss0
+    v8 = load.i32 notrap v7
+    return v8
 }
             "#
         );
@@ -1970,7 +2048,7 @@ block3(v6: i32):
         builder.ins().return_(&[val]);
 
         builder.seal_all_blocks();
-        builder.finalize();
+        builder.finalize(systemv_frontend_config());
 
         assert_eq_output!(
             func.display().to_string(),
@@ -1981,10 +2059,12 @@ function %sample(i32) -> i32 system_v {
     fn0 = colocated u0:0 sig0
 
 block0(v0: i32):
-    stack_store v0, ss0
+    v3 = stack_addr.i64 ss0
+    store notrap v0, v3
     call fn0(), stack_map=[i32 @ ss0+0]
-    v1 = stack_load.i32 ss0
-    return v1
+    v1 = stack_addr.i64 ss0
+    v2 = load.i32 notrap v1
+    return v2
 }
             "#
         );
@@ -2046,7 +2126,7 @@ block0(v0: i32):
         builder.ins().return_(&[arg, val]);
 
         builder.seal_all_blocks();
-        builder.finalize();
+        builder.finalize(systemv_frontend_config());
 
         assert_eq_output!(
             func.display().to_string(),
@@ -2058,13 +2138,17 @@ function %sample(i32) -> i32, i32 system_v {
     fn0 = colocated u0:0 sig0
 
 block0(v0: i32):
-    stack_store v0, ss0
+    v7 = stack_addr.i64 ss0
+    store notrap v0, v7
     v1 = iconst.i32 42
-    stack_store v1, ss1  ; v1 = 42
+    v6 = stack_addr.i64 ss1
+    store notrap v1, v6  ; v1 = 42
     call fn0(), stack_map=[i32 @ ss0+0, i32 @ ss1+0]
-    v2 = stack_load.i32 ss0
-    v3 = stack_load.i32 ss1
-    return v2, v3
+    v2 = stack_addr.i64 ss0
+    v3 = load.i32 notrap v2
+    v4 = stack_addr.i64 ss1
+    v5 = load.i32 notrap v4
+    return v3, v5
 }
             "#
         );
@@ -2144,7 +2228,7 @@ block0(v0: i32):
         builder.ins().jump(block1, &[]);
 
         builder.seal_all_blocks();
-        builder.finalize();
+        builder.finalize(systemv_frontend_config());
 
         assert_eq_output!(
             func.display().to_string(),
@@ -2157,13 +2241,15 @@ function %sample(i32) system_v {
     fn1 = colocated u1:1 sig1
 
 block0(v0: i32):
-    stack_store v0, ss0
+    v3 = stack_addr.i64 ss0
+    store notrap v0, v3
     jump block1
 
 block1:
     call fn0(), stack_map=[i32 @ ss0+0]
-    v1 = stack_load.i32 ss0
-    call fn1(v1), stack_map=[i32 @ ss0+0]
+    v1 = stack_addr.i64 ss0
+    v2 = load.i32 notrap v1
+    call fn1(v2), stack_map=[i32 @ ss0+0]
     call fn0(), stack_map=[i32 @ ss0+0]
     jump block1
 }
@@ -2270,7 +2356,7 @@ block1:
         builder.ins().jump(block1, &[]);
 
         builder.seal_all_blocks();
-        builder.finalize();
+        builder.finalize(systemv_frontend_config());
 
         assert_eq_output!(
             func.display().to_string(),
@@ -2283,7 +2369,8 @@ function %sample(i32, i32) system_v {
     fn1 = colocated u1:1 sig1
 
 block0(v0: i32, v1: i32):
-    stack_store v1, ss0
+    v6 = stack_addr.i64 ss0
+    store notrap v1, v6
     brif v0, block1, block2
 
 block1:
@@ -2294,15 +2381,17 @@ block2:
 
 block3:
     call fn0(), stack_map=[i32 @ ss0+0]
-    v3 = stack_load.i32 ss0
-    call fn1(v3), stack_map=[i32 @ ss0+0]
+    v4 = stack_addr.i64 ss0
+    v5 = load.i32 notrap v4
+    call fn1(v5), stack_map=[i32 @ ss0+0]
     call fn0(), stack_map=[i32 @ ss0+0]
     jump block2
 
 block4:
     call fn0(), stack_map=[i32 @ ss0+0]
-    v2 = stack_load.i32 ss0
-    call fn1(v2), stack_map=[i32 @ ss0+0]
+    v2 = stack_addr.i64 ss0
+    v3 = load.i32 notrap v2
+    call fn1(v3), stack_map=[i32 @ ss0+0]
     call fn0(), stack_map=[i32 @ ss0+0]
     jump block1
 }
@@ -2422,7 +2511,7 @@ block4:
         builder.ins().jump(block2, &[]);
 
         builder.seal_all_blocks();
-        builder.finalize();
+        builder.finalize(systemv_frontend_config());
 
         assert_eq_output!(
             func.display().to_string(),
@@ -2437,22 +2526,27 @@ function %sample(i32, i32, i32, i32) system_v {
     fn1 = colocated u1:1 sig1
 
 block0(v0: i32, v1: i32, v2: i32, v3: i32):
-    stack_store v0, ss0
-    stack_store v1, ss1
-    stack_store v2, ss2
+    v13 = stack_addr.i64 ss0
+    store notrap v0, v13
+    v14 = stack_addr.i64 ss1
+    store notrap v1, v14
+    v15 = stack_addr.i64 ss2
+    store notrap v2, v15
     jump block1(v3)
 
 block1(v4: i32):
     call fn0(), stack_map=[i32 @ ss0+0, i32 @ ss1+0, i32 @ ss2+0]
-    v9 = stack_load.i32 ss0
-    call fn1(v9), stack_map=[i32 @ ss0+0, i32 @ ss1+0, i32 @ ss2+0]
+    v11 = stack_addr.i64 ss0
+    v12 = load.i32 notrap v11
+    call fn1(v12), stack_map=[i32 @ ss0+0, i32 @ ss1+0, i32 @ ss2+0]
     call fn0(), stack_map=[i32 @ ss0+0, i32 @ ss1+0, i32 @ ss2+0]
     jump block2
 
 block2:
     call fn0(), stack_map=[i32 @ ss0+0, i32 @ ss1+0, i32 @ ss2+0]
-    v8 = stack_load.i32 ss1
-    call fn1(v8), stack_map=[i32 @ ss0+0, i32 @ ss1+0, i32 @ ss2+0]
+    v9 = stack_addr.i64 ss1
+    v10 = load.i32 notrap v9
+    call fn1(v10), stack_map=[i32 @ ss0+0, i32 @ ss1+0, i32 @ ss2+0]
     call fn0(), stack_map=[i32 @ ss0+0, i32 @ ss1+0, i32 @ ss2+0]
     v5 = iconst.i32 -1
     v6 = iadd.i32 v4, v5  ; v5 = -1
@@ -2460,8 +2554,9 @@ block2:
 
 block3:
     call fn0(), stack_map=[i32 @ ss0+0, i32 @ ss1+0, i32 @ ss2+0]
-    v7 = stack_load.i32 ss2
-    call fn1(v7), stack_map=[i32 @ ss0+0, i32 @ ss1+0, i32 @ ss2+0]
+    v7 = stack_addr.i64 ss2
+    v8 = load.i32 notrap v7
+    call fn1(v8), stack_map=[i32 @ ss0+0, i32 @ ss1+0, i32 @ ss2+0]
     call fn0(), stack_map=[i32 @ ss0+0, i32 @ ss1+0, i32 @ ss2+0]
     jump block2
 }
@@ -2723,7 +2818,7 @@ block3:
         builder.seal_block(block_return);
         builder.ins().return_(&[]);
 
-        builder.finalize();
+        builder.finalize(systemv_frontend_config());
         assert_eq_output!(
             func.display().to_string(),
             r#"
@@ -2756,11 +2851,13 @@ block0:
 
 block1(v22: i32):
     v21 -> v22
-    stack_store v22, ss1
+    v44 = stack_addr.i64 ss1
+    store notrap v22, v44
     v1 = call fn1(), stack_map=[i32 @ ss1+0]
     v8 -> v1
     v18 -> v1
-    stack_store v1, ss0
+    v43 = stack_addr.i64 ss0
+    store notrap v1, v43
     v2 = iconst.i32 0
     jump block2(v2)  ; v2 = 0
 
@@ -2770,51 +2867,61 @@ block2(v3: i32):
     brif v5, block3, block4
 
 block3:
-    v24 = stack_load.i32 ss0
-    call fn2(v24, v4), stack_map=[i32 @ ss0+0, i32 @ ss1+0]  ; v4 = 1
+    v24 = stack_addr.i64 ss0
+    v25 = load.i32 notrap v24
+    call fn2(v25, v4), stack_map=[i32 @ ss0+0, i32 @ ss1+0]  ; v4 = 1
     v6 = iconst.i32 1
     v7 = iadd.i32 v4, v6  ; v4 = 1, v6 = 1
     jump block2(v7)
 
 block4:
-    v32 = stack_load.i32 ss1
-    jump block5(v32)
+    v41 = stack_addr.i64 ss1
+    v42 = load.i32 notrap v41
+    jump block5(v42)
 
 block5(v20: i32):
     v19 -> v20
-    stack_store v20, ss2
+    v40 = stack_addr.i64 ss2
+    store notrap v20, v40
     v9 = iconst.i32 0
-    v31 = stack_load.i32 ss0
-    v10 = icmp eq v31, v9  ; v9 = 0
+    v38 = stack_addr.i64 ss0
+    v39 = load.i32 notrap v38
+    v10 = icmp eq v39, v9  ; v9 = 0
     brif v10, block8(v9), block6  ; v9 = 0
 
 block6:
-    v30 = stack_load.i32 ss0
-    v11 = call fn3(v30), stack_map=[i32 @ ss0+0, i32 @ ss2+0]
+    v36 = stack_addr.i64 ss0
+    v37 = load.i32 notrap v36
+    v11 = call fn3(v37), stack_map=[i32 @ ss0+0, i32 @ ss2+0]
     v12 = iconst.i32 -1091584273
     v13 = icmp eq v11, v12  ; v12 = -1091584273
     v14 = iconst.i32 1
     brif v13, block8(v14), block7  ; v14 = 1
 
 block7:
-    v29 = stack_load.i32 ss0
-    v15 = call fn4(v29, v12), stack_map=[i32 @ ss0+0, i32 @ ss2+0]  ; v12 = -1091584273
+    v34 = stack_addr.i64 ss0
+    v35 = load.i32 notrap v34
+    v15 = call fn4(v35, v12), stack_map=[i32 @ ss0+0, i32 @ ss2+0]  ; v12 = -1091584273
     jump block8(v15)
 
 block8(v16: i32):
     trapz v16, user1
-    v28 = stack_load.i32 ss0
-    call fn5(v28), stack_map=[i32 @ ss0+0, i32 @ ss2+0]
+    v32 = stack_addr.i64 ss0
+    v33 = load.i32 notrap v32
+    call fn5(v33), stack_map=[i32 @ ss0+0, i32 @ ss2+0]
     v17 = call fn6(), stack_map=[i32 @ ss0+0, i32 @ ss2+0]
-    v27 = stack_load.i32 ss2
-    brif v17, block5(v27), block9
+    v30 = stack_addr.i64 ss2
+    v31 = load.i32 notrap v30
+    brif v17, block5(v31), block9
 
 block9:
-    v26 = stack_load.i32 ss2
-    call fn7(v26), stack_map=[i32 @ ss2+0]
+    v28 = stack_addr.i64 ss2
+    v29 = load.i32 notrap v28
+    call fn7(v29), stack_map=[i32 @ ss2+0]
     v23 = call fn8(), stack_map=[i32 @ ss2+0]
-    v25 = stack_load.i32 ss2
-    brif v23, block10, block1(v25)
+    v26 = stack_addr.i64 ss2
+    v27 = load.i32 notrap v26
+    brif v23, block10, block1(v27)
 
 block10:
     return
@@ -2916,7 +3023,7 @@ block10:
         builder.ins().return_(&[]);
 
         builder.seal_all_blocks();
-        builder.finalize();
+        builder.finalize(systemv_frontend_config());
 
         // The try_call should have a stack_map with v0 (and v1 should NOT
         // be in it since v1 is not used after the try_call).
@@ -3001,7 +3108,7 @@ block10:
 
         builder.seal_all_blocks();
 
-        builder.finalize();
+        builder.finalize(systemv_frontend_config());
 
         // The SSA construction / `Variable` infrastructure makes this value
         // into an alias. But it is also an alias of a value that needs
@@ -3022,17 +3129,20 @@ function %sample(i32) system_v {
 block0(v0: i32):
     v1 = call fn0()
     v2 -> v1
-    stack_store v1, ss0
+    v7 = stack_addr.i64 ss0
+    store notrap v1, v7
     brif v0, block1, block2
 
 block1:
     jump block2
 
 block2:
-    v4 = stack_load.i32 ss0
-    call fn1(v4), stack_map=[i32 @ ss0+0]
-    v3 = stack_load.i32 ss0
-    call fn1(v3)
+    v5 = stack_addr.i64 ss0
+    v6 = load.i32 notrap v5
+    call fn1(v6), stack_map=[i32 @ ss0+0]
+    v3 = stack_addr.i64 ss0
+    v4 = load.i32 notrap v3
+    call fn1(v4)
     return
 }
             "#,
@@ -3105,7 +3215,7 @@ block2:
         builder.ins().return_(&[v1_use, v2_use]);
 
         builder.seal_all_blocks();
-        builder.finalize();
+        builder.finalize(systemv_frontend_config());
 
         assert_eq_output!(
             func.display().to_string(),
@@ -3118,13 +3228,17 @@ function %sample() -> i32, i32 system_v {
 
 block0:
     v0 = iconst.i32 11
-    stack_store v0, ss0  ; v0 = 11
+    v7 = stack_addr.i64 ss0
+    store notrap v0, v7  ; v0 = 11
     v1 = iconst.i32 22
-    stack_store v1, ss1  ; v1 = 22
+    v6 = stack_addr.i64 ss1
+    store notrap v1, v6  ; v1 = 22
     call fn0(), stack_map=[i32 @ ss0+0, i32 @ ss1+0]
-    v2 = stack_load.i32 ss0
-    v3 = stack_load.i32 ss1
-    return v2, v3
+    v2 = stack_addr.i64 ss0
+    v3 = load.i32 notrap v2
+    v4 = stack_addr.i64 ss1
+    v5 = load.i32 notrap v4
+    return v3, v5
 }
             "#
         );
@@ -3202,7 +3316,7 @@ block0:
         builder.ins().return_(&[]);
 
         builder.seal_all_blocks();
-        builder.finalize();
+        builder.finalize(systemv_frontend_config());
 
         // `v0` and `v1` should be spilled and reloaded from different stack
         // slots.
@@ -3219,26 +3333,34 @@ function %sample() system_v {
 
 block0:
     v0 = call fn0()
-    stack_store v0, ss1
+    v13 = stack_addr.i64 ss1
+    store notrap v0, v13
     jump block1
 
 block1:
-    v6 = stack_load.i32 ss1
-    call fn1(v6), stack_map=[i32 @ ss1+0]
+    v11 = stack_addr.i64 ss1
+    v12 = load.i32 notrap v11
+    call fn1(v12), stack_map=[i32 @ ss1+0]
     v1 = call fn0(), stack_map=[i32 @ ss1+0]
-    stack_store v1, ss0
-    v5 = stack_load.i32 ss0
-    call fn1(v5), stack_map=[i32 @ ss1+0, i32 @ ss0+0]
-    v4 = stack_load.i32 ss0
-    brif v4, block2, block1
+    v10 = stack_addr.i64 ss0
+    store notrap v1, v10
+    v8 = stack_addr.i64 ss0
+    v9 = load.i32 notrap v8
+    call fn1(v9), stack_map=[i32 @ ss1+0, i32 @ ss0+0]
+    v6 = stack_addr.i64 ss0
+    v7 = load.i32 notrap v6
+    brif v7, block2, block1
 
 block2:
-    v3 = stack_load.i32 ss0
-    call fn1(v3), stack_map=[i32 @ ss0+0]
-    v2 = stack_load.i32 ss0
-    call fn1(v2)
+    v4 = stack_addr.i64 ss0
+    v5 = load.i32 notrap v4
+    call fn1(v5), stack_map=[i32 @ ss0+0]
+    v2 = stack_addr.i64 ss0
+    v3 = load.i32 notrap v2
+    call fn1(v3)
     return
-}            "#
+}
+            "#
         );
     }
 }

--- a/cranelift/frontend/src/lib.rs
+++ b/cranelift/frontend/src/lib.rs
@@ -63,8 +63,9 @@
 //! ```rust
 //! use cranelift_codegen::ir::types::*;
 //! use cranelift_codegen::ir::{AbiParam, UserFuncName, Function, InstBuilder, Signature};
-//! use cranelift_codegen::isa::CallConv;
+//! use cranelift_codegen::isa::{CallConv, TargetFrontendConfig};
 //! use cranelift_codegen::settings;
+//! use target_lexicon::PointerWidth;
 //! use cranelift_codegen::verifier::verify_function;
 //! use cranelift_frontend::{FunctionBuilder, FunctionBuilderContext};
 //!
@@ -140,7 +141,11 @@
 //!     builder.ins().jump(block1, &[]);
 //!     builder.seal_block(block1);
 //!
-//!     builder.finalize();
+//!     builder.finalize(TargetFrontendConfig {
+//!         default_call_conv: CallConv::SystemV,
+//!         pointer_width: PointerWidth::U64,
+//!         page_size_align_log2: 12,
+//!     });
 //! }
 //!
 //! let flags = settings::Flags::new(settings::builder());

--- a/cranelift/frontend/src/switch.rs
+++ b/cranelift/frontend/src/switch.rs
@@ -336,6 +336,15 @@ mod tests {
     use super::*;
     use crate::frontend::FunctionBuilderContext;
     use alloc::string::ToString;
+    use cranelift_codegen::isa::{CallConv, TargetFrontendConfig};
+
+    fn systemv_frontend_config() -> TargetFrontendConfig {
+        TargetFrontendConfig {
+            default_call_conv: CallConv::SystemV,
+            pointer_width: target_lexicon::PointerWidth::U64,
+            page_size_align_log2: 12,
+        }
+    }
 
     macro_rules! setup {
         ($default:expr, [$($index:expr,)*]) => {{
@@ -569,7 +578,7 @@ block4:
                 builder.ins().return_(&[]);
             }
 
-            builder.finalize(); // Will panic if some blocks are not sealed
+            builder.finalize(systemv_frontend_config()); // Will panic if some blocks are not sealed
         }
     }
 

--- a/cranelift/fuzzgen/src/function_generator.rs
+++ b/cranelift/fuzzgen/src/function_generator.rs
@@ -123,59 +123,6 @@ fn insert_call(
     insert_call_to_function(fgen, builder, opcode, &sig, sig_ref, func_ref)
 }
 
-fn insert_stack_load(
-    fgen: &mut FunctionGenerator,
-    builder: &mut FunctionBuilder,
-    _opcode: Opcode,
-    _args: &[Type],
-    rets: &[Type],
-) -> Result<()> {
-    let typevar = rets[0];
-    let type_size = typevar.bytes();
-    let (slot, slot_size, _align, category) = fgen.stack_slot_with_size(type_size)?;
-
-    // `stack_load` doesn't support setting MemFlagsData, and it does not set any
-    // alias analysis bits, so we can only emit it for `Other` slots.
-    if category != AACategory::Other {
-        return Err(arbitrary::Error::IncorrectFormat.into());
-    }
-
-    let offset = fgen.u.int_in_range(0..=(slot_size - type_size))? as i32;
-
-    let val = builder.ins().stack_load(typevar, slot, offset);
-    let var = fgen.get_variable_of_type(typevar)?;
-    builder.def_var(var, val);
-
-    Ok(())
-}
-
-fn insert_stack_store(
-    fgen: &mut FunctionGenerator,
-    builder: &mut FunctionBuilder,
-    _opcode: Opcode,
-    args: &[Type],
-    _rets: &[Type],
-) -> Result<()> {
-    let typevar = args[0];
-    let type_size = typevar.bytes();
-
-    let (slot, slot_size, _align, category) = fgen.stack_slot_with_size(type_size)?;
-
-    // `stack_store` doesn't support setting MemFlagsData, and it does not set any
-    // alias analysis bits, so we can only emit it for `Other` slots.
-    if category != AACategory::Other {
-        return Err(arbitrary::Error::IncorrectFormat.into());
-    }
-
-    let offset = fgen.u.int_in_range(0..=(slot_size - type_size))? as i32;
-
-    let arg0 = fgen.get_variable_of_type(typevar)?;
-    let arg0 = builder.use_var(arg0);
-
-    builder.ins().stack_store(arg0, slot, offset);
-    Ok(())
-}
-
 fn insert_cmp(
     fgen: &mut FunctionGenerator,
     builder: &mut FunctionBuilder,
@@ -603,17 +550,6 @@ fn valid_for_target(triple: &Triple, op: Opcode, args: &[Type], rets: &[Type]) -
                 // Nothing wrong with this select. But we have an isle rule that can optimize it
                 // into a `min`/`max` instructions, which we don't have implemented yet.
                 (Opcode::Select, &[_, I128, I128]),
-                // These stack accesses can cause segfaults if they are merged into an SSE instruction.
-                // See: #5922
-                (
-                    Opcode::StackStore,
-                    &[I8X16 | I16X8 | I32X4 | I64X2 | F32X4 | F64X2]
-                ),
-                (
-                    Opcode::StackLoad,
-                    &[],
-                    &[I8X16 | I16X8 | I32X4 | I64X2 | F32X4 | F64X2]
-                ),
                 // TODO
                 (
                     Opcode::Sshr | Opcode::Ushr | Opcode::Ishl,
@@ -912,8 +848,6 @@ static OPCODE_SIGNATURES: LazyLock<Vec<OpcodeSignature>> = LazyLock::new(|| {
                 (Opcode::Uload32x2),
                 (Opcode::Sload32x2),
                 (Opcode::StackAddr),
-                (Opcode::DynamicStackLoad),
-                (Opcode::DynamicStackStore),
                 (Opcode::DynamicStackAddr),
                 (Opcode::GlobalValue),
                 (Opcode::SymbolValue),
@@ -1069,8 +1003,7 @@ fn inserter_for_format(fmt: InstructionFormat) -> OpcodeInserter {
         InstructionFormat::Call => insert_call,
         InstructionFormat::CallIndirect => insert_call,
         InstructionFormat::CondTrap => todo!(),
-        InstructionFormat::DynamicStackLoad => todo!(),
-        InstructionFormat::DynamicStackStore => todo!(),
+        InstructionFormat::DynamicStackAddr => todo!(),
         InstructionFormat::FloatCompare => insert_cmp,
         InstructionFormat::FuncAddr => todo!(),
         InstructionFormat::IntAddTrap => todo!(),
@@ -1079,8 +1012,7 @@ fn inserter_for_format(fmt: InstructionFormat) -> OpcodeInserter {
         InstructionFormat::LoadNoOffset => insert_load_store,
         InstructionFormat::NullAry => insert_opcode,
         InstructionFormat::Shuffle => insert_shuffle,
-        InstructionFormat::StackLoad => insert_stack_load,
-        InstructionFormat::StackStore => insert_stack_store,
+        InstructionFormat::StackAddr => todo!(),
         InstructionFormat::Store => insert_load_store,
         InstructionFormat::StoreNoOffset => insert_load_store,
         InstructionFormat::Ternary => insert_opcode,
@@ -1986,7 +1918,7 @@ where
         }
 
         builder.seal_all_blocks();
-        builder.finalize();
+        builder.finalize(self.isa.frontend_config());
 
         Ok(func)
     }

--- a/cranelift/interpreter/src/interpreter.rs
+++ b/cranelift/interpreter/src/interpreter.rs
@@ -724,10 +724,14 @@ mod tests {
             ss1 = explicit_slot 8
 
         block0(v0: i64, v1: i64):
-            stack_store.i64 v0, ss0
-            stack_store.i64 v1, ss1
-            v2 = stack_load.i64 ss0
-            v3 = stack_load.i64 ss1
+            v5 = stack_addr.i64 ss0
+            store.i64 v0, v5
+            v6 = stack_addr.i64 ss1
+            store.i64 v1, v6
+            v7 = stack_addr.i64 ss0
+            v2 = load.i64 v7
+            v8 = stack_addr.i64 ss1
+            v3 = load.i64 v8
             v4 = iadd.i64 v2, v3
             return v4
         }
@@ -738,13 +742,17 @@ mod tests {
             ss1 = explicit_slot 8
 
         block0(v0: i64, v1: i64, v2: i64, v3: i64):
-            stack_store.i64 v0, ss0
-            stack_store.i64 v1, ss1
+            v9 = stack_addr.i64 ss0
+            store.i64 v0, v9
+            v10 = stack_addr.i64 ss1
+            store.i64 v1, v10
 
             v4 = call fn0(v2, v3)
 
-            v5 = stack_load.i64 ss0
-            v6 = stack_load.i64 ss1
+            v11 = stack_addr.i64 ss0
+            v5 = load.i64 v11
+            v12 = stack_addr.i64 ss1
+            v6 = load.i64 v12
 
             v7 = iadd.i64 v4, v5
             v8 = iadd.i64 v7, v6
@@ -780,7 +788,8 @@ mod tests {
 
         block0:
             v0 = iconst.i64 10
-            stack_store.i64 v0, ss0+8
+            v1 = stack_addr.i64 ss0+8
+            store.i64 v0, v1
             return
         }";
 
@@ -806,7 +815,8 @@ mod tests {
 
         block0:
             v0 = iconst.i64 10
-            stack_store.i64 v0, ss0+4
+            v1 = stack_addr.i64 ss0+4
+            store.i64 v0, v1
             return
         }";
 
@@ -831,7 +841,8 @@ mod tests {
             ss0 = explicit_slot 8
 
         block0:
-            v0 = stack_load.i64 ss0+8
+            v1 = stack_addr.i64 ss0+8
+            v0 = load.i64 v1
             return
         }";
 
@@ -856,7 +867,8 @@ mod tests {
             ss0 = explicit_slot 8
 
         block0:
-            v0 = stack_load.i64 ss0+4
+            v1 = stack_addr.i64 ss0+4
+            v0 = load.i64 v1
             return
         }";
 

--- a/cranelift/interpreter/src/step.rs
+++ b/cranelift/interpreter/src/step.rs
@@ -9,7 +9,7 @@ use cranelift_codegen::data_value::DataValue;
 use cranelift_codegen::ir::condcodes::{FloatCC, IntCC};
 use cranelift_codegen::ir::{
     AbiParam, AtomicRmwOp, Block, BlockArg, BlockCall, Endianness, ExternalName, FuncRef, Function,
-    InstructionData, MemFlagsData, Opcode, TrapCode, Type, Value as ValueRef, types,
+    InstructionData, Opcode, TrapCode, Type, Value as ValueRef, types,
 };
 use log::trace;
 use smallvec::{SmallVec, smallvec};
@@ -151,8 +151,7 @@ where
             InstructionData::UnaryIeee32 { imm, .. } => DataValue::from(imm),
             InstructionData::Load { offset, .. }
             | InstructionData::Store { offset, .. }
-            | InstructionData::StackLoad { offset, .. }
-            | InstructionData::StackStore { offset, .. } => DataValue::from(offset),
+            | InstructionData::StackAddr { offset, .. } => DataValue::from(offset),
             // 64-bit.
             InstructionData::UnaryImm { imm, .. } => DataValue::from(imm.bits()),
             InstructionData::UnaryIeee64 { imm, .. } => DataValue::from(imm),
@@ -532,28 +531,6 @@ where
                     .and_then(|addr| state.checked_store(addr, reduced, mem_flags)),
             )
         }
-        Opcode::StackLoad => {
-            let load_ty = inst_context.controlling_type().unwrap();
-            let slot = inst.stack_slot().unwrap();
-            let offset = sum_unsigned(imm(), args())? as u64;
-            let mem_flags = MemFlagsData::new();
-            assign_or_memtrap({
-                state
-                    .stack_address(AddressSize::_64, slot, offset)
-                    .and_then(|addr| state.checked_load(addr, load_ty, mem_flags))
-            })
-        }
-        Opcode::StackStore => {
-            let arg = arg(0);
-            let slot = inst.stack_slot().unwrap();
-            let offset = sum_unsigned(imm(), args_range(1..)?)? as u64;
-            let mem_flags = MemFlagsData::new();
-            continue_or_memtrap({
-                state
-                    .stack_address(AddressSize::_64, slot, offset)
-                    .and_then(|addr| state.checked_store(addr, arg, mem_flags))
-            })
-        }
         Opcode::StackAddr => {
             let load_ty = inst_context.controlling_type().unwrap();
             let slot = inst.stack_slot().unwrap();
@@ -567,8 +544,6 @@ where
             })
         }
         Opcode::DynamicStackAddr => unimplemented!("DynamicStackSlot"),
-        Opcode::DynamicStackLoad => unimplemented!("DynamicStackLoad"),
-        Opcode::DynamicStackStore => unimplemented!("DynamicStackStore"),
         Opcode::GlobalValue | Opcode::SymbolValue | Opcode::TlsValue => {
             if let InstructionData::UnaryGlobalValue { global_value, .. } = inst {
                 assign_or_memtrap(state.resolve_global_value(global_value))

--- a/cranelift/jit/examples/jit-minimal.rs
+++ b/cranelift/jit/examples/jit-minimal.rs
@@ -48,7 +48,7 @@ fn main() {
         let add = bcx.ins().iadd(cst, param);
         bcx.ins().return_(&[add]);
         bcx.seal_all_blocks();
-        bcx.finalize();
+        bcx.finalize(module.target_config());
     }
     module.define_function(func_a, &mut ctx).unwrap();
     module.clear_context(&mut ctx);
@@ -71,7 +71,7 @@ fn main() {
         };
         bcx.ins().return_(&[value]);
         bcx.seal_all_blocks();
-        bcx.finalize();
+        bcx.finalize(module.target_config());
     }
     module.define_function(func_b, &mut ctx).unwrap();
     module.clear_context(&mut ctx);

--- a/cranelift/jit/tests/basic.rs
+++ b/cranelift/jit/tests/basic.rs
@@ -132,7 +132,11 @@ fn switch_error() {
         bcx.ins().return_(&[r]);
 
         bcx.seal_all_blocks();
-        bcx.finalize();
+        bcx.finalize(cranelift_codegen::isa::TargetFrontendConfig {
+            default_call_conv: CallConv::SystemV,
+            pointer_width: target_lexicon::PointerWidth::U64,
+            page_size_align_log2: 12,
+        });
     }
 
     let flags = settings::Flags::new(settings::builder());

--- a/cranelift/object/tests/basic.rs
+++ b/cranelift/object/tests/basic.rs
@@ -149,7 +149,11 @@ fn switch_error() {
         bcx.ins().return_(&[r]);
 
         bcx.seal_all_blocks();
-        bcx.finalize();
+        bcx.finalize(cranelift_codegen::isa::TargetFrontendConfig {
+            default_call_conv: CallConv::SystemV,
+            pointer_width: target_lexicon::PointerWidth::U64,
+            page_size_align_log2: 12,
+        });
     }
 
     let flags = settings::Flags::new(settings::builder());
@@ -301,7 +305,7 @@ fn aarch64_colocated_data_symbol_reloc() {
         bcx.ins().return_(&[addr]);
 
         bcx.seal_all_blocks();
-        bcx.finalize();
+        bcx.finalize(module.target_config());
     }
 
     module.define_function(func_id, &mut ctx).unwrap();
@@ -353,7 +357,7 @@ mod eh_frame {
             bcx.switch_to_block(block);
             bcx.ins().return_(&[]);
             bcx.seal_all_blocks();
-            bcx.finalize();
+            bcx.finalize(module.target_config());
         }
         module.define_function(func_id, &mut ctx).unwrap();
         func_id
@@ -547,7 +551,7 @@ mod eh_frame {
             bcx.switch_to_block(block);
             bcx.ins().return_(&[]);
             bcx.seal_all_blocks();
-            bcx.finalize();
+            bcx.finalize(module.target_config());
         }
         module.define_function(func_id, &mut ctx).unwrap();
 

--- a/cranelift/reader/src/parser.rs
+++ b/cranelift/reader/src/parser.rs
@@ -2918,45 +2918,21 @@ impl<'a> Parser<'a> {
                 ctx.check_fn(func_ref, self.loc)?;
                 InstructionData::FuncAddr { opcode, func_ref }
             }
-            InstructionFormat::StackLoad => {
+            InstructionFormat::StackAddr => {
                 let ss = self.match_ss("expected stack slot number: ss«n»")?;
                 ctx.check_ss(ss, self.loc)?;
                 let offset = self.optional_offset32()?;
-                InstructionData::StackLoad {
+                InstructionData::StackAddr {
                     opcode,
                     stack_slot: ss,
                     offset,
                 }
             }
-            InstructionFormat::StackStore => {
-                let arg = self.match_value("expected SSA value operand")?;
-                self.match_token(Token::Comma, "expected ',' between operands")?;
-                let ss = self.match_ss("expected stack slot number: ss«n»")?;
-                ctx.check_ss(ss, self.loc)?;
-                let offset = self.optional_offset32()?;
-                InstructionData::StackStore {
-                    opcode,
-                    arg,
-                    stack_slot: ss,
-                    offset,
-                }
-            }
-            InstructionFormat::DynamicStackLoad => {
+            InstructionFormat::DynamicStackAddr => {
                 let dss = self.match_dss("expected dynamic stack slot number: dss«n»")?;
                 ctx.check_dss(dss, self.loc)?;
-                InstructionData::DynamicStackLoad {
+                InstructionData::DynamicStackAddr {
                     opcode,
-                    dynamic_stack_slot: dss,
-                }
-            }
-            InstructionFormat::DynamicStackStore => {
-                let arg = self.match_value("expected SSA value operand")?;
-                self.match_token(Token::Comma, "expected ',' between operands")?;
-                let dss = self.match_dss("expected dynamic stack slot number: dss«n»")?;
-                ctx.check_dss(dss, self.loc)?;
-                InstructionData::DynamicStackStore {
-                    opcode,
-                    arg,
                     dynamic_stack_slot: dss,
                 }
             }

--- a/cranelift/src/bugpoint.rs
+++ b/cranelift/src/bugpoint.rs
@@ -539,8 +539,7 @@ impl Mutator for RemoveUnusedEntities {
                     for inst in func.layout.block_insts(block) {
                         match func.dfg.insts[inst] {
                             // Add new cases when there are new instruction formats taking a `StackSlot`.
-                            InstructionData::StackLoad { stack_slot, .. }
-                            | InstructionData::StackStore { stack_slot, .. } => {
+                            InstructionData::StackAddr { stack_slot, .. } => {
                                 stack_slot_usage_map
                                     .entry(stack_slot)
                                     .or_insert_with(Vec::new)
@@ -560,8 +559,7 @@ impl Mutator for RemoveUnusedEntities {
                         for &inst in stack_slot_usage {
                             match &mut func.dfg.insts[inst] {
                                 // Keep in sync with the above match.
-                                InstructionData::StackLoad { stack_slot, .. }
-                                | InstructionData::StackStore { stack_slot, .. } => {
+                                InstructionData::StackAddr { stack_slot, .. } => {
                                     *stack_slot = new_stack_slot;
                                 }
                                 _ => unreachable!(),

--- a/crates/cranelift/src/compiler.rs
+++ b/crates/cranelift/src/compiler.rs
@@ -292,7 +292,7 @@ impl Compiler {
         let results =
             self.load_values_from_array(wasm_func_ty.results(), &mut builder, args_base, args_len);
         builder.ins().return_(&results);
-        builder.finalize();
+        builder.finalize(self.isa().frontend_config());
 
         Ok(CompiledFunctionBody {
             code: box_dyn_any_compiler_context(Some(compiler.cx)),
@@ -389,7 +389,7 @@ impl Compiler {
         } else {
             builder.ins().return_(&[]);
         }
-        builder.finalize();
+        builder.finalize(self.isa().frontend_config());
 
         Ok(CompiledFunctionBody {
             code: box_dyn_any_compiler_context(Some(compiler.cx)),
@@ -1516,7 +1516,7 @@ impl Compiler {
         let false_return = builder.ins().iconst(ir::types::I8, 0);
         builder.ins().return_(&[false_return]);
 
-        builder.finalize();
+        builder.finalize(self.isa().frontend_config());
 
         Ok(CompiledFunctionBody {
             code: box_dyn_any_compiler_context(Some(compiler.cx)),

--- a/crates/cranelift/src/compiler/component.rs
+++ b/crates/cranelift/src/compiler/component.rs
@@ -1650,7 +1650,7 @@ impl ComponentCompiler for Compiler {
         );
 
         c.translate(&component.trampolines[trampoline_index]);
-        c.builder.finalize();
+        c.builder.finalize(c.isa.frontend_config());
         compiler.cx.abi = Some(abi);
 
         Ok(CompiledFunctionBody {
@@ -1773,7 +1773,7 @@ impl ComponentCompiler for Compiler {
             | UnsafeIntrinsic::ContextSetI32_1 => c.translate_context_intrinsic(intrinsic)?,
         }
 
-        c.builder.finalize();
+        c.builder.finalize(c.isa.frontend_config());
         compiler.cx.abi = Some(abi);
 
         Ok(CompiledFunctionBody {

--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -1455,7 +1455,9 @@ impl<'module_environment> FuncEnvironment<'module_environment> {
             // This is a native-endian store (the only mode for
             // `stack_store`) because it is read by host code directly
             // as a pointer.
-            builder.ins().stack_store(vmctx, slot, 0);
+            builder
+                .ins()
+                .stack_store(self.pointer_type(), vmctx, slot, 0);
         }
     }
 

--- a/crates/cranelift/src/translate/func_translator.rs
+++ b/crates/cranelift/src/translate/func_translator.rs
@@ -92,7 +92,7 @@ impl FuncTranslator {
         parse_local_decls(&mut reader, &mut builder, num_params, environ, validator)?;
         parse_function_body(validator, reader, &mut builder, environ)?;
 
-        builder.finalize();
+        builder.finalize(environ.target_config());
         log::trace!("translated Wasm to CLIF:\n{}", func.display());
         Ok(())
     }
@@ -113,7 +113,7 @@ impl FuncTranslator {
         environ.translate_module_startup(&mut builder)?;
         environ.after_translate_function(&mut builder)?;
         builder.ins().return_(&[]);
-        builder.finalize();
+        builder.finalize(environ.target_config());
         Ok(())
     }
 }

--- a/tests/disas/array-fill-funcref.wat
+++ b/tests/disas/array-fill-funcref.wat
@@ -159,15 +159,15 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
-;;                                     v62 = stack_addr.i64 ss0
-;;                                     store notrap v2, v62
+;;                                     v54 = stack_addr.i64 ss0
+;;                                     store notrap v2, v54
 ;; @0053                               v5 = iconst.i32 3
 ;; @0053                               v7 = call fn0(v0, v5), stack_map=[i32 @ ss0+0]  ; v5 = 3
-;;                                     v50 = load.i32 notrap v62
-;; @0057                               trapz v50, user16
-;; @0057                               v58 = load.i64 notrap aligned readonly can_move v0+8
-;; @0057                               v9 = load.i64 notrap aligned readonly can_move v58+32
-;; @0057                               v8 = uextend.i64 v50
+;;                                     v53 = load.i32 notrap v54
+;; @0057                               trapz v53, user16
+;; @0057                               v61 = load.i64 notrap aligned readonly can_move v0+8
+;; @0057                               v9 = load.i64 notrap aligned readonly can_move v61+32
+;; @0057                               v8 = uextend.i64 v53
 ;; @0057                               v10 = iadd v9, v8
 ;; @0057                               v11 = iconst.i64 16
 ;; @0057                               v12 = iadd v10, v11  ; v11 = 16
@@ -178,7 +178,7 @@
 ;; @0057                               v14 = uextend.i64 v13
 ;; @0057                               v20 = icmp ugt v19, v14
 ;; @0057                               trapnz v20, user17
-;; @0057                               v34 = load.i64 notrap aligned v58+40
+;; @0057                               v34 = load.i64 notrap aligned v61+40
 ;; @0057                               v24 = iconst.i64 20
 ;; @0057                               v25 = iadd v10, v24  ; v24 = 20
 ;;                                     v65 = iconst.i64 2

--- a/tests/disas/gc/array-copy-with-fuel.wat
+++ b/tests/disas/gc/array-copy-with-fuel.wat
@@ -25,10 +25,10 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32, v6: i32):
-;;                                     v201 = stack_addr.i64 ss0
-;;                                     store notrap v2, v201
-;;                                     v200 = stack_addr.i64 ss1
-;;                                     store notrap v4, v200
+;;                                     v176 = stack_addr.i64 ss0
+;;                                     store notrap v2, v176
+;;                                     v177 = stack_addr.i64 ss1
+;;                                     store notrap v4, v177
 ;; @0020                               v7 = load.i64 notrap aligned readonly can_move v0+8
 ;; @0020                               v8 = load.i64 notrap aligned v7
 ;; @0020                               v9 = iconst.i64 1
@@ -45,10 +45,10 @@
 ;; @0020                               jump block3(v17)
 ;;
 ;;                                 block3(v82: i64):
-;;                                     v157 = load.i32 notrap v201
-;; @002b                               trapz v157, user16
+;;                                     v175 = load.i32 notrap v176
+;; @002b                               trapz v175, user16
 ;; @002b                               v24 = load.i64 notrap aligned readonly can_move v7+32
-;; @002b                               v23 = uextend.i64 v157
+;; @002b                               v23 = uextend.i64 v175
 ;; @002b                               v25 = iadd v24, v23
 ;; @002b                               v26 = iconst.i64 16
 ;; @002b                               v27 = iadd v25, v26  ; v26 = 16
@@ -59,9 +59,9 @@
 ;; @002b                               v29 = uextend.i64 v28
 ;; @002b                               v35 = icmp ugt v34, v29
 ;; @002b                               trapnz v35, user17
-;;                                     v154 = load.i32 notrap v200
-;; @002b                               trapz v154, user16
-;; @002b                               v45 = uextend.i64 v154
+;;                                     v169 = load.i32 notrap v177
+;; @002b                               trapz v169, user16
+;; @002b                               v45 = uextend.i64 v169
 ;; @002b                               v47 = iadd v24, v45
 ;; @002b                               v49 = iadd v47, v26  ; v26 = 16
 ;; @002b                               v50 = load.i32 user2 readonly region0 v49
@@ -92,8 +92,8 @@
 ;; @002b                               brif.i32 v6, block4, block7(v84)
 ;;
 ;;                                 block4:
-;;                                     v148 = load.i32 notrap v201
-;;                                     v149 = load.i32 notrap v200
+;;                                     v157 = load.i32 notrap v176
+;;                                     v159 = load.i32 notrap v177
 ;; @002b                               v85 = icmp.i64 ult v44, v66
 ;;                                     v211 = iadd.i64 v82, v83  ; v83 = 6
 ;; @002b                               v90 = iadd.i64 v44, v208
@@ -101,11 +101,11 @@
 ;; @002b                               v93 = iadd.i32 v5, v6
 ;; @002b                               v42 = iconst.i64 4
 ;; @002b                               v136 = iconst.i32 1
-;; @002b                               brif v85, block5(v44, v66, v5, v148, v149, v211), block6(v90, v91, v93, v148, v149, v211)
+;; @002b                               brif v85, block5(v44, v66, v5, v157, v159, v211), block6(v90, v91, v93, v157, v159, v211)
 ;;
 ;;                                 block5(v94: i64, v95: i64, v96: i32, v97: i32, v98: i32, v99: i64):
-;;                                     store notrap v97, v201
-;;                                     store notrap v98, v200
+;;                                     store notrap v97, v176
+;;                                     store notrap v98, v177
 ;;                                     v221 = iconst.i64 1
 ;;                                     v222 = iadd v99, v221  ; v221 = 1
 ;;                                     v223 = iconst.i64 0
@@ -113,8 +113,8 @@
 ;; @002b                               brif v224, block8, block9(v222)
 ;;
 ;;                                 block6(v117: i64, v118: i64, v119: i32, v120: i32, v121: i32, v122: i64):
-;;                                     store notrap v120, v200
-;;                                     store notrap v121, v201
+;;                                     store notrap v120, v177
+;;                                     store notrap v121, v176
 ;;                                     v212 = iconst.i64 1
 ;;                                     v213 = iadd v122, v212  ; v212 = 1
 ;;                                     v214 = iconst.i64 0
@@ -133,15 +133,15 @@
 ;;                                 block9(v140: i64):
 ;; @002b                               v109 = load.i32 user2 little region0 v95
 ;; @002b                               store user2 little region0 v109, v94
-;;                                     v144 = load.i32 notrap v201
-;;                                     v145 = load.i32 notrap v200
+;;                                     v145 = load.i32 notrap v176
+;;                                     v147 = load.i32 notrap v177
 ;;                                     v225 = iconst.i64 4
 ;;                                     v226 = iadd.i64 v95, v225  ; v225 = 4
 ;; @002b                               v116 = icmp eq v226, v91
 ;;                                     v227 = iadd.i64 v94, v225  ; v225 = 4
 ;;                                     v228 = iconst.i32 1
 ;;                                     v229 = iadd.i32 v96, v228  ; v228 = 1
-;; @002b                               brif v116, block7(v140), block5(v227, v226, v229, v144, v145, v140)
+;; @002b                               brif v116, block7(v140), block5(v227, v226, v229, v145, v147, v140)
 ;;
 ;;                                 block10:
 ;; @002b                               store.i64 notrap aligned v213, v7
@@ -155,12 +155,12 @@
 ;; @002b                               v138 = load.i32 user2 little region0 v217
 ;;                                     v218 = isub.i64 v117, v216  ; v216 = 4
 ;; @002b                               store user2 little region0 v138, v218
-;;                                     v146 = load.i32 notrap v200
-;;                                     v147 = load.i32 notrap v201
+;;                                     v151 = load.i32 notrap v177
+;;                                     v153 = load.i32 notrap v176
 ;; @002b                               v139 = icmp eq v217, v66
 ;;                                     v219 = iconst.i32 1
 ;;                                     v220 = isub.i32 v119, v219  ; v219 = 1
-;; @002b                               brif v139, block7(v141), block6(v218, v217, v220, v146, v147, v141)
+;; @002b                               brif v139, block7(v141), block6(v218, v217, v220, v151, v153, v141)
 ;;
 ;;                                 block1:
 ;; @002f                               store.i64 notrap aligned v143, v7

--- a/tests/disas/gc/array-new-data.wat
+++ b/tests/disas/gc/array-new-data.wat
@@ -152,8 +152,8 @@
 ;; @0025                               jump block4(v45, v48)
 ;;
 ;;                                 block4(v57: i32, v58: i64):
-;;                                     v124 = stack_addr.i64 ss0
-;;                                     store notrap v57, v124
+;;                                     v116 = stack_addr.i64 ss0
+;;                                     store notrap v57, v116
 ;; @0025                               v59 = iconst.i64 16
 ;; @0025                               v60 = iadd v58, v59  ; v59 = 16
 ;; @0025                               store.i32 user2 region1 v3, v60
@@ -181,9 +181,9 @@
 ;; @0025                               trapnz v106, user2
 ;; @0025                               v96 = iadd v94, v8
 ;; @0025                               call fn1(v0, v79, v96, v9), stack_map=[i32 @ ss0+0]
-;;                                     v108 = load.i32 notrap v124
+;;                                     v109 = load.i32 notrap v116
 ;; @0029                               jump block1
 ;;
 ;;                                 block1:
-;; @0029                               return v108
+;; @0029                               return v109
 ;; }

--- a/tests/disas/gc/array-new-default-f32.wat
+++ b/tests/disas/gc/array-new-default-f32.wat
@@ -83,8 +83,8 @@
 ;; @001f                               jump block4(v31, v34)
 ;;
 ;;                                 block4(v43: i32, v44: i64):
-;;                                     v97 = stack_addr.i64 ss0
-;;                                     store notrap v43, v97
+;;                                     v89 = stack_addr.i64 ss0
+;;                                     store notrap v43, v89
 ;; @001f                               v45 = iconst.i64 16
 ;; @001f                               v46 = iadd v44, v45  ; v45 = 16
 ;; @001f                               store.i32 user2 region1 v2, v46
@@ -107,9 +107,9 @@
 ;; @001f                               trapnz v78, user2
 ;; @001f                               v48 = iconst.i32 0
 ;; @001f                               call fn1(v0, v66, v48, v103), stack_map=[i32 @ ss0+0]  ; v48 = 0
-;;                                     v81 = load.i32 notrap v97
+;;                                     v82 = load.i32 notrap v89
 ;; @0022                               jump block1
 ;;
 ;;                                 block1:
-;; @0022                               return v81
+;; @0022                               return v82
 ;; }

--- a/tests/disas/gc/array-new-default-f64.wat
+++ b/tests/disas/gc/array-new-default-f64.wat
@@ -83,8 +83,8 @@
 ;; @001f                               jump block4(v31, v34)
 ;;
 ;;                                 block4(v43: i32, v44: i64):
-;;                                     v97 = stack_addr.i64 ss0
-;;                                     store notrap v43, v97
+;;                                     v89 = stack_addr.i64 ss0
+;;                                     store notrap v43, v89
 ;; @001f                               v45 = iconst.i64 16
 ;; @001f                               v46 = iadd v44, v45  ; v45 = 16
 ;; @001f                               store.i32 user2 region1 v2, v46
@@ -107,9 +107,9 @@
 ;; @001f                               trapnz v78, user2
 ;; @001f                               v48 = iconst.i32 0
 ;; @001f                               call fn1(v0, v66, v48, v103), stack_map=[i32 @ ss0+0]  ; v48 = 0
-;;                                     v81 = load.i32 notrap v97
+;;                                     v82 = load.i32 notrap v89
 ;; @0022                               jump block1
 ;;
 ;;                                 block1:
-;; @0022                               return v81
+;; @0022                               return v82
 ;; }

--- a/tests/disas/gc/array-new-default-funcref.wat
+++ b/tests/disas/gc/array-new-default-funcref.wat
@@ -83,8 +83,8 @@
 ;; @001f                               jump block4(v31, v34)
 ;;
 ;;                                 block4(v43: i32, v44: i64):
-;;                                     v105 = stack_addr.i64 ss0
-;;                                     store notrap v43, v105
+;;                                     v97 = stack_addr.i64 ss0
+;;                                     store notrap v43, v97
 ;; @001f                               v45 = iconst.i64 16
 ;; @001f                               v46 = iadd v44, v45  ; v45 = 16
 ;; @001f                               store.i32 user2 region1 v2, v46
@@ -121,9 +121,9 @@
 ;; @001f                               brif v88, block6, block5(v157)
 ;;
 ;;                                 block6:
-;;                                     v89 = load.i32 notrap v105
+;;                                     v90 = load.i32 notrap v97
 ;; @0022                               jump block1
 ;;
 ;;                                 block1:
-;; @0022                               return v89
+;; @0022                               return v90
 ;; }

--- a/tests/disas/gc/array-new-default-i16.wat
+++ b/tests/disas/gc/array-new-default-i16.wat
@@ -82,8 +82,8 @@
 ;; @001f                               jump block4(v31, v34)
 ;;
 ;;                                 block4(v43: i32, v44: i64):
-;;                                     v97 = stack_addr.i64 ss0
-;;                                     store notrap v43, v97
+;;                                     v89 = stack_addr.i64 ss0
+;;                                     store notrap v43, v89
 ;; @001f                               v45 = iconst.i64 16
 ;; @001f                               v46 = iadd v44, v45  ; v45 = 16
 ;; @001f                               store.i32 user2 region1 v2, v46
@@ -106,9 +106,9 @@
 ;; @001f                               trapnz v78, user2
 ;; @001f                               v47 = iconst.i32 0
 ;; @001f                               call fn1(v0, v66, v47, v104), stack_map=[i32 @ ss0+0]  ; v47 = 0
-;;                                     v81 = load.i32 notrap v97
+;;                                     v82 = load.i32 notrap v89
 ;; @0022                               jump block1
 ;;
 ;;                                 block1:
-;; @0022                               return v81
+;; @0022                               return v82
 ;; }

--- a/tests/disas/gc/array-new-default-i32.wat
+++ b/tests/disas/gc/array-new-default-i32.wat
@@ -83,8 +83,8 @@
 ;; @001f                               jump block4(v31, v34)
 ;;
 ;;                                 block4(v43: i32, v44: i64):
-;;                                     v97 = stack_addr.i64 ss0
-;;                                     store notrap v43, v97
+;;                                     v89 = stack_addr.i64 ss0
+;;                                     store notrap v43, v89
 ;; @001f                               v45 = iconst.i64 16
 ;; @001f                               v46 = iadd v44, v45  ; v45 = 16
 ;; @001f                               store.i32 user2 region1 v2, v46
@@ -107,9 +107,9 @@
 ;; @001f                               trapnz v78, user2
 ;; @001f                               v47 = iconst.i32 0
 ;; @001f                               call fn1(v0, v66, v47, v103), stack_map=[i32 @ ss0+0]  ; v47 = 0
-;;                                     v81 = load.i32 notrap v97
+;;                                     v82 = load.i32 notrap v89
 ;; @0022                               jump block1
 ;;
 ;;                                 block1:
-;; @0022                               return v81
+;; @0022                               return v82
 ;; }

--- a/tests/disas/gc/array-new-default-i64.wat
+++ b/tests/disas/gc/array-new-default-i64.wat
@@ -83,8 +83,8 @@
 ;; @001f                               jump block4(v31, v34)
 ;;
 ;;                                 block4(v43: i32, v44: i64):
-;;                                     v97 = stack_addr.i64 ss0
-;;                                     store notrap v43, v97
+;;                                     v89 = stack_addr.i64 ss0
+;;                                     store notrap v43, v89
 ;; @001f                               v45 = iconst.i64 16
 ;; @001f                               v46 = iadd v44, v45  ; v45 = 16
 ;; @001f                               store.i32 user2 region1 v2, v46
@@ -107,9 +107,9 @@
 ;; @001f                               trapnz v78, user2
 ;; @001f                               v48 = iconst.i32 0
 ;; @001f                               call fn1(v0, v66, v48, v103), stack_map=[i32 @ ss0+0]  ; v48 = 0
-;;                                     v81 = load.i32 notrap v97
+;;                                     v82 = load.i32 notrap v89
 ;; @0022                               jump block1
 ;;
 ;;                                 block1:
-;; @0022                               return v81
+;; @0022                               return v82
 ;; }

--- a/tests/disas/gc/array-new-default-i8.wat
+++ b/tests/disas/gc/array-new-default-i8.wat
@@ -79,8 +79,8 @@
 ;; @001f                               jump block4(v31, v34)
 ;;
 ;;                                 block4(v43: i32, v44: i64):
-;;                                     v96 = stack_addr.i64 ss0
-;;                                     store notrap v43, v96
+;;                                     v88 = stack_addr.i64 ss0
+;;                                     store notrap v43, v88
 ;; @001f                               v45 = iconst.i64 16
 ;; @001f                               v46 = iadd v44, v45  ; v45 = 16
 ;; @001f                               store.i32 user2 region1 v2, v46
@@ -103,9 +103,9 @@
 ;; @001f                               trapnz v78, user2
 ;; @001f                               v47 = iconst.i32 0
 ;; @001f                               call fn1(v0, v66, v47, v5), stack_map=[i32 @ ss0+0]  ; v47 = 0
-;;                                     v80 = load.i32 notrap v96
+;;                                     v81 = load.i32 notrap v88
 ;; @0022                               jump block1
 ;;
 ;;                                 block1:
-;; @0022                               return v80
+;; @0022                               return v81
 ;; }

--- a/tests/disas/gc/copying/array-new-fixed-of-gc-refs.wat
+++ b/tests/disas/gc/copying/array-new-fixed-of-gc-refs.wat
@@ -26,12 +26,12 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
-;;                                     v152 = stack_addr.i64 ss2
-;;                                     store notrap v2, v152
-;;                                     v151 = stack_addr.i64 ss1
-;;                                     store notrap v3, v151
-;;                                     v150 = stack_addr.i64 ss0
-;;                                     store notrap v4, v150
+;;                                     v134 = stack_addr.i64 ss2
+;;                                     store notrap v2, v134
+;;                                     v135 = stack_addr.i64 ss1
+;;                                     store notrap v3, v135
+;;                                     v136 = stack_addr.i64 ss0
+;;                                     store notrap v4, v136
 ;; @0025                               v16 = load.i64 notrap aligned readonly can_move v0+32
 ;; @0025                               v17 = load.i32 notrap aligned v16
 ;; @0025                               v18 = load.i32 notrap aligned v16+4
@@ -65,8 +65,8 @@
 ;;                                     v164 = iconst.i32 32
 ;; @0025                               v33 = iconst.i32 16
 ;; @0025                               v34 = call fn0(v0, v29, v32, v164, v33), stack_map=[i32 @ ss2+0, i32 @ ss1+0, i32 @ ss0+0]  ; v29 = -1476394994, v164 = 32, v33 = 16
-;; @0025                               v146 = load.i64 notrap aligned readonly can_move v0+8
-;; @0025                               v35 = load.i64 notrap aligned readonly can_move v146+32
+;; @0025                               v149 = load.i64 notrap aligned readonly can_move v0+8
+;; @0025                               v35 = load.i64 notrap aligned readonly can_move v149+32
 ;; @0025                               v36 = uextend.i64 v34
 ;; @0025                               v37 = iadd v35, v36
 ;; @0025                               jump block4(v34, v37)
@@ -95,13 +95,13 @@
 ;; @0025                               v7 = iconst.i32 20
 ;; @0025                               v65 = uadd_overflow_trap v194, v7, user2  ; v7 = 20
 ;; @0025                               v69 = uadd_overflow_trap v46, v65, user2
-;;                                     v130 = load.i32 notrap v152
+;;                                     v133 = load.i32 notrap v134
 ;; @0025                               v70 = uextend.i64 v69
 ;; @0025                               v72 = iadd v280, v70
 ;; @0025                               v73 = isub v65, v7  ; v7 = 20
 ;; @0025                               v74 = uextend.i64 v73
 ;; @0025                               v75 = isub v72, v74
-;; @0025                               store user2 little region1 v130, v75
+;; @0025                               store user2 little region1 v133, v75
 ;; @0025                               v82 = load.i32 user2 readonly region1 v55
 ;; @0025                               v76 = iconst.i32 1
 ;;                                     v211 = icmp ugt v82, v76  ; v76 = 1
@@ -113,14 +113,14 @@
 ;;                                     v220 = ishl v82, v193  ; v193 = 2
 ;; @0025                               v91 = uadd_overflow_trap v220, v7, user2  ; v7 = 20
 ;; @0025                               v95 = uadd_overflow_trap v46, v91, user2
-;;                                     v129 = load.i32 notrap v151
+;;                                     v131 = load.i32 notrap v135
 ;; @0025                               v96 = uextend.i64 v95
 ;; @0025                               v98 = iadd v280, v96
 ;;                                     v233 = iconst.i32 24
 ;; @0025                               v99 = isub v91, v233  ; v233 = 24
 ;; @0025                               v100 = uextend.i64 v99
 ;; @0025                               v101 = isub v98, v100
-;; @0025                               store user2 little region1 v129, v101
+;; @0025                               store user2 little region1 v131, v101
 ;; @0025                               v108 = load.i32 user2 readonly region1 v55
 ;;                                     v239 = icmp ugt v108, v193  ; v193 = 2
 ;; @0025                               trapz v239, user17
@@ -131,14 +131,14 @@
 ;;                                     v248 = ishl v108, v193  ; v193 = 2
 ;; @0025                               v117 = uadd_overflow_trap v248, v7, user2  ; v7 = 20
 ;; @0025                               v121 = uadd_overflow_trap v46, v117, user2
-;;                                     v128 = load.i32 notrap v150
+;;                                     v129 = load.i32 notrap v136
 ;; @0025                               v122 = uextend.i64 v121
 ;; @0025                               v124 = iadd v280, v122
 ;;                                     v266 = iconst.i32 28
 ;; @0025                               v125 = isub v117, v266  ; v266 = 28
 ;; @0025                               v126 = uextend.i64 v125
 ;; @0025                               v127 = isub v124, v126
-;; @0025                               store user2 little region1 v128, v127
+;; @0025                               store user2 little region1 v129, v127
 ;; @0029                               jump block1(v46)
 ;;
 ;;                                 block1(v5: i32):

--- a/tests/disas/gc/copying/funcref-in-gc-heap-new.wat
+++ b/tests/disas/gc/copying/funcref-in-gc-heap-new.wat
@@ -72,9 +72,9 @@
 ;; @0020                               v38 = iconst.i64 16
 ;; @0020                               v39 = iadd v37, v38  ; v38 = 16
 ;; @0020                               store user2 little region1 v42, v39
-;;                                     v43 = load.i32 notrap v45
+;;                                     v44 = load.i32 notrap v45
 ;; @0023                               jump block1
 ;;
 ;;                                 block1:
-;; @0023                               return v43
+;; @0023                               return v44
 ;; }

--- a/tests/disas/gc/copying/struct-new.wat
+++ b/tests/disas/gc/copying/struct-new.wat
@@ -25,8 +25,8 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: f32, v3: i32, v4: i32):
-;;                                     v52 = stack_addr.i64 ss0
-;;                                     store notrap v4, v52
+;;                                     v48 = stack_addr.i64 ss0
+;;                                     store notrap v4, v48
 ;; @002a                               v8 = load.i64 notrap aligned readonly can_move v0+32
 ;; @002a                               v9 = load.i32 notrap aligned v8
 ;; @002a                               v10 = load.i32 notrap aligned v8+4
@@ -60,8 +60,8 @@
 ;; @002a                               v6 = iconst.i32 32
 ;; @002a                               v25 = iconst.i32 16
 ;; @002a                               v26 = call fn0(v0, v21, v24, v6, v25), stack_map=[i32 @ ss0+0]  ; v21 = -1342177246, v6 = 32, v25 = 16
-;; @002a                               v48 = load.i64 notrap aligned readonly can_move v0+8
-;; @002a                               v27 = load.i64 notrap aligned readonly can_move v48+32
+;; @002a                               v49 = load.i64 notrap aligned readonly can_move v0+8
+;; @002a                               v27 = load.i64 notrap aligned readonly can_move v49+32
 ;; @002a                               v28 = uextend.i64 v26
 ;; @002a                               v29 = iadd v27, v28
 ;; @002a                               jump block4(v26, v29)
@@ -73,10 +73,10 @@
 ;; @002a                               v42 = iconst.i64 20
 ;; @002a                               v43 = iadd v39, v42  ; v42 = 20
 ;; @002a                               istore8.i32 user2 little region1 v3, v43
-;;                                     v46 = load.i32 notrap v52
+;;                                     v47 = load.i32 notrap v48
 ;; @002a                               v44 = iconst.i64 24
 ;; @002a                               v45 = iadd v39, v44  ; v44 = 24
-;; @002a                               store user2 little region1 v46, v45
+;; @002a                               store user2 little region1 v47, v45
 ;; @002d                               jump block1(v38)
 ;;
 ;;                                 block1(v5: i32):

--- a/tests/disas/gc/drc/array-new-fixed-of-gc-refs.wat
+++ b/tests/disas/gc/drc/array-new-fixed-of-gc-refs.wat
@@ -26,12 +26,12 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
-;;                                     v220 = stack_addr.i64 ss2
-;;                                     store notrap v2, v220
-;;                                     v219 = stack_addr.i64 ss1
-;;                                     store notrap v3, v219
-;;                                     v218 = stack_addr.i64 ss0
-;;                                     store notrap v4, v218
+;;                                     v192 = stack_addr.i64 ss2
+;;                                     store notrap v2, v192
+;;                                     v193 = stack_addr.i64 ss1
+;;                                     store notrap v3, v193
+;;                                     v194 = stack_addr.i64 ss0
+;;                                     store notrap v4, v194
 ;; @0025                               v16 = iconst.i32 -1476395008
 ;; @0025                               v18 = load.i64 notrap aligned readonly can_move v0+40
 ;; @0025                               v19 = load.i32 notrap aligned readonly can_move v18
@@ -39,8 +39,8 @@
 ;; @0025                               v20 = iconst.i32 8
 ;; @0025                               v21 = call fn0(v0, v16, v19, v232, v20), stack_map=[i32 @ ss2+0, i32 @ ss1+0, i32 @ ss0+0]  ; v16 = -1476395008, v232 = 40, v20 = 8
 ;; @0025                               v6 = iconst.i32 3
-;; @0025                               v216 = load.i64 notrap aligned readonly can_move v0+8
-;; @0025                               v22 = load.i64 notrap aligned readonly can_move v216+32
+;; @0025                               v219 = load.i64 notrap aligned readonly can_move v0+8
+;; @0025                               v22 = load.i64 notrap aligned readonly can_move v219+32
 ;; @0025                               v23 = uextend.i64 v21
 ;; @0025                               v24 = iadd v22, v23
 ;; @0025                               v25 = iconst.i64 24
@@ -48,18 +48,18 @@
 ;; @0025                               store user2 region0 v6, v26  ; v6 = 3
 ;; @0025                               trapz v21, user16
 ;; @0025                               v46 = uadd_overflow_trap v21, v232, user2  ; v232 = 40
-;;                                     v176 = load.i32 notrap v220
+;;                                     v191 = load.i32 notrap v192
 ;; @0025                               v53 = iconst.i32 1
-;; @0025                               v54 = band v176, v53  ; v53 = 1
+;; @0025                               v54 = band v191, v53  ; v53 = 1
 ;; @0025                               v27 = iconst.i32 0
-;; @0025                               v56 = icmp eq v176, v27  ; v27 = 0
+;; @0025                               v56 = icmp eq v191, v27  ; v27 = 0
 ;; @0025                               v57 = uextend.i32 v56
 ;; @0025                               v58 = bor v54, v57
 ;; @0025                               brif v58, block3, block2
 ;;
 ;;                                 block2:
-;;                                     v174 = load.i32 notrap v220
-;; @0025                               v59 = uextend.i64 v174
+;;                                     v187 = load.i32 notrap v192
+;; @0025                               v59 = uextend.i64 v187
 ;; @0025                               v61 = iadd.i64 v22, v59
 ;; @0025                               v62 = iconst.i64 8
 ;; @0025                               v63 = iadd v61, v62  ; v62 = 8
@@ -70,12 +70,12 @@
 ;; @0025                               jump block3
 ;;
 ;;                                 block3:
-;;                                     v172 = load.i32 notrap v220
+;;                                     v183 = load.i32 notrap v192
 ;; @0025                               v47 = uextend.i64 v46
 ;; @0025                               v49 = iadd.i64 v22, v47
 ;;                                     v222 = iconst.i64 12
 ;; @0025                               v52 = isub v49, v222  ; v222 = 12
-;; @0025                               store user2 little region0 v172, v52
+;; @0025                               store user2 little region0 v183, v52
 ;;                                     v325 = iadd.i64 v24, v25  ; v25 = 24
 ;; @0025                               v78 = load.i32 user2 readonly region0 v325
 ;;                                     v326 = iconst.i32 1
@@ -92,17 +92,17 @@
 ;; @0025                               v7 = iconst.i32 28
 ;; @0025                               v87 = uadd_overflow_trap v274, v7, user2  ; v7 = 28
 ;; @0025                               v91 = uadd_overflow_trap.i32 v21, v87, user2
-;;                                     v171 = load.i32 notrap v219
-;;                                     v328 = band v171, v326  ; v326 = 1
+;;                                     v181 = load.i32 notrap v193
+;;                                     v328 = band v181, v326  ; v326 = 1
 ;;                                     v329 = iconst.i32 0
-;;                                     v330 = icmp eq v171, v329  ; v329 = 0
+;;                                     v330 = icmp eq v181, v329  ; v329 = 0
 ;; @0025                               v102 = uextend.i32 v330
 ;; @0025                               v103 = bor v328, v102
 ;; @0025                               brif v103, block5, block4
 ;;
 ;;                                 block4:
-;;                                     v169 = load.i32 notrap v219
-;; @0025                               v104 = uextend.i64 v169
+;;                                     v177 = load.i32 notrap v193
+;; @0025                               v104 = uextend.i64 v177
 ;; @0025                               v106 = iadd.i64 v22, v104
 ;;                                     v331 = iconst.i64 8
 ;; @0025                               v108 = iadd v106, v331  ; v331 = 8
@@ -113,14 +113,14 @@
 ;; @0025                               jump block5
 ;;
 ;;                                 block5:
-;;                                     v167 = load.i32 notrap v219
+;;                                     v173 = load.i32 notrap v193
 ;; @0025                               v92 = uextend.i64 v91
 ;; @0025                               v94 = iadd.i64 v22, v92
 ;;                                     v287 = iconst.i32 32
 ;; @0025                               v95 = isub.i32 v87, v287  ; v287 = 32
 ;; @0025                               v96 = uextend.i64 v95
 ;; @0025                               v97 = isub v94, v96
-;; @0025                               store user2 little region0 v167, v97
+;; @0025                               store user2 little region0 v173, v97
 ;;                                     v333 = iadd.i64 v24, v25  ; v25 = 24
 ;; @0025                               v123 = load.i32 user2 readonly region0 v333
 ;;                                     v334 = iconst.i32 2
@@ -136,18 +136,18 @@
 ;;                                     v341 = iconst.i32 28
 ;; @0025                               v132 = uadd_overflow_trap v340, v341, user2  ; v341 = 28
 ;; @0025                               v136 = uadd_overflow_trap.i32 v21, v132, user2
-;;                                     v166 = load.i32 notrap v218
+;;                                     v171 = load.i32 notrap v194
 ;;                                     v342 = iconst.i32 1
-;;                                     v343 = band v166, v342  ; v342 = 1
+;;                                     v343 = band v171, v342  ; v342 = 1
 ;;                                     v344 = iconst.i32 0
-;;                                     v345 = icmp eq v166, v344  ; v344 = 0
+;;                                     v345 = icmp eq v171, v344  ; v344 = 0
 ;; @0025                               v147 = uextend.i32 v345
 ;; @0025                               v148 = bor v343, v147
 ;; @0025                               brif v148, block7, block6
 ;;
 ;;                                 block6:
-;;                                     v164 = load.i32 notrap v218
-;; @0025                               v149 = uextend.i64 v164
+;;                                     v167 = load.i32 notrap v194
+;; @0025                               v149 = uextend.i64 v167
 ;; @0025                               v151 = iadd.i64 v22, v149
 ;;                                     v346 = iconst.i64 8
 ;; @0025                               v153 = iadd v151, v346  ; v346 = 8
@@ -158,14 +158,14 @@
 ;; @0025                               jump block7
 ;;
 ;;                                 block7:
-;;                                     v162 = load.i32 notrap v218
+;;                                     v163 = load.i32 notrap v194
 ;; @0025                               v137 = uextend.i64 v136
 ;; @0025                               v139 = iadd.i64 v22, v137
 ;;                                     v319 = iconst.i32 36
 ;; @0025                               v140 = isub.i32 v132, v319  ; v319 = 36
 ;; @0025                               v141 = uextend.i64 v140
 ;; @0025                               v142 = isub v139, v141
-;; @0025                               store user2 little region0 v162, v142
+;; @0025                               store user2 little region0 v163, v142
 ;; @0029                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/drc/externref-globals.wat
+++ b/tests/disas/gc/drc/externref-globals.wat
@@ -31,8 +31,8 @@
 ;; @0034                               v4 = iconst.i64 48
 ;; @0034                               v5 = iadd v0, v4  ; v4 = 48
 ;; @0034                               v6 = load.i32 notrap aligned v5
-;;                                     v92 = stack_addr.i64 ss0
-;;                                     store notrap v6, v92
+;;                                     v82 = stack_addr.i64 ss0
+;;                                     store notrap v6, v82
 ;; @0034                               v7 = iconst.i32 1
 ;; @0034                               v8 = band v6, v7  ; v7 = 1
 ;; @0034                               v9 = iconst.i32 0
@@ -42,8 +42,8 @@
 ;; @0034                               brif v12, block4, block2
 ;;
 ;;                                 block2:
-;; @0034                               v87 = load.i64 notrap aligned readonly can_move v0+8
-;; @0034                               v14 = load.i64 notrap aligned readonly can_move v87+32
+;; @0034                               v91 = load.i64 notrap aligned readonly can_move v0+8
+;; @0034                               v14 = load.i64 notrap aligned readonly can_move v91+32
 ;; @0034                               v13 = uextend.i64 v6
 ;; @0034                               v15 = iadd v14, v13
 ;; @0034                               v16 = load.i32 user2 region0 v15
@@ -86,11 +86,11 @@
 ;; @0034                               jump block4
 ;;
 ;;                                 block4:
-;;                                     v64 = load.i32 notrap v92
+;;                                     v65 = load.i32 notrap v82
 ;; @0036                               jump block1
 ;;
 ;;                                 block1:
-;; @0036                               return v64
+;; @0036                               return v65
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) tail {

--- a/tests/disas/gc/drc/funcref-in-gc-heap-new.wat
+++ b/tests/disas/gc/drc/funcref-in-gc-heap-new.wat
@@ -31,20 +31,20 @@
 ;; @0020                               v4 = iconst.i32 32
 ;; @0020                               v10 = iconst.i32 8
 ;; @0020                               v11 = call fn0(v0, v6, v9, v4, v10)  ; v6 = -1342177280, v4 = 32, v10 = 8
-;;                                     v26 = stack_addr.i64 ss0
-;;                                     store notrap v11, v26
+;;                                     v24 = stack_addr.i64 ss0
+;;                                     store notrap v11, v24
 ;; @0020                               v18 = call fn1(v0, v2), stack_map=[i32 @ ss0+0]
 ;; @0020                               v19 = ireduce.i32 v18
-;; @0020                               v24 = load.i64 notrap aligned readonly can_move v0+8
-;; @0020                               v12 = load.i64 notrap aligned readonly can_move v24+32
+;; @0020                               v25 = load.i64 notrap aligned readonly can_move v0+8
+;; @0020                               v12 = load.i64 notrap aligned readonly can_move v25+32
 ;; @0020                               v13 = uextend.i64 v11
 ;; @0020                               v14 = iadd v12, v13
 ;; @0020                               v15 = iconst.i64 24
 ;; @0020                               v16 = iadd v14, v15  ; v15 = 24
 ;; @0020                               store user2 little region0 v19, v16
-;;                                     v20 = load.i32 notrap v26
+;;                                     v21 = load.i32 notrap v24
 ;; @0023                               jump block1
 ;;
 ;;                                 block1:
-;; @0023                               return v20
+;; @0023                               return v21
 ;; }

--- a/tests/disas/gc/drc/struct-get.wat
+++ b/tests/disas/gc/drc/struct-get.wat
@@ -127,8 +127,8 @@
 ;; @004e                               v7 = iconst.i64 32
 ;; @004e                               v8 = iadd v6, v7  ; v7 = 32
 ;; @004e                               v9 = load.i32 user2 little region0 v8
-;;                                     v95 = stack_addr.i64 ss0
-;;                                     store notrap v9, v95
+;;                                     v85 = stack_addr.i64 ss0
+;;                                     store notrap v9, v85
 ;; @004e                               v10 = iconst.i32 1
 ;; @004e                               v11 = band v9, v10  ; v10 = 1
 ;; @004e                               v12 = iconst.i32 0
@@ -180,9 +180,9 @@
 ;; @004e                               jump block4
 ;;
 ;;                                 block4:
-;;                                     v67 = load.i32 notrap v95
+;;                                     v68 = load.i32 notrap v85
 ;; @0052                               jump block1
 ;;
 ;;                                 block1:
-;; @0052                               return v67
+;; @0052                               return v68
 ;; }

--- a/tests/disas/gc/drc/struct-new.wat
+++ b/tests/disas/gc/drc/struct-new.wat
@@ -26,16 +26,16 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: f32, v3: i32, v4: i32):
-;;                                     v58 = stack_addr.i64 ss0
-;;                                     store notrap v4, v58
+;;                                     v52 = stack_addr.i64 ss0
+;;                                     store notrap v4, v52
 ;; @002a                               v8 = iconst.i32 -1342177280
 ;; @002a                               v10 = load.i64 notrap aligned readonly can_move v0+40
 ;; @002a                               v11 = load.i32 notrap aligned readonly can_move v10
 ;; @002a                               v6 = iconst.i32 40
 ;; @002a                               v12 = iconst.i32 8
 ;; @002a                               v13 = call fn0(v0, v8, v11, v6, v12), stack_map=[i32 @ ss0+0]  ; v8 = -1342177280, v6 = 40, v12 = 8
-;; @002a                               v56 = load.i64 notrap aligned readonly can_move v0+8
-;; @002a                               v14 = load.i64 notrap aligned readonly can_move v56+32
+;; @002a                               v57 = load.i64 notrap aligned readonly can_move v0+8
+;; @002a                               v14 = load.i64 notrap aligned readonly can_move v57+32
 ;; @002a                               v15 = uextend.i64 v13
 ;; @002a                               v16 = iadd v14, v15
 ;; @002a                               v17 = iconst.i64 24
@@ -44,17 +44,17 @@
 ;; @002a                               v19 = iconst.i64 28
 ;; @002a                               v20 = iadd v16, v19  ; v19 = 28
 ;; @002a                               istore8 user2 little region0 v3, v20
-;;                                     v46 = load.i32 notrap v58
+;;                                     v51 = load.i32 notrap v52
 ;; @002a                               v23 = iconst.i32 1
-;; @002a                               v24 = band v46, v23  ; v23 = 1
+;; @002a                               v24 = band v51, v23  ; v23 = 1
 ;; @002a                               v25 = iconst.i32 0
-;; @002a                               v26 = icmp eq v46, v25  ; v25 = 0
+;; @002a                               v26 = icmp eq v51, v25  ; v25 = 0
 ;; @002a                               v27 = uextend.i32 v26
 ;; @002a                               v28 = bor v24, v27
 ;; @002a                               brif v28, block3, block2
 ;;
 ;;                                 block2:
-;; @002a                               v29 = uextend.i64 v46
+;; @002a                               v29 = uextend.i64 v51
 ;; @002a                               v31 = iadd.i64 v14, v29
 ;; @002a                               v32 = iconst.i64 8
 ;; @002a                               v33 = iadd v31, v32  ; v32 = 8
@@ -67,7 +67,7 @@
 ;;                                 block3:
 ;; @002a                               v21 = iconst.i64 32
 ;; @002a                               v22 = iadd.i64 v16, v21  ; v21 = 32
-;; @002a                               store.i32 user2 little region0 v46, v22
+;; @002a                               store.i32 user2 little region0 v51, v22
 ;; @002d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/null/array-new-fixed-of-gc-refs.wat
+++ b/tests/disas/gc/null/array-new-fixed-of-gc-refs.wat
@@ -27,12 +27,12 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
-;;                                     v145 = stack_addr.i64 ss2
-;;                                     store notrap v2, v145
-;;                                     v144 = stack_addr.i64 ss1
-;;                                     store notrap v3, v144
-;;                                     v143 = stack_addr.i64 ss0
-;;                                     store notrap v4, v143
+;;                                     v127 = stack_addr.i64 ss2
+;;                                     store notrap v2, v127
+;;                                     v128 = stack_addr.i64 ss1
+;;                                     store notrap v3, v128
+;;                                     v129 = stack_addr.i64 ss0
+;;                                     store notrap v4, v129
 ;; @0025                               v19 = load.i64 notrap aligned readonly region0 v0+32
 ;; @0025                               v20 = load.i32 user2 region1 v19
 ;;                                     v163 = iconst.i32 7
@@ -41,15 +41,15 @@
 ;; @0025                               v25 = band v23, v169  ; v169 = -8
 ;;                                     v156 = iconst.i32 24
 ;; @0025                               v26 = uadd_overflow_trap v25, v156, user18  ; v156 = 24
-;; @0025                               v141 = load.i64 notrap aligned readonly can_move v0+8
-;; @0025                               v28 = load.i64 notrap aligned v141+40
+;; @0025                               v144 = load.i64 notrap aligned readonly can_move v0+8
+;; @0025                               v28 = load.i64 notrap aligned v144+40
 ;; @0025                               v27 = uextend.i64 v26
 ;; @0025                               v29 = icmp ule v27, v28
 ;; @0025                               brif v29, block2, block3
 ;;
 ;;                                 block2:
 ;;                                     v170 = iconst.i32 -1476394984
-;; @0025                               v33 = load.i64 notrap aligned readonly can_move v141+32
+;; @0025                               v33 = load.i64 notrap aligned readonly can_move v144+32
 ;;                                     v268 = band.i32 v23, v169  ; v169 = -8
 ;;                                     v269 = uextend.i64 v268
 ;; @0025                               v35 = iadd v33, v269
@@ -65,12 +65,12 @@
 ;; @0025                               trapz v268, user16
 ;;                                     v270 = iconst.i32 24
 ;; @0025                               v62 = uadd_overflow_trap v268, v270, user2  ; v270 = 24
-;;                                     v123 = load.i32 notrap v145
+;;                                     v126 = load.i32 notrap v127
 ;; @0025                               v63 = uextend.i64 v62
 ;; @0025                               v65 = iadd v33, v63
 ;;                                     v147 = iconst.i64 12
 ;; @0025                               v68 = isub v65, v147  ; v147 = 12
-;; @0025                               store user2 little region1 v123, v68
+;; @0025                               store user2 little region1 v126, v68
 ;; @0025                               v75 = load.i32 user2 readonly region1 v42
 ;; @0025                               v69 = iconst.i32 1
 ;;                                     v208 = icmp ugt v75, v69  ; v69 = 1
@@ -86,14 +86,14 @@
 ;; @0025                               v7 = iconst.i32 12
 ;; @0025                               v84 = uadd_overflow_trap v217, v7, user2  ; v7 = 12
 ;; @0025                               v88 = uadd_overflow_trap v268, v84, user2
-;;                                     v122 = load.i32 notrap v144
+;;                                     v124 = load.i32 notrap v128
 ;; @0025                               v89 = uextend.i64 v88
 ;; @0025                               v91 = iadd v33, v89
 ;;                                     v230 = iconst.i32 16
 ;; @0025                               v92 = isub v84, v230  ; v230 = 16
 ;; @0025                               v93 = uextend.i64 v92
 ;; @0025                               v94 = isub v91, v93
-;; @0025                               store user2 little region1 v122, v94
+;; @0025                               store user2 little region1 v124, v94
 ;; @0025                               v101 = load.i32 user2 readonly region1 v42
 ;;                                     v236 = icmp ugt v101, v187  ; v187 = 2
 ;; @0025                               trapz v236, user17
@@ -104,14 +104,14 @@
 ;;                                     v245 = ishl v101, v187  ; v187 = 2
 ;; @0025                               v110 = uadd_overflow_trap v245, v7, user2  ; v7 = 12
 ;; @0025                               v114 = uadd_overflow_trap v268, v110, user2
-;;                                     v121 = load.i32 notrap v143
+;;                                     v122 = load.i32 notrap v129
 ;; @0025                               v115 = uextend.i64 v114
 ;; @0025                               v117 = iadd v33, v115
 ;;                                     v262 = iconst.i32 20
 ;; @0025                               v118 = isub v110, v262  ; v262 = 20
 ;; @0025                               v119 = uextend.i64 v118
 ;; @0025                               v120 = isub v117, v119
-;; @0025                               store user2 little region1 v121, v120
+;; @0025                               store user2 little region1 v122, v120
 ;; @0029                               jump block1
 ;;
 ;;                                 block3 cold:

--- a/tests/disas/gc/null/struct-new.wat
+++ b/tests/disas/gc/null/struct-new.wat
@@ -27,8 +27,8 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: f32, v3: i32, v4: i32):
-;;                                     v45 = stack_addr.i64 ss0
-;;                                     store notrap v4, v45
+;;                                     v41 = stack_addr.i64 ss0
+;;                                     store notrap v4, v41
 ;; @002a                               v11 = load.i64 notrap aligned readonly region0 v0+32
 ;; @002a                               v12 = load.i32 user2 region1 v11
 ;;                                     v52 = iconst.i32 7
@@ -37,15 +37,15 @@
 ;; @002a                               v17 = band v15, v58  ; v58 = -8
 ;; @002a                               v6 = iconst.i32 24
 ;; @002a                               v18 = uadd_overflow_trap v17, v6, user18  ; v6 = 24
-;; @002a                               v43 = load.i64 notrap aligned readonly can_move v0+8
-;; @002a                               v20 = load.i64 notrap aligned v43+40
+;; @002a                               v44 = load.i64 notrap aligned readonly can_move v0+8
+;; @002a                               v20 = load.i64 notrap aligned v44+40
 ;; @002a                               v19 = uextend.i64 v18
 ;; @002a                               v21 = icmp ule v19, v20
 ;; @002a                               brif v21, block2, block3
 ;;
 ;;                                 block2:
 ;;                                     v59 = iconst.i32 -1342177256
-;; @002a                               v25 = load.i64 notrap aligned readonly can_move v43+32
+;; @002a                               v25 = load.i64 notrap aligned readonly can_move v44+32
 ;;                                     v65 = band.i32 v15, v58  ; v58 = -8
 ;;                                     v66 = uextend.i64 v65
 ;; @002a                               v27 = iadd v25, v66
@@ -60,10 +60,10 @@
 ;; @002a                               v35 = iconst.i64 12
 ;; @002a                               v36 = iadd v27, v35  ; v35 = 12
 ;; @002a                               istore8.i32 user2 little region1 v3, v36
-;;                                     v39 = load.i32 notrap v45
+;;                                     v40 = load.i32 notrap v41
 ;; @002a                               v37 = iconst.i64 16
 ;; @002a                               v38 = iadd v27, v37  ; v37 = 16
-;; @002a                               store user2 little region1 v39, v38
+;; @002a                               store user2 little region1 v40, v38
 ;; @002d                               jump block1
 ;;
 ;;                                 block3 cold:

--- a/tests/disas/gc/struct-new.wat
+++ b/tests/disas/gc/struct-new.wat
@@ -26,8 +26,8 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: f32, v3: i32, v4: i32):
-;;                                     v52 = stack_addr.i64 ss0
-;;                                     store notrap v4, v52
+;;                                     v48 = stack_addr.i64 ss0
+;;                                     store notrap v4, v48
 ;; @002a                               v8 = load.i64 notrap aligned readonly can_move v0+32
 ;; @002a                               v9 = load.i32 notrap aligned v8
 ;; @002a                               v10 = load.i32 notrap aligned v8+4
@@ -61,8 +61,8 @@
 ;; @002a                               v6 = iconst.i32 32
 ;; @002a                               v25 = iconst.i32 16
 ;; @002a                               v26 = call fn0(v0, v21, v24, v6, v25), stack_map=[i32 @ ss0+0]  ; v21 = -1342177246, v6 = 32, v25 = 16
-;; @002a                               v48 = load.i64 notrap aligned readonly can_move v0+8
-;; @002a                               v27 = load.i64 notrap aligned readonly can_move v48+32
+;; @002a                               v49 = load.i64 notrap aligned readonly can_move v0+8
+;; @002a                               v27 = load.i64 notrap aligned readonly can_move v49+32
 ;; @002a                               v28 = uextend.i64 v26
 ;; @002a                               v29 = iadd v27, v28
 ;; @002a                               jump block4(v26, v29)
@@ -74,10 +74,10 @@
 ;; @002a                               v42 = iconst.i64 20
 ;; @002a                               v43 = iadd v39, v42  ; v42 = 20
 ;; @002a                               istore8.i32 user2 little region1 v3, v43
-;;                                     v46 = load.i32 notrap v52
+;;                                     v47 = load.i32 notrap v48
 ;; @002a                               v44 = iconst.i64 24
 ;; @002a                               v45 = iadd v39, v44  ; v44 = 24
-;; @002a                               store user2 little region1 v46, v45
+;; @002a                               store user2 little region1 v47, v45
 ;; @002d                               jump block1(v38)
 ;;
 ;;                                 block1(v5: i32):

--- a/tests/disas/gc/typed-select-and-stack-maps.wat
+++ b/tests/disas/gc/typed-select-and-stack-maps.wat
@@ -56,10 +56,10 @@
 ;; @004c                               v8 = load.i64 notrap aligned readonly can_move v0+88
 ;; @004c                               v7 = load.i64 notrap aligned readonly can_move v0+104
 ;; @004c                               call_indirect sig0, v8(v7, v0), stack_map=[i32 @ ss0+0]
-;;                                     v12 = load.i32 notrap v14
+;;                                     v13 = load.i32 notrap v14
 ;; @004e                               v11 = load.i64 notrap aligned readonly can_move v0+56
 ;; @004e                               v10 = load.i64 notrap aligned readonly can_move v0+72
-;; @004e                               call_indirect sig1, v11(v10, v0, v12)
+;; @004e                               call_indirect sig1, v11(v10, v0, v13)
 ;; @0050                               jump block1
 ;;
 ;;                                 block1:


### PR DESCRIPTION
These get immediately legalized to `stack_addr` and `load` or `store`, so frontends should just emit that pair directly. For convenience and backwards compat, we add `InstBuilder::stack_load` and `InstBuilder::stack_store` methods that emit the pair as a single operation. Unfortunately, these methods have to take an additional pointer-type parameter that the old version didn't have to take because the rewrite didn't happen until legalization time, so these new methods are not 100% backwards compatible. This also necessitated passing in a `TargetFrontendConfig` to `FuncBuilder::finalize`, which resulted in a bit of churn, but is fully mechanical.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
