### PR TITLE
feat(MachO): Cranelift: align stack prologue/epilogue with compact unwind format

### DIFF
--- a/cranelift/codegen/meta/src/shared/settings.rs
+++ b/cranelift/codegen/meta/src/shared/settings.rs
@@ -356,6 +356,24 @@ pub(crate) fn define() -> SettingGroup {
         0,
     );
 
+    settings.add_bool(
+        "enable_compact_unwind_abi",
+        "Enable Mach-O compact unwind compatible code emission.",
+        r#"
+            This constrains function prologues and epilogues to the ABI shape
+            that Mach-O compact unwind can encode. Unwind instructions describe
+            which pairs of callee-save registers are saved and restored, but the
+            canonical stack frame layout is still expected: nonvolatile registers
+            must be placed near the top of the frame, immediately below the
+            return address.
+
+            The unwind encoding only supports register pairs emitted with `stp`;
+            it cannot encode individual registers. This may result in slightly
+            larger stack frames.
+        "#,
+        false,
+    );
+
     // When adding new settings please check if they can also be added
     // in cranelift/fuzzgen/src/lib.rs for fuzzing.
     settings.build()

--- a/cranelift/codegen/src/isa/aarch64/abi.rs
+++ b/cranelift/codegen/src/isa/aarch64/abi.rs
@@ -1,5 +1,8 @@
 //! Implementation of a standard AArch64 ABI.
 
+use core::cmp::Reverse;
+use std::collections::HashSet;
+
 use crate::CodegenResult;
 use crate::ir;
 use crate::ir::MemFlagsData;
@@ -76,6 +79,46 @@ fn compute_clobber_size(
     };
 
     int_save_bytes + vec_save_bytes
+}
+
+/// The compact unwinding encoding can only represent pushes and pops of adjacent register pairs,
+/// so unused callee-saved registers may also need to be pushed.
+fn add_macho_compact_unwind_paired_regs(regs: &mut Vec<Writable<RealReg>>) {
+    let int_regs: HashSet<_> = regs
+        .iter()
+        .filter_map(|r| {
+            if r.to_reg().class() == RegClass::Int {
+                Some(r.to_reg().hw_enc())
+            } else {
+                None
+            }
+        })
+        .collect();
+    for (a, b) in [(19, 20), (21, 22), (23, 24), (25, 26), (27, 28)] {
+        if int_regs.contains(&a) && !int_regs.contains(&b) {
+            regs.push(Writable::from_reg(xreg(b).to_real_reg().unwrap()))
+        } else if int_regs.contains(&b) && !int_regs.contains(&a) {
+            regs.push(Writable::from_reg(xreg(a).to_real_reg().unwrap()))
+        }
+    }
+
+    let fp_regs: HashSet<_> = regs
+        .iter()
+        .filter_map(|r| {
+            if r.to_reg().class() == RegClass::Float {
+                Some(r.to_reg().hw_enc())
+            } else {
+                None
+            }
+        })
+        .collect();
+    for (a, b) in [(8, 9), (10, 11), (12, 13), (14, 15)] {
+        if fp_regs.contains(&a) && !fp_regs.contains(&b) {
+            regs.push(Writable::from_reg(vreg(b).to_real_reg().unwrap()))
+        } else if fp_regs.contains(&b) && !fp_regs.contains(&a) {
+            regs.push(Writable::from_reg(vreg(a).to_real_reg().unwrap()))
+        }
+    }
 }
 
 /// AArch64-specific ABI behavior. This struct just serves as an implementation
@@ -1155,6 +1198,9 @@ impl ABIMachineSpec for AArch64MachineDeps {
             // Wasmtime).
             (isa::CallConv::PreserveAll, true) => ALL_CLOBBERS,
             (isa::CallConv::SystemV, _) => DEFAULT_AAPCS_CLOBBERS,
+            // On Mach-O, the compact unwind info properly describes how are callee-save
+            // registers restored during unwinding.
+            (isa::CallConv::AppleAarch64, true) => DEFAULT_AAPCS_CLOBBERS,
             (isa::CallConv::PreserveAll, _) => NO_CLOBBERS,
             (_, false) => DEFAULT_AAPCS_CLOBBERS,
             (_, true) => panic!("unimplemented clobbers for exn abi of {call_conv:?}"),
@@ -1192,9 +1238,20 @@ impl ABIMachineSpec for AArch64MachineDeps {
             })
             .collect();
 
