### PR TITLE
wizer: support init func as a wave function call (components only)

### DIFF
--- a/crates/test-programs/src/bin/wizer_component_interfaces.rs
+++ b/crates/test-programs/src/bin/wizer_component_interfaces.rs
@@ -1,0 +1,50 @@
+/// Stub so that Cargo can build this test as a binary
+pub fn main() {
+    eprintln!("dont use as a command");
+    std::process::exit(-1)
+}
+
+wit_bindgen::generate!({
+    inline: "
+package local:local@0.1.0;
+
+interface init {
+    add-string: func(arg: string);
+    add-int: func(arg: s32);
+}
+
+interface run {
+    variant elem { str(string), int(s32) }
+    get-inits: func() -> list<elem>;
+}
+
+world wizer-test {
+    export init;
+    export run;
+}
+    ",
+    world: "wizer-test",
+});
+
+pub struct C;
+export!(C);
+
+use std::sync::Mutex;
+
+static INITS: Mutex<Vec<Elem>> = Mutex::new(Vec::new());
+
+impl exports::local::local::init::Guest for C {
+    fn add_string(s: String) {
+        INITS.lock().unwrap().push(Elem::Str(s))
+    }
+    fn add_int(i: i32) {
+        INITS.lock().unwrap().push(Elem::Int(i))
+    }
+}
+
+use exports::local::local::run::Elem;
+impl exports::local::local::run::Guest for C {
+    fn get_inits() -> Vec<Elem> {
+        INITS.lock().unwrap().clone()
+    }
+}

