### PR TITLE
Cranelift: add `_imm_s`/`_imm_u` instruction builder helpers

### DIFF
--- a/cranelift/codegen/meta/src/gen_inst.rs
+++ b/cranelift/codegen/meta/src/gen_inst.rs
@@ -1346,14 +1346,19 @@ fn gen_inst_builder(inst: &Instruction, format: &InstructionFormat, fmt: &mut Fo
     });
 }
 
-/// Emit an additional `{name}_imm` convenience method for `inst`, requested via
-/// `.inst_builder_imm_method(true)`.
+/// Emit the `{name}_imm_s`, `{name}_imm_u`, and (deprecated) `{name}_imm`
+/// convenience methods for `inst`, requested via `.inst_builder_imm_method(true)`.
 ///
-/// The generated method has the same shape as `inst`'s normal builder method,
+/// Each generated method has the same shape as `inst`'s normal builder method,
 /// except that its trailing value operand is taken as an `Into<Imm64>`
-/// immediate. That immediate is materialized as an `iconst` (sign- or
-/// zero-extended to the controlling type as needed, see
-/// `InstBuilder::build_imm_const`) and then `inst` is built with it.
+/// immediate. That immediate is materialized as an `iconst` (extended to the
+/// controlling type as needed, see `InstBuilder::build_imm_const`) and then
+/// `inst` is built with it. The `_imm_s` variant sign-extends the immediate
+/// while `_imm_u` zero-extends it; this only matters for `i128`.
+///
+/// The bare `_imm` method is kept around for backwards-compatibility, with the
+/// sign-/zero-extension behavior the now-removed `*_imm` instructions used to
+/// have. It is deprecated in favor of the explicit `_imm_s`/`_imm_u` variants.
 fn gen_imm_inst_builder(inst: &Instruction, fmt: &mut Formatter) {
     // Only the simple, fixed-operand, single-result integer instructions that
     // used to have a `binary_imm64`/`int_compare_imm` counterpart are
@@ -1376,6 +1381,36 @@ fn gen_imm_inst_builder(inst: &Instruction, fmt: &mut Formatter) {
         inst.value_opnums.len()
     );
 
+    // Whether the now-removed `*_imm` instruction historically sign-extended its
+    // immediate. This is what the deprecated bare `_imm` method preserves.
+    let historically_signed = matches!(
+        inst.name.as_str(),
+        "iadd" | "imul" | "sdiv" | "srem" | "icmp"
+    );
+
+    gen_one_imm_inst_builder(inst, fmt, "_imm_s", true, None);
+    fmt.empty_line();
+    gen_one_imm_inst_builder(inst, fmt, "_imm_u", false, None);
+    fmt.empty_line();
+    let name = inst.snake_name();
+    let deprecation = format!(
+        "use `{name}_imm_s` (sign-extends the immediate) or `{name}_imm_u` \
+         (zero-extends the immediate) instead",
+    );
+    gen_one_imm_inst_builder(inst, fmt, "_imm", historically_signed, Some(&deprecation));
+}
+
+/// Emit a single immediate convenience method for `inst` with the given method
+/// name `suffix` (e.g. `"_imm_s"`). `signed` selects sign- vs zero-extension of
+/// the materialized immediate, and `deprecation`, if set, marks the method
+/// `#[deprecated]` with the given note.
+fn gen_one_imm_inst_builder(
+    inst: &Instruction,
+    fmt: &mut Formatter,
+    suffix: &str,
+    signed: bool,
+    deprecation: Option<&str>,
+) {
     // The immediate replaces the trailing value operand; the first value
     // operand provides the controlling type for the synthesized `iconst`.
     let imm_opnum = *inst.value_opnums.last().unwrap();
@@ -1399,15 +1434,20 @@ fn gen_imm_inst_builder(inst: &Instruction, fmt: &mut Formatter) {
     }
 
     let proto = format!(
-        "{}_imm<T: Into<ir::immediates::Imm64>>({}) -> Value",
+        "{}{suffix}<T: Into<ir::immediates::Imm64>>({}) -> Value",
         inst.snake_name(),
         args.join(", "),
     );
 
+    let extends = if signed {
+        "sign-extended"
+    } else {
+        "zero-extended"
+    };
     fmt.doc_comment(format!(
         "Convenience method that is like [`{name}`][Self::{name}], but takes its \
          trailing operand as an immediate integer constant which is materialized \
-         with an `iconst`.",
+         with an `iconst` and {extends} to the controlling type.",
         name = inst.snake_name(),
     ));
     fmt.line("///");
@@ -1417,6 +1457,9 @@ fn gen_imm_inst_builder(inst: &Instruction, fmt: &mut Formatter) {
         fmt.doc_comment(doc_line);
     }
 
+    if let Some(note) = deprecation {
+        fmtln!(fmt, "#[deprecated(note = \"{note}\")]");
+    }
     fmt.line("#[allow(non_snake_case, reason = \"generated code\")]");
     fmt.add_block(&format!("fn {proto}"), |fmt| {
         fmtln!(fmt, "let {imm_name} = {imm_name}.into();");
@@ -1426,8 +1469,7 @@ fn gen_imm_inst_builder(inst: &Instruction, fmt: &mut Formatter) {
         );
         fmtln!(
             fmt,
-            "let {imm_name} = self.build_imm_const(imm_ty, {imm_name}, Opcode::{});",
-            inst.camel_name
+            "let {imm_name} = self.build_imm_const(imm_ty, {imm_name}, {signed});",
         );
         let call_args = inst
             .operands_in

--- a/cranelift/codegen/src/ir/builder.rs
+++ b/cranelift/codegen/src/ir/builder.rs
@@ -46,20 +46,11 @@ pub trait InstBuilderBase<'f>: Sized {
     ///
     /// The constant's type is `controlling_type`, or, for vector controlling
     /// types, its lane type. Because `iconst` only supports `i8` through `i64`,
-    /// an `i128` constant is built as an `iconst.i64` that is then sign- or
-    /// zero-extended.
-    ///
-    /// Whether the immediate is sign- or zero-extended matches the historical
-    /// semantics of the `*_imm` instruction for `base_opcode`:
-    ///
-    /// * Sign-extended: `iadd`, `imul`, `sdiv`, `srem`, and `icmp`
-    /// * Zero-extended: Everything else
-    fn build_imm_const(
-        &mut self,
-        controlling_type: Type,
-        imm: Imm64,
-        base_opcode: Opcode,
-    ) -> Value {
+    /// an `i128` constant is built as an `iconst.i64` that is then extended:
+    /// sign-extended when `signed` is true, zero-extended otherwise. For narrower
+    /// types the `signed` flag has no effect, as the masked immediate is the same
+    /// either way.
+    fn build_imm_const(&mut self, controlling_type: Type, imm: Imm64, signed: bool) -> Value {
         if controlling_type == types::I128 {
             let mut data = InstructionData::UnaryImm {
                 opcode: Opcode::Iconst,
@@ -69,12 +60,7 @@ pub trait InstBuilderBase<'f>: Sized {
             let lo = self.build_aux_inst(data, types::I64);
             let lo = self.data_flow_graph().first_result(lo);
 
-            // The immediates of these instructions were historically sign-extended
-            // by their `*_imm` variants; all the others were zero-extended.
-            let opcode = if matches!(
-                base_opcode,
-                Opcode::Iadd | Opcode::Imul | Opcode::Sdiv | Opcode::Srem | Opcode::Icmp
-            ) {
+            let opcode = if signed {
                 Opcode::Sextend
             } else {
                 Opcode::Uextend
@@ -343,7 +329,7 @@ mod tests {
         let mut pos = FuncCursor::new(&mut func);
         pos.insert_block(block0);
 
-        let v0 = pos.ins().iadd_imm(arg0, 17);
+        let v0 = pos.ins().iadd_imm_s(arg0, 17);
         assert_eq!(pos.func.dfg.value_type(v0), I32);
         let iadd = pos.prev_inst().unwrap();
         assert_eq!(pos.func.dfg.value_def(v0), ValueDef::Result(iadd, 0));
@@ -376,7 +362,7 @@ mod tests {
         let inst = func.layout.last_inst(block0).unwrap();
         assert_eq!(func.dfg.insts[inst].opcode(), Opcode::Icmp);
 
-        let result = func.replace(inst).icmp_imm(IntCC::Equal, arg0, 42);
+        let result = func.replace(inst).icmp_imm_s(IntCC::Equal, arg0, 42);
 
         // The replaced instruction is still an `icmp`, now comparing against a
         // freshly materialized constant.
@@ -389,6 +375,39 @@ mod tests {
         let iconst_result = func.dfg.first_result(iconst);
         assert_eq!(func.dfg.value_type(iconst_result), I32);
         assert_eq!(func.dfg.inst_args(inst), &[arg0, iconst_result]);
+    }
+
+    #[test]
+    fn imm_s_and_imm_u_extend_i128() {
+        // For an `i128` controlling type the immediate is materialized as an
+        // `iconst.i64` and then extended. `_imm_s` sign-extends, `_imm_u`
+        // zero-extends, and the deprecated `_imm` keeps the historical behavior
+        // (signed, for `iadd`).
+        let mut func = Function::new();
+        let block0 = func.dfg.make_block();
+        let arg = func.dfg.append_block_param(block0, I128);
+        let mut pos = FuncCursor::new(&mut func);
+        pos.insert_block(block0);
+
+        // Opcode of the instruction that extends `iadd`'s materialized immediate.
+        fn ext_opcode(pos: &FuncCursor, iadd: crate::ir::Inst) -> Opcode {
+            let imm = pos.func.dfg.inst_args(iadd)[1];
+            let ext = pos.func.dfg.value_def(imm).unwrap_inst();
+            pos.func.dfg.insts[ext].opcode()
+        }
+
+        pos.ins().iadd_imm_s(arg, -1);
+        let iadd = pos.prev_inst().unwrap();
+        assert_eq!(ext_opcode(&pos, iadd), Opcode::Sextend);
+
+        pos.ins().iadd_imm_u(arg, -1);
+        let iadd = pos.prev_inst().unwrap();
+        assert_eq!(ext_opcode(&pos, iadd), Opcode::Uextend);
+
+        #[allow(deprecated, reason = "exercising the deprecated `_imm` shim")]
+        pos.ins().iadd_imm(arg, -1);
+        let iadd = pos.prev_inst().unwrap();
+        assert_eq!(ext_opcode(&pos, iadd), Opcode::Sextend);
     }
 
     #[test]

--- a/cranelift/frontend/src/frontend.rs
+++ b/cranelift/frontend/src/frontend.rs
@@ -1156,7 +1156,7 @@ impl<'a> FunctionBuilder<'a> {
         let pointer_type = config.pointer_type();
         let size = self.ins().iconst(pointer_type, size as i64);
         let cmp = self.call_memcmp(config, left, right, size);
-        self.ins().icmp_imm(zero_cc, cmp, 0)
+        self.ins().icmp_imm_s(zero_cc, cmp, 0)
     }
 }
 

--- a/cranelift/frontend/src/frontend/safepoints.rs
+++ b/cranelift/frontend/src/frontend/safepoints.rs
@@ -1065,7 +1065,7 @@ block0:
         // a value as keeping it live, regardless if the use has side effects or
         // is otherwise itself live, so an `iadd_imm` suffices to keep `v1` live
         // here.
-        builder.ins().iadd_imm(v1, 0);
+        builder.ins().iadd_imm_s(v1, 0);
         builder.ins().return_(&[]);
 
         builder.seal_all_blocks();
@@ -1157,7 +1157,7 @@ block3:
         // a value as keeping it live, regardless if the use has side effects or
         // is otherwise itself live, so an `iadd_imm` suffices to keep `v1` live
         // here.
-        builder.ins().iadd_imm(v1, 0);
+        builder.ins().iadd_imm_s(v1, 0);
         builder.ins().return_(&[]);
 
         builder.seal_all_blocks();
@@ -1226,7 +1226,7 @@ block2:
         builder.ins().brif(v0, block1, &[], block2, &[]);
 
         builder.switch_to_block(block1);
-        builder.ins().iadd_imm(v1, 0);
+        builder.ins().iadd_imm_s(v1, 0);
         builder.ins().return_(&[]);
 
         builder.switch_to_block(block2);
@@ -1318,7 +1318,7 @@ block2:
         // a value as keeping it live, regardless if the use has side effects or
         // is otherwise itself live, so an `iadd_imm` suffices to keep `v1` live
         // here.
-        builder.ins().iadd_imm(v1, 0);
+        builder.ins().iadd_imm_s(v1, 0);
         builder.ins().return_(&[]);
 
         builder.seal_all_blocks();
@@ -1386,7 +1386,7 @@ block2:
         builder.ins().brif(v0, block1, &[], block2, &[]);
 
         builder.switch_to_block(block1);
-        builder.ins().iadd_imm(v1, 0);
+        builder.ins().iadd_imm_s(v1, 0);
         builder.ins().return_(&[]);
 
         builder.switch_to_block(block2);
@@ -1498,7 +1498,7 @@ block2:
         // a value as keeping it live, regardless if the use has side effects or
         // is otherwise itself live, so an `iadd_imm` suffices to keep `v1` live
         // here.
-        builder.ins().iadd_imm(v1, 0);
+        builder.ins().iadd_imm_s(v1, 0);
         builder.ins().return_(&[]);
 
         builder.seal_all_blocks();
@@ -2412,7 +2412,7 @@ block4:
         builder.ins().call(foo_func_ref, &[]);
         builder.ins().call(bar_func_ref, &[v1]);
         builder.ins().call(foo_func_ref, &[]);
-        let v5 = builder.ins().iadd_imm(v4, -1);
+        let v5 = builder.ins().iadd_imm_s(v4, -1);
         builder.ins().brif(v4, block1, &[v5.into()], block3, &[]);
 
         builder.switch_to_block(block3);

--- a/cranelift/frontend/src/ssa.rs
+++ b/cranelift/frontend/src/ssa.rs
@@ -1047,7 +1047,7 @@ mod tests {
         let x3 = ssa.use_var(&mut func, x_var, I32, block2).0;
         let x4 = {
             let mut cur = FuncCursor::new(&mut func).at_bottom(block2);
-            cur.ins().iadd_imm(x3, 1)
+            cur.ins().iadd_imm_s(x3, 1)
         };
         ssa.def_var(x_var, x4, block2);
         {

--- a/cranelift/frontend/src/switch.rs
+++ b/cranelift/frontend/src/switch.rs
@@ -225,7 +225,8 @@ impl Switch {
             val
         } else {
             if let Ok(first_index) = u64::try_from(first_index) {
-                bx.ins().iadd_imm(val, (first_index as i64).wrapping_neg())
+                bx.ins()
+                    .iadd_imm_s(val, (first_index as i64).wrapping_neg())
             } else {
                 let (lsb, msb) = (first_index as u64, (first_index >> 64) as u64);
                 let lsb = bx.ins().iconst(types::I64, lsb as i64);
@@ -241,7 +242,7 @@ impl Switch {
                 let new_block = bx.create_block();
                 let bigger_than_u32 =
                     bx.ins()
-                        .icmp_imm(IntCC::UnsignedGreaterThan, discr, u32::MAX as i64);
+                        .icmp_imm_s(IntCC::UnsignedGreaterThan, discr, u32::MAX as i64);
                 bx.ins()
                     .brif(bigger_than_u32, otherwise, &[], new_block, &[]);
                 bx.seal_block(new_block);
@@ -281,9 +282,9 @@ impl Switch {
 fn icmp_imm_u128(bx: &mut FunctionBuilder, cond: IntCC, x: Value, y: u128) -> Value {
     if bx.func.dfg.value_type(x) != types::I128 {
         assert!(u64::try_from(y).is_ok());
-        bx.ins().icmp_imm(cond, x, y as i64)
+        bx.ins().icmp_imm_s(cond, x, y as i64)
     } else if let Ok(index) = i64::try_from(y) {
-        bx.ins().icmp_imm(cond, x, index)
+        bx.ins().icmp_imm_s(cond, x, index)
     } else {
         let (lsb, msb) = (y as u64, (y >> 64) as u64);
         let lsb = bx.ins().iconst(types::I64, lsb as i64);

--- a/cranelift/fuzzgen/src/function_generator.rs
+++ b/cranelift/fuzzgen/src/function_generator.rs
@@ -345,7 +345,7 @@ fn insert_atomic_rmw(
     let (address, flags, offset) = fgen.generate_address_and_memflags(builder, type_size, true)?;
 
     // AtomicRMW does not directly support offsets, so add the offset to the address separately.
-    let address = builder.ins().iadd_imm(address, i64::from(offset));
+    let address = builder.ins().iadd_imm_s(address, i64::from(offset));
 
     // Load and store target variables
     let source_var = fgen.get_variable_of_type(ctrl_type)?;
@@ -373,7 +373,7 @@ fn insert_atomic_cas(
     let (address, flags, offset) = fgen.generate_address_and_memflags(builder, type_size, true)?;
 
     // AtomicCas does not directly support offsets, so add the offset to the address separately.
-    let address = builder.ins().iadd_imm(address, i64::from(offset));
+    let address = builder.ins().iadd_imm_s(address, i64::from(offset));
 
     // Source and Target variables
     let expected_var = fgen.get_variable_of_type(ctrl_type)?;

--- a/cranelift/fuzzgen/src/passes/int_divz.rs
+++ b/cranelift/fuzzgen/src/passes/int_divz.rs
@@ -53,7 +53,7 @@ fn insert_int_divz_sequence(pos: &mut FuncCursor, inst: Inst) {
         // Srem and Sdiv can also trap on INT_MIN / -1. So we need to check for the second one
 
         // 1 << (ty bits - 1) to get INT_MIN
-        let int_min = pos.ins().ishl_imm(one, ty.lane_bits() as i64 - 1);
+        let int_min = pos.ins().ishl_imm_u(one, ty.lane_bits() as i64 - 1);
 
         // Get a -1 const
         // TODO: A iconst -1 would be clearer, but #2906 makes this impossible for i128

--- a/crates/cranelift/src/compiler.rs
+++ b/crates/cranelift/src/compiler.rs
@@ -275,7 +275,7 @@ impl Compiler {
                 vmstore_ctx_ptr,
                 i32::from(ptr_size.vmstore_context_execution_version()),
             );
-            let new_version = builder.ins().iadd_imm(old_version, 1);
+            let new_version = builder.ins().iadd_imm_s(old_version, 1);
             builder.ins().store(
                 MemFlagsData::trusted(),
                 new_version,
@@ -1359,7 +1359,7 @@ impl Compiler {
         if !self.emit_debug_checks {
             return;
         }
-        let enough_capacity = builder.ins().icmp_imm(
+        let enough_capacity = builder.ins().icmp_imm_s(
             ir::condcodes::IntCC::UnsignedGreaterThanOrEqual,
             capacity,
             ir::immediates::Imm64::new(length.try_into().unwrap()),
@@ -1382,7 +1382,7 @@ impl Compiler {
             vmctx,
             0,
         );
-        let is_expected_vmctx = builder.ins().icmp_imm(
+        let is_expected_vmctx = builder.ins().icmp_imm_s(
             ir::condcodes::IntCC::Equal,
             magic,
             i64::from(expected_vmctx_magic),

--- a/crates/cranelift/src/compiler/component.rs
+++ b/crates/cranelift/src/compiler/component.rs
@@ -1228,7 +1228,7 @@ impl<'a> TrampolineCompiler<'a> {
         // Conditionally emit destructor-execution code based on whether we
         // statically know that a destructor exists or not.
         if has_destructor {
-            let rep = self.builder.ins().ushr_imm(should_run_destructor, 1);
+            let rep = self.builder.ins().ushr_imm_u(should_run_destructor, 1);
             let rep = self.builder.ins().ireduce(ir::types::I32, rep);
             let index = self.types[resource].unwrap_concrete_ty();
             // NB: despite the vmcontext storing nullable funcrefs for function
@@ -1514,7 +1514,7 @@ impl<'a> TrampolineCompiler<'a> {
         let may_leave_bit = self
             .builder
             .ins()
-            .band_imm(flags, i64::from(FLAG_MAY_LEAVE));
+            .band_imm_u(flags, i64::from(FLAG_MAY_LEAVE));
         let (mut traps, builder) = self.traps();
         traps.trapz(builder, may_leave_bit, TRAP_CANNOT_LEAVE_COMPONENT);
     }

--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -635,7 +635,7 @@ impl<'module_environment> FuncEnvironment<'module_environment> {
         }
 
         let fuel = builder.use_var(self.fuel_var);
-        let fuel = builder.ins().iadd_imm(fuel, consumption);
+        let fuel = builder.ins().iadd_imm_s(fuel, consumption);
         builder.def_var(self.fuel_var, fuel);
     }
 
@@ -987,7 +987,7 @@ impl<'module_environment> FuncEnvironment<'module_environment> {
                     // lengths (in pages) that have the sign bit set.
                     let extended = pos.ins().uextend(desired_type, val);
                     let neg_one = pos.ins().iconst(desired_type, -1);
-                    let is_failure = pos.ins().icmp_imm(IntCC::Equal, val, -1);
+                    let is_failure = pos.ins().icmp_imm_s(IntCC::Equal, val, -1);
                     pos.ins().select(is_failure, neg_one, extended)
                 }
             }
@@ -1024,7 +1024,7 @@ impl<'module_environment> FuncEnvironment<'module_environment> {
         // always -2 so assert that part doesn't change and then thread through
         // -2 as the immediate.
         assert_eq!(FUNCREF_MASK as isize, -2);
-        let value_masked = builder.ins().band_imm(value, Imm64::from(-2));
+        let value_masked = builder.ins().band_imm_u(value, Imm64::from(-2));
 
         let null_block = builder.create_block();
         let continuation_block = builder.create_block();
@@ -2718,7 +2718,7 @@ impl FuncEnvironment<'_> {
         let value_with_init_bit = if self.tunables.table_lazy_init {
             builder
                 .ins()
-                .bor_imm(value, Imm64::from(FUNCREF_INIT_BIT as i64))
+                .bor_imm_u(value, Imm64::from(FUNCREF_INIT_BIT as i64))
         } else {
             value
         };
@@ -2753,10 +2753,10 @@ impl FuncEnvironment<'_> {
         val: ir::Value,
     ) -> WasmResult<ir::Value> {
         debug_assert_eq!(pos.func.dfg.value_type(val), ir::types::I32);
-        let shifted = pos.ins().ishl_imm(val, 1);
+        let shifted = pos.ins().ishl_imm_u(val, 1);
         let tagged = pos
             .ins()
-            .bor_imm(shifted, i64::from(crate::I31_REF_DISCRIMINANT));
+            .bor_imm_u(shifted, i64::from(crate::I31_REF_DISCRIMINANT));
         let (ref_ty, _needs_stack_map) = self.reference_type(WasmHeapType::I31);
         debug_assert_eq!(ref_ty, ir::types::I32);
         Ok(tagged)
@@ -2771,7 +2771,7 @@ impl FuncEnvironment<'_> {
         // null i31)`, we could omit the `trapz`. But plumbing that type info
         // from `wasmparser` and through to here is a bit funky.
         self.trapz(builder, i31ref, crate::TRAP_NULL_REFERENCE);
-        Ok(builder.ins().sshr_imm(i31ref, 1))
+        Ok(builder.ins().sshr_imm_u(i31ref, 1))
     }
 
     pub fn translate_i31_get_u(
@@ -2783,7 +2783,7 @@ impl FuncEnvironment<'_> {
         // null i31)`, we could omit the `trapz`. But plumbing that type info
         // from `wasmparser` and through to here is a bit funky.
         self.trapz(builder, i31ref, crate::TRAP_NULL_REFERENCE);
-        Ok(builder.ins().ushr_imm(i31ref, 1))
+        Ok(builder.ins().ushr_imm_u(i31ref, 1))
     }
 
     pub fn struct_fields_len(&mut self, struct_type_index: TypeIndex) -> WasmResult<usize> {
@@ -3125,11 +3125,11 @@ impl FuncEnvironment<'_> {
                 let (_revision, contref) =
                     stack_switching::fatpointer::deconstruct(self, &mut pos, value);
                 pos.ins()
-                    .icmp_imm(cranelift_codegen::ir::condcodes::IntCC::Equal, contref, 0)
+                    .icmp_imm_s(cranelift_codegen::ir::condcodes::IntCC::Equal, contref, 0)
             }
             _ => pos
                 .ins()
-                .icmp_imm(cranelift_codegen::ir::condcodes::IntCC::Equal, value, 0),
+                .icmp_imm_s(cranelift_codegen::ir::condcodes::IntCC::Equal, value, 0),
         };
 
         Ok(pos.ins().uextend(ir::types::I32, byte_is_null))
@@ -3195,7 +3195,7 @@ impl FuncEnvironment<'_> {
 
                 let (gv, offset) = self.get_global_location(builder.func, global_index);
                 let gv = builder.ins().global_value(self.pointer_type(), gv);
-                let src = builder.ins().iadd_imm(gv, i64::from(offset));
+                let src = builder.ins().iadd_imm_s(gv, i64::from(offset));
 
                 let flags = if global_ty.mutability || gc::gc_compiler(self)?.is_moving_collector()
                 {
@@ -3259,7 +3259,7 @@ impl FuncEnvironment<'_> {
 
                 let (gv, offset) = self.get_global_location(builder.func, global_index);
                 let gv = builder.ins().global_value(self.pointer_type(), gv);
-                let src = builder.ins().iadd_imm(gv, i64::from(offset));
+                let src = builder.ins().iadd_imm_s(gv, i64::from(offset));
 
                 let mut gc = gc::gc_compiler(self)?;
                 if initialized {
@@ -3496,8 +3496,9 @@ impl FuncEnvironment<'_> {
                             .load(pointer_type, ir::MemFlagsData::trusted(), base, offset);
                     let vmmemory_definition_offset =
                         i64::from(self.offsets.ptr.vmmemory_definition_current_length());
-                    let vmmemory_definition_ptr =
-                        pos.ins().iadd_imm(vmmemory_ptr, vmmemory_definition_offset);
+                    let vmmemory_definition_ptr = pos
+                        .ins()
+                        .iadd_imm_s(vmmemory_ptr, vmmemory_definition_offset);
                     // This atomic access of the
                     // `VMMemoryDefinition::current_length` is direct; no bounds
                     // check is needed. This is possible because shared memory
@@ -3528,8 +3529,9 @@ impl FuncEnvironment<'_> {
                 if is_shared {
                     let vmmemory_definition_offset =
                         i64::from(self.offsets.ptr.vmmemory_definition_current_length());
-                    let vmmemory_definition_ptr =
-                        pos.ins().iadd_imm(vmmemory_ptr, vmmemory_definition_offset);
+                    let vmmemory_definition_ptr = pos
+                        .ins()
+                        .iadd_imm_s(vmmemory_ptr, vmmemory_definition_offset);
                     pos.ins().atomic_load(
                         pointer_type,
                         ir::MemFlagsData::trusted(),
@@ -3555,7 +3557,9 @@ impl FuncEnvironment<'_> {
         let current_length_in_bytes = self.memory_size_in_bytes(&mut pos, index);
 
         let page_size_log2 = i64::from(self.module.memories[index].page_size_log2);
-        let current_length_in_pages = pos.ins().ushr_imm(current_length_in_bytes, page_size_log2);
+        let current_length_in_pages = pos
+            .ins()
+            .ushr_imm_u(current_length_in_bytes, page_size_log2);
         let single_byte_pages = match page_size_log2 {
             16 => false,
             0 => true,
@@ -3930,7 +3934,7 @@ impl FuncEnvironment<'_> {
         assert_eq!(builder.func.dfg.value_type(copy_len), pointer_ty);
         let elem_ty = entity.storage_type(self);
         let elem_size = entity.element_size(self, builder.func)?;
-        let copy_byte_len = builder.ins().imul_imm(copy_len, i64::from(elem_size));
+        let copy_byte_len = builder.ins().imul_imm_s(copy_len, i64::from(elem_size));
         if let CheckedEntity::Array { .. } = entity {
             self.emit_defensive_array_bounds_check(builder, dst_elem_addr, copy_byte_len)?;
         }
@@ -4001,7 +4005,7 @@ impl FuncEnvironment<'_> {
         // is then skip over the entire loop, otherwise enter the loop and
         // perform the first ieration.
         let end_addr = builder.ins().iadd(dst_elem_addr, copy_byte_len);
-        let empty = builder.ins().icmp_imm(IntCC::Equal, copy_len, 0);
+        let empty = builder.ins().icmp_imm_s(IntCC::Equal, copy_len, 0);
         builder.ins().brif(
             empty,
             continue_block,
@@ -4047,7 +4051,7 @@ impl FuncEnvironment<'_> {
             }
             _ => unreachable!(),
         }
-        let next_elem_addr = builder.ins().iadd_imm(elem_addr, i64::from(elem_size));
+        let next_elem_addr = builder.ins().iadd_imm_s(elem_addr, i64::from(elem_size));
         let done = builder.ins().icmp(IntCC::Equal, next_elem_addr, end_addr);
         builder.ins().brif(
             done,
@@ -4356,7 +4360,7 @@ impl FuncEnvironment<'_> {
             IndexType::I32 => {
                 let idx64 = builder.ins().uextend(I64, idx);
                 let len64 = builder.ins().uextend(I64, len);
-                let len64 = builder.ins().imul_imm(len64, i64::from(len_factor));
+                let len64 = builder.ins().imul_imm_s(len64, i64::from(len_factor));
                 builder.ins().iadd(idx64, len64)
             }
             IndexType::I64 => {
@@ -4427,7 +4431,7 @@ impl FuncEnvironment<'_> {
                 let layout = self.array_layout(ty)?;
                 builder
                     .ins()
-                    .iadd_imm(array_base, i64::from(layout.base_size))
+                    .iadd_imm_s(array_base, i64::from(layout.base_size))
             }
         };
         assert_eq!(builder.func.dfg.value_type(base), pointer_type);
@@ -4441,7 +4445,7 @@ impl FuncEnvironment<'_> {
             CheckedEntity::Data { .. } => idx,
             _ => {
                 let elem_size = entity.element_size(self, builder.func)?;
-                builder.ins().imul_imm(idx, i64::from(elem_size))
+                builder.ins().imul_imm_s(idx, i64::from(elem_size))
             }
         };
         Ok(builder.ins().iadd(base, byte_offset))
@@ -4596,10 +4600,10 @@ impl FuncEnvironment<'_> {
         let src_element_size = src_entity.element_size(self, builder.func)?;
         let dst_copy_byte_len = builder
             .ins()
-            .imul_imm(copy_len, i64::from(dst_element_size));
+            .imul_imm_s(copy_len, i64::from(dst_element_size));
         let src_copy_byte_len = builder
             .ins()
-            .imul_imm(copy_len, i64::from(src_element_size));
+            .imul_imm_s(copy_len, i64::from(src_element_size));
         if let CheckedEntity::Array { .. } = dst_entity {
             self.emit_defensive_array_bounds_check(builder, dst_elem_addr, dst_copy_byte_len)?;
         }
@@ -4903,10 +4907,10 @@ impl FuncEnvironment<'_> {
         let src_element_size = src_entity.element_size(self, builder.func)?;
         let dst_copy_byte_len = builder
             .ins()
-            .imul_imm(copy_len, i64::from(dst_element_size));
+            .imul_imm_s(copy_len, i64::from(dst_element_size));
         let src_copy_byte_len = builder
             .ins()
-            .imul_imm(copy_len, i64::from(src_element_size));
+            .imul_imm_s(copy_len, i64::from(src_element_size));
         let dst_end_addr = builder.ins().iadd(dst_elem_addr, dst_copy_byte_len);
         let src_end_addr = builder.ins().iadd(src_elem_addr, src_copy_byte_len);
         let copy_len_as_src_index_ty = match (self.pointer_type(), src_index_ty) {
@@ -4981,9 +4985,13 @@ impl FuncEnvironment<'_> {
         }
         self.translate_loop_header(builder)?;
         copy_one(self, builder, dst_cur, src_cur, src_index)?;
-        let dst_next = builder.ins().iadd_imm(dst_cur, i64::from(dst_element_size));
-        let src_next = builder.ins().iadd_imm(src_cur, i64::from(src_element_size));
-        let src_index_next = builder.ins().iadd_imm(src_index, 1);
+        let dst_next = builder
+            .ins()
+            .iadd_imm_s(dst_cur, i64::from(dst_element_size));
+        let src_next = builder
+            .ins()
+            .iadd_imm_s(src_cur, i64::from(src_element_size));
+        let src_index_next = builder.ins().iadd_imm_s(src_index, 1);
         let done = builder.ins().icmp(IntCC::Equal, src_next, src_end_addr);
         let forward_next_args: SmallVec<[ir::BlockArg; 5]> = [dst_next, src_next, src_index_next]
             .iter()
@@ -5922,7 +5930,7 @@ impl FuncEnvironment<'_> {
 
                     let dst = builder
                         .ins()
-                        .iadd_imm(base, i64::try_from(i.checked_mul(16).unwrap()).unwrap());
+                        .iadd_imm_s(base, i64::try_from(i.checked_mul(16).unwrap()).unwrap());
                     match ty.heap_type.top() {
                         WasmHeapTopType::Extern | WasmHeapTopType::Any | WasmHeapTopType::Exn => {
                             let ty = WasmStorageType::Val(WasmValType::Ref(*ty));
@@ -6010,14 +6018,14 @@ impl FuncEnvironment<'_> {
             TableSegmentElements::Functions(indices) => {
                 for (i, func) in indices.iter().enumerate() {
                     let func = self.translate_ref_func(builder.cursor(), *func)?;
-                    let index = builder.ins().iadd_imm(offset, i64::try_from(i).unwrap());
+                    let index = builder.ins().iadd_imm_s(offset, i64::try_from(i).unwrap());
                     self.translate_table_set(builder, segment.table_index, func, index)?;
                 }
             }
             TableSegmentElements::Expressions { exprs, ty: _ } => {
                 for (i, expr) in exprs.iter().enumerate() {
                     let val = self.translate_const_expr(builder, expr)?;
-                    let index = builder.ins().iadd_imm(offset, i64::try_from(i).unwrap());
+                    let index = builder.ins().iadd_imm_s(offset, i64::try_from(i).unwrap());
                     self.translate_table_set(builder, segment.table_index, val, index)?;
                 }
             }

--- a/crates/cranelift/src/func_environ/gc.rs
+++ b/crates/cranelift/src/func_environ/gc.rs
@@ -913,7 +913,7 @@ fn emit_array_size_info(
     let array_len = builder.ins().uextend(ir::types::I64, array_len);
     let all_elems_size = builder.ins().imul(one_elem_size, array_len);
 
-    let high_bits = builder.ins().ushr_imm(all_elems_size, 32);
+    let high_bits = builder.ins().ushr_imm_u(all_elems_size, 32);
     builder.ins().trapnz(high_bits, TRAP_GC_HEAP_CORRUPT);
 
     let all_elems_size = builder.ins().ireduce(ir::types::I32, all_elems_size);
@@ -1338,8 +1338,8 @@ fn emit_array_size(
     let len = builder.ins().uextend(ir::types::I64, len);
     let elems_size_64 = builder
         .ins()
-        .imul_imm(len, i64::from(array_layout.elem_size));
-    let high_bits = builder.ins().ushr_imm(elems_size_64, 32);
+        .imul_imm_s(len, i64::from(array_layout.elem_size));
+    let high_bits = builder.ins().ushr_imm_u(elems_size_64, 32);
     func_env.trapnz(builder, high_bits, crate::TRAP_ALLOCATION_TOO_LARGE);
     let elems_size = builder.ins().ireduce(ir::types::I32, elems_size_64);
 
@@ -1382,7 +1382,9 @@ fn initialize_struct_fields(
     for ((ty, val), offset) in field_types.into_iter().zip(field_values).zip(field_offsets) {
         let size_of_access = wasmtime_environ::byte_size_of_wasm_ty_in_gc_heap(&ty.element_type);
         assert!(offset + size_of_access <= struct_size);
-        let field_addr = builder.ins().iadd_imm(raw_ptr_to_struct, i64::from(offset));
+        let field_addr = builder
+            .ins()
+            .iadd_imm_s(raw_ptr_to_struct, i64::from(offset));
         gc_compiler(func_env)?.init_field(func_env, builder, ty.element_type, field_addr, *val)?;
     }
 
@@ -1642,16 +1644,20 @@ impl FuncEnvironment<'_> {
             (false, false) => builder.ins().iconst(ir::types::I32, 0),
 
             // This GC reference is always non-null, but might be an i31.
-            (false, true) => builder.ins().band_imm(gc_ref, i64::from(I31_DISCRIMINANT)),
+            (false, true) => builder
+                .ins()
+                .band_imm_u(gc_ref, i64::from(I31_DISCRIMINANT)),
 
             // This GC reference might be null, but can never be an i31.
-            (true, false) => builder.ins().icmp_imm(IntCC::Equal, gc_ref, 0),
+            (true, false) => builder.ins().icmp_imm_s(IntCC::Equal, gc_ref, 0),
 
             // Fully general case: this GC reference could be either null or an
             // i31.
             (true, true) => {
-                let is_i31 = builder.ins().band_imm(gc_ref, i64::from(I31_DISCRIMINANT));
-                let is_null = builder.ins().icmp_imm(IntCC::Equal, gc_ref, 0);
+                let is_i31 = builder
+                    .ins()
+                    .band_imm_u(gc_ref, i64::from(I31_DISCRIMINANT));
+                let is_null = builder.ins().icmp_imm_s(IntCC::Equal, gc_ref, 0);
                 let is_null = builder.ins().uextend(ir::types::I32, is_null);
                 builder.ins().bor(is_i31, is_null)
             }

--- a/crates/cranelift/src/func_environ/gc/copying.rs
+++ b/crates/cranelift/src/func_environ/gc/copying.rs
@@ -248,7 +248,7 @@ impl GcCompiler for CopyingCompiler {
             size,
             reserved_bits,
         )?;
-        let len_addr = builder.ins().iadd_imm(object_addr, i64::from(len_offset));
+        let len_addr = builder.ins().iadd_imm_s(object_addr, i64::from(len_offset));
         let flags = func_env.gc_memflags(&mut builder.func);
         builder.ins().store(flags, len, len_addr, 0);
 
@@ -332,7 +332,7 @@ impl GcCompiler for CopyingCompiler {
         // Initialize tag fields.
         let instance_id_addr = builder
             .ins()
-            .iadd_imm(raw_ptr_to_exn, i64::from(EXCEPTION_TAG_INSTANCE_OFFSET));
+            .iadd_imm_s(raw_ptr_to_exn, i64::from(EXCEPTION_TAG_INSTANCE_OFFSET));
         self.init_field(
             func_env,
             builder,
@@ -342,7 +342,7 @@ impl GcCompiler for CopyingCompiler {
         )?;
         let tag_addr = builder
             .ins()
-            .iadd_imm(raw_ptr_to_exn, i64::from(EXCEPTION_TAG_DEFINED_OFFSET));
+            .iadd_imm_s(raw_ptr_to_exn, i64::from(EXCEPTION_TAG_DEFINED_OFFSET));
         self.init_field(
             func_env,
             builder,

--- a/crates/cranelift/src/func_environ/gc/drc.rs
+++ b/crates/cranelift/src/func_environ/gc/drc.rs
@@ -107,7 +107,7 @@ impl DrcCompiler {
     ) -> ir::Value {
         debug_assert!(delta == -1 || delta == 1);
         let old_ref_count = self.load_ref_count(func_env, builder, gc_ref);
-        let new_ref_count = builder.ins().iadd_imm(old_ref_count, delta);
+        let new_ref_count = builder.ins().iadd_imm_s(old_ref_count, delta);
         self.store_ref_count(func_env, builder, gc_ref, new_ref_count);
         new_ref_count
     }
@@ -153,7 +153,7 @@ impl DrcCompiler {
         // meaning that there are always fewer objects in the GC heap than
         // `u32::MAX`.
         let current_len = self.load_current_over_approximated_stack_roots_len(func_env, builder);
-        let new_current_len = builder.ins().iadd_imm(current_len, 1);
+        let new_current_len = builder.ins().iadd_imm_s(current_len, 1);
         self.store_current_over_approximated_stack_roots_len(func_env, builder, new_current_len);
     }
 
@@ -174,7 +174,7 @@ impl DrcCompiler {
         if offset == 0 {
             ptr
         } else {
-            builder.ins().iadd_imm(ptr, offset)
+            builder.ins().iadd_imm_s(ptr, offset)
         }
     }
 
@@ -390,7 +390,7 @@ impl GcCompiler for DrcCompiler {
         let extended_array_ref =
             uextend_i32_to_pointer_type(builder, func_env.pointer_type(), array_ref);
         let object_addr = builder.ins().iadd(base, extended_array_ref);
-        let len_addr = builder.ins().iadd_imm(object_addr, i64::from(len_offset));
+        let len_addr = builder.ins().iadd_imm_s(object_addr, i64::from(len_offset));
         let flags = func_env.gc_memflags(&mut builder.func);
         builder.ins().store(flags, len, len_addr, 0);
         Ok(array_ref)
@@ -496,7 +496,7 @@ impl GcCompiler for DrcCompiler {
         // Finally, initialize the tag fields.
         let instance_id_addr = builder
             .ins()
-            .iadd_imm(raw_ptr_to_exn, i64::from(EXCEPTION_TAG_INSTANCE_OFFSET));
+            .iadd_imm_s(raw_ptr_to_exn, i64::from(EXCEPTION_TAG_INSTANCE_OFFSET));
         self.init_field(
             func_env,
             builder,
@@ -506,7 +506,7 @@ impl GcCompiler for DrcCompiler {
         )?;
         let tag_addr = builder
             .ins()
-            .iadd_imm(raw_ptr_to_exn, i64::from(EXCEPTION_TAG_DEFINED_OFFSET));
+            .iadd_imm_s(raw_ptr_to_exn, i64::from(EXCEPTION_TAG_DEFINED_OFFSET));
         self.init_field(
             func_env,
             builder,
@@ -830,8 +830,8 @@ impl GcCompiler for DrcCompiler {
             "DRC write barrier: decrement old ref's ref count and check for zero ref count"
         );
         let ref_count = self.load_ref_count(func_env, builder, old_val);
-        let new_ref_count = builder.ins().iadd_imm(ref_count, -1);
-        let old_val_needs_drop = builder.ins().icmp_imm(IntCC::Equal, new_ref_count, 0);
+        let new_ref_count = builder.ins().iadd_imm_s(ref_count, -1);
+        let old_val_needs_drop = builder.ins().icmp_imm_s(IntCC::Equal, new_ref_count, 0);
         builder.ins().brif(
             old_val_needs_drop,
             drop_old_val_block,

--- a/crates/cranelift/src/func_environ/gc/null.rs
+++ b/crates/cranelift/src/func_environ/gc/null.rs
@@ -223,7 +223,9 @@ impl GcCompiler for NullCompiler {
         // Note: we don't need to bounds-check the GC ref access here, because
         // the result of the inline allocation is trusted and we aren't reading
         // any pointers or offsets out from the (untrusted) GC heap.
-        let len_addr = builder.ins().iadd_imm(ptr_to_object, i64::from(len_offset));
+        let len_addr = builder
+            .ins()
+            .iadd_imm_s(ptr_to_object, i64::from(len_offset));
         let flags = func_env.gc_memflags(&mut builder.func);
         builder.ins().store(flags, len, len_addr, 0);
 
@@ -327,7 +329,7 @@ impl GcCompiler for NullCompiler {
         // Initialize the tag fields.
         let instance_id_addr = builder
             .ins()
-            .iadd_imm(raw_exn_pointer, i64::from(EXCEPTION_TAG_INSTANCE_OFFSET));
+            .iadd_imm_s(raw_exn_pointer, i64::from(EXCEPTION_TAG_INSTANCE_OFFSET));
         write_field_at_addr(
             func_env,
             builder,
@@ -337,7 +339,7 @@ impl GcCompiler for NullCompiler {
         )?;
         let tag_addr = builder
             .ins()
-            .iadd_imm(raw_exn_pointer, i64::from(EXCEPTION_TAG_DEFINED_OFFSET));
+            .iadd_imm_s(raw_exn_pointer, i64::from(EXCEPTION_TAG_DEFINED_OFFSET));
         write_field_at_addr(
             func_env,
             builder,

--- a/crates/cranelift/src/func_environ/stack_switching/control_effect.rs
+++ b/crates/cranelift/src/func_environ/stack_switching/control_effect.rs
@@ -15,7 +15,7 @@ pub struct ControlEffect(ir::Value);
 impl ControlEffect {
     // Returns the discriminant
     pub fn signal(&self, builder: &mut FunctionBuilder) -> ir::Value {
-        builder.ins().ushr_imm(self.0, 32)
+        builder.ins().ushr_imm_u(self.0, 32)
     }
 
     pub fn from_u64(val: ir::Value) -> Self {
@@ -31,7 +31,7 @@ impl ControlEffect {
             I64,
             i64::from(wasmtime_environ::CONTROL_EFFECT_RESUME_DISCRIMINANT),
         );
-        let val = builder.ins().ishl_imm(discriminant, 32);
+        let val = builder.ins().ishl_imm_u(discriminant, 32);
 
         Self(val)
     }
@@ -41,7 +41,7 @@ impl ControlEffect {
             I64,
             i64::from(wasmtime_environ::CONTROL_EFFECT_SWITCH_DISCRIMINANT),
         );
-        let val = builder.ins().ishl_imm(discriminant, 32);
+        let val = builder.ins().ishl_imm_u(discriminant, 32);
 
         Self(val)
     }
@@ -51,7 +51,7 @@ impl ControlEffect {
             I64,
             i64::from(wasmtime_environ::CONTROL_EFFECT_SUSPEND_DISCRIMINANT),
         );
-        let val = builder.ins().ishl_imm(discriminant, 32);
+        let val = builder.ins().ishl_imm_u(discriminant, 32);
         let handler_index = builder.ins().uextend(I64, handler_index);
         let val = builder.ins().bor(val, handler_index);
 

--- a/crates/cranelift/src/func_environ/stack_switching/fatpointer.rs
+++ b/crates/cranelift/src/func_environ/stack_switching/fatpointer.rs
@@ -25,7 +25,7 @@ pub(crate) fn deconstruct<'a>(
     let ptr_bits = ptr_ty.bits();
 
     let contref = pos.ins().ireduce(ptr_ty, contobj);
-    let shifted = pos.ins().ushr_imm(contobj, i64::from(ptr_bits));
+    let shifted = pos.ins().ushr_imm_u(contobj, i64::from(ptr_bits));
     let revision_counter = pos.ins().ireduce(ptr_ty, shifted);
 
     (revision_counter, contref)
@@ -48,7 +48,7 @@ pub(crate) fn construct<'a>(
 
     let contref_addr = pos.ins().uextend(fat_ptr_ty, contref_addr);
     let revision_counter = pos.ins().uextend(fat_ptr_ty, revision_counter);
-    let shifted_counter = pos.ins().ishl_imm(revision_counter, i64::from(ptr_bits));
+    let shifted_counter = pos.ins().ishl_imm_u(revision_counter, i64::from(ptr_bits));
     let contobj = pos.ins().bor(shifted_counter, contref_addr);
 
     contobj

--- a/crates/cranelift/src/func_environ/stack_switching/instructions.rs
+++ b/crates/cranelift/src/func_environ/stack_switching/instructions.rs
@@ -103,7 +103,7 @@ pub(crate) mod stack_switching_helpers {
             builder: &mut FunctionBuilder,
         ) -> VMPayloads {
             let offset: i64 = env.offsets.ptr.vmcontref_args().into();
-            let address = builder.ins().iadd_imm(self.address, offset);
+            let address = builder.ins().iadd_imm_s(self.address, offset);
             VMPayloads::new(address)
         }
 
@@ -113,7 +113,7 @@ pub(crate) mod stack_switching_helpers {
             builder: &mut FunctionBuilder,
         ) -> VMPayloads {
             let offset: i64 = env.offsets.ptr.vmcontref_values().into();
-            let address = builder.ins().iadd_imm(self.address, offset);
+            let address = builder.ins().iadd_imm_s(self.address, offset);
             VMPayloads::new(address)
         }
 
@@ -123,7 +123,7 @@ pub(crate) mod stack_switching_helpers {
             builder: &mut FunctionBuilder,
         ) -> VMCommonStackInformation {
             let offset: i64 = env.offsets.ptr.vmcontref_common_stack_information().into();
-            let address = builder.ins().iadd_imm(self.address, offset);
+            let address = builder.ins().iadd_imm_s(self.address, offset);
             VMCommonStackInformation { address }
         }
 
@@ -201,7 +201,7 @@ pub(crate) mod stack_switching_helpers {
         ) -> ir::Value {
             let mem_flags = ir::MemFlagsData::trusted();
             let offset: i32 = env.offsets.ptr.vmcontref_revision().into();
-            let revision_plus1 = builder.ins().iadd_imm(revision, 1);
+            let revision_plus1 = builder.ins().iadd_imm_s(revision, 1);
             builder
                 .ins()
                 .store(mem_flags, revision_plus1, self.address, offset);
@@ -215,7 +215,7 @@ pub(crate) mod stack_switching_helpers {
         ) -> VMContinuationStack {
             // The top of stack field is stored at offset 0 of the `FiberStack`.
             let offset: i64 = env.offsets.ptr.vmcontref_stack().into();
-            let fiber_stack_top_of_stack_ptr = builder.ins().iadd_imm(self.address, offset);
+            let fiber_stack_top_of_stack_ptr = builder.ins().iadd_imm_s(self.address, offset);
             VMContinuationStack::new(fiber_stack_top_of_stack_ptr)
         }
     }
@@ -308,14 +308,14 @@ pub(crate) mod stack_switching_helpers {
             let original_length = self.get_length(env, builder);
             let new_length = builder
                 .ins()
-                .iadd_imm(original_length, i64::from(arg_count));
+                .iadd_imm_s(original_length, i64::from(arg_count));
             self.set_length(env, builder, new_length);
 
             let (_align, entry_size) = T::vmhostarray_entry_layout(&env.offsets.ptr);
             let original_length = builder.ins().uextend(I64, original_length);
             let byte_offset = builder
                 .ins()
-                .imul_imm(original_length, i64::from(entry_size));
+                .imul_imm_s(original_length, i64::from(entry_size));
             builder.ins().iadd(data, byte_offset)
         }
 
@@ -489,7 +489,7 @@ pub(crate) mod stack_switching_helpers {
             _env: &mut crate::func_environ::FuncEnvironment<'a>,
             builder: &mut FunctionBuilder,
         ) -> ir::Value {
-            builder.ins().icmp_imm(
+            builder.ins().icmp_imm_s(
                 IntCC::Equal,
                 self.discriminant,
                 i64::try_from(wasmtime_environ::STACK_CHAIN_INITIAL_STACK_DISCRIMINANT).unwrap(),
@@ -587,7 +587,7 @@ pub(crate) mod stack_switching_helpers {
         ) -> ir::Value {
             let offset: i64 = env.offsets.ptr.vmcommon_stack_information_state().into();
 
-            builder.ins().iadd_imm(self.address, offset)
+            builder.ins().iadd_imm_s(self.address, offset)
         }
 
         fn get_stack_limits_ptr<'a>(
@@ -597,7 +597,7 @@ pub(crate) mod stack_switching_helpers {
         ) -> ir::Value {
             let offset: i64 = env.offsets.ptr.vmcommon_stack_information_limits().into();
 
-            builder.ins().iadd_imm(self.address, offset)
+            builder.ins().iadd_imm_s(self.address, offset)
         }
 
         fn load_state<'a>(
@@ -671,7 +671,7 @@ pub(crate) mod stack_switching_helpers {
             let allocated = wasmtime_environ::STACK_STATE_FRESH_DISCRIMINANT;
             builder
                 .ins()
-                .icmp_imm(IntCC::NotEqual, actual_state, i64::from(allocated))
+                .icmp_imm_s(IntCC::NotEqual, actual_state, i64::from(allocated))
         }
 
         pub fn get_handler_list<'a>(
@@ -680,7 +680,7 @@ pub(crate) mod stack_switching_helpers {
             builder: &mut FunctionBuilder,
         ) -> VMHandlerList {
             let offset: i64 = env.offsets.ptr.vmcommon_stack_information_handlers().into();
-            let address = builder.ins().iadd_imm(self.address, offset);
+            let address = builder.ins().iadd_imm_s(self.address, offset);
             VMHandlerList::new(address)
         }
 
@@ -832,7 +832,7 @@ pub(crate) mod stack_switching_helpers {
         ) -> ir::Value {
             let tos = self.load_top_of_stack(env, builder);
             // Control context begins 24 bytes below top of stack (see unix.rs)
-            builder.ins().iadd_imm(tos, -0x18)
+            builder.ins().iadd_imm_s(tos, -0x18)
         }
     }
 }
@@ -917,7 +917,7 @@ pub(crate) fn tag_address<'a>(
     let pointer_type = env.pointer_type();
     if let Some(def_index) = env.module.defined_tag_index(tag_index) {
         let offset = i32::try_from(env.offsets.vmctx_vmtag_definition(def_index)).unwrap();
-        builder.ins().iadd_imm(vmctx, i64::from(offset))
+        builder.ins().iadd_imm_s(vmctx, i64::from(offset))
     } else {
         let offset = i32::try_from(env.offsets.vmctx_vmtag_import_from(tag_index)).unwrap();
         builder.ins().load(
@@ -1138,7 +1138,7 @@ fn search_handler<'a>(
 
         let base = handler_list_data_ptr;
         let entry_size = env.pointer_type().bytes();
-        let offset = builder.ins().imul_imm(index, i64::from(entry_size));
+        let offset = builder.ins().imul_imm_s(index, i64::from(entry_size));
         let offset = builder.ins().uextend(I64, offset);
         let entry_address = builder.ins().iadd(base, offset);
 
@@ -1149,7 +1149,7 @@ fn search_handler<'a>(
             .load(env.pointer_type(), memflags, entry_address, 0);
 
         let tags_match = builder.ins().icmp(IntCC::Equal, handled_tag, tag_address);
-        let incremented_index = builder.ins().iadd_imm(index, 1);
+        let incremented_index = builder.ins().iadd_imm_s(index, 1);
         builder.ins().brif(
             tags_match,
             on_match,

--- a/crates/cranelift/src/translate/code_translator.rs
+++ b/crates/cranelift/src/translate/code_translator.rs
@@ -1358,7 +1358,7 @@ pub fn translate_operator(
         }
         Operator::I32Eqz | Operator::I64Eqz => {
             let arg = environ.stacks.pop1();
-            let val = builder.ins().icmp_imm(IntCC::Equal, arg, 0);
+            let val = builder.ins().icmp_imm_s(IntCC::Equal, arg, 0);
             environ.stacks.push1(builder.ins().uextend(I32, val));
         }
         Operator::I32Eq | Operator::I64Eq => translate_icmp(IntCC::Equal, builder, environ),
@@ -3695,13 +3695,13 @@ fn align_atomic_addr(
         let effective_addr = if memarg.offset == 0 {
             addr
         } else {
-            builder.ins().iadd_imm(addr, memarg.offset.cast_signed())
+            builder.ins().iadd_imm_s(addr, memarg.offset.cast_signed())
         };
         debug_assert!(loaded_bytes.is_power_of_two());
         let misalignment = builder
             .ins()
-            .band_imm(effective_addr, i64::from(loaded_bytes - 1));
-        let f = builder.ins().icmp_imm(IntCC::NotEqual, misalignment, 0);
+            .band_imm_u(effective_addr, i64::from(loaded_bytes - 1));
+        let f = builder.ins().icmp_imm_s(IntCC::NotEqual, misalignment, 0);
         environ.trapnz(builder, f, crate::TRAP_HEAP_MISALIGNED);
     }
 }

--- a/crates/cranelift/src/translate/table.rs
+++ b/crates/cranelift/src/translate/table.rs
@@ -99,9 +99,9 @@ impl TableData {
             index
         } else if element_size.is_power_of_two() {
             pos.ins()
-                .ishl_imm(index, i64::from(element_size.trailing_zeros()))
+                .ishl_imm_u(index, i64::from(element_size.trailing_zeros()))
         } else {
-            pos.ins().imul_imm(index, element_size as i64)
+            pos.ins().imul_imm_s(index, element_size as i64)
         };
 
         let element_addr = pos.ins().iadd(base, offset);


### PR DESCRIPTION
Fixes #13529. Follow-up to the discussion in #13527.

Today the generated `<inst>_imm` builder picks sign- vs zero-extension from
a hardcoded list of opcodes in `build_imm_const`, which is easy to trip on.
This adds explicit `<inst>_imm_s` (sign-extend) and `<inst>_imm_u`
(zero-extend) variants instead, and `build_imm_const` now takes a plain
`signed: bool`. The extension only matters for `i128`; below that the masked
immediate is the same either way.

`<inst>_imm` stays for back-compat but is now `#[deprecated]` in favor of the
explicit ones. I migrated the ~100 in-tree callers over by their historical
signedness — that part is a no-op (nothing internal uses these on `i128`),
which is why the diff is big but boring.

Skipped the `SImm128`/`UImm128` newtype idea for now since the `_s`/`_u`
names already carry the signedness — can do it as a follow-up if you want.

Tested with the cranelift-codegen/frontend suites and the filetests, plus a
new unit test for the `i128` extension behavior.