-        // Sort registers for deterministic code output. We can do an unstable
-        // sort because the registers will be unique (there are no dups).
-        regs.sort_unstable();
+        if call_conv == isa::CallConv::AppleAarch64 {
+            add_macho_compact_unwind_paired_regs(&mut regs);
+            // For Mach-O compact unwind, these pushes/pops must be emitted in
+            // the fixed expected order. The encoding specifies only which
+            // callee-saved register pairs are preserved; the order is mandatory.
+            regs.sort_unstable_by_key(|r| {
+                let reg = r.to_reg();
+                (reg.class(), Reverse(reg.hw_enc()))
+            });
+        } else {
+            // Sort registers for deterministic code output. We can do an unstable
+            // sort because the registers will be unique (there are no dups).
+            regs.sort_unstable();
+        }
 
         // Compute clobber size.
         let clobber_size = compute_clobber_size(call_conv, &regs);
@@ -1239,9 +1296,10 @@ impl ABIMachineSpec for AArch64MachineDeps {
     fn exception_payload_regs(call_conv: isa::CallConv) -> &'static [Reg] {
         const PAYLOAD_REGS: &'static [Reg] = &[regs::xreg(0), regs::xreg(1)];
         match call_conv {
-            isa::CallConv::SystemV | isa::CallConv::Tail | isa::CallConv::PreserveAll => {
-                PAYLOAD_REGS
-            }
+            isa::CallConv::SystemV
+            | isa::CallConv::Tail
+            | isa::CallConv::PreserveAll
+            | isa::CallConv::AppleAarch64 => PAYLOAD_REGS,
             _ => &[],
         }
     }

--- a/cranelift/codegen/src/isa/aarch64/abi.rs
+++ b/cranelift/codegen/src/isa/aarch64/abi.rs
@@ -1,9 +1,9 @@
 //! Implementation of a standard AArch64 ABI.
 
 use core::cmp::Reverse;
-use std::collections::HashSet;
 
 use crate::CodegenResult;
+use crate::FxHashSet;
 use crate::ir;
 use crate::ir::MemFlagsData;
 use crate::ir::types;