--- a/crates/test-programs/src/bin/wizer_component_interfaces.rs
+++ b/crates/test-programs/src/bin/wizer_component_interfaces.rs
@@ -9,8 +9,9 @@ wit_bindgen::generate!({
 package local:local@0.1.0;
 
 interface init {
-    add-string: func(arg: string);
-    add-int: func(arg: s32);
+    use run.{elem};
+    add-string: func(arg: string) -> list<elem>;
+    add-int: func(arg: s32) -> list<elem>;
 }
 
 interface run {
@@ -34,11 +35,15 @@ use std::sync::Mutex;
 static INITS: Mutex<Vec<Elem>> = Mutex::new(Vec::new());
 
 impl exports::local::local::init::Guest for C {
-    fn add_string(s: String) {
-        INITS.lock().unwrap().push(Elem::Str(s))
+    fn add_string(s: String) -> Vec<Elem> {
+        let mut inits = INITS.lock().unwrap();
+        inits.push(Elem::Str(s));
+        inits.clone()
     }
-    fn add_int(i: i32) {
-        INITS.lock().unwrap().push(Elem::Int(i))
+    fn add_int(i: i32) -> Vec<Elem> {
+        let mut inits = INITS.lock().unwrap();
+        inits.push(Elem::Int(i));
+        inits.clone()
     }
 }
 

--- a/crates/wizer/Cargo.toml
+++ b/crates/wizer/Cargo.toml
@@ -62,6 +62,9 @@ wasmtime = [
   'wasmtime/gc',
   'wasmtime/gc-null',
   'wasmtime/async',
+  # Need wave and wit-parser features to parse init func expressions
+  'wasmtime/wave',
+  'wasmtime/wit-parser',
 ]
 
 # Enable support for wizening components.

--- a/crates/wizer/src/component/wasmtime.rs
+++ b/crates/wizer/src/component/wasmtime.rs
@@ -15,7 +15,7 @@ impl Wizer {
         store: &mut Store<T>,
         wasm: &[u8],
         instantiate: impl AsyncFnOnce(&mut Store<T>, &Component) -> Result<Instance>,
-    ) -> wasmtime::Result<Vec<u8>> {
+    ) -> wasmtime::Result<(Vec<u8>, Vec<Val>)> {
         let (cx, instrumented_wasm) = self.instrument_component(wasm)?;
 
         #[cfg(feature = "wasmprinter")]
@@ -27,13 +27,14 @@ impl Wizer {
         let engine = store.engine();
         let component = Component::new(engine, &instrumented_wasm)
             .context("failed to compile the Wasm component")?;
-        let (index, args, rets) = self.validate_component_init_func(&component)?;
+        let (index, args, mut rets) = self.validate_component_init_func(&component)?;
 
         let instance = instantiate(store, &component).await?;
-        self.initialize_component(store, &instance, index, args, rets)
+        self.initialize_component(store, &instance, index, args, &mut rets)
             .await?;
-        self.snapshot_component(cx, &mut WasmtimeWizerComponent { store, instance })
-            .await
+        let snap = self.snapshot_component(cx, &mut WasmtimeWizerComponent { store, instance })
+            .await?;
+        Ok((snap, rets))
     }
 
     fn validate_component_init_func(
@@ -97,16 +98,15 @@ impl Wizer {
         instance: &Instance,
         index: ComponentExportIndex,
         args: Vec<Val>,
-        mut rets: Vec<Val>,
+        rets: &mut Vec<Val>,
     ) -> wasmtime::Result<()> {
         let init_func = instance
             .get_func(&mut *store, index)
             .expect("checked by `validate_init_func`");
         init_func
-            .call_async(&mut *store, &args, &mut rets)
+            .call_async(&mut *store, &args, rets)
             .await
             .with_context(|| format!("the initialization function trapped"))?;
-        // TODO: do we want some way to report the values of `rets` back up?
         Ok(())
     }
 }

--- a/crates/wizer/src/component/wasmtime.rs
+++ b/crates/wizer/src/component/wasmtime.rs
@@ -32,7 +32,8 @@ impl Wizer {
         let instance = instantiate(store, &component).await?;
         self.initialize_component(store, &instance, index, args, &mut rets)
             .await?;
-        let snap = self.snapshot_component(cx, &mut WasmtimeWizerComponent { store, instance })
+        let snap = self
+            .snapshot_component(cx, &mut WasmtimeWizerComponent { store, instance })
             .await?;
         Ok((snap, rets))
     }

--- a/crates/wizer/src/component/wasmtime.rs
+++ b/crates/wizer/src/component/wasmtime.rs
@@ -30,7 +30,8 @@ impl Wizer {
         let (index, args, rets) = self.validate_component_init_func(&component)?;
 
         let instance = instantiate(store, &component).await?;
-        self.initialize_component(store, &instance, index, args, rets).await?;
+        self.initialize_component(store, &instance, index, args, rets)
+            .await?;
         self.snapshot_component(cx, &mut WasmtimeWizerComponent { store, instance })
             .await
     }

--- a/crates/wizer/src/component/wasmtime.rs
+++ b/crates/wizer/src/component/wasmtime.rs
@@ -1,7 +1,7 @@
 use crate::Wizer;
 use crate::component::ComponentInstanceState;
 use wasmtime::component::{
-    Component, ComponentExportIndex, Instance, Lift, WasmList, types::ComponentItem,
+    Component, ComponentExportIndex, Instance, Lift, Val, WasmList, types::ComponentItem,
 };
 use wasmtime::{Result, Store, error::Context as _, format_err};
 
@@ -27,10 +27,10 @@ impl Wizer {
         let engine = store.engine();
         let component = Component::new(engine, &instrumented_wasm)
             .context("failed to compile the Wasm component")?;
-        let index = self.validate_component_init_func(&component)?;
+        let (index, args, rets) = self.validate_component_init_func(&component)?;
 
         let instance = instantiate(store, &component).await?;
-        self.initialize_component(store, &instance, index).await?;
+        self.initialize_component(store, &instance, index, args, rets).await?;
         self.snapshot_component(cx, &mut WasmtimeWizerComponent { store, instance })
             .await
     }
@@ -38,10 +38,31 @@ impl Wizer {
     fn validate_component_init_func(
         &self,
         component: &Component,
-    ) -> wasmtime::Result<ComponentExportIndex> {
+    ) -> wasmtime::Result<(ComponentExportIndex, Vec<Val>, Vec<Val>)> {
         let init_func = self.get_init_func();
+
+        use wasmtime::component::wasm_wave::{untyped::UntypedFuncCall, wasm::WasmFunc};
+        use wasmtime::component::wit_parser::ItemName;
+        let (func_name, func_call) = if init_func.contains('(') {
+            let call = UntypedFuncCall::parse(init_func)
+                .with_context(|| format!("parsing `{init_func}` as wave function call"))?;
+            let item_name = call
+                .item_name()
+                .map_err(wasmtime::Error::from_anyhow)
+                .with_context(|| format!("parsing `{init_func}` as wave function call"))?;
+            (item_name, Some(call))
+        } else {
+            (
+                init_func
+                    .parse::<ItemName>()
+                    .map_err(wasmtime::Error::from_anyhow)
+                    .with_context(|| format!("parsing `{init_func}` as wit item name"))?,
+                None,
+            )
+        };
+
         let (ty, index) = component
-            .get_export(None, init_func)
+            .get_export(None, func_name)
             .ok_or_else(|| format_err!("the component does export the function `{init_func}`"))?;
 
         let ty = match ty {
@@ -49,12 +70,24 @@ impl Wizer {
             _ => wasmtime::bail!("the component's `{init_func}` export is not a function",),
         };
 
-        if ty.params().len() != 0 || ty.results().len() != 0 {
-            wasmtime::bail!(
-                "the component's `{init_func}` function export does not have type `[] -> []`",
-            );
+        if let Some(func_call) = func_call {
+            let param_types = WasmFunc::params(&ty).collect::<Vec<_>>();
+            let param_vals = func_call.to_wasm_params(&param_types).with_context(|| {
+                format!("parsing `{init_func}` params as types {param_types:?}")
+            })?;
+            Ok((
+                index,
+                param_vals,
+                vec![Val::Bool(false); ty.results().len()],
+            ))
+        } else {
+            if ty.params().len() != 0 || ty.results().len() != 0 {
+                wasmtime::bail!(
+                    "the component's `{init_func}` function export does not have type `[] -> []`",
+                );
+            }
+            Ok((index, vec![], vec![]))
         }
-        Ok(index)
     }
 
     async fn initialize_component<T: Send>(
@@ -62,15 +95,17 @@ impl Wizer {
         store: &mut Store<T>,
         instance: &Instance,
         index: ComponentExportIndex,
+        args: Vec<Val>,
+        mut rets: Vec<Val>,
     ) -> wasmtime::Result<()> {
         let init_func = instance
-            .get_typed_func::<(), ()>(&mut *store, index)
+            .get_func(&mut *store, index)
             .expect("checked by `validate_init_func`");
         init_func
-            .call_async(&mut *store, ())
+            .call_async(&mut *store, &args, &mut rets)
             .await
             .with_context(|| format!("the initialization function trapped"))?;
-
+        // TODO: do we want some way to report the values of `rets` back up?
         Ok(())
     }
 }

--- a/crates/wizer/src/lib.rs
+++ b/crates/wizer/src/lib.rs
@@ -56,6 +56,10 @@ const DEFAULT_KEEP_INIT_FUNC: bool = false;
 pub struct Wizer {
     /// The Wasm export name of the function that should be executed to
     /// initialize the Wasm module.
+    ///
+    /// When used with components, this can be either the item name of a
+    /// function (e.g. `wasi:cli/run.run`) or a complete wave-encoded function
+    /// call (e.g. `your:package/iface.func("hello world")`)
     #[cfg_attr(
         feature = "clap",
         arg(short = 'f', long, default_value = "wizer-initialize")

--- a/crates/wizer/tests/all/component.rs
+++ b/crates/wizer/tests/all/component.rs
@@ -745,7 +745,10 @@ async fn component_interfaces() -> Result<()> {
         .run_component(&mut store, component, instantiate)
         .await
         .context("Wizer::run_component")?;
-    assert_eq!(wasm_wave::wasm::DisplayFuncResults(&rets).to_string(), "[str(\"hello world\")]");
+    assert_eq!(
+        wasm_wave::wasm::DisplayFuncResults(&rets).to_string(),
+        "[str(\"hello world\")]"
+    );
 
     let (wizened_component, rets) = Wizer::new()
         .init_func("local:local/init.add-int@0.1.0(42)")
@@ -753,7 +756,10 @@ async fn component_interfaces() -> Result<()> {
         .run_component(&mut store, &wizened_component, instantiate)
         .await
         .context("Wizer::run_component")?;
-    assert_eq!(wasm_wave::wasm::DisplayFuncResults(&rets).to_string(), "[str(\"hello world\"), int(42)]");
+    assert_eq!(
+        wasm_wave::wasm::DisplayFuncResults(&rets).to_string(),
+        "[str(\"hello world\"), int(42)]"
+    );
 
     let (wizened_component, _) = Wizer::new()
         .init_func("local:local/init.add-string@0.1.0(\"wizer is better with wave\")")
@@ -761,7 +767,10 @@ async fn component_interfaces() -> Result<()> {
         .run_component(&mut store, &wizened_component, instantiate)
         .await
         .context("Wizer::run_component")?;
-    assert_eq!(wasm_wave::wasm::DisplayFuncResults(&rets).to_string(), "[str(\"hello world\"), int(42), str(\"wizer is better with wave\")]");
+    assert_eq!(
+        wasm_wave::wasm::DisplayFuncResults(&rets).to_string(),
+        "[str(\"hello world\"), int(42), str(\"wizer is better with wave\")]"
+    );
 
     let out = run_wasm(&wizened_component).await.context("run_wasm")?;
     assert_eq!(

--- a/crates/wizer/tests/all/component.rs
+++ b/crates/wizer/tests/all/component.rs
@@ -1,3 +1,5 @@
+use wasmtime::component::wasm_wave;
+use wasmtime::component::wit_parser::ItemName;
 use wasmtime::component::{Component, Instance, Linker, ResourceTable, Val};
 use wasmtime::{Engine, Result, Store, ToWasmtimeResult as _, bail, error::Context as _};
 use wasmtime_wasi::{WasiCtx, WasiCtxBuilder, WasiCtxView, WasiView, p2};
@@ -699,6 +701,68 @@ async fn rust_regex() -> Result<()> {
     run_wasm(1, 42, &wizened_component)
         .await
         .context("run_wasm")?;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn component_interfaces() -> Result<()> {
+    async fn run_wasm(wasm: &[u8]) -> Result<String> {
+        let mut store = store()?;
+        let module =
+            Component::new(store.engine(), wasm).context("Wasm test case failed to compile")?;
+
+        let mut linker = Linker::new(store.engine());
+        p2::add_to_linker_async(&mut linker)?;
+        let instance = linker.instantiate_async(&mut store, &module).await?;
+
+        let run = instance
+            .get_func(
+                &mut store,
+                "local:local/run.get-inits@0.1.0"
+                    .parse::<ItemName>()
+                    .unwrap(),
+            )
+            .ok_or_else(|| {
+                wasmtime::format_err!("the test Wasm component does not export a `local:local/run.get-init@0.1.0` function")
+            })?;
+
+        let mut actual = [Val::U8(0)];
+        run.call_async(&mut store, &[], &mut actual).await?;
+        Ok(wasm_wave::to_string(&actual[0])?)
+    }
+
+    let _ = env_logger::try_init();
+    let component = test_programs_artifacts::wizer_component_interfaces_component_bytes!();
+
+    let mut store = store()?;
+
+    let wizened_component = Wizer::new()
+        .init_func("local:local/init.add-string@0.1.0(\"hello, world\")")
+        .keep_init_func(true)
+        .run_component(&mut store, component, instantiate)
+        .await
+        .context("Wizer::run_component")?;
+
+    let wizened_component = Wizer::new()
+        .init_func("local:local/init.add-int@0.1.0(42)")
+        .keep_init_func(true)
+        .run_component(&mut store, &wizened_component, instantiate)
+        .await
+        .context("Wizer::run_component")?;
+
+    let wizened_component = Wizer::new()
+        .init_func("local:local/init.add-string@0.1.0(\"wizer is better with wave\")")
+        .keep_init_func(true)
+        .run_component(&mut store, &wizened_component, instantiate)
+        .await
+        .context("Wizer::run_component")?;
+
+    let out = run_wasm(&wizened_component).await.context("run_wasm")?;
+    assert_eq!(
+        out,
+        "[str(\"hello, world\"), int(42), str(\"wizer is better with wave\")]"
+    );
 
     Ok(())
 }

--- a/crates/wizer/tests/all/component.rs
+++ b/crates/wizer/tests/all/component.rs
@@ -747,7 +747,7 @@ async fn component_interfaces() -> Result<()> {
         .context("Wizer::run_component")?;
     assert_eq!(
         wasm_wave::wasm::DisplayFuncResults(&rets).to_string(),
-        "[str(\"hello world\")]"
+        "[str(\"hello, world\")]"
     );
 
     let (wizened_component, rets) = Wizer::new()
@@ -758,10 +758,10 @@ async fn component_interfaces() -> Result<()> {
         .context("Wizer::run_component")?;
     assert_eq!(
         wasm_wave::wasm::DisplayFuncResults(&rets).to_string(),
-        "[str(\"hello world\"), int(42)]"
+        "[str(\"hello, world\"), int(42)]"
     );
 
-    let (wizened_component, _) = Wizer::new()
+    let (wizened_component, rets) = Wizer::new()
         .init_func("local:local/init.add-string@0.1.0(\"wizer is better with wave\")")
         .keep_init_func(true)
         .run_component(&mut store, &wizened_component, instantiate)
@@ -769,7 +769,7 @@ async fn component_interfaces() -> Result<()> {
         .context("Wizer::run_component")?;
     assert_eq!(
         wasm_wave::wasm::DisplayFuncResults(&rets).to_string(),
-        "[str(\"hello world\"), int(42), str(\"wizer is better with wave\")]"
+        "[str(\"hello, world\"), int(42), str(\"wizer is better with wave\")]"
     );
 
     let out = run_wasm(&wizened_component).await.context("run_wasm")?;

--- a/crates/wizer/tests/all/component.rs
+++ b/crates/wizer/tests/all/component.rs
@@ -165,14 +165,16 @@ async fn wizen(wasm: &[u8]) -> Result<Vec<u8>> {
         wasmprinter::print_bytes(&wasm).unwrap()
     );
     let mut store = store()?;
-    let wasm = Wizer::new()
+    let (wasm, rets) = Wizer::new()
         .run_component(&mut store, &wasm, instantiate)
         .await?;
     log::debug!(
         "=== Wizened Wasm ==========================================================\n\
       {}\n\
-      ===========================================================================",
-        wasmprinter::print_bytes(&wasm).unwrap()
+      ===========================================================================\n
+        {}\n",
+        wasmprinter::print_bytes(&wasm).unwrap(),
+        wasm_wave::wasm::DisplayFuncResults(&rets),
     );
     if log::log_enabled!(log::Level::Debug) {
         std::fs::write("test.wasm", &wasm).unwrap();
@@ -692,7 +694,7 @@ async fn rust_regex() -> Result<()> {
     // Wizer directly here because, currently, this test is broken if
     // `keep_init_func(true)` is not set.
     let mut store = store()?;
-    let wizened_component = Wizer::new()
+    let (wizened_component, _) = Wizer::new()
         .keep_init_func(true)
         .run_component(&mut store, component, instantiate)
         .await
@@ -737,26 +739,29 @@ async fn component_interfaces() -> Result<()> {
 
     let mut store = store()?;
 
-    let wizened_component = Wizer::new()
+    let (wizened_component, rets) = Wizer::new()
         .init_func("local:local/init.add-string@0.1.0(\"hello, world\")")
         .keep_init_func(true)
         .run_component(&mut store, component, instantiate)
         .await
         .context("Wizer::run_component")?;
+    assert_eq!(wasm_wave::wasm::DisplayFuncResults(&rets).to_string(), "[str(\"hello world\")]");
 
-    let wizened_component = Wizer::new()
+    let (wizened_component, rets) = Wizer::new()
         .init_func("local:local/init.add-int@0.1.0(42)")
         .keep_init_func(true)
         .run_component(&mut store, &wizened_component, instantiate)
         .await
         .context("Wizer::run_component")?;
+    assert_eq!(wasm_wave::wasm::DisplayFuncResults(&rets).to_string(), "[str(\"hello world\"), int(42)]");
 
-    let wizened_component = Wizer::new()
+    let (wizened_component, _) = Wizer::new()
         .init_func("local:local/init.add-string@0.1.0(\"wizer is better with wave\")")
         .keep_init_func(true)
         .run_component(&mut store, &wizened_component, instantiate)
         .await
         .context("Wizer::run_component")?;
+    assert_eq!(wasm_wave::wasm::DisplayFuncResults(&rets).to_string(), "[str(\"hello world\"), int(42), str(\"wizer is better with wave\")]");
 
     let out = run_wasm(&wizened_component).await.context("run_wasm")?;
     assert_eq!(

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -42,7 +42,17 @@ pub struct RunCommand {
     #[expect(missing_docs, reason = "don't want to mess with clap doc-strings")]
     pub run: RunCommon,
 
-    /// The name of the function to run
+    /// The the function to run
+    ///
+    /// When used with modules, this must be the export name of a function.
+    /// Arguments to the function are parsed from trailing arguments provided
+    /// after all options.
+    ///
+    /// When used with components, this must be a wave-encoded function call,
+    /// e.g. `wasi:cli/run.run@0.2.0()` or
+    /// `your:pkg/iface.func("arguments in wave encoding")`. Bare function
+    /// names (e.g. `run()`) are accepted and searched for in all exported
+    /// instances, and must be unambigious.
     #[arg(long, value_name = "FUNCTION")]
     pub invoke: Option<String>,
 

--- a/src/commands/wizer.rs
+++ b/src/commands/wizer.rs
@@ -74,13 +74,19 @@ impl WizerCommand {
         let wasm = wat::parse_bytes(&wasm)?;
         let is_component = wasmparser::Parser::is_component(&wasm);
 
+        let init_func = self.wizer.get_init_func();
+
         let mut run = RunCommand {
             run: self.run,
             argv0: None,
             invoke: Some(if is_component {
-                format!("{}()", self.wizer.get_init_func())
+                if !init_func.contains(')') {
+                    format!("{init_func}()")
+                } else {
+                    init_func.to_string()
+                }
             } else {
-                self.wizer.get_init_func().to_string()
+                init_func.to_string()
             }),
             module_and_args: vec![self.input.clone().into()],
             preloads: self.preloads.clone(),

--- a/tests/all/cli_tests.rs
+++ b/tests/all/cli_tests.rs
@@ -3403,7 +3403,7 @@ fn wizer_components() -> Result<()> {
 #[test]
 fn wizer_components_wave() -> Result<()> {
     let dir = tempfile::tempdir()?;
-    run_wasmtime(&[
+    let output = run_wasmtime(&[
         "wizer",
         "-Scli",
         "-Ccache=n",
@@ -3415,6 +3415,8 @@ fn wizer_components_wave() -> Result<()> {
         dir.path().join("stage1.wasm").to_str().unwrap(),
     ])?;
 
+    assert_eq!(output, "[str(\"hello, world\")]\n");
+
     let output = run_wasmtime(&[
         "run",
         "--invoke",
@@ -3425,7 +3427,7 @@ fn wizer_components_wave() -> Result<()> {
 
     assert_eq!(output, "[str(\"hello, world\")]\n");
 
-    run_wasmtime(&[
+    let output = run_wasmtime(&[
         "wizer",
         "-Scli",
         "-Ccache=n",
@@ -3436,8 +3438,9 @@ fn wizer_components_wave() -> Result<()> {
         "-o",
         dir.path().join("stage2.wasm").to_str().unwrap(),
     ])?;
+    assert_eq!(output, "[str(\"hello, world\"), int(12345)]\n");
 
-    run_wasmtime(&[
+    let output = run_wasmtime(&[
         "wizer",
         "-Scli",
         "-Ccache=n",
@@ -3448,6 +3451,10 @@ fn wizer_components_wave() -> Result<()> {
         "-o",
         dir.path().join("stage3.wasm").to_str().unwrap(),
     ])?;
+    assert_eq!(
+        output,
+        "[str(\"hello, world\"), int(12345), str(\"wave is pretty cool\")]\n"
+    );
 
     let output = run_wasmtime(&[
         "run",

--- a/tests/all/cli_tests.rs
+++ b/tests/all/cli_tests.rs
@@ -3296,7 +3296,7 @@ fn big_table_in_pooling_allocator() -> Result<()> {
     Ok(())
 }
 
-fn wizen(args: &[&str], wat: &str) -> Result<Output> {
+fn wizen(args: &[&str], wasm: impl AsRef<[u8]>) -> Result<Output> {
     let mut cmd = get_wasmtime_command()?;
     cmd.arg("wizer").args(args).arg("-");
     cmd.stdin(Stdio::piped())
@@ -3304,7 +3304,7 @@ fn wizen(args: &[&str], wat: &str) -> Result<Output> {
         .stderr(Stdio::piped());
     let mut child = cmd.spawn()?;
     let mut stdin = child.stdin.take().unwrap();
-    stdin.write_all(wat.as_bytes())?;
+    stdin.write_all(wasm.as_ref())?;
     drop(stdin);
 
     let output = child.wait_with_output()?;
@@ -3397,6 +3397,70 @@ fn wizer_components() -> Result<()> {
     let result = wizen(&["-Scli"], component_with_wasi)?;
     assert!(result.status.success());
 
+    Ok(())
+}
+
+#[test]
+fn wizer_components_wave() -> Result<()> {
+    let dir = tempfile::tempdir()?;
+    run_wasmtime(&[
+        "wizer",
+        "-Scli",
+        "-Ccache=n",
+        "--keep-init-func=true",
+        "--init-func",
+        "local:local/init.add-string@0.1.0(\"hello, world\")",
+        test_programs_artifacts::WIZER_COMPONENT_INTERFACES_COMPONENT,
+        "-o",
+        dir.path().join("stage1.wasm").to_str().unwrap(),
+    ])?;
+
+    let output = run_wasmtime(&[
+        "run",
+        "--invoke",
+        "local:local/run.get-inits@0.1.0()",
+        "-Ccache=n",
+        dir.path().join("stage1.wasm").to_str().unwrap(),
+    ])?;
+
+    assert_eq!(output, "[str(\"hello, world\")]\n");
+
+    run_wasmtime(&[
+        "wizer",
+        "-Scli",
+        "-Ccache=n",
+        "--keep-init-func=true",
+        "--init-func",
+        "local:local/init.add-int@0.1.0(12345)",
+        dir.path().join("stage1.wasm").to_str().unwrap(),
+        "-o",
+        dir.path().join("stage2.wasm").to_str().unwrap(),
+    ])?;
+
+    run_wasmtime(&[
+        "wizer",
+        "-Scli",
+        "-Ccache=n",
+        "--keep-init-func=true",
+        "--init-func",
+        "local:local/init.add-string@0.1.0(\"wave is pretty cool\")",
+        dir.path().join("stage2.wasm").to_str().unwrap(),
+        "-o",
+        dir.path().join("stage3.wasm").to_str().unwrap(),
+    ])?;
+
+    let output = run_wasmtime(&[
+        "run",
+        "--invoke",
+        "local:local/run.get-inits@0.1.0()",
+        "-Ccache=n",
+        dir.path().join("stage3.wasm").to_str().unwrap(),
+    ])?;
+
+    assert_eq!(
+        output,
+        "[str(\"hello, world\"), int(12345), str(\"wave is pretty cool\")]\n"
+    );
     Ok(())
 }
 


### PR DESCRIPTION
Wizer now supports wave function call expressions being used as an init func for components, e.g. `local:local/init.add-string@0.1.0("hello, world")`

This works from both the crate interface and the wasmtime-cli interface.

When `wasmtime wizer --init-func (func expr)` is used with a component, it will print the function results in wave to stdout. This opens up a clever mode where you can use a component on disk as a stateful rpc server with wave encoding for the request and response.

The diff for the change is straightforward. New test-program to exercise, and a test exercising this functionality has been added to the wizer crate and wasmtime-cli.

Docs for the wasmtime-cli options were updated, including a case I missed from `run --invoke` in #13564 