@@ -84,7 +84,7 @@ fn compute_clobber_size(
 /// The compact unwinding encoding can only represent pushes and pops of adjacent register pairs,
 /// so unused callee-saved registers may also need to be pushed.
 fn add_macho_compact_unwind_paired_regs(regs: &mut Vec<Writable<RealReg>>) {
-    let int_regs: HashSet<_> = regs
+    let int_regs: FxHashSet<_> = regs
         .iter()
         .filter_map(|r| {
             if r.to_reg().class() == RegClass::Int {
@@ -102,7 +102,7 @@ fn add_macho_compact_unwind_paired_regs(regs: &mut Vec<Writable<RealReg>>) {
         }
     }
 
-    let fp_regs: HashSet<_> = regs
+    let fp_regs: FxHashSet<_> = regs
         .iter()
         .filter_map(|r| {
             if r.to_reg().class() == RegClass::Float {

--- a/cranelift/codegen/src/isa/aarch64/abi.rs
+++ b/cranelift/codegen/src/isa/aarch64/abi.rs
@@ -1238,7 +1238,7 @@ impl ABIMachineSpec for AArch64MachineDeps {
             })
             .collect();
 
-        if call_conv == isa::CallConv::AppleAarch64 {
+        if call_conv == isa::CallConv::AppleAarch64 && flags.enable_compact_unwind_abi() {
             add_macho_compact_unwind_paired_regs(&mut regs);
             // For Mach-O compact unwind, these pushes/pops must be emitted in
             // the fixed expected order. The encoding specifies only which

--- a/cranelift/codegen/src/isa/call_conv.rs
+++ b/cranelift/codegen/src/isa/call_conv.rs
@@ -95,7 +95,11 @@ impl CallConv {
     /// Does this calling convention support exceptions?
     pub fn supports_exceptions(&self) -> bool {
         match self {
-            CallConv::Tail | CallConv::SystemV | CallConv::Winch | CallConv::PreserveAll => true,
+            CallConv::Tail
+            | CallConv::SystemV
+            | CallConv::Winch
+            | CallConv::PreserveAll
+            | CallConv::AppleAarch64 => true,
             _ => false,
         }
     }
@@ -113,11 +117,13 @@ impl CallConv {
     /// destinations as this return value.
     pub fn exception_payload_types(&self, pointer_ty: Type) -> &[Type] {
         match self {
-            CallConv::Tail | CallConv::SystemV | CallConv::PreserveAll => match pointer_ty {
-                types::I32 => &[types::I32, types::I32],
-                types::I64 => &[types::I64, types::I64],
-                _ => unreachable!(),
-            },
+            CallConv::Tail | CallConv::SystemV | CallConv::PreserveAll | CallConv::AppleAarch64 => {
+                match pointer_ty {
+                    types::I32 => &[types::I32, types::I32],
+                    types::I64 => &[types::I64, types::I64],
+                    _ => unreachable!(),
+                }
+            }
             _ => &[],
         }
     }

--- a/cranelift/codegen/src/settings.rs
+++ b/cranelift/codegen/src/settings.rs
@@ -513,6 +513,7 @@ enable_probestack = false
 enable_heap_access_spectre_mitigation = true
 enable_table_access_spectre_mitigation = true
 enable_incremental_compilation_cache_checks = false
+enable_compact_unwind_abi = false
 "#;
         if actual != expected {
             panic!(

--- a/cranelift/filetests/filetests/isa/aarch64/compact-unwind.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/compact-unwind.clif
@@ -1,0 +1,55 @@
+test compile precise-output
+set enable_compact_unwind_abi=true
+target aarch64
+
+function %compact_unwind_adds_integer_pairs(i64, i64, i64) -> i64 apple_aarch64 {
+    fn0 = colocated %callee() apple_aarch64
+
+block0(v0: i64, v1: i64, v2: i64):
+    call fn0()
+    v5 = iadd v0, v1
+    v6 = iadd v5, v2
+    return v6
+}
+
+; VCode:
+;   stp fp, lr, [sp, #-16]!
+;   mov fp, sp
+;   stp x20, x19, [sp, #-16]!
+;   stp x22, x21, [sp, #-16]!
+; block0:
+;   mov x19, x2
+;   mov x20, x1
+;   mov x21, x0
+;   bl 0
+;   mov x0, x21
+;   mov x1, x20
+;   add x6, x0, x1
+;   mov x2, x19
+;   add x0, x6, x2
+;   ldp x22, x21, [sp], #16
+;   ldp x20, x19, [sp], #16
+;   ldp fp, lr, [sp], #16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+;   stp x20, x19, [sp, #-0x10]!
+;   stp x22, x21, [sp, #-0x10]!
+; block1: ; offset 0x10
+;   mov x19, x2
+;   mov x20, x1
+;   mov x21, x0
+;   bl #0x1c ; reloc_external Call %callee 0
+;   mov x0, x21
+;   mov x1, x20
+;   add x6, x0, x1
+;   mov x2, x19
+;   add x0, x6, x2
+;   ldp x22, x21, [sp], #0x10
+;   ldp x20, x19, [sp], #0x10
+;   ldp x29, x30, [sp], #0x10
+;   ret
+

--- a/cranelift/fuzzgen/src/lib.rs
+++ b/cranelift/fuzzgen/src/lib.rs
@@ -190,6 +190,7 @@ where
             "enable_heap_access_spectre_mitigation",
             "enable_table_access_spectre_mitigation",
             "enable_incremental_compilation_cache_checks",
+            "enable_compact_unwind_abi",
             "regalloc_checker",
             "enable_llvm_abi_extensions",
         ];

--- a/crates/wasmtime/src/engine.rs
+++ b/crates/wasmtime/src/engine.rs
@@ -499,6 +499,7 @@ information about this check\
             | "is_pic"
             | "bb_padding_log2_minus_one"
             | "log2_min_function_alignment"
+            | "enable_compact_unwind_abi"
             | "machine_code_cfg_info"
             | "tls_model" // wasmtime doesn't use tls right now
             | "opt_level" // opt level doesn't change semantics


### PR DESCRIPTION
This change is motivated by a compatibility difference between LLVM and the Cranelift compiler. The PR enables Cranelift to emit proper compact unwind information for the Mach-O AArch64 platform, based on `UnwindInst` and `FinalizedMachCallSite`.

The change has two parts:
1. Unwind instructions only describe **which** pairs of callee-save registers are saved and restored. The canonical stack frame layout is still expected: nonvolatile registers must be placed near the top of the frame, immediately below the return address.
2. The unwind encoding only supports register pairs emitted with `stp`; it cannot encode individual registers. This results in slightly larger stack frames, but the increase should hopefully be manageable.

Collected statistics for a larger WASM module (total function count: ~37K):


```
function count: diff: newly spilled registers
9828 diff=+0: newly spilled=0
1958 diff=+0: newly spilled=10
3457 diff=+0: newly spilled=2
3828 diff=+0: newly spilled=4
1038 diff=+0: newly spilled=6
 552 diff=+0: newly spilled=8
 639 diff=+1: newly spilled=10
 882 diff=+1: newly spilled=2
6639 diff=+1: newly spilled=4
2393 diff=+1: newly spilled=6
1072 diff=+1: newly spilled=8
 359 diff=+2: newly spilled=10
2229 diff=+2: newly spilled=4
1062 diff=+2: newly spilled=6
 523 diff=+2: newly spilled=8
 118 diff=+3: newly spilled=10
 505 diff=+3: newly spilled=6
 226 diff=+3: newly spilled=8
  54 diff=+4: newly spilled=10
  68 diff=+4: newly spilled=8
   7 diff=+5: newly spilled=10
```


Pair-register encoding constant defined in LLVM:
https://github.com/llvm/llvm-project/blob/main/libunwind/include/mach-o/compact_unwind_encoding.h?utm_source=chatgpt.com#L292-L300

