### PR TITLE
Remove some uses of `ir::GlobalValue`s from Wasm-to-CLIF translation

### DIFF
--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -1479,9 +1479,9 @@ impl TranslateTrap for FuncEnvironment<'_> {
     }
 
     fn vmctx_val(&mut self, pos: &mut FuncCursor<'_>) -> ir::Value {
-        let pointer_type = self.pointer_type();
-        let vmctx = self.vmctx(&mut pos.func);
-        pos.ins().global_value(pointer_type, vmctx)
+        pos.func
+            .special_param(ir::ArgumentPurpose::VMContext)
+            .expect("Missing vmctx parameter")
     }
 
     fn builtin_funcref(

--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -478,6 +478,13 @@ impl<'module_environment> FuncEnvironment<'module_environment> {
 
     /// Get or create the `ir::Global` for the `*mut VMStoreContext` in our
     /// `VMContext`.
+    #[cfg_attr(
+        not(feature = "gc"),
+        expect(
+            dead_code,
+            reason = "only used to derive the GC heap base/bound globals"
+        )
+    )]
     fn get_vmstore_context_ptr_global(&mut self, func: &mut ir::Function) -> ir::GlobalValue {
         if let Some(ptr) = self.vm_store_context {
             return ptr;
@@ -502,8 +509,15 @@ impl<'module_environment> FuncEnvironment<'module_environment> {
 
     /// Get the `*mut VMStoreContext` value for our `VMContext`.
     fn get_vmstore_context_ptr(&mut self, builder: &mut FunctionBuilder) -> ir::Value {
-        let global = self.get_vmstore_context_ptr_global(&mut builder.func);
-        builder.ins().global_value(self.pointer_type(), global)
+        let pointer_type = self.pointer_type();
+        let offset = i32::from(self.offsets.ptr.vmctx_store_context());
+        let vmctx = self.vmctx_val(&mut builder.cursor());
+        builder.ins().load(
+            pointer_type,
+            ir::MemFlagsData::trusted().with_readonly().with_can_move(),
+            vmctx,
+            offset,
+        )
     }
 
     fn fuel_function_entry(&mut self, builder: &mut FunctionBuilder<'_>) {

--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -814,9 +814,8 @@ impl<'module_environment> FuncEnvironment<'module_environment> {
     }
 
     fn epoch_ptr(&mut self, builder: &mut FunctionBuilder<'_>) -> ir::Value {
-        let vmctx = self.vmctx(builder.func);
         let pointer_type = self.pointer_type();
-        let base = builder.ins().global_value(pointer_type, vmctx);
+        let base = self.vmctx_val(&mut builder.cursor());
         let offset = i32::from(self.offsets.ptr.vmctx_epoch_ptr());
         let epoch_ptr = builder
             .ins()

--- a/tests/disas/alias-region-tables.wat
+++ b/tests/disas/alias-region-tables.wat
@@ -33,9 +33,9 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i64):
-;; @0043                               v64 = load.i64 notrap aligned readonly can_move v0+48
-;; @0043                               v5 = load.i64 notrap aligned v64+8
-;; @0043                               v9 = load.i64 notrap aligned v64
+;; @0043                               v62 = load.i64 notrap aligned readonly can_move v0+48
+;; @0043                               v5 = load.i64 notrap aligned v62+8
+;; @0043                               v9 = load.i64 notrap aligned v62
 ;; @0043                               v15 = iconst.i64 1
 ;; @0043                               v16 = bor v3, v15  ; v15 = 1
 ;; @0043                               v6 = ireduce.i32 v5
@@ -60,20 +60,20 @@
 ;;
 ;;                                 block2 cold:
 ;; @004d                               v43 = iconst.i32 0
-;; @004d                               v46 = call fn0(v0, v43, v8)  ; v43 = 0
-;; @004d                               jump block3(v46)
+;; @004d                               v45 = call fn0(v0, v43, v8)  ; v43 = 0
+;; @004d                               jump block3(v45)
 ;;
 ;;                                 block3(v42: i64):
-;; @004d                               v50 = load.i32 user7 aligned readonly v42+16
-;; @004d                               v48 = load.i64 notrap aligned readonly can_move v0+40
-;; @004d                               v49 = load.i32 notrap aligned readonly can_move v48
-;; @004d                               v51 = icmp eq v50, v49
-;; @004d                               trapz v51, user8
-;; @004d                               v53 = load.i64 notrap aligned readonly v42+8
-;; @004d                               v54 = load.i64 notrap aligned readonly v42+24
-;; @004d                               v55 = call_indirect sig0, v53(v54, v0)
+;; @004d                               v48 = load.i32 user7 aligned readonly v42+16
+;; @004d                               v46 = load.i64 notrap aligned readonly can_move v0+40
+;; @004d                               v47 = load.i32 notrap aligned readonly can_move v46
+;; @004d                               v49 = icmp eq v48, v47
+;; @004d                               trapz v49, user8
+;; @004d                               v51 = load.i64 notrap aligned readonly v42+8
+;; @004d                               v52 = load.i64 notrap aligned readonly v42+24
+;; @004d                               v53 = call_indirect sig0, v51(v52, v0)
 ;; @0050                               jump block1
 ;;
 ;;                                 block1:
-;; @0050                               return v55
+;; @0050                               return v53
 ;; }

--- a/tests/disas/array-copy-i64.wat
+++ b/tests/disas/array-copy-i64.wat
@@ -24,8 +24,8 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32, v6: i32):
 ;; @002b                               trapz v2, user16
-;; @002b                               v81 = load.i64 notrap aligned readonly can_move v0+8
-;; @002b                               v8 = load.i64 notrap aligned readonly can_move v81+32
+;; @002b                               v80 = load.i64 notrap aligned readonly can_move v0+8
+;; @002b                               v8 = load.i64 notrap aligned readonly can_move v80+32
 ;; @002b                               v7 = uextend.i64 v2
 ;; @002b                               v9 = iadd v8, v7
 ;; @002b                               v10 = iconst.i64 16
@@ -47,24 +47,24 @@
 ;; @002b                               v35 = uextend.i64 v34
 ;; @002b                               v41 = icmp ugt v40, v35
 ;; @002b                               trapnz v41, user17
-;; @002b                               v57 = load.i64 notrap aligned v81+40
+;; @002b                               v57 = load.i64 notrap aligned v80+40
 ;; @002b                               v23 = iconst.i64 24
 ;; @002b                               v24 = iadd v9, v23  ; v23 = 24
-;;                                     v85 = iconst.i64 3
-;;                                     v86 = ishl v14, v85  ; v85 = 3
-;; @002b                               v28 = iadd v24, v86
-;;                                     v90 = ishl v15, v85  ; v85 = 3
-;; @002b                               v59 = uadd_overflow_trap v28, v90, user2
+;;                                     v84 = iconst.i64 3
+;;                                     v85 = ishl v14, v84  ; v84 = 3
+;; @002b                               v28 = iadd v24, v85
+;;                                     v89 = ishl v15, v84  ; v84 = 3
+;; @002b                               v59 = uadd_overflow_trap v28, v89, user2
 ;; @002b                               v58 = iadd v8, v57
 ;; @002b                               v60 = icmp ugt v59, v58
 ;; @002b                               trapnz v60, user2
 ;; @002b                               v46 = iadd v31, v23  ; v23 = 24
-;;                                     v88 = ishl v36, v85  ; v85 = 3
-;; @002b                               v50 = iadd v46, v88
-;; @002b                               v64 = uadd_overflow_trap v50, v90, user2
+;;                                     v87 = ishl v36, v84  ; v84 = 3
+;; @002b                               v50 = iadd v46, v87
+;; @002b                               v64 = uadd_overflow_trap v50, v89, user2
 ;; @002b                               v65 = icmp ugt v64, v58
 ;; @002b                               trapnz v65, user2
-;; @002b                               call fn0(v0, v28, v50, v90)
+;; @002b                               call fn0(v0, v28, v50, v89)
 ;; @002f                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/array-copy-i8.wat
+++ b/tests/disas/array-copy-i8.wat
@@ -24,8 +24,8 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32, v6: i32):
 ;; @002b                               trapz v2, user16
-;; @002b                               v81 = load.i64 notrap aligned readonly can_move v0+8
-;; @002b                               v8 = load.i64 notrap aligned readonly can_move v81+32
+;; @002b                               v80 = load.i64 notrap aligned readonly can_move v0+8
+;; @002b                               v8 = load.i64 notrap aligned readonly can_move v80+32
 ;; @002b                               v7 = uextend.i64 v2
 ;; @002b                               v9 = iadd v8, v7
 ;; @002b                               v10 = iconst.i64 16
@@ -47,7 +47,7 @@
 ;; @002b                               v35 = uextend.i64 v34
 ;; @002b                               v41 = icmp ugt v40, v35
 ;; @002b                               trapnz v41, user17
-;; @002b                               v57 = load.i64 notrap aligned v81+40
+;; @002b                               v57 = load.i64 notrap aligned v80+40
 ;; @002b                               v23 = iconst.i64 20
 ;; @002b                               v24 = iadd v9, v23  ; v23 = 20
 ;; @002b                               v28 = iadd v24, v14

--- a/tests/disas/array-fill-f32.wat
+++ b/tests/disas/array-fill-f32.wat
@@ -89,8 +89,8 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
 ;; @0041                               trapz v2, user16
-;; @0041                               v44 = load.i64 notrap aligned readonly can_move v0+8
-;; @0041                               v7 = load.i64 notrap aligned readonly can_move v44+32
+;; @0041                               v43 = load.i64 notrap aligned readonly can_move v0+8
+;; @0041                               v7 = load.i64 notrap aligned readonly can_move v43+32
 ;; @0041                               v6 = uextend.i64 v2
 ;; @0041                               v8 = iadd v7, v6
 ;; @0041                               v9 = iconst.i64 16
@@ -102,19 +102,19 @@
 ;; @0041                               v12 = uextend.i64 v11
 ;; @0041                               v18 = icmp ugt v17, v12
 ;; @0041                               trapnz v18, user17
-;; @0041                               v32 = load.i64 notrap aligned v44+40
+;; @0041                               v32 = load.i64 notrap aligned v43+40
 ;; @0041                               v22 = iconst.i64 20
 ;; @0041                               v23 = iadd v8, v22  ; v22 = 20
-;;                                     v48 = iconst.i64 2
-;;                                     v49 = ishl v13, v48  ; v48 = 2
-;; @0041                               v27 = iadd v23, v49
-;;                                     v51 = ishl v14, v48  ; v48 = 2
-;; @0041                               v34 = uadd_overflow_trap v27, v51, user2
+;;                                     v47 = iconst.i64 2
+;;                                     v48 = ishl v13, v47  ; v47 = 2
+;; @0041                               v27 = iadd v23, v48
+;;                                     v50 = ishl v14, v47  ; v47 = 2
+;; @0041                               v34 = uadd_overflow_trap v27, v50, user2
 ;; @0041                               v33 = iadd v7, v32
 ;; @0041                               v35 = icmp ugt v34, v33
 ;; @0041                               trapnz v35, user2
 ;; @0041                               v36 = iconst.i32 0
-;; @0041                               call fn0(v0, v27, v36, v51)  ; v36 = 0
+;; @0041                               call fn0(v0, v27, v36, v50)  ; v36 = 0
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/array-fill-f64.wat
+++ b/tests/disas/array-fill-f64.wat
@@ -89,8 +89,8 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
 ;; @0045                               trapz v2, user16
-;; @0045                               v44 = load.i64 notrap aligned readonly can_move v0+8
-;; @0045                               v7 = load.i64 notrap aligned readonly can_move v44+32
+;; @0045                               v43 = load.i64 notrap aligned readonly can_move v0+8
+;; @0045                               v7 = load.i64 notrap aligned readonly can_move v43+32
 ;; @0045                               v6 = uextend.i64 v2
 ;; @0045                               v8 = iadd v7, v6
 ;; @0045                               v9 = iconst.i64 16
@@ -102,19 +102,19 @@
 ;; @0045                               v12 = uextend.i64 v11
 ;; @0045                               v18 = icmp ugt v17, v12
 ;; @0045                               trapnz v18, user17
-;; @0045                               v32 = load.i64 notrap aligned v44+40
+;; @0045                               v32 = load.i64 notrap aligned v43+40
 ;; @0045                               v22 = iconst.i64 24
 ;; @0045                               v23 = iadd v8, v22  ; v22 = 24
-;;                                     v48 = iconst.i64 3
-;;                                     v49 = ishl v13, v48  ; v48 = 3
-;; @0045                               v27 = iadd v23, v49
-;;                                     v51 = ishl v14, v48  ; v48 = 3
-;; @0045                               v34 = uadd_overflow_trap v27, v51, user2
+;;                                     v47 = iconst.i64 3
+;;                                     v48 = ishl v13, v47  ; v47 = 3
+;; @0045                               v27 = iadd v23, v48
+;;                                     v50 = ishl v14, v47  ; v47 = 3
+;; @0045                               v34 = uadd_overflow_trap v27, v50, user2
 ;; @0045                               v33 = iadd v7, v32
 ;; @0045                               v35 = icmp ugt v34, v33
 ;; @0045                               trapnz v35, user2
 ;; @0045                               v36 = iconst.i32 0
-;; @0045                               call fn0(v0, v27, v36, v51)  ; v36 = 0
+;; @0045                               call fn0(v0, v27, v36, v50)  ; v36 = 0
 ;; @0048                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/array-fill-funcref.wat
+++ b/tests/disas/array-fill-funcref.wat
@@ -35,8 +35,8 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i64, v5: i32):
 ;; @003b                               trapz v2, user16
-;; @003b                               v52 = load.i64 notrap aligned readonly can_move v0+8
-;; @003b                               v7 = load.i64 notrap aligned readonly can_move v52+32
+;; @003b                               v51 = load.i64 notrap aligned readonly can_move v0+8
+;; @003b                               v7 = load.i64 notrap aligned readonly can_move v51+32
 ;; @003b                               v6 = uextend.i64 v2
 ;; @003b                               v8 = iadd v7, v6
 ;; @003b                               v9 = iconst.i64 16
@@ -48,31 +48,31 @@
 ;; @003b                               v12 = uextend.i64 v11
 ;; @003b                               v18 = icmp ugt v17, v12
 ;; @003b                               trapnz v18, user17
-;; @003b                               v32 = load.i64 notrap aligned v52+40
+;; @003b                               v32 = load.i64 notrap aligned v51+40
 ;; @003b                               v22 = iconst.i64 20
 ;; @003b                               v23 = iadd v8, v22  ; v22 = 20
-;;                                     v56 = iconst.i64 2
-;;                                     v57 = ishl v13, v56  ; v56 = 2
-;; @003b                               v27 = iadd v23, v57
-;;                                     v59 = ishl v14, v56  ; v56 = 2
-;; @003b                               v34 = uadd_overflow_trap v27, v59, user2
+;;                                     v55 = iconst.i64 2
+;;                                     v56 = ishl v13, v55  ; v55 = 2
+;; @003b                               v27 = iadd v23, v56
+;;                                     v58 = ishl v14, v55  ; v55 = 2
+;; @003b                               v34 = uadd_overflow_trap v27, v58, user2
 ;; @003b                               v33 = iadd v7, v32
 ;; @003b                               v35 = icmp ugt v34, v33
 ;; @003b                               trapnz v35, user2
-;; @003b                               v37 = call fn0(v0, v4)
-;;                                     v54 = iconst.i64 0
-;; @003b                               v41 = icmp eq v14, v54  ; v54 = 0
-;; @003b                               v38 = ireduce.i32 v37
+;; @003b                               v36 = call fn0(v0, v4)
+;;                                     v53 = iconst.i64 0
+;; @003b                               v40 = icmp eq v14, v53  ; v53 = 0
+;; @003b                               v37 = ireduce.i32 v36
 ;; @003b                               v25 = iconst.i64 4
-;; @003b                               v39 = iadd v27, v59
-;; @003b                               brif v41, block3, block2(v27)
+;; @003b                               v38 = iadd v27, v58
+;; @003b                               brif v40, block3, block2(v27)
 ;;
-;;                                 block2(v42: i64):
-;; @003b                               store.i32 notrap aligned little v38, v42
-;;                                     v61 = iconst.i64 4
-;;                                     v62 = iadd v42, v61  ; v61 = 4
-;; @003b                               v45 = icmp eq v62, v39
-;; @003b                               brif v45, block3, block2(v62)
+;;                                 block2(v41: i64):
+;; @003b                               store.i32 notrap aligned little v37, v41
+;;                                     v60 = iconst.i64 4
+;;                                     v61 = iadd v41, v60  ; v60 = 4
+;; @003b                               v44 = icmp eq v61, v38
+;; @003b                               brif v44, block3, block2(v61)
 ;;
 ;;                                 block3:
 ;; @003e                               jump block1
@@ -96,8 +96,8 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
 ;; @0049                               trapz v2, user16
-;; @0049                               v52 = load.i64 notrap aligned readonly can_move v0+8
-;; @0049                               v7 = load.i64 notrap aligned readonly can_move v52+32
+;; @0049                               v51 = load.i64 notrap aligned readonly can_move v0+8
+;; @0049                               v7 = load.i64 notrap aligned readonly can_move v51+32
 ;; @0049                               v6 = uextend.i64 v2
 ;; @0049                               v8 = iadd v7, v6
 ;; @0049                               v9 = iconst.i64 16
@@ -109,31 +109,31 @@
 ;; @0049                               v12 = uextend.i64 v11
 ;; @0049                               v18 = icmp ugt v17, v12
 ;; @0049                               trapnz v18, user17
-;; @0049                               v32 = load.i64 notrap aligned v52+40
+;; @0049                               v32 = load.i64 notrap aligned v51+40
 ;; @0049                               v22 = iconst.i64 20
 ;; @0049                               v23 = iadd v8, v22  ; v22 = 20
-;;                                     v55 = iconst.i64 2
-;;                                     v56 = ishl v13, v55  ; v55 = 2
-;; @0049                               v27 = iadd v23, v56
-;;                                     v58 = ishl v14, v55  ; v55 = 2
-;; @0049                               v34 = uadd_overflow_trap v27, v58, user2
+;;                                     v54 = iconst.i64 2
+;;                                     v55 = ishl v13, v54  ; v54 = 2
+;; @0049                               v27 = iadd v23, v55
+;;                                     v57 = ishl v14, v54  ; v54 = 2
+;; @0049                               v34 = uadd_overflow_trap v27, v57, user2
 ;; @0049                               v33 = iadd v7, v32
 ;; @0049                               v35 = icmp ugt v34, v33
 ;; @0049                               trapnz v35, user2
 ;; @0045                               v5 = iconst.i64 0
-;; @0049                               v37 = call fn0(v0, v5)  ; v5 = 0
-;; @0049                               v41 = icmp eq v14, v5  ; v5 = 0
-;; @0049                               v38 = ireduce.i32 v37
+;; @0049                               v36 = call fn0(v0, v5)  ; v5 = 0
+;; @0049                               v40 = icmp eq v14, v5  ; v5 = 0
+;; @0049                               v37 = ireduce.i32 v36
 ;; @0049                               v25 = iconst.i64 4
-;; @0049                               v39 = iadd v27, v58
-;; @0049                               brif v41, block3, block2(v27)
+;; @0049                               v38 = iadd v27, v57
+;; @0049                               brif v40, block3, block2(v27)
 ;;
-;;                                 block2(v42: i64):
-;; @0049                               store.i32 notrap aligned little v38, v42
-;;                                     v60 = iconst.i64 4
-;;                                     v61 = iadd v42, v60  ; v60 = 4
-;; @0049                               v45 = icmp eq v61, v39
-;; @0049                               brif v45, block3, block2(v61)
+;;                                 block2(v41: i64):
+;; @0049                               store.i32 notrap aligned little v37, v41
+;;                                     v59 = iconst.i64 4
+;;                                     v60 = iadd v41, v59  ; v59 = 4
+;; @0049                               v44 = icmp eq v60, v38
+;; @0049                               brif v44, block3, block2(v60)
 ;;
 ;;                                 block3:
 ;; @004c                               jump block1
@@ -159,50 +159,50 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
-;;                                     v54 = stack_addr.i64 ss0
-;;                                     store notrap v2, v54
+;;                                     v52 = stack_addr.i64 ss0
+;;                                     store notrap v2, v52
 ;; @0053                               v5 = iconst.i32 3
-;; @0053                               v7 = call fn0(v0, v5), stack_map=[i32 @ ss0+0]  ; v5 = 3
-;;                                     v53 = load.i32 notrap v54
-;; @0057                               trapz v53, user16
-;; @0057                               v61 = load.i64 notrap aligned readonly can_move v0+8
-;; @0057                               v9 = load.i64 notrap aligned readonly can_move v61+32
-;; @0057                               v8 = uextend.i64 v53
-;; @0057                               v10 = iadd v9, v8
-;; @0057                               v11 = iconst.i64 16
-;; @0057                               v12 = iadd v10, v11  ; v11 = 16
-;; @0057                               v13 = load.i32 user2 readonly region0 v12
-;; @0057                               v15 = uextend.i64 v3
-;; @0057                               v16 = uextend.i64 v4
-;; @0057                               v19 = iadd v15, v16
-;; @0057                               v14 = uextend.i64 v13
-;; @0057                               v20 = icmp ugt v19, v14
-;; @0057                               trapnz v20, user17
-;; @0057                               v34 = load.i64 notrap aligned v61+40
-;; @0057                               v24 = iconst.i64 20
-;; @0057                               v25 = iadd v10, v24  ; v24 = 20
-;;                                     v65 = iconst.i64 2
-;;                                     v66 = ishl v15, v65  ; v65 = 2
-;; @0057                               v29 = iadd v25, v66
-;;                                     v68 = ishl v16, v65  ; v65 = 2
-;; @0057                               v36 = uadd_overflow_trap v29, v68, user2
-;; @0057                               v35 = iadd v9, v34
-;; @0057                               v37 = icmp ugt v36, v35
-;; @0057                               trapnz v37, user2
-;; @0057                               v39 = call fn1(v0, v7)
-;;                                     v63 = iconst.i64 0
-;; @0057                               v43 = icmp eq v16, v63  ; v63 = 0
-;; @0057                               v40 = ireduce.i32 v39
-;; @0057                               v27 = iconst.i64 4
-;; @0057                               v41 = iadd v29, v68
-;; @0057                               brif v43, block3, block2(v29)
+;; @0053                               v6 = call fn0(v0, v5), stack_map=[i32 @ ss0+0]  ; v5 = 3
+;;                                     v51 = load.i32 notrap v52
+;; @0057                               trapz v51, user16
+;; @0057                               v59 = load.i64 notrap aligned readonly can_move v0+8
+;; @0057                               v8 = load.i64 notrap aligned readonly can_move v59+32
+;; @0057                               v7 = uextend.i64 v51
+;; @0057                               v9 = iadd v8, v7
+;; @0057                               v10 = iconst.i64 16
+;; @0057                               v11 = iadd v9, v10  ; v10 = 16
+;; @0057                               v12 = load.i32 user2 readonly region0 v11
+;; @0057                               v14 = uextend.i64 v3
+;; @0057                               v15 = uextend.i64 v4
+;; @0057                               v18 = iadd v14, v15
+;; @0057                               v13 = uextend.i64 v12
+;; @0057                               v19 = icmp ugt v18, v13
+;; @0057                               trapnz v19, user17
+;; @0057                               v33 = load.i64 notrap aligned v59+40
+;; @0057                               v23 = iconst.i64 20
+;; @0057                               v24 = iadd v9, v23  ; v23 = 20
+;;                                     v63 = iconst.i64 2
+;;                                     v64 = ishl v14, v63  ; v63 = 2
+;; @0057                               v28 = iadd v24, v64
+;;                                     v66 = ishl v15, v63  ; v63 = 2
+;; @0057                               v35 = uadd_overflow_trap v28, v66, user2
+;; @0057                               v34 = iadd v8, v33
+;; @0057                               v36 = icmp ugt v35, v34
+;; @0057                               trapnz v36, user2
+;; @0057                               v37 = call fn1(v0, v6)
+;;                                     v61 = iconst.i64 0
+;; @0057                               v41 = icmp eq v15, v61  ; v61 = 0
+;; @0057                               v38 = ireduce.i32 v37
+;; @0057                               v26 = iconst.i64 4
+;; @0057                               v39 = iadd v28, v66
+;; @0057                               brif v41, block3, block2(v28)
 ;;
-;;                                 block2(v44: i64):
-;; @0057                               store.i32 notrap aligned little v40, v44
-;;                                     v70 = iconst.i64 4
-;;                                     v71 = iadd v44, v70  ; v70 = 4
-;; @0057                               v47 = icmp eq v71, v41
-;; @0057                               brif v47, block3, block2(v71)
+;;                                 block2(v42: i64):
+;; @0057                               store.i32 notrap aligned little v38, v42
+;;                                     v68 = iconst.i64 4
+;;                                     v69 = iadd v42, v68  ; v68 = 4
+;; @0057                               v45 = icmp eq v69, v39
+;; @0057                               brif v45, block3, block2(v69)
 ;;
 ;;                                 block3:
 ;; @005a                               jump block1

--- a/tests/disas/array-fill-i16.wat
+++ b/tests/disas/array-fill-i16.wat
@@ -93,8 +93,8 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
 ;; @003f                               trapz v2, user16
-;; @003f                               v44 = load.i64 notrap aligned readonly can_move v0+8
-;; @003f                               v7 = load.i64 notrap aligned readonly can_move v44+32
+;; @003f                               v43 = load.i64 notrap aligned readonly can_move v0+8
+;; @003f                               v7 = load.i64 notrap aligned readonly can_move v43+32
 ;; @003f                               v6 = uextend.i64 v2
 ;; @003f                               v8 = iadd v7, v6
 ;; @003f                               v9 = iconst.i64 16
@@ -106,19 +106,19 @@
 ;; @003f                               v12 = uextend.i64 v11
 ;; @003f                               v18 = icmp ugt v17, v12
 ;; @003f                               trapnz v18, user17
-;; @003f                               v32 = load.i64 notrap aligned v44+40
+;; @003f                               v32 = load.i64 notrap aligned v43+40
 ;; @003f                               v22 = iconst.i64 20
 ;; @003f                               v23 = iadd v8, v22  ; v22 = 20
 ;; @003f                               v15 = iconst.i64 1
-;;                                     v49 = ishl v13, v15  ; v15 = 1
-;; @003f                               v27 = iadd v23, v49
-;;                                     v53 = ishl v14, v15  ; v15 = 1
-;; @003f                               v34 = uadd_overflow_trap v27, v53, user2
+;;                                     v48 = ishl v13, v15  ; v15 = 1
+;; @003f                               v27 = iadd v23, v48
+;;                                     v52 = ishl v14, v15  ; v15 = 1
+;; @003f                               v34 = uadd_overflow_trap v27, v52, user2
 ;; @003f                               v33 = iadd v7, v32
 ;; @003f                               v35 = icmp ugt v34, v33
 ;; @003f                               trapnz v35, user2
 ;; @003b                               v5 = iconst.i32 0
-;; @003f                               call fn0(v0, v27, v5, v53)  ; v5 = 0
+;; @003f                               call fn0(v0, v27, v5, v52)  ; v5 = 0
 ;; @0042                               jump block1
 ;;
 ;;                                 block1:
@@ -140,8 +140,8 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
 ;; @004d                               trapz v2, user16
-;; @004d                               v44 = load.i64 notrap aligned readonly can_move v0+8
-;; @004d                               v7 = load.i64 notrap aligned readonly can_move v44+32
+;; @004d                               v43 = load.i64 notrap aligned readonly can_move v0+8
+;; @004d                               v7 = load.i64 notrap aligned readonly can_move v43+32
 ;; @004d                               v6 = uextend.i64 v2
 ;; @004d                               v8 = iadd v7, v6
 ;; @004d                               v9 = iconst.i64 16
@@ -153,19 +153,19 @@
 ;; @004d                               v12 = uextend.i64 v11
 ;; @004d                               v18 = icmp ugt v17, v12
 ;; @004d                               trapnz v18, user17
-;; @004d                               v32 = load.i64 notrap aligned v44+40
+;; @004d                               v32 = load.i64 notrap aligned v43+40
 ;; @004d                               v22 = iconst.i64 20
 ;; @004d                               v23 = iadd v8, v22  ; v22 = 20
 ;; @004d                               v15 = iconst.i64 1
-;;                                     v49 = ishl v13, v15  ; v15 = 1
-;; @004d                               v27 = iadd v23, v49
-;;                                     v53 = ishl v14, v15  ; v15 = 1
-;; @004d                               v34 = uadd_overflow_trap v27, v53, user2
+;;                                     v48 = ishl v13, v15  ; v15 = 1
+;; @004d                               v27 = iadd v23, v48
+;;                                     v52 = ishl v14, v15  ; v15 = 1
+;; @004d                               v34 = uadd_overflow_trap v27, v52, user2
 ;; @004d                               v33 = iadd v7, v32
 ;; @004d                               v35 = icmp ugt v34, v33
 ;; @004d                               trapnz v35, user2
 ;; @004d                               v36 = iconst.i32 255
-;; @004d                               call fn0(v0, v27, v36, v53)  ; v36 = 255
+;; @004d                               call fn0(v0, v27, v36, v52)  ; v36 = 255
 ;; @0050                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/array-fill-i32.wat
+++ b/tests/disas/array-fill-i32.wat
@@ -93,8 +93,8 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
 ;; @003f                               trapz v2, user16
-;; @003f                               v44 = load.i64 notrap aligned readonly can_move v0+8
-;; @003f                               v7 = load.i64 notrap aligned readonly can_move v44+32
+;; @003f                               v43 = load.i64 notrap aligned readonly can_move v0+8
+;; @003f                               v7 = load.i64 notrap aligned readonly can_move v43+32
 ;; @003f                               v6 = uextend.i64 v2
 ;; @003f                               v8 = iadd v7, v6
 ;; @003f                               v9 = iconst.i64 16
@@ -106,19 +106,19 @@
 ;; @003f                               v12 = uextend.i64 v11
 ;; @003f                               v18 = icmp ugt v17, v12
 ;; @003f                               trapnz v18, user17
-;; @003f                               v32 = load.i64 notrap aligned v44+40
+;; @003f                               v32 = load.i64 notrap aligned v43+40
 ;; @003f                               v22 = iconst.i64 20
 ;; @003f                               v23 = iadd v8, v22  ; v22 = 20
-;;                                     v48 = iconst.i64 2
-;;                                     v49 = ishl v13, v48  ; v48 = 2
-;; @003f                               v27 = iadd v23, v49
-;;                                     v51 = ishl v14, v48  ; v48 = 2
-;; @003f                               v34 = uadd_overflow_trap v27, v51, user2
+;;                                     v47 = iconst.i64 2
+;;                                     v48 = ishl v13, v47  ; v47 = 2
+;; @003f                               v27 = iadd v23, v48
+;;                                     v50 = ishl v14, v47  ; v47 = 2
+;; @003f                               v34 = uadd_overflow_trap v27, v50, user2
 ;; @003f                               v33 = iadd v7, v32
 ;; @003f                               v35 = icmp ugt v34, v33
 ;; @003f                               trapnz v35, user2
 ;; @003b                               v5 = iconst.i32 0
-;; @003f                               call fn0(v0, v27, v5, v51)  ; v5 = 0
+;; @003f                               call fn0(v0, v27, v5, v50)  ; v5 = 0
 ;; @0042                               jump block1
 ;;
 ;;                                 block1:
@@ -140,8 +140,8 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
 ;; @004d                               trapz v2, user16
-;; @004d                               v44 = load.i64 notrap aligned readonly can_move v0+8
-;; @004d                               v7 = load.i64 notrap aligned readonly can_move v44+32
+;; @004d                               v43 = load.i64 notrap aligned readonly can_move v0+8
+;; @004d                               v7 = load.i64 notrap aligned readonly can_move v43+32
 ;; @004d                               v6 = uextend.i64 v2
 ;; @004d                               v8 = iadd v7, v6
 ;; @004d                               v9 = iconst.i64 16
@@ -153,19 +153,19 @@
 ;; @004d                               v12 = uextend.i64 v11
 ;; @004d                               v18 = icmp ugt v17, v12
 ;; @004d                               trapnz v18, user17
-;; @004d                               v32 = load.i64 notrap aligned v44+40
+;; @004d                               v32 = load.i64 notrap aligned v43+40
 ;; @004d                               v22 = iconst.i64 20
 ;; @004d                               v23 = iadd v8, v22  ; v22 = 20
-;;                                     v48 = iconst.i64 2
-;;                                     v49 = ishl v13, v48  ; v48 = 2
-;; @004d                               v27 = iadd v23, v49
-;;                                     v51 = ishl v14, v48  ; v48 = 2
-;; @004d                               v34 = uadd_overflow_trap v27, v51, user2
+;;                                     v47 = iconst.i64 2
+;;                                     v48 = ishl v13, v47  ; v47 = 2
+;; @004d                               v27 = iadd v23, v48
+;;                                     v50 = ishl v14, v47  ; v47 = 2
+;; @004d                               v34 = uadd_overflow_trap v27, v50, user2
 ;; @004d                               v33 = iadd v7, v32
 ;; @004d                               v35 = icmp ugt v34, v33
 ;; @004d                               trapnz v35, user2
 ;; @004d                               v36 = iconst.i32 255
-;; @004d                               call fn0(v0, v27, v36, v51)  ; v36 = 255
+;; @004d                               call fn0(v0, v27, v36, v50)  ; v36 = 255
 ;; @0050                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/array-fill-i64.wat
+++ b/tests/disas/array-fill-i64.wat
@@ -93,8 +93,8 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
 ;; @003f                               trapz v2, user16
-;; @003f                               v44 = load.i64 notrap aligned readonly can_move v0+8
-;; @003f                               v7 = load.i64 notrap aligned readonly can_move v44+32
+;; @003f                               v43 = load.i64 notrap aligned readonly can_move v0+8
+;; @003f                               v7 = load.i64 notrap aligned readonly can_move v43+32
 ;; @003f                               v6 = uextend.i64 v2
 ;; @003f                               v8 = iadd v7, v6
 ;; @003f                               v9 = iconst.i64 16
@@ -106,19 +106,19 @@
 ;; @003f                               v12 = uextend.i64 v11
 ;; @003f                               v18 = icmp ugt v17, v12
 ;; @003f                               trapnz v18, user17
-;; @003f                               v32 = load.i64 notrap aligned v44+40
+;; @003f                               v32 = load.i64 notrap aligned v43+40
 ;; @003f                               v22 = iconst.i64 24
 ;; @003f                               v23 = iadd v8, v22  ; v22 = 24
-;;                                     v47 = iconst.i64 3
-;;                                     v48 = ishl v13, v47  ; v47 = 3
-;; @003f                               v27 = iadd v23, v48
-;;                                     v50 = ishl v14, v47  ; v47 = 3
-;; @003f                               v34 = uadd_overflow_trap v27, v50, user2
+;;                                     v46 = iconst.i64 3
+;;                                     v47 = ishl v13, v46  ; v46 = 3
+;; @003f                               v27 = iadd v23, v47
+;;                                     v49 = ishl v14, v46  ; v46 = 3
+;; @003f                               v34 = uadd_overflow_trap v27, v49, user2
 ;; @003f                               v33 = iadd v7, v32
 ;; @003f                               v35 = icmp ugt v34, v33
 ;; @003f                               trapnz v35, user2
 ;; @003f                               v36 = iconst.i32 0
-;; @003f                               call fn0(v0, v27, v36, v50)  ; v36 = 0
+;; @003f                               call fn0(v0, v27, v36, v49)  ; v36 = 0
 ;; @0042                               jump block1
 ;;
 ;;                                 block1:
@@ -140,8 +140,8 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
 ;; @004d                               trapz v2, user16
-;; @004d                               v44 = load.i64 notrap aligned readonly can_move v0+8
-;; @004d                               v7 = load.i64 notrap aligned readonly can_move v44+32
+;; @004d                               v43 = load.i64 notrap aligned readonly can_move v0+8
+;; @004d                               v7 = load.i64 notrap aligned readonly can_move v43+32
 ;; @004d                               v6 = uextend.i64 v2
 ;; @004d                               v8 = iadd v7, v6
 ;; @004d                               v9 = iconst.i64 16
@@ -153,19 +153,19 @@
 ;; @004d                               v12 = uextend.i64 v11
 ;; @004d                               v18 = icmp ugt v17, v12
 ;; @004d                               trapnz v18, user17
-;; @004d                               v32 = load.i64 notrap aligned v44+40
+;; @004d                               v32 = load.i64 notrap aligned v43+40
 ;; @004d                               v22 = iconst.i64 24
 ;; @004d                               v23 = iadd v8, v22  ; v22 = 24
-;;                                     v48 = iconst.i64 3
-;;                                     v49 = ishl v13, v48  ; v48 = 3
-;; @004d                               v27 = iadd v23, v49
-;;                                     v51 = ishl v14, v48  ; v48 = 3
-;; @004d                               v34 = uadd_overflow_trap v27, v51, user2
+;;                                     v47 = iconst.i64 3
+;;                                     v48 = ishl v13, v47  ; v47 = 3
+;; @004d                               v27 = iadd v23, v48
+;;                                     v50 = ishl v14, v47  ; v47 = 3
+;; @004d                               v34 = uadd_overflow_trap v27, v50, user2
 ;; @004d                               v33 = iadd v7, v32
 ;; @004d                               v35 = icmp ugt v34, v33
 ;; @004d                               trapnz v35, user2
 ;; @004d                               v36 = iconst.i32 255
-;; @004d                               call fn0(v0, v27, v36, v51)  ; v36 = 255
+;; @004d                               call fn0(v0, v27, v36, v50)  ; v36 = 255
 ;; @0050                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/call-indirect-with-gc.wat
+++ b/tests/disas/call-indirect-with-gc.wat
@@ -40,20 +40,20 @@
 ;;
 ;;                                 block2 cold:
 ;; @0035                               v19 = iconst.i32 0
-;; @0035                               v22 = call fn0(v0, v19, v8)  ; v19 = 0
-;; @0035                               jump block3(v22)
+;; @0035                               v21 = call fn0(v0, v19, v8)  ; v19 = 0
+;; @0035                               jump block3(v21)
 ;;
 ;;                                 block3(v18: i64):
-;; @0035                               v26 = load.i32 user7 aligned readonly v18+16
-;; @0035                               v24 = load.i64 notrap aligned readonly can_move v0+40
-;; @0035                               v25 = load.i32 notrap aligned readonly can_move v24+4
-;; @0035                               v27 = icmp eq v26, v25
-;; @0035                               trapz v27, user8
-;; @0035                               v29 = load.i64 notrap aligned readonly v18+8
-;; @0035                               v30 = load.i64 notrap aligned readonly v18+24
-;; @0035                               v31 = call_indirect sig0, v29(v30, v0, v2)
+;; @0035                               v24 = load.i32 user7 aligned readonly v18+16
+;; @0035                               v22 = load.i64 notrap aligned readonly can_move v0+40
+;; @0035                               v23 = load.i32 notrap aligned readonly can_move v22+4
+;; @0035                               v25 = icmp eq v24, v23
+;; @0035                               trapz v25, user8
+;; @0035                               v27 = load.i64 notrap aligned readonly v18+8
+;; @0035                               v28 = load.i64 notrap aligned readonly v18+24
+;; @0035                               v29 = call_indirect sig0, v27(v28, v0, v2)
 ;; @0038                               jump block1
 ;;
 ;;                                 block1:
-;; @0038                               return v31
+;; @0038                               return v29
 ;; }

--- a/tests/disas/call-indirect.wat
+++ b/tests/disas/call-indirect.wat
@@ -1,6 +1,4 @@
 ;;! target = "x86_64"
-;;! flags = "-W function-references=n,gc=n"
-;;! test = "optimize"
 
 (module
   (table (export "t") 0 100 funcref)
@@ -24,14 +22,14 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0035                               v5 = load.i64 notrap aligned v0+56
-;; @0035                               v9 = load.i64 notrap aligned v0+48
 ;; @0035                               v6 = ireduce.i32 v5
 ;; @0035                               v7 = icmp uge v3, v6
-;; @0035                               v13 = iconst.i64 0
 ;; @0035                               v8 = uextend.i64 v3
+;; @0035                               v9 = load.i64 notrap aligned v0+48
 ;; @0035                               v10 = iconst.i64 3
 ;; @0035                               v11 = ishl v8, v10  ; v10 = 3
 ;; @0035                               v12 = iadd v9, v11
+;; @0035                               v13 = iconst.i64 0
 ;; @0035                               v14 = select_spectre_guard v7, v13, v12  ; v13 = 0
 ;; @0035                               v15 = load.i64 user6 aligned region0 v14
 ;; @0035                               v16 = iconst.i64 -2
@@ -40,15 +38,17 @@
 ;;
 ;;                                 block2 cold:
 ;; @0035                               v19 = iconst.i32 0
-;; @0035                               v21 = call fn0(v0, v19, v8)  ; v19 = 0
+;; @0035                               v20 = uextend.i64 v3
+;; @0035                               v21 = call fn0(v0, v19, v20)  ; v19 = 0
 ;; @0035                               jump block3(v21)
 ;;
 ;;                                 block3(v18: i64):
-;; @0035                               v24 = load.i32 user7 aligned readonly v18+16
 ;; @0035                               v22 = load.i64 notrap aligned readonly can_move v0+40
 ;; @0035                               v23 = load.i32 notrap aligned readonly can_move v22+4
+;; @0035                               v24 = load.i32 user7 aligned readonly v18+16
 ;; @0035                               v25 = icmp eq v24, v23
-;; @0035                               trapz v25, user8
+;; @0035                               v26 = uextend.i32 v25
+;; @0035                               trapz v26, user8
 ;; @0035                               v27 = load.i64 notrap aligned readonly v18+8
 ;; @0035                               v28 = load.i64 notrap aligned readonly v18+24
 ;; @0035                               v29 = call_indirect sig0, v27(v28, v0, v2)

--- a/tests/disas/duplicate-function-types.wat
+++ b/tests/disas/duplicate-function-types.wat
@@ -31,13 +31,13 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @002d                               v66 = load.i64 notrap aligned readonly can_move v0+48
-;; @002d                               v5 = load.i64 notrap aligned v66+8
+;; @002d                               v62 = load.i64 notrap aligned readonly can_move v0+48
+;; @002d                               v5 = load.i64 notrap aligned v62+8
 ;; @002d                               v6 = ireduce.i32 v5
 ;; @002d                               v7 = icmp uge v2, v6
 ;; @002d                               v8 = uextend.i64 v2
-;; @002d                               v64 = load.i64 notrap aligned readonly can_move v0+48
-;; @002d                               v9 = load.i64 notrap aligned v64
+;; @002d                               v60 = load.i64 notrap aligned readonly can_move v0+48
+;; @002d                               v9 = load.i64 notrap aligned v60
 ;; @002d                               v10 = iconst.i64 3
 ;; @002d                               v11 = ishl v8, v10  ; v10 = 3
 ;; @002d                               v12 = iadd v9, v11
@@ -50,55 +50,55 @@
 ;;
 ;;                                 block2 cold:
 ;; @002d                               v19 = iconst.i32 0
-;; @002d                               v21 = uextend.i64 v2
-;; @002d                               v22 = call fn0(v0, v19, v21)  ; v19 = 0
-;; @002d                               jump block3(v22)
+;; @002d                               v20 = uextend.i64 v2
+;; @002d                               v21 = call fn0(v0, v19, v20)  ; v19 = 0
+;; @002d                               jump block3(v21)
 ;;
 ;;                                 block3(v18: i64):
-;; @002d                               v24 = load.i64 notrap aligned readonly can_move v0+40
-;; @002d                               v25 = load.i32 notrap aligned readonly can_move v24
-;; @002d                               v26 = load.i32 user7 aligned readonly v18+16
-;; @002d                               v27 = icmp eq v26, v25
-;; @002d                               v28 = uextend.i32 v27
-;; @002d                               trapz v28, user8
-;; @002d                               v29 = load.i64 notrap aligned readonly v18+8
-;; @002d                               v30 = load.i64 notrap aligned readonly v18+24
-;; @002d                               v31 = call_indirect sig0, v29(v30, v0)
-;; @0032                               v62 = load.i64 notrap aligned readonly can_move v0+48
-;; @0032                               v33 = load.i64 notrap aligned v62+8
-;; @0032                               v34 = ireduce.i32 v33
-;; @0032                               v35 = icmp.i32 uge v2, v34
-;; @0032                               v36 = uextend.i64 v2
-;; @0032                               v60 = load.i64 notrap aligned readonly can_move v0+48
-;; @0032                               v37 = load.i64 notrap aligned v60
-;; @0032                               v38 = iconst.i64 3
-;; @0032                               v39 = ishl v36, v38  ; v38 = 3
-;; @0032                               v40 = iadd v37, v39
-;; @0032                               v41 = iconst.i64 0
-;; @0032                               v42 = select_spectre_guard v35, v41, v40  ; v41 = 0
-;; @0032                               v43 = load.i64 user6 aligned region0 v42
-;; @0032                               v44 = iconst.i64 -2
-;; @0032                               v45 = band v43, v44  ; v44 = -2
-;; @0032                               brif v43, block5(v45), block4
+;; @002d                               v22 = load.i64 notrap aligned readonly can_move v0+40
+;; @002d                               v23 = load.i32 notrap aligned readonly can_move v22
+;; @002d                               v24 = load.i32 user7 aligned readonly v18+16
+;; @002d                               v25 = icmp eq v24, v23
+;; @002d                               v26 = uextend.i32 v25
+;; @002d                               trapz v26, user8
+;; @002d                               v27 = load.i64 notrap aligned readonly v18+8
+;; @002d                               v28 = load.i64 notrap aligned readonly v18+24
+;; @002d                               v29 = call_indirect sig0, v27(v28, v0)
+;; @0032                               v58 = load.i64 notrap aligned readonly can_move v0+48
+;; @0032                               v31 = load.i64 notrap aligned v58+8
+;; @0032                               v32 = ireduce.i32 v31
+;; @0032                               v33 = icmp.i32 uge v2, v32
+;; @0032                               v34 = uextend.i64 v2
+;; @0032                               v56 = load.i64 notrap aligned readonly can_move v0+48
+;; @0032                               v35 = load.i64 notrap aligned v56
+;; @0032                               v36 = iconst.i64 3
+;; @0032                               v37 = ishl v34, v36  ; v36 = 3
+;; @0032                               v38 = iadd v35, v37
+;; @0032                               v39 = iconst.i64 0
+;; @0032                               v40 = select_spectre_guard v33, v39, v38  ; v39 = 0
+;; @0032                               v41 = load.i64 user6 aligned region0 v40
+;; @0032                               v42 = iconst.i64 -2
+;; @0032                               v43 = band v41, v42  ; v42 = -2
+;; @0032                               brif v41, block5(v43), block4
 ;;
 ;;                                 block4 cold:
-;; @0032                               v47 = iconst.i32 0
-;; @0032                               v49 = uextend.i64 v2
-;; @0032                               v50 = call fn0(v0, v47, v49)  ; v47 = 0
-;; @0032                               jump block5(v50)
+;; @0032                               v45 = iconst.i32 0
+;; @0032                               v46 = uextend.i64 v2
+;; @0032                               v47 = call fn0(v0, v45, v46)  ; v45 = 0
+;; @0032                               jump block5(v47)
 ;;
-;;                                 block5(v46: i64):
-;; @0032                               v52 = load.i64 notrap aligned readonly can_move v0+40
-;; @0032                               v53 = load.i32 notrap aligned readonly can_move v52
-;; @0032                               v54 = load.i32 user7 aligned readonly v46+16
-;; @0032                               v55 = icmp eq v54, v53
-;; @0032                               v56 = uextend.i32 v55
-;; @0032                               trapz v56, user8
-;; @0032                               v57 = load.i64 notrap aligned readonly v46+8
-;; @0032                               v58 = load.i64 notrap aligned readonly v46+24
-;; @0032                               v59 = call_indirect sig0, v57(v58, v0)
+;;                                 block5(v44: i64):
+;; @0032                               v48 = load.i64 notrap aligned readonly can_move v0+40
+;; @0032                               v49 = load.i32 notrap aligned readonly can_move v48
+;; @0032                               v50 = load.i32 user7 aligned readonly v44+16
+;; @0032                               v51 = icmp eq v50, v49
+;; @0032                               v52 = uextend.i32 v51
+;; @0032                               trapz v52, user8
+;; @0032                               v53 = load.i64 notrap aligned readonly v44+8
+;; @0032                               v54 = load.i64 notrap aligned readonly v44+24
+;; @0032                               v55 = call_indirect sig0, v53(v54, v0)
 ;; @0035                               jump block1
 ;;
 ;;                                 block1:
-;; @0035                               return v31, v59
+;; @0035                               return v29, v55
 ;; }

--- a/tests/disas/epoch-interruption.wat
+++ b/tests/disas/epoch-interruption.wat
@@ -8,40 +8,39 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx) -> i64 tail
 ;;     fn0 = colocated u805306368:13 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @0016                               v3 = load.i64 notrap aligned v0+24
-;; @0016                               v4 = load.i64 notrap aligned v3
-;; @0016                               v5 = load.i64 notrap aligned readonly can_move v0+8
-;; @0016                               v6 = load.i64 notrap aligned v5+8
-;; @0016                               v7 = icmp uge v4, v6
-;; @0016                               brif v7, block3, block2(v6)
+;; @0016                               v2 = load.i64 notrap aligned v0+24
+;; @0016                               v3 = load.i64 notrap aligned v2
+;; @0016                               v4 = load.i64 notrap aligned readonly can_move v0+8
+;; @0016                               v5 = load.i64 notrap aligned v4+8
+;; @0016                               v6 = icmp uge v3, v5
+;; @0016                               brif v6, block3, block2(v5)
 ;;
 ;;                                 block3 cold:
-;; @0016                               v8 = call fn0(v0)
-;; @0016                               jump block2(v8)
+;; @0016                               v7 = call fn0(v0)
+;; @0016                               jump block2(v7)
 ;;
-;;                                 block2(v19: i64):
-;; @0017                               jump block4(v19)
+;;                                 block2(v18: i64):
+;; @0017                               jump block4(v18)
 ;;
-;;                                 block4(v11: i64):
-;; @0017                               v10 = load.i64 notrap aligned v3
-;; @0017                               v12 = icmp uge v10, v11
-;; @0017                               brif v12, block7, block6(v11)
+;;                                 block4(v10: i64):
+;; @0017                               v9 = load.i64 notrap aligned v2
+;; @0017                               v11 = icmp uge v9, v10
+;; @0017                               brif v11, block7, block6(v10)
 ;;
 ;;                                 block7 cold:
-;; @0017                               v14 = load.i64 notrap aligned v5+8
-;; @0017                               v15 = icmp.i64 uge v10, v14
-;; @0017                               brif v15, block8, block6(v14)
+;; @0017                               v13 = load.i64 notrap aligned v4+8
+;; @0017                               v14 = icmp.i64 uge v9, v13
+;; @0017                               brif v14, block8, block6(v13)
 ;;
 ;;                                 block8 cold:
-;; @0017                               v16 = call fn0(v0)
-;; @0017                               jump block6(v16)
+;; @0017                               v15 = call fn0(v0)
+;; @0017                               jump block6(v15)
 ;;
-;;                                 block6(v20: i64):
-;; @0019                               jump block4(v20)
+;;                                 block6(v19: i64):
+;; @0019                               jump block4(v19)
 ;; }

--- a/tests/disas/epoch-interruption.wat
+++ b/tests/disas/epoch-interruption.wat
@@ -23,26 +23,26 @@
 ;; @0016                               brif v7, block3, block2(v6)
 ;;
 ;;                                 block3 cold:
-;; @0016                               v9 = call fn0(v0)
-;; @0016                               jump block2(v9)
+;; @0016                               v8 = call fn0(v0)
+;; @0016                               jump block2(v8)
 ;;
-;;                                 block2(v21: i64):
-;; @0017                               jump block4(v21)
+;;                                 block2(v19: i64):
+;; @0017                               jump block4(v19)
 ;;
-;;                                 block4(v12: i64):
-;; @0017                               v11 = load.i64 notrap aligned v3
-;; @0017                               v13 = icmp uge v11, v12
-;; @0017                               brif v13, block7, block6(v12)
+;;                                 block4(v11: i64):
+;; @0017                               v10 = load.i64 notrap aligned v3
+;; @0017                               v12 = icmp uge v10, v11
+;; @0017                               brif v12, block7, block6(v11)
 ;;
 ;;                                 block7 cold:
-;; @0017                               v15 = load.i64 notrap aligned v5+8
-;; @0017                               v16 = icmp.i64 uge v11, v15
-;; @0017                               brif v16, block8, block6(v15)
+;; @0017                               v14 = load.i64 notrap aligned v5+8
+;; @0017                               v15 = icmp.i64 uge v10, v14
+;; @0017                               brif v15, block8, block6(v14)
 ;;
 ;;                                 block8 cold:
-;; @0017                               v18 = call fn0(v0)
-;; @0017                               jump block6(v18)
+;; @0017                               v16 = call fn0(v0)
+;; @0017                               jump block6(v16)
 ;;
-;;                                 block6(v22: i64):
-;; @0019                               jump block4(v22)
+;;                                 block6(v20: i64):
+;; @0019                               jump block4(v20)
 ;; }

--- a/tests/disas/epoch-interruption.wat
+++ b/tests/disas/epoch-interruption.wat
@@ -9,7 +9,6 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
 ;;     sig0 = (i64 vmctx) -> i64 tail
 ;;     fn0 = colocated u805306368:13 sig0
 ;;     stack_limit = gv2

--- a/tests/disas/foo.wat
+++ b/tests/disas/foo.wat
@@ -36,9 +36,9 @@
 ;; @0040                               v6 = uextend.i64 v3
 ;; @0040                               v8 = iadd v7, v6
 ;; @0040                               v9 = load.i32 little region0 v8
-;; @0043                               v77 = load.i64 notrap aligned readonly can_move v0+72
-;; @0043                               v10 = load.i64 notrap aligned v77+8
-;; @0043                               v14 = load.i64 notrap aligned v77
+;; @0043                               v73 = load.i64 notrap aligned readonly can_move v0+72
+;; @0043                               v10 = load.i64 notrap aligned v73+8
+;; @0043                               v14 = load.i64 notrap aligned v73
 ;; @0043                               v11 = ireduce.i32 v10
 ;; @0043                               v12 = icmp uge v9, v11
 ;; @0043                               v18 = iconst.i64 0
@@ -54,48 +54,48 @@
 ;;
 ;;                                 block2 cold:
 ;; @0043                               v24 = iconst.i32 0
-;; @0043                               v27 = call fn0(v0, v24, v13)  ; v24 = 0
-;; @0043                               jump block3(v27)
+;; @0043                               v26 = call fn0(v0, v24, v13)  ; v24 = 0
+;; @0043                               jump block3(v26)
 ;;
 ;;                                 block3(v23: i64):
-;; @0043                               v31 = load.i32 user7 aligned readonly v23+16
-;; @0043                               v29 = load.i64 notrap aligned readonly can_move v0+40
-;; @0043                               v30 = load.i32 notrap aligned readonly can_move v29+4
-;; @0043                               v32 = icmp eq v31, v30
-;; @0043                               trapz v32, user8
-;; @0043                               v34 = load.i64 notrap aligned readonly v23+8
-;; @0043                               v35 = load.i64 notrap aligned readonly v23+24
-;; @0043                               v36 = call_indirect sig0, v34(v35, v0, v2)
-;; @004a                               v42 = load.i32 little region0 v8
-;; @004d                               v43 = load.i64 notrap aligned v77+8
-;; @004d                               v47 = load.i64 notrap aligned v77
-;; @004d                               v44 = ireduce.i32 v43
-;; @004d                               v45 = icmp uge v42, v44
-;; @004d                               v46 = uextend.i64 v42
-;;                                     v80 = iconst.i64 3
-;;                                     v81 = ishl v46, v80  ; v80 = 3
-;; @004d                               v50 = iadd v47, v81
-;;                                     v82 = iconst.i64 0
-;;                                     v83 = select_spectre_guard v45, v82, v50  ; v82 = 0
-;; @004d                               v53 = load.i64 user6 aligned region1 v83
-;;                                     v84 = iconst.i64 -2
-;;                                     v85 = band v53, v84  ; v84 = -2
-;; @004d                               brif v53, block5(v85), block4
+;; @0043                               v29 = load.i32 user7 aligned readonly v23+16
+;; @0043                               v27 = load.i64 notrap aligned readonly can_move v0+40
+;; @0043                               v28 = load.i32 notrap aligned readonly can_move v27+4
+;; @0043                               v30 = icmp eq v29, v28
+;; @0043                               trapz v30, user8
+;; @0043                               v32 = load.i64 notrap aligned readonly v23+8
+;; @0043                               v33 = load.i64 notrap aligned readonly v23+24
+;; @0043                               v34 = call_indirect sig0, v32(v33, v0, v2)
+;; @004a                               v40 = load.i32 little region0 v8
+;; @004d                               v41 = load.i64 notrap aligned v73+8
+;; @004d                               v45 = load.i64 notrap aligned v73
+;; @004d                               v42 = ireduce.i32 v41
+;; @004d                               v43 = icmp uge v40, v42
+;; @004d                               v44 = uextend.i64 v40
+;;                                     v76 = iconst.i64 3
+;;                                     v77 = ishl v44, v76  ; v76 = 3
+;; @004d                               v48 = iadd v45, v77
+;;                                     v78 = iconst.i64 0
+;;                                     v79 = select_spectre_guard v43, v78, v48  ; v78 = 0
+;; @004d                               v51 = load.i64 user6 aligned region1 v79
+;;                                     v80 = iconst.i64 -2
+;;                                     v81 = band v51, v80  ; v80 = -2
+;; @004d                               brif v51, block5(v81), block4
 ;;
 ;;                                 block4 cold:
-;;                                     v86 = iconst.i32 0
-;; @004d                               v60 = call fn0(v0, v86, v46)  ; v86 = 0
-;; @004d                               jump block5(v60)
+;;                                     v82 = iconst.i32 0
+;; @004d                               v57 = call fn0(v0, v82, v44)  ; v82 = 0
+;; @004d                               jump block5(v57)
 ;;
-;;                                 block5(v56: i64):
-;; @004d                               v64 = load.i32 user7 aligned readonly v56+16
-;; @004d                               v65 = icmp eq v64, v30
-;; @004d                               trapz v65, user8
-;; @004d                               v67 = load.i64 notrap aligned readonly v56+8
-;; @004d                               v68 = load.i64 notrap aligned readonly v56+24
-;; @004d                               v69 = call_indirect sig0, v67(v68, v0, v2)
+;;                                 block5(v54: i64):
+;; @004d                               v60 = load.i32 user7 aligned readonly v54+16
+;; @004d                               v61 = icmp eq v60, v28
+;; @004d                               trapz v61, user8
+;; @004d                               v63 = load.i64 notrap aligned readonly v54+8
+;; @004d                               v64 = load.i64 notrap aligned readonly v54+24
+;; @004d                               v65 = call_indirect sig0, v63(v64, v0, v2)
 ;; @0050                               jump block1
 ;;
 ;;                                 block1:
-;; @0050                               return v36, v69
+;; @0050                               return v34, v65
 ;; }

--- a/tests/disas/gc/array-copy-with-fuel.wat
+++ b/tests/disas/gc/array-copy-with-fuel.wat
@@ -38,8 +38,8 @@
 ;; @0020                               brif v12, block2, block3(v10)
 ;;
 ;;                                 block2:
-;;                                     v207 = iadd.i64 v8, v9  ; v9 = 1
-;; @0020                               store notrap aligned v207, v7
+;;                                     v199 = iadd.i64 v8, v9  ; v9 = 1
+;; @0020                               store notrap aligned v199, v7
 ;; @0020                               v14 = call fn0(v0), stack_map=[i32 @ ss0+0, i32 @ ss1+0]
 ;; @0020                               v16 = load.i64 notrap aligned v7
 ;; @0020                               jump block3(v16)
@@ -73,18 +73,18 @@
 ;; @002b                               v72 = load.i64 notrap aligned v7+40
 ;; @002b                               v38 = iconst.i64 20
 ;; @002b                               v39 = iadd v24, v38  ; v38 = 20
-;;                                     v200 = iconst.i64 2
-;;                                     v201 = ishl v29, v200  ; v200 = 2
-;; @002b                               v43 = iadd v39, v201
-;;                                     v205 = ishl v30, v200  ; v200 = 2
-;; @002b                               v74 = uadd_overflow_trap v43, v205, user2
+;;                                     v192 = iconst.i64 2
+;;                                     v193 = ishl v29, v192  ; v192 = 2
+;; @002b                               v43 = iadd v39, v193
+;;                                     v197 = ishl v30, v192  ; v192 = 2
+;; @002b                               v74 = uadd_overflow_trap v43, v197, user2
 ;; @002b                               v73 = iadd v23, v72
 ;; @002b                               v75 = icmp ugt v74, v73
 ;; @002b                               trapnz v75, user2
 ;; @002b                               v61 = iadd v46, v38  ; v38 = 20
-;;                                     v203 = ishl v51, v200  ; v200 = 2
-;; @002b                               v65 = iadd v61, v203
-;; @002b                               v79 = uadd_overflow_trap v65, v205, user2
+;;                                     v195 = ishl v51, v192  ; v192 = 2
+;; @002b                               v65 = iadd v61, v195
+;; @002b                               v79 = uadd_overflow_trap v65, v197, user2
 ;; @002b                               v80 = icmp ugt v79, v73
 ;; @002b                               trapnz v80, user2
 ;; @002b                               v82 = iconst.i64 6
@@ -95,37 +95,37 @@
 ;;                                     v154 = load.i32 notrap v173
 ;;                                     v156 = load.i32 notrap v174
 ;; @002b                               v84 = icmp.i64 ult v43, v65
-;;                                     v208 = iadd.i64 v81, v82  ; v82 = 6
-;; @002b                               v89 = iadd.i64 v43, v205
-;; @002b                               v90 = iadd.i64 v65, v205
+;;                                     v200 = iadd.i64 v81, v82  ; v82 = 6
+;; @002b                               v89 = iadd.i64 v43, v197
+;; @002b                               v90 = iadd.i64 v65, v197
 ;; @002b                               v92 = iadd.i32 v5, v6
 ;; @002b                               v41 = iconst.i64 4
 ;; @002b                               v133 = iconst.i32 1
-;; @002b                               brif v84, block5(v43, v65, v5, v154, v156, v208), block6(v89, v90, v92, v154, v156, v208)
+;; @002b                               brif v84, block5(v43, v65, v5, v154, v156, v200), block6(v89, v90, v92, v154, v156, v200)
 ;;
 ;;                                 block5(v93: i64, v94: i64, v95: i32, v96: i32, v97: i32, v98: i64):
 ;;                                     store notrap v96, v173
 ;;                                     store notrap v97, v174
-;;                                     v218 = iconst.i64 1
-;;                                     v219 = iadd v98, v218  ; v218 = 1
-;;                                     v220 = iconst.i64 0
-;;                                     v221 = icmp sge v219, v220  ; v220 = 0
-;; @002b                               brif v221, block8, block9(v219)
+;;                                     v210 = iconst.i64 1
+;;                                     v211 = iadd v98, v210  ; v210 = 1
+;;                                     v212 = iconst.i64 0
+;;                                     v213 = icmp sge v211, v212  ; v212 = 0
+;; @002b                               brif v213, block8, block9(v211)
 ;;
 ;;                                 block6(v115: i64, v116: i64, v117: i32, v118: i32, v119: i32, v120: i64):
 ;;                                     store notrap v118, v174
 ;;                                     store notrap v119, v173
-;;                                     v209 = iconst.i64 1
-;;                                     v210 = iadd v120, v209  ; v209 = 1
-;;                                     v211 = iconst.i64 0
-;;                                     v212 = icmp sge v210, v211  ; v211 = 0
-;; @002b                               brif v212, block10, block11(v210)
+;;                                     v201 = iconst.i64 1
+;;                                     v202 = iadd v120, v201  ; v201 = 1
+;;                                     v203 = iconst.i64 0
+;;                                     v204 = icmp sge v202, v203  ; v203 = 0
+;; @002b                               brif v204, block10, block11(v202)
 ;;
 ;;                                 block7(v140: i64):
 ;; @002f                               jump block1
 ;;
 ;;                                 block8:
-;; @002b                               store.i64 notrap aligned v219, v7
+;; @002b                               store.i64 notrap aligned v211, v7
 ;; @002b                               v104 = call fn0(v0), stack_map=[i32 @ ss0+0, i32 @ ss1+0]
 ;; @002b                               v106 = load.i64 notrap aligned v7
 ;; @002b                               jump block9(v106)
@@ -135,32 +135,32 @@
 ;; @002b                               store user2 little region0 v107, v93
 ;;                                     v142 = load.i32 notrap v173
 ;;                                     v144 = load.i32 notrap v174
-;;                                     v222 = iconst.i64 4
-;;                                     v223 = iadd.i64 v94, v222  ; v222 = 4
-;; @002b                               v114 = icmp eq v223, v90
-;;                                     v224 = iadd.i64 v93, v222  ; v222 = 4
-;;                                     v225 = iconst.i32 1
-;;                                     v226 = iadd.i32 v95, v225  ; v225 = 1
-;; @002b                               brif v114, block7(v137), block5(v224, v223, v226, v142, v144, v137)
+;;                                     v214 = iconst.i64 4
+;;                                     v215 = iadd.i64 v94, v214  ; v214 = 4
+;; @002b                               v114 = icmp eq v215, v90
+;;                                     v216 = iadd.i64 v93, v214  ; v214 = 4
+;;                                     v217 = iconst.i32 1
+;;                                     v218 = iadd.i32 v95, v217  ; v217 = 1
+;; @002b                               brif v114, block7(v137), block5(v216, v215, v218, v142, v144, v137)
 ;;
 ;;                                 block10:
-;; @002b                               store.i64 notrap aligned v210, v7
+;; @002b                               store.i64 notrap aligned v202, v7
 ;; @002b                               v126 = call fn0(v0), stack_map=[i32 @ ss1+0, i32 @ ss0+0]
 ;; @002b                               v128 = load.i64 notrap aligned v7
 ;; @002b                               jump block11(v128)
 ;;
 ;;                                 block11(v138: i64):
-;;                                     v213 = iconst.i64 4
-;;                                     v214 = isub.i64 v116, v213  ; v213 = 4
-;; @002b                               v135 = load.i32 user2 little region0 v214
-;;                                     v215 = isub.i64 v115, v213  ; v213 = 4
-;; @002b                               store user2 little region0 v135, v215
+;;                                     v205 = iconst.i64 4
+;;                                     v206 = isub.i64 v116, v205  ; v205 = 4
+;; @002b                               v135 = load.i32 user2 little region0 v206
+;;                                     v207 = isub.i64 v115, v205  ; v205 = 4
+;; @002b                               store user2 little region0 v135, v207
 ;;                                     v148 = load.i32 notrap v174
 ;;                                     v150 = load.i32 notrap v173
-;; @002b                               v136 = icmp eq v214, v65
-;;                                     v216 = iconst.i32 1
-;;                                     v217 = isub.i32 v117, v216  ; v216 = 1
-;; @002b                               brif v136, block7(v138), block6(v215, v214, v217, v148, v150, v138)
+;; @002b                               v136 = icmp eq v206, v65
+;;                                     v208 = iconst.i32 1
+;;                                     v209 = isub.i32 v117, v208  ; v208 = 1
+;; @002b                               brif v136, block7(v138), block6(v207, v206, v209, v148, v150, v138)
 ;;
 ;;                                 block1:
 ;; @002f                               store.i64 notrap aligned v140, v7

--- a/tests/disas/gc/array-copy-with-fuel.wat
+++ b/tests/disas/gc/array-copy-with-fuel.wat
@@ -25,10 +25,10 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32, v6: i32):
-;;                                     v176 = stack_addr.i64 ss0
-;;                                     store notrap v2, v176
-;;                                     v177 = stack_addr.i64 ss1
-;;                                     store notrap v4, v177
+;;                                     v173 = stack_addr.i64 ss0
+;;                                     store notrap v2, v173
+;;                                     v174 = stack_addr.i64 ss1
+;;                                     store notrap v4, v174
 ;; @0020                               v7 = load.i64 notrap aligned readonly can_move v0+8
 ;; @0020                               v8 = load.i64 notrap aligned v7
 ;; @0020                               v9 = iconst.i64 1
@@ -38,131 +38,131 @@
 ;; @0020                               brif v12, block2, block3(v10)
 ;;
 ;;                                 block2:
-;;                                     v210 = iadd.i64 v8, v9  ; v9 = 1
-;; @0020                               store notrap aligned v210, v7
-;; @0020                               v15 = call fn0(v0), stack_map=[i32 @ ss0+0, i32 @ ss1+0]
-;; @0020                               v17 = load.i64 notrap aligned v7
-;; @0020                               jump block3(v17)
+;;                                     v207 = iadd.i64 v8, v9  ; v9 = 1
+;; @0020                               store notrap aligned v207, v7
+;; @0020                               v14 = call fn0(v0), stack_map=[i32 @ ss0+0, i32 @ ss1+0]
+;; @0020                               v16 = load.i64 notrap aligned v7
+;; @0020                               jump block3(v16)
 ;;
-;;                                 block3(v82: i64):
-;;                                     v175 = load.i32 notrap v176
-;; @002b                               trapz v175, user16
-;; @002b                               v24 = load.i64 notrap aligned readonly can_move v7+32
-;; @002b                               v23 = uextend.i64 v175
-;; @002b                               v25 = iadd v24, v23
-;; @002b                               v26 = iconst.i64 16
-;; @002b                               v27 = iadd v25, v26  ; v26 = 16
-;; @002b                               v28 = load.i32 user2 readonly region0 v27
-;; @002b                               v30 = uextend.i64 v3
-;; @002b                               v31 = uextend.i64 v6
-;; @002b                               v34 = iadd v30, v31
-;; @002b                               v29 = uextend.i64 v28
-;; @002b                               v35 = icmp ugt v34, v29
-;; @002b                               trapnz v35, user17
-;;                                     v169 = load.i32 notrap v177
-;; @002b                               trapz v169, user16
-;; @002b                               v45 = uextend.i64 v169
-;; @002b                               v47 = iadd v24, v45
-;; @002b                               v49 = iadd v47, v26  ; v26 = 16
-;; @002b                               v50 = load.i32 user2 readonly region0 v49
-;; @002b                               v52 = uextend.i64 v5
-;; @002b                               v56 = iadd v52, v31
-;; @002b                               v51 = uextend.i64 v50
-;; @002b                               v57 = icmp ugt v56, v51
-;; @002b                               trapnz v57, user17
-;; @002b                               v73 = load.i64 notrap aligned v7+40
-;; @002b                               v39 = iconst.i64 20
-;; @002b                               v40 = iadd v25, v39  ; v39 = 20
-;;                                     v203 = iconst.i64 2
-;;                                     v204 = ishl v30, v203  ; v203 = 2
-;; @002b                               v44 = iadd v40, v204
-;;                                     v208 = ishl v31, v203  ; v203 = 2
-;; @002b                               v75 = uadd_overflow_trap v44, v208, user2
-;; @002b                               v74 = iadd v24, v73
-;; @002b                               v76 = icmp ugt v75, v74
-;; @002b                               trapnz v76, user2
-;; @002b                               v62 = iadd v47, v39  ; v39 = 20
-;;                                     v206 = ishl v52, v203  ; v203 = 2
-;; @002b                               v66 = iadd v62, v206
-;; @002b                               v80 = uadd_overflow_trap v66, v208, user2
-;; @002b                               v81 = icmp ugt v80, v74
-;; @002b                               trapnz v81, user2
-;; @002b                               v83 = iconst.i64 6
-;; @002b                               v84 = iadd v82, v83  ; v83 = 6
-;; @002b                               brif.i32 v6, block4, block7(v84)
+;;                                 block3(v81: i64):
+;;                                     v172 = load.i32 notrap v173
+;; @002b                               trapz v172, user16
+;; @002b                               v23 = load.i64 notrap aligned readonly can_move v7+32
+;; @002b                               v22 = uextend.i64 v172
+;; @002b                               v24 = iadd v23, v22
+;; @002b                               v25 = iconst.i64 16
+;; @002b                               v26 = iadd v24, v25  ; v25 = 16
+;; @002b                               v27 = load.i32 user2 readonly region0 v26
+;; @002b                               v29 = uextend.i64 v3
+;; @002b                               v30 = uextend.i64 v6
+;; @002b                               v33 = iadd v29, v30
+;; @002b                               v28 = uextend.i64 v27
+;; @002b                               v34 = icmp ugt v33, v28
+;; @002b                               trapnz v34, user17
+;;                                     v166 = load.i32 notrap v174
+;; @002b                               trapz v166, user16
+;; @002b                               v44 = uextend.i64 v166
+;; @002b                               v46 = iadd v23, v44
+;; @002b                               v48 = iadd v46, v25  ; v25 = 16
+;; @002b                               v49 = load.i32 user2 readonly region0 v48
+;; @002b                               v51 = uextend.i64 v5
+;; @002b                               v55 = iadd v51, v30
+;; @002b                               v50 = uextend.i64 v49
+;; @002b                               v56 = icmp ugt v55, v50
+;; @002b                               trapnz v56, user17
+;; @002b                               v72 = load.i64 notrap aligned v7+40
+;; @002b                               v38 = iconst.i64 20
+;; @002b                               v39 = iadd v24, v38  ; v38 = 20
+;;                                     v200 = iconst.i64 2
+;;                                     v201 = ishl v29, v200  ; v200 = 2
+;; @002b                               v43 = iadd v39, v201
+;;                                     v205 = ishl v30, v200  ; v200 = 2
+;; @002b                               v74 = uadd_overflow_trap v43, v205, user2
+;; @002b                               v73 = iadd v23, v72
+;; @002b                               v75 = icmp ugt v74, v73
+;; @002b                               trapnz v75, user2
+;; @002b                               v61 = iadd v46, v38  ; v38 = 20
+;;                                     v203 = ishl v51, v200  ; v200 = 2
+;; @002b                               v65 = iadd v61, v203
+;; @002b                               v79 = uadd_overflow_trap v65, v205, user2
+;; @002b                               v80 = icmp ugt v79, v73
+;; @002b                               trapnz v80, user2
+;; @002b                               v82 = iconst.i64 6
+;; @002b                               v83 = iadd v81, v82  ; v82 = 6
+;; @002b                               brif.i32 v6, block4, block7(v83)
 ;;
 ;;                                 block4:
-;;                                     v157 = load.i32 notrap v176
-;;                                     v159 = load.i32 notrap v177
-;; @002b                               v85 = icmp.i64 ult v44, v66
-;;                                     v211 = iadd.i64 v82, v83  ; v83 = 6
-;; @002b                               v90 = iadd.i64 v44, v208
-;; @002b                               v91 = iadd.i64 v66, v208
-;; @002b                               v93 = iadd.i32 v5, v6
-;; @002b                               v42 = iconst.i64 4
-;; @002b                               v136 = iconst.i32 1
-;; @002b                               brif v85, block5(v44, v66, v5, v157, v159, v211), block6(v90, v91, v93, v157, v159, v211)
+;;                                     v154 = load.i32 notrap v173
+;;                                     v156 = load.i32 notrap v174
+;; @002b                               v84 = icmp.i64 ult v43, v65
+;;                                     v208 = iadd.i64 v81, v82  ; v82 = 6
+;; @002b                               v89 = iadd.i64 v43, v205
+;; @002b                               v90 = iadd.i64 v65, v205
+;; @002b                               v92 = iadd.i32 v5, v6
+;; @002b                               v41 = iconst.i64 4
+;; @002b                               v133 = iconst.i32 1
+;; @002b                               brif v84, block5(v43, v65, v5, v154, v156, v208), block6(v89, v90, v92, v154, v156, v208)
 ;;
-;;                                 block5(v94: i64, v95: i64, v96: i32, v97: i32, v98: i32, v99: i64):
-;;                                     store notrap v97, v176
-;;                                     store notrap v98, v177
-;;                                     v221 = iconst.i64 1
-;;                                     v222 = iadd v99, v221  ; v221 = 1
-;;                                     v223 = iconst.i64 0
-;;                                     v224 = icmp sge v222, v223  ; v223 = 0
-;; @002b                               brif v224, block8, block9(v222)
+;;                                 block5(v93: i64, v94: i64, v95: i32, v96: i32, v97: i32, v98: i64):
+;;                                     store notrap v96, v173
+;;                                     store notrap v97, v174
+;;                                     v218 = iconst.i64 1
+;;                                     v219 = iadd v98, v218  ; v218 = 1
+;;                                     v220 = iconst.i64 0
+;;                                     v221 = icmp sge v219, v220  ; v220 = 0
+;; @002b                               brif v221, block8, block9(v219)
 ;;
-;;                                 block6(v117: i64, v118: i64, v119: i32, v120: i32, v121: i32, v122: i64):
-;;                                     store notrap v120, v177
-;;                                     store notrap v121, v176
-;;                                     v212 = iconst.i64 1
-;;                                     v213 = iadd v122, v212  ; v212 = 1
-;;                                     v214 = iconst.i64 0
-;;                                     v215 = icmp sge v213, v214  ; v214 = 0
-;; @002b                               brif v215, block10, block11(v213)
+;;                                 block6(v115: i64, v116: i64, v117: i32, v118: i32, v119: i32, v120: i64):
+;;                                     store notrap v118, v174
+;;                                     store notrap v119, v173
+;;                                     v209 = iconst.i64 1
+;;                                     v210 = iadd v120, v209  ; v209 = 1
+;;                                     v211 = iconst.i64 0
+;;                                     v212 = icmp sge v210, v211  ; v211 = 0
+;; @002b                               brif v212, block10, block11(v210)
 ;;
-;;                                 block7(v143: i64):
+;;                                 block7(v140: i64):
 ;; @002f                               jump block1
 ;;
 ;;                                 block8:
-;; @002b                               store.i64 notrap aligned v222, v7
-;; @002b                               v106 = call fn0(v0), stack_map=[i32 @ ss0+0, i32 @ ss1+0]
-;; @002b                               v108 = load.i64 notrap aligned v7
-;; @002b                               jump block9(v108)
+;; @002b                               store.i64 notrap aligned v219, v7
+;; @002b                               v104 = call fn0(v0), stack_map=[i32 @ ss0+0, i32 @ ss1+0]
+;; @002b                               v106 = load.i64 notrap aligned v7
+;; @002b                               jump block9(v106)
 ;;
-;;                                 block9(v140: i64):
-;; @002b                               v109 = load.i32 user2 little region0 v95
-;; @002b                               store user2 little region0 v109, v94
-;;                                     v145 = load.i32 notrap v176
-;;                                     v147 = load.i32 notrap v177
-;;                                     v225 = iconst.i64 4
-;;                                     v226 = iadd.i64 v95, v225  ; v225 = 4
-;; @002b                               v116 = icmp eq v226, v91
-;;                                     v227 = iadd.i64 v94, v225  ; v225 = 4
-;;                                     v228 = iconst.i32 1
-;;                                     v229 = iadd.i32 v96, v228  ; v228 = 1
-;; @002b                               brif v116, block7(v140), block5(v227, v226, v229, v145, v147, v140)
+;;                                 block9(v137: i64):
+;; @002b                               v107 = load.i32 user2 little region0 v94
+;; @002b                               store user2 little region0 v107, v93
+;;                                     v142 = load.i32 notrap v173
+;;                                     v144 = load.i32 notrap v174
+;;                                     v222 = iconst.i64 4
+;;                                     v223 = iadd.i64 v94, v222  ; v222 = 4
+;; @002b                               v114 = icmp eq v223, v90
+;;                                     v224 = iadd.i64 v93, v222  ; v222 = 4
+;;                                     v225 = iconst.i32 1
+;;                                     v226 = iadd.i32 v95, v225  ; v225 = 1
+;; @002b                               brif v114, block7(v137), block5(v224, v223, v226, v142, v144, v137)
 ;;
 ;;                                 block10:
-;; @002b                               store.i64 notrap aligned v213, v7
-;; @002b                               v129 = call fn0(v0), stack_map=[i32 @ ss1+0, i32 @ ss0+0]
-;; @002b                               v131 = load.i64 notrap aligned v7
-;; @002b                               jump block11(v131)
+;; @002b                               store.i64 notrap aligned v210, v7
+;; @002b                               v126 = call fn0(v0), stack_map=[i32 @ ss1+0, i32 @ ss0+0]
+;; @002b                               v128 = load.i64 notrap aligned v7
+;; @002b                               jump block11(v128)
 ;;
-;;                                 block11(v141: i64):
-;;                                     v216 = iconst.i64 4
-;;                                     v217 = isub.i64 v118, v216  ; v216 = 4
-;; @002b                               v138 = load.i32 user2 little region0 v217
-;;                                     v218 = isub.i64 v117, v216  ; v216 = 4
-;; @002b                               store user2 little region0 v138, v218
-;;                                     v151 = load.i32 notrap v177
-;;                                     v153 = load.i32 notrap v176
-;; @002b                               v139 = icmp eq v217, v66
-;;                                     v219 = iconst.i32 1
-;;                                     v220 = isub.i32 v119, v219  ; v219 = 1
-;; @002b                               brif v139, block7(v141), block6(v218, v217, v220, v151, v153, v141)
+;;                                 block11(v138: i64):
+;;                                     v213 = iconst.i64 4
+;;                                     v214 = isub.i64 v116, v213  ; v213 = 4
+;; @002b                               v135 = load.i32 user2 little region0 v214
+;;                                     v215 = isub.i64 v115, v213  ; v213 = 4
+;; @002b                               store user2 little region0 v135, v215
+;;                                     v148 = load.i32 notrap v174
+;;                                     v150 = load.i32 notrap v173
+;; @002b                               v136 = icmp eq v214, v65
+;;                                     v216 = iconst.i32 1
+;;                                     v217 = isub.i32 v117, v216  ; v216 = 1
+;; @002b                               brif v136, block7(v138), block6(v215, v214, v217, v148, v150, v138)
 ;;
 ;;                                 block1:
-;; @002f                               store.i64 notrap aligned v143, v7
+;; @002f                               store.i64 notrap aligned v140, v7
 ;; @002f                               return
 ;; }

--- a/tests/disas/gc/array-fill-i8.wat
+++ b/tests/disas/gc/array-fill-i8.wat
@@ -24,8 +24,8 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):
 ;; @0027                               trapz v2, user16
-;; @0027                               v43 = load.i64 notrap aligned readonly can_move v0+8
-;; @0027                               v7 = load.i64 notrap aligned readonly can_move v43+32
+;; @0027                               v42 = load.i64 notrap aligned readonly can_move v0+8
+;; @0027                               v7 = load.i64 notrap aligned readonly can_move v42+32
 ;; @0027                               v6 = uextend.i64 v2
 ;; @0027                               v8 = iadd v7, v6
 ;; @0027                               v9 = iconst.i64 16
@@ -37,7 +37,7 @@
 ;; @0027                               v12 = uextend.i64 v11
 ;; @0027                               v18 = icmp ugt v17, v12
 ;; @0027                               trapnz v18, user17
-;; @0027                               v32 = load.i64 notrap aligned v43+40
+;; @0027                               v32 = load.i64 notrap aligned v42+40
 ;; @0027                               v22 = iconst.i64 20
 ;; @0027                               v23 = iadd v8, v22  ; v22 = 20
 ;; @0027                               v27 = iadd v23, v13

--- a/tests/disas/gc/array-init-data.wat
+++ b/tests/disas/gc/array-init-data.wat
@@ -28,8 +28,8 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):
 ;; @002a                               trapz v2, user16
-;; @002a                               v58 = load.i64 notrap aligned readonly can_move v0+8
-;; @002a                               v7 = load.i64 notrap aligned readonly can_move v58+32
+;; @002a                               v55 = load.i64 notrap aligned readonly can_move v0+8
+;; @002a                               v7 = load.i64 notrap aligned readonly can_move v55+32
 ;; @002a                               v6 = uextend.i64 v2
 ;; @002a                               v8 = iadd v7, v6
 ;; @002a                               v9 = iconst.i64 16
@@ -41,23 +41,23 @@
 ;; @002a                               v12 = uextend.i64 v11
 ;; @002a                               v18 = icmp ugt v17, v12
 ;; @002a                               trapnz v18, user17
-;; @002a                               v29 = load.i32 notrap aligned v0+56
-;; @002a                               v31 = uextend.i64 v4
-;; @002a                               v35 = iadd v31, v14
-;; @002a                               v30 = uextend.i64 v29
-;; @002a                               v36 = icmp ugt v35, v30
-;; @002a                               trapnz v36, heap_oob
-;; @002a                               v38 = load.i64 notrap aligned v0+48
-;; @002a                               v47 = load.i64 notrap aligned v58+40
+;; @002a                               v28 = load.i32 notrap aligned v0+56
+;; @002a                               v30 = uextend.i64 v4
+;; @002a                               v34 = iadd v30, v14
+;; @002a                               v29 = uextend.i64 v28
+;; @002a                               v35 = icmp ugt v34, v29
+;; @002a                               trapnz v35, heap_oob
+;; @002a                               v36 = load.i64 notrap aligned v0+48
+;; @002a                               v45 = load.i64 notrap aligned v55+40
 ;; @002a                               v22 = iconst.i64 20
 ;; @002a                               v23 = iadd v8, v22  ; v22 = 20
 ;; @002a                               v27 = iadd v23, v13
-;; @002a                               v49 = uadd_overflow_trap v27, v14, user2
-;; @002a                               v48 = iadd v7, v47
-;; @002a                               v50 = icmp ugt v49, v48
-;; @002a                               trapnz v50, user2
-;; @002a                               v40 = iadd v38, v31
-;; @002a                               call fn0(v0, v27, v40, v14)
+;; @002a                               v47 = uadd_overflow_trap v27, v14, user2
+;; @002a                               v46 = iadd v7, v45
+;; @002a                               v48 = icmp ugt v47, v46
+;; @002a                               trapnz v48, user2
+;; @002a                               v38 = iadd v36, v30
+;; @002a                               call fn0(v0, v27, v38, v14)
 ;; @002e                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/array-new-data.wat
+++ b/tests/disas/gc/array-new-data.wat
@@ -93,97 +93,97 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
-;; @0025                               v6 = load.i32 notrap aligned v0+56
-;; @0025                               v8 = uextend.i64 v2
-;; @0025                               v9 = uextend.i64 v3
-;; @0025                               v12 = iadd v8, v9
-;; @0025                               v7 = uextend.i64 v6
-;; @0025                               v13 = icmp ugt v12, v7
-;; @0025                               trapnz v13, heap_oob
-;; @0025                               v15 = load.i64 notrap aligned v0+48
-;; @0025                               v22 = iconst.i64 32
-;; @0025                               v23 = ushr v9, v22  ; v22 = 32
-;; @0025                               trapnz v23, user18
-;; @0025                               v18 = iconst.i32 20
-;; @0025                               v25 = uadd_overflow_trap v18, v3, user18  ; v18 = 20
-;; @0025                               v27 = load.i64 notrap aligned readonly can_move v0+32
-;; @0025                               v28 = load.i32 notrap aligned v27
-;; @0025                               v29 = load.i32 notrap aligned v27+4
-;; @0025                               v35 = uextend.i64 v28
-;; @0025                               v30 = uextend.i64 v25
-;; @0025                               v31 = iconst.i64 15
-;; @0025                               v33 = iadd v30, v31  ; v31 = 15
-;; @0025                               v32 = iconst.i64 -16
-;; @0025                               v34 = band v33, v32  ; v32 = -16
-;; @0025                               v36 = iadd v35, v34
-;; @0025                               v37 = uextend.i64 v29
-;; @0025                               v38 = icmp ule v36, v37
-;; @0025                               brif v38, block2, block3
+;; @0025                               v5 = load.i32 notrap aligned v0+56
+;; @0025                               v7 = uextend.i64 v2
+;; @0025                               v8 = uextend.i64 v3
+;; @0025                               v11 = iadd v7, v8
+;; @0025                               v6 = uextend.i64 v5
+;; @0025                               v12 = icmp ugt v11, v6
+;; @0025                               trapnz v12, heap_oob
+;; @0025                               v13 = load.i64 notrap aligned v0+48
+;; @0025                               v20 = iconst.i64 32
+;; @0025                               v21 = ushr v8, v20  ; v20 = 32
+;; @0025                               trapnz v21, user18
+;; @0025                               v16 = iconst.i32 20
+;; @0025                               v23 = uadd_overflow_trap v16, v3, user18  ; v16 = 20
+;; @0025                               v24 = load.i64 notrap aligned readonly can_move v0+32
+;; @0025                               v25 = load.i32 notrap aligned v24
+;; @0025                               v26 = load.i32 notrap aligned v24+4
+;; @0025                               v32 = uextend.i64 v25
+;; @0025                               v27 = uextend.i64 v23
+;; @0025                               v28 = iconst.i64 15
+;; @0025                               v30 = iadd v27, v28  ; v28 = 15
+;; @0025                               v29 = iconst.i64 -16
+;; @0025                               v31 = band v30, v29  ; v29 = -16
+;; @0025                               v33 = iadd v32, v31
+;; @0025                               v34 = uextend.i64 v26
+;; @0025                               v35 = icmp ule v33, v34
+;; @0025                               brif v35, block2, block3
 ;;
 ;;                                 block2:
-;;                                     v136 = iconst.i32 15
-;;                                     v137 = iadd.i32 v25, v136  ; v136 = 15
-;;                                     v140 = iconst.i32 -16
-;;                                     v141 = band v137, v140  ; v140 = -16
-;;                                     v143 = iadd.i32 v28, v141
-;; @0025                               store notrap aligned region0 v143, v27
-;;                                     v157 = iconst.i32 -1476395002
-;;                                     v158 = load.i64 notrap aligned readonly can_move v0+8
-;;                                     v159 = load.i64 notrap aligned readonly can_move v158+32
-;; @0025                               v52 = iadd v159, v35
-;; @0025                               store notrap aligned v157, v52  ; v157 = -1476395002
-;;                                     v160 = load.i64 notrap aligned readonly can_move v0+40
-;;                                     v161 = load.i32 notrap aligned readonly can_move v160
-;; @0025                               store notrap aligned v161, v52+4
-;;                                     v162 = band.i64 v33, v32  ; v32 = -16
-;; @0025                               istore32 notrap aligned v162, v52+8
-;; @0025                               jump block4(v28, v52)
+;;                                     v127 = iconst.i32 15
+;;                                     v128 = iadd.i32 v23, v127  ; v127 = 15
+;;                                     v131 = iconst.i32 -16
+;;                                     v132 = band v128, v131  ; v131 = -16
+;;                                     v134 = iadd.i32 v25, v132
+;; @0025                               store notrap aligned region0 v134, v24
+;;                                     v148 = iconst.i32 -1476395002
+;;                                     v149 = load.i64 notrap aligned readonly can_move v0+8
+;;                                     v150 = load.i64 notrap aligned readonly can_move v149+32
+;; @0025                               v47 = iadd v150, v32
+;; @0025                               store notrap aligned v148, v47  ; v148 = -1476395002
+;;                                     v151 = load.i64 notrap aligned readonly can_move v0+40
+;;                                     v152 = load.i32 notrap aligned readonly can_move v151
+;; @0025                               store notrap aligned v152, v47+4
+;;                                     v153 = band.i64 v30, v29  ; v29 = -16
+;; @0025                               istore32 notrap aligned v153, v47+8
+;; @0025                               jump block4(v25, v47)
 ;;
 ;;                                 block3 cold:
-;; @0025                               v40 = iconst.i32 -1476395002
-;; @0025                               v42 = load.i64 notrap aligned readonly can_move v0+40
-;; @0025                               v43 = load.i32 notrap aligned readonly can_move v42
-;; @0025                               v44 = iconst.i32 16
-;; @0025                               v45 = call fn0(v0, v40, v43, v25, v44)  ; v40 = -1476395002, v44 = 16
-;; @0025                               v125 = load.i64 notrap aligned readonly can_move v0+8
-;; @0025                               v46 = load.i64 notrap aligned readonly can_move v125+32
-;; @0025                               v47 = uextend.i64 v45
-;; @0025                               v48 = iadd v46, v47
-;; @0025                               jump block4(v45, v48)
+;; @0025                               v36 = iconst.i32 -1476395002
+;; @0025                               v37 = load.i64 notrap aligned readonly can_move v0+40
+;; @0025                               v38 = load.i32 notrap aligned readonly can_move v37
+;; @0025                               v39 = iconst.i32 16
+;; @0025                               v40 = call fn0(v0, v36, v38, v23, v39)  ; v36 = -1476395002, v39 = 16
+;; @0025                               v116 = load.i64 notrap aligned readonly can_move v0+8
+;; @0025                               v41 = load.i64 notrap aligned readonly can_move v116+32
+;; @0025                               v42 = uextend.i64 v40
+;; @0025                               v43 = iadd v41, v42
+;; @0025                               jump block4(v40, v43)
 ;;
-;;                                 block4(v57: i32, v58: i64):
-;;                                     v116 = stack_addr.i64 ss0
-;;                                     store notrap v57, v116
-;; @0025                               v59 = iconst.i64 16
-;; @0025                               v60 = iadd v58, v59  ; v59 = 16
-;; @0025                               store.i32 user2 region1 v3, v60
-;; @0025                               trapz v57, user16
-;;                                     v163 = load.i64 notrap aligned readonly can_move v0+8
-;;                                     v164 = load.i64 notrap aligned readonly can_move v163+32
-;; @0025                               v62 = uextend.i64 v57
-;; @0025                               v64 = iadd v164, v62
-;; @0025                               v66 = iadd v64, v59  ; v59 = 16
-;; @0025                               v67 = load.i32 user2 readonly region1 v66
-;; @0025                               v68 = uextend.i64 v67
-;; @0025                               v74 = icmp.i64 ugt v9, v68
-;; @0025                               trapnz v74, user17
-;; @0025                               v85 = load.i32 notrap aligned v0+56
-;; @0025                               v86 = uextend.i64 v85
-;; @0025                               v92 = icmp.i64 ugt v12, v86
-;; @0025                               trapnz v92, heap_oob
-;; @0025                               v94 = load.i64 notrap aligned v0+48
-;; @0025                               v103 = load.i64 notrap aligned v163+40
-;; @0025                               v78 = iconst.i64 20
-;; @0025                               v79 = iadd v64, v78  ; v78 = 20
-;; @0025                               v105 = uadd_overflow_trap v79, v9, user2
-;; @0025                               v104 = iadd v164, v103
-;; @0025                               v106 = icmp ugt v105, v104
-;; @0025                               trapnz v106, user2
-;; @0025                               v96 = iadd v94, v8
-;; @0025                               call fn1(v0, v79, v96, v9), stack_map=[i32 @ ss0+0]
-;;                                     v109 = load.i32 notrap v116
+;;                                 block4(v51: i32, v52: i64):
+;;                                     v107 = stack_addr.i64 ss0
+;;                                     store notrap v51, v107
+;; @0025                               v53 = iconst.i64 16
+;; @0025                               v54 = iadd v52, v53  ; v53 = 16
+;; @0025                               store.i32 user2 region1 v3, v54
+;; @0025                               trapz v51, user16
+;;                                     v154 = load.i64 notrap aligned readonly can_move v0+8
+;;                                     v155 = load.i64 notrap aligned readonly can_move v154+32
+;; @0025                               v56 = uextend.i64 v51
+;; @0025                               v58 = iadd v155, v56
+;; @0025                               v60 = iadd v58, v53  ; v53 = 16
+;; @0025                               v61 = load.i32 user2 readonly region1 v60
+;; @0025                               v62 = uextend.i64 v61
+;; @0025                               v68 = icmp.i64 ugt v8, v62
+;; @0025                               trapnz v68, user17
+;; @0025                               v78 = load.i32 notrap aligned v0+56
+;; @0025                               v79 = uextend.i64 v78
+;; @0025                               v85 = icmp.i64 ugt v11, v79
+;; @0025                               trapnz v85, heap_oob
+;; @0025                               v86 = load.i64 notrap aligned v0+48
+;; @0025                               v95 = load.i64 notrap aligned v154+40
+;; @0025                               v72 = iconst.i64 20
+;; @0025                               v73 = iadd v58, v72  ; v72 = 20
+;; @0025                               v97 = uadd_overflow_trap v73, v8, user2
+;; @0025                               v96 = iadd v155, v95
+;; @0025                               v98 = icmp ugt v97, v96
+;; @0025                               trapnz v98, user2
+;; @0025                               v88 = iadd v86, v7
+;; @0025                               call fn1(v0, v73, v88, v8), stack_map=[i32 @ ss0+0]
+;;                                     v100 = load.i32 notrap v107
 ;; @0029                               jump block1
 ;;
 ;;                                 block1:
-;; @0029                               return v109
+;; @0029                               return v100
 ;; }

--- a/tests/disas/gc/array-new-default-anyref.wat
+++ b/tests/disas/gc/array-new-default-anyref.wat
@@ -25,98 +25,98 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @001f                               v5 = uextend.i64 v2
-;;                                     v98 = iconst.i64 2
-;;                                     v99 = ishl v5, v98  ; v98 = 2
+;;                                     v94 = iconst.i64 2
+;;                                     v95 = ishl v5, v94  ; v94 = 2
 ;; @001f                               v8 = iconst.i64 32
-;; @001f                               v9 = ushr v99, v8  ; v8 = 32
+;; @001f                               v9 = ushr v95, v8  ; v8 = 32
 ;; @001f                               trapnz v9, user18
 ;; @001f                               v4 = iconst.i32 20
-;;                                     v105 = iconst.i32 2
-;;                                     v106 = ishl v2, v105  ; v105 = 2
-;; @001f                               v11 = uadd_overflow_trap v4, v106, user18  ; v4 = 20
-;; @001f                               v13 = load.i64 notrap aligned readonly can_move v0+32
-;; @001f                               v14 = load.i32 notrap aligned v13
-;; @001f                               v15 = load.i32 notrap aligned v13+4
-;; @001f                               v21 = uextend.i64 v14
-;; @001f                               v16 = uextend.i64 v11
-;; @001f                               v17 = iconst.i64 15
-;; @001f                               v19 = iadd v16, v17  ; v17 = 15
-;; @001f                               v18 = iconst.i64 -16
-;; @001f                               v20 = band v19, v18  ; v18 = -16
-;; @001f                               v22 = iadd v21, v20
-;; @001f                               v23 = uextend.i64 v15
-;; @001f                               v24 = icmp ule v22, v23
-;; @001f                               brif v24, block2, block3
+;;                                     v101 = iconst.i32 2
+;;                                     v102 = ishl v2, v101  ; v101 = 2
+;; @001f                               v11 = uadd_overflow_trap v4, v102, user18  ; v4 = 20
+;; @001f                               v12 = load.i64 notrap aligned readonly can_move v0+32
+;; @001f                               v13 = load.i32 notrap aligned v12
+;; @001f                               v14 = load.i32 notrap aligned v12+4
+;; @001f                               v20 = uextend.i64 v13
+;; @001f                               v15 = uextend.i64 v11
+;; @001f                               v16 = iconst.i64 15
+;; @001f                               v18 = iadd v15, v16  ; v16 = 15
+;; @001f                               v17 = iconst.i64 -16
+;; @001f                               v19 = band v18, v17  ; v17 = -16
+;; @001f                               v21 = iadd v20, v19
+;; @001f                               v22 = uextend.i64 v14
+;; @001f                               v23 = icmp ule v21, v22
+;; @001f                               brif v23, block2, block3
 ;;
 ;;                                 block2:
-;;                                     v114 = iconst.i32 15
-;;                                     v115 = iadd.i32 v11, v114  ; v114 = 15
-;;                                     v118 = iconst.i32 -16
-;;                                     v119 = band v115, v118  ; v118 = -16
-;;                                     v121 = iadd.i32 v14, v119
-;; @001f                               store notrap aligned region0 v121, v13
-;;                                     v137 = iconst.i32 -1476394994
-;;                                     v138 = load.i64 notrap aligned readonly can_move v0+8
-;;                                     v139 = load.i64 notrap aligned readonly can_move v138+32
-;; @001f                               v38 = iadd v139, v21
-;; @001f                               store notrap aligned v137, v38  ; v137 = -1476394994
-;;                                     v140 = load.i64 notrap aligned readonly can_move v0+40
-;;                                     v141 = load.i32 notrap aligned readonly can_move v140
-;; @001f                               store notrap aligned v141, v38+4
-;;                                     v142 = band.i64 v19, v18  ; v18 = -16
-;; @001f                               istore32 notrap aligned v142, v38+8
-;; @001f                               jump block4(v14, v38)
+;;                                     v110 = iconst.i32 15
+;;                                     v111 = iadd.i32 v11, v110  ; v110 = 15
+;;                                     v114 = iconst.i32 -16
+;;                                     v115 = band v111, v114  ; v114 = -16
+;;                                     v117 = iadd.i32 v13, v115
+;; @001f                               store notrap aligned region0 v117, v12
+;;                                     v133 = iconst.i32 -1476394994
+;;                                     v134 = load.i64 notrap aligned readonly can_move v0+8
+;;                                     v135 = load.i64 notrap aligned readonly can_move v134+32
+;; @001f                               v35 = iadd v135, v20
+;; @001f                               store notrap aligned v133, v35  ; v133 = -1476394994
+;;                                     v136 = load.i64 notrap aligned readonly can_move v0+40
+;;                                     v137 = load.i32 notrap aligned readonly can_move v136
+;; @001f                               store notrap aligned v137, v35+4
+;;                                     v138 = band.i64 v18, v17  ; v17 = -16
+;; @001f                               istore32 notrap aligned v138, v35+8
+;; @001f                               jump block4(v13, v35)
 ;;
 ;;                                 block3 cold:
-;; @001f                               v26 = iconst.i32 -1476394994
-;; @001f                               v28 = load.i64 notrap aligned readonly can_move v0+40
-;; @001f                               v29 = load.i32 notrap aligned readonly can_move v28
-;; @001f                               v30 = iconst.i32 16
-;; @001f                               v31 = call fn0(v0, v26, v29, v11, v30)  ; v26 = -1476394994, v30 = 16
-;; @001f                               v94 = load.i64 notrap aligned readonly can_move v0+8
-;; @001f                               v32 = load.i64 notrap aligned readonly can_move v94+32
-;; @001f                               v33 = uextend.i64 v31
-;; @001f                               v34 = iadd v32, v33
-;; @001f                               jump block4(v31, v34)
+;; @001f                               v24 = iconst.i32 -1476394994
+;; @001f                               v25 = load.i64 notrap aligned readonly can_move v0+40
+;; @001f                               v26 = load.i32 notrap aligned readonly can_move v25
+;; @001f                               v27 = iconst.i32 16
+;; @001f                               v28 = call fn0(v0, v24, v26, v11, v27)  ; v24 = -1476394994, v27 = 16
+;; @001f                               v90 = load.i64 notrap aligned readonly can_move v0+8
+;; @001f                               v29 = load.i64 notrap aligned readonly can_move v90+32
+;; @001f                               v30 = uextend.i64 v28
+;; @001f                               v31 = iadd v29, v30
+;; @001f                               jump block4(v28, v31)
 ;;
-;;                                 block4(v43: i32, v44: i64):
-;; @001f                               v45 = iconst.i64 16
-;; @001f                               v46 = iadd v44, v45  ; v45 = 16
-;; @001f                               store.i32 user2 region1 v2, v46
-;; @001f                               trapz v43, user16
-;;                                     v143 = load.i64 notrap aligned readonly can_move v0+8
-;;                                     v144 = load.i64 notrap aligned readonly can_move v143+32
-;; @001f                               v49 = uextend.i64 v43
-;; @001f                               v51 = iadd v144, v49
-;; @001f                               v53 = iadd v51, v45  ; v45 = 16
-;; @001f                               v54 = load.i32 user2 readonly region1 v53
-;; @001f                               v55 = uextend.i64 v54
-;; @001f                               v61 = icmp.i64 ugt v5, v55
-;; @001f                               trapnz v61, user17
-;; @001f                               v75 = load.i64 notrap aligned v143+40
-;; @001f                               v65 = iconst.i64 20
-;; @001f                               v66 = iadd v51, v65  ; v65 = 20
-;; @001f                               v77 = uadd_overflow_trap v66, v99, user2
-;; @001f                               v76 = iadd v144, v75
-;; @001f                               v78 = icmp ugt v77, v76
-;; @001f                               trapnz v78, user2
-;;                                     v123 = iconst.i64 0
-;; @001f                               v81 = icmp.i64 eq v5, v123  ; v123 = 0
-;; @001f                               v47 = iconst.i32 0
+;;                                 block4(v39: i32, v40: i64):
+;; @001f                               v41 = iconst.i64 16
+;; @001f                               v42 = iadd v40, v41  ; v41 = 16
+;; @001f                               store.i32 user2 region1 v2, v42
+;; @001f                               trapz v39, user16
+;;                                     v139 = load.i64 notrap aligned readonly can_move v0+8
+;;                                     v140 = load.i64 notrap aligned readonly can_move v139+32
+;; @001f                               v45 = uextend.i64 v39
+;; @001f                               v47 = iadd v140, v45
+;; @001f                               v49 = iadd v47, v41  ; v41 = 16
+;; @001f                               v50 = load.i32 user2 readonly region1 v49
+;; @001f                               v51 = uextend.i64 v50
+;; @001f                               v57 = icmp.i64 ugt v5, v51
+;; @001f                               trapnz v57, user17
+;; @001f                               v71 = load.i64 notrap aligned v139+40
+;; @001f                               v61 = iconst.i64 20
+;; @001f                               v62 = iadd v47, v61  ; v61 = 20
+;; @001f                               v73 = uadd_overflow_trap v62, v95, user2
+;; @001f                               v72 = iadd v140, v71
+;; @001f                               v74 = icmp ugt v73, v72
+;; @001f                               trapnz v74, user2
+;;                                     v119 = iconst.i64 0
+;; @001f                               v77 = icmp.i64 eq v5, v119  ; v119 = 0
+;; @001f                               v43 = iconst.i32 0
 ;; @001f                               v6 = iconst.i64 4
-;; @001f                               v79 = iadd v66, v99
-;; @001f                               brif v81, block6, block5(v66)
+;; @001f                               v75 = iadd v62, v95
+;; @001f                               brif v77, block6, block5(v62)
 ;;
-;;                                 block5(v82: i64):
-;;                                     v145 = iconst.i32 0
-;; @001f                               store user2 little region1 v145, v82  ; v145 = 0
-;;                                     v146 = iconst.i64 4
-;;                                     v147 = iadd v82, v146  ; v146 = 4
-;; @001f                               v85 = icmp eq v147, v79
-;; @001f                               brif v85, block6, block5(v147)
+;;                                 block5(v78: i64):
+;;                                     v141 = iconst.i32 0
+;; @001f                               store user2 little region1 v141, v78  ; v141 = 0
+;;                                     v142 = iconst.i64 4
+;;                                     v143 = iadd v78, v142  ; v142 = 4
+;; @001f                               v81 = icmp eq v143, v75
+;; @001f                               brif v81, block6, block5(v143)
 ;;
 ;;                                 block6:
-;; @0022                               jump block1(v43)
+;; @0022                               jump block1(v39)
 ;;
 ;;                                 block1(v3: i32):
 ;; @0022                               return v3

--- a/tests/disas/gc/array-new-default-exnref.wat
+++ b/tests/disas/gc/array-new-default-exnref.wat
@@ -25,98 +25,98 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @001f                               v5 = uextend.i64 v2
-;;                                     v98 = iconst.i64 2
-;;                                     v99 = ishl v5, v98  ; v98 = 2
+;;                                     v94 = iconst.i64 2
+;;                                     v95 = ishl v5, v94  ; v94 = 2
 ;; @001f                               v8 = iconst.i64 32
-;; @001f                               v9 = ushr v99, v8  ; v8 = 32
+;; @001f                               v9 = ushr v95, v8  ; v8 = 32
 ;; @001f                               trapnz v9, user18
 ;; @001f                               v4 = iconst.i32 20
-;;                                     v105 = iconst.i32 2
-;;                                     v106 = ishl v2, v105  ; v105 = 2
-;; @001f                               v11 = uadd_overflow_trap v4, v106, user18  ; v4 = 20
-;; @001f                               v13 = load.i64 notrap aligned readonly can_move v0+32
-;; @001f                               v14 = load.i32 notrap aligned v13
-;; @001f                               v15 = load.i32 notrap aligned v13+4
-;; @001f                               v21 = uextend.i64 v14
-;; @001f                               v16 = uextend.i64 v11
-;; @001f                               v17 = iconst.i64 15
-;; @001f                               v19 = iadd v16, v17  ; v17 = 15
-;; @001f                               v18 = iconst.i64 -16
-;; @001f                               v20 = band v19, v18  ; v18 = -16
-;; @001f                               v22 = iadd v21, v20
-;; @001f                               v23 = uextend.i64 v15
-;; @001f                               v24 = icmp ule v22, v23
-;; @001f                               brif v24, block2, block3
+;;                                     v101 = iconst.i32 2
+;;                                     v102 = ishl v2, v101  ; v101 = 2
+;; @001f                               v11 = uadd_overflow_trap v4, v102, user18  ; v4 = 20
+;; @001f                               v12 = load.i64 notrap aligned readonly can_move v0+32
+;; @001f                               v13 = load.i32 notrap aligned v12
+;; @001f                               v14 = load.i32 notrap aligned v12+4
+;; @001f                               v20 = uextend.i64 v13
+;; @001f                               v15 = uextend.i64 v11
+;; @001f                               v16 = iconst.i64 15
+;; @001f                               v18 = iadd v15, v16  ; v16 = 15
+;; @001f                               v17 = iconst.i64 -16
+;; @001f                               v19 = band v18, v17  ; v17 = -16
+;; @001f                               v21 = iadd v20, v19
+;; @001f                               v22 = uextend.i64 v14
+;; @001f                               v23 = icmp ule v21, v22
+;; @001f                               brif v23, block2, block3
 ;;
 ;;                                 block2:
-;;                                     v114 = iconst.i32 15
-;;                                     v115 = iadd.i32 v11, v114  ; v114 = 15
-;;                                     v118 = iconst.i32 -16
-;;                                     v119 = band v115, v118  ; v118 = -16
-;;                                     v121 = iadd.i32 v14, v119
-;; @001f                               store notrap aligned region0 v121, v13
-;;                                     v137 = iconst.i32 -1476394994
-;;                                     v138 = load.i64 notrap aligned readonly can_move v0+8
-;;                                     v139 = load.i64 notrap aligned readonly can_move v138+32
-;; @001f                               v38 = iadd v139, v21
-;; @001f                               store notrap aligned v137, v38  ; v137 = -1476394994
-;;                                     v140 = load.i64 notrap aligned readonly can_move v0+40
-;;                                     v141 = load.i32 notrap aligned readonly can_move v140
-;; @001f                               store notrap aligned v141, v38+4
-;;                                     v142 = band.i64 v19, v18  ; v18 = -16
-;; @001f                               istore32 notrap aligned v142, v38+8
-;; @001f                               jump block4(v14, v38)
+;;                                     v110 = iconst.i32 15
+;;                                     v111 = iadd.i32 v11, v110  ; v110 = 15
+;;                                     v114 = iconst.i32 -16
+;;                                     v115 = band v111, v114  ; v114 = -16
+;;                                     v117 = iadd.i32 v13, v115
+;; @001f                               store notrap aligned region0 v117, v12
+;;                                     v133 = iconst.i32 -1476394994
+;;                                     v134 = load.i64 notrap aligned readonly can_move v0+8
+;;                                     v135 = load.i64 notrap aligned readonly can_move v134+32
+;; @001f                               v35 = iadd v135, v20
+;; @001f                               store notrap aligned v133, v35  ; v133 = -1476394994
+;;                                     v136 = load.i64 notrap aligned readonly can_move v0+40
+;;                                     v137 = load.i32 notrap aligned readonly can_move v136
+;; @001f                               store notrap aligned v137, v35+4
+;;                                     v138 = band.i64 v18, v17  ; v17 = -16
+;; @001f                               istore32 notrap aligned v138, v35+8
+;; @001f                               jump block4(v13, v35)
 ;;
 ;;                                 block3 cold:
-;; @001f                               v26 = iconst.i32 -1476394994
-;; @001f                               v28 = load.i64 notrap aligned readonly can_move v0+40
-;; @001f                               v29 = load.i32 notrap aligned readonly can_move v28
-;; @001f                               v30 = iconst.i32 16
-;; @001f                               v31 = call fn0(v0, v26, v29, v11, v30)  ; v26 = -1476394994, v30 = 16
-;; @001f                               v94 = load.i64 notrap aligned readonly can_move v0+8
-;; @001f                               v32 = load.i64 notrap aligned readonly can_move v94+32
-;; @001f                               v33 = uextend.i64 v31
-;; @001f                               v34 = iadd v32, v33
-;; @001f                               jump block4(v31, v34)
+;; @001f                               v24 = iconst.i32 -1476394994
+;; @001f                               v25 = load.i64 notrap aligned readonly can_move v0+40
+;; @001f                               v26 = load.i32 notrap aligned readonly can_move v25
+;; @001f                               v27 = iconst.i32 16
+;; @001f                               v28 = call fn0(v0, v24, v26, v11, v27)  ; v24 = -1476394994, v27 = 16
+;; @001f                               v90 = load.i64 notrap aligned readonly can_move v0+8
+;; @001f                               v29 = load.i64 notrap aligned readonly can_move v90+32
+;; @001f                               v30 = uextend.i64 v28
+;; @001f                               v31 = iadd v29, v30
+;; @001f                               jump block4(v28, v31)
 ;;
-;;                                 block4(v43: i32, v44: i64):
-;; @001f                               v45 = iconst.i64 16
-;; @001f                               v46 = iadd v44, v45  ; v45 = 16
-;; @001f                               store.i32 user2 region1 v2, v46
-;; @001f                               trapz v43, user16
-;;                                     v143 = load.i64 notrap aligned readonly can_move v0+8
-;;                                     v144 = load.i64 notrap aligned readonly can_move v143+32
-;; @001f                               v49 = uextend.i64 v43
-;; @001f                               v51 = iadd v144, v49
-;; @001f                               v53 = iadd v51, v45  ; v45 = 16
-;; @001f                               v54 = load.i32 user2 readonly region1 v53
-;; @001f                               v55 = uextend.i64 v54
-;; @001f                               v61 = icmp.i64 ugt v5, v55
-;; @001f                               trapnz v61, user17
-;; @001f                               v75 = load.i64 notrap aligned v143+40
-;; @001f                               v65 = iconst.i64 20
-;; @001f                               v66 = iadd v51, v65  ; v65 = 20
-;; @001f                               v77 = uadd_overflow_trap v66, v99, user2
-;; @001f                               v76 = iadd v144, v75
-;; @001f                               v78 = icmp ugt v77, v76
-;; @001f                               trapnz v78, user2
-;;                                     v123 = iconst.i64 0
-;; @001f                               v81 = icmp.i64 eq v5, v123  ; v123 = 0
-;; @001f                               v47 = iconst.i32 0
+;;                                 block4(v39: i32, v40: i64):
+;; @001f                               v41 = iconst.i64 16
+;; @001f                               v42 = iadd v40, v41  ; v41 = 16
+;; @001f                               store.i32 user2 region1 v2, v42
+;; @001f                               trapz v39, user16
+;;                                     v139 = load.i64 notrap aligned readonly can_move v0+8
+;;                                     v140 = load.i64 notrap aligned readonly can_move v139+32
+;; @001f                               v45 = uextend.i64 v39
+;; @001f                               v47 = iadd v140, v45
+;; @001f                               v49 = iadd v47, v41  ; v41 = 16
+;; @001f                               v50 = load.i32 user2 readonly region1 v49
+;; @001f                               v51 = uextend.i64 v50
+;; @001f                               v57 = icmp.i64 ugt v5, v51
+;; @001f                               trapnz v57, user17
+;; @001f                               v71 = load.i64 notrap aligned v139+40
+;; @001f                               v61 = iconst.i64 20
+;; @001f                               v62 = iadd v47, v61  ; v61 = 20
+;; @001f                               v73 = uadd_overflow_trap v62, v95, user2
+;; @001f                               v72 = iadd v140, v71
+;; @001f                               v74 = icmp ugt v73, v72
+;; @001f                               trapnz v74, user2
+;;                                     v119 = iconst.i64 0
+;; @001f                               v77 = icmp.i64 eq v5, v119  ; v119 = 0
+;; @001f                               v43 = iconst.i32 0
 ;; @001f                               v6 = iconst.i64 4
-;; @001f                               v79 = iadd v66, v99
-;; @001f                               brif v81, block6, block5(v66)
+;; @001f                               v75 = iadd v62, v95
+;; @001f                               brif v77, block6, block5(v62)
 ;;
-;;                                 block5(v82: i64):
-;;                                     v145 = iconst.i32 0
-;; @001f                               store user2 little region1 v145, v82  ; v145 = 0
-;;                                     v146 = iconst.i64 4
-;;                                     v147 = iadd v82, v146  ; v146 = 4
-;; @001f                               v85 = icmp eq v147, v79
-;; @001f                               brif v85, block6, block5(v147)
+;;                                 block5(v78: i64):
+;;                                     v141 = iconst.i32 0
+;; @001f                               store user2 little region1 v141, v78  ; v141 = 0
+;;                                     v142 = iconst.i64 4
+;;                                     v143 = iadd v78, v142  ; v142 = 4
+;; @001f                               v81 = icmp eq v143, v75
+;; @001f                               brif v81, block6, block5(v143)
 ;;
 ;;                                 block6:
-;; @0022                               jump block1(v43)
+;; @0022                               jump block1(v39)
 ;;
 ;;                                 block1(v3: i32):
 ;; @0022                               return v3

--- a/tests/disas/gc/array-new-default-externref.wat
+++ b/tests/disas/gc/array-new-default-externref.wat
@@ -25,98 +25,98 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @001f                               v5 = uextend.i64 v2
-;;                                     v98 = iconst.i64 2
-;;                                     v99 = ishl v5, v98  ; v98 = 2
+;;                                     v94 = iconst.i64 2
+;;                                     v95 = ishl v5, v94  ; v94 = 2
 ;; @001f                               v8 = iconst.i64 32
-;; @001f                               v9 = ushr v99, v8  ; v8 = 32
+;; @001f                               v9 = ushr v95, v8  ; v8 = 32
 ;; @001f                               trapnz v9, user18
 ;; @001f                               v4 = iconst.i32 20
-;;                                     v105 = iconst.i32 2
-;;                                     v106 = ishl v2, v105  ; v105 = 2
-;; @001f                               v11 = uadd_overflow_trap v4, v106, user18  ; v4 = 20
-;; @001f                               v13 = load.i64 notrap aligned readonly can_move v0+32
-;; @001f                               v14 = load.i32 notrap aligned v13
-;; @001f                               v15 = load.i32 notrap aligned v13+4
-;; @001f                               v21 = uextend.i64 v14
-;; @001f                               v16 = uextend.i64 v11
-;; @001f                               v17 = iconst.i64 15
-;; @001f                               v19 = iadd v16, v17  ; v17 = 15
-;; @001f                               v18 = iconst.i64 -16
-;; @001f                               v20 = band v19, v18  ; v18 = -16
-;; @001f                               v22 = iadd v21, v20
-;; @001f                               v23 = uextend.i64 v15
-;; @001f                               v24 = icmp ule v22, v23
-;; @001f                               brif v24, block2, block3
+;;                                     v101 = iconst.i32 2
+;;                                     v102 = ishl v2, v101  ; v101 = 2
+;; @001f                               v11 = uadd_overflow_trap v4, v102, user18  ; v4 = 20
+;; @001f                               v12 = load.i64 notrap aligned readonly can_move v0+32
+;; @001f                               v13 = load.i32 notrap aligned v12
+;; @001f                               v14 = load.i32 notrap aligned v12+4
+;; @001f                               v20 = uextend.i64 v13
+;; @001f                               v15 = uextend.i64 v11
+;; @001f                               v16 = iconst.i64 15
+;; @001f                               v18 = iadd v15, v16  ; v16 = 15
+;; @001f                               v17 = iconst.i64 -16
+;; @001f                               v19 = band v18, v17  ; v17 = -16
+;; @001f                               v21 = iadd v20, v19
+;; @001f                               v22 = uextend.i64 v14
+;; @001f                               v23 = icmp ule v21, v22
+;; @001f                               brif v23, block2, block3
 ;;
 ;;                                 block2:
-;;                                     v114 = iconst.i32 15
-;;                                     v115 = iadd.i32 v11, v114  ; v114 = 15
-;;                                     v118 = iconst.i32 -16
-;;                                     v119 = band v115, v118  ; v118 = -16
-;;                                     v121 = iadd.i32 v14, v119
-;; @001f                               store notrap aligned region0 v121, v13
-;;                                     v137 = iconst.i32 -1476394994
-;;                                     v138 = load.i64 notrap aligned readonly can_move v0+8
-;;                                     v139 = load.i64 notrap aligned readonly can_move v138+32
-;; @001f                               v38 = iadd v139, v21
-;; @001f                               store notrap aligned v137, v38  ; v137 = -1476394994
-;;                                     v140 = load.i64 notrap aligned readonly can_move v0+40
-;;                                     v141 = load.i32 notrap aligned readonly can_move v140
-;; @001f                               store notrap aligned v141, v38+4
-;;                                     v142 = band.i64 v19, v18  ; v18 = -16
-;; @001f                               istore32 notrap aligned v142, v38+8
-;; @001f                               jump block4(v14, v38)
+;;                                     v110 = iconst.i32 15
+;;                                     v111 = iadd.i32 v11, v110  ; v110 = 15
+;;                                     v114 = iconst.i32 -16
+;;                                     v115 = band v111, v114  ; v114 = -16
+;;                                     v117 = iadd.i32 v13, v115
+;; @001f                               store notrap aligned region0 v117, v12
+;;                                     v133 = iconst.i32 -1476394994
+;;                                     v134 = load.i64 notrap aligned readonly can_move v0+8
+;;                                     v135 = load.i64 notrap aligned readonly can_move v134+32
+;; @001f                               v35 = iadd v135, v20
+;; @001f                               store notrap aligned v133, v35  ; v133 = -1476394994
+;;                                     v136 = load.i64 notrap aligned readonly can_move v0+40
+;;                                     v137 = load.i32 notrap aligned readonly can_move v136
+;; @001f                               store notrap aligned v137, v35+4
+;;                                     v138 = band.i64 v18, v17  ; v17 = -16
+;; @001f                               istore32 notrap aligned v138, v35+8
+;; @001f                               jump block4(v13, v35)
 ;;
 ;;                                 block3 cold:
-;; @001f                               v26 = iconst.i32 -1476394994
-;; @001f                               v28 = load.i64 notrap aligned readonly can_move v0+40
-;; @001f                               v29 = load.i32 notrap aligned readonly can_move v28
-;; @001f                               v30 = iconst.i32 16
-;; @001f                               v31 = call fn0(v0, v26, v29, v11, v30)  ; v26 = -1476394994, v30 = 16
-;; @001f                               v94 = load.i64 notrap aligned readonly can_move v0+8
-;; @001f                               v32 = load.i64 notrap aligned readonly can_move v94+32
-;; @001f                               v33 = uextend.i64 v31
-;; @001f                               v34 = iadd v32, v33
-;; @001f                               jump block4(v31, v34)
+;; @001f                               v24 = iconst.i32 -1476394994
+;; @001f                               v25 = load.i64 notrap aligned readonly can_move v0+40
+;; @001f                               v26 = load.i32 notrap aligned readonly can_move v25
+;; @001f                               v27 = iconst.i32 16
+;; @001f                               v28 = call fn0(v0, v24, v26, v11, v27)  ; v24 = -1476394994, v27 = 16
+;; @001f                               v90 = load.i64 notrap aligned readonly can_move v0+8
+;; @001f                               v29 = load.i64 notrap aligned readonly can_move v90+32
+;; @001f                               v30 = uextend.i64 v28
+;; @001f                               v31 = iadd v29, v30
+;; @001f                               jump block4(v28, v31)
 ;;
-;;                                 block4(v43: i32, v44: i64):
-;; @001f                               v45 = iconst.i64 16
-;; @001f                               v46 = iadd v44, v45  ; v45 = 16
-;; @001f                               store.i32 user2 region1 v2, v46
-;; @001f                               trapz v43, user16
-;;                                     v143 = load.i64 notrap aligned readonly can_move v0+8
-;;                                     v144 = load.i64 notrap aligned readonly can_move v143+32
-;; @001f                               v49 = uextend.i64 v43
-;; @001f                               v51 = iadd v144, v49
-;; @001f                               v53 = iadd v51, v45  ; v45 = 16
-;; @001f                               v54 = load.i32 user2 readonly region1 v53
-;; @001f                               v55 = uextend.i64 v54
-;; @001f                               v61 = icmp.i64 ugt v5, v55
-;; @001f                               trapnz v61, user17
-;; @001f                               v75 = load.i64 notrap aligned v143+40
-;; @001f                               v65 = iconst.i64 20
-;; @001f                               v66 = iadd v51, v65  ; v65 = 20
-;; @001f                               v77 = uadd_overflow_trap v66, v99, user2
-;; @001f                               v76 = iadd v144, v75
-;; @001f                               v78 = icmp ugt v77, v76
-;; @001f                               trapnz v78, user2
-;;                                     v123 = iconst.i64 0
-;; @001f                               v81 = icmp.i64 eq v5, v123  ; v123 = 0
-;; @001f                               v47 = iconst.i32 0
+;;                                 block4(v39: i32, v40: i64):
+;; @001f                               v41 = iconst.i64 16
+;; @001f                               v42 = iadd v40, v41  ; v41 = 16
+;; @001f                               store.i32 user2 region1 v2, v42
+;; @001f                               trapz v39, user16
+;;                                     v139 = load.i64 notrap aligned readonly can_move v0+8
+;;                                     v140 = load.i64 notrap aligned readonly can_move v139+32
+;; @001f                               v45 = uextend.i64 v39
+;; @001f                               v47 = iadd v140, v45
+;; @001f                               v49 = iadd v47, v41  ; v41 = 16
+;; @001f                               v50 = load.i32 user2 readonly region1 v49
+;; @001f                               v51 = uextend.i64 v50
+;; @001f                               v57 = icmp.i64 ugt v5, v51
+;; @001f                               trapnz v57, user17
+;; @001f                               v71 = load.i64 notrap aligned v139+40
+;; @001f                               v61 = iconst.i64 20
+;; @001f                               v62 = iadd v47, v61  ; v61 = 20
+;; @001f                               v73 = uadd_overflow_trap v62, v95, user2
+;; @001f                               v72 = iadd v140, v71
+;; @001f                               v74 = icmp ugt v73, v72
+;; @001f                               trapnz v74, user2
+;;                                     v119 = iconst.i64 0
+;; @001f                               v77 = icmp.i64 eq v5, v119  ; v119 = 0
+;; @001f                               v43 = iconst.i32 0
 ;; @001f                               v6 = iconst.i64 4
-;; @001f                               v79 = iadd v66, v99
-;; @001f                               brif v81, block6, block5(v66)
+;; @001f                               v75 = iadd v62, v95
+;; @001f                               brif v77, block6, block5(v62)
 ;;
-;;                                 block5(v82: i64):
-;;                                     v145 = iconst.i32 0
-;; @001f                               store user2 little region1 v145, v82  ; v145 = 0
-;;                                     v146 = iconst.i64 4
-;;                                     v147 = iadd v82, v146  ; v146 = 4
-;; @001f                               v85 = icmp eq v147, v79
-;; @001f                               brif v85, block6, block5(v147)
+;;                                 block5(v78: i64):
+;;                                     v141 = iconst.i32 0
+;; @001f                               store user2 little region1 v141, v78  ; v141 = 0
+;;                                     v142 = iconst.i64 4
+;;                                     v143 = iadd v78, v142  ; v142 = 4
+;; @001f                               v81 = icmp eq v143, v75
+;; @001f                               brif v81, block6, block5(v143)
 ;;
 ;;                                 block6:
-;; @0022                               jump block1(v43)
+;; @0022                               jump block1(v39)
 ;;
 ;;                                 block1(v3: i32):
 ;; @0022                               return v3

--- a/tests/disas/gc/array-new-default-f32.wat
+++ b/tests/disas/gc/array-new-default-f32.wat
@@ -28,88 +28,88 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @001f                               v5 = uextend.i64 v2
-;;                                     v102 = iconst.i64 2
-;;                                     v103 = ishl v5, v102  ; v102 = 2
+;;                                     v97 = iconst.i64 2
+;;                                     v98 = ishl v5, v97  ; v97 = 2
 ;; @001f                               v8 = iconst.i64 32
-;; @001f                               v9 = ushr v103, v8  ; v8 = 32
+;; @001f                               v9 = ushr v98, v8  ; v8 = 32
 ;; @001f                               trapnz v9, user18
 ;; @001f                               v4 = iconst.i32 20
-;;                                     v109 = iconst.i32 2
-;;                                     v110 = ishl v2, v109  ; v109 = 2
-;; @001f                               v11 = uadd_overflow_trap v4, v110, user18  ; v4 = 20
-;; @001f                               v13 = load.i64 notrap aligned readonly can_move v0+32
-;; @001f                               v14 = load.i32 notrap aligned v13
-;; @001f                               v15 = load.i32 notrap aligned v13+4
-;; @001f                               v21 = uextend.i64 v14
-;; @001f                               v16 = uextend.i64 v11
-;; @001f                               v17 = iconst.i64 15
-;; @001f                               v19 = iadd v16, v17  ; v17 = 15
-;; @001f                               v18 = iconst.i64 -16
-;; @001f                               v20 = band v19, v18  ; v18 = -16
-;; @001f                               v22 = iadd v21, v20
-;; @001f                               v23 = uextend.i64 v15
-;; @001f                               v24 = icmp ule v22, v23
-;; @001f                               brif v24, block2, block3
+;;                                     v104 = iconst.i32 2
+;;                                     v105 = ishl v2, v104  ; v104 = 2
+;; @001f                               v11 = uadd_overflow_trap v4, v105, user18  ; v4 = 20
+;; @001f                               v12 = load.i64 notrap aligned readonly can_move v0+32
+;; @001f                               v13 = load.i32 notrap aligned v12
+;; @001f                               v14 = load.i32 notrap aligned v12+4
+;; @001f                               v20 = uextend.i64 v13
+;; @001f                               v15 = uextend.i64 v11
+;; @001f                               v16 = iconst.i64 15
+;; @001f                               v18 = iadd v15, v16  ; v16 = 15
+;; @001f                               v17 = iconst.i64 -16
+;; @001f                               v19 = band v18, v17  ; v17 = -16
+;; @001f                               v21 = iadd v20, v19
+;; @001f                               v22 = uextend.i64 v14
+;; @001f                               v23 = icmp ule v21, v22
+;; @001f                               brif v23, block2, block3
 ;;
 ;;                                 block2:
-;;                                     v118 = iconst.i32 15
-;;                                     v119 = iadd.i32 v11, v118  ; v118 = 15
-;;                                     v122 = iconst.i32 -16
-;;                                     v123 = band v119, v122  ; v122 = -16
-;;                                     v125 = iadd.i32 v14, v123
-;; @001f                               store notrap aligned region0 v125, v13
-;;                                     v141 = iconst.i32 -1476395002
-;;                                     v142 = load.i64 notrap aligned readonly can_move v0+8
-;;                                     v143 = load.i64 notrap aligned readonly can_move v142+32
-;; @001f                               v38 = iadd v143, v21
-;; @001f                               store notrap aligned v141, v38  ; v141 = -1476395002
-;;                                     v144 = load.i64 notrap aligned readonly can_move v0+40
-;;                                     v145 = load.i32 notrap aligned readonly can_move v144
-;; @001f                               store notrap aligned v145, v38+4
-;;                                     v146 = band.i64 v19, v18  ; v18 = -16
-;; @001f                               istore32 notrap aligned v146, v38+8
-;; @001f                               jump block4(v14, v38)
+;;                                     v113 = iconst.i32 15
+;;                                     v114 = iadd.i32 v11, v113  ; v113 = 15
+;;                                     v117 = iconst.i32 -16
+;;                                     v118 = band v114, v117  ; v117 = -16
+;;                                     v120 = iadd.i32 v13, v118
+;; @001f                               store notrap aligned region0 v120, v12
+;;                                     v136 = iconst.i32 -1476395002
+;;                                     v137 = load.i64 notrap aligned readonly can_move v0+8
+;;                                     v138 = load.i64 notrap aligned readonly can_move v137+32
+;; @001f                               v35 = iadd v138, v20
+;; @001f                               store notrap aligned v136, v35  ; v136 = -1476395002
+;;                                     v139 = load.i64 notrap aligned readonly can_move v0+40
+;;                                     v140 = load.i32 notrap aligned readonly can_move v139
+;; @001f                               store notrap aligned v140, v35+4
+;;                                     v141 = band.i64 v18, v17  ; v17 = -16
+;; @001f                               istore32 notrap aligned v141, v35+8
+;; @001f                               jump block4(v13, v35)
 ;;
 ;;                                 block3 cold:
-;; @001f                               v26 = iconst.i32 -1476395002
-;; @001f                               v28 = load.i64 notrap aligned readonly can_move v0+40
-;; @001f                               v29 = load.i32 notrap aligned readonly can_move v28
-;; @001f                               v30 = iconst.i32 16
-;; @001f                               v31 = call fn0(v0, v26, v29, v11, v30)  ; v26 = -1476395002, v30 = 16
-;; @001f                               v98 = load.i64 notrap aligned readonly can_move v0+8
-;; @001f                               v32 = load.i64 notrap aligned readonly can_move v98+32
-;; @001f                               v33 = uextend.i64 v31
-;; @001f                               v34 = iadd v32, v33
-;; @001f                               jump block4(v31, v34)
+;; @001f                               v24 = iconst.i32 -1476395002
+;; @001f                               v25 = load.i64 notrap aligned readonly can_move v0+40
+;; @001f                               v26 = load.i32 notrap aligned readonly can_move v25
+;; @001f                               v27 = iconst.i32 16
+;; @001f                               v28 = call fn0(v0, v24, v26, v11, v27)  ; v24 = -1476395002, v27 = 16
+;; @001f                               v93 = load.i64 notrap aligned readonly can_move v0+8
+;; @001f                               v29 = load.i64 notrap aligned readonly can_move v93+32
+;; @001f                               v30 = uextend.i64 v28
+;; @001f                               v31 = iadd v29, v30
+;; @001f                               jump block4(v28, v31)
 ;;
-;;                                 block4(v43: i32, v44: i64):
-;;                                     v89 = stack_addr.i64 ss0
-;;                                     store notrap v43, v89
-;; @001f                               v45 = iconst.i64 16
-;; @001f                               v46 = iadd v44, v45  ; v45 = 16
-;; @001f                               store.i32 user2 region1 v2, v46
-;; @001f                               trapz v43, user16
-;;                                     v147 = load.i64 notrap aligned readonly can_move v0+8
-;;                                     v148 = load.i64 notrap aligned readonly can_move v147+32
-;; @001f                               v49 = uextend.i64 v43
-;; @001f                               v51 = iadd v148, v49
-;; @001f                               v53 = iadd v51, v45  ; v45 = 16
-;; @001f                               v54 = load.i32 user2 readonly region1 v53
-;; @001f                               v55 = uextend.i64 v54
-;; @001f                               v61 = icmp.i64 ugt v5, v55
-;; @001f                               trapnz v61, user17
-;; @001f                               v75 = load.i64 notrap aligned v147+40
-;; @001f                               v65 = iconst.i64 20
-;; @001f                               v66 = iadd v51, v65  ; v65 = 20
-;; @001f                               v77 = uadd_overflow_trap v66, v103, user2
-;; @001f                               v76 = iadd v148, v75
-;; @001f                               v78 = icmp ugt v77, v76
-;; @001f                               trapnz v78, user2
-;; @001f                               v48 = iconst.i32 0
-;; @001f                               call fn1(v0, v66, v48, v103), stack_map=[i32 @ ss0+0]  ; v48 = 0
-;;                                     v82 = load.i32 notrap v89
+;;                                 block4(v39: i32, v40: i64):
+;;                                     v84 = stack_addr.i64 ss0
+;;                                     store notrap v39, v84
+;; @001f                               v41 = iconst.i64 16
+;; @001f                               v42 = iadd v40, v41  ; v41 = 16
+;; @001f                               store.i32 user2 region1 v2, v42
+;; @001f                               trapz v39, user16
+;;                                     v142 = load.i64 notrap aligned readonly can_move v0+8
+;;                                     v143 = load.i64 notrap aligned readonly can_move v142+32
+;; @001f                               v45 = uextend.i64 v39
+;; @001f                               v47 = iadd v143, v45
+;; @001f                               v49 = iadd v47, v41  ; v41 = 16
+;; @001f                               v50 = load.i32 user2 readonly region1 v49
+;; @001f                               v51 = uextend.i64 v50
+;; @001f                               v57 = icmp.i64 ugt v5, v51
+;; @001f                               trapnz v57, user17
+;; @001f                               v71 = load.i64 notrap aligned v142+40
+;; @001f                               v61 = iconst.i64 20
+;; @001f                               v62 = iadd v47, v61  ; v61 = 20
+;; @001f                               v73 = uadd_overflow_trap v62, v98, user2
+;; @001f                               v72 = iadd v143, v71
+;; @001f                               v74 = icmp ugt v73, v72
+;; @001f                               trapnz v74, user2
+;; @001f                               v44 = iconst.i32 0
+;; @001f                               call fn1(v0, v62, v44, v98), stack_map=[i32 @ ss0+0]  ; v44 = 0
+;;                                     v77 = load.i32 notrap v84
 ;; @0022                               jump block1
 ;;
 ;;                                 block1:
-;; @0022                               return v82
+;; @0022                               return v77
 ;; }

--- a/tests/disas/gc/array-new-default-f64.wat
+++ b/tests/disas/gc/array-new-default-f64.wat
@@ -28,88 +28,88 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @001f                               v5 = uextend.i64 v2
-;;                                     v102 = iconst.i64 3
-;;                                     v103 = ishl v5, v102  ; v102 = 3
+;;                                     v97 = iconst.i64 3
+;;                                     v98 = ishl v5, v97  ; v97 = 3
 ;; @001f                               v8 = iconst.i64 32
-;; @001f                               v9 = ushr v103, v8  ; v8 = 32
+;; @001f                               v9 = ushr v98, v8  ; v8 = 32
 ;; @001f                               trapnz v9, user18
 ;; @001f                               v4 = iconst.i32 24
-;;                                     v109 = iconst.i32 3
-;;                                     v110 = ishl v2, v109  ; v109 = 3
-;; @001f                               v11 = uadd_overflow_trap v4, v110, user18  ; v4 = 24
-;; @001f                               v13 = load.i64 notrap aligned readonly can_move v0+32
-;; @001f                               v14 = load.i32 notrap aligned v13
-;; @001f                               v15 = load.i32 notrap aligned v13+4
-;; @001f                               v21 = uextend.i64 v14
-;; @001f                               v16 = uextend.i64 v11
-;; @001f                               v17 = iconst.i64 15
-;; @001f                               v19 = iadd v16, v17  ; v17 = 15
-;; @001f                               v18 = iconst.i64 -16
-;; @001f                               v20 = band v19, v18  ; v18 = -16
-;; @001f                               v22 = iadd v21, v20
-;; @001f                               v23 = uextend.i64 v15
-;; @001f                               v24 = icmp ule v22, v23
-;; @001f                               brif v24, block2, block3
+;;                                     v104 = iconst.i32 3
+;;                                     v105 = ishl v2, v104  ; v104 = 3
+;; @001f                               v11 = uadd_overflow_trap v4, v105, user18  ; v4 = 24
+;; @001f                               v12 = load.i64 notrap aligned readonly can_move v0+32
+;; @001f                               v13 = load.i32 notrap aligned v12
+;; @001f                               v14 = load.i32 notrap aligned v12+4
+;; @001f                               v20 = uextend.i64 v13
+;; @001f                               v15 = uextend.i64 v11
+;; @001f                               v16 = iconst.i64 15
+;; @001f                               v18 = iadd v15, v16  ; v16 = 15
+;; @001f                               v17 = iconst.i64 -16
+;; @001f                               v19 = band v18, v17  ; v17 = -16
+;; @001f                               v21 = iadd v20, v19
+;; @001f                               v22 = uextend.i64 v14
+;; @001f                               v23 = icmp ule v21, v22
+;; @001f                               brif v23, block2, block3
 ;;
 ;;                                 block2:
-;;                                     v118 = iconst.i32 15
-;;                                     v119 = iadd.i32 v11, v118  ; v118 = 15
-;;                                     v122 = iconst.i32 -16
-;;                                     v123 = band v119, v122  ; v122 = -16
-;;                                     v125 = iadd.i32 v14, v123
-;; @001f                               store notrap aligned region0 v125, v13
-;;                                     v141 = iconst.i32 -1476395002
-;;                                     v142 = load.i64 notrap aligned readonly can_move v0+8
-;;                                     v143 = load.i64 notrap aligned readonly can_move v142+32
-;; @001f                               v38 = iadd v143, v21
-;; @001f                               store notrap aligned v141, v38  ; v141 = -1476395002
-;;                                     v144 = load.i64 notrap aligned readonly can_move v0+40
-;;                                     v145 = load.i32 notrap aligned readonly can_move v144
-;; @001f                               store notrap aligned v145, v38+4
-;;                                     v146 = band.i64 v19, v18  ; v18 = -16
-;; @001f                               istore32 notrap aligned v146, v38+8
-;; @001f                               jump block4(v14, v38)
+;;                                     v113 = iconst.i32 15
+;;                                     v114 = iadd.i32 v11, v113  ; v113 = 15
+;;                                     v117 = iconst.i32 -16
+;;                                     v118 = band v114, v117  ; v117 = -16
+;;                                     v120 = iadd.i32 v13, v118
+;; @001f                               store notrap aligned region0 v120, v12
+;;                                     v136 = iconst.i32 -1476395002
+;;                                     v137 = load.i64 notrap aligned readonly can_move v0+8
+;;                                     v138 = load.i64 notrap aligned readonly can_move v137+32
+;; @001f                               v35 = iadd v138, v20
+;; @001f                               store notrap aligned v136, v35  ; v136 = -1476395002
+;;                                     v139 = load.i64 notrap aligned readonly can_move v0+40
+;;                                     v140 = load.i32 notrap aligned readonly can_move v139
+;; @001f                               store notrap aligned v140, v35+4
+;;                                     v141 = band.i64 v18, v17  ; v17 = -16
+;; @001f                               istore32 notrap aligned v141, v35+8
+;; @001f                               jump block4(v13, v35)
 ;;
 ;;                                 block3 cold:
-;; @001f                               v26 = iconst.i32 -1476395002
-;; @001f                               v28 = load.i64 notrap aligned readonly can_move v0+40
-;; @001f                               v29 = load.i32 notrap aligned readonly can_move v28
-;; @001f                               v30 = iconst.i32 16
-;; @001f                               v31 = call fn0(v0, v26, v29, v11, v30)  ; v26 = -1476395002, v30 = 16
-;; @001f                               v98 = load.i64 notrap aligned readonly can_move v0+8
-;; @001f                               v32 = load.i64 notrap aligned readonly can_move v98+32
-;; @001f                               v33 = uextend.i64 v31
-;; @001f                               v34 = iadd v32, v33
-;; @001f                               jump block4(v31, v34)
+;; @001f                               v24 = iconst.i32 -1476395002
+;; @001f                               v25 = load.i64 notrap aligned readonly can_move v0+40
+;; @001f                               v26 = load.i32 notrap aligned readonly can_move v25
+;; @001f                               v27 = iconst.i32 16
+;; @001f                               v28 = call fn0(v0, v24, v26, v11, v27)  ; v24 = -1476395002, v27 = 16
+;; @001f                               v93 = load.i64 notrap aligned readonly can_move v0+8
+;; @001f                               v29 = load.i64 notrap aligned readonly can_move v93+32
+;; @001f                               v30 = uextend.i64 v28
+;; @001f                               v31 = iadd v29, v30
+;; @001f                               jump block4(v28, v31)
 ;;
-;;                                 block4(v43: i32, v44: i64):
-;;                                     v89 = stack_addr.i64 ss0
-;;                                     store notrap v43, v89
-;; @001f                               v45 = iconst.i64 16
-;; @001f                               v46 = iadd v44, v45  ; v45 = 16
-;; @001f                               store.i32 user2 region1 v2, v46
-;; @001f                               trapz v43, user16
-;;                                     v147 = load.i64 notrap aligned readonly can_move v0+8
-;;                                     v148 = load.i64 notrap aligned readonly can_move v147+32
-;; @001f                               v49 = uextend.i64 v43
-;; @001f                               v51 = iadd v148, v49
-;; @001f                               v53 = iadd v51, v45  ; v45 = 16
-;; @001f                               v54 = load.i32 user2 readonly region1 v53
-;; @001f                               v55 = uextend.i64 v54
-;; @001f                               v61 = icmp.i64 ugt v5, v55
-;; @001f                               trapnz v61, user17
-;; @001f                               v75 = load.i64 notrap aligned v147+40
-;; @001f                               v65 = iconst.i64 24
-;; @001f                               v66 = iadd v51, v65  ; v65 = 24
-;; @001f                               v77 = uadd_overflow_trap v66, v103, user2
-;; @001f                               v76 = iadd v148, v75
-;; @001f                               v78 = icmp ugt v77, v76
-;; @001f                               trapnz v78, user2
-;; @001f                               v48 = iconst.i32 0
-;; @001f                               call fn1(v0, v66, v48, v103), stack_map=[i32 @ ss0+0]  ; v48 = 0
-;;                                     v82 = load.i32 notrap v89
+;;                                 block4(v39: i32, v40: i64):
+;;                                     v84 = stack_addr.i64 ss0
+;;                                     store notrap v39, v84
+;; @001f                               v41 = iconst.i64 16
+;; @001f                               v42 = iadd v40, v41  ; v41 = 16
+;; @001f                               store.i32 user2 region1 v2, v42
+;; @001f                               trapz v39, user16
+;;                                     v142 = load.i64 notrap aligned readonly can_move v0+8
+;;                                     v143 = load.i64 notrap aligned readonly can_move v142+32
+;; @001f                               v45 = uextend.i64 v39
+;; @001f                               v47 = iadd v143, v45
+;; @001f                               v49 = iadd v47, v41  ; v41 = 16
+;; @001f                               v50 = load.i32 user2 readonly region1 v49
+;; @001f                               v51 = uextend.i64 v50
+;; @001f                               v57 = icmp.i64 ugt v5, v51
+;; @001f                               trapnz v57, user17
+;; @001f                               v71 = load.i64 notrap aligned v142+40
+;; @001f                               v61 = iconst.i64 24
+;; @001f                               v62 = iadd v47, v61  ; v61 = 24
+;; @001f                               v73 = uadd_overflow_trap v62, v98, user2
+;; @001f                               v72 = iadd v143, v71
+;; @001f                               v74 = icmp ugt v73, v72
+;; @001f                               trapnz v74, user2
+;; @001f                               v44 = iconst.i32 0
+;; @001f                               call fn1(v0, v62, v44, v98), stack_map=[i32 @ ss0+0]  ; v44 = 0
+;;                                     v77 = load.i32 notrap v84
 ;; @0022                               jump block1
 ;;
 ;;                                 block1:
-;; @0022                               return v82
+;; @0022                               return v77
 ;; }

--- a/tests/disas/gc/array-new-default-funcref.wat
+++ b/tests/disas/gc/array-new-default-funcref.wat
@@ -28,102 +28,102 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @001f                               v5 = uextend.i64 v2
-;;                                     v110 = iconst.i64 2
-;;                                     v111 = ishl v5, v110  ; v110 = 2
+;;                                     v105 = iconst.i64 2
+;;                                     v106 = ishl v5, v105  ; v105 = 2
 ;; @001f                               v8 = iconst.i64 32
-;; @001f                               v9 = ushr v111, v8  ; v8 = 32
+;; @001f                               v9 = ushr v106, v8  ; v8 = 32
 ;; @001f                               trapnz v9, user18
 ;; @001f                               v4 = iconst.i32 20
-;;                                     v117 = iconst.i32 2
-;;                                     v118 = ishl v2, v117  ; v117 = 2
-;; @001f                               v11 = uadd_overflow_trap v4, v118, user18  ; v4 = 20
-;; @001f                               v13 = load.i64 notrap aligned readonly can_move v0+32
-;; @001f                               v14 = load.i32 notrap aligned v13
-;; @001f                               v15 = load.i32 notrap aligned v13+4
-;; @001f                               v21 = uextend.i64 v14
-;; @001f                               v16 = uextend.i64 v11
-;; @001f                               v17 = iconst.i64 15
-;; @001f                               v19 = iadd v16, v17  ; v17 = 15
-;; @001f                               v18 = iconst.i64 -16
-;; @001f                               v20 = band v19, v18  ; v18 = -16
-;; @001f                               v22 = iadd v21, v20
-;; @001f                               v23 = uextend.i64 v15
-;; @001f                               v24 = icmp ule v22, v23
-;; @001f                               brif v24, block2, block3
+;;                                     v112 = iconst.i32 2
+;;                                     v113 = ishl v2, v112  ; v112 = 2
+;; @001f                               v11 = uadd_overflow_trap v4, v113, user18  ; v4 = 20
+;; @001f                               v12 = load.i64 notrap aligned readonly can_move v0+32
+;; @001f                               v13 = load.i32 notrap aligned v12
+;; @001f                               v14 = load.i32 notrap aligned v12+4
+;; @001f                               v20 = uextend.i64 v13
+;; @001f                               v15 = uextend.i64 v11
+;; @001f                               v16 = iconst.i64 15
+;; @001f                               v18 = iadd v15, v16  ; v16 = 15
+;; @001f                               v17 = iconst.i64 -16
+;; @001f                               v19 = band v18, v17  ; v17 = -16
+;; @001f                               v21 = iadd v20, v19
+;; @001f                               v22 = uextend.i64 v14
+;; @001f                               v23 = icmp ule v21, v22
+;; @001f                               brif v23, block2, block3
 ;;
 ;;                                 block2:
-;;                                     v126 = iconst.i32 15
-;;                                     v127 = iadd.i32 v11, v126  ; v126 = 15
-;;                                     v130 = iconst.i32 -16
-;;                                     v131 = band v127, v130  ; v130 = -16
-;;                                     v133 = iadd.i32 v14, v131
-;; @001f                               store notrap aligned region0 v133, v13
-;;                                     v148 = iconst.i32 -1476395002
-;;                                     v149 = load.i64 notrap aligned readonly can_move v0+8
-;;                                     v150 = load.i64 notrap aligned readonly can_move v149+32
-;; @001f                               v38 = iadd v150, v21
-;; @001f                               store notrap aligned v148, v38  ; v148 = -1476395002
-;;                                     v151 = load.i64 notrap aligned readonly can_move v0+40
-;;                                     v152 = load.i32 notrap aligned readonly can_move v151
-;; @001f                               store notrap aligned v152, v38+4
-;;                                     v153 = band.i64 v19, v18  ; v18 = -16
-;; @001f                               istore32 notrap aligned v153, v38+8
-;; @001f                               jump block4(v14, v38)
+;;                                     v121 = iconst.i32 15
+;;                                     v122 = iadd.i32 v11, v121  ; v121 = 15
+;;                                     v125 = iconst.i32 -16
+;;                                     v126 = band v122, v125  ; v125 = -16
+;;                                     v128 = iadd.i32 v13, v126
+;; @001f                               store notrap aligned region0 v128, v12
+;;                                     v143 = iconst.i32 -1476395002
+;;                                     v144 = load.i64 notrap aligned readonly can_move v0+8
+;;                                     v145 = load.i64 notrap aligned readonly can_move v144+32
+;; @001f                               v35 = iadd v145, v20
+;; @001f                               store notrap aligned v143, v35  ; v143 = -1476395002
+;;                                     v146 = load.i64 notrap aligned readonly can_move v0+40
+;;                                     v147 = load.i32 notrap aligned readonly can_move v146
+;; @001f                               store notrap aligned v147, v35+4
+;;                                     v148 = band.i64 v18, v17  ; v17 = -16
+;; @001f                               istore32 notrap aligned v148, v35+8
+;; @001f                               jump block4(v13, v35)
 ;;
 ;;                                 block3 cold:
-;; @001f                               v26 = iconst.i32 -1476395002
-;; @001f                               v28 = load.i64 notrap aligned readonly can_move v0+40
-;; @001f                               v29 = load.i32 notrap aligned readonly can_move v28
-;; @001f                               v30 = iconst.i32 16
-;; @001f                               v31 = call fn0(v0, v26, v29, v11, v30)  ; v26 = -1476395002, v30 = 16
-;; @001f                               v106 = load.i64 notrap aligned readonly can_move v0+8
-;; @001f                               v32 = load.i64 notrap aligned readonly can_move v106+32
-;; @001f                               v33 = uextend.i64 v31
-;; @001f                               v34 = iadd v32, v33
-;; @001f                               jump block4(v31, v34)
+;; @001f                               v24 = iconst.i32 -1476395002
+;; @001f                               v25 = load.i64 notrap aligned readonly can_move v0+40
+;; @001f                               v26 = load.i32 notrap aligned readonly can_move v25
+;; @001f                               v27 = iconst.i32 16
+;; @001f                               v28 = call fn0(v0, v24, v26, v11, v27)  ; v24 = -1476395002, v27 = 16
+;; @001f                               v101 = load.i64 notrap aligned readonly can_move v0+8
+;; @001f                               v29 = load.i64 notrap aligned readonly can_move v101+32
+;; @001f                               v30 = uextend.i64 v28
+;; @001f                               v31 = iadd v29, v30
+;; @001f                               jump block4(v28, v31)
 ;;
-;;                                 block4(v43: i32, v44: i64):
-;;                                     v97 = stack_addr.i64 ss0
-;;                                     store notrap v43, v97
-;; @001f                               v45 = iconst.i64 16
-;; @001f                               v46 = iadd v44, v45  ; v45 = 16
-;; @001f                               store.i32 user2 region1 v2, v46
-;; @001f                               trapz v43, user16
-;;                                     v154 = load.i64 notrap aligned readonly can_move v0+8
-;;                                     v155 = load.i64 notrap aligned readonly can_move v154+32
-;; @001f                               v49 = uextend.i64 v43
-;; @001f                               v51 = iadd v155, v49
-;; @001f                               v53 = iadd v51, v45  ; v45 = 16
-;; @001f                               v54 = load.i32 user2 readonly region1 v53
-;; @001f                               v55 = uextend.i64 v54
-;; @001f                               v61 = icmp.i64 ugt v5, v55
-;; @001f                               trapnz v61, user17
-;; @001f                               v75 = load.i64 notrap aligned v154+40
-;; @001f                               v65 = iconst.i64 20
-;; @001f                               v66 = iadd v51, v65  ; v65 = 20
-;; @001f                               v77 = uadd_overflow_trap v66, v111, user2
-;; @001f                               v76 = iadd v155, v75
-;; @001f                               v78 = icmp ugt v77, v76
-;; @001f                               trapnz v78, user2
-;; @001f                               v47 = iconst.i64 0
-;; @001f                               v80 = call fn1(v0, v47), stack_map=[i32 @ ss0+0]  ; v47 = 0
-;; @001f                               v84 = icmp.i64 eq v5, v47  ; v47 = 0
-;; @001f                               v81 = ireduce.i32 v80
+;;                                 block4(v39: i32, v40: i64):
+;;                                     v92 = stack_addr.i64 ss0
+;;                                     store notrap v39, v92
+;; @001f                               v41 = iconst.i64 16
+;; @001f                               v42 = iadd v40, v41  ; v41 = 16
+;; @001f                               store.i32 user2 region1 v2, v42
+;; @001f                               trapz v39, user16
+;;                                     v149 = load.i64 notrap aligned readonly can_move v0+8
+;;                                     v150 = load.i64 notrap aligned readonly can_move v149+32
+;; @001f                               v45 = uextend.i64 v39
+;; @001f                               v47 = iadd v150, v45
+;; @001f                               v49 = iadd v47, v41  ; v41 = 16
+;; @001f                               v50 = load.i32 user2 readonly region1 v49
+;; @001f                               v51 = uextend.i64 v50
+;; @001f                               v57 = icmp.i64 ugt v5, v51
+;; @001f                               trapnz v57, user17
+;; @001f                               v71 = load.i64 notrap aligned v149+40
+;; @001f                               v61 = iconst.i64 20
+;; @001f                               v62 = iadd v47, v61  ; v61 = 20
+;; @001f                               v73 = uadd_overflow_trap v62, v106, user2
+;; @001f                               v72 = iadd v150, v71
+;; @001f                               v74 = icmp ugt v73, v72
+;; @001f                               trapnz v74, user2
+;; @001f                               v43 = iconst.i64 0
+;; @001f                               v75 = call fn1(v0, v43), stack_map=[i32 @ ss0+0]  ; v43 = 0
+;; @001f                               v79 = icmp.i64 eq v5, v43  ; v43 = 0
+;; @001f                               v76 = ireduce.i32 v75
 ;; @001f                               v6 = iconst.i64 4
-;; @001f                               v82 = iadd v66, v111
-;; @001f                               brif v84, block6, block5(v66)
+;; @001f                               v77 = iadd v62, v106
+;; @001f                               brif v79, block6, block5(v62)
 ;;
-;;                                 block5(v85: i64):
-;; @001f                               store.i32 notrap aligned little v81, v85
-;;                                     v156 = iconst.i64 4
-;;                                     v157 = iadd v85, v156  ; v156 = 4
-;; @001f                               v88 = icmp eq v157, v82
-;; @001f                               brif v88, block6, block5(v157)
+;;                                 block5(v80: i64):
+;; @001f                               store.i32 notrap aligned little v76, v80
+;;                                     v151 = iconst.i64 4
+;;                                     v152 = iadd v80, v151  ; v151 = 4
+;; @001f                               v83 = icmp eq v152, v77
+;; @001f                               brif v83, block6, block5(v152)
 ;;
 ;;                                 block6:
-;;                                     v90 = load.i32 notrap v97
+;;                                     v85 = load.i32 notrap v92
 ;; @0022                               jump block1
 ;;
 ;;                                 block1:
-;; @0022                               return v90
+;; @0022                               return v85
 ;; }

--- a/tests/disas/gc/array-new-default-i16.wat
+++ b/tests/disas/gc/array-new-default-i16.wat
@@ -28,87 +28,87 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @001f                               v5 = uextend.i64 v2
-;;                                     v103 = iconst.i64 1
-;;                                     v104 = ishl v5, v103  ; v103 = 1
+;;                                     v98 = iconst.i64 1
+;;                                     v99 = ishl v5, v98  ; v98 = 1
 ;; @001f                               v8 = iconst.i64 32
-;; @001f                               v9 = ushr v104, v8  ; v8 = 32
+;; @001f                               v9 = ushr v99, v8  ; v8 = 32
 ;; @001f                               trapnz v9, user18
 ;; @001f                               v4 = iconst.i32 20
-;;                                     v108 = iadd v2, v2
-;; @001f                               v11 = uadd_overflow_trap v4, v108, user18  ; v4 = 20
-;; @001f                               v13 = load.i64 notrap aligned readonly can_move v0+32
-;; @001f                               v14 = load.i32 notrap aligned v13
-;; @001f                               v15 = load.i32 notrap aligned v13+4
-;; @001f                               v21 = uextend.i64 v14
-;; @001f                               v16 = uextend.i64 v11
-;; @001f                               v17 = iconst.i64 15
-;; @001f                               v19 = iadd v16, v17  ; v17 = 15
-;; @001f                               v18 = iconst.i64 -16
-;; @001f                               v20 = band v19, v18  ; v18 = -16
-;; @001f                               v22 = iadd v21, v20
-;; @001f                               v23 = uextend.i64 v15
-;; @001f                               v24 = icmp ule v22, v23
-;; @001f                               brif v24, block2, block3
+;;                                     v103 = iadd v2, v2
+;; @001f                               v11 = uadd_overflow_trap v4, v103, user18  ; v4 = 20
+;; @001f                               v12 = load.i64 notrap aligned readonly can_move v0+32
+;; @001f                               v13 = load.i32 notrap aligned v12
+;; @001f                               v14 = load.i32 notrap aligned v12+4
+;; @001f                               v20 = uextend.i64 v13
+;; @001f                               v15 = uextend.i64 v11
+;; @001f                               v16 = iconst.i64 15
+;; @001f                               v18 = iadd v15, v16  ; v16 = 15
+;; @001f                               v17 = iconst.i64 -16
+;; @001f                               v19 = band v18, v17  ; v17 = -16
+;; @001f                               v21 = iadd v20, v19
+;; @001f                               v22 = uextend.i64 v14
+;; @001f                               v23 = icmp ule v21, v22
+;; @001f                               brif v23, block2, block3
 ;;
 ;;                                 block2:
-;;                                     v123 = iconst.i32 15
-;;                                     v124 = iadd.i32 v11, v123  ; v123 = 15
-;;                                     v127 = iconst.i32 -16
-;;                                     v128 = band v124, v127  ; v127 = -16
-;;                                     v130 = iadd.i32 v14, v128
-;; @001f                               store notrap aligned region0 v130, v13
-;;                                     v151 = iconst.i32 -1476395002
-;;                                     v152 = load.i64 notrap aligned readonly can_move v0+8
-;;                                     v153 = load.i64 notrap aligned readonly can_move v152+32
-;; @001f                               v38 = iadd v153, v21
-;; @001f                               store notrap aligned v151, v38  ; v151 = -1476395002
-;;                                     v154 = load.i64 notrap aligned readonly can_move v0+40
-;;                                     v155 = load.i32 notrap aligned readonly can_move v154
-;; @001f                               store notrap aligned v155, v38+4
-;;                                     v156 = band.i64 v19, v18  ; v18 = -16
-;; @001f                               istore32 notrap aligned v156, v38+8
-;; @001f                               jump block4(v14, v38)
+;;                                     v118 = iconst.i32 15
+;;                                     v119 = iadd.i32 v11, v118  ; v118 = 15
+;;                                     v122 = iconst.i32 -16
+;;                                     v123 = band v119, v122  ; v122 = -16
+;;                                     v125 = iadd.i32 v13, v123
+;; @001f                               store notrap aligned region0 v125, v12
+;;                                     v146 = iconst.i32 -1476395002
+;;                                     v147 = load.i64 notrap aligned readonly can_move v0+8
+;;                                     v148 = load.i64 notrap aligned readonly can_move v147+32
+;; @001f                               v35 = iadd v148, v20
+;; @001f                               store notrap aligned v146, v35  ; v146 = -1476395002
+;;                                     v149 = load.i64 notrap aligned readonly can_move v0+40
+;;                                     v150 = load.i32 notrap aligned readonly can_move v149
+;; @001f                               store notrap aligned v150, v35+4
+;;                                     v151 = band.i64 v18, v17  ; v17 = -16
+;; @001f                               istore32 notrap aligned v151, v35+8
+;; @001f                               jump block4(v13, v35)
 ;;
 ;;                                 block3 cold:
-;; @001f                               v26 = iconst.i32 -1476395002
-;; @001f                               v28 = load.i64 notrap aligned readonly can_move v0+40
-;; @001f                               v29 = load.i32 notrap aligned readonly can_move v28
-;; @001f                               v30 = iconst.i32 16
-;; @001f                               v31 = call fn0(v0, v26, v29, v11, v30)  ; v26 = -1476395002, v30 = 16
-;; @001f                               v98 = load.i64 notrap aligned readonly can_move v0+8
-;; @001f                               v32 = load.i64 notrap aligned readonly can_move v98+32
-;; @001f                               v33 = uextend.i64 v31
-;; @001f                               v34 = iadd v32, v33
-;; @001f                               jump block4(v31, v34)
+;; @001f                               v24 = iconst.i32 -1476395002
+;; @001f                               v25 = load.i64 notrap aligned readonly can_move v0+40
+;; @001f                               v26 = load.i32 notrap aligned readonly can_move v25
+;; @001f                               v27 = iconst.i32 16
+;; @001f                               v28 = call fn0(v0, v24, v26, v11, v27)  ; v24 = -1476395002, v27 = 16
+;; @001f                               v93 = load.i64 notrap aligned readonly can_move v0+8
+;; @001f                               v29 = load.i64 notrap aligned readonly can_move v93+32
+;; @001f                               v30 = uextend.i64 v28
+;; @001f                               v31 = iadd v29, v30
+;; @001f                               jump block4(v28, v31)
 ;;
-;;                                 block4(v43: i32, v44: i64):
-;;                                     v89 = stack_addr.i64 ss0
-;;                                     store notrap v43, v89
-;; @001f                               v45 = iconst.i64 16
-;; @001f                               v46 = iadd v44, v45  ; v45 = 16
-;; @001f                               store.i32 user2 region1 v2, v46
-;; @001f                               trapz v43, user16
-;;                                     v157 = load.i64 notrap aligned readonly can_move v0+8
-;;                                     v158 = load.i64 notrap aligned readonly can_move v157+32
-;; @001f                               v49 = uextend.i64 v43
-;; @001f                               v51 = iadd v158, v49
-;; @001f                               v53 = iadd v51, v45  ; v45 = 16
-;; @001f                               v54 = load.i32 user2 readonly region1 v53
-;; @001f                               v55 = uextend.i64 v54
-;; @001f                               v61 = icmp.i64 ugt v5, v55
-;; @001f                               trapnz v61, user17
-;; @001f                               v75 = load.i64 notrap aligned v157+40
-;; @001f                               v65 = iconst.i64 20
-;; @001f                               v66 = iadd v51, v65  ; v65 = 20
-;; @001f                               v77 = uadd_overflow_trap v66, v104, user2
-;; @001f                               v76 = iadd v158, v75
-;; @001f                               v78 = icmp ugt v77, v76
-;; @001f                               trapnz v78, user2
-;; @001f                               v47 = iconst.i32 0
-;; @001f                               call fn1(v0, v66, v47, v104), stack_map=[i32 @ ss0+0]  ; v47 = 0
-;;                                     v82 = load.i32 notrap v89
+;;                                 block4(v39: i32, v40: i64):
+;;                                     v84 = stack_addr.i64 ss0
+;;                                     store notrap v39, v84
+;; @001f                               v41 = iconst.i64 16
+;; @001f                               v42 = iadd v40, v41  ; v41 = 16
+;; @001f                               store.i32 user2 region1 v2, v42
+;; @001f                               trapz v39, user16
+;;                                     v152 = load.i64 notrap aligned readonly can_move v0+8
+;;                                     v153 = load.i64 notrap aligned readonly can_move v152+32
+;; @001f                               v45 = uextend.i64 v39
+;; @001f                               v47 = iadd v153, v45
+;; @001f                               v49 = iadd v47, v41  ; v41 = 16
+;; @001f                               v50 = load.i32 user2 readonly region1 v49
+;; @001f                               v51 = uextend.i64 v50
+;; @001f                               v57 = icmp.i64 ugt v5, v51
+;; @001f                               trapnz v57, user17
+;; @001f                               v71 = load.i64 notrap aligned v152+40
+;; @001f                               v61 = iconst.i64 20
+;; @001f                               v62 = iadd v47, v61  ; v61 = 20
+;; @001f                               v73 = uadd_overflow_trap v62, v99, user2
+;; @001f                               v72 = iadd v153, v71
+;; @001f                               v74 = icmp ugt v73, v72
+;; @001f                               trapnz v74, user2
+;; @001f                               v43 = iconst.i32 0
+;; @001f                               call fn1(v0, v62, v43, v99), stack_map=[i32 @ ss0+0]  ; v43 = 0
+;;                                     v77 = load.i32 notrap v84
 ;; @0022                               jump block1
 ;;
 ;;                                 block1:
-;; @0022                               return v82
+;; @0022                               return v77
 ;; }

--- a/tests/disas/gc/array-new-default-i32.wat
+++ b/tests/disas/gc/array-new-default-i32.wat
@@ -28,88 +28,88 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @001f                               v5 = uextend.i64 v2
-;;                                     v102 = iconst.i64 2
-;;                                     v103 = ishl v5, v102  ; v102 = 2
+;;                                     v97 = iconst.i64 2
+;;                                     v98 = ishl v5, v97  ; v97 = 2
 ;; @001f                               v8 = iconst.i64 32
-;; @001f                               v9 = ushr v103, v8  ; v8 = 32
+;; @001f                               v9 = ushr v98, v8  ; v8 = 32
 ;; @001f                               trapnz v9, user18
 ;; @001f                               v4 = iconst.i32 20
-;;                                     v109 = iconst.i32 2
-;;                                     v110 = ishl v2, v109  ; v109 = 2
-;; @001f                               v11 = uadd_overflow_trap v4, v110, user18  ; v4 = 20
-;; @001f                               v13 = load.i64 notrap aligned readonly can_move v0+32
-;; @001f                               v14 = load.i32 notrap aligned v13
-;; @001f                               v15 = load.i32 notrap aligned v13+4
-;; @001f                               v21 = uextend.i64 v14
-;; @001f                               v16 = uextend.i64 v11
-;; @001f                               v17 = iconst.i64 15
-;; @001f                               v19 = iadd v16, v17  ; v17 = 15
-;; @001f                               v18 = iconst.i64 -16
-;; @001f                               v20 = band v19, v18  ; v18 = -16
-;; @001f                               v22 = iadd v21, v20
-;; @001f                               v23 = uextend.i64 v15
-;; @001f                               v24 = icmp ule v22, v23
-;; @001f                               brif v24, block2, block3
+;;                                     v104 = iconst.i32 2
+;;                                     v105 = ishl v2, v104  ; v104 = 2
+;; @001f                               v11 = uadd_overflow_trap v4, v105, user18  ; v4 = 20
+;; @001f                               v12 = load.i64 notrap aligned readonly can_move v0+32
+;; @001f                               v13 = load.i32 notrap aligned v12
+;; @001f                               v14 = load.i32 notrap aligned v12+4
+;; @001f                               v20 = uextend.i64 v13
+;; @001f                               v15 = uextend.i64 v11
+;; @001f                               v16 = iconst.i64 15
+;; @001f                               v18 = iadd v15, v16  ; v16 = 15
+;; @001f                               v17 = iconst.i64 -16
+;; @001f                               v19 = band v18, v17  ; v17 = -16
+;; @001f                               v21 = iadd v20, v19
+;; @001f                               v22 = uextend.i64 v14
+;; @001f                               v23 = icmp ule v21, v22
+;; @001f                               brif v23, block2, block3
 ;;
 ;;                                 block2:
-;;                                     v118 = iconst.i32 15
-;;                                     v119 = iadd.i32 v11, v118  ; v118 = 15
-;;                                     v122 = iconst.i32 -16
-;;                                     v123 = band v119, v122  ; v122 = -16
-;;                                     v125 = iadd.i32 v14, v123
-;; @001f                               store notrap aligned region0 v125, v13
-;;                                     v141 = iconst.i32 -1476395002
-;;                                     v142 = load.i64 notrap aligned readonly can_move v0+8
-;;                                     v143 = load.i64 notrap aligned readonly can_move v142+32
-;; @001f                               v38 = iadd v143, v21
-;; @001f                               store notrap aligned v141, v38  ; v141 = -1476395002
-;;                                     v144 = load.i64 notrap aligned readonly can_move v0+40
-;;                                     v145 = load.i32 notrap aligned readonly can_move v144
-;; @001f                               store notrap aligned v145, v38+4
-;;                                     v146 = band.i64 v19, v18  ; v18 = -16
-;; @001f                               istore32 notrap aligned v146, v38+8
-;; @001f                               jump block4(v14, v38)
+;;                                     v113 = iconst.i32 15
+;;                                     v114 = iadd.i32 v11, v113  ; v113 = 15
+;;                                     v117 = iconst.i32 -16
+;;                                     v118 = band v114, v117  ; v117 = -16
+;;                                     v120 = iadd.i32 v13, v118
+;; @001f                               store notrap aligned region0 v120, v12
+;;                                     v136 = iconst.i32 -1476395002
+;;                                     v137 = load.i64 notrap aligned readonly can_move v0+8
+;;                                     v138 = load.i64 notrap aligned readonly can_move v137+32
+;; @001f                               v35 = iadd v138, v20
+;; @001f                               store notrap aligned v136, v35  ; v136 = -1476395002
+;;                                     v139 = load.i64 notrap aligned readonly can_move v0+40
+;;                                     v140 = load.i32 notrap aligned readonly can_move v139
+;; @001f                               store notrap aligned v140, v35+4
+;;                                     v141 = band.i64 v18, v17  ; v17 = -16
+;; @001f                               istore32 notrap aligned v141, v35+8
+;; @001f                               jump block4(v13, v35)
 ;;
 ;;                                 block3 cold:
-;; @001f                               v26 = iconst.i32 -1476395002
-;; @001f                               v28 = load.i64 notrap aligned readonly can_move v0+40
-;; @001f                               v29 = load.i32 notrap aligned readonly can_move v28
-;; @001f                               v30 = iconst.i32 16
-;; @001f                               v31 = call fn0(v0, v26, v29, v11, v30)  ; v26 = -1476395002, v30 = 16
-;; @001f                               v98 = load.i64 notrap aligned readonly can_move v0+8
-;; @001f                               v32 = load.i64 notrap aligned readonly can_move v98+32
-;; @001f                               v33 = uextend.i64 v31
-;; @001f                               v34 = iadd v32, v33
-;; @001f                               jump block4(v31, v34)
+;; @001f                               v24 = iconst.i32 -1476395002
+;; @001f                               v25 = load.i64 notrap aligned readonly can_move v0+40
+;; @001f                               v26 = load.i32 notrap aligned readonly can_move v25
+;; @001f                               v27 = iconst.i32 16
+;; @001f                               v28 = call fn0(v0, v24, v26, v11, v27)  ; v24 = -1476395002, v27 = 16
+;; @001f                               v93 = load.i64 notrap aligned readonly can_move v0+8
+;; @001f                               v29 = load.i64 notrap aligned readonly can_move v93+32
+;; @001f                               v30 = uextend.i64 v28
+;; @001f                               v31 = iadd v29, v30
+;; @001f                               jump block4(v28, v31)
 ;;
-;;                                 block4(v43: i32, v44: i64):
-;;                                     v89 = stack_addr.i64 ss0
-;;                                     store notrap v43, v89
-;; @001f                               v45 = iconst.i64 16
-;; @001f                               v46 = iadd v44, v45  ; v45 = 16
-;; @001f                               store.i32 user2 region1 v2, v46
-;; @001f                               trapz v43, user16
-;;                                     v147 = load.i64 notrap aligned readonly can_move v0+8
-;;                                     v148 = load.i64 notrap aligned readonly can_move v147+32
-;; @001f                               v49 = uextend.i64 v43
-;; @001f                               v51 = iadd v148, v49
-;; @001f                               v53 = iadd v51, v45  ; v45 = 16
-;; @001f                               v54 = load.i32 user2 readonly region1 v53
-;; @001f                               v55 = uextend.i64 v54
-;; @001f                               v61 = icmp.i64 ugt v5, v55
-;; @001f                               trapnz v61, user17
-;; @001f                               v75 = load.i64 notrap aligned v147+40
-;; @001f                               v65 = iconst.i64 20
-;; @001f                               v66 = iadd v51, v65  ; v65 = 20
-;; @001f                               v77 = uadd_overflow_trap v66, v103, user2
-;; @001f                               v76 = iadd v148, v75
-;; @001f                               v78 = icmp ugt v77, v76
-;; @001f                               trapnz v78, user2
-;; @001f                               v47 = iconst.i32 0
-;; @001f                               call fn1(v0, v66, v47, v103), stack_map=[i32 @ ss0+0]  ; v47 = 0
-;;                                     v82 = load.i32 notrap v89
+;;                                 block4(v39: i32, v40: i64):
+;;                                     v84 = stack_addr.i64 ss0
+;;                                     store notrap v39, v84
+;; @001f                               v41 = iconst.i64 16
+;; @001f                               v42 = iadd v40, v41  ; v41 = 16
+;; @001f                               store.i32 user2 region1 v2, v42
+;; @001f                               trapz v39, user16
+;;                                     v142 = load.i64 notrap aligned readonly can_move v0+8
+;;                                     v143 = load.i64 notrap aligned readonly can_move v142+32
+;; @001f                               v45 = uextend.i64 v39
+;; @001f                               v47 = iadd v143, v45
+;; @001f                               v49 = iadd v47, v41  ; v41 = 16
+;; @001f                               v50 = load.i32 user2 readonly region1 v49
+;; @001f                               v51 = uextend.i64 v50
+;; @001f                               v57 = icmp.i64 ugt v5, v51
+;; @001f                               trapnz v57, user17
+;; @001f                               v71 = load.i64 notrap aligned v142+40
+;; @001f                               v61 = iconst.i64 20
+;; @001f                               v62 = iadd v47, v61  ; v61 = 20
+;; @001f                               v73 = uadd_overflow_trap v62, v98, user2
+;; @001f                               v72 = iadd v143, v71
+;; @001f                               v74 = icmp ugt v73, v72
+;; @001f                               trapnz v74, user2
+;; @001f                               v43 = iconst.i32 0
+;; @001f                               call fn1(v0, v62, v43, v98), stack_map=[i32 @ ss0+0]  ; v43 = 0
+;;                                     v77 = load.i32 notrap v84
 ;; @0022                               jump block1
 ;;
 ;;                                 block1:
-;; @0022                               return v82
+;; @0022                               return v77
 ;; }

--- a/tests/disas/gc/array-new-default-i64.wat
+++ b/tests/disas/gc/array-new-default-i64.wat
@@ -28,88 +28,88 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @001f                               v5 = uextend.i64 v2
-;;                                     v102 = iconst.i64 3
-;;                                     v103 = ishl v5, v102  ; v102 = 3
+;;                                     v97 = iconst.i64 3
+;;                                     v98 = ishl v5, v97  ; v97 = 3
 ;; @001f                               v8 = iconst.i64 32
-;; @001f                               v9 = ushr v103, v8  ; v8 = 32
+;; @001f                               v9 = ushr v98, v8  ; v8 = 32
 ;; @001f                               trapnz v9, user18
 ;; @001f                               v4 = iconst.i32 24
-;;                                     v109 = iconst.i32 3
-;;                                     v110 = ishl v2, v109  ; v109 = 3
-;; @001f                               v11 = uadd_overflow_trap v4, v110, user18  ; v4 = 24
-;; @001f                               v13 = load.i64 notrap aligned readonly can_move v0+32
-;; @001f                               v14 = load.i32 notrap aligned v13
-;; @001f                               v15 = load.i32 notrap aligned v13+4
-;; @001f                               v21 = uextend.i64 v14
-;; @001f                               v16 = uextend.i64 v11
-;; @001f                               v17 = iconst.i64 15
-;; @001f                               v19 = iadd v16, v17  ; v17 = 15
-;; @001f                               v18 = iconst.i64 -16
-;; @001f                               v20 = band v19, v18  ; v18 = -16
-;; @001f                               v22 = iadd v21, v20
-;; @001f                               v23 = uextend.i64 v15
-;; @001f                               v24 = icmp ule v22, v23
-;; @001f                               brif v24, block2, block3
+;;                                     v104 = iconst.i32 3
+;;                                     v105 = ishl v2, v104  ; v104 = 3
+;; @001f                               v11 = uadd_overflow_trap v4, v105, user18  ; v4 = 24
+;; @001f                               v12 = load.i64 notrap aligned readonly can_move v0+32
+;; @001f                               v13 = load.i32 notrap aligned v12
+;; @001f                               v14 = load.i32 notrap aligned v12+4
+;; @001f                               v20 = uextend.i64 v13
+;; @001f                               v15 = uextend.i64 v11
+;; @001f                               v16 = iconst.i64 15
+;; @001f                               v18 = iadd v15, v16  ; v16 = 15
+;; @001f                               v17 = iconst.i64 -16
+;; @001f                               v19 = band v18, v17  ; v17 = -16
+;; @001f                               v21 = iadd v20, v19
+;; @001f                               v22 = uextend.i64 v14
+;; @001f                               v23 = icmp ule v21, v22
+;; @001f                               brif v23, block2, block3
 ;;
 ;;                                 block2:
-;;                                     v118 = iconst.i32 15
-;;                                     v119 = iadd.i32 v11, v118  ; v118 = 15
-;;                                     v122 = iconst.i32 -16
-;;                                     v123 = band v119, v122  ; v122 = -16
-;;                                     v125 = iadd.i32 v14, v123
-;; @001f                               store notrap aligned region0 v125, v13
-;;                                     v140 = iconst.i32 -1476395002
-;;                                     v141 = load.i64 notrap aligned readonly can_move v0+8
-;;                                     v142 = load.i64 notrap aligned readonly can_move v141+32
-;; @001f                               v38 = iadd v142, v21
-;; @001f                               store notrap aligned v140, v38  ; v140 = -1476395002
-;;                                     v143 = load.i64 notrap aligned readonly can_move v0+40
-;;                                     v144 = load.i32 notrap aligned readonly can_move v143
-;; @001f                               store notrap aligned v144, v38+4
-;;                                     v145 = band.i64 v19, v18  ; v18 = -16
-;; @001f                               istore32 notrap aligned v145, v38+8
-;; @001f                               jump block4(v14, v38)
+;;                                     v113 = iconst.i32 15
+;;                                     v114 = iadd.i32 v11, v113  ; v113 = 15
+;;                                     v117 = iconst.i32 -16
+;;                                     v118 = band v114, v117  ; v117 = -16
+;;                                     v120 = iadd.i32 v13, v118
+;; @001f                               store notrap aligned region0 v120, v12
+;;                                     v135 = iconst.i32 -1476395002
+;;                                     v136 = load.i64 notrap aligned readonly can_move v0+8
+;;                                     v137 = load.i64 notrap aligned readonly can_move v136+32
+;; @001f                               v35 = iadd v137, v20
+;; @001f                               store notrap aligned v135, v35  ; v135 = -1476395002
+;;                                     v138 = load.i64 notrap aligned readonly can_move v0+40
+;;                                     v139 = load.i32 notrap aligned readonly can_move v138
+;; @001f                               store notrap aligned v139, v35+4
+;;                                     v140 = band.i64 v18, v17  ; v17 = -16
+;; @001f                               istore32 notrap aligned v140, v35+8
+;; @001f                               jump block4(v13, v35)
 ;;
 ;;                                 block3 cold:
-;; @001f                               v26 = iconst.i32 -1476395002
-;; @001f                               v28 = load.i64 notrap aligned readonly can_move v0+40
-;; @001f                               v29 = load.i32 notrap aligned readonly can_move v28
-;; @001f                               v30 = iconst.i32 16
-;; @001f                               v31 = call fn0(v0, v26, v29, v11, v30)  ; v26 = -1476395002, v30 = 16
-;; @001f                               v98 = load.i64 notrap aligned readonly can_move v0+8
-;; @001f                               v32 = load.i64 notrap aligned readonly can_move v98+32
-;; @001f                               v33 = uextend.i64 v31
-;; @001f                               v34 = iadd v32, v33
-;; @001f                               jump block4(v31, v34)
+;; @001f                               v24 = iconst.i32 -1476395002
+;; @001f                               v25 = load.i64 notrap aligned readonly can_move v0+40
+;; @001f                               v26 = load.i32 notrap aligned readonly can_move v25
+;; @001f                               v27 = iconst.i32 16
+;; @001f                               v28 = call fn0(v0, v24, v26, v11, v27)  ; v24 = -1476395002, v27 = 16
+;; @001f                               v93 = load.i64 notrap aligned readonly can_move v0+8
+;; @001f                               v29 = load.i64 notrap aligned readonly can_move v93+32
+;; @001f                               v30 = uextend.i64 v28
+;; @001f                               v31 = iadd v29, v30
+;; @001f                               jump block4(v28, v31)
 ;;
-;;                                 block4(v43: i32, v44: i64):
-;;                                     v89 = stack_addr.i64 ss0
-;;                                     store notrap v43, v89
-;; @001f                               v45 = iconst.i64 16
-;; @001f                               v46 = iadd v44, v45  ; v45 = 16
-;; @001f                               store.i32 user2 region1 v2, v46
-;; @001f                               trapz v43, user16
-;;                                     v146 = load.i64 notrap aligned readonly can_move v0+8
-;;                                     v147 = load.i64 notrap aligned readonly can_move v146+32
-;; @001f                               v49 = uextend.i64 v43
-;; @001f                               v51 = iadd v147, v49
-;; @001f                               v53 = iadd v51, v45  ; v45 = 16
-;; @001f                               v54 = load.i32 user2 readonly region1 v53
-;; @001f                               v55 = uextend.i64 v54
-;; @001f                               v61 = icmp.i64 ugt v5, v55
-;; @001f                               trapnz v61, user17
-;; @001f                               v75 = load.i64 notrap aligned v146+40
-;; @001f                               v65 = iconst.i64 24
-;; @001f                               v66 = iadd v51, v65  ; v65 = 24
-;; @001f                               v77 = uadd_overflow_trap v66, v103, user2
-;; @001f                               v76 = iadd v147, v75
-;; @001f                               v78 = icmp ugt v77, v76
-;; @001f                               trapnz v78, user2
-;; @001f                               v48 = iconst.i32 0
-;; @001f                               call fn1(v0, v66, v48, v103), stack_map=[i32 @ ss0+0]  ; v48 = 0
-;;                                     v82 = load.i32 notrap v89
+;;                                 block4(v39: i32, v40: i64):
+;;                                     v84 = stack_addr.i64 ss0
+;;                                     store notrap v39, v84
+;; @001f                               v41 = iconst.i64 16
+;; @001f                               v42 = iadd v40, v41  ; v41 = 16
+;; @001f                               store.i32 user2 region1 v2, v42
+;; @001f                               trapz v39, user16
+;;                                     v141 = load.i64 notrap aligned readonly can_move v0+8
+;;                                     v142 = load.i64 notrap aligned readonly can_move v141+32
+;; @001f                               v45 = uextend.i64 v39
+;; @001f                               v47 = iadd v142, v45
+;; @001f                               v49 = iadd v47, v41  ; v41 = 16
+;; @001f                               v50 = load.i32 user2 readonly region1 v49
+;; @001f                               v51 = uextend.i64 v50
+;; @001f                               v57 = icmp.i64 ugt v5, v51
+;; @001f                               trapnz v57, user17
+;; @001f                               v71 = load.i64 notrap aligned v141+40
+;; @001f                               v61 = iconst.i64 24
+;; @001f                               v62 = iadd v47, v61  ; v61 = 24
+;; @001f                               v73 = uadd_overflow_trap v62, v98, user2
+;; @001f                               v72 = iadd v142, v71
+;; @001f                               v74 = icmp ugt v73, v72
+;; @001f                               trapnz v74, user2
+;; @001f                               v44 = iconst.i32 0
+;; @001f                               call fn1(v0, v62, v44, v98), stack_map=[i32 @ ss0+0]  ; v44 = 0
+;;                                     v77 = load.i32 notrap v84
 ;; @0022                               jump block1
 ;;
 ;;                                 block1:
-;; @0022                               return v82
+;; @0022                               return v77
 ;; }

--- a/tests/disas/gc/array-new-default-i8.wat
+++ b/tests/disas/gc/array-new-default-i8.wat
@@ -33,79 +33,79 @@
 ;; @001f                               trapnz v9, user18
 ;; @001f                               v4 = iconst.i32 20
 ;; @001f                               v11 = uadd_overflow_trap v4, v2, user18  ; v4 = 20
-;; @001f                               v13 = load.i64 notrap aligned readonly can_move v0+32
-;; @001f                               v14 = load.i32 notrap aligned v13
-;; @001f                               v15 = load.i32 notrap aligned v13+4
-;; @001f                               v21 = uextend.i64 v14
-;; @001f                               v16 = uextend.i64 v11
-;; @001f                               v17 = iconst.i64 15
-;; @001f                               v19 = iadd v16, v17  ; v17 = 15
-;; @001f                               v18 = iconst.i64 -16
-;; @001f                               v20 = band v19, v18  ; v18 = -16
-;; @001f                               v22 = iadd v21, v20
-;; @001f                               v23 = uextend.i64 v15
-;; @001f                               v24 = icmp ule v22, v23
-;; @001f                               brif v24, block2, block3
+;; @001f                               v12 = load.i64 notrap aligned readonly can_move v0+32
+;; @001f                               v13 = load.i32 notrap aligned v12
+;; @001f                               v14 = load.i32 notrap aligned v12+4
+;; @001f                               v20 = uextend.i64 v13
+;; @001f                               v15 = uextend.i64 v11
+;; @001f                               v16 = iconst.i64 15
+;; @001f                               v18 = iadd v15, v16  ; v16 = 15
+;; @001f                               v17 = iconst.i64 -16
+;; @001f                               v19 = band v18, v17  ; v17 = -16
+;; @001f                               v21 = iadd v20, v19
+;; @001f                               v22 = uextend.i64 v14
+;; @001f                               v23 = icmp ule v21, v22
+;; @001f                               brif v23, block2, block3
 ;;
 ;;                                 block2:
-;;                                     v108 = iconst.i32 15
-;;                                     v109 = iadd.i32 v11, v108  ; v108 = 15
-;;                                     v112 = iconst.i32 -16
-;;                                     v113 = band v109, v112  ; v112 = -16
-;;                                     v115 = iadd.i32 v14, v113
-;; @001f                               store notrap aligned region0 v115, v13
-;;                                     v129 = iconst.i32 -1476395002
-;;                                     v130 = load.i64 notrap aligned readonly can_move v0+8
-;;                                     v131 = load.i64 notrap aligned readonly can_move v130+32
-;; @001f                               v38 = iadd v131, v21
-;; @001f                               store notrap aligned v129, v38  ; v129 = -1476395002
-;;                                     v132 = load.i64 notrap aligned readonly can_move v0+40
-;;                                     v133 = load.i32 notrap aligned readonly can_move v132
-;; @001f                               store notrap aligned v133, v38+4
-;;                                     v134 = band.i64 v19, v18  ; v18 = -16
-;; @001f                               istore32 notrap aligned v134, v38+8
-;; @001f                               jump block4(v14, v38)
+;;                                     v103 = iconst.i32 15
+;;                                     v104 = iadd.i32 v11, v103  ; v103 = 15
+;;                                     v107 = iconst.i32 -16
+;;                                     v108 = band v104, v107  ; v107 = -16
+;;                                     v110 = iadd.i32 v13, v108
+;; @001f                               store notrap aligned region0 v110, v12
+;;                                     v124 = iconst.i32 -1476395002
+;;                                     v125 = load.i64 notrap aligned readonly can_move v0+8
+;;                                     v126 = load.i64 notrap aligned readonly can_move v125+32
+;; @001f                               v35 = iadd v126, v20
+;; @001f                               store notrap aligned v124, v35  ; v124 = -1476395002
+;;                                     v127 = load.i64 notrap aligned readonly can_move v0+40
+;;                                     v128 = load.i32 notrap aligned readonly can_move v127
+;; @001f                               store notrap aligned v128, v35+4
+;;                                     v129 = band.i64 v18, v17  ; v17 = -16
+;; @001f                               istore32 notrap aligned v129, v35+8
+;; @001f                               jump block4(v13, v35)
 ;;
 ;;                                 block3 cold:
-;; @001f                               v26 = iconst.i32 -1476395002
-;; @001f                               v28 = load.i64 notrap aligned readonly can_move v0+40
-;; @001f                               v29 = load.i32 notrap aligned readonly can_move v28
-;; @001f                               v30 = iconst.i32 16
-;; @001f                               v31 = call fn0(v0, v26, v29, v11, v30)  ; v26 = -1476395002, v30 = 16
-;; @001f                               v97 = load.i64 notrap aligned readonly can_move v0+8
-;; @001f                               v32 = load.i64 notrap aligned readonly can_move v97+32
-;; @001f                               v33 = uextend.i64 v31
-;; @001f                               v34 = iadd v32, v33
-;; @001f                               jump block4(v31, v34)
+;; @001f                               v24 = iconst.i32 -1476395002
+;; @001f                               v25 = load.i64 notrap aligned readonly can_move v0+40
+;; @001f                               v26 = load.i32 notrap aligned readonly can_move v25
+;; @001f                               v27 = iconst.i32 16
+;; @001f                               v28 = call fn0(v0, v24, v26, v11, v27)  ; v24 = -1476395002, v27 = 16
+;; @001f                               v92 = load.i64 notrap aligned readonly can_move v0+8
+;; @001f                               v29 = load.i64 notrap aligned readonly can_move v92+32
+;; @001f                               v30 = uextend.i64 v28
+;; @001f                               v31 = iadd v29, v30
+;; @001f                               jump block4(v28, v31)
 ;;
-;;                                 block4(v43: i32, v44: i64):
-;;                                     v88 = stack_addr.i64 ss0
-;;                                     store notrap v43, v88
-;; @001f                               v45 = iconst.i64 16
-;; @001f                               v46 = iadd v44, v45  ; v45 = 16
-;; @001f                               store.i32 user2 region1 v2, v46
-;; @001f                               trapz v43, user16
-;;                                     v135 = load.i64 notrap aligned readonly can_move v0+8
-;;                                     v136 = load.i64 notrap aligned readonly can_move v135+32
-;; @001f                               v49 = uextend.i64 v43
-;; @001f                               v51 = iadd v136, v49
-;; @001f                               v53 = iadd v51, v45  ; v45 = 16
-;; @001f                               v54 = load.i32 user2 readonly region1 v53
-;; @001f                               v55 = uextend.i64 v54
-;; @001f                               v61 = icmp.i64 ugt v5, v55
-;; @001f                               trapnz v61, user17
-;; @001f                               v75 = load.i64 notrap aligned v135+40
-;; @001f                               v65 = iconst.i64 20
-;; @001f                               v66 = iadd v51, v65  ; v65 = 20
-;; @001f                               v77 = uadd_overflow_trap v66, v5, user2
-;; @001f                               v76 = iadd v136, v75
-;; @001f                               v78 = icmp ugt v77, v76
-;; @001f                               trapnz v78, user2
-;; @001f                               v47 = iconst.i32 0
-;; @001f                               call fn1(v0, v66, v47, v5), stack_map=[i32 @ ss0+0]  ; v47 = 0
-;;                                     v81 = load.i32 notrap v88
+;;                                 block4(v39: i32, v40: i64):
+;;                                     v83 = stack_addr.i64 ss0
+;;                                     store notrap v39, v83
+;; @001f                               v41 = iconst.i64 16
+;; @001f                               v42 = iadd v40, v41  ; v41 = 16
+;; @001f                               store.i32 user2 region1 v2, v42
+;; @001f                               trapz v39, user16
+;;                                     v130 = load.i64 notrap aligned readonly can_move v0+8
+;;                                     v131 = load.i64 notrap aligned readonly can_move v130+32
+;; @001f                               v45 = uextend.i64 v39
+;; @001f                               v47 = iadd v131, v45
+;; @001f                               v49 = iadd v47, v41  ; v41 = 16
+;; @001f                               v50 = load.i32 user2 readonly region1 v49
+;; @001f                               v51 = uextend.i64 v50
+;; @001f                               v57 = icmp.i64 ugt v5, v51
+;; @001f                               trapnz v57, user17
+;; @001f                               v71 = load.i64 notrap aligned v130+40
+;; @001f                               v61 = iconst.i64 20
+;; @001f                               v62 = iadd v47, v61  ; v61 = 20
+;; @001f                               v73 = uadd_overflow_trap v62, v5, user2
+;; @001f                               v72 = iadd v131, v71
+;; @001f                               v74 = icmp ugt v73, v72
+;; @001f                               trapnz v74, user2
+;; @001f                               v43 = iconst.i32 0
+;; @001f                               call fn1(v0, v62, v43, v5), stack_map=[i32 @ ss0+0]  ; v43 = 0
+;;                                     v76 = load.i32 notrap v83
 ;; @0022                               jump block1
 ;;
 ;;                                 block1:
-;; @0022                               return v81
+;; @0022                               return v76
 ;; }

--- a/tests/disas/gc/call-indirect-final-type.wat
+++ b/tests/disas/gc/call-indirect-final-type.wat
@@ -46,22 +46,22 @@
 ;;
 ;;                                 block2 cold:
 ;; @002b                               v19 = iconst.i32 0
-;; @002b                               v22 = call fn0(v0, v19, v8)  ; v19 = 0
-;; @002b                               jump block3(v22)
+;; @002b                               v21 = call fn0(v0, v19, v8)  ; v19 = 0
+;; @002b                               jump block3(v21)
 ;;
 ;;                                 block3(v18: i64):
-;; @002b                               v26 = load.i32 user7 aligned readonly v18+16
-;; @002b                               v24 = load.i64 notrap aligned readonly can_move v0+40
-;; @002b                               v25 = load.i32 notrap aligned readonly can_move v24
-;; @002b                               v27 = icmp eq v26, v25
-;; @002b                               trapz v27, user8
-;; @002b                               v29 = load.i64 notrap aligned readonly v18+8
-;; @002b                               v30 = load.i64 notrap aligned readonly v18+24
-;; @002b                               v31 = call_indirect sig0, v29(v30, v0, v2)
+;; @002b                               v24 = load.i32 user7 aligned readonly v18+16
+;; @002b                               v22 = load.i64 notrap aligned readonly can_move v0+40
+;; @002b                               v23 = load.i32 notrap aligned readonly can_move v22
+;; @002b                               v25 = icmp eq v24, v23
+;; @002b                               trapz v25, user8
+;; @002b                               v27 = load.i64 notrap aligned readonly v18+8
+;; @002b                               v28 = load.i64 notrap aligned readonly v18+24
+;; @002b                               v29 = call_indirect sig0, v27(v28, v0, v2)
 ;; @002e                               jump block1
 ;;
 ;;                                 block1:
-;; @002e                               return v31
+;; @002e                               return v29
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32, i32) -> i32 tail {
@@ -95,16 +95,16 @@
 ;;
 ;;                                 block2 cold:
 ;; @0035                               v19 = iconst.i32 0
-;; @0035                               v22 = call fn0(v0, v19, v8)  ; v19 = 0
-;; @0035                               jump block3(v22)
+;; @0035                               v21 = call fn0(v0, v19, v8)  ; v19 = 0
+;; @0035                               jump block3(v21)
 ;;
 ;;                                 block3(v18: i64):
-;; @0035                               v26 = load.i32 user7 aligned readonly v18+16
-;; @0035                               v24 = load.i64 notrap aligned readonly can_move v0+40
-;; @0035                               v25 = load.i32 notrap aligned readonly can_move v24
-;; @0035                               v27 = icmp eq v26, v25
-;; @0035                               trapz v27, user8
-;; @0035                               v29 = load.i64 notrap aligned readonly v18+8
-;; @0035                               v30 = load.i64 notrap aligned readonly v18+24
-;; @0035                               return_call_indirect sig0, v29(v30, v0, v2)
+;; @0035                               v24 = load.i32 user7 aligned readonly v18+16
+;; @0035                               v22 = load.i64 notrap aligned readonly can_move v0+40
+;; @0035                               v23 = load.i32 notrap aligned readonly can_move v22
+;; @0035                               v25 = icmp eq v24, v23
+;; @0035                               trapz v25, user8
+;; @0035                               v27 = load.i64 notrap aligned readonly v18+8
+;; @0035                               v28 = load.i64 notrap aligned readonly v18+24
+;; @0035                               return_call_indirect sig0, v27(v28, v0, v2)
 ;; }

--- a/tests/disas/gc/copying/array-new-fixed-of-gc-refs.wat
+++ b/tests/disas/gc/copying/array-new-fixed-of-gc-refs.wat
@@ -26,120 +26,120 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
-;;                                     v134 = stack_addr.i64 ss2
-;;                                     store notrap v2, v134
-;;                                     v135 = stack_addr.i64 ss1
-;;                                     store notrap v3, v135
-;;                                     v136 = stack_addr.i64 ss0
-;;                                     store notrap v4, v136
-;; @0025                               v16 = load.i64 notrap aligned readonly can_move v0+32
-;; @0025                               v17 = load.i32 notrap aligned v16
-;; @0025                               v18 = load.i32 notrap aligned v16+4
-;; @0025                               v24 = uextend.i64 v17
+;;                                     v130 = stack_addr.i64 ss2
+;;                                     store notrap v2, v130
+;;                                     v131 = stack_addr.i64 ss1
+;;                                     store notrap v3, v131
+;;                                     v132 = stack_addr.i64 ss0
+;;                                     store notrap v4, v132
+;; @0025                               v15 = load.i64 notrap aligned readonly can_move v0+32
+;; @0025                               v16 = load.i32 notrap aligned v15
+;; @0025                               v17 = load.i32 notrap aligned v15+4
+;; @0025                               v23 = uextend.i64 v16
 ;; @0025                               v11 = iconst.i64 32
-;; @0025                               v25 = iadd v24, v11  ; v11 = 32
-;; @0025                               v26 = uextend.i64 v18
-;; @0025                               v27 = icmp ule v25, v26
-;; @0025                               brif v27, block2, block3
+;; @0025                               v24 = iadd v23, v11  ; v11 = 32
+;; @0025                               v25 = uextend.i64 v17
+;; @0025                               v26 = icmp ule v24, v25
+;; @0025                               brif v26, block2, block3
 ;;
 ;;                                 block2:
-;;                                     v272 = iconst.i32 32
-;;                                     v178 = iadd.i32 v17, v272  ; v272 = 32
-;; @0025                               store notrap aligned region0 v178, v16
-;;                                     v273 = iconst.i32 -1476394994
-;;                                     v274 = load.i64 notrap aligned readonly can_move v0+8
-;;                                     v275 = load.i64 notrap aligned readonly can_move v274+32
-;; @0025                               v41 = iadd v275, v24
-;; @0025                               store notrap aligned v273, v41  ; v273 = -1476394994
-;;                                     v276 = load.i64 notrap aligned readonly can_move v0+40
-;;                                     v277 = load.i32 notrap aligned readonly can_move v276
-;; @0025                               store notrap aligned v277, v41+4
-;;                                     v278 = iconst.i64 32
-;; @0025                               istore32 notrap aligned v278, v41+8  ; v278 = 32
-;; @0025                               jump block4(v17, v41)
+;;                                     v268 = iconst.i32 32
+;;                                     v174 = iadd.i32 v16, v268  ; v268 = 32
+;; @0025                               store notrap aligned region0 v174, v15
+;;                                     v269 = iconst.i32 -1476394994
+;;                                     v270 = load.i64 notrap aligned readonly can_move v0+8
+;;                                     v271 = load.i64 notrap aligned readonly can_move v270+32
+;; @0025                               v38 = iadd v271, v23
+;; @0025                               store notrap aligned v269, v38  ; v269 = -1476394994
+;;                                     v272 = load.i64 notrap aligned readonly can_move v0+40
+;;                                     v273 = load.i32 notrap aligned readonly can_move v272
+;; @0025                               store notrap aligned v273, v38+4
+;;                                     v274 = iconst.i64 32
+;; @0025                               istore32 notrap aligned v274, v38+8  ; v274 = 32
+;; @0025                               jump block4(v16, v38)
 ;;
 ;;                                 block3 cold:
-;; @0025                               v29 = iconst.i32 -1476394994
-;; @0025                               v31 = load.i64 notrap aligned readonly can_move v0+40
-;; @0025                               v32 = load.i32 notrap aligned readonly can_move v31
-;;                                     v164 = iconst.i32 32
-;; @0025                               v33 = iconst.i32 16
-;; @0025                               v34 = call fn0(v0, v29, v32, v164, v33), stack_map=[i32 @ ss2+0, i32 @ ss1+0, i32 @ ss0+0]  ; v29 = -1476394994, v164 = 32, v33 = 16
-;; @0025                               v149 = load.i64 notrap aligned readonly can_move v0+8
-;; @0025                               v35 = load.i64 notrap aligned readonly can_move v149+32
-;; @0025                               v36 = uextend.i64 v34
-;; @0025                               v37 = iadd v35, v36
-;; @0025                               jump block4(v34, v37)
+;; @0025                               v27 = iconst.i32 -1476394994
+;; @0025                               v28 = load.i64 notrap aligned readonly can_move v0+40
+;; @0025                               v29 = load.i32 notrap aligned readonly can_move v28
+;;                                     v160 = iconst.i32 32
+;; @0025                               v30 = iconst.i32 16
+;; @0025                               v31 = call fn0(v0, v27, v29, v160, v30), stack_map=[i32 @ ss2+0, i32 @ ss1+0, i32 @ ss0+0]  ; v27 = -1476394994, v160 = 32, v30 = 16
+;; @0025                               v145 = load.i64 notrap aligned readonly can_move v0+8
+;; @0025                               v32 = load.i64 notrap aligned readonly can_move v145+32
+;; @0025                               v33 = uextend.i64 v31
+;; @0025                               v34 = iadd v32, v33
+;; @0025                               jump block4(v31, v34)
 ;;
-;;                                 block4(v46: i32, v47: i64):
+;;                                 block4(v42: i32, v43: i64):
 ;; @0025                               v6 = iconst.i32 3
-;; @0025                               v48 = iconst.i64 16
-;; @0025                               v49 = iadd v47, v48  ; v48 = 16
-;; @0025                               store user2 region1 v6, v49  ; v6 = 3
-;; @0025                               trapz v46, user16
-;;                                     v279 = load.i64 notrap aligned readonly can_move v0+8
-;;                                     v280 = load.i64 notrap aligned readonly can_move v279+32
-;; @0025                               v51 = uextend.i64 v46
-;; @0025                               v53 = iadd v280, v51
-;; @0025                               v55 = iadd v53, v48  ; v48 = 16
-;; @0025                               v56 = load.i32 user2 readonly region1 v55
-;; @0025                               trapz v56, user17
-;; @0025                               v59 = uextend.i64 v56
-;;                                     v155 = iconst.i64 2
-;;                                     v184 = ishl v59, v155  ; v155 = 2
-;;                                     v281 = iconst.i64 32
-;;                                     v282 = ushr v184, v281  ; v281 = 32
-;; @0025                               trapnz v282, user2
-;;                                     v193 = iconst.i32 2
-;;                                     v194 = ishl v56, v193  ; v193 = 2
+;; @0025                               v44 = iconst.i64 16
+;; @0025                               v45 = iadd v43, v44  ; v44 = 16
+;; @0025                               store user2 region1 v6, v45  ; v6 = 3
+;; @0025                               trapz v42, user16
+;;                                     v275 = load.i64 notrap aligned readonly can_move v0+8
+;;                                     v276 = load.i64 notrap aligned readonly can_move v275+32
+;; @0025                               v47 = uextend.i64 v42
+;; @0025                               v49 = iadd v276, v47
+;; @0025                               v51 = iadd v49, v44  ; v44 = 16
+;; @0025                               v52 = load.i32 user2 readonly region1 v51
+;; @0025                               trapz v52, user17
+;; @0025                               v55 = uextend.i64 v52
+;;                                     v151 = iconst.i64 2
+;;                                     v180 = ishl v55, v151  ; v151 = 2
+;;                                     v277 = iconst.i64 32
+;;                                     v278 = ushr v180, v277  ; v277 = 32
+;; @0025                               trapnz v278, user2
+;;                                     v189 = iconst.i32 2
+;;                                     v190 = ishl v52, v189  ; v189 = 2
 ;; @0025                               v7 = iconst.i32 20
-;; @0025                               v65 = uadd_overflow_trap v194, v7, user2  ; v7 = 20
-;; @0025                               v69 = uadd_overflow_trap v46, v65, user2
-;;                                     v133 = load.i32 notrap v134
+;; @0025                               v61 = uadd_overflow_trap v190, v7, user2  ; v7 = 20
+;; @0025                               v65 = uadd_overflow_trap v42, v61, user2
+;;                                     v129 = load.i32 notrap v130
+;; @0025                               v66 = uextend.i64 v65
+;; @0025                               v68 = iadd v276, v66
+;; @0025                               v69 = isub v61, v7  ; v7 = 20
 ;; @0025                               v70 = uextend.i64 v69
-;; @0025                               v72 = iadd v280, v70
-;; @0025                               v73 = isub v65, v7  ; v7 = 20
-;; @0025                               v74 = uextend.i64 v73
-;; @0025                               v75 = isub v72, v74
-;; @0025                               store user2 little region1 v133, v75
-;; @0025                               v82 = load.i32 user2 readonly region1 v55
-;; @0025                               v76 = iconst.i32 1
-;;                                     v211 = icmp ugt v82, v76  ; v76 = 1
-;; @0025                               trapz v211, user17
-;; @0025                               v85 = uextend.i64 v82
-;;                                     v213 = ishl v85, v155  ; v155 = 2
-;;                                     v283 = ushr v213, v281  ; v281 = 32
-;; @0025                               trapnz v283, user2
-;;                                     v220 = ishl v82, v193  ; v193 = 2
-;; @0025                               v91 = uadd_overflow_trap v220, v7, user2  ; v7 = 20
-;; @0025                               v95 = uadd_overflow_trap v46, v91, user2
-;;                                     v131 = load.i32 notrap v135
+;; @0025                               v71 = isub v68, v70
+;; @0025                               store user2 little region1 v129, v71
+;; @0025                               v78 = load.i32 user2 readonly region1 v51
+;; @0025                               v72 = iconst.i32 1
+;;                                     v207 = icmp ugt v78, v72  ; v72 = 1
+;; @0025                               trapz v207, user17
+;; @0025                               v81 = uextend.i64 v78
+;;                                     v209 = ishl v81, v151  ; v151 = 2
+;;                                     v279 = ushr v209, v277  ; v277 = 32
+;; @0025                               trapnz v279, user2
+;;                                     v216 = ishl v78, v189  ; v189 = 2
+;; @0025                               v87 = uadd_overflow_trap v216, v7, user2  ; v7 = 20
+;; @0025                               v91 = uadd_overflow_trap v42, v87, user2
+;;                                     v127 = load.i32 notrap v131
+;; @0025                               v92 = uextend.i64 v91
+;; @0025                               v94 = iadd v276, v92
+;;                                     v229 = iconst.i32 24
+;; @0025                               v95 = isub v87, v229  ; v229 = 24
 ;; @0025                               v96 = uextend.i64 v95
-;; @0025                               v98 = iadd v280, v96
-;;                                     v233 = iconst.i32 24
-;; @0025                               v99 = isub v91, v233  ; v233 = 24
-;; @0025                               v100 = uextend.i64 v99
-;; @0025                               v101 = isub v98, v100
-;; @0025                               store user2 little region1 v131, v101
-;; @0025                               v108 = load.i32 user2 readonly region1 v55
-;;                                     v239 = icmp ugt v108, v193  ; v193 = 2
-;; @0025                               trapz v239, user17
-;; @0025                               v111 = uextend.i64 v108
-;;                                     v241 = ishl v111, v155  ; v155 = 2
-;;                                     v284 = ushr v241, v281  ; v281 = 32
-;; @0025                               trapnz v284, user2
-;;                                     v248 = ishl v108, v193  ; v193 = 2
-;; @0025                               v117 = uadd_overflow_trap v248, v7, user2  ; v7 = 20
-;; @0025                               v121 = uadd_overflow_trap v46, v117, user2
-;;                                     v129 = load.i32 notrap v136
+;; @0025                               v97 = isub v94, v96
+;; @0025                               store user2 little region1 v127, v97
+;; @0025                               v104 = load.i32 user2 readonly region1 v51
+;;                                     v235 = icmp ugt v104, v189  ; v189 = 2
+;; @0025                               trapz v235, user17
+;; @0025                               v107 = uextend.i64 v104
+;;                                     v237 = ishl v107, v151  ; v151 = 2
+;;                                     v280 = ushr v237, v277  ; v277 = 32
+;; @0025                               trapnz v280, user2
+;;                                     v244 = ishl v104, v189  ; v189 = 2
+;; @0025                               v113 = uadd_overflow_trap v244, v7, user2  ; v7 = 20
+;; @0025                               v117 = uadd_overflow_trap v42, v113, user2
+;;                                     v125 = load.i32 notrap v132
+;; @0025                               v118 = uextend.i64 v117
+;; @0025                               v120 = iadd v276, v118
+;;                                     v262 = iconst.i32 28
+;; @0025                               v121 = isub v113, v262  ; v262 = 28
 ;; @0025                               v122 = uextend.i64 v121
-;; @0025                               v124 = iadd v280, v122
-;;                                     v266 = iconst.i32 28
-;; @0025                               v125 = isub v117, v266  ; v266 = 28
-;; @0025                               v126 = uextend.i64 v125
-;; @0025                               v127 = isub v124, v126
-;; @0025                               store user2 little region1 v129, v127
-;; @0029                               jump block1(v46)
+;; @0025                               v123 = isub v120, v122
+;; @0025                               store user2 little region1 v125, v123
+;; @0029                               jump block1(v42)
 ;;
 ;;                                 block1(v5: i32):
 ;; @0029                               return v5

--- a/tests/disas/gc/copying/array-new-fixed.wat
+++ b/tests/disas/gc/copying/array-new-fixed.wat
@@ -23,111 +23,111 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i64, v4: i64):
-;; @0025                               v16 = load.i64 notrap aligned readonly can_move v0+32
-;; @0025                               v17 = load.i32 notrap aligned v16
-;; @0025                               v18 = load.i32 notrap aligned v16+4
-;; @0025                               v24 = uextend.i64 v17
-;;                                     v154 = iconst.i64 48
-;; @0025                               v25 = iadd v24, v154  ; v154 = 48
-;; @0025                               v26 = uextend.i64 v18
-;; @0025                               v27 = icmp ule v25, v26
-;; @0025                               brif v27, block2, block3
+;; @0025                               v15 = load.i64 notrap aligned readonly can_move v0+32
+;; @0025                               v16 = load.i32 notrap aligned v15
+;; @0025                               v17 = load.i32 notrap aligned v15+4
+;; @0025                               v23 = uextend.i64 v16
+;;                                     v150 = iconst.i64 48
+;; @0025                               v24 = iadd v23, v150  ; v150 = 48
+;; @0025                               v25 = uextend.i64 v17
+;; @0025                               v26 = icmp ule v24, v25
+;; @0025                               brif v26, block2, block3
 ;;
 ;;                                 block2:
-;;                                     v260 = iconst.i32 48
-;;                                     v168 = iadd.i32 v17, v260  ; v260 = 48
-;; @0025                               store notrap aligned region0 v168, v16
-;;                                     v261 = iconst.i32 -1476395002
-;;                                     v262 = load.i64 notrap aligned readonly can_move v0+8
-;;                                     v263 = load.i64 notrap aligned readonly can_move v262+32
-;; @0025                               v41 = iadd v263, v24
-;; @0025                               store notrap aligned v261, v41  ; v261 = -1476395002
-;;                                     v264 = load.i64 notrap aligned readonly can_move v0+40
-;;                                     v265 = load.i32 notrap aligned readonly can_move v264
-;; @0025                               store notrap aligned v265, v41+4
-;;                                     v266 = iconst.i64 48
-;; @0025                               istore32 notrap aligned v266, v41+8  ; v266 = 48
-;; @0025                               jump block4(v17, v41)
+;;                                     v256 = iconst.i32 48
+;;                                     v164 = iadd.i32 v16, v256  ; v256 = 48
+;; @0025                               store notrap aligned region0 v164, v15
+;;                                     v257 = iconst.i32 -1476395002
+;;                                     v258 = load.i64 notrap aligned readonly can_move v0+8
+;;                                     v259 = load.i64 notrap aligned readonly can_move v258+32
+;; @0025                               v38 = iadd v259, v23
+;; @0025                               store notrap aligned v257, v38  ; v257 = -1476395002
+;;                                     v260 = load.i64 notrap aligned readonly can_move v0+40
+;;                                     v261 = load.i32 notrap aligned readonly can_move v260
+;; @0025                               store notrap aligned v261, v38+4
+;;                                     v262 = iconst.i64 48
+;; @0025                               istore32 notrap aligned v262, v38+8  ; v262 = 48
+;; @0025                               jump block4(v16, v38)
 ;;
 ;;                                 block3 cold:
-;; @0025                               v29 = iconst.i32 -1476395002
-;; @0025                               v31 = load.i64 notrap aligned readonly can_move v0+40
-;; @0025                               v32 = load.i32 notrap aligned readonly can_move v31
-;;                                     v153 = iconst.i32 48
-;; @0025                               v33 = iconst.i32 16
-;; @0025                               v34 = call fn0(v0, v29, v32, v153, v33)  ; v29 = -1476395002, v153 = 48, v33 = 16
-;; @0025                               v140 = load.i64 notrap aligned readonly can_move v0+8
-;; @0025                               v35 = load.i64 notrap aligned readonly can_move v140+32
-;; @0025                               v36 = uextend.i64 v34
-;; @0025                               v37 = iadd v35, v36
-;; @0025                               jump block4(v34, v37)
+;; @0025                               v27 = iconst.i32 -1476395002
+;; @0025                               v28 = load.i64 notrap aligned readonly can_move v0+40
+;; @0025                               v29 = load.i32 notrap aligned readonly can_move v28
+;;                                     v149 = iconst.i32 48
+;; @0025                               v30 = iconst.i32 16
+;; @0025                               v31 = call fn0(v0, v27, v29, v149, v30)  ; v27 = -1476395002, v149 = 48, v30 = 16
+;; @0025                               v136 = load.i64 notrap aligned readonly can_move v0+8
+;; @0025                               v32 = load.i64 notrap aligned readonly can_move v136+32
+;; @0025                               v33 = uextend.i64 v31
+;; @0025                               v34 = iadd v32, v33
+;; @0025                               jump block4(v31, v34)
 ;;
-;;                                 block4(v46: i32, v47: i64):
+;;                                 block4(v42: i32, v43: i64):
 ;; @0025                               v6 = iconst.i32 3
-;; @0025                               v48 = iconst.i64 16
-;; @0025                               v49 = iadd v47, v48  ; v48 = 16
-;; @0025                               store user2 region1 v6, v49  ; v6 = 3
-;; @0025                               trapz v46, user16
-;;                                     v267 = load.i64 notrap aligned readonly can_move v0+8
-;;                                     v268 = load.i64 notrap aligned readonly can_move v267+32
-;; @0025                               v51 = uextend.i64 v46
-;; @0025                               v53 = iadd v268, v51
-;; @0025                               v55 = iadd v53, v48  ; v48 = 16
-;; @0025                               v56 = load.i32 user2 readonly region1 v55
-;; @0025                               trapz v56, user17
-;; @0025                               v59 = uextend.i64 v56
-;;                                     v144 = iconst.i64 3
-;;                                     v174 = ishl v59, v144  ; v144 = 3
+;; @0025                               v44 = iconst.i64 16
+;; @0025                               v45 = iadd v43, v44  ; v44 = 16
+;; @0025                               store user2 region1 v6, v45  ; v6 = 3
+;; @0025                               trapz v42, user16
+;;                                     v263 = load.i64 notrap aligned readonly can_move v0+8
+;;                                     v264 = load.i64 notrap aligned readonly can_move v263+32
+;; @0025                               v47 = uextend.i64 v42
+;; @0025                               v49 = iadd v264, v47
+;; @0025                               v51 = iadd v49, v44  ; v44 = 16
+;; @0025                               v52 = load.i32 user2 readonly region1 v51
+;; @0025                               trapz v52, user17
+;; @0025                               v55 = uextend.i64 v52
+;;                                     v140 = iconst.i64 3
+;;                                     v170 = ishl v55, v140  ; v140 = 3
 ;; @0025                               v11 = iconst.i64 32
-;; @0025                               v62 = ushr v174, v11  ; v11 = 32
-;; @0025                               trapnz v62, user2
-;;                                     v183 = ishl v56, v6  ; v6 = 3
+;; @0025                               v58 = ushr v170, v11  ; v11 = 32
+;; @0025                               trapnz v58, user2
+;;                                     v179 = ishl v52, v6  ; v6 = 3
 ;; @0025                               v7 = iconst.i32 24
-;; @0025                               v65 = uadd_overflow_trap v183, v7, user2  ; v7 = 24
-;; @0025                               v69 = uadd_overflow_trap v46, v65, user2
+;; @0025                               v61 = uadd_overflow_trap v179, v7, user2  ; v7 = 24
+;; @0025                               v65 = uadd_overflow_trap v42, v61, user2
+;; @0025                               v66 = uextend.i64 v65
+;; @0025                               v68 = iadd v264, v66
+;; @0025                               v69 = isub v61, v7  ; v7 = 24
 ;; @0025                               v70 = uextend.i64 v69
-;; @0025                               v72 = iadd v268, v70
-;; @0025                               v73 = isub v65, v7  ; v7 = 24
-;; @0025                               v74 = uextend.i64 v73
-;; @0025                               v75 = isub v72, v74
-;; @0025                               store.i64 user2 little region1 v2, v75
-;; @0025                               v82 = load.i32 user2 readonly region1 v55
-;; @0025                               v76 = iconst.i32 1
-;;                                     v200 = icmp ugt v82, v76  ; v76 = 1
-;; @0025                               trapz v200, user17
-;; @0025                               v85 = uextend.i64 v82
-;;                                     v202 = ishl v85, v144  ; v144 = 3
-;; @0025                               v88 = ushr v202, v11  ; v11 = 32
-;; @0025                               trapnz v88, user2
-;;                                     v209 = ishl v82, v6  ; v6 = 3
-;; @0025                               v91 = uadd_overflow_trap v209, v7, user2  ; v7 = 24
-;; @0025                               v95 = uadd_overflow_trap v46, v91, user2
+;; @0025                               v71 = isub v68, v70
+;; @0025                               store.i64 user2 little region1 v2, v71
+;; @0025                               v78 = load.i32 user2 readonly region1 v51
+;; @0025                               v72 = iconst.i32 1
+;;                                     v196 = icmp ugt v78, v72  ; v72 = 1
+;; @0025                               trapz v196, user17
+;; @0025                               v81 = uextend.i64 v78
+;;                                     v198 = ishl v81, v140  ; v140 = 3
+;; @0025                               v84 = ushr v198, v11  ; v11 = 32
+;; @0025                               trapnz v84, user2
+;;                                     v205 = ishl v78, v6  ; v6 = 3
+;; @0025                               v87 = uadd_overflow_trap v205, v7, user2  ; v7 = 24
+;; @0025                               v91 = uadd_overflow_trap v42, v87, user2
+;; @0025                               v92 = uextend.i64 v91
+;; @0025                               v94 = iadd v264, v92
+;;                                     v218 = iconst.i32 32
+;; @0025                               v95 = isub v87, v218  ; v218 = 32
 ;; @0025                               v96 = uextend.i64 v95
-;; @0025                               v98 = iadd v268, v96
-;;                                     v222 = iconst.i32 32
-;; @0025                               v99 = isub v91, v222  ; v222 = 32
-;; @0025                               v100 = uextend.i64 v99
-;; @0025                               v101 = isub v98, v100
-;; @0025                               store.i64 user2 little region1 v3, v101
-;; @0025                               v108 = load.i32 user2 readonly region1 v55
-;; @0025                               v102 = iconst.i32 2
-;;                                     v228 = icmp ugt v108, v102  ; v102 = 2
-;; @0025                               trapz v228, user17
-;; @0025                               v111 = uextend.i64 v108
-;;                                     v230 = ishl v111, v144  ; v144 = 3
-;; @0025                               v114 = ushr v230, v11  ; v11 = 32
-;; @0025                               trapnz v114, user2
-;;                                     v237 = ishl v108, v6  ; v6 = 3
-;; @0025                               v117 = uadd_overflow_trap v237, v7, user2  ; v7 = 24
-;; @0025                               v121 = uadd_overflow_trap v46, v117, user2
+;; @0025                               v97 = isub v94, v96
+;; @0025                               store.i64 user2 little region1 v3, v97
+;; @0025                               v104 = load.i32 user2 readonly region1 v51
+;; @0025                               v98 = iconst.i32 2
+;;                                     v224 = icmp ugt v104, v98  ; v98 = 2
+;; @0025                               trapz v224, user17
+;; @0025                               v107 = uextend.i64 v104
+;;                                     v226 = ishl v107, v140  ; v140 = 3
+;; @0025                               v110 = ushr v226, v11  ; v11 = 32
+;; @0025                               trapnz v110, user2
+;;                                     v233 = ishl v104, v6  ; v6 = 3
+;; @0025                               v113 = uadd_overflow_trap v233, v7, user2  ; v7 = 24
+;; @0025                               v117 = uadd_overflow_trap v42, v113, user2
+;; @0025                               v118 = uextend.i64 v117
+;; @0025                               v120 = iadd v264, v118
+;;                                     v250 = iconst.i32 40
+;; @0025                               v121 = isub v113, v250  ; v250 = 40
 ;; @0025                               v122 = uextend.i64 v121
-;; @0025                               v124 = iadd v268, v122
-;;                                     v254 = iconst.i32 40
-;; @0025                               v125 = isub v117, v254  ; v254 = 40
-;; @0025                               v126 = uextend.i64 v125
-;; @0025                               v127 = isub v124, v126
-;; @0025                               store.i64 user2 little region1 v4, v127
-;; @0029                               jump block1(v46)
+;; @0025                               v123 = isub v120, v122
+;; @0025                               store.i64 user2 little region1 v4, v123
+;; @0029                               jump block1(v42)
 ;;
 ;;                                 block1(v5: i32):
 ;; @0029                               return v5

--- a/tests/disas/gc/copying/array-new.wat
+++ b/tests/disas/gc/copying/array-new.wat
@@ -24,96 +24,96 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0022                               v6 = uextend.i64 v3
-;;                                     v98 = iconst.i64 3
-;;                                     v99 = ishl v6, v98  ; v98 = 3
+;;                                     v94 = iconst.i64 3
+;;                                     v95 = ishl v6, v94  ; v94 = 3
 ;; @0022                               v9 = iconst.i64 32
-;; @0022                               v10 = ushr v99, v9  ; v9 = 32
+;; @0022                               v10 = ushr v95, v9  ; v9 = 32
 ;; @0022                               trapnz v10, user18
 ;; @0022                               v5 = iconst.i32 24
-;;                                     v105 = iconst.i32 3
-;;                                     v106 = ishl v3, v105  ; v105 = 3
-;; @0022                               v12 = uadd_overflow_trap v5, v106, user18  ; v5 = 24
-;; @0022                               v14 = load.i64 notrap aligned readonly can_move v0+32
-;; @0022                               v15 = load.i32 notrap aligned v14
-;; @0022                               v16 = load.i32 notrap aligned v14+4
-;; @0022                               v22 = uextend.i64 v15
-;; @0022                               v17 = uextend.i64 v12
-;; @0022                               v18 = iconst.i64 15
-;; @0022                               v20 = iadd v17, v18  ; v18 = 15
-;; @0022                               v19 = iconst.i64 -16
-;; @0022                               v21 = band v20, v19  ; v19 = -16
-;; @0022                               v23 = iadd v22, v21
-;; @0022                               v24 = uextend.i64 v16
-;; @0022                               v25 = icmp ule v23, v24
-;; @0022                               brif v25, block2, block3
+;;                                     v101 = iconst.i32 3
+;;                                     v102 = ishl v3, v101  ; v101 = 3
+;; @0022                               v12 = uadd_overflow_trap v5, v102, user18  ; v5 = 24
+;; @0022                               v13 = load.i64 notrap aligned readonly can_move v0+32
+;; @0022                               v14 = load.i32 notrap aligned v13
+;; @0022                               v15 = load.i32 notrap aligned v13+4
+;; @0022                               v21 = uextend.i64 v14
+;; @0022                               v16 = uextend.i64 v12
+;; @0022                               v17 = iconst.i64 15
+;; @0022                               v19 = iadd v16, v17  ; v17 = 15
+;; @0022                               v18 = iconst.i64 -16
+;; @0022                               v20 = band v19, v18  ; v18 = -16
+;; @0022                               v22 = iadd v21, v20
+;; @0022                               v23 = uextend.i64 v15
+;; @0022                               v24 = icmp ule v22, v23
+;; @0022                               brif v24, block2, block3
 ;;
 ;;                                 block2:
-;;                                     v114 = iconst.i32 15
-;;                                     v115 = iadd.i32 v12, v114  ; v114 = 15
-;;                                     v118 = iconst.i32 -16
-;;                                     v119 = band v115, v118  ; v118 = -16
-;;                                     v121 = iadd.i32 v15, v119
-;; @0022                               store notrap aligned region0 v121, v14
-;;                                     v137 = iconst.i32 -1476395002
-;;                                     v138 = load.i64 notrap aligned readonly can_move v0+8
-;;                                     v139 = load.i64 notrap aligned readonly can_move v138+32
-;; @0022                               v39 = iadd v139, v22
-;; @0022                               store notrap aligned v137, v39  ; v137 = -1476395002
-;;                                     v140 = load.i64 notrap aligned readonly can_move v0+40
-;;                                     v141 = load.i32 notrap aligned readonly can_move v140
-;; @0022                               store notrap aligned v141, v39+4
-;;                                     v142 = band.i64 v20, v19  ; v19 = -16
-;; @0022                               istore32 notrap aligned v142, v39+8
-;; @0022                               jump block4(v15, v39)
+;;                                     v110 = iconst.i32 15
+;;                                     v111 = iadd.i32 v12, v110  ; v110 = 15
+;;                                     v114 = iconst.i32 -16
+;;                                     v115 = band v111, v114  ; v114 = -16
+;;                                     v117 = iadd.i32 v14, v115
+;; @0022                               store notrap aligned region0 v117, v13
+;;                                     v133 = iconst.i32 -1476395002
+;;                                     v134 = load.i64 notrap aligned readonly can_move v0+8
+;;                                     v135 = load.i64 notrap aligned readonly can_move v134+32
+;; @0022                               v36 = iadd v135, v21
+;; @0022                               store notrap aligned v133, v36  ; v133 = -1476395002
+;;                                     v136 = load.i64 notrap aligned readonly can_move v0+40
+;;                                     v137 = load.i32 notrap aligned readonly can_move v136
+;; @0022                               store notrap aligned v137, v36+4
+;;                                     v138 = band.i64 v19, v18  ; v18 = -16
+;; @0022                               istore32 notrap aligned v138, v36+8
+;; @0022                               jump block4(v14, v36)
 ;;
 ;;                                 block3 cold:
-;; @0022                               v27 = iconst.i32 -1476395002
-;; @0022                               v29 = load.i64 notrap aligned readonly can_move v0+40
-;; @0022                               v30 = load.i32 notrap aligned readonly can_move v29
-;; @0022                               v31 = iconst.i32 16
-;; @0022                               v32 = call fn0(v0, v27, v30, v12, v31)  ; v27 = -1476395002, v31 = 16
-;; @0022                               v94 = load.i64 notrap aligned readonly can_move v0+8
-;; @0022                               v33 = load.i64 notrap aligned readonly can_move v94+32
-;; @0022                               v34 = uextend.i64 v32
-;; @0022                               v35 = iadd v33, v34
-;; @0022                               jump block4(v32, v35)
+;; @0022                               v25 = iconst.i32 -1476395002
+;; @0022                               v26 = load.i64 notrap aligned readonly can_move v0+40
+;; @0022                               v27 = load.i32 notrap aligned readonly can_move v26
+;; @0022                               v28 = iconst.i32 16
+;; @0022                               v29 = call fn0(v0, v25, v27, v12, v28)  ; v25 = -1476395002, v28 = 16
+;; @0022                               v90 = load.i64 notrap aligned readonly can_move v0+8
+;; @0022                               v30 = load.i64 notrap aligned readonly can_move v90+32
+;; @0022                               v31 = uextend.i64 v29
+;; @0022                               v32 = iadd v30, v31
+;; @0022                               jump block4(v29, v32)
 ;;
-;;                                 block4(v44: i32, v45: i64):
-;; @0022                               v46 = iconst.i64 16
-;; @0022                               v47 = iadd v45, v46  ; v46 = 16
-;; @0022                               store.i32 user2 region1 v3, v47
-;; @0022                               trapz v44, user16
-;;                                     v143 = load.i64 notrap aligned readonly can_move v0+8
-;;                                     v144 = load.i64 notrap aligned readonly can_move v143+32
-;; @0022                               v49 = uextend.i64 v44
-;; @0022                               v51 = iadd v144, v49
-;; @0022                               v53 = iadd v51, v46  ; v46 = 16
-;; @0022                               v54 = load.i32 user2 readonly region1 v53
-;; @0022                               v55 = uextend.i64 v54
-;; @0022                               v61 = icmp.i64 ugt v6, v55
-;; @0022                               trapnz v61, user17
-;; @0022                               v75 = load.i64 notrap aligned v143+40
-;; @0022                               v65 = iconst.i64 24
-;; @0022                               v66 = iadd v51, v65  ; v65 = 24
-;; @0022                               v77 = uadd_overflow_trap v66, v99, user2
-;; @0022                               v76 = iadd v144, v75
-;; @0022                               v78 = icmp ugt v77, v76
-;; @0022                               trapnz v78, user2
-;;                                     v123 = iconst.i64 0
-;; @0022                               v81 = icmp.i64 eq v6, v123  ; v123 = 0
+;;                                 block4(v40: i32, v41: i64):
+;; @0022                               v42 = iconst.i64 16
+;; @0022                               v43 = iadd v41, v42  ; v42 = 16
+;; @0022                               store.i32 user2 region1 v3, v43
+;; @0022                               trapz v40, user16
+;;                                     v139 = load.i64 notrap aligned readonly can_move v0+8
+;;                                     v140 = load.i64 notrap aligned readonly can_move v139+32
+;; @0022                               v45 = uextend.i64 v40
+;; @0022                               v47 = iadd v140, v45
+;; @0022                               v49 = iadd v47, v42  ; v42 = 16
+;; @0022                               v50 = load.i32 user2 readonly region1 v49
+;; @0022                               v51 = uextend.i64 v50
+;; @0022                               v57 = icmp.i64 ugt v6, v51
+;; @0022                               trapnz v57, user17
+;; @0022                               v71 = load.i64 notrap aligned v139+40
+;; @0022                               v61 = iconst.i64 24
+;; @0022                               v62 = iadd v47, v61  ; v61 = 24
+;; @0022                               v73 = uadd_overflow_trap v62, v95, user2
+;; @0022                               v72 = iadd v140, v71
+;; @0022                               v74 = icmp ugt v73, v72
+;; @0022                               trapnz v74, user2
+;;                                     v119 = iconst.i64 0
+;; @0022                               v77 = icmp.i64 eq v6, v119  ; v119 = 0
 ;; @0022                               v7 = iconst.i64 8
-;; @0022                               v79 = iadd v66, v99
-;; @0022                               brif v81, block6, block5(v66)
+;; @0022                               v75 = iadd v62, v95
+;; @0022                               brif v77, block6, block5(v62)
 ;;
-;;                                 block5(v82: i64):
-;; @0022                               store.i64 user2 little region1 v2, v82
-;;                                     v145 = iconst.i64 8
-;;                                     v146 = iadd v82, v145  ; v145 = 8
-;; @0022                               v85 = icmp eq v146, v79
-;; @0022                               brif v85, block6, block5(v146)
+;;                                 block5(v78: i64):
+;; @0022                               store.i64 user2 little region1 v2, v78
+;;                                     v141 = iconst.i64 8
+;;                                     v142 = iadd v78, v141  ; v141 = 8
+;; @0022                               v81 = icmp eq v142, v75
+;; @0022                               brif v81, block6, block5(v142)
 ;;
 ;;                                 block6:
-;; @0025                               jump block1(v44)
+;; @0025                               jump block1(v40)
 ;;
 ;;                                 block1(v4: i32):
 ;; @0025                               return v4

--- a/tests/disas/gc/copying/br-on-cast-fail.wat
+++ b/tests/disas/gc/copying/br-on-cast-fail.wat
@@ -35,35 +35,35 @@
 ;;                                 block3:
 ;; @002e                               v8 = iconst.i32 1
 ;; @002e                               v9 = band.i32 v2, v8  ; v8 = 1
-;;                                     v31 = iconst.i32 0
-;; @002e                               brif v9, block5(v31), block4  ; v31 = 0
+;;                                     v30 = iconst.i32 0
+;; @002e                               brif v9, block5(v30), block4  ; v30 = 0
 ;;
 ;;                                 block4:
-;; @002e                               v29 = load.i64 notrap aligned readonly can_move v0+8
-;; @002e                               v15 = load.i64 notrap aligned readonly can_move v29+32
-;; @002e                               v14 = uextend.i64 v2
-;; @002e                               v16 = iadd v15, v14
-;; @002e                               v17 = iconst.i64 4
-;; @002e                               v18 = iadd v16, v17  ; v17 = 4
-;; @002e                               v19 = load.i32 user2 readonly region0 v18
-;; @002e                               v12 = load.i64 notrap aligned readonly can_move v0+40
-;; @002e                               v13 = load.i32 notrap aligned readonly can_move v12
-;; @002e                               v20 = icmp eq v19, v13
-;; @002e                               v21 = uextend.i32 v20
-;; @002e                               jump block5(v21)
+;; @002e                               v28 = load.i64 notrap aligned readonly can_move v0+8
+;; @002e                               v14 = load.i64 notrap aligned readonly can_move v28+32
+;; @002e                               v13 = uextend.i64 v2
+;; @002e                               v15 = iadd v14, v13
+;; @002e                               v16 = iconst.i64 4
+;; @002e                               v17 = iadd v15, v16  ; v16 = 4
+;; @002e                               v18 = load.i32 user2 readonly region0 v17
+;; @002e                               v11 = load.i64 notrap aligned readonly can_move v0+40
+;; @002e                               v12 = load.i32 notrap aligned readonly can_move v11
+;; @002e                               v19 = icmp eq v18, v12
+;; @002e                               v20 = uextend.i32 v19
+;; @002e                               jump block5(v20)
 ;;
-;;                                 block5(v22: i32):
-;; @002e                               brif v22, block6, block2
+;;                                 block5(v21: i32):
+;; @002e                               brif v21, block6, block2
 ;;
 ;;                                 block6:
-;; @0034                               v25 = load.i64 notrap aligned readonly can_move v0+56
-;; @0034                               v24 = load.i64 notrap aligned readonly can_move v0+72
-;; @0034                               call_indirect sig0, v25(v24, v0)
+;; @0034                               v24 = load.i64 notrap aligned readonly can_move v0+56
+;; @0034                               v23 = load.i64 notrap aligned readonly can_move v0+72
+;; @0034                               call_indirect sig0, v24(v23, v0)
 ;; @0036                               return
 ;;
 ;;                                 block2:
-;; @0038                               v28 = load.i64 notrap aligned readonly can_move v0+88
-;; @0038                               v27 = load.i64 notrap aligned readonly can_move v0+104
-;; @0038                               call_indirect sig0, v28(v27, v0)
+;; @0038                               v27 = load.i64 notrap aligned readonly can_move v0+88
+;; @0038                               v26 = load.i64 notrap aligned readonly can_move v0+104
+;; @0038                               call_indirect sig0, v27(v26, v0)
 ;; @003a                               return
 ;; }

--- a/tests/disas/gc/copying/br-on-cast.wat
+++ b/tests/disas/gc/copying/br-on-cast.wat
@@ -35,35 +35,35 @@
 ;;                                 block3:
 ;; @002f                               v8 = iconst.i32 1
 ;; @002f                               v9 = band.i32 v2, v8  ; v8 = 1
-;;                                     v31 = iconst.i32 0
-;; @002f                               brif v9, block5(v31), block4  ; v31 = 0
+;;                                     v30 = iconst.i32 0
+;; @002f                               brif v9, block5(v30), block4  ; v30 = 0
 ;;
 ;;                                 block4:
-;; @002f                               v29 = load.i64 notrap aligned readonly can_move v0+8
-;; @002f                               v15 = load.i64 notrap aligned readonly can_move v29+32
-;; @002f                               v14 = uextend.i64 v2
-;; @002f                               v16 = iadd v15, v14
-;; @002f                               v17 = iconst.i64 4
-;; @002f                               v18 = iadd v16, v17  ; v17 = 4
-;; @002f                               v19 = load.i32 user2 readonly region0 v18
-;; @002f                               v12 = load.i64 notrap aligned readonly can_move v0+40
-;; @002f                               v13 = load.i32 notrap aligned readonly can_move v12
-;; @002f                               v20 = icmp eq v19, v13
-;; @002f                               v21 = uextend.i32 v20
-;; @002f                               jump block5(v21)
+;; @002f                               v28 = load.i64 notrap aligned readonly can_move v0+8
+;; @002f                               v14 = load.i64 notrap aligned readonly can_move v28+32
+;; @002f                               v13 = uextend.i64 v2
+;; @002f                               v15 = iadd v14, v13
+;; @002f                               v16 = iconst.i64 4
+;; @002f                               v17 = iadd v15, v16  ; v16 = 4
+;; @002f                               v18 = load.i32 user2 readonly region0 v17
+;; @002f                               v11 = load.i64 notrap aligned readonly can_move v0+40
+;; @002f                               v12 = load.i32 notrap aligned readonly can_move v11
+;; @002f                               v19 = icmp eq v18, v12
+;; @002f                               v20 = uextend.i32 v19
+;; @002f                               jump block5(v20)
 ;;
-;;                                 block5(v22: i32):
-;; @002f                               brif v22, block2, block6
+;;                                 block5(v21: i32):
+;; @002f                               brif v21, block2, block6
 ;;
 ;;                                 block6:
-;; @0035                               v25 = load.i64 notrap aligned readonly can_move v0+56
-;; @0035                               v24 = load.i64 notrap aligned readonly can_move v0+72
-;; @0035                               call_indirect sig0, v25(v24, v0)
+;; @0035                               v24 = load.i64 notrap aligned readonly can_move v0+56
+;; @0035                               v23 = load.i64 notrap aligned readonly can_move v0+72
+;; @0035                               call_indirect sig0, v24(v23, v0)
 ;; @0037                               return
 ;;
 ;;                                 block2:
-;; @0039                               v28 = load.i64 notrap aligned readonly can_move v0+88
-;; @0039                               v27 = load.i64 notrap aligned readonly can_move v0+104
-;; @0039                               call_indirect sig0, v28(v27, v0)
+;; @0039                               v27 = load.i64 notrap aligned readonly can_move v0+88
+;; @0039                               v26 = load.i64 notrap aligned readonly can_move v0+104
+;; @0039                               call_indirect sig0, v27(v26, v0)
 ;; @003b                               return
 ;; }

--- a/tests/disas/gc/copying/call-indirect-and-subtyping.wat
+++ b/tests/disas/gc/copying/call-indirect-and-subtyping.wat
@@ -46,26 +46,26 @@
 ;;
 ;;                                 block2 cold:
 ;; @005c                               v16 = iconst.i32 0
-;; @005c                               v19 = call fn0(v0, v16, v5)  ; v16 = 0
-;; @005c                               jump block3(v19)
+;; @005c                               v18 = call fn0(v0, v16, v5)  ; v16 = 0
+;; @005c                               jump block3(v18)
 ;;
 ;;                                 block3(v15: i64):
-;; @005c                               v23 = load.i32 user7 aligned readonly v15+16
-;; @005c                               v21 = load.i64 notrap aligned readonly can_move v0+40
-;; @005c                               v22 = load.i32 notrap aligned readonly can_move v21
-;; @005c                               v24 = icmp eq v23, v22
-;; @005c                               v25 = uextend.i32 v24
-;; @005c                               brif v24, block5(v25), block4
+;; @005c                               v21 = load.i32 user7 aligned readonly v15+16
+;; @005c                               v19 = load.i64 notrap aligned readonly can_move v0+40
+;; @005c                               v20 = load.i32 notrap aligned readonly can_move v19
+;; @005c                               v22 = icmp eq v21, v20
+;; @005c                               v23 = uextend.i32 v22
+;; @005c                               brif v22, block5(v23), block4
 ;;
 ;;                                 block4:
-;; @005c                               v27 = call fn1(v0, v23, v22)
-;; @005c                               jump block5(v27)
+;; @005c                               v24 = call fn1(v0, v21, v20)
+;; @005c                               jump block5(v24)
 ;;
-;;                                 block5(v28: i32):
-;; @005c                               trapz v28, user8
-;; @005c                               v29 = load.i64 notrap aligned readonly v15+8
-;; @005c                               v30 = load.i64 notrap aligned readonly v15+24
-;; @005c                               call_indirect sig0, v29(v30, v0)
+;;                                 block5(v25: i32):
+;; @005c                               trapz v25, user8
+;; @005c                               v26 = load.i64 notrap aligned readonly v15+8
+;; @005c                               v27 = load.i64 notrap aligned readonly v15+24
+;; @005c                               call_indirect sig0, v26(v27, v0)
 ;; @005f                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/copying/funcref-in-gc-heap-get.wat
+++ b/tests/disas/gc/copying/funcref-in-gc-heap-get.wat
@@ -23,17 +23,17 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0020                               trapz v2, user16
-;; @0020                               v13 = load.i64 notrap aligned readonly can_move v0+8
-;; @0020                               v5 = load.i64 notrap aligned readonly can_move v13+32
+;; @0020                               v12 = load.i64 notrap aligned readonly can_move v0+8
+;; @0020                               v5 = load.i64 notrap aligned readonly can_move v12+32
 ;; @0020                               v4 = uextend.i64 v2
 ;; @0020                               v6 = iadd v5, v4
 ;; @0020                               v7 = iconst.i64 16
 ;; @0020                               v8 = iadd v6, v7  ; v7 = 16
-;; @0020                               v11 = load.i32 user2 little region0 v8
+;; @0020                               v10 = load.i32 user2 little region0 v8
 ;; @0020                               v9 = iconst.i32 -1
-;; @0020                               v12 = call fn0(v0, v11, v9)  ; v9 = -1
+;; @0020                               v11 = call fn0(v0, v10, v9)  ; v9 = -1
 ;; @0024                               jump block1
 ;;
 ;;                                 block1:
-;; @0024                               return v12
+;; @0024                               return v11
 ;; }

--- a/tests/disas/gc/copying/funcref-in-gc-heap-new.wat
+++ b/tests/disas/gc/copying/funcref-in-gc-heap-new.wat
@@ -25,56 +25,56 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0020                               v6 = load.i64 notrap aligned readonly can_move v0+32
-;; @0020                               v7 = load.i32 notrap aligned v6
-;; @0020                               v8 = load.i32 notrap aligned v6+4
-;; @0020                               v14 = uextend.i64 v7
-;;                                     v50 = iconst.i64 32
-;; @0020                               v15 = iadd v14, v50  ; v50 = 32
-;; @0020                               v16 = uextend.i64 v8
-;; @0020                               v17 = icmp ule v15, v16
-;; @0020                               brif v17, block2, block3
+;; @0020                               v5 = load.i64 notrap aligned readonly can_move v0+32
+;; @0020                               v6 = load.i32 notrap aligned v5
+;; @0020                               v7 = load.i32 notrap aligned v5+4
+;; @0020                               v13 = uextend.i64 v6
+;;                                     v45 = iconst.i64 32
+;; @0020                               v14 = iadd v13, v45  ; v45 = 32
+;; @0020                               v15 = uextend.i64 v7
+;; @0020                               v16 = icmp ule v14, v15
+;; @0020                               brif v16, block2, block3
 ;;
 ;;                                 block2:
-;;                                     v66 = iconst.i32 32
-;;                                     v64 = iadd.i32 v7, v66  ; v66 = 32
-;; @0020                               store notrap aligned region0 v64, v6
-;;                                     v67 = iconst.i32 -1342177278
-;;                                     v68 = load.i64 notrap aligned readonly can_move v0+8
-;;                                     v69 = load.i64 notrap aligned readonly can_move v68+32
-;; @0020                               v31 = iadd v69, v14
-;; @0020                               store notrap aligned v67, v31  ; v67 = -1342177278
-;;                                     v70 = load.i64 notrap aligned readonly can_move v0+40
-;;                                     v71 = load.i32 notrap aligned readonly can_move v70
-;; @0020                               store notrap aligned v71, v31+4
-;;                                     v72 = iconst.i64 32
-;; @0020                               istore32 notrap aligned v72, v31+8  ; v72 = 32
-;; @0020                               jump block4(v7, v31)
+;;                                     v61 = iconst.i32 32
+;;                                     v59 = iadd.i32 v6, v61  ; v61 = 32
+;; @0020                               store notrap aligned region0 v59, v5
+;;                                     v62 = iconst.i32 -1342177278
+;;                                     v63 = load.i64 notrap aligned readonly can_move v0+8
+;;                                     v64 = load.i64 notrap aligned readonly can_move v63+32
+;; @0020                               v28 = iadd v64, v13
+;; @0020                               store notrap aligned v62, v28  ; v62 = -1342177278
+;;                                     v65 = load.i64 notrap aligned readonly can_move v0+40
+;;                                     v66 = load.i32 notrap aligned readonly can_move v65
+;; @0020                               store notrap aligned v66, v28+4
+;;                                     v67 = iconst.i64 32
+;; @0020                               istore32 notrap aligned v67, v28+8  ; v67 = 32
+;; @0020                               jump block4(v6, v28)
 ;;
 ;;                                 block3 cold:
-;; @0020                               v19 = iconst.i32 -1342177278
-;; @0020                               v21 = load.i64 notrap aligned readonly can_move v0+40
-;; @0020                               v22 = load.i32 notrap aligned readonly can_move v21
+;; @0020                               v17 = iconst.i32 -1342177278
+;; @0020                               v18 = load.i64 notrap aligned readonly can_move v0+40
+;; @0020                               v19 = load.i32 notrap aligned readonly can_move v18
 ;; @0020                               v4 = iconst.i32 32
-;; @0020                               v23 = iconst.i32 16
-;; @0020                               v24 = call fn0(v0, v19, v22, v4, v23)  ; v19 = -1342177278, v4 = 32, v23 = 16
-;; @0020                               v46 = load.i64 notrap aligned readonly can_move v0+8
-;; @0020                               v25 = load.i64 notrap aligned readonly can_move v46+32
-;; @0020                               v26 = uextend.i64 v24
-;; @0020                               v27 = iadd v25, v26
-;; @0020                               jump block4(v24, v27)
+;; @0020                               v20 = iconst.i32 16
+;; @0020                               v21 = call fn0(v0, v17, v19, v4, v20)  ; v17 = -1342177278, v4 = 32, v20 = 16
+;; @0020                               v41 = load.i64 notrap aligned readonly can_move v0+8
+;; @0020                               v22 = load.i64 notrap aligned readonly can_move v41+32
+;; @0020                               v23 = uextend.i64 v21
+;; @0020                               v24 = iadd v22, v23
+;; @0020                               jump block4(v21, v24)
 ;;
-;;                                 block4(v36: i32, v37: i64):
-;;                                     v45 = stack_addr.i64 ss0
-;;                                     store notrap v36, v45
-;; @0020                               v41 = call fn1(v0, v2), stack_map=[i32 @ ss0+0]
-;; @0020                               v42 = ireduce.i32 v41
-;; @0020                               v38 = iconst.i64 16
-;; @0020                               v39 = iadd v37, v38  ; v38 = 16
-;; @0020                               store user2 little region1 v42, v39
-;;                                     v44 = load.i32 notrap v45
+;;                                 block4(v32: i32, v33: i64):
+;;                                     v40 = stack_addr.i64 ss0
+;;                                     store notrap v32, v40
+;; @0020                               v36 = call fn1(v0, v2), stack_map=[i32 @ ss0+0]
+;; @0020                               v37 = ireduce.i32 v36
+;; @0020                               v34 = iconst.i64 16
+;; @0020                               v35 = iadd v33, v34  ; v34 = 16
+;; @0020                               store user2 little region1 v37, v35
+;;                                     v39 = load.i32 notrap v40
 ;; @0023                               jump block1
 ;;
 ;;                                 block1:
-;; @0023                               return v44
+;; @0023                               return v39
 ;; }

--- a/tests/disas/gc/copying/funcref-in-gc-heap-set.wat
+++ b/tests/disas/gc/copying/funcref-in-gc-heap-set.wat
@@ -23,15 +23,15 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i64):
 ;; @0022                               trapz v2, user16
-;; @0022                               v10 = call fn0(v0, v3)
-;; @0022                               v11 = ireduce.i32 v10
-;; @0022                               v12 = load.i64 notrap aligned readonly can_move v0+8
-;; @0022                               v5 = load.i64 notrap aligned readonly can_move v12+32
+;; @0022                               v9 = call fn0(v0, v3)
+;; @0022                               v10 = ireduce.i32 v9
+;; @0022                               v11 = load.i64 notrap aligned readonly can_move v0+8
+;; @0022                               v5 = load.i64 notrap aligned readonly can_move v11+32
 ;; @0022                               v4 = uextend.i64 v2
 ;; @0022                               v6 = iadd v5, v4
 ;; @0022                               v7 = iconst.i64 16
 ;; @0022                               v8 = iadd v6, v7  ; v7 = 16
-;; @0022                               store user2 little region0 v11, v8
+;; @0022                               store user2 little region0 v10, v8
 ;; @0026                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/copying/ref-cast.wat
+++ b/tests/disas/gc/copying/ref-cast.wat
@@ -26,25 +26,25 @@
 ;;                                 block2:
 ;; @001e                               v8 = iconst.i32 1
 ;; @001e                               v9 = band.i32 v2, v8  ; v8 = 1
-;;                                     v25 = iconst.i32 0
-;; @001e                               brif v9, block4(v25), block3  ; v25 = 0
+;;                                     v24 = iconst.i32 0
+;; @001e                               brif v9, block4(v24), block3  ; v24 = 0
 ;;
 ;;                                 block3:
-;; @001e                               v23 = load.i64 notrap aligned readonly can_move v0+8
-;; @001e                               v15 = load.i64 notrap aligned readonly can_move v23+32
-;; @001e                               v14 = uextend.i64 v2
-;; @001e                               v16 = iadd v15, v14
-;; @001e                               v17 = iconst.i64 4
-;; @001e                               v18 = iadd v16, v17  ; v17 = 4
-;; @001e                               v19 = load.i32 user2 readonly region0 v18
-;; @001e                               v12 = load.i64 notrap aligned readonly can_move v0+40
-;; @001e                               v13 = load.i32 notrap aligned readonly can_move v12
-;; @001e                               v20 = icmp eq v19, v13
-;; @001e                               v21 = uextend.i32 v20
-;; @001e                               jump block4(v21)
+;; @001e                               v22 = load.i64 notrap aligned readonly can_move v0+8
+;; @001e                               v14 = load.i64 notrap aligned readonly can_move v22+32
+;; @001e                               v13 = uextend.i64 v2
+;; @001e                               v15 = iadd v14, v13
+;; @001e                               v16 = iconst.i64 4
+;; @001e                               v17 = iadd v15, v16  ; v16 = 4
+;; @001e                               v18 = load.i32 user2 readonly region0 v17
+;; @001e                               v11 = load.i64 notrap aligned readonly can_move v0+40
+;; @001e                               v12 = load.i32 notrap aligned readonly can_move v11
+;; @001e                               v19 = icmp eq v18, v12
+;; @001e                               v20 = uextend.i32 v19
+;; @001e                               jump block4(v20)
 ;;
-;;                                 block4(v22: i32):
-;; @001e                               trapz v22, user19
+;;                                 block4(v21: i32):
+;; @001e                               trapz v21, user19
 ;; @0021                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/copying/ref-test-concrete-func-type.wat
+++ b/tests/disas/gc/copying/ref-test-concrete-func-type.wat
@@ -12,7 +12,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
@@ -25,15 +24,15 @@
 ;; @0020                               jump block3
 ;;
 ;;                                 block3:
-;; @0020                               v11 = load.i32 user2 readonly region0 v2+16
-;; @0020                               v9 = load.i64 notrap aligned readonly can_move v0+40
-;; @0020                               v10 = load.i32 notrap aligned readonly can_move v9
-;; @0020                               v12 = icmp eq v11, v10
-;; @0020                               v13 = uextend.i32 v12
-;; @0020                               jump block4(v13)
+;; @0020                               v10 = load.i32 user2 readonly region0 v2+16
+;; @0020                               v8 = load.i64 notrap aligned readonly can_move v0+40
+;; @0020                               v9 = load.i32 notrap aligned readonly can_move v8
+;; @0020                               v11 = icmp eq v10, v9
+;; @0020                               v12 = uextend.i32 v11
+;; @0020                               jump block4(v12)
 ;;
-;;                                 block4(v14: i32):
-;; @0023                               jump block1(v14)
+;;                                 block4(v13: i32):
+;; @0023                               jump block1(v13)
 ;;
 ;;                                 block1(v3: i32):
 ;; @0023                               return v3

--- a/tests/disas/gc/copying/ref-test-concrete-type.wat
+++ b/tests/disas/gc/copying/ref-test-concrete-type.wat
@@ -26,25 +26,25 @@
 ;;                                 block2:
 ;; @001d                               v8 = iconst.i32 1
 ;; @001d                               v9 = band.i32 v2, v8  ; v8 = 1
-;;                                     v25 = iconst.i32 0
-;; @001d                               brif v9, block4(v25), block3  ; v25 = 0
+;;                                     v24 = iconst.i32 0
+;; @001d                               brif v9, block4(v24), block3  ; v24 = 0
 ;;
 ;;                                 block3:
-;; @001d                               v23 = load.i64 notrap aligned readonly can_move v0+8
-;; @001d                               v15 = load.i64 notrap aligned readonly can_move v23+32
-;; @001d                               v14 = uextend.i64 v2
-;; @001d                               v16 = iadd v15, v14
-;; @001d                               v17 = iconst.i64 4
-;; @001d                               v18 = iadd v16, v17  ; v17 = 4
-;; @001d                               v19 = load.i32 user2 readonly region0 v18
-;; @001d                               v12 = load.i64 notrap aligned readonly can_move v0+40
-;; @001d                               v13 = load.i32 notrap aligned readonly can_move v12
-;; @001d                               v20 = icmp eq v19, v13
-;; @001d                               v21 = uextend.i32 v20
-;; @001d                               jump block4(v21)
+;; @001d                               v22 = load.i64 notrap aligned readonly can_move v0+8
+;; @001d                               v14 = load.i64 notrap aligned readonly can_move v22+32
+;; @001d                               v13 = uextend.i64 v2
+;; @001d                               v15 = iadd v14, v13
+;; @001d                               v16 = iconst.i64 4
+;; @001d                               v17 = iadd v15, v16  ; v16 = 4
+;; @001d                               v18 = load.i32 user2 readonly region0 v17
+;; @001d                               v11 = load.i64 notrap aligned readonly can_move v0+40
+;; @001d                               v12 = load.i32 notrap aligned readonly can_move v11
+;; @001d                               v19 = icmp eq v18, v12
+;; @001d                               v20 = uextend.i32 v19
+;; @001d                               jump block4(v20)
 ;;
-;;                                 block4(v22: i32):
-;; @0020                               jump block1(v22)
+;;                                 block4(v21: i32):
+;; @0020                               jump block1(v21)
 ;;
 ;;                                 block1(v3: i32):
 ;; @0020                               return v3

--- a/tests/disas/gc/copying/struct-new-default.wat
+++ b/tests/disas/gc/copying/struct-new-default.wat
@@ -24,58 +24,58 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @0021                               v8 = load.i64 notrap aligned readonly can_move v0+32
-;; @0021                               v9 = load.i32 notrap aligned v8
-;; @0021                               v10 = load.i32 notrap aligned v8+4
-;; @0021                               v16 = uextend.i64 v9
-;;                                     v50 = iconst.i64 32
-;; @0021                               v17 = iadd v16, v50  ; v50 = 32
-;; @0021                               v18 = uextend.i64 v10
-;; @0021                               v19 = icmp ule v17, v18
-;; @0021                               brif v19, block2, block3
+;; @0021                               v7 = load.i64 notrap aligned readonly can_move v0+32
+;; @0021                               v8 = load.i32 notrap aligned v7
+;; @0021                               v9 = load.i32 notrap aligned v7+4
+;; @0021                               v15 = uextend.i64 v8
+;;                                     v46 = iconst.i64 32
+;; @0021                               v16 = iadd v15, v46  ; v46 = 32
+;; @0021                               v17 = uextend.i64 v9
+;; @0021                               v18 = icmp ule v16, v17
+;; @0021                               brif v18, block2, block3
 ;;
 ;;                                 block2:
-;;                                     v66 = iconst.i32 32
-;;                                     v64 = iadd.i32 v9, v66  ; v66 = 32
-;; @0021                               store notrap aligned region0 v64, v8
-;;                                     v67 = iconst.i32 -1342177246
-;;                                     v68 = load.i64 notrap aligned readonly can_move v0+8
-;;                                     v69 = load.i64 notrap aligned readonly can_move v68+32
-;; @0021                               v33 = iadd v69, v16
-;; @0021                               store notrap aligned v67, v33  ; v67 = -1342177246
-;;                                     v70 = load.i64 notrap aligned readonly can_move v0+40
-;;                                     v71 = load.i32 notrap aligned readonly can_move v70
-;; @0021                               store notrap aligned v71, v33+4
-;;                                     v72 = iconst.i64 32
-;; @0021                               istore32 notrap aligned v72, v33+8  ; v72 = 32
-;; @0021                               jump block4(v9, v33)
+;;                                     v62 = iconst.i32 32
+;;                                     v60 = iadd.i32 v8, v62  ; v62 = 32
+;; @0021                               store notrap aligned region0 v60, v7
+;;                                     v63 = iconst.i32 -1342177246
+;;                                     v64 = load.i64 notrap aligned readonly can_move v0+8
+;;                                     v65 = load.i64 notrap aligned readonly can_move v64+32
+;; @0021                               v30 = iadd v65, v15
+;; @0021                               store notrap aligned v63, v30  ; v63 = -1342177246
+;;                                     v66 = load.i64 notrap aligned readonly can_move v0+40
+;;                                     v67 = load.i32 notrap aligned readonly can_move v66
+;; @0021                               store notrap aligned v67, v30+4
+;;                                     v68 = iconst.i64 32
+;; @0021                               istore32 notrap aligned v68, v30+8  ; v68 = 32
+;; @0021                               jump block4(v8, v30)
 ;;
 ;;                                 block3 cold:
-;; @0021                               v21 = iconst.i32 -1342177246
-;; @0021                               v23 = load.i64 notrap aligned readonly can_move v0+40
-;; @0021                               v24 = load.i32 notrap aligned readonly can_move v23
+;; @0021                               v19 = iconst.i32 -1342177246
+;; @0021                               v20 = load.i64 notrap aligned readonly can_move v0+40
+;; @0021                               v21 = load.i32 notrap aligned readonly can_move v20
 ;; @0021                               v6 = iconst.i32 32
-;; @0021                               v25 = iconst.i32 16
-;; @0021                               v26 = call fn0(v0, v21, v24, v6, v25)  ; v21 = -1342177246, v6 = 32, v25 = 16
-;; @0021                               v46 = load.i64 notrap aligned readonly can_move v0+8
-;; @0021                               v27 = load.i64 notrap aligned readonly can_move v46+32
-;; @0021                               v28 = uextend.i64 v26
-;; @0021                               v29 = iadd v27, v28
-;; @0021                               jump block4(v26, v29)
+;; @0021                               v22 = iconst.i32 16
+;; @0021                               v23 = call fn0(v0, v19, v21, v6, v22)  ; v19 = -1342177246, v6 = 32, v22 = 16
+;; @0021                               v42 = load.i64 notrap aligned readonly can_move v0+8
+;; @0021                               v24 = load.i64 notrap aligned readonly can_move v42+32
+;; @0021                               v25 = uextend.i64 v23
+;; @0021                               v26 = iadd v24, v25
+;; @0021                               jump block4(v23, v26)
 ;;
-;;                                 block4(v38: i32, v39: i64):
+;;                                 block4(v34: i32, v35: i64):
 ;; @0021                               v3 = f32const 0.0
-;; @0021                               v40 = iconst.i64 16
-;; @0021                               v41 = iadd v39, v40  ; v40 = 16
-;; @0021                               store user2 little region1 v3, v41  ; v3 = 0.0
+;; @0021                               v36 = iconst.i64 16
+;; @0021                               v37 = iadd v35, v36  ; v36 = 16
+;; @0021                               store user2 little region1 v3, v37  ; v3 = 0.0
 ;; @0021                               v4 = iconst.i32 0
-;; @0021                               v42 = iconst.i64 20
-;; @0021                               v43 = iadd v39, v42  ; v42 = 20
-;; @0021                               istore8 user2 little region1 v4, v43  ; v4 = 0
-;; @0021                               v44 = iconst.i64 24
-;; @0021                               v45 = iadd v39, v44  ; v44 = 24
-;; @0021                               store user2 little region1 v4, v45  ; v4 = 0
-;; @0024                               jump block1(v38)
+;; @0021                               v38 = iconst.i64 20
+;; @0021                               v39 = iadd v35, v38  ; v38 = 20
+;; @0021                               istore8 user2 little region1 v4, v39  ; v4 = 0
+;; @0021                               v40 = iconst.i64 24
+;; @0021                               v41 = iadd v35, v40  ; v40 = 24
+;; @0021                               store user2 little region1 v4, v41  ; v4 = 0
+;; @0024                               jump block1(v34)
 ;;
 ;;                                 block1(v2: i32):
 ;; @0024                               return v2

--- a/tests/disas/gc/copying/struct-new.wat
+++ b/tests/disas/gc/copying/struct-new.wat
@@ -25,59 +25,59 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: f32, v3: i32, v4: i32):
-;;                                     v48 = stack_addr.i64 ss0
-;;                                     store notrap v4, v48
-;; @002a                               v8 = load.i64 notrap aligned readonly can_move v0+32
-;; @002a                               v9 = load.i32 notrap aligned v8
-;; @002a                               v10 = load.i32 notrap aligned v8+4
-;; @002a                               v16 = uextend.i64 v9
-;;                                     v53 = iconst.i64 32
-;; @002a                               v17 = iadd v16, v53  ; v53 = 32
-;; @002a                               v18 = uextend.i64 v10
-;; @002a                               v19 = icmp ule v17, v18
-;; @002a                               brif v19, block2, block3
+;;                                     v44 = stack_addr.i64 ss0
+;;                                     store notrap v4, v44
+;; @002a                               v7 = load.i64 notrap aligned readonly can_move v0+32
+;; @002a                               v8 = load.i32 notrap aligned v7
+;; @002a                               v9 = load.i32 notrap aligned v7+4
+;; @002a                               v15 = uextend.i64 v8
+;;                                     v49 = iconst.i64 32
+;; @002a                               v16 = iadd v15, v49  ; v49 = 32
+;; @002a                               v17 = uextend.i64 v9
+;; @002a                               v18 = icmp ule v16, v17
+;; @002a                               brif v18, block2, block3
 ;;
 ;;                                 block2:
-;;                                     v69 = iconst.i32 32
-;;                                     v67 = iadd.i32 v9, v69  ; v69 = 32
-;; @002a                               store notrap aligned region0 v67, v8
-;;                                     v70 = iconst.i32 -1342177246
-;;                                     v71 = load.i64 notrap aligned readonly can_move v0+8
-;;                                     v72 = load.i64 notrap aligned readonly can_move v71+32
-;; @002a                               v33 = iadd v72, v16
-;; @002a                               store notrap aligned v70, v33  ; v70 = -1342177246
-;;                                     v73 = load.i64 notrap aligned readonly can_move v0+40
-;;                                     v74 = load.i32 notrap aligned readonly can_move v73
-;; @002a                               store notrap aligned v74, v33+4
-;;                                     v75 = iconst.i64 32
-;; @002a                               istore32 notrap aligned v75, v33+8  ; v75 = 32
-;; @002a                               jump block4(v9, v33)
+;;                                     v65 = iconst.i32 32
+;;                                     v63 = iadd.i32 v8, v65  ; v65 = 32
+;; @002a                               store notrap aligned region0 v63, v7
+;;                                     v66 = iconst.i32 -1342177246
+;;                                     v67 = load.i64 notrap aligned readonly can_move v0+8
+;;                                     v68 = load.i64 notrap aligned readonly can_move v67+32
+;; @002a                               v30 = iadd v68, v15
+;; @002a                               store notrap aligned v66, v30  ; v66 = -1342177246
+;;                                     v69 = load.i64 notrap aligned readonly can_move v0+40
+;;                                     v70 = load.i32 notrap aligned readonly can_move v69
+;; @002a                               store notrap aligned v70, v30+4
+;;                                     v71 = iconst.i64 32
+;; @002a                               istore32 notrap aligned v71, v30+8  ; v71 = 32
+;; @002a                               jump block4(v8, v30)
 ;;
 ;;                                 block3 cold:
-;; @002a                               v21 = iconst.i32 -1342177246
-;; @002a                               v23 = load.i64 notrap aligned readonly can_move v0+40
-;; @002a                               v24 = load.i32 notrap aligned readonly can_move v23
+;; @002a                               v19 = iconst.i32 -1342177246
+;; @002a                               v20 = load.i64 notrap aligned readonly can_move v0+40
+;; @002a                               v21 = load.i32 notrap aligned readonly can_move v20
 ;; @002a                               v6 = iconst.i32 32
-;; @002a                               v25 = iconst.i32 16
-;; @002a                               v26 = call fn0(v0, v21, v24, v6, v25), stack_map=[i32 @ ss0+0]  ; v21 = -1342177246, v6 = 32, v25 = 16
-;; @002a                               v49 = load.i64 notrap aligned readonly can_move v0+8
-;; @002a                               v27 = load.i64 notrap aligned readonly can_move v49+32
-;; @002a                               v28 = uextend.i64 v26
-;; @002a                               v29 = iadd v27, v28
-;; @002a                               jump block4(v26, v29)
+;; @002a                               v22 = iconst.i32 16
+;; @002a                               v23 = call fn0(v0, v19, v21, v6, v22), stack_map=[i32 @ ss0+0]  ; v19 = -1342177246, v6 = 32, v22 = 16
+;; @002a                               v45 = load.i64 notrap aligned readonly can_move v0+8
+;; @002a                               v24 = load.i64 notrap aligned readonly can_move v45+32
+;; @002a                               v25 = uextend.i64 v23
+;; @002a                               v26 = iadd v24, v25
+;; @002a                               jump block4(v23, v26)
 ;;
-;;                                 block4(v38: i32, v39: i64):
-;; @002a                               v40 = iconst.i64 16
-;; @002a                               v41 = iadd v39, v40  ; v40 = 16
-;; @002a                               store.f32 user2 little region1 v2, v41
-;; @002a                               v42 = iconst.i64 20
-;; @002a                               v43 = iadd v39, v42  ; v42 = 20
-;; @002a                               istore8.i32 user2 little region1 v3, v43
-;;                                     v47 = load.i32 notrap v48
-;; @002a                               v44 = iconst.i64 24
-;; @002a                               v45 = iadd v39, v44  ; v44 = 24
-;; @002a                               store user2 little region1 v47, v45
-;; @002d                               jump block1(v38)
+;;                                 block4(v34: i32, v35: i64):
+;; @002a                               v36 = iconst.i64 16
+;; @002a                               v37 = iadd v35, v36  ; v36 = 16
+;; @002a                               store.f32 user2 little region1 v2, v37
+;; @002a                               v38 = iconst.i64 20
+;; @002a                               v39 = iadd v35, v38  ; v38 = 20
+;; @002a                               istore8.i32 user2 little region1 v3, v39
+;;                                     v43 = load.i32 notrap v44
+;; @002a                               v40 = iconst.i64 24
+;; @002a                               v41 = iadd v35, v40  ; v40 = 24
+;; @002a                               store user2 little region1 v43, v41
+;; @002d                               jump block1(v34)
 ;;
 ;;                                 block1(v5: i32):
 ;; @002d                               return v5

--- a/tests/disas/gc/drc/array-new-fixed-of-gc-refs.wat
+++ b/tests/disas/gc/drc/array-new-fixed-of-gc-refs.wat
@@ -26,148 +26,148 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
-;;                                     v192 = stack_addr.i64 ss2
-;;                                     store notrap v2, v192
-;;                                     v193 = stack_addr.i64 ss1
-;;                                     store notrap v3, v193
-;;                                     v194 = stack_addr.i64 ss0
-;;                                     store notrap v4, v194
-;; @0025                               v16 = iconst.i32 -1476395008
-;; @0025                               v18 = load.i64 notrap aligned readonly can_move v0+40
-;; @0025                               v19 = load.i32 notrap aligned readonly can_move v18
-;;                                     v232 = iconst.i32 40
-;; @0025                               v20 = iconst.i32 8
-;; @0025                               v21 = call fn0(v0, v16, v19, v232, v20), stack_map=[i32 @ ss2+0, i32 @ ss1+0, i32 @ ss0+0]  ; v16 = -1476395008, v232 = 40, v20 = 8
+;;                                     v190 = stack_addr.i64 ss2
+;;                                     store notrap v2, v190
+;;                                     v191 = stack_addr.i64 ss1
+;;                                     store notrap v3, v191
+;;                                     v192 = stack_addr.i64 ss0
+;;                                     store notrap v4, v192
+;; @0025                               v15 = iconst.i32 -1476395008
+;; @0025                               v16 = load.i64 notrap aligned readonly can_move v0+40
+;; @0025                               v17 = load.i32 notrap aligned readonly can_move v16
+;;                                     v230 = iconst.i32 40
+;; @0025                               v18 = iconst.i32 8
+;; @0025                               v19 = call fn0(v0, v15, v17, v230, v18), stack_map=[i32 @ ss2+0, i32 @ ss1+0, i32 @ ss0+0]  ; v15 = -1476395008, v230 = 40, v18 = 8
 ;; @0025                               v6 = iconst.i32 3
-;; @0025                               v219 = load.i64 notrap aligned readonly can_move v0+8
-;; @0025                               v22 = load.i64 notrap aligned readonly can_move v219+32
-;; @0025                               v23 = uextend.i64 v21
-;; @0025                               v24 = iadd v22, v23
-;; @0025                               v25 = iconst.i64 24
-;; @0025                               v26 = iadd v24, v25  ; v25 = 24
-;; @0025                               store user2 region0 v6, v26  ; v6 = 3
-;; @0025                               trapz v21, user16
-;; @0025                               v46 = uadd_overflow_trap v21, v232, user2  ; v232 = 40
-;;                                     v191 = load.i32 notrap v192
-;; @0025                               v53 = iconst.i32 1
-;; @0025                               v54 = band v191, v53  ; v53 = 1
-;; @0025                               v27 = iconst.i32 0
-;; @0025                               v56 = icmp eq v191, v27  ; v27 = 0
-;; @0025                               v57 = uextend.i32 v56
-;; @0025                               v58 = bor v54, v57
-;; @0025                               brif v58, block3, block2
+;; @0025                               v217 = load.i64 notrap aligned readonly can_move v0+8
+;; @0025                               v20 = load.i64 notrap aligned readonly can_move v217+32
+;; @0025                               v21 = uextend.i64 v19
+;; @0025                               v22 = iadd v20, v21
+;; @0025                               v23 = iconst.i64 24
+;; @0025                               v24 = iadd v22, v23  ; v23 = 24
+;; @0025                               store user2 region0 v6, v24  ; v6 = 3
+;; @0025                               trapz v19, user16
+;; @0025                               v44 = uadd_overflow_trap v19, v230, user2  ; v230 = 40
+;;                                     v189 = load.i32 notrap v190
+;; @0025                               v51 = iconst.i32 1
+;; @0025                               v52 = band v189, v51  ; v51 = 1
+;; @0025                               v25 = iconst.i32 0
+;; @0025                               v54 = icmp eq v189, v25  ; v25 = 0
+;; @0025                               v55 = uextend.i32 v54
+;; @0025                               v56 = bor v52, v55
+;; @0025                               brif v56, block3, block2
 ;;
 ;;                                 block2:
-;;                                     v187 = load.i32 notrap v192
-;; @0025                               v59 = uextend.i64 v187
-;; @0025                               v61 = iadd.i64 v22, v59
-;; @0025                               v62 = iconst.i64 8
-;; @0025                               v63 = iadd v61, v62  ; v62 = 8
-;; @0025                               v64 = load.i64 user2 region0 v63
-;; @0025                               v65 = iconst.i64 1
-;; @0025                               v66 = iadd v64, v65  ; v65 = 1
-;; @0025                               store user2 region0 v66, v63
+;;                                     v185 = load.i32 notrap v190
+;; @0025                               v57 = uextend.i64 v185
+;; @0025                               v59 = iadd.i64 v20, v57
+;; @0025                               v60 = iconst.i64 8
+;; @0025                               v61 = iadd v59, v60  ; v60 = 8
+;; @0025                               v62 = load.i64 user2 region0 v61
+;; @0025                               v63 = iconst.i64 1
+;; @0025                               v64 = iadd v62, v63  ; v63 = 1
+;; @0025                               store user2 region0 v64, v61
 ;; @0025                               jump block3
 ;;
 ;;                                 block3:
-;;                                     v183 = load.i32 notrap v192
-;; @0025                               v47 = uextend.i64 v46
-;; @0025                               v49 = iadd.i64 v22, v47
-;;                                     v222 = iconst.i64 12
-;; @0025                               v52 = isub v49, v222  ; v222 = 12
-;; @0025                               store user2 little region0 v183, v52
-;;                                     v325 = iadd.i64 v24, v25  ; v25 = 24
-;; @0025                               v78 = load.i32 user2 readonly region0 v325
-;;                                     v326 = iconst.i32 1
-;;                                     v327 = icmp ugt v78, v326  ; v326 = 1
-;; @0025                               trapz v327, user17
-;; @0025                               v81 = uextend.i64 v78
-;;                                     v223 = iconst.i64 2
-;;                                     v267 = ishl v81, v223  ; v223 = 2
+;;                                     v181 = load.i32 notrap v190
+;; @0025                               v45 = uextend.i64 v44
+;; @0025                               v47 = iadd.i64 v20, v45
+;;                                     v220 = iconst.i64 12
+;; @0025                               v50 = isub v47, v220  ; v220 = 12
+;; @0025                               store user2 little region0 v181, v50
+;;                                     v323 = iadd.i64 v22, v23  ; v23 = 24
+;; @0025                               v76 = load.i32 user2 readonly region0 v323
+;;                                     v324 = iconst.i32 1
+;;                                     v325 = icmp ugt v76, v324  ; v324 = 1
+;; @0025                               trapz v325, user17
+;; @0025                               v79 = uextend.i64 v76
+;;                                     v221 = iconst.i64 2
+;;                                     v265 = ishl v79, v221  ; v221 = 2
 ;; @0025                               v11 = iconst.i64 32
-;; @0025                               v84 = ushr v267, v11  ; v11 = 32
-;; @0025                               trapnz v84, user2
-;;                                     v244 = iconst.i32 2
-;;                                     v274 = ishl v78, v244  ; v244 = 2
+;; @0025                               v82 = ushr v265, v11  ; v11 = 32
+;; @0025                               trapnz v82, user2
+;;                                     v242 = iconst.i32 2
+;;                                     v272 = ishl v76, v242  ; v242 = 2
 ;; @0025                               v7 = iconst.i32 28
-;; @0025                               v87 = uadd_overflow_trap v274, v7, user2  ; v7 = 28
-;; @0025                               v91 = uadd_overflow_trap.i32 v21, v87, user2
-;;                                     v181 = load.i32 notrap v193
-;;                                     v328 = band v181, v326  ; v326 = 1
-;;                                     v329 = iconst.i32 0
-;;                                     v330 = icmp eq v181, v329  ; v329 = 0
-;; @0025                               v102 = uextend.i32 v330
-;; @0025                               v103 = bor v328, v102
-;; @0025                               brif v103, block5, block4
+;; @0025                               v85 = uadd_overflow_trap v272, v7, user2  ; v7 = 28
+;; @0025                               v89 = uadd_overflow_trap.i32 v19, v85, user2
+;;                                     v179 = load.i32 notrap v191
+;;                                     v326 = band v179, v324  ; v324 = 1
+;;                                     v327 = iconst.i32 0
+;;                                     v328 = icmp eq v179, v327  ; v327 = 0
+;; @0025                               v100 = uextend.i32 v328
+;; @0025                               v101 = bor v326, v100
+;; @0025                               brif v101, block5, block4
 ;;
 ;;                                 block4:
-;;                                     v177 = load.i32 notrap v193
-;; @0025                               v104 = uextend.i64 v177
-;; @0025                               v106 = iadd.i64 v22, v104
-;;                                     v331 = iconst.i64 8
-;; @0025                               v108 = iadd v106, v331  ; v331 = 8
-;; @0025                               v109 = load.i64 user2 region0 v108
-;;                                     v332 = iconst.i64 1
-;; @0025                               v111 = iadd v109, v332  ; v332 = 1
-;; @0025                               store user2 region0 v111, v108
+;;                                     v175 = load.i32 notrap v191
+;; @0025                               v102 = uextend.i64 v175
+;; @0025                               v104 = iadd.i64 v20, v102
+;;                                     v329 = iconst.i64 8
+;; @0025                               v106 = iadd v104, v329  ; v329 = 8
+;; @0025                               v107 = load.i64 user2 region0 v106
+;;                                     v330 = iconst.i64 1
+;; @0025                               v109 = iadd v107, v330  ; v330 = 1
+;; @0025                               store user2 region0 v109, v106
 ;; @0025                               jump block5
 ;;
 ;;                                 block5:
-;;                                     v173 = load.i32 notrap v193
-;; @0025                               v92 = uextend.i64 v91
-;; @0025                               v94 = iadd.i64 v22, v92
-;;                                     v287 = iconst.i32 32
-;; @0025                               v95 = isub.i32 v87, v287  ; v287 = 32
-;; @0025                               v96 = uextend.i64 v95
-;; @0025                               v97 = isub v94, v96
-;; @0025                               store user2 little region0 v173, v97
-;;                                     v333 = iadd.i64 v24, v25  ; v25 = 24
-;; @0025                               v123 = load.i32 user2 readonly region0 v333
-;;                                     v334 = iconst.i32 2
-;;                                     v335 = icmp ugt v123, v334  ; v334 = 2
-;; @0025                               trapz v335, user17
-;; @0025                               v126 = uextend.i64 v123
-;;                                     v336 = iconst.i64 2
-;;                                     v337 = ishl v126, v336  ; v336 = 2
-;;                                     v338 = iconst.i64 32
-;;                                     v339 = ushr v337, v338  ; v338 = 32
-;; @0025                               trapnz v339, user2
-;;                                     v340 = ishl v123, v334  ; v334 = 2
-;;                                     v341 = iconst.i32 28
-;; @0025                               v132 = uadd_overflow_trap v340, v341, user2  ; v341 = 28
-;; @0025                               v136 = uadd_overflow_trap.i32 v21, v132, user2
-;;                                     v171 = load.i32 notrap v194
-;;                                     v342 = iconst.i32 1
-;;                                     v343 = band v171, v342  ; v342 = 1
-;;                                     v344 = iconst.i32 0
-;;                                     v345 = icmp eq v171, v344  ; v344 = 0
-;; @0025                               v147 = uextend.i32 v345
-;; @0025                               v148 = bor v343, v147
-;; @0025                               brif v148, block7, block6
+;;                                     v171 = load.i32 notrap v191
+;; @0025                               v90 = uextend.i64 v89
+;; @0025                               v92 = iadd.i64 v20, v90
+;;                                     v285 = iconst.i32 32
+;; @0025                               v93 = isub.i32 v85, v285  ; v285 = 32
+;; @0025                               v94 = uextend.i64 v93
+;; @0025                               v95 = isub v92, v94
+;; @0025                               store user2 little region0 v171, v95
+;;                                     v331 = iadd.i64 v22, v23  ; v23 = 24
+;; @0025                               v121 = load.i32 user2 readonly region0 v331
+;;                                     v332 = iconst.i32 2
+;;                                     v333 = icmp ugt v121, v332  ; v332 = 2
+;; @0025                               trapz v333, user17
+;; @0025                               v124 = uextend.i64 v121
+;;                                     v334 = iconst.i64 2
+;;                                     v335 = ishl v124, v334  ; v334 = 2
+;;                                     v336 = iconst.i64 32
+;;                                     v337 = ushr v335, v336  ; v336 = 32
+;; @0025                               trapnz v337, user2
+;;                                     v338 = ishl v121, v332  ; v332 = 2
+;;                                     v339 = iconst.i32 28
+;; @0025                               v130 = uadd_overflow_trap v338, v339, user2  ; v339 = 28
+;; @0025                               v134 = uadd_overflow_trap.i32 v19, v130, user2
+;;                                     v169 = load.i32 notrap v192
+;;                                     v340 = iconst.i32 1
+;;                                     v341 = band v169, v340  ; v340 = 1
+;;                                     v342 = iconst.i32 0
+;;                                     v343 = icmp eq v169, v342  ; v342 = 0
+;; @0025                               v145 = uextend.i32 v343
+;; @0025                               v146 = bor v341, v145
+;; @0025                               brif v146, block7, block6
 ;;
 ;;                                 block6:
-;;                                     v167 = load.i32 notrap v194
-;; @0025                               v149 = uextend.i64 v167
-;; @0025                               v151 = iadd.i64 v22, v149
-;;                                     v346 = iconst.i64 8
-;; @0025                               v153 = iadd v151, v346  ; v346 = 8
-;; @0025                               v154 = load.i64 user2 region0 v153
-;;                                     v347 = iconst.i64 1
-;; @0025                               v156 = iadd v154, v347  ; v347 = 1
-;; @0025                               store user2 region0 v156, v153
+;;                                     v165 = load.i32 notrap v192
+;; @0025                               v147 = uextend.i64 v165
+;; @0025                               v149 = iadd.i64 v20, v147
+;;                                     v344 = iconst.i64 8
+;; @0025                               v151 = iadd v149, v344  ; v344 = 8
+;; @0025                               v152 = load.i64 user2 region0 v151
+;;                                     v345 = iconst.i64 1
+;; @0025                               v154 = iadd v152, v345  ; v345 = 1
+;; @0025                               store user2 region0 v154, v151
 ;; @0025                               jump block7
 ;;
 ;;                                 block7:
-;;                                     v163 = load.i32 notrap v194
-;; @0025                               v137 = uextend.i64 v136
-;; @0025                               v139 = iadd.i64 v22, v137
-;;                                     v319 = iconst.i32 36
-;; @0025                               v140 = isub.i32 v132, v319  ; v319 = 36
-;; @0025                               v141 = uextend.i64 v140
-;; @0025                               v142 = isub v139, v141
-;; @0025                               store user2 little region0 v163, v142
+;;                                     v161 = load.i32 notrap v192
+;; @0025                               v135 = uextend.i64 v134
+;; @0025                               v137 = iadd.i64 v20, v135
+;;                                     v317 = iconst.i32 36
+;; @0025                               v138 = isub.i32 v130, v317  ; v317 = 36
+;; @0025                               v139 = uextend.i64 v138
+;; @0025                               v140 = isub v137, v139
+;; @0025                               store user2 little region0 v161, v140
 ;; @0029                               jump block1
 ;;
 ;;                                 block1:
-;; @0029                               return v21
+;; @0029                               return v19
 ;; }

--- a/tests/disas/gc/drc/array-new-fixed.wat
+++ b/tests/disas/gc/drc/array-new-fixed.wat
@@ -23,67 +23,67 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i64, v4: i64):
-;; @0025                               v16 = iconst.i32 -1476395008
-;; @0025                               v18 = load.i64 notrap aligned readonly can_move v0+40
-;; @0025                               v19 = load.i32 notrap aligned readonly can_move v18
-;;                                     v129 = iconst.i32 56
-;; @0025                               v20 = iconst.i32 8
-;; @0025                               v21 = call fn0(v0, v16, v19, v129, v20)  ; v16 = -1476395008, v129 = 56, v20 = 8
+;; @0025                               v15 = iconst.i32 -1476395008
+;; @0025                               v16 = load.i64 notrap aligned readonly can_move v0+40
+;; @0025                               v17 = load.i32 notrap aligned readonly can_move v16
+;;                                     v127 = iconst.i32 56
+;; @0025                               v18 = iconst.i32 8
+;; @0025                               v19 = call fn0(v0, v15, v17, v127, v18)  ; v15 = -1476395008, v127 = 56, v18 = 8
 ;; @0025                               v6 = iconst.i32 3
-;; @0025                               v117 = load.i64 notrap aligned readonly can_move v0+8
-;; @0025                               v22 = load.i64 notrap aligned readonly can_move v117+32
-;; @0025                               v23 = uextend.i64 v21
-;; @0025                               v24 = iadd v22, v23
-;;                                     v120 = iconst.i64 24
-;; @0025                               v26 = iadd v24, v120  ; v120 = 24
-;; @0025                               store user2 region0 v6, v26  ; v6 = 3
-;; @0025                               trapz v21, user16
-;; @0025                               v46 = uadd_overflow_trap v21, v129, user2  ; v129 = 56
-;; @0025                               v47 = uextend.i64 v46
-;; @0025                               v49 = iadd v22, v47
-;; @0025                               v52 = isub v49, v120  ; v120 = 24
-;; @0025                               store user2 little region0 v2, v52
-;; @0025                               v59 = load.i32 user2 readonly region0 v26
-;; @0025                               v53 = iconst.i32 1
-;;                                     v160 = icmp ugt v59, v53  ; v53 = 1
-;; @0025                               trapz v160, user17
-;; @0025                               v62 = uextend.i64 v59
-;;                                     v119 = iconst.i64 3
-;;                                     v162 = ishl v62, v119  ; v119 = 3
+;; @0025                               v115 = load.i64 notrap aligned readonly can_move v0+8
+;; @0025                               v20 = load.i64 notrap aligned readonly can_move v115+32
+;; @0025                               v21 = uextend.i64 v19
+;; @0025                               v22 = iadd v20, v21
+;;                                     v118 = iconst.i64 24
+;; @0025                               v24 = iadd v22, v118  ; v118 = 24
+;; @0025                               store user2 region0 v6, v24  ; v6 = 3
+;; @0025                               trapz v19, user16
+;; @0025                               v44 = uadd_overflow_trap v19, v127, user2  ; v127 = 56
+;; @0025                               v45 = uextend.i64 v44
+;; @0025                               v47 = iadd v20, v45
+;; @0025                               v50 = isub v47, v118  ; v118 = 24
+;; @0025                               store user2 little region0 v2, v50
+;; @0025                               v57 = load.i32 user2 readonly region0 v24
+;; @0025                               v51 = iconst.i32 1
+;;                                     v158 = icmp ugt v57, v51  ; v51 = 1
+;; @0025                               trapz v158, user17
+;; @0025                               v60 = uextend.i64 v57
+;;                                     v117 = iconst.i64 3
+;;                                     v160 = ishl v60, v117  ; v117 = 3
 ;; @0025                               v11 = iconst.i64 32
-;; @0025                               v65 = ushr v162, v11  ; v11 = 32
-;; @0025                               trapnz v65, user2
-;;                                     v169 = ishl v59, v6  ; v6 = 3
+;; @0025                               v63 = ushr v160, v11  ; v11 = 32
+;; @0025                               trapnz v63, user2
+;;                                     v167 = ishl v57, v6  ; v6 = 3
 ;; @0025                               v7 = iconst.i32 32
-;; @0025                               v68 = uadd_overflow_trap v169, v7, user2  ; v7 = 32
-;; @0025                               v72 = uadd_overflow_trap v21, v68, user2
-;; @0025                               v73 = uextend.i64 v72
-;; @0025                               v75 = iadd v22, v73
-;;                                     v182 = iconst.i32 40
-;; @0025                               v76 = isub v68, v182  ; v182 = 40
-;; @0025                               v77 = uextend.i64 v76
-;; @0025                               v78 = isub v75, v77
-;; @0025                               store user2 little region0 v3, v78
-;; @0025                               v85 = load.i32 user2 readonly region0 v26
-;; @0025                               v79 = iconst.i32 2
-;;                                     v188 = icmp ugt v85, v79  ; v79 = 2
-;; @0025                               trapz v188, user17
-;; @0025                               v88 = uextend.i64 v85
-;;                                     v190 = ishl v88, v119  ; v119 = 3
-;; @0025                               v91 = ushr v190, v11  ; v11 = 32
-;; @0025                               trapnz v91, user2
-;;                                     v197 = ishl v85, v6  ; v6 = 3
-;; @0025                               v94 = uadd_overflow_trap v197, v7, user2  ; v7 = 32
-;; @0025                               v98 = uadd_overflow_trap v21, v94, user2
-;; @0025                               v99 = uextend.i64 v98
-;; @0025                               v101 = iadd v22, v99
-;;                                     v215 = iconst.i32 48
-;; @0025                               v102 = isub v94, v215  ; v215 = 48
-;; @0025                               v103 = uextend.i64 v102
-;; @0025                               v104 = isub v101, v103
-;; @0025                               store user2 little region0 v4, v104
+;; @0025                               v66 = uadd_overflow_trap v167, v7, user2  ; v7 = 32
+;; @0025                               v70 = uadd_overflow_trap v19, v66, user2
+;; @0025                               v71 = uextend.i64 v70
+;; @0025                               v73 = iadd v20, v71
+;;                                     v180 = iconst.i32 40
+;; @0025                               v74 = isub v66, v180  ; v180 = 40
+;; @0025                               v75 = uextend.i64 v74
+;; @0025                               v76 = isub v73, v75
+;; @0025                               store user2 little region0 v3, v76
+;; @0025                               v83 = load.i32 user2 readonly region0 v24
+;; @0025                               v77 = iconst.i32 2
+;;                                     v186 = icmp ugt v83, v77  ; v77 = 2
+;; @0025                               trapz v186, user17
+;; @0025                               v86 = uextend.i64 v83
+;;                                     v188 = ishl v86, v117  ; v117 = 3
+;; @0025                               v89 = ushr v188, v11  ; v11 = 32
+;; @0025                               trapnz v89, user2
+;;                                     v195 = ishl v83, v6  ; v6 = 3
+;; @0025                               v92 = uadd_overflow_trap v195, v7, user2  ; v7 = 32
+;; @0025                               v96 = uadd_overflow_trap v19, v92, user2
+;; @0025                               v97 = uextend.i64 v96
+;; @0025                               v99 = iadd v20, v97
+;;                                     v213 = iconst.i32 48
+;; @0025                               v100 = isub v92, v213  ; v213 = 48
+;; @0025                               v101 = uextend.i64 v100
+;; @0025                               v102 = isub v99, v101
+;; @0025                               store user2 little region0 v4, v102
 ;; @0029                               jump block1
 ;;
 ;;                                 block1:
-;; @0029                               return v21
+;; @0029                               return v19
 ;; }

--- a/tests/disas/gc/drc/array-new.wat
+++ b/tests/disas/gc/drc/array-new.wat
@@ -24,50 +24,50 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0022                               v6 = uextend.i64 v3
-;;                                     v73 = iconst.i64 3
-;;                                     v74 = ishl v6, v73  ; v73 = 3
+;;                                     v71 = iconst.i64 3
+;;                                     v72 = ishl v6, v71  ; v71 = 3
 ;; @0022                               v9 = iconst.i64 32
-;; @0022                               v10 = ushr v74, v9  ; v9 = 32
+;; @0022                               v10 = ushr v72, v9  ; v9 = 32
 ;; @0022                               trapnz v10, user18
 ;; @0022                               v5 = iconst.i32 32
-;;                                     v80 = iconst.i32 3
-;;                                     v81 = ishl v3, v80  ; v80 = 3
-;; @0022                               v12 = uadd_overflow_trap v5, v81, user18  ; v5 = 32
-;; @0022                               v14 = iconst.i32 -1476395008
-;; @0022                               v16 = load.i64 notrap aligned readonly can_move v0+40
-;; @0022                               v17 = load.i32 notrap aligned readonly can_move v16
-;;                                     v78 = iconst.i32 8
-;; @0022                               v19 = call fn0(v0, v14, v17, v12, v78)  ; v14 = -1476395008, v78 = 8
-;; @0022                               v71 = load.i64 notrap aligned readonly can_move v0+8
-;; @0022                               v20 = load.i64 notrap aligned readonly can_move v71+32
-;; @0022                               v21 = uextend.i64 v19
-;; @0022                               v22 = iadd v20, v21
-;; @0022                               v23 = iconst.i64 24
-;; @0022                               v24 = iadd v22, v23  ; v23 = 24
-;; @0022                               store user2 region0 v3, v24
-;; @0022                               trapz v19, user16
-;; @0022                               v52 = load.i64 notrap aligned v71+40
-;; @0022                               v43 = iadd v22, v9  ; v9 = 32
-;; @0022                               v54 = uadd_overflow_trap v43, v74, user2
-;; @0022                               v53 = iadd v20, v52
-;; @0022                               v55 = icmp ugt v54, v53
-;; @0022                               trapnz v55, user2
-;;                                     v84 = iconst.i64 0
-;; @0022                               v58 = icmp eq v6, v84  ; v84 = 0
+;;                                     v78 = iconst.i32 3
+;;                                     v79 = ishl v3, v78  ; v78 = 3
+;; @0022                               v12 = uadd_overflow_trap v5, v79, user18  ; v5 = 32
+;; @0022                               v13 = iconst.i32 -1476395008
+;; @0022                               v14 = load.i64 notrap aligned readonly can_move v0+40
+;; @0022                               v15 = load.i32 notrap aligned readonly can_move v14
+;;                                     v76 = iconst.i32 8
+;; @0022                               v17 = call fn0(v0, v13, v15, v12, v76)  ; v13 = -1476395008, v76 = 8
+;; @0022                               v69 = load.i64 notrap aligned readonly can_move v0+8
+;; @0022                               v18 = load.i64 notrap aligned readonly can_move v69+32
+;; @0022                               v19 = uextend.i64 v17
+;; @0022                               v20 = iadd v18, v19
+;; @0022                               v21 = iconst.i64 24
+;; @0022                               v22 = iadd v20, v21  ; v21 = 24
+;; @0022                               store user2 region0 v3, v22
+;; @0022                               trapz v17, user16
+;; @0022                               v50 = load.i64 notrap aligned v69+40
+;; @0022                               v41 = iadd v20, v9  ; v9 = 32
+;; @0022                               v52 = uadd_overflow_trap v41, v72, user2
+;; @0022                               v51 = iadd v18, v50
+;; @0022                               v53 = icmp ugt v52, v51
+;; @0022                               trapnz v53, user2
+;;                                     v82 = iconst.i64 0
+;; @0022                               v56 = icmp eq v6, v82  ; v82 = 0
 ;; @0022                               v7 = iconst.i64 8
-;; @0022                               v56 = iadd v43, v74
-;; @0022                               brif v58, block3, block2(v43)
+;; @0022                               v54 = iadd v41, v72
+;; @0022                               brif v56, block3, block2(v41)
 ;;
-;;                                 block2(v59: i64):
-;; @0022                               store.i64 user2 little region0 v2, v59
-;;                                     v99 = iconst.i64 8
-;;                                     v100 = iadd v59, v99  ; v99 = 8
-;; @0022                               v62 = icmp eq v100, v56
-;; @0022                               brif v62, block3, block2(v100)
+;;                                 block2(v57: i64):
+;; @0022                               store.i64 user2 little region0 v2, v57
+;;                                     v97 = iconst.i64 8
+;;                                     v98 = iadd v57, v97  ; v97 = 8
+;; @0022                               v60 = icmp eq v98, v54
+;; @0022                               brif v60, block3, block2(v98)
 ;;
 ;;                                 block3:
 ;; @0025                               jump block1
 ;;
 ;;                                 block1:
-;; @0025                               return v19
+;; @0025                               return v17
 ;; }

--- a/tests/disas/gc/drc/br-on-cast-fail.wat
+++ b/tests/disas/gc/drc/br-on-cast-fail.wat
@@ -36,35 +36,35 @@
 ;;                                 block3:
 ;; @002e                               v8 = iconst.i32 1
 ;; @002e                               v9 = band.i32 v2, v8  ; v8 = 1
-;;                                     v31 = iconst.i32 0
-;; @002e                               brif v9, block5(v31), block4  ; v31 = 0
+;;                                     v30 = iconst.i32 0
+;; @002e                               brif v9, block5(v30), block4  ; v30 = 0
 ;;
 ;;                                 block4:
-;; @002e                               v29 = load.i64 notrap aligned readonly can_move v0+8
-;; @002e                               v15 = load.i64 notrap aligned readonly can_move v29+32
-;; @002e                               v14 = uextend.i64 v2
-;; @002e                               v16 = iadd v15, v14
-;; @002e                               v17 = iconst.i64 4
-;; @002e                               v18 = iadd v16, v17  ; v17 = 4
-;; @002e                               v19 = load.i32 user2 readonly region0 v18
-;; @002e                               v12 = load.i64 notrap aligned readonly can_move v0+40
-;; @002e                               v13 = load.i32 notrap aligned readonly can_move v12
-;; @002e                               v20 = icmp eq v19, v13
-;; @002e                               v21 = uextend.i32 v20
-;; @002e                               jump block5(v21)
+;; @002e                               v28 = load.i64 notrap aligned readonly can_move v0+8
+;; @002e                               v14 = load.i64 notrap aligned readonly can_move v28+32
+;; @002e                               v13 = uextend.i64 v2
+;; @002e                               v15 = iadd v14, v13
+;; @002e                               v16 = iconst.i64 4
+;; @002e                               v17 = iadd v15, v16  ; v16 = 4
+;; @002e                               v18 = load.i32 user2 readonly region0 v17
+;; @002e                               v11 = load.i64 notrap aligned readonly can_move v0+40
+;; @002e                               v12 = load.i32 notrap aligned readonly can_move v11
+;; @002e                               v19 = icmp eq v18, v12
+;; @002e                               v20 = uextend.i32 v19
+;; @002e                               jump block5(v20)
 ;;
-;;                                 block5(v22: i32):
-;; @002e                               brif v22, block6, block2
+;;                                 block5(v21: i32):
+;; @002e                               brif v21, block6, block2
 ;;
 ;;                                 block6:
-;; @0034                               v25 = load.i64 notrap aligned readonly can_move v0+56
-;; @0034                               v24 = load.i64 notrap aligned readonly can_move v0+72
-;; @0034                               call_indirect sig0, v25(v24, v0)
+;; @0034                               v24 = load.i64 notrap aligned readonly can_move v0+56
+;; @0034                               v23 = load.i64 notrap aligned readonly can_move v0+72
+;; @0034                               call_indirect sig0, v24(v23, v0)
 ;; @0036                               return
 ;;
 ;;                                 block2:
-;; @0038                               v28 = load.i64 notrap aligned readonly can_move v0+88
-;; @0038                               v27 = load.i64 notrap aligned readonly can_move v0+104
-;; @0038                               call_indirect sig0, v28(v27, v0)
+;; @0038                               v27 = load.i64 notrap aligned readonly can_move v0+88
+;; @0038                               v26 = load.i64 notrap aligned readonly can_move v0+104
+;; @0038                               call_indirect sig0, v27(v26, v0)
 ;; @003a                               return
 ;; }

--- a/tests/disas/gc/drc/br-on-cast.wat
+++ b/tests/disas/gc/drc/br-on-cast.wat
@@ -36,35 +36,35 @@
 ;;                                 block3:
 ;; @002f                               v8 = iconst.i32 1
 ;; @002f                               v9 = band.i32 v2, v8  ; v8 = 1
-;;                                     v31 = iconst.i32 0
-;; @002f                               brif v9, block5(v31), block4  ; v31 = 0
+;;                                     v30 = iconst.i32 0
+;; @002f                               brif v9, block5(v30), block4  ; v30 = 0
 ;;
 ;;                                 block4:
-;; @002f                               v29 = load.i64 notrap aligned readonly can_move v0+8
-;; @002f                               v15 = load.i64 notrap aligned readonly can_move v29+32
-;; @002f                               v14 = uextend.i64 v2
-;; @002f                               v16 = iadd v15, v14
-;; @002f                               v17 = iconst.i64 4
-;; @002f                               v18 = iadd v16, v17  ; v17 = 4
-;; @002f                               v19 = load.i32 user2 readonly region0 v18
-;; @002f                               v12 = load.i64 notrap aligned readonly can_move v0+40
-;; @002f                               v13 = load.i32 notrap aligned readonly can_move v12
-;; @002f                               v20 = icmp eq v19, v13
-;; @002f                               v21 = uextend.i32 v20
-;; @002f                               jump block5(v21)
+;; @002f                               v28 = load.i64 notrap aligned readonly can_move v0+8
+;; @002f                               v14 = load.i64 notrap aligned readonly can_move v28+32
+;; @002f                               v13 = uextend.i64 v2
+;; @002f                               v15 = iadd v14, v13
+;; @002f                               v16 = iconst.i64 4
+;; @002f                               v17 = iadd v15, v16  ; v16 = 4
+;; @002f                               v18 = load.i32 user2 readonly region0 v17
+;; @002f                               v11 = load.i64 notrap aligned readonly can_move v0+40
+;; @002f                               v12 = load.i32 notrap aligned readonly can_move v11
+;; @002f                               v19 = icmp eq v18, v12
+;; @002f                               v20 = uextend.i32 v19
+;; @002f                               jump block5(v20)
 ;;
-;;                                 block5(v22: i32):
-;; @002f                               brif v22, block2, block6
+;;                                 block5(v21: i32):
+;; @002f                               brif v21, block2, block6
 ;;
 ;;                                 block6:
-;; @0035                               v25 = load.i64 notrap aligned readonly can_move v0+56
-;; @0035                               v24 = load.i64 notrap aligned readonly can_move v0+72
-;; @0035                               call_indirect sig0, v25(v24, v0)
+;; @0035                               v24 = load.i64 notrap aligned readonly can_move v0+56
+;; @0035                               v23 = load.i64 notrap aligned readonly can_move v0+72
+;; @0035                               call_indirect sig0, v24(v23, v0)
 ;; @0037                               return
 ;;
 ;;                                 block2:
-;; @0039                               v28 = load.i64 notrap aligned readonly can_move v0+88
-;; @0039                               v27 = load.i64 notrap aligned readonly can_move v0+104
-;; @0039                               call_indirect sig0, v28(v27, v0)
+;; @0039                               v27 = load.i64 notrap aligned readonly can_move v0+88
+;; @0039                               v26 = load.i64 notrap aligned readonly can_move v0+104
+;; @0039                               call_indirect sig0, v27(v26, v0)
 ;; @003b                               return
 ;; }

--- a/tests/disas/gc/drc/call-indirect-and-subtyping.wat
+++ b/tests/disas/gc/drc/call-indirect-and-subtyping.wat
@@ -47,26 +47,26 @@
 ;;
 ;;                                 block2 cold:
 ;; @005c                               v16 = iconst.i32 0
-;; @005c                               v19 = call fn0(v0, v16, v5)  ; v16 = 0
-;; @005c                               jump block3(v19)
+;; @005c                               v18 = call fn0(v0, v16, v5)  ; v16 = 0
+;; @005c                               jump block3(v18)
 ;;
 ;;                                 block3(v15: i64):
-;; @005c                               v23 = load.i32 user7 aligned readonly v15+16
-;; @005c                               v21 = load.i64 notrap aligned readonly can_move v0+40
-;; @005c                               v22 = load.i32 notrap aligned readonly can_move v21
-;; @005c                               v24 = icmp eq v23, v22
-;; @005c                               v25 = uextend.i32 v24
-;; @005c                               brif v24, block5(v25), block4
+;; @005c                               v21 = load.i32 user7 aligned readonly v15+16
+;; @005c                               v19 = load.i64 notrap aligned readonly can_move v0+40
+;; @005c                               v20 = load.i32 notrap aligned readonly can_move v19
+;; @005c                               v22 = icmp eq v21, v20
+;; @005c                               v23 = uextend.i32 v22
+;; @005c                               brif v22, block5(v23), block4
 ;;
 ;;                                 block4:
-;; @005c                               v27 = call fn1(v0, v23, v22)
-;; @005c                               jump block5(v27)
+;; @005c                               v24 = call fn1(v0, v21, v20)
+;; @005c                               jump block5(v24)
 ;;
-;;                                 block5(v28: i32):
-;; @005c                               trapz v28, user8
-;; @005c                               v29 = load.i64 notrap aligned readonly v15+8
-;; @005c                               v30 = load.i64 notrap aligned readonly v15+24
-;; @005c                               call_indirect sig0, v29(v30, v0)
+;;                                 block5(v25: i32):
+;; @005c                               trapz v25, user8
+;; @005c                               v26 = load.i64 notrap aligned readonly v15+8
+;; @005c                               v27 = load.i64 notrap aligned readonly v15+24
+;; @005c                               call_indirect sig0, v26(v27, v0)
 ;; @005f                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/drc/externref-globals.wat
+++ b/tests/disas/gc/drc/externref-globals.wat
@@ -31,8 +31,8 @@
 ;; @0034                               v4 = iconst.i64 48
 ;; @0034                               v5 = iadd v0, v4  ; v4 = 48
 ;; @0034                               v6 = load.i32 notrap aligned v5
-;;                                     v82 = stack_addr.i64 ss0
-;;                                     store notrap v6, v82
+;;                                     v81 = stack_addr.i64 ss0
+;;                                     store notrap v6, v81
 ;; @0034                               v7 = iconst.i32 1
 ;; @0034                               v8 = band v6, v7  ; v7 = 1
 ;; @0034                               v9 = iconst.i32 0
@@ -42,8 +42,8 @@
 ;; @0034                               brif v12, block4, block2
 ;;
 ;;                                 block2:
-;; @0034                               v91 = load.i64 notrap aligned readonly can_move v0+8
-;; @0034                               v14 = load.i64 notrap aligned readonly can_move v91+32
+;; @0034                               v90 = load.i64 notrap aligned readonly can_move v0+8
+;; @0034                               v14 = load.i64 notrap aligned readonly can_move v90+32
 ;; @0034                               v13 = uextend.i64 v6
 ;; @0034                               v15 = iadd v14, v13
 ;; @0034                               v16 = load.i32 user2 region0 v15
@@ -57,9 +57,9 @@
 ;; @0034                               v25 = iconst.i64 16
 ;; @0034                               v26 = iadd.i64 v15, v25  ; v25 = 16
 ;; @0034                               store user2 region0 v21, v26
-;;                                     v93 = iconst.i32 2
-;;                                     v94 = bor.i32 v16, v93  ; v93 = 2
-;; @0034                               store user2 region0 v94, v15
+;;                                     v92 = iconst.i32 2
+;;                                     v93 = bor.i32 v16, v92  ; v92 = 2
+;; @0034                               store user2 region0 v93, v15
 ;; @0034                               v35 = iconst.i64 8
 ;; @0034                               v36 = iadd.i64 v15, v35  ; v35 = 8
 ;; @0034                               v37 = load.i64 user2 region0 v36
@@ -68,29 +68,29 @@
 ;; @0034                               store user2 region0 v39, v36
 ;; @0034                               store.i32 user2 region0 v6, v20
 ;; @0034                               v47 = load.i32 notrap aligned v20+4
-;;                                     v95 = iconst.i32 1
-;;                                     v96 = iadd v47, v95  ; v95 = 1
-;; @0034                               store notrap aligned v96, v20+4
+;;                                     v94 = iconst.i32 1
+;;                                     v95 = iadd v47, v94  ; v94 = 1
+;; @0034                               store notrap aligned v95, v20+4
 ;; @0034                               v57 = load.i32 notrap aligned v20+8
 ;; @0034                               v58 = iadd v57, v57
 ;; @0034                               v59 = iconst.i32 1024
 ;; @0034                               v60 = umax v58, v59  ; v59 = 1024
-;; @0034                               v61 = icmp uge v96, v60
+;; @0034                               v61 = icmp uge v95, v60
 ;; @0034                               brif v61, block5, block6
 ;;
 ;;                                 block5 cold:
-;; @0034                               v63 = call fn0(v0), stack_map=[i32 @ ss0+0]
+;; @0034                               v62 = call fn0(v0), stack_map=[i32 @ ss0+0]
 ;; @0034                               jump block6
 ;;
 ;;                                 block6:
 ;; @0034                               jump block4
 ;;
 ;;                                 block4:
-;;                                     v65 = load.i32 notrap v82
+;;                                     v64 = load.i32 notrap v81
 ;; @0036                               jump block1
 ;;
 ;;                                 block1:
-;; @0036                               return v65
+;; @0036                               return v64
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) tail {
@@ -119,8 +119,8 @@
 ;; @003b                               brif v12, block3, block2
 ;;
 ;;                                 block2:
-;; @003b                               v54 = load.i64 notrap aligned readonly can_move v0+8
-;; @003b                               v14 = load.i64 notrap aligned readonly can_move v54+32
+;; @003b                               v53 = load.i64 notrap aligned readonly can_move v0+8
+;; @003b                               v14 = load.i64 notrap aligned readonly can_move v53+32
 ;; @003b                               v13 = uextend.i64 v2
 ;; @003b                               v15 = iadd v14, v13
 ;; @003b                               v16 = iconst.i64 8
@@ -132,27 +132,27 @@
 ;; @003b                               jump block3
 ;;
 ;;                                 block3:
-;;                                     v68 = iadd.i64 v0, v4  ; v4 = 48
-;; @003b                               store.i32 notrap aligned v2, v68
-;;                                     v69 = iconst.i32 1
-;;                                     v70 = band.i32 v6, v69  ; v69 = 1
-;;                                     v71 = iconst.i32 0
-;;                                     v72 = icmp.i32 eq v6, v71  ; v71 = 0
-;; @003b                               v30 = uextend.i32 v72
-;; @003b                               v31 = bor v70, v30
+;;                                     v67 = iadd.i64 v0, v4  ; v4 = 48
+;; @003b                               store.i32 notrap aligned v2, v67
+;;                                     v68 = iconst.i32 1
+;;                                     v69 = band.i32 v6, v68  ; v68 = 1
+;;                                     v70 = iconst.i32 0
+;;                                     v71 = icmp.i32 eq v6, v70  ; v70 = 0
+;; @003b                               v30 = uextend.i32 v71
+;; @003b                               v31 = bor v69, v30
 ;; @003b                               brif v31, block7, block4
 ;;
 ;;                                 block4:
-;;                                     v73 = load.i64 notrap aligned readonly can_move v0+8
-;;                                     v74 = load.i64 notrap aligned readonly can_move v73+32
+;;                                     v72 = load.i64 notrap aligned readonly can_move v0+8
+;;                                     v73 = load.i64 notrap aligned readonly can_move v72+32
 ;; @003b                               v32 = uextend.i64 v6
-;; @003b                               v34 = iadd v74, v32
-;;                                     v75 = iconst.i64 8
-;; @003b                               v36 = iadd v34, v75  ; v75 = 8
+;; @003b                               v34 = iadd v73, v32
+;;                                     v74 = iconst.i64 8
+;; @003b                               v36 = iadd v34, v74  ; v74 = 8
 ;; @003b                               v37 = load.i64 user2 region0 v36
-;;                                     v76 = iconst.i64 1
-;;                                     v66 = icmp eq v37, v76  ; v76 = 1
-;; @003b                               brif v66, block5, block6
+;;                                     v75 = iconst.i64 1
+;;                                     v65 = icmp eq v37, v75  ; v75 = 1
+;; @003b                               brif v65, block5, block6
 ;;
 ;;                                 block5 cold:
 ;; @003b                               call fn0(v0, v6)
@@ -161,8 +161,8 @@
 ;;                                 block6:
 ;; @003b                               v38 = iconst.i64 -1
 ;; @003b                               v39 = iadd.i64 v37, v38  ; v38 = -1
-;;                                     v77 = iadd.i64 v34, v75  ; v75 = 8
-;; @003b                               store user2 region0 v39, v77
+;;                                     v76 = iadd.i64 v34, v74  ; v74 = 8
+;; @003b                               store user2 region0 v39, v76
 ;; @003b                               jump block7
 ;;
 ;;                                 block7:

--- a/tests/disas/gc/drc/funcref-in-gc-heap-get.wat
+++ b/tests/disas/gc/drc/funcref-in-gc-heap-get.wat
@@ -24,17 +24,17 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0020                               trapz v2, user16
-;; @0020                               v13 = load.i64 notrap aligned readonly can_move v0+8
-;; @0020                               v5 = load.i64 notrap aligned readonly can_move v13+32
+;; @0020                               v12 = load.i64 notrap aligned readonly can_move v0+8
+;; @0020                               v5 = load.i64 notrap aligned readonly can_move v12+32
 ;; @0020                               v4 = uextend.i64 v2
 ;; @0020                               v6 = iadd v5, v4
 ;; @0020                               v7 = iconst.i64 24
 ;; @0020                               v8 = iadd v6, v7  ; v7 = 24
-;; @0020                               v11 = load.i32 user2 little region0 v8
+;; @0020                               v10 = load.i32 user2 little region0 v8
 ;; @0020                               v9 = iconst.i32 -1
-;; @0020                               v12 = call fn0(v0, v11, v9)  ; v9 = -1
+;; @0020                               v11 = call fn0(v0, v10, v9)  ; v9 = -1
 ;; @0024                               jump block1
 ;;
 ;;                                 block1:
-;; @0024                               return v12
+;; @0024                               return v11
 ;; }

--- a/tests/disas/gc/drc/funcref-in-gc-heap-new.wat
+++ b/tests/disas/gc/drc/funcref-in-gc-heap-new.wat
@@ -25,26 +25,26 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0020                               v6 = iconst.i32 -1342177280
-;; @0020                               v8 = load.i64 notrap aligned readonly can_move v0+40
-;; @0020                               v9 = load.i32 notrap aligned readonly can_move v8
+;; @0020                               v5 = iconst.i32 -1342177280
+;; @0020                               v6 = load.i64 notrap aligned readonly can_move v0+40
+;; @0020                               v7 = load.i32 notrap aligned readonly can_move v6
 ;; @0020                               v4 = iconst.i32 32
-;; @0020                               v10 = iconst.i32 8
-;; @0020                               v11 = call fn0(v0, v6, v9, v4, v10)  ; v6 = -1342177280, v4 = 32, v10 = 8
-;;                                     v24 = stack_addr.i64 ss0
-;;                                     store notrap v11, v24
-;; @0020                               v18 = call fn1(v0, v2), stack_map=[i32 @ ss0+0]
-;; @0020                               v19 = ireduce.i32 v18
-;; @0020                               v25 = load.i64 notrap aligned readonly can_move v0+8
-;; @0020                               v12 = load.i64 notrap aligned readonly can_move v25+32
-;; @0020                               v13 = uextend.i64 v11
-;; @0020                               v14 = iadd v12, v13
-;; @0020                               v15 = iconst.i64 24
-;; @0020                               v16 = iadd v14, v15  ; v15 = 24
-;; @0020                               store user2 little region0 v19, v16
-;;                                     v21 = load.i32 notrap v24
+;; @0020                               v8 = iconst.i32 8
+;; @0020                               v9 = call fn0(v0, v5, v7, v4, v8)  ; v5 = -1342177280, v4 = 32, v8 = 8
+;;                                     v21 = stack_addr.i64 ss0
+;;                                     store notrap v9, v21
+;; @0020                               v15 = call fn1(v0, v2), stack_map=[i32 @ ss0+0]
+;; @0020                               v16 = ireduce.i32 v15
+;; @0020                               v22 = load.i64 notrap aligned readonly can_move v0+8
+;; @0020                               v10 = load.i64 notrap aligned readonly can_move v22+32
+;; @0020                               v11 = uextend.i64 v9
+;; @0020                               v12 = iadd v10, v11
+;; @0020                               v13 = iconst.i64 24
+;; @0020                               v14 = iadd v12, v13  ; v13 = 24
+;; @0020                               store user2 little region0 v16, v14
+;;                                     v18 = load.i32 notrap v21
 ;; @0023                               jump block1
 ;;
 ;;                                 block1:
-;; @0023                               return v21
+;; @0023                               return v18
 ;; }

--- a/tests/disas/gc/drc/funcref-in-gc-heap-set.wat
+++ b/tests/disas/gc/drc/funcref-in-gc-heap-set.wat
@@ -24,15 +24,15 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i64):
 ;; @0022                               trapz v2, user16
-;; @0022                               v10 = call fn0(v0, v3)
-;; @0022                               v11 = ireduce.i32 v10
-;; @0022                               v12 = load.i64 notrap aligned readonly can_move v0+8
-;; @0022                               v5 = load.i64 notrap aligned readonly can_move v12+32
+;; @0022                               v9 = call fn0(v0, v3)
+;; @0022                               v10 = ireduce.i32 v9
+;; @0022                               v11 = load.i64 notrap aligned readonly can_move v0+8
+;; @0022                               v5 = load.i64 notrap aligned readonly can_move v11+32
 ;; @0022                               v4 = uextend.i64 v2
 ;; @0022                               v6 = iadd v5, v4
 ;; @0022                               v7 = iconst.i64 24
 ;; @0022                               v8 = iadd v6, v7  ; v7 = 24
-;; @0022                               store user2 little region0 v11, v8
+;; @0022                               store user2 little region0 v10, v8
 ;; @0026                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/drc/ref-cast.wat
+++ b/tests/disas/gc/drc/ref-cast.wat
@@ -27,25 +27,25 @@
 ;;                                 block2:
 ;; @001e                               v8 = iconst.i32 1
 ;; @001e                               v9 = band.i32 v2, v8  ; v8 = 1
-;;                                     v25 = iconst.i32 0
-;; @001e                               brif v9, block4(v25), block3  ; v25 = 0
+;;                                     v24 = iconst.i32 0
+;; @001e                               brif v9, block4(v24), block3  ; v24 = 0
 ;;
 ;;                                 block3:
-;; @001e                               v23 = load.i64 notrap aligned readonly can_move v0+8
-;; @001e                               v15 = load.i64 notrap aligned readonly can_move v23+32
-;; @001e                               v14 = uextend.i64 v2
-;; @001e                               v16 = iadd v15, v14
-;; @001e                               v17 = iconst.i64 4
-;; @001e                               v18 = iadd v16, v17  ; v17 = 4
-;; @001e                               v19 = load.i32 user2 readonly region0 v18
-;; @001e                               v12 = load.i64 notrap aligned readonly can_move v0+40
-;; @001e                               v13 = load.i32 notrap aligned readonly can_move v12
-;; @001e                               v20 = icmp eq v19, v13
-;; @001e                               v21 = uextend.i32 v20
-;; @001e                               jump block4(v21)
+;; @001e                               v22 = load.i64 notrap aligned readonly can_move v0+8
+;; @001e                               v14 = load.i64 notrap aligned readonly can_move v22+32
+;; @001e                               v13 = uextend.i64 v2
+;; @001e                               v15 = iadd v14, v13
+;; @001e                               v16 = iconst.i64 4
+;; @001e                               v17 = iadd v15, v16  ; v16 = 4
+;; @001e                               v18 = load.i32 user2 readonly region0 v17
+;; @001e                               v11 = load.i64 notrap aligned readonly can_move v0+40
+;; @001e                               v12 = load.i32 notrap aligned readonly can_move v11
+;; @001e                               v19 = icmp eq v18, v12
+;; @001e                               v20 = uextend.i32 v19
+;; @001e                               jump block4(v20)
 ;;
-;;                                 block4(v22: i32):
-;; @001e                               trapz v22, user19
+;;                                 block4(v21: i32):
+;; @001e                               trapz v21, user19
 ;; @0021                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/drc/ref-test-concrete-func-type.wat
+++ b/tests/disas/gc/drc/ref-test-concrete-func-type.wat
@@ -13,7 +13,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
@@ -26,15 +25,15 @@
 ;; @0020                               jump block3
 ;;
 ;;                                 block3:
-;; @0020                               v11 = load.i32 user2 readonly region0 v2+16
-;; @0020                               v9 = load.i64 notrap aligned readonly can_move v0+40
-;; @0020                               v10 = load.i32 notrap aligned readonly can_move v9
-;; @0020                               v12 = icmp eq v11, v10
-;; @0020                               v13 = uextend.i32 v12
-;; @0020                               jump block4(v13)
+;; @0020                               v10 = load.i32 user2 readonly region0 v2+16
+;; @0020                               v8 = load.i64 notrap aligned readonly can_move v0+40
+;; @0020                               v9 = load.i32 notrap aligned readonly can_move v8
+;; @0020                               v11 = icmp eq v10, v9
+;; @0020                               v12 = uextend.i32 v11
+;; @0020                               jump block4(v12)
 ;;
-;;                                 block4(v14: i32):
-;; @0023                               jump block1(v14)
+;;                                 block4(v13: i32):
+;; @0023                               jump block1(v13)
 ;;
 ;;                                 block1(v3: i32):
 ;; @0023                               return v3

--- a/tests/disas/gc/drc/ref-test-concrete-type.wat
+++ b/tests/disas/gc/drc/ref-test-concrete-type.wat
@@ -27,25 +27,25 @@
 ;;                                 block2:
 ;; @001d                               v8 = iconst.i32 1
 ;; @001d                               v9 = band.i32 v2, v8  ; v8 = 1
-;;                                     v25 = iconst.i32 0
-;; @001d                               brif v9, block4(v25), block3  ; v25 = 0
+;;                                     v24 = iconst.i32 0
+;; @001d                               brif v9, block4(v24), block3  ; v24 = 0
 ;;
 ;;                                 block3:
-;; @001d                               v23 = load.i64 notrap aligned readonly can_move v0+8
-;; @001d                               v15 = load.i64 notrap aligned readonly can_move v23+32
-;; @001d                               v14 = uextend.i64 v2
-;; @001d                               v16 = iadd v15, v14
-;; @001d                               v17 = iconst.i64 4
-;; @001d                               v18 = iadd v16, v17  ; v17 = 4
-;; @001d                               v19 = load.i32 user2 readonly region0 v18
-;; @001d                               v12 = load.i64 notrap aligned readonly can_move v0+40
-;; @001d                               v13 = load.i32 notrap aligned readonly can_move v12
-;; @001d                               v20 = icmp eq v19, v13
-;; @001d                               v21 = uextend.i32 v20
-;; @001d                               jump block4(v21)
+;; @001d                               v22 = load.i64 notrap aligned readonly can_move v0+8
+;; @001d                               v14 = load.i64 notrap aligned readonly can_move v22+32
+;; @001d                               v13 = uextend.i64 v2
+;; @001d                               v15 = iadd v14, v13
+;; @001d                               v16 = iconst.i64 4
+;; @001d                               v17 = iadd v15, v16  ; v16 = 4
+;; @001d                               v18 = load.i32 user2 readonly region0 v17
+;; @001d                               v11 = load.i64 notrap aligned readonly can_move v0+40
+;; @001d                               v12 = load.i32 notrap aligned readonly can_move v11
+;; @001d                               v19 = icmp eq v18, v12
+;; @001d                               v20 = uextend.i32 v19
+;; @001d                               jump block4(v20)
 ;;
-;;                                 block4(v22: i32):
-;; @0020                               jump block1(v22)
+;;                                 block4(v21: i32):
+;; @0020                               jump block1(v21)
 ;;
 ;;                                 block1(v3: i32):
 ;; @0020                               return v3

--- a/tests/disas/gc/drc/struct-get.wat
+++ b/tests/disas/gc/drc/struct-get.wat
@@ -120,15 +120,15 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @004e                               trapz v2, user16
-;; @004e                               v96 = load.i64 notrap aligned readonly can_move v0+8
-;; @004e                               v5 = load.i64 notrap aligned readonly can_move v96+32
+;; @004e                               v95 = load.i64 notrap aligned readonly can_move v0+8
+;; @004e                               v5 = load.i64 notrap aligned readonly can_move v95+32
 ;; @004e                               v4 = uextend.i64 v2
 ;; @004e                               v6 = iadd v5, v4
 ;; @004e                               v7 = iconst.i64 32
 ;; @004e                               v8 = iadd v6, v7  ; v7 = 32
 ;; @004e                               v9 = load.i32 user2 little region0 v8
-;;                                     v85 = stack_addr.i64 ss0
-;;                                     store notrap v9, v85
+;;                                     v84 = stack_addr.i64 ss0
+;;                                     store notrap v9, v84
 ;; @004e                               v10 = iconst.i32 1
 ;; @004e                               v11 = band v9, v10  ; v10 = 1
 ;; @004e                               v12 = iconst.i32 0
@@ -151,9 +151,9 @@
 ;; @004e                               v28 = iconst.i64 16
 ;; @004e                               v29 = iadd.i64 v18, v28  ; v28 = 16
 ;; @004e                               store user2 region0 v24, v29
-;;                                     v98 = iconst.i32 2
-;;                                     v99 = bor.i32 v19, v98  ; v98 = 2
-;; @004e                               store user2 region0 v99, v18
+;;                                     v97 = iconst.i32 2
+;;                                     v98 = bor.i32 v19, v97  ; v97 = 2
+;; @004e                               store user2 region0 v98, v18
 ;; @004e                               v38 = iconst.i64 8
 ;; @004e                               v39 = iadd.i64 v18, v38  ; v38 = 8
 ;; @004e                               v40 = load.i64 user2 region0 v39
@@ -162,27 +162,27 @@
 ;; @004e                               store user2 region0 v42, v39
 ;; @004e                               store.i32 user2 region0 v9, v23
 ;; @004e                               v50 = load.i32 notrap aligned v23+4
-;;                                     v100 = iconst.i32 1
-;;                                     v101 = iadd v50, v100  ; v100 = 1
-;; @004e                               store notrap aligned v101, v23+4
+;;                                     v99 = iconst.i32 1
+;;                                     v100 = iadd v50, v99  ; v99 = 1
+;; @004e                               store notrap aligned v100, v23+4
 ;; @004e                               v60 = load.i32 notrap aligned v23+8
 ;; @004e                               v61 = iadd v60, v60
 ;; @004e                               v62 = iconst.i32 1024
 ;; @004e                               v63 = umax v61, v62  ; v62 = 1024
-;; @004e                               v64 = icmp uge v101, v63
+;; @004e                               v64 = icmp uge v100, v63
 ;; @004e                               brif v64, block5, block6
 ;;
 ;;                                 block5 cold:
-;; @004e                               v66 = call fn0(v0), stack_map=[i32 @ ss0+0]
+;; @004e                               v65 = call fn0(v0), stack_map=[i32 @ ss0+0]
 ;; @004e                               jump block6
 ;;
 ;;                                 block6:
 ;; @004e                               jump block4
 ;;
 ;;                                 block4:
-;;                                     v68 = load.i32 notrap v85
+;;                                     v67 = load.i32 notrap v84
 ;; @0052                               jump block1
 ;;
 ;;                                 block1:
-;; @0052                               return v68
+;; @0052                               return v67
 ;; }

--- a/tests/disas/gc/drc/struct-new-default.wat
+++ b/tests/disas/gc/drc/struct-new-default.wat
@@ -25,33 +25,33 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @0021                               v8 = iconst.i32 -1342177280
-;; @0021                               v10 = load.i64 notrap aligned readonly can_move v0+40
-;; @0021                               v11 = load.i32 notrap aligned readonly can_move v10
+;; @0021                               v7 = iconst.i32 -1342177280
+;; @0021                               v8 = load.i64 notrap aligned readonly can_move v0+40
+;; @0021                               v9 = load.i32 notrap aligned readonly can_move v8
 ;; @0021                               v6 = iconst.i32 40
-;; @0021                               v12 = iconst.i32 8
-;; @0021                               v13 = call fn0(v0, v8, v11, v6, v12)  ; v8 = -1342177280, v6 = 40, v12 = 8
+;; @0021                               v10 = iconst.i32 8
+;; @0021                               v11 = call fn0(v0, v7, v9, v6, v10)  ; v7 = -1342177280, v6 = 40, v10 = 8
 ;; @0021                               v3 = f32const 0.0
-;; @0021                               v46 = load.i64 notrap aligned readonly can_move v0+8
-;; @0021                               v14 = load.i64 notrap aligned readonly can_move v46+32
-;; @0021                               v15 = uextend.i64 v13
-;; @0021                               v16 = iadd v14, v15
-;; @0021                               v17 = iconst.i64 24
-;; @0021                               v18 = iadd v16, v17  ; v17 = 24
-;; @0021                               store user2 little region0 v3, v18  ; v3 = 0.0
+;; @0021                               v44 = load.i64 notrap aligned readonly can_move v0+8
+;; @0021                               v12 = load.i64 notrap aligned readonly can_move v44+32
+;; @0021                               v13 = uextend.i64 v11
+;; @0021                               v14 = iadd v12, v13
+;; @0021                               v15 = iconst.i64 24
+;; @0021                               v16 = iadd v14, v15  ; v15 = 24
+;; @0021                               store user2 little region0 v3, v16  ; v3 = 0.0
 ;; @0021                               v4 = iconst.i32 0
-;; @0021                               v19 = iconst.i64 28
-;; @0021                               v20 = iadd v16, v19  ; v19 = 28
-;; @0021                               istore8 user2 little region0 v4, v20  ; v4 = 0
+;; @0021                               v17 = iconst.i64 28
+;; @0021                               v18 = iadd v14, v17  ; v17 = 28
+;; @0021                               istore8 user2 little region0 v4, v18  ; v4 = 0
 ;;                                     jump block3
 ;;
 ;;                                 block3:
-;;                                     v65 = iconst.i32 0
-;; @0021                               v21 = iconst.i64 32
-;; @0021                               v22 = iadd.i64 v16, v21  ; v21 = 32
-;; @0021                               store user2 little region0 v65, v22  ; v65 = 0
+;;                                     v63 = iconst.i32 0
+;; @0021                               v19 = iconst.i64 32
+;; @0021                               v20 = iadd.i64 v14, v19  ; v19 = 32
+;; @0021                               store user2 little region0 v63, v20  ; v63 = 0
 ;; @0024                               jump block1
 ;;
 ;;                                 block1:
-;; @0024                               return v13
+;; @0024                               return v11
 ;; }

--- a/tests/disas/gc/drc/struct-new.wat
+++ b/tests/disas/gc/drc/struct-new.wat
@@ -26,50 +26,50 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: f32, v3: i32, v4: i32):
-;;                                     v52 = stack_addr.i64 ss0
-;;                                     store notrap v4, v52
-;; @002a                               v8 = iconst.i32 -1342177280
-;; @002a                               v10 = load.i64 notrap aligned readonly can_move v0+40
-;; @002a                               v11 = load.i32 notrap aligned readonly can_move v10
+;;                                     v50 = stack_addr.i64 ss0
+;;                                     store notrap v4, v50
+;; @002a                               v7 = iconst.i32 -1342177280
+;; @002a                               v8 = load.i64 notrap aligned readonly can_move v0+40
+;; @002a                               v9 = load.i32 notrap aligned readonly can_move v8
 ;; @002a                               v6 = iconst.i32 40
-;; @002a                               v12 = iconst.i32 8
-;; @002a                               v13 = call fn0(v0, v8, v11, v6, v12), stack_map=[i32 @ ss0+0]  ; v8 = -1342177280, v6 = 40, v12 = 8
-;; @002a                               v57 = load.i64 notrap aligned readonly can_move v0+8
-;; @002a                               v14 = load.i64 notrap aligned readonly can_move v57+32
-;; @002a                               v15 = uextend.i64 v13
-;; @002a                               v16 = iadd v14, v15
-;; @002a                               v17 = iconst.i64 24
-;; @002a                               v18 = iadd v16, v17  ; v17 = 24
-;; @002a                               store user2 little region0 v2, v18
-;; @002a                               v19 = iconst.i64 28
-;; @002a                               v20 = iadd v16, v19  ; v19 = 28
-;; @002a                               istore8 user2 little region0 v3, v20
-;;                                     v51 = load.i32 notrap v52
-;; @002a                               v23 = iconst.i32 1
-;; @002a                               v24 = band v51, v23  ; v23 = 1
-;; @002a                               v25 = iconst.i32 0
-;; @002a                               v26 = icmp eq v51, v25  ; v25 = 0
-;; @002a                               v27 = uextend.i32 v26
-;; @002a                               v28 = bor v24, v27
-;; @002a                               brif v28, block3, block2
+;; @002a                               v10 = iconst.i32 8
+;; @002a                               v11 = call fn0(v0, v7, v9, v6, v10), stack_map=[i32 @ ss0+0]  ; v7 = -1342177280, v6 = 40, v10 = 8
+;; @002a                               v55 = load.i64 notrap aligned readonly can_move v0+8
+;; @002a                               v12 = load.i64 notrap aligned readonly can_move v55+32
+;; @002a                               v13 = uextend.i64 v11
+;; @002a                               v14 = iadd v12, v13
+;; @002a                               v15 = iconst.i64 24
+;; @002a                               v16 = iadd v14, v15  ; v15 = 24
+;; @002a                               store user2 little region0 v2, v16
+;; @002a                               v17 = iconst.i64 28
+;; @002a                               v18 = iadd v14, v17  ; v17 = 28
+;; @002a                               istore8 user2 little region0 v3, v18
+;;                                     v49 = load.i32 notrap v50
+;; @002a                               v21 = iconst.i32 1
+;; @002a                               v22 = band v49, v21  ; v21 = 1
+;; @002a                               v23 = iconst.i32 0
+;; @002a                               v24 = icmp eq v49, v23  ; v23 = 0
+;; @002a                               v25 = uextend.i32 v24
+;; @002a                               v26 = bor v22, v25
+;; @002a                               brif v26, block3, block2
 ;;
 ;;                                 block2:
-;; @002a                               v29 = uextend.i64 v51
-;; @002a                               v31 = iadd.i64 v14, v29
-;; @002a                               v32 = iconst.i64 8
-;; @002a                               v33 = iadd v31, v32  ; v32 = 8
-;; @002a                               v34 = load.i64 user2 region0 v33
-;; @002a                               v35 = iconst.i64 1
-;; @002a                               v36 = iadd v34, v35  ; v35 = 1
-;; @002a                               store user2 region0 v36, v33
+;; @002a                               v27 = uextend.i64 v49
+;; @002a                               v29 = iadd.i64 v12, v27
+;; @002a                               v30 = iconst.i64 8
+;; @002a                               v31 = iadd v29, v30  ; v30 = 8
+;; @002a                               v32 = load.i64 user2 region0 v31
+;; @002a                               v33 = iconst.i64 1
+;; @002a                               v34 = iadd v32, v33  ; v33 = 1
+;; @002a                               store user2 region0 v34, v31
 ;; @002a                               jump block3
 ;;
 ;;                                 block3:
-;; @002a                               v21 = iconst.i64 32
-;; @002a                               v22 = iadd.i64 v16, v21  ; v21 = 32
-;; @002a                               store.i32 user2 little region0 v51, v22
+;; @002a                               v19 = iconst.i64 32
+;; @002a                               v20 = iadd.i64 v14, v19  ; v19 = 32
+;; @002a                               store.i32 user2 little region0 v49, v20
 ;; @002d                               jump block1
 ;;
 ;;                                 block1:
-;; @002d                               return v13
+;; @002d                               return v11
 ;; }

--- a/tests/disas/gc/drc/struct-set.wat
+++ b/tests/disas/gc/drc/struct-set.wat
@@ -86,8 +86,8 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @004a                               trapz v2, user16
-;; @004a                               v59 = load.i64 notrap aligned readonly can_move v0+8
-;; @004a                               v5 = load.i64 notrap aligned readonly can_move v59+32
+;; @004a                               v58 = load.i64 notrap aligned readonly can_move v0+8
+;; @004a                               v5 = load.i64 notrap aligned readonly can_move v58+32
 ;; @004a                               v4 = uextend.i64 v2
 ;; @004a                               v6 = iadd v5, v4
 ;; @004a                               v7 = iconst.i64 32
@@ -113,25 +113,25 @@
 ;; @004a                               jump block3
 ;;
 ;;                                 block3:
-;;                                     v73 = iadd.i64 v6, v7  ; v7 = 32
-;; @004a                               store.i32 user2 little region0 v3, v73
-;;                                     v74 = iconst.i32 1
-;;                                     v75 = band.i32 v9, v74  ; v74 = 1
-;;                                     v76 = iconst.i32 0
-;;                                     v77 = icmp.i32 eq v9, v76  ; v76 = 0
-;; @004a                               v33 = uextend.i32 v77
-;; @004a                               v34 = bor v75, v33
+;;                                     v72 = iadd.i64 v6, v7  ; v7 = 32
+;; @004a                               store.i32 user2 little region0 v3, v72
+;;                                     v73 = iconst.i32 1
+;;                                     v74 = band.i32 v9, v73  ; v73 = 1
+;;                                     v75 = iconst.i32 0
+;;                                     v76 = icmp.i32 eq v9, v75  ; v75 = 0
+;; @004a                               v33 = uextend.i32 v76
+;; @004a                               v34 = bor v74, v33
 ;; @004a                               brif v34, block7, block4
 ;;
 ;;                                 block4:
 ;; @004a                               v35 = uextend.i64 v9
 ;; @004a                               v37 = iadd.i64 v5, v35
-;;                                     v78 = iconst.i64 8
-;; @004a                               v39 = iadd v37, v78  ; v78 = 8
+;;                                     v77 = iconst.i64 8
+;; @004a                               v39 = iadd v37, v77  ; v77 = 8
 ;; @004a                               v40 = load.i64 user2 region0 v39
-;;                                     v79 = iconst.i64 1
-;;                                     v71 = icmp eq v40, v79  ; v79 = 1
-;; @004a                               brif v71, block5, block6
+;;                                     v78 = iconst.i64 1
+;;                                     v70 = icmp eq v40, v78  ; v78 = 1
+;; @004a                               brif v70, block5, block6
 ;;
 ;;                                 block5 cold:
 ;; @004a                               call fn0(v0, v9)
@@ -140,8 +140,8 @@
 ;;                                 block6:
 ;; @004a                               v41 = iconst.i64 -1
 ;; @004a                               v42 = iadd.i64 v40, v41  ; v41 = -1
-;;                                     v80 = iadd.i64 v37, v78  ; v78 = 8
-;; @004a                               store user2 region0 v42, v80
+;;                                     v79 = iadd.i64 v37, v77  ; v77 = 8
+;; @004a                               store user2 region0 v42, v79
 ;; @004a                               jump block7
 ;;
 ;;                                 block7:

--- a/tests/disas/gc/null/array-new-fixed-of-gc-refs.wat
+++ b/tests/disas/gc/null/array-new-fixed-of-gc-refs.wat
@@ -27,99 +27,99 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
-;;                                     v127 = stack_addr.i64 ss2
-;;                                     store notrap v2, v127
-;;                                     v128 = stack_addr.i64 ss1
-;;                                     store notrap v3, v128
-;;                                     v129 = stack_addr.i64 ss0
-;;                                     store notrap v4, v129
-;; @0025                               v19 = load.i64 notrap aligned readonly region0 v0+32
-;; @0025                               v20 = load.i32 user2 region1 v19
-;;                                     v163 = iconst.i32 7
-;; @0025                               v23 = uadd_overflow_trap v20, v163, user18  ; v163 = 7
-;;                                     v169 = iconst.i32 -8
-;; @0025                               v25 = band v23, v169  ; v169 = -8
-;;                                     v156 = iconst.i32 24
-;; @0025                               v26 = uadd_overflow_trap v25, v156, user18  ; v156 = 24
-;; @0025                               v144 = load.i64 notrap aligned readonly can_move v0+8
-;; @0025                               v28 = load.i64 notrap aligned v144+40
-;; @0025                               v27 = uextend.i64 v26
-;; @0025                               v29 = icmp ule v27, v28
-;; @0025                               brif v29, block2, block3
+;;                                     v124 = stack_addr.i64 ss2
+;;                                     store notrap v2, v124
+;;                                     v125 = stack_addr.i64 ss1
+;;                                     store notrap v3, v125
+;;                                     v126 = stack_addr.i64 ss0
+;;                                     store notrap v4, v126
+;; @0025                               v18 = load.i64 notrap aligned readonly region0 v0+32
+;; @0025                               v19 = load.i32 user2 region1 v18
+;;                                     v160 = iconst.i32 7
+;; @0025                               v22 = uadd_overflow_trap v19, v160, user18  ; v160 = 7
+;;                                     v166 = iconst.i32 -8
+;; @0025                               v24 = band v22, v166  ; v166 = -8
+;;                                     v153 = iconst.i32 24
+;; @0025                               v25 = uadd_overflow_trap v24, v153, user18  ; v153 = 24
+;; @0025                               v141 = load.i64 notrap aligned readonly can_move v0+8
+;; @0025                               v27 = load.i64 notrap aligned v141+40
+;; @0025                               v26 = uextend.i64 v25
+;; @0025                               v28 = icmp ule v26, v27
+;; @0025                               brif v28, block2, block3
 ;;
 ;;                                 block2:
-;;                                     v170 = iconst.i32 -1476394984
-;; @0025                               v33 = load.i64 notrap aligned readonly can_move v144+32
-;;                                     v268 = band.i32 v23, v169  ; v169 = -8
-;;                                     v269 = uextend.i64 v268
-;; @0025                               v35 = iadd v33, v269
-;; @0025                               store user2 region1 v170, v35  ; v170 = -1476394984
-;; @0025                               v39 = load.i64 notrap aligned readonly can_move v0+40
-;; @0025                               v40 = load.i32 notrap aligned readonly can_move v39
-;; @0025                               store user2 region1 v40, v35+4
-;; @0025                               store.i32 user2 region1 v26, v19
+;;                                     v167 = iconst.i32 -1476394984
+;; @0025                               v31 = load.i64 notrap aligned readonly can_move v141+32
+;;                                     v265 = band.i32 v22, v166  ; v166 = -8
+;;                                     v266 = uextend.i64 v265
+;; @0025                               v33 = iadd v31, v266
+;; @0025                               store user2 region1 v167, v33  ; v167 = -1476394984
+;; @0025                               v36 = load.i64 notrap aligned readonly can_move v0+40
+;; @0025                               v37 = load.i32 notrap aligned readonly can_move v36
+;; @0025                               store user2 region1 v37, v33+4
+;; @0025                               store.i32 user2 region1 v25, v18
 ;; @0025                               v6 = iconst.i32 3
-;; @0025                               v41 = iconst.i64 8
-;; @0025                               v42 = iadd v35, v41  ; v41 = 8
-;; @0025                               store user2 region1 v6, v42  ; v6 = 3
-;; @0025                               trapz v268, user16
-;;                                     v270 = iconst.i32 24
-;; @0025                               v62 = uadd_overflow_trap v268, v270, user2  ; v270 = 24
-;;                                     v126 = load.i32 notrap v127
-;; @0025                               v63 = uextend.i64 v62
-;; @0025                               v65 = iadd v33, v63
-;;                                     v147 = iconst.i64 12
-;; @0025                               v68 = isub v65, v147  ; v147 = 12
-;; @0025                               store user2 little region1 v126, v68
-;; @0025                               v75 = load.i32 user2 readonly region1 v42
-;; @0025                               v69 = iconst.i32 1
-;;                                     v208 = icmp ugt v75, v69  ; v69 = 1
-;; @0025                               trapz v208, user17
-;; @0025                               v78 = uextend.i64 v75
-;;                                     v148 = iconst.i64 2
-;;                                     v210 = ishl v78, v148  ; v148 = 2
+;; @0025                               v38 = iconst.i64 8
+;; @0025                               v39 = iadd v33, v38  ; v38 = 8
+;; @0025                               store user2 region1 v6, v39  ; v6 = 3
+;; @0025                               trapz v265, user16
+;;                                     v267 = iconst.i32 24
+;; @0025                               v59 = uadd_overflow_trap v265, v267, user2  ; v267 = 24
+;;                                     v123 = load.i32 notrap v124
+;; @0025                               v60 = uextend.i64 v59
+;; @0025                               v62 = iadd v31, v60
+;;                                     v144 = iconst.i64 12
+;; @0025                               v65 = isub v62, v144  ; v144 = 12
+;; @0025                               store user2 little region1 v123, v65
+;; @0025                               v72 = load.i32 user2 readonly region1 v39
+;; @0025                               v66 = iconst.i32 1
+;;                                     v205 = icmp ugt v72, v66  ; v66 = 1
+;; @0025                               trapz v205, user17
+;; @0025                               v75 = uextend.i64 v72
+;;                                     v145 = iconst.i64 2
+;;                                     v207 = ishl v75, v145  ; v145 = 2
 ;; @0025                               v11 = iconst.i64 32
-;; @0025                               v81 = ushr v210, v11  ; v11 = 32
-;; @0025                               trapnz v81, user2
-;;                                     v187 = iconst.i32 2
-;;                                     v217 = ishl v75, v187  ; v187 = 2
+;; @0025                               v78 = ushr v207, v11  ; v11 = 32
+;; @0025                               trapnz v78, user2
+;;                                     v184 = iconst.i32 2
+;;                                     v214 = ishl v72, v184  ; v184 = 2
 ;; @0025                               v7 = iconst.i32 12
-;; @0025                               v84 = uadd_overflow_trap v217, v7, user2  ; v7 = 12
-;; @0025                               v88 = uadd_overflow_trap v268, v84, user2
-;;                                     v124 = load.i32 notrap v128
-;; @0025                               v89 = uextend.i64 v88
-;; @0025                               v91 = iadd v33, v89
-;;                                     v230 = iconst.i32 16
-;; @0025                               v92 = isub v84, v230  ; v230 = 16
-;; @0025                               v93 = uextend.i64 v92
-;; @0025                               v94 = isub v91, v93
-;; @0025                               store user2 little region1 v124, v94
-;; @0025                               v101 = load.i32 user2 readonly region1 v42
-;;                                     v236 = icmp ugt v101, v187  ; v187 = 2
-;; @0025                               trapz v236, user17
-;; @0025                               v104 = uextend.i64 v101
-;;                                     v238 = ishl v104, v148  ; v148 = 2
-;; @0025                               v107 = ushr v238, v11  ; v11 = 32
-;; @0025                               trapnz v107, user2
-;;                                     v245 = ishl v101, v187  ; v187 = 2
-;; @0025                               v110 = uadd_overflow_trap v245, v7, user2  ; v7 = 12
-;; @0025                               v114 = uadd_overflow_trap v268, v110, user2
-;;                                     v122 = load.i32 notrap v129
-;; @0025                               v115 = uextend.i64 v114
-;; @0025                               v117 = iadd v33, v115
-;;                                     v262 = iconst.i32 20
-;; @0025                               v118 = isub v110, v262  ; v262 = 20
-;; @0025                               v119 = uextend.i64 v118
-;; @0025                               v120 = isub v117, v119
-;; @0025                               store user2 little region1 v122, v120
+;; @0025                               v81 = uadd_overflow_trap v214, v7, user2  ; v7 = 12
+;; @0025                               v85 = uadd_overflow_trap v265, v81, user2
+;;                                     v121 = load.i32 notrap v125
+;; @0025                               v86 = uextend.i64 v85
+;; @0025                               v88 = iadd v31, v86
+;;                                     v227 = iconst.i32 16
+;; @0025                               v89 = isub v81, v227  ; v227 = 16
+;; @0025                               v90 = uextend.i64 v89
+;; @0025                               v91 = isub v88, v90
+;; @0025                               store user2 little region1 v121, v91
+;; @0025                               v98 = load.i32 user2 readonly region1 v39
+;;                                     v233 = icmp ugt v98, v184  ; v184 = 2
+;; @0025                               trapz v233, user17
+;; @0025                               v101 = uextend.i64 v98
+;;                                     v235 = ishl v101, v145  ; v145 = 2
+;; @0025                               v104 = ushr v235, v11  ; v11 = 32
+;; @0025                               trapnz v104, user2
+;;                                     v242 = ishl v98, v184  ; v184 = 2
+;; @0025                               v107 = uadd_overflow_trap v242, v7, user2  ; v7 = 12
+;; @0025                               v111 = uadd_overflow_trap v265, v107, user2
+;;                                     v119 = load.i32 notrap v126
+;; @0025                               v112 = uextend.i64 v111
+;; @0025                               v114 = iadd v31, v112
+;;                                     v259 = iconst.i32 20
+;; @0025                               v115 = isub v107, v259  ; v259 = 20
+;; @0025                               v116 = uextend.i64 v115
+;; @0025                               v117 = isub v114, v116
+;; @0025                               store user2 little region1 v119, v117
 ;; @0029                               jump block1
 ;;
 ;;                                 block3 cold:
-;; @0025                               v31 = isub.i64 v27, v28
-;; @0025                               v32 = call fn0(v0, v31), stack_map=[i32 @ ss2+0, i32 @ ss1+0, i32 @ ss0+0]
+;; @0025                               v29 = isub.i64 v26, v27
+;; @0025                               v30 = call fn0(v0, v29), stack_map=[i32 @ ss2+0, i32 @ ss1+0, i32 @ ss0+0]
 ;; @0025                               jump block2
 ;;
 ;;                                 block1:
-;;                                     v271 = band.i32 v23, v169  ; v169 = -8
-;; @0029                               return v271
+;;                                     v268 = band.i32 v22, v166  ; v166 = -8
+;; @0029                               return v268
 ;; }

--- a/tests/disas/gc/null/array-new-fixed.wat
+++ b/tests/disas/gc/null/array-new-fixed.wat
@@ -24,90 +24,90 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i64, v4: i64):
-;; @0025                               v19 = load.i64 notrap aligned readonly region0 v0+32
-;; @0025                               v20 = load.i32 user2 region1 v19
-;;                                     v154 = iconst.i32 7
-;; @0025                               v23 = uadd_overflow_trap v20, v154, user18  ; v154 = 7
-;;                                     v160 = iconst.i32 -8
-;; @0025                               v25 = band v23, v160  ; v160 = -8
-;;                                     v147 = iconst.i32 40
-;; @0025                               v26 = uadd_overflow_trap v25, v147, user18  ; v147 = 40
-;; @0025                               v135 = load.i64 notrap aligned readonly can_move v0+8
-;; @0025                               v28 = load.i64 notrap aligned v135+40
-;; @0025                               v27 = uextend.i64 v26
-;; @0025                               v29 = icmp ule v27, v28
-;; @0025                               brif v29, block2, block3
+;; @0025                               v18 = load.i64 notrap aligned readonly region0 v0+32
+;; @0025                               v19 = load.i32 user2 region1 v18
+;;                                     v151 = iconst.i32 7
+;; @0025                               v22 = uadd_overflow_trap v19, v151, user18  ; v151 = 7
+;;                                     v157 = iconst.i32 -8
+;; @0025                               v24 = band v22, v157  ; v157 = -8
+;;                                     v144 = iconst.i32 40
+;; @0025                               v25 = uadd_overflow_trap v24, v144, user18  ; v144 = 40
+;; @0025                               v132 = load.i64 notrap aligned readonly can_move v0+8
+;; @0025                               v27 = load.i64 notrap aligned v132+40
+;; @0025                               v26 = uextend.i64 v25
+;; @0025                               v28 = icmp ule v26, v27
+;; @0025                               brif v28, block2, block3
 ;;
 ;;                                 block2:
-;;                                     v161 = iconst.i32 -1476394968
-;; @0025                               v33 = load.i64 notrap aligned readonly can_move v135+32
-;;                                     v256 = band.i32 v23, v160  ; v160 = -8
-;;                                     v257 = uextend.i64 v256
-;; @0025                               v35 = iadd v33, v257
-;; @0025                               store user2 region1 v161, v35  ; v161 = -1476394968
-;; @0025                               v39 = load.i64 notrap aligned readonly can_move v0+40
-;; @0025                               v40 = load.i32 notrap aligned readonly can_move v39
-;; @0025                               store user2 region1 v40, v35+4
-;; @0025                               store.i32 user2 region1 v26, v19
+;;                                     v158 = iconst.i32 -1476394968
+;; @0025                               v31 = load.i64 notrap aligned readonly can_move v132+32
+;;                                     v253 = band.i32 v22, v157  ; v157 = -8
+;;                                     v254 = uextend.i64 v253
+;; @0025                               v33 = iadd v31, v254
+;; @0025                               store user2 region1 v158, v33  ; v158 = -1476394968
+;; @0025                               v36 = load.i64 notrap aligned readonly can_move v0+40
+;; @0025                               v37 = load.i32 notrap aligned readonly can_move v36
+;; @0025                               store user2 region1 v37, v33+4
+;; @0025                               store.i32 user2 region1 v25, v18
 ;; @0025                               v6 = iconst.i32 3
 ;; @0025                               v9 = iconst.i64 8
-;; @0025                               v42 = iadd v35, v9  ; v9 = 8
-;; @0025                               store user2 region1 v6, v42  ; v6 = 3
-;; @0025                               trapz v256, user16
-;;                                     v258 = iconst.i32 40
-;; @0025                               v62 = uadd_overflow_trap v256, v258, user2  ; v258 = 40
-;; @0025                               v63 = uextend.i64 v62
-;; @0025                               v65 = iadd v33, v63
-;;                                     v138 = iconst.i64 24
-;; @0025                               v68 = isub v65, v138  ; v138 = 24
-;; @0025                               store.i64 user2 little region1 v2, v68
-;; @0025                               v75 = load.i32 user2 readonly region1 v42
-;; @0025                               v69 = iconst.i32 1
-;;                                     v197 = icmp ugt v75, v69  ; v69 = 1
-;; @0025                               trapz v197, user17
-;; @0025                               v78 = uextend.i64 v75
-;;                                     v137 = iconst.i64 3
-;;                                     v199 = ishl v78, v137  ; v137 = 3
+;; @0025                               v39 = iadd v33, v9  ; v9 = 8
+;; @0025                               store user2 region1 v6, v39  ; v6 = 3
+;; @0025                               trapz v253, user16
+;;                                     v255 = iconst.i32 40
+;; @0025                               v59 = uadd_overflow_trap v253, v255, user2  ; v255 = 40
+;; @0025                               v60 = uextend.i64 v59
+;; @0025                               v62 = iadd v31, v60
+;;                                     v135 = iconst.i64 24
+;; @0025                               v65 = isub v62, v135  ; v135 = 24
+;; @0025                               store.i64 user2 little region1 v2, v65
+;; @0025                               v72 = load.i32 user2 readonly region1 v39
+;; @0025                               v66 = iconst.i32 1
+;;                                     v194 = icmp ugt v72, v66  ; v66 = 1
+;; @0025                               trapz v194, user17
+;; @0025                               v75 = uextend.i64 v72
+;;                                     v134 = iconst.i64 3
+;;                                     v196 = ishl v75, v134  ; v134 = 3
 ;; @0025                               v11 = iconst.i64 32
-;; @0025                               v81 = ushr v199, v11  ; v11 = 32
-;; @0025                               trapnz v81, user2
-;;                                     v206 = ishl v75, v6  ; v6 = 3
+;; @0025                               v78 = ushr v196, v11  ; v11 = 32
+;; @0025                               trapnz v78, user2
+;;                                     v203 = ishl v72, v6  ; v6 = 3
 ;; @0025                               v7 = iconst.i32 16
-;; @0025                               v84 = uadd_overflow_trap v206, v7, user2  ; v7 = 16
-;; @0025                               v88 = uadd_overflow_trap v256, v84, user2
-;; @0025                               v89 = uextend.i64 v88
-;; @0025                               v91 = iadd v33, v89
-;;                                     v146 = iconst.i32 24
-;; @0025                               v92 = isub v84, v146  ; v146 = 24
-;; @0025                               v93 = uextend.i64 v92
-;; @0025                               v94 = isub v91, v93
-;; @0025                               store.i64 user2 little region1 v3, v94
-;; @0025                               v101 = load.i32 user2 readonly region1 v42
-;; @0025                               v95 = iconst.i32 2
-;;                                     v224 = icmp ugt v101, v95  ; v95 = 2
-;; @0025                               trapz v224, user17
-;; @0025                               v104 = uextend.i64 v101
-;;                                     v226 = ishl v104, v137  ; v137 = 3
-;; @0025                               v107 = ushr v226, v11  ; v11 = 32
-;; @0025                               trapnz v107, user2
-;;                                     v233 = ishl v101, v6  ; v6 = 3
-;; @0025                               v110 = uadd_overflow_trap v233, v7, user2  ; v7 = 16
-;; @0025                               v114 = uadd_overflow_trap v256, v110, user2
-;; @0025                               v115 = uextend.i64 v114
-;; @0025                               v117 = iadd v33, v115
-;;                                     v250 = iconst.i32 32
-;; @0025                               v118 = isub v110, v250  ; v250 = 32
-;; @0025                               v119 = uextend.i64 v118
-;; @0025                               v120 = isub v117, v119
-;; @0025                               store.i64 user2 little region1 v4, v120
+;; @0025                               v81 = uadd_overflow_trap v203, v7, user2  ; v7 = 16
+;; @0025                               v85 = uadd_overflow_trap v253, v81, user2
+;; @0025                               v86 = uextend.i64 v85
+;; @0025                               v88 = iadd v31, v86
+;;                                     v143 = iconst.i32 24
+;; @0025                               v89 = isub v81, v143  ; v143 = 24
+;; @0025                               v90 = uextend.i64 v89
+;; @0025                               v91 = isub v88, v90
+;; @0025                               store.i64 user2 little region1 v3, v91
+;; @0025                               v98 = load.i32 user2 readonly region1 v39
+;; @0025                               v92 = iconst.i32 2
+;;                                     v221 = icmp ugt v98, v92  ; v92 = 2
+;; @0025                               trapz v221, user17
+;; @0025                               v101 = uextend.i64 v98
+;;                                     v223 = ishl v101, v134  ; v134 = 3
+;; @0025                               v104 = ushr v223, v11  ; v11 = 32
+;; @0025                               trapnz v104, user2
+;;                                     v230 = ishl v98, v6  ; v6 = 3
+;; @0025                               v107 = uadd_overflow_trap v230, v7, user2  ; v7 = 16
+;; @0025                               v111 = uadd_overflow_trap v253, v107, user2
+;; @0025                               v112 = uextend.i64 v111
+;; @0025                               v114 = iadd v31, v112
+;;                                     v247 = iconst.i32 32
+;; @0025                               v115 = isub v107, v247  ; v247 = 32
+;; @0025                               v116 = uextend.i64 v115
+;; @0025                               v117 = isub v114, v116
+;; @0025                               store.i64 user2 little region1 v4, v117
 ;; @0029                               jump block1
 ;;
 ;;                                 block3 cold:
-;; @0025                               v31 = isub.i64 v27, v28
-;; @0025                               v32 = call fn0(v0, v31)
+;; @0025                               v29 = isub.i64 v26, v27
+;; @0025                               v30 = call fn0(v0, v29)
 ;; @0025                               jump block2
 ;;
 ;;                                 block1:
-;;                                     v259 = band.i32 v23, v160  ; v160 = -8
-;; @0029                               return v259
+;;                                     v256 = band.i32 v22, v157  ; v157 = -8
+;; @0029                               return v256
 ;; }

--- a/tests/disas/gc/null/array-new.wat
+++ b/tests/disas/gc/null/array-new.wat
@@ -25,75 +25,75 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0022                               v6 = uextend.i64 v3
-;;                                     v91 = iconst.i64 3
-;;                                     v92 = ishl v6, v91  ; v91 = 3
+;;                                     v88 = iconst.i64 3
+;;                                     v89 = ishl v6, v88  ; v88 = 3
 ;; @0022                               v9 = iconst.i64 32
-;; @0022                               v10 = ushr v92, v9  ; v9 = 32
+;; @0022                               v10 = ushr v89, v9  ; v9 = 32
 ;; @0022                               trapnz v10, user18
 ;; @0022                               v5 = iconst.i32 16
-;;                                     v98 = iconst.i32 3
-;;                                     v99 = ishl v3, v98  ; v98 = 3
-;; @0022                               v12 = uadd_overflow_trap v5, v99, user18  ; v5 = 16
+;;                                     v95 = iconst.i32 3
+;;                                     v96 = ishl v3, v95  ; v95 = 3
+;; @0022                               v12 = uadd_overflow_trap v5, v96, user18  ; v5 = 16
 ;; @0022                               v14 = iconst.i32 -67108864
 ;; @0022                               v15 = band v12, v14  ; v14 = -67108864
 ;; @0022                               trapnz v15, user18
-;; @0022                               v17 = load.i64 notrap aligned readonly region0 v0+32
-;; @0022                               v18 = load.i32 user2 region1 v17
-;;                                     v102 = iconst.i32 7
-;; @0022                               v21 = uadd_overflow_trap v18, v102, user18  ; v102 = 7
-;;                                     v108 = iconst.i32 -8
-;; @0022                               v23 = band v21, v108  ; v108 = -8
-;; @0022                               v24 = uadd_overflow_trap v23, v12, user18
-;; @0022                               v89 = load.i64 notrap aligned readonly can_move v0+8
-;; @0022                               v26 = load.i64 notrap aligned v89+40
-;; @0022                               v25 = uextend.i64 v24
-;; @0022                               v27 = icmp ule v25, v26
-;; @0022                               brif v27, block2, block3
+;; @0022                               v16 = load.i64 notrap aligned readonly region0 v0+32
+;; @0022                               v17 = load.i32 user2 region1 v16
+;;                                     v99 = iconst.i32 7
+;; @0022                               v20 = uadd_overflow_trap v17, v99, user18  ; v99 = 7
+;;                                     v105 = iconst.i32 -8
+;; @0022                               v22 = band v20, v105  ; v105 = -8
+;; @0022                               v23 = uadd_overflow_trap v22, v12, user18
+;; @0022                               v86 = load.i64 notrap aligned readonly can_move v0+8
+;; @0022                               v25 = load.i64 notrap aligned v86+40
+;; @0022                               v24 = uextend.i64 v23
+;; @0022                               v26 = icmp ule v24, v25
+;; @0022                               brif v26, block2, block3
 ;;
 ;;                                 block2:
-;; @0022                               v34 = iconst.i32 -1476395008
-;;                                     v109 = bor.i32 v12, v34  ; v34 = -1476395008
-;; @0022                               v31 = load.i64 notrap aligned readonly can_move v89+32
-;;                                     v126 = band.i32 v21, v108  ; v108 = -8
-;;                                     v127 = uextend.i64 v126
-;; @0022                               v33 = iadd v31, v127
-;; @0022                               store user2 region1 v109, v33
-;; @0022                               v37 = load.i64 notrap aligned readonly can_move v0+40
-;; @0022                               v38 = load.i32 notrap aligned readonly can_move v37
-;; @0022                               store user2 region1 v38, v33+4
-;; @0022                               store.i32 user2 region1 v24, v17
+;; @0022                               v32 = iconst.i32 -1476395008
+;;                                     v106 = bor.i32 v12, v32  ; v32 = -1476395008
+;; @0022                               v29 = load.i64 notrap aligned readonly can_move v86+32
+;;                                     v123 = band.i32 v20, v105  ; v105 = -8
+;;                                     v124 = uextend.i64 v123
+;; @0022                               v31 = iadd v29, v124
+;; @0022                               store user2 region1 v106, v31
+;; @0022                               v34 = load.i64 notrap aligned readonly can_move v0+40
+;; @0022                               v35 = load.i32 notrap aligned readonly can_move v34
+;; @0022                               store user2 region1 v35, v31+4
+;; @0022                               store.i32 user2 region1 v23, v16
 ;; @0022                               v7 = iconst.i64 8
-;; @0022                               v40 = iadd v33, v7  ; v7 = 8
-;; @0022                               store.i32 user2 region1 v3, v40
-;; @0022                               trapz v126, user16
-;; @0022                               v68 = load.i64 notrap aligned v89+40
-;; @0022                               v58 = iconst.i64 16
-;; @0022                               v59 = iadd v33, v58  ; v58 = 16
-;; @0022                               v70 = uadd_overflow_trap v59, v92, user2
-;; @0022                               v69 = iadd v31, v68
-;; @0022                               v71 = icmp ugt v70, v69
-;; @0022                               trapnz v71, user2
-;;                                     v111 = iconst.i64 0
-;; @0022                               v74 = icmp.i64 eq v6, v111  ; v111 = 0
-;; @0022                               v72 = iadd v59, v92
-;; @0022                               brif v74, block5, block4(v59)
+;; @0022                               v37 = iadd v31, v7  ; v7 = 8
+;; @0022                               store.i32 user2 region1 v3, v37
+;; @0022                               trapz v123, user16
+;; @0022                               v65 = load.i64 notrap aligned v86+40
+;; @0022                               v55 = iconst.i64 16
+;; @0022                               v56 = iadd v31, v55  ; v55 = 16
+;; @0022                               v67 = uadd_overflow_trap v56, v89, user2
+;; @0022                               v66 = iadd v29, v65
+;; @0022                               v68 = icmp ugt v67, v66
+;; @0022                               trapnz v68, user2
+;;                                     v108 = iconst.i64 0
+;; @0022                               v71 = icmp.i64 eq v6, v108  ; v108 = 0
+;; @0022                               v69 = iadd v56, v89
+;; @0022                               brif v71, block5, block4(v56)
 ;;
-;;                                 block4(v75: i64):
-;; @0022                               store.i64 user2 little region1 v2, v75
-;;                                     v128 = iconst.i64 8
-;;                                     v129 = iadd v75, v128  ; v128 = 8
-;; @0022                               v78 = icmp eq v129, v72
-;; @0022                               brif v78, block5, block4(v129)
+;;                                 block4(v72: i64):
+;; @0022                               store.i64 user2 little region1 v2, v72
+;;                                     v125 = iconst.i64 8
+;;                                     v126 = iadd v72, v125  ; v125 = 8
+;; @0022                               v75 = icmp eq v126, v69
+;; @0022                               brif v75, block5, block4(v126)
 ;;
 ;;                                 block5:
 ;; @0025                               jump block1
 ;;
 ;;                                 block3 cold:
-;; @0022                               v29 = isub.i64 v25, v26
-;; @0022                               v30 = call fn0(v0, v29)
+;; @0022                               v27 = isub.i64 v24, v25
+;; @0022                               v28 = call fn0(v0, v27)
 ;; @0022                               jump block2
 ;;
 ;;                                 block1:
-;;                                     v130 = band.i32 v21, v108  ; v108 = -8
-;; @0025                               return v130
+;;                                     v127 = band.i32 v20, v105  ; v105 = -8
+;; @0025                               return v127
 ;; }

--- a/tests/disas/gc/null/br-on-cast-fail.wat
+++ b/tests/disas/gc/null/br-on-cast-fail.wat
@@ -36,35 +36,35 @@
 ;;                                 block3:
 ;; @002e                               v8 = iconst.i32 1
 ;; @002e                               v9 = band.i32 v2, v8  ; v8 = 1
-;;                                     v31 = iconst.i32 0
-;; @002e                               brif v9, block5(v31), block4  ; v31 = 0
+;;                                     v30 = iconst.i32 0
+;; @002e                               brif v9, block5(v30), block4  ; v30 = 0
 ;;
 ;;                                 block4:
-;; @002e                               v29 = load.i64 notrap aligned readonly can_move v0+8
-;; @002e                               v15 = load.i64 notrap aligned readonly can_move v29+32
-;; @002e                               v14 = uextend.i64 v2
-;; @002e                               v16 = iadd v15, v14
-;; @002e                               v17 = iconst.i64 4
-;; @002e                               v18 = iadd v16, v17  ; v17 = 4
-;; @002e                               v19 = load.i32 user2 readonly region0 v18
-;; @002e                               v12 = load.i64 notrap aligned readonly can_move v0+40
-;; @002e                               v13 = load.i32 notrap aligned readonly can_move v12
-;; @002e                               v20 = icmp eq v19, v13
-;; @002e                               v21 = uextend.i32 v20
-;; @002e                               jump block5(v21)
+;; @002e                               v28 = load.i64 notrap aligned readonly can_move v0+8
+;; @002e                               v14 = load.i64 notrap aligned readonly can_move v28+32
+;; @002e                               v13 = uextend.i64 v2
+;; @002e                               v15 = iadd v14, v13
+;; @002e                               v16 = iconst.i64 4
+;; @002e                               v17 = iadd v15, v16  ; v16 = 4
+;; @002e                               v18 = load.i32 user2 readonly region0 v17
+;; @002e                               v11 = load.i64 notrap aligned readonly can_move v0+40
+;; @002e                               v12 = load.i32 notrap aligned readonly can_move v11
+;; @002e                               v19 = icmp eq v18, v12
+;; @002e                               v20 = uextend.i32 v19
+;; @002e                               jump block5(v20)
 ;;
-;;                                 block5(v22: i32):
-;; @002e                               brif v22, block6, block2
+;;                                 block5(v21: i32):
+;; @002e                               brif v21, block6, block2
 ;;
 ;;                                 block6:
-;; @0034                               v25 = load.i64 notrap aligned readonly can_move v0+56
-;; @0034                               v24 = load.i64 notrap aligned readonly can_move v0+72
-;; @0034                               call_indirect sig0, v25(v24, v0)
+;; @0034                               v24 = load.i64 notrap aligned readonly can_move v0+56
+;; @0034                               v23 = load.i64 notrap aligned readonly can_move v0+72
+;; @0034                               call_indirect sig0, v24(v23, v0)
 ;; @0036                               return
 ;;
 ;;                                 block2:
-;; @0038                               v28 = load.i64 notrap aligned readonly can_move v0+88
-;; @0038                               v27 = load.i64 notrap aligned readonly can_move v0+104
-;; @0038                               call_indirect sig0, v28(v27, v0)
+;; @0038                               v27 = load.i64 notrap aligned readonly can_move v0+88
+;; @0038                               v26 = load.i64 notrap aligned readonly can_move v0+104
+;; @0038                               call_indirect sig0, v27(v26, v0)
 ;; @003a                               return
 ;; }

--- a/tests/disas/gc/null/br-on-cast.wat
+++ b/tests/disas/gc/null/br-on-cast.wat
@@ -36,35 +36,35 @@
 ;;                                 block3:
 ;; @002f                               v8 = iconst.i32 1
 ;; @002f                               v9 = band.i32 v2, v8  ; v8 = 1
-;;                                     v31 = iconst.i32 0
-;; @002f                               brif v9, block5(v31), block4  ; v31 = 0
+;;                                     v30 = iconst.i32 0
+;; @002f                               brif v9, block5(v30), block4  ; v30 = 0
 ;;
 ;;                                 block4:
-;; @002f                               v29 = load.i64 notrap aligned readonly can_move v0+8
-;; @002f                               v15 = load.i64 notrap aligned readonly can_move v29+32
-;; @002f                               v14 = uextend.i64 v2
-;; @002f                               v16 = iadd v15, v14
-;; @002f                               v17 = iconst.i64 4
-;; @002f                               v18 = iadd v16, v17  ; v17 = 4
-;; @002f                               v19 = load.i32 user2 readonly region0 v18
-;; @002f                               v12 = load.i64 notrap aligned readonly can_move v0+40
-;; @002f                               v13 = load.i32 notrap aligned readonly can_move v12
-;; @002f                               v20 = icmp eq v19, v13
-;; @002f                               v21 = uextend.i32 v20
-;; @002f                               jump block5(v21)
+;; @002f                               v28 = load.i64 notrap aligned readonly can_move v0+8
+;; @002f                               v14 = load.i64 notrap aligned readonly can_move v28+32
+;; @002f                               v13 = uextend.i64 v2
+;; @002f                               v15 = iadd v14, v13
+;; @002f                               v16 = iconst.i64 4
+;; @002f                               v17 = iadd v15, v16  ; v16 = 4
+;; @002f                               v18 = load.i32 user2 readonly region0 v17
+;; @002f                               v11 = load.i64 notrap aligned readonly can_move v0+40
+;; @002f                               v12 = load.i32 notrap aligned readonly can_move v11
+;; @002f                               v19 = icmp eq v18, v12
+;; @002f                               v20 = uextend.i32 v19
+;; @002f                               jump block5(v20)
 ;;
-;;                                 block5(v22: i32):
-;; @002f                               brif v22, block2, block6
+;;                                 block5(v21: i32):
+;; @002f                               brif v21, block2, block6
 ;;
 ;;                                 block6:
-;; @0035                               v25 = load.i64 notrap aligned readonly can_move v0+56
-;; @0035                               v24 = load.i64 notrap aligned readonly can_move v0+72
-;; @0035                               call_indirect sig0, v25(v24, v0)
+;; @0035                               v24 = load.i64 notrap aligned readonly can_move v0+56
+;; @0035                               v23 = load.i64 notrap aligned readonly can_move v0+72
+;; @0035                               call_indirect sig0, v24(v23, v0)
 ;; @0037                               return
 ;;
 ;;                                 block2:
-;; @0039                               v28 = load.i64 notrap aligned readonly can_move v0+88
-;; @0039                               v27 = load.i64 notrap aligned readonly can_move v0+104
-;; @0039                               call_indirect sig0, v28(v27, v0)
+;; @0039                               v27 = load.i64 notrap aligned readonly can_move v0+88
+;; @0039                               v26 = load.i64 notrap aligned readonly can_move v0+104
+;; @0039                               call_indirect sig0, v27(v26, v0)
 ;; @003b                               return
 ;; }

--- a/tests/disas/gc/null/call-indirect-and-subtyping.wat
+++ b/tests/disas/gc/null/call-indirect-and-subtyping.wat
@@ -47,26 +47,26 @@
 ;;
 ;;                                 block2 cold:
 ;; @005c                               v16 = iconst.i32 0
-;; @005c                               v19 = call fn0(v0, v16, v5)  ; v16 = 0
-;; @005c                               jump block3(v19)
+;; @005c                               v18 = call fn0(v0, v16, v5)  ; v16 = 0
+;; @005c                               jump block3(v18)
 ;;
 ;;                                 block3(v15: i64):
-;; @005c                               v23 = load.i32 user7 aligned readonly v15+16
-;; @005c                               v21 = load.i64 notrap aligned readonly can_move v0+40
-;; @005c                               v22 = load.i32 notrap aligned readonly can_move v21
-;; @005c                               v24 = icmp eq v23, v22
-;; @005c                               v25 = uextend.i32 v24
-;; @005c                               brif v24, block5(v25), block4
+;; @005c                               v21 = load.i32 user7 aligned readonly v15+16
+;; @005c                               v19 = load.i64 notrap aligned readonly can_move v0+40
+;; @005c                               v20 = load.i32 notrap aligned readonly can_move v19
+;; @005c                               v22 = icmp eq v21, v20
+;; @005c                               v23 = uextend.i32 v22
+;; @005c                               brif v22, block5(v23), block4
 ;;
 ;;                                 block4:
-;; @005c                               v27 = call fn1(v0, v23, v22)
-;; @005c                               jump block5(v27)
+;; @005c                               v24 = call fn1(v0, v21, v20)
+;; @005c                               jump block5(v24)
 ;;
-;;                                 block5(v28: i32):
-;; @005c                               trapz v28, user8
-;; @005c                               v29 = load.i64 notrap aligned readonly v15+8
-;; @005c                               v30 = load.i64 notrap aligned readonly v15+24
-;; @005c                               call_indirect sig0, v29(v30, v0)
+;;                                 block5(v25: i32):
+;; @005c                               trapz v25, user8
+;; @005c                               v26 = load.i64 notrap aligned readonly v15+8
+;; @005c                               v27 = load.i64 notrap aligned readonly v15+24
+;; @005c                               call_indirect sig0, v26(v27, v0)
 ;; @005f                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/null/funcref-in-gc-heap-get.wat
+++ b/tests/disas/gc/null/funcref-in-gc-heap-get.wat
@@ -24,17 +24,17 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0020                               trapz v2, user16
-;; @0020                               v13 = load.i64 notrap aligned readonly can_move v0+8
-;; @0020                               v5 = load.i64 notrap aligned readonly can_move v13+32
+;; @0020                               v12 = load.i64 notrap aligned readonly can_move v0+8
+;; @0020                               v5 = load.i64 notrap aligned readonly can_move v12+32
 ;; @0020                               v4 = uextend.i64 v2
 ;; @0020                               v6 = iadd v5, v4
 ;; @0020                               v7 = iconst.i64 8
 ;; @0020                               v8 = iadd v6, v7  ; v7 = 8
-;; @0020                               v11 = load.i32 user2 little region0 v8
+;; @0020                               v10 = load.i32 user2 little region0 v8
 ;; @0020                               v9 = iconst.i32 -1
-;; @0020                               v12 = call fn0(v0, v11, v9)  ; v9 = -1
+;; @0020                               v11 = call fn0(v0, v10, v9)  ; v9 = -1
 ;; @0024                               jump block1
 ;;
 ;;                                 block1:
-;; @0024                               return v12
+;; @0024                               return v11
 ;; }

--- a/tests/disas/gc/null/funcref-in-gc-heap-new.wat
+++ b/tests/disas/gc/null/funcref-in-gc-heap-new.wat
@@ -26,44 +26,44 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0020                               v9 = load.i64 notrap aligned readonly region0 v0+32
-;; @0020                               v10 = load.i32 user2 region1 v9
-;;                                     v46 = iconst.i32 7
-;; @0020                               v13 = uadd_overflow_trap v10, v46, user18  ; v46 = 7
-;;                                     v52 = iconst.i32 -8
-;; @0020                               v15 = band v13, v52  ; v52 = -8
+;; @0020                               v8 = load.i64 notrap aligned readonly region0 v0+32
+;; @0020                               v9 = load.i32 user2 region1 v8
+;;                                     v42 = iconst.i32 7
+;; @0020                               v12 = uadd_overflow_trap v9, v42, user18  ; v42 = 7
+;;                                     v48 = iconst.i32 -8
+;; @0020                               v14 = band v12, v48  ; v48 = -8
 ;; @0020                               v4 = iconst.i32 16
-;; @0020                               v16 = uadd_overflow_trap v15, v4, user18  ; v4 = 16
-;; @0020                               v38 = load.i64 notrap aligned readonly can_move v0+8
-;; @0020                               v18 = load.i64 notrap aligned v38+40
-;; @0020                               v17 = uextend.i64 v16
-;; @0020                               v19 = icmp ule v17, v18
-;; @0020                               brif v19, block2, block3
+;; @0020                               v15 = uadd_overflow_trap v14, v4, user18  ; v4 = 16
+;; @0020                               v34 = load.i64 notrap aligned readonly can_move v0+8
+;; @0020                               v17 = load.i64 notrap aligned v34+40
+;; @0020                               v16 = uextend.i64 v15
+;; @0020                               v18 = icmp ule v16, v17
+;; @0020                               brif v18, block2, block3
 ;;
 ;;                                 block2:
-;;                                     v53 = iconst.i32 -1342177264
-;; @0020                               v23 = load.i64 notrap aligned readonly can_move v38+32
-;;                                     v59 = band.i32 v13, v52  ; v52 = -8
-;;                                     v60 = uextend.i64 v59
-;; @0020                               v25 = iadd v23, v60
-;; @0020                               store user2 region1 v53, v25  ; v53 = -1342177264
-;; @0020                               v29 = load.i64 notrap aligned readonly can_move v0+40
-;; @0020                               v30 = load.i32 notrap aligned readonly can_move v29
-;; @0020                               store user2 region1 v30, v25+4
-;; @0020                               store.i32 user2 region1 v16, v9
-;; @0020                               v34 = call fn1(v0, v2)
-;; @0020                               v35 = ireduce.i32 v34
-;; @0020                               v31 = iconst.i64 8
-;; @0020                               v32 = iadd v25, v31  ; v31 = 8
-;; @0020                               store user2 little region1 v35, v32
+;;                                     v49 = iconst.i32 -1342177264
+;; @0020                               v21 = load.i64 notrap aligned readonly can_move v34+32
+;;                                     v55 = band.i32 v12, v48  ; v48 = -8
+;;                                     v56 = uextend.i64 v55
+;; @0020                               v23 = iadd v21, v56
+;; @0020                               store user2 region1 v49, v23  ; v49 = -1342177264
+;; @0020                               v26 = load.i64 notrap aligned readonly can_move v0+40
+;; @0020                               v27 = load.i32 notrap aligned readonly can_move v26
+;; @0020                               store user2 region1 v27, v23+4
+;; @0020                               store.i32 user2 region1 v15, v8
+;; @0020                               v30 = call fn1(v0, v2)
+;; @0020                               v31 = ireduce.i32 v30
+;; @0020                               v28 = iconst.i64 8
+;; @0020                               v29 = iadd v23, v28  ; v28 = 8
+;; @0020                               store user2 little region1 v31, v29
 ;; @0023                               jump block1
 ;;
 ;;                                 block3 cold:
-;; @0020                               v21 = isub.i64 v17, v18
-;; @0020                               v22 = call fn0(v0, v21)
+;; @0020                               v19 = isub.i64 v16, v17
+;; @0020                               v20 = call fn0(v0, v19)
 ;; @0020                               jump block2
 ;;
 ;;                                 block1:
-;;                                     v61 = band.i32 v13, v52  ; v52 = -8
-;; @0023                               return v61
+;;                                     v57 = band.i32 v12, v48  ; v48 = -8
+;; @0023                               return v57
 ;; }

--- a/tests/disas/gc/null/funcref-in-gc-heap-set.wat
+++ b/tests/disas/gc/null/funcref-in-gc-heap-set.wat
@@ -24,15 +24,15 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i64):
 ;; @0022                               trapz v2, user16
-;; @0022                               v10 = call fn0(v0, v3)
-;; @0022                               v11 = ireduce.i32 v10
-;; @0022                               v12 = load.i64 notrap aligned readonly can_move v0+8
-;; @0022                               v5 = load.i64 notrap aligned readonly can_move v12+32
+;; @0022                               v9 = call fn0(v0, v3)
+;; @0022                               v10 = ireduce.i32 v9
+;; @0022                               v11 = load.i64 notrap aligned readonly can_move v0+8
+;; @0022                               v5 = load.i64 notrap aligned readonly can_move v11+32
 ;; @0022                               v4 = uextend.i64 v2
 ;; @0022                               v6 = iadd v5, v4
 ;; @0022                               v7 = iconst.i64 8
 ;; @0022                               v8 = iadd v6, v7  ; v7 = 8
-;; @0022                               store user2 little region0 v11, v8
+;; @0022                               store user2 little region0 v10, v8
 ;; @0026                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/null/ref-cast.wat
+++ b/tests/disas/gc/null/ref-cast.wat
@@ -27,25 +27,25 @@
 ;;                                 block2:
 ;; @001e                               v8 = iconst.i32 1
 ;; @001e                               v9 = band.i32 v2, v8  ; v8 = 1
-;;                                     v25 = iconst.i32 0
-;; @001e                               brif v9, block4(v25), block3  ; v25 = 0
+;;                                     v24 = iconst.i32 0
+;; @001e                               brif v9, block4(v24), block3  ; v24 = 0
 ;;
 ;;                                 block3:
-;; @001e                               v23 = load.i64 notrap aligned readonly can_move v0+8
-;; @001e                               v15 = load.i64 notrap aligned readonly can_move v23+32
-;; @001e                               v14 = uextend.i64 v2
-;; @001e                               v16 = iadd v15, v14
-;; @001e                               v17 = iconst.i64 4
-;; @001e                               v18 = iadd v16, v17  ; v17 = 4
-;; @001e                               v19 = load.i32 user2 readonly region0 v18
-;; @001e                               v12 = load.i64 notrap aligned readonly can_move v0+40
-;; @001e                               v13 = load.i32 notrap aligned readonly can_move v12
-;; @001e                               v20 = icmp eq v19, v13
-;; @001e                               v21 = uextend.i32 v20
-;; @001e                               jump block4(v21)
+;; @001e                               v22 = load.i64 notrap aligned readonly can_move v0+8
+;; @001e                               v14 = load.i64 notrap aligned readonly can_move v22+32
+;; @001e                               v13 = uextend.i64 v2
+;; @001e                               v15 = iadd v14, v13
+;; @001e                               v16 = iconst.i64 4
+;; @001e                               v17 = iadd v15, v16  ; v16 = 4
+;; @001e                               v18 = load.i32 user2 readonly region0 v17
+;; @001e                               v11 = load.i64 notrap aligned readonly can_move v0+40
+;; @001e                               v12 = load.i32 notrap aligned readonly can_move v11
+;; @001e                               v19 = icmp eq v18, v12
+;; @001e                               v20 = uextend.i32 v19
+;; @001e                               jump block4(v20)
 ;;
-;;                                 block4(v22: i32):
-;; @001e                               trapz v22, user19
+;;                                 block4(v21: i32):
+;; @001e                               trapz v21, user19
 ;; @0021                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/null/ref-test-concrete-func-type.wat
+++ b/tests/disas/gc/null/ref-test-concrete-func-type.wat
@@ -13,7 +13,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
@@ -26,15 +25,15 @@
 ;; @0020                               jump block3
 ;;
 ;;                                 block3:
-;; @0020                               v11 = load.i32 user2 readonly region0 v2+16
-;; @0020                               v9 = load.i64 notrap aligned readonly can_move v0+40
-;; @0020                               v10 = load.i32 notrap aligned readonly can_move v9
-;; @0020                               v12 = icmp eq v11, v10
-;; @0020                               v13 = uextend.i32 v12
-;; @0020                               jump block4(v13)
+;; @0020                               v10 = load.i32 user2 readonly region0 v2+16
+;; @0020                               v8 = load.i64 notrap aligned readonly can_move v0+40
+;; @0020                               v9 = load.i32 notrap aligned readonly can_move v8
+;; @0020                               v11 = icmp eq v10, v9
+;; @0020                               v12 = uextend.i32 v11
+;; @0020                               jump block4(v12)
 ;;
-;;                                 block4(v14: i32):
-;; @0023                               jump block1(v14)
+;;                                 block4(v13: i32):
+;; @0023                               jump block1(v13)
 ;;
 ;;                                 block1(v3: i32):
 ;; @0023                               return v3

--- a/tests/disas/gc/null/ref-test-concrete-type.wat
+++ b/tests/disas/gc/null/ref-test-concrete-type.wat
@@ -27,25 +27,25 @@
 ;;                                 block2:
 ;; @001d                               v8 = iconst.i32 1
 ;; @001d                               v9 = band.i32 v2, v8  ; v8 = 1
-;;                                     v25 = iconst.i32 0
-;; @001d                               brif v9, block4(v25), block3  ; v25 = 0
+;;                                     v24 = iconst.i32 0
+;; @001d                               brif v9, block4(v24), block3  ; v24 = 0
 ;;
 ;;                                 block3:
-;; @001d                               v23 = load.i64 notrap aligned readonly can_move v0+8
-;; @001d                               v15 = load.i64 notrap aligned readonly can_move v23+32
-;; @001d                               v14 = uextend.i64 v2
-;; @001d                               v16 = iadd v15, v14
-;; @001d                               v17 = iconst.i64 4
-;; @001d                               v18 = iadd v16, v17  ; v17 = 4
-;; @001d                               v19 = load.i32 user2 readonly region0 v18
-;; @001d                               v12 = load.i64 notrap aligned readonly can_move v0+40
-;; @001d                               v13 = load.i32 notrap aligned readonly can_move v12
-;; @001d                               v20 = icmp eq v19, v13
-;; @001d                               v21 = uextend.i32 v20
-;; @001d                               jump block4(v21)
+;; @001d                               v22 = load.i64 notrap aligned readonly can_move v0+8
+;; @001d                               v14 = load.i64 notrap aligned readonly can_move v22+32
+;; @001d                               v13 = uextend.i64 v2
+;; @001d                               v15 = iadd v14, v13
+;; @001d                               v16 = iconst.i64 4
+;; @001d                               v17 = iadd v15, v16  ; v16 = 4
+;; @001d                               v18 = load.i32 user2 readonly region0 v17
+;; @001d                               v11 = load.i64 notrap aligned readonly can_move v0+40
+;; @001d                               v12 = load.i32 notrap aligned readonly can_move v11
+;; @001d                               v19 = icmp eq v18, v12
+;; @001d                               v20 = uextend.i32 v19
+;; @001d                               jump block4(v20)
 ;;
-;;                                 block4(v22: i32):
-;; @0020                               jump block1(v22)
+;;                                 block4(v21: i32):
+;; @0020                               jump block1(v21)
 ;;
 ;;                                 block1(v3: i32):
 ;; @0020                               return v3

--- a/tests/disas/gc/null/struct-new-default.wat
+++ b/tests/disas/gc/null/struct-new-default.wat
@@ -26,50 +26,50 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @0021                               v11 = load.i64 notrap aligned readonly region0 v0+32
-;; @0021                               v12 = load.i32 user2 region1 v11
-;;                                     v48 = iconst.i32 7
-;; @0021                               v15 = uadd_overflow_trap v12, v48, user18  ; v48 = 7
-;;                                     v54 = iconst.i32 -8
-;; @0021                               v17 = band v15, v54  ; v54 = -8
+;; @0021                               v10 = load.i64 notrap aligned readonly region0 v0+32
+;; @0021                               v11 = load.i32 user2 region1 v10
+;;                                     v45 = iconst.i32 7
+;; @0021                               v14 = uadd_overflow_trap v11, v45, user18  ; v45 = 7
+;;                                     v51 = iconst.i32 -8
+;; @0021                               v16 = band v14, v51  ; v51 = -8
 ;; @0021                               v6 = iconst.i32 24
-;; @0021                               v18 = uadd_overflow_trap v17, v6, user18  ; v6 = 24
-;; @0021                               v41 = load.i64 notrap aligned readonly can_move v0+8
-;; @0021                               v20 = load.i64 notrap aligned v41+40
-;; @0021                               v19 = uextend.i64 v18
-;; @0021                               v21 = icmp ule v19, v20
-;; @0021                               brif v21, block2, block3
+;; @0021                               v17 = uadd_overflow_trap v16, v6, user18  ; v6 = 24
+;; @0021                               v38 = load.i64 notrap aligned readonly can_move v0+8
+;; @0021                               v19 = load.i64 notrap aligned v38+40
+;; @0021                               v18 = uextend.i64 v17
+;; @0021                               v20 = icmp ule v18, v19
+;; @0021                               brif v20, block2, block3
 ;;
 ;;                                 block2:
-;;                                     v55 = iconst.i32 -1342177256
-;; @0021                               v25 = load.i64 notrap aligned readonly can_move v41+32
-;;                                     v61 = band.i32 v15, v54  ; v54 = -8
-;;                                     v62 = uextend.i64 v61
-;; @0021                               v27 = iadd v25, v62
-;; @0021                               store user2 region1 v55, v27  ; v55 = -1342177256
-;; @0021                               v31 = load.i64 notrap aligned readonly can_move v0+40
-;; @0021                               v32 = load.i32 notrap aligned readonly can_move v31
-;; @0021                               store user2 region1 v32, v27+4
-;; @0021                               store.i32 user2 region1 v18, v11
+;;                                     v52 = iconst.i32 -1342177256
+;; @0021                               v23 = load.i64 notrap aligned readonly can_move v38+32
+;;                                     v58 = band.i32 v14, v51  ; v51 = -8
+;;                                     v59 = uextend.i64 v58
+;; @0021                               v25 = iadd v23, v59
+;; @0021                               store user2 region1 v52, v25  ; v52 = -1342177256
+;; @0021                               v28 = load.i64 notrap aligned readonly can_move v0+40
+;; @0021                               v29 = load.i32 notrap aligned readonly can_move v28
+;; @0021                               store user2 region1 v29, v25+4
+;; @0021                               store.i32 user2 region1 v17, v10
 ;; @0021                               v3 = f32const 0.0
-;; @0021                               v33 = iconst.i64 8
-;; @0021                               v34 = iadd v27, v33  ; v33 = 8
-;; @0021                               store user2 little region1 v3, v34  ; v3 = 0.0
+;; @0021                               v30 = iconst.i64 8
+;; @0021                               v31 = iadd v25, v30  ; v30 = 8
+;; @0021                               store user2 little region1 v3, v31  ; v3 = 0.0
 ;; @0021                               v4 = iconst.i32 0
-;; @0021                               v35 = iconst.i64 12
-;; @0021                               v36 = iadd v27, v35  ; v35 = 12
-;; @0021                               istore8 user2 little region1 v4, v36  ; v4 = 0
-;; @0021                               v37 = iconst.i64 16
-;; @0021                               v38 = iadd v27, v37  ; v37 = 16
-;; @0021                               store user2 little region1 v4, v38  ; v4 = 0
+;; @0021                               v32 = iconst.i64 12
+;; @0021                               v33 = iadd v25, v32  ; v32 = 12
+;; @0021                               istore8 user2 little region1 v4, v33  ; v4 = 0
+;; @0021                               v34 = iconst.i64 16
+;; @0021                               v35 = iadd v25, v34  ; v34 = 16
+;; @0021                               store user2 little region1 v4, v35  ; v4 = 0
 ;; @0024                               jump block1
 ;;
 ;;                                 block3 cold:
-;; @0021                               v23 = isub.i64 v19, v20
-;; @0021                               v24 = call fn0(v0, v23)
+;; @0021                               v21 = isub.i64 v18, v19
+;; @0021                               v22 = call fn0(v0, v21)
 ;; @0021                               jump block2
 ;;
 ;;                                 block1:
-;;                                     v63 = band.i32 v15, v54  ; v54 = -8
-;; @0024                               return v63
+;;                                     v60 = band.i32 v14, v51  ; v51 = -8
+;; @0024                               return v60
 ;; }

--- a/tests/disas/gc/null/struct-new.wat
+++ b/tests/disas/gc/null/struct-new.wat
@@ -27,51 +27,51 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: f32, v3: i32, v4: i32):
-;;                                     v41 = stack_addr.i64 ss0
-;;                                     store notrap v4, v41
-;; @002a                               v11 = load.i64 notrap aligned readonly region0 v0+32
-;; @002a                               v12 = load.i32 user2 region1 v11
-;;                                     v52 = iconst.i32 7
-;; @002a                               v15 = uadd_overflow_trap v12, v52, user18  ; v52 = 7
-;;                                     v58 = iconst.i32 -8
-;; @002a                               v17 = band v15, v58  ; v58 = -8
+;;                                     v38 = stack_addr.i64 ss0
+;;                                     store notrap v4, v38
+;; @002a                               v10 = load.i64 notrap aligned readonly region0 v0+32
+;; @002a                               v11 = load.i32 user2 region1 v10
+;;                                     v49 = iconst.i32 7
+;; @002a                               v14 = uadd_overflow_trap v11, v49, user18  ; v49 = 7
+;;                                     v55 = iconst.i32 -8
+;; @002a                               v16 = band v14, v55  ; v55 = -8
 ;; @002a                               v6 = iconst.i32 24
-;; @002a                               v18 = uadd_overflow_trap v17, v6, user18  ; v6 = 24
-;; @002a                               v44 = load.i64 notrap aligned readonly can_move v0+8
-;; @002a                               v20 = load.i64 notrap aligned v44+40
-;; @002a                               v19 = uextend.i64 v18
-;; @002a                               v21 = icmp ule v19, v20
-;; @002a                               brif v21, block2, block3
+;; @002a                               v17 = uadd_overflow_trap v16, v6, user18  ; v6 = 24
+;; @002a                               v41 = load.i64 notrap aligned readonly can_move v0+8
+;; @002a                               v19 = load.i64 notrap aligned v41+40
+;; @002a                               v18 = uextend.i64 v17
+;; @002a                               v20 = icmp ule v18, v19
+;; @002a                               brif v20, block2, block3
 ;;
 ;;                                 block2:
-;;                                     v59 = iconst.i32 -1342177256
-;; @002a                               v25 = load.i64 notrap aligned readonly can_move v44+32
-;;                                     v65 = band.i32 v15, v58  ; v58 = -8
-;;                                     v66 = uextend.i64 v65
-;; @002a                               v27 = iadd v25, v66
-;; @002a                               store user2 region1 v59, v27  ; v59 = -1342177256
-;; @002a                               v31 = load.i64 notrap aligned readonly can_move v0+40
-;; @002a                               v32 = load.i32 notrap aligned readonly can_move v31
-;; @002a                               store user2 region1 v32, v27+4
-;; @002a                               store.i32 user2 region1 v18, v11
-;; @002a                               v33 = iconst.i64 8
-;; @002a                               v34 = iadd v27, v33  ; v33 = 8
-;; @002a                               store.f32 user2 little region1 v2, v34
-;; @002a                               v35 = iconst.i64 12
-;; @002a                               v36 = iadd v27, v35  ; v35 = 12
-;; @002a                               istore8.i32 user2 little region1 v3, v36
-;;                                     v40 = load.i32 notrap v41
-;; @002a                               v37 = iconst.i64 16
-;; @002a                               v38 = iadd v27, v37  ; v37 = 16
-;; @002a                               store user2 little region1 v40, v38
+;;                                     v56 = iconst.i32 -1342177256
+;; @002a                               v23 = load.i64 notrap aligned readonly can_move v41+32
+;;                                     v62 = band.i32 v14, v55  ; v55 = -8
+;;                                     v63 = uextend.i64 v62
+;; @002a                               v25 = iadd v23, v63
+;; @002a                               store user2 region1 v56, v25  ; v56 = -1342177256
+;; @002a                               v28 = load.i64 notrap aligned readonly can_move v0+40
+;; @002a                               v29 = load.i32 notrap aligned readonly can_move v28
+;; @002a                               store user2 region1 v29, v25+4
+;; @002a                               store.i32 user2 region1 v17, v10
+;; @002a                               v30 = iconst.i64 8
+;; @002a                               v31 = iadd v25, v30  ; v30 = 8
+;; @002a                               store.f32 user2 little region1 v2, v31
+;; @002a                               v32 = iconst.i64 12
+;; @002a                               v33 = iadd v25, v32  ; v32 = 12
+;; @002a                               istore8.i32 user2 little region1 v3, v33
+;;                                     v37 = load.i32 notrap v38
+;; @002a                               v34 = iconst.i64 16
+;; @002a                               v35 = iadd v25, v34  ; v34 = 16
+;; @002a                               store user2 little region1 v37, v35
 ;; @002d                               jump block1
 ;;
 ;;                                 block3 cold:
-;; @002a                               v23 = isub.i64 v19, v20
-;; @002a                               v24 = call fn0(v0, v23), stack_map=[i32 @ ss0+0]
+;; @002a                               v21 = isub.i64 v18, v19
+;; @002a                               v22 = call fn0(v0, v21), stack_map=[i32 @ ss0+0]
 ;; @002a                               jump block2
 ;;
 ;;                                 block1:
-;;                                     v67 = band.i32 v15, v58  ; v58 = -8
-;; @002d                               return v67
+;;                                     v64 = band.i32 v14, v55  ; v55 = -8
+;; @002d                               return v64
 ;; }

--- a/tests/disas/gc/ref-test-cast-final-type.wat
+++ b/tests/disas/gc/ref-test-cast-final-type.wat
@@ -33,25 +33,25 @@
 ;;                                 block2:
 ;; @0024                               v8 = iconst.i32 1
 ;; @0024                               v9 = band.i32 v2, v8  ; v8 = 1
-;;                                     v25 = iconst.i32 0
-;; @0024                               brif v9, block4(v25), block3  ; v25 = 0
+;;                                     v24 = iconst.i32 0
+;; @0024                               brif v9, block4(v24), block3  ; v24 = 0
 ;;
 ;;                                 block3:
-;; @0024                               v23 = load.i64 notrap aligned readonly can_move v0+8
-;; @0024                               v15 = load.i64 notrap aligned readonly can_move v23+32
-;; @0024                               v14 = uextend.i64 v2
-;; @0024                               v16 = iadd v15, v14
-;; @0024                               v17 = iconst.i64 4
-;; @0024                               v18 = iadd v16, v17  ; v17 = 4
-;; @0024                               v19 = load.i32 user2 readonly region0 v18
-;; @0024                               v12 = load.i64 notrap aligned readonly can_move v0+40
-;; @0024                               v13 = load.i32 notrap aligned readonly can_move v12
-;; @0024                               v20 = icmp eq v19, v13
-;; @0024                               v21 = uextend.i32 v20
-;; @0024                               jump block4(v21)
+;; @0024                               v22 = load.i64 notrap aligned readonly can_move v0+8
+;; @0024                               v14 = load.i64 notrap aligned readonly can_move v22+32
+;; @0024                               v13 = uextend.i64 v2
+;; @0024                               v15 = iadd v14, v13
+;; @0024                               v16 = iconst.i64 4
+;; @0024                               v17 = iadd v15, v16  ; v16 = 4
+;; @0024                               v18 = load.i32 user2 readonly region0 v17
+;; @0024                               v11 = load.i64 notrap aligned readonly can_move v0+40
+;; @0024                               v12 = load.i32 notrap aligned readonly can_move v11
+;; @0024                               v19 = icmp eq v18, v12
+;; @0024                               v20 = uextend.i32 v19
+;; @0024                               jump block4(v20)
 ;;
-;;                                 block4(v22: i32):
-;; @0027                               jump block1(v22)
+;;                                 block4(v21: i32):
+;; @0027                               jump block1(v21)
 ;;
 ;;                                 block1(v3: i32):
 ;; @0027                               return v3
@@ -76,25 +76,25 @@
 ;;                                 block2:
 ;; @002c                               v8 = iconst.i32 1
 ;; @002c                               v9 = band.i32 v2, v8  ; v8 = 1
-;;                                     v25 = iconst.i32 0
-;; @002c                               brif v9, block4(v25), block3  ; v25 = 0
+;;                                     v24 = iconst.i32 0
+;; @002c                               brif v9, block4(v24), block3  ; v24 = 0
 ;;
 ;;                                 block3:
-;; @002c                               v23 = load.i64 notrap aligned readonly can_move v0+8
-;; @002c                               v15 = load.i64 notrap aligned readonly can_move v23+32
-;; @002c                               v14 = uextend.i64 v2
-;; @002c                               v16 = iadd v15, v14
-;; @002c                               v17 = iconst.i64 4
-;; @002c                               v18 = iadd v16, v17  ; v17 = 4
-;; @002c                               v19 = load.i32 user2 readonly region0 v18
-;; @002c                               v12 = load.i64 notrap aligned readonly can_move v0+40
-;; @002c                               v13 = load.i32 notrap aligned readonly can_move v12
-;; @002c                               v20 = icmp eq v19, v13
-;; @002c                               v21 = uextend.i32 v20
-;; @002c                               jump block4(v21)
+;; @002c                               v22 = load.i64 notrap aligned readonly can_move v0+8
+;; @002c                               v14 = load.i64 notrap aligned readonly can_move v22+32
+;; @002c                               v13 = uextend.i64 v2
+;; @002c                               v15 = iadd v14, v13
+;; @002c                               v16 = iconst.i64 4
+;; @002c                               v17 = iadd v15, v16  ; v16 = 4
+;; @002c                               v18 = load.i32 user2 readonly region0 v17
+;; @002c                               v11 = load.i64 notrap aligned readonly can_move v0+40
+;; @002c                               v12 = load.i32 notrap aligned readonly can_move v11
+;; @002c                               v19 = icmp eq v18, v12
+;; @002c                               v20 = uextend.i32 v19
+;; @002c                               jump block4(v20)
 ;;
-;;                                 block4(v22: i32):
-;; @002c                               trapz v22, user19
+;;                                 block4(v21: i32):
+;; @002c                               trapz v21, user19
 ;; @002f                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/struct-new-default.wat
+++ b/tests/disas/gc/struct-new-default.wat
@@ -27,62 +27,62 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @0023                               v9 = load.i64 notrap aligned readonly can_move v0+32
-;; @0023                               v10 = load.i32 notrap aligned v9
-;; @0023                               v11 = load.i32 notrap aligned v9+4
-;; @0023                               v17 = uextend.i64 v10
-;;                                     v53 = iconst.i64 48
-;; @0023                               v18 = iadd v17, v53  ; v53 = 48
-;; @0023                               v19 = uextend.i64 v11
-;; @0023                               v20 = icmp ule v18, v19
-;; @0023                               brif v20, block2, block3
+;; @0023                               v8 = load.i64 notrap aligned readonly can_move v0+32
+;; @0023                               v9 = load.i32 notrap aligned v8
+;; @0023                               v10 = load.i32 notrap aligned v8+4
+;; @0023                               v16 = uextend.i64 v9
+;;                                     v49 = iconst.i64 48
+;; @0023                               v17 = iadd v16, v49  ; v49 = 48
+;; @0023                               v18 = uextend.i64 v10
+;; @0023                               v19 = icmp ule v17, v18
+;; @0023                               brif v19, block2, block3
 ;;
 ;;                                 block2:
-;;                                     v69 = iconst.i32 48
-;;                                     v67 = iadd.i32 v10, v69  ; v69 = 48
-;; @0023                               store notrap aligned region0 v67, v9
-;;                                     v70 = iconst.i32 -1342177246
-;;                                     v71 = load.i64 notrap aligned readonly can_move v0+8
-;;                                     v72 = load.i64 notrap aligned readonly can_move v71+32
-;; @0023                               v34 = iadd v72, v17
-;; @0023                               store notrap aligned v70, v34  ; v70 = -1342177246
-;;                                     v73 = load.i64 notrap aligned readonly can_move v0+40
-;;                                     v74 = load.i32 notrap aligned readonly can_move v73
-;; @0023                               store notrap aligned v74, v34+4
-;;                                     v75 = iconst.i64 48
-;; @0023                               istore32 notrap aligned v75, v34+8  ; v75 = 48
-;; @0023                               jump block4(v10, v34)
+;;                                     v65 = iconst.i32 48
+;;                                     v63 = iadd.i32 v9, v65  ; v65 = 48
+;; @0023                               store notrap aligned region0 v63, v8
+;;                                     v66 = iconst.i32 -1342177246
+;;                                     v67 = load.i64 notrap aligned readonly can_move v0+8
+;;                                     v68 = load.i64 notrap aligned readonly can_move v67+32
+;; @0023                               v31 = iadd v68, v16
+;; @0023                               store notrap aligned v66, v31  ; v66 = -1342177246
+;;                                     v69 = load.i64 notrap aligned readonly can_move v0+40
+;;                                     v70 = load.i32 notrap aligned readonly can_move v69
+;; @0023                               store notrap aligned v70, v31+4
+;;                                     v71 = iconst.i64 48
+;; @0023                               istore32 notrap aligned v71, v31+8  ; v71 = 48
+;; @0023                               jump block4(v9, v31)
 ;;
 ;;                                 block3 cold:
-;; @0023                               v22 = iconst.i32 -1342177246
-;; @0023                               v24 = load.i64 notrap aligned readonly can_move v0+40
-;; @0023                               v25 = load.i32 notrap aligned readonly can_move v24
+;; @0023                               v20 = iconst.i32 -1342177246
+;; @0023                               v21 = load.i64 notrap aligned readonly can_move v0+40
+;; @0023                               v22 = load.i32 notrap aligned readonly can_move v21
 ;; @0023                               v7 = iconst.i32 48
-;; @0023                               v26 = iconst.i32 16
-;; @0023                               v27 = call fn0(v0, v22, v25, v7, v26)  ; v22 = -1342177246, v7 = 48, v26 = 16
-;; @0023                               v49 = load.i64 notrap aligned readonly can_move v0+8
-;; @0023                               v28 = load.i64 notrap aligned readonly can_move v49+32
-;; @0023                               v29 = uextend.i64 v27
-;; @0023                               v30 = iadd v28, v29
-;; @0023                               jump block4(v27, v30)
+;; @0023                               v23 = iconst.i32 16
+;; @0023                               v24 = call fn0(v0, v20, v22, v7, v23)  ; v20 = -1342177246, v7 = 48, v23 = 16
+;; @0023                               v45 = load.i64 notrap aligned readonly can_move v0+8
+;; @0023                               v25 = load.i64 notrap aligned readonly can_move v45+32
+;; @0023                               v26 = uextend.i64 v24
+;; @0023                               v27 = iadd v25, v26
+;; @0023                               jump block4(v24, v27)
 ;;
-;;                                 block4(v39: i32, v40: i64):
+;;                                 block4(v35: i32, v36: i64):
 ;; @0023                               v3 = f32const 0.0
-;; @0023                               v41 = iconst.i64 16
-;; @0023                               v42 = iadd v40, v41  ; v41 = 16
-;; @0023                               store user2 little region1 v3, v42  ; v3 = 0.0
+;; @0023                               v37 = iconst.i64 16
+;; @0023                               v38 = iadd v36, v37  ; v37 = 16
+;; @0023                               store user2 little region1 v3, v38  ; v3 = 0.0
 ;; @0023                               v4 = iconst.i32 0
-;; @0023                               v43 = iconst.i64 20
-;; @0023                               v44 = iadd v40, v43  ; v43 = 20
-;; @0023                               istore8 user2 little region1 v4, v44  ; v4 = 0
-;; @0023                               v45 = iconst.i64 24
-;; @0023                               v46 = iadd v40, v45  ; v45 = 24
-;; @0023                               store user2 little region1 v4, v46  ; v4 = 0
+;; @0023                               v39 = iconst.i64 20
+;; @0023                               v40 = iadd v36, v39  ; v39 = 20
+;; @0023                               istore8 user2 little region1 v4, v40  ; v4 = 0
+;; @0023                               v41 = iconst.i64 24
+;; @0023                               v42 = iadd v36, v41  ; v41 = 24
+;; @0023                               store user2 little region1 v4, v42  ; v4 = 0
 ;; @0023                               v6 = vconst.i8x16 const0
-;; @0023                               v47 = iconst.i64 32
-;; @0023                               v48 = iadd v40, v47  ; v47 = 32
-;; @0023                               store user2 little region1 v6, v48  ; v6 = const0
-;; @0026                               jump block1(v39)
+;; @0023                               v43 = iconst.i64 32
+;; @0023                               v44 = iadd v36, v43  ; v43 = 32
+;; @0023                               store user2 little region1 v6, v44  ; v6 = const0
+;; @0026                               jump block1(v35)
 ;;
 ;;                                 block1(v2: i32):
 ;; @0026                               return v2

--- a/tests/disas/gc/struct-new.wat
+++ b/tests/disas/gc/struct-new.wat
@@ -26,59 +26,59 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: f32, v3: i32, v4: i32):
-;;                                     v48 = stack_addr.i64 ss0
-;;                                     store notrap v4, v48
-;; @002a                               v8 = load.i64 notrap aligned readonly can_move v0+32
-;; @002a                               v9 = load.i32 notrap aligned v8
-;; @002a                               v10 = load.i32 notrap aligned v8+4
-;; @002a                               v16 = uextend.i64 v9
-;;                                     v53 = iconst.i64 32
-;; @002a                               v17 = iadd v16, v53  ; v53 = 32
-;; @002a                               v18 = uextend.i64 v10
-;; @002a                               v19 = icmp ule v17, v18
-;; @002a                               brif v19, block2, block3
+;;                                     v44 = stack_addr.i64 ss0
+;;                                     store notrap v4, v44
+;; @002a                               v7 = load.i64 notrap aligned readonly can_move v0+32
+;; @002a                               v8 = load.i32 notrap aligned v7
+;; @002a                               v9 = load.i32 notrap aligned v7+4
+;; @002a                               v15 = uextend.i64 v8
+;;                                     v49 = iconst.i64 32
+;; @002a                               v16 = iadd v15, v49  ; v49 = 32
+;; @002a                               v17 = uextend.i64 v9
+;; @002a                               v18 = icmp ule v16, v17
+;; @002a                               brif v18, block2, block3
 ;;
 ;;                                 block2:
-;;                                     v69 = iconst.i32 32
-;;                                     v67 = iadd.i32 v9, v69  ; v69 = 32
-;; @002a                               store notrap aligned region0 v67, v8
-;;                                     v70 = iconst.i32 -1342177246
-;;                                     v71 = load.i64 notrap aligned readonly can_move v0+8
-;;                                     v72 = load.i64 notrap aligned readonly can_move v71+32
-;; @002a                               v33 = iadd v72, v16
-;; @002a                               store notrap aligned v70, v33  ; v70 = -1342177246
-;;                                     v73 = load.i64 notrap aligned readonly can_move v0+40
-;;                                     v74 = load.i32 notrap aligned readonly can_move v73
-;; @002a                               store notrap aligned v74, v33+4
-;;                                     v75 = iconst.i64 32
-;; @002a                               istore32 notrap aligned v75, v33+8  ; v75 = 32
-;; @002a                               jump block4(v9, v33)
+;;                                     v65 = iconst.i32 32
+;;                                     v63 = iadd.i32 v8, v65  ; v65 = 32
+;; @002a                               store notrap aligned region0 v63, v7
+;;                                     v66 = iconst.i32 -1342177246
+;;                                     v67 = load.i64 notrap aligned readonly can_move v0+8
+;;                                     v68 = load.i64 notrap aligned readonly can_move v67+32
+;; @002a                               v30 = iadd v68, v15
+;; @002a                               store notrap aligned v66, v30  ; v66 = -1342177246
+;;                                     v69 = load.i64 notrap aligned readonly can_move v0+40
+;;                                     v70 = load.i32 notrap aligned readonly can_move v69
+;; @002a                               store notrap aligned v70, v30+4
+;;                                     v71 = iconst.i64 32
+;; @002a                               istore32 notrap aligned v71, v30+8  ; v71 = 32
+;; @002a                               jump block4(v8, v30)
 ;;
 ;;                                 block3 cold:
-;; @002a                               v21 = iconst.i32 -1342177246
-;; @002a                               v23 = load.i64 notrap aligned readonly can_move v0+40
-;; @002a                               v24 = load.i32 notrap aligned readonly can_move v23
+;; @002a                               v19 = iconst.i32 -1342177246
+;; @002a                               v20 = load.i64 notrap aligned readonly can_move v0+40
+;; @002a                               v21 = load.i32 notrap aligned readonly can_move v20
 ;; @002a                               v6 = iconst.i32 32
-;; @002a                               v25 = iconst.i32 16
-;; @002a                               v26 = call fn0(v0, v21, v24, v6, v25), stack_map=[i32 @ ss0+0]  ; v21 = -1342177246, v6 = 32, v25 = 16
-;; @002a                               v49 = load.i64 notrap aligned readonly can_move v0+8
-;; @002a                               v27 = load.i64 notrap aligned readonly can_move v49+32
-;; @002a                               v28 = uextend.i64 v26
-;; @002a                               v29 = iadd v27, v28
-;; @002a                               jump block4(v26, v29)
+;; @002a                               v22 = iconst.i32 16
+;; @002a                               v23 = call fn0(v0, v19, v21, v6, v22), stack_map=[i32 @ ss0+0]  ; v19 = -1342177246, v6 = 32, v22 = 16
+;; @002a                               v45 = load.i64 notrap aligned readonly can_move v0+8
+;; @002a                               v24 = load.i64 notrap aligned readonly can_move v45+32
+;; @002a                               v25 = uextend.i64 v23
+;; @002a                               v26 = iadd v24, v25
+;; @002a                               jump block4(v23, v26)
 ;;
-;;                                 block4(v38: i32, v39: i64):
-;; @002a                               v40 = iconst.i64 16
-;; @002a                               v41 = iadd v39, v40  ; v40 = 16
-;; @002a                               store.f32 user2 little region1 v2, v41
-;; @002a                               v42 = iconst.i64 20
-;; @002a                               v43 = iadd v39, v42  ; v42 = 20
-;; @002a                               istore8.i32 user2 little region1 v3, v43
-;;                                     v47 = load.i32 notrap v48
-;; @002a                               v44 = iconst.i64 24
-;; @002a                               v45 = iadd v39, v44  ; v44 = 24
-;; @002a                               store user2 little region1 v47, v45
-;; @002d                               jump block1(v38)
+;;                                 block4(v34: i32, v35: i64):
+;; @002a                               v36 = iconst.i64 16
+;; @002a                               v37 = iadd v35, v36  ; v36 = 16
+;; @002a                               store.f32 user2 little region1 v2, v37
+;; @002a                               v38 = iconst.i64 20
+;; @002a                               v39 = iadd v35, v38  ; v38 = 20
+;; @002a                               istore8.i32 user2 little region1 v3, v39
+;;                                     v43 = load.i32 notrap v44
+;; @002a                               v40 = iconst.i64 24
+;; @002a                               v41 = iadd v35, v40  ; v40 = 24
+;; @002a                               store user2 little region1 v43, v41
+;; @002d                               jump block1(v34)
 ;;
 ;;                                 block1(v5: i32):
 ;; @002d                               return v5

--- a/tests/disas/icall-loop.wat
+++ b/tests/disas/icall-loop.wat
@@ -46,28 +46,28 @@
 ;; @002b                               v12 = select_spectre_guard v5, v11, v10  ; v11 = 0
 ;; @002b                               v14 = iconst.i64 -2
 ;; @002b                               v17 = iconst.i32 0
-;; @002b                               v22 = load.i64 notrap aligned readonly can_move v0+40
-;; @002b                               v23 = load.i32 notrap aligned readonly can_move v22
+;; @002b                               v20 = load.i64 notrap aligned readonly can_move v0+40
+;; @002b                               v21 = load.i32 notrap aligned readonly can_move v20
 ;; @0027                               jump block2
 ;;
 ;;                                 block2:
 ;; @002b                               v13 = load.i64 user6 aligned region0 v12
-;;                                     v32 = iconst.i64 -2
-;;                                     v33 = band v13, v32  ; v32 = -2
-;; @002b                               brif v13, block5(v33), block4
+;;                                     v30 = iconst.i64 -2
+;;                                     v31 = band v13, v30  ; v30 = -2
+;; @002b                               brif v13, block5(v31), block4
 ;;
 ;;                                 block4 cold:
-;;                                     v34 = iconst.i32 0
-;; @002b                               v20 = call fn0(v0, v34, v6)  ; v34 = 0
-;; @002b                               jump block5(v20)
+;;                                     v32 = iconst.i32 0
+;; @002b                               v19 = call fn0(v0, v32, v6)  ; v32 = 0
+;; @002b                               jump block5(v19)
 ;;
 ;;                                 block5(v16: i64):
-;; @002b                               v24 = load.i32 user7 aligned readonly v16+16
-;; @002b                               v25 = icmp eq v24, v23
-;; @002b                               trapz v25, user8
-;; @002b                               v27 = load.i64 notrap aligned readonly v16+8
-;; @002b                               v28 = load.i64 notrap aligned readonly v16+24
-;; @002b                               v29 = call_indirect sig0, v27(v28, v0)
+;; @002b                               v22 = load.i32 user7 aligned readonly v16+16
+;; @002b                               v23 = icmp eq v22, v21
+;; @002b                               trapz v23, user8
+;; @002b                               v25 = load.i64 notrap aligned readonly v16+8
+;; @002b                               v26 = load.i64 notrap aligned readonly v16+24
+;; @002b                               v27 = call_indirect sig0, v25(v26, v0)
 ;; @002e                               jump block2
 ;; }
 ;;
@@ -85,34 +85,34 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64):
 ;; @0038                               v6 = load.i64 notrap aligned readonly can_move v0+48
-;;                                     v37 = iconst.i64 8
-;; @0038                               v9 = iadd v6, v37  ; v37 = 8
+;;                                     v35 = iconst.i64 8
+;; @0038                               v9 = iadd v6, v35  ; v35 = 8
 ;; @0038                               v13 = iconst.i64 -2
 ;; @0038                               v16 = iconst.i32 0
-;;                                     v36 = iconst.i64 1
-;; @0038                               v21 = load.i64 notrap aligned readonly can_move v0+40
-;; @0038                               v22 = load.i32 notrap aligned readonly can_move v21
+;;                                     v34 = iconst.i64 1
+;; @0038                               v19 = load.i64 notrap aligned readonly can_move v0+40
+;; @0038                               v20 = load.i32 notrap aligned readonly can_move v19
 ;; @0034                               jump block2
 ;;
 ;;                                 block2:
-;;                                     v38 = iadd.i64 v6, v37  ; v37 = 8
-;; @0038                               v12 = load.i64 user6 aligned region0 v38
-;;                                     v39 = iconst.i64 -2
-;;                                     v40 = band v12, v39  ; v39 = -2
-;; @0038                               brif v12, block5(v40), block4
+;;                                     v36 = iadd.i64 v6, v35  ; v35 = 8
+;; @0038                               v12 = load.i64 user6 aligned region0 v36
+;;                                     v37 = iconst.i64 -2
+;;                                     v38 = band v12, v37  ; v37 = -2
+;; @0038                               brif v12, block5(v38), block4
 ;;
 ;;                                 block4 cold:
-;;                                     v41 = iconst.i32 0
-;;                                     v42 = iconst.i64 1
-;; @0038                               v19 = call fn0(v0, v41, v42)  ; v41 = 0, v42 = 1
-;; @0038                               jump block5(v19)
+;;                                     v39 = iconst.i32 0
+;;                                     v40 = iconst.i64 1
+;; @0038                               v18 = call fn0(v0, v39, v40)  ; v39 = 0, v40 = 1
+;; @0038                               jump block5(v18)
 ;;
 ;;                                 block5(v15: i64):
-;; @0038                               v23 = load.i32 user7 aligned readonly v15+16
-;; @0038                               v24 = icmp eq v23, v22
-;; @0038                               trapz v24, user8
-;; @0038                               v26 = load.i64 notrap aligned readonly v15+8
-;; @0038                               v27 = load.i64 notrap aligned readonly v15+24
-;; @0038                               v28 = call_indirect sig0, v26(v27, v0)
+;; @0038                               v21 = load.i32 user7 aligned readonly v15+16
+;; @0038                               v22 = icmp eq v21, v20
+;; @0038                               trapz v22, user8
+;; @0038                               v24 = load.i64 notrap aligned readonly v15+8
+;; @0038                               v25 = load.i64 notrap aligned readonly v15+24
+;; @0038                               v26 = call_indirect sig0, v24(v25, v0)
 ;; @003b                               jump block2
 ;; }

--- a/tests/disas/icall-simd.wat
+++ b/tests/disas/icall-simd.wat
@@ -37,22 +37,22 @@
 ;;
 ;;                                 block2 cold:
 ;; @0033                               v18 = iconst.i32 0
-;; @0033                               v20 = uextend.i64 v2
-;; @0033                               v21 = call fn0(v0, v18, v20)  ; v18 = 0
-;; @0033                               jump block3(v21)
+;; @0033                               v19 = uextend.i64 v2
+;; @0033                               v20 = call fn0(v0, v18, v19)  ; v18 = 0
+;; @0033                               jump block3(v20)
 ;;
 ;;                                 block3(v17: i64):
-;; @0033                               v23 = load.i64 notrap aligned readonly can_move v0+40
-;; @0033                               v24 = load.i32 notrap aligned readonly can_move v23
-;; @0033                               v25 = load.i32 user7 aligned readonly v17+16
-;; @0033                               v26 = icmp eq v25, v24
-;; @0033                               v27 = uextend.i32 v26
-;; @0033                               trapz v27, user8
-;; @0033                               v28 = load.i64 notrap aligned readonly v17+8
-;; @0033                               v29 = load.i64 notrap aligned readonly v17+24
-;; @0033                               v30 = call_indirect sig0, v28(v29, v0, v3)
+;; @0033                               v21 = load.i64 notrap aligned readonly can_move v0+40
+;; @0033                               v22 = load.i32 notrap aligned readonly can_move v21
+;; @0033                               v23 = load.i32 user7 aligned readonly v17+16
+;; @0033                               v24 = icmp eq v23, v22
+;; @0033                               v25 = uextend.i32 v24
+;; @0033                               trapz v25, user8
+;; @0033                               v26 = load.i64 notrap aligned readonly v17+8
+;; @0033                               v27 = load.i64 notrap aligned readonly v17+24
+;; @0033                               v28 = call_indirect sig0, v26(v27, v0, v3)
 ;; @0036                               jump block1
 ;;
 ;;                                 block1:
-;; @0036                               return v30
+;; @0036                               return v28
 ;; }

--- a/tests/disas/icall.wat
+++ b/tests/disas/icall.wat
@@ -37,22 +37,22 @@
 ;;
 ;;                                 block2 cold:
 ;; @0033                               v18 = iconst.i32 0
-;; @0033                               v20 = uextend.i64 v2
-;; @0033                               v21 = call fn0(v0, v18, v20)  ; v18 = 0
-;; @0033                               jump block3(v21)
+;; @0033                               v19 = uextend.i64 v2
+;; @0033                               v20 = call fn0(v0, v18, v19)  ; v18 = 0
+;; @0033                               jump block3(v20)
 ;;
 ;;                                 block3(v17: i64):
-;; @0033                               v23 = load.i64 notrap aligned readonly can_move v0+40
-;; @0033                               v24 = load.i32 notrap aligned readonly can_move v23
-;; @0033                               v25 = load.i32 user7 aligned readonly v17+16
-;; @0033                               v26 = icmp eq v25, v24
-;; @0033                               v27 = uextend.i32 v26
-;; @0033                               trapz v27, user8
-;; @0033                               v28 = load.i64 notrap aligned readonly v17+8
-;; @0033                               v29 = load.i64 notrap aligned readonly v17+24
-;; @0033                               v30 = call_indirect sig0, v28(v29, v0, v3)
+;; @0033                               v21 = load.i64 notrap aligned readonly can_move v0+40
+;; @0033                               v22 = load.i32 notrap aligned readonly can_move v21
+;; @0033                               v23 = load.i32 user7 aligned readonly v17+16
+;; @0033                               v24 = icmp eq v23, v22
+;; @0033                               v25 = uextend.i32 v24
+;; @0033                               trapz v25, user8
+;; @0033                               v26 = load.i64 notrap aligned readonly v17+8
+;; @0033                               v27 = load.i64 notrap aligned readonly v17+24
+;; @0033                               v28 = call_indirect sig0, v26(v27, v0, v3)
 ;; @0036                               jump block1
 ;;
 ;;                                 block1:
-;; @0036                               return v30
+;; @0036                               return v28
 ;; }

--- a/tests/disas/indirect-call-no-caching.wat
+++ b/tests/disas/indirect-call-no-caching.wat
@@ -91,22 +91,22 @@
 ;;
 ;;                                 block2 cold:
 ;; @0050                               v17 = iconst.i32 0
-;; @0050                               v19 = uextend.i64 v2
-;; @0050                               v20 = call fn0(v0, v17, v19)  ; v17 = 0
-;; @0050                               jump block3(v20)
+;; @0050                               v18 = uextend.i64 v2
+;; @0050                               v19 = call fn0(v0, v17, v18)  ; v17 = 0
+;; @0050                               jump block3(v19)
 ;;
 ;;                                 block3(v16: i64):
-;; @0050                               v22 = load.i64 notrap aligned readonly can_move v0+40
-;; @0050                               v23 = load.i32 notrap aligned readonly can_move v22
-;; @0050                               v24 = load.i32 user7 aligned readonly v16+16
-;; @0050                               v25 = icmp eq v24, v23
-;; @0050                               v26 = uextend.i32 v25
-;; @0050                               trapz v26, user8
-;; @0050                               v27 = load.i64 notrap aligned readonly v16+8
-;; @0050                               v28 = load.i64 notrap aligned readonly v16+24
-;; @0050                               v29 = call_indirect sig0, v27(v28, v0)
+;; @0050                               v20 = load.i64 notrap aligned readonly can_move v0+40
+;; @0050                               v21 = load.i32 notrap aligned readonly can_move v20
+;; @0050                               v22 = load.i32 user7 aligned readonly v16+16
+;; @0050                               v23 = icmp eq v22, v21
+;; @0050                               v24 = uextend.i32 v23
+;; @0050                               trapz v24, user8
+;; @0050                               v25 = load.i64 notrap aligned readonly v16+8
+;; @0050                               v26 = load.i64 notrap aligned readonly v16+24
+;; @0050                               v27 = call_indirect sig0, v25(v26, v0)
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:
-;; @0053                               return v29
+;; @0053                               return v27
 ;; }

--- a/tests/disas/memory-copy-epochs.wat
+++ b/tests/disas/memory-copy-epochs.wat
@@ -22,112 +22,112 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
-;; @001e                               v6 = load.i64 notrap aligned v0+24
-;; @001e                               v7 = load.i64 notrap aligned v6
-;; @001e                               v8 = load.i64 notrap aligned readonly can_move v0+8
-;; @001e                               v9 = load.i64 notrap aligned v8+8
-;; @001e                               v10 = icmp uge v7, v9
-;; @001e                               brif v10, block3, block2(v9)
+;; @001e                               v5 = load.i64 notrap aligned v0+24
+;; @001e                               v6 = load.i64 notrap aligned v5
+;; @001e                               v7 = load.i64 notrap aligned readonly can_move v0+8
+;; @001e                               v8 = load.i64 notrap aligned v7+8
+;; @001e                               v9 = icmp uge v6, v8
+;; @001e                               brif v9, block3, block2(v8)
 ;;
 ;;                                 block3 cold:
-;; @001e                               v11 = call fn0(v0)
-;; @001e                               jump block2(v11)
+;; @001e                               v10 = call fn0(v0)
+;; @001e                               jump block2(v10)
 ;;
-;;                                 block2(v62: i64):
-;; @0025                               v16 = load.i64 notrap aligned v0+64
-;; @0025                               v17 = uextend.i64 v2
-;; @0025                               v18 = uextend.i64 v4
-;; @0025                               v21 = iadd v17, v18
-;; @0025                               v22 = icmp ugt v21, v16
-;; @0025                               trapnz v22, heap_oob
-;; @0025                               v30 = uextend.i64 v3
-;; @0025                               v34 = iadd v30, v18
-;; @0025                               v35 = icmp ugt v34, v16
-;; @0025                               trapnz v35, heap_oob
-;; @0025                               v23 = load.i64 notrap aligned readonly can_move v0+56
-;; @0025                               v40 = iadd v23, v30
-;; @0025                               v27 = iadd v23, v17
-;; @0025                               v43 = icmp ugt v40, v27
-;; @0025                               brif v43, block6, block7
+;;                                 block2(v61: i64):
+;; @0025                               v15 = load.i64 notrap aligned v0+64
+;; @0025                               v16 = uextend.i64 v2
+;; @0025                               v17 = uextend.i64 v4
+;; @0025                               v20 = iadd v16, v17
+;; @0025                               v21 = icmp ugt v20, v15
+;; @0025                               trapnz v21, heap_oob
+;; @0025                               v29 = uextend.i64 v3
+;; @0025                               v33 = iadd v29, v17
+;; @0025                               v34 = icmp ugt v33, v15
+;; @0025                               trapnz v34, heap_oob
+;; @0025                               v22 = load.i64 notrap aligned readonly can_move v0+56
+;; @0025                               v39 = iadd v22, v29
+;; @0025                               v26 = iadd v22, v16
+;; @0025                               v42 = icmp ugt v39, v26
+;; @0025                               brif v42, block6, block7
 ;;
-;;                                 block4(v45: i64, v46: i64, v47: i64, v50: i64):
-;; @0025                               v49 = load.i64 notrap aligned v6
-;; @0025                               v51 = icmp uge v49, v50
-;; @0025                               brif v51, block9, block8(v50)
+;;                                 block4(v44: i64, v45: i64, v46: i64, v49: i64):
+;; @0025                               v48 = load.i64 notrap aligned v5
+;; @0025                               v50 = icmp uge v48, v49
+;; @0025                               brif v50, block9, block8(v49)
 ;;
-;;                                 block5(v89: i64, v90: i64, v91: i64, v95: i64):
-;; @0025                               v94 = load.i64 notrap aligned v6
-;; @0025                               v97 = icmp uge v94, v95
-;; @0025                               brif v97, block17, block16
+;;                                 block5(v88: i64, v89: i64, v90: i64, v94: i64):
+;; @0025                               v93 = load.i64 notrap aligned v5
+;; @0025                               v96 = icmp uge v93, v94
+;; @0025                               brif v96, block17, block16
 ;;
 ;;                                 block6:
-;;                                     v113 = iconst.i64 0x0800_0000
-;;                                     v114 = icmp.i64 ugt v18, v113  ; v113 = 0x0800_0000
-;; @0025                               brif v114, block4(v27, v40, v18, v62), block5(v27, v40, v18, v62)
+;;                                     v112 = iconst.i64 0x0800_0000
+;;                                     v113 = icmp.i64 ugt v17, v112  ; v112 = 0x0800_0000
+;; @0025                               brif v113, block4(v26, v39, v17, v61), block5(v26, v39, v17, v61)
 ;;
 ;;                                 block9 cold:
-;; @0025                               v53 = load.i64 notrap aligned v8+8
-;; @0025                               v54 = icmp.i64 uge v49, v53
-;; @0025                               brif v54, block10, block8(v53)
+;; @0025                               v52 = load.i64 notrap aligned v7+8
+;; @0025                               v53 = icmp.i64 uge v48, v52
+;; @0025                               brif v53, block10, block8(v52)
 ;;
 ;;                                 block10 cold:
-;; @0025                               v55 = call fn0(v0)
-;; @0025                               jump block8(v55)
+;; @0025                               v54 = call fn0(v0)
+;; @0025                               jump block8(v54)
 ;;
-;;                                 block8(v63: i64):
-;; @0025                               call fn1(v0, v45, v46, v113)  ; v113 = 0x0800_0000
-;; @0025                               v58 = isub.i64 v47, v113  ; v113 = 0x0800_0000
-;; @0025                               v59 = icmp ugt v58, v113  ; v113 = 0x0800_0000
-;; @0025                               v56 = iadd.i64 v45, v113  ; v113 = 0x0800_0000
-;; @0025                               v57 = iadd.i64 v46, v113  ; v113 = 0x0800_0000
-;; @0025                               brif v59, block4(v56, v57, v58, v63), block5(v56, v57, v58, v63)
+;;                                 block8(v62: i64):
+;; @0025                               call fn1(v0, v44, v45, v112)  ; v112 = 0x0800_0000
+;; @0025                               v57 = isub.i64 v46, v112  ; v112 = 0x0800_0000
+;; @0025                               v58 = icmp ugt v57, v112  ; v112 = 0x0800_0000
+;; @0025                               v55 = iadd.i64 v44, v112  ; v112 = 0x0800_0000
+;; @0025                               v56 = iadd.i64 v45, v112  ; v112 = 0x0800_0000
+;; @0025                               brif v58, block4(v55, v56, v57, v62), block5(v55, v56, v57, v62)
 ;;
 ;;                                 block7:
-;; @0025                               v42 = iconst.i64 0x0800_0000
-;; @0025                               v66 = icmp.i64 ugt v18, v42  ; v42 = 0x0800_0000
-;; @0025                               v64 = iadd.i64 v27, v18
-;; @0025                               v65 = iadd.i64 v40, v18
-;; @0025                               brif v66, block11(v64, v65, v18, v62), block12(v64, v65, v18, v62)
+;; @0025                               v41 = iconst.i64 0x0800_0000
+;; @0025                               v65 = icmp.i64 ugt v17, v41  ; v41 = 0x0800_0000
+;; @0025                               v63 = iadd.i64 v26, v17
+;; @0025                               v64 = iadd.i64 v39, v17
+;; @0025                               brif v65, block11(v63, v64, v17, v61), block12(v63, v64, v17, v61)
 ;;
-;;                                 block11(v67: i64, v68: i64, v69: i64, v74: i64):
-;; @0025                               v73 = load.i64 notrap aligned v6
-;; @0025                               v75 = icmp uge v73, v74
-;; @0025                               brif v75, block14, block13(v74)
+;;                                 block11(v66: i64, v67: i64, v68: i64, v73: i64):
+;; @0025                               v72 = load.i64 notrap aligned v5
+;; @0025                               v74 = icmp uge v72, v73
+;; @0025                               brif v74, block14, block13(v73)
 ;;
 ;;                                 block14 cold:
-;; @0025                               v77 = load.i64 notrap aligned v8+8
-;; @0025                               v78 = icmp.i64 uge v73, v77
-;; @0025                               brif v78, block15, block13(v77)
+;; @0025                               v76 = load.i64 notrap aligned v7+8
+;; @0025                               v77 = icmp.i64 uge v72, v76
+;; @0025                               brif v77, block15, block13(v76)
 ;;
 ;;                                 block15 cold:
-;; @0025                               v79 = call fn0(v0)
-;; @0025                               jump block13(v79)
+;; @0025                               v78 = call fn0(v0)
+;; @0025                               jump block13(v78)
 ;;
-;;                                 block13(v83: i64):
-;;                                     v108 = iconst.i64 0x0800_0000
-;;                                     v109 = isub.i64 v67, v108  ; v108 = 0x0800_0000
-;;                                     v110 = isub.i64 v68, v108  ; v108 = 0x0800_0000
-;; @0025                               call fn1(v0, v109, v110, v108)  ; v108 = 0x0800_0000
-;;                                     v111 = isub.i64 v69, v108  ; v108 = 0x0800_0000
-;;                                     v112 = icmp ugt v111, v108  ; v108 = 0x0800_0000
-;; @0025                               brif v112, block11(v109, v110, v111, v83), block12(v109, v110, v111, v83)
+;;                                 block13(v82: i64):
+;;                                     v107 = iconst.i64 0x0800_0000
+;;                                     v108 = isub.i64 v66, v107  ; v107 = 0x0800_0000
+;;                                     v109 = isub.i64 v67, v107  ; v107 = 0x0800_0000
+;; @0025                               call fn1(v0, v108, v109, v107)  ; v107 = 0x0800_0000
+;;                                     v110 = isub.i64 v68, v107  ; v107 = 0x0800_0000
+;;                                     v111 = icmp ugt v110, v107  ; v107 = 0x0800_0000
+;; @0025                               brif v111, block11(v108, v109, v110, v82), block12(v108, v109, v110, v82)
 ;;
-;;                                 block12(v84: i64, v85: i64, v86: i64, v96: i64):
-;; @0025                               v87 = isub v84, v86
-;; @0025                               v88 = isub v85, v86
-;; @0025                               jump block5(v87, v88, v86, v96)
+;;                                 block12(v83: i64, v84: i64, v85: i64, v95: i64):
+;; @0025                               v86 = isub v83, v85
+;; @0025                               v87 = isub v84, v85
+;; @0025                               jump block5(v86, v87, v85, v95)
 ;;
 ;;                                 block17 cold:
-;; @0025                               v99 = load.i64 notrap aligned v8+8
-;; @0025                               v100 = icmp.i64 uge v94, v99
-;; @0025                               brif v100, block18, block16
+;; @0025                               v98 = load.i64 notrap aligned v7+8
+;; @0025                               v99 = icmp.i64 uge v93, v98
+;; @0025                               brif v99, block18, block16
 ;;
 ;;                                 block18 cold:
-;; @0025                               v101 = call fn0(v0)
+;; @0025                               v100 = call fn0(v0)
 ;; @0025                               jump block16
 ;;
 ;;                                 block16:
-;; @0025                               call fn1(v0, v89, v90, v91)
+;; @0025                               call fn1(v0, v88, v89, v90)
 ;; @0029                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/memory-copy-epochs.wat
+++ b/tests/disas/memory-copy-epochs.wat
@@ -13,9 +13,8 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
-;;     gv5 = load.i64 notrap aligned gv3+64
-;;     gv6 = load.i64 notrap aligned readonly can_move gv3+56
+;;     gv4 = load.i64 notrap aligned gv3+64
+;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     sig0 = (i64 vmctx) -> i64 tail
 ;;     sig1 = (i64 vmctx, i64, i64, i64) tail
 ;;     fn0 = colocated u805306368:13 sig0
@@ -62,9 +61,9 @@
 ;; @0025                               brif v97, block17, block16
 ;;
 ;;                                 block6:
-;;                                     v117 = iconst.i64 0x0800_0000
-;;                                     v118 = icmp.i64 ugt v18, v117  ; v117 = 0x0800_0000
-;; @0025                               brif v118, block4(v27, v40, v18, v62), block5(v27, v40, v18, v62)
+;;                                     v113 = iconst.i64 0x0800_0000
+;;                                     v114 = icmp.i64 ugt v18, v113  ; v113 = 0x0800_0000
+;; @0025                               brif v114, block4(v27, v40, v18, v62), block5(v27, v40, v18, v62)
 ;;
 ;;                                 block9 cold:
 ;; @0025                               v53 = load.i64 notrap aligned v8+8
@@ -76,11 +75,11 @@
 ;; @0025                               jump block8(v55)
 ;;
 ;;                                 block8(v63: i64):
-;; @0025                               call fn1(v0, v45, v46, v117)  ; v117 = 0x0800_0000
-;; @0025                               v58 = isub.i64 v47, v117  ; v117 = 0x0800_0000
-;; @0025                               v59 = icmp ugt v58, v117  ; v117 = 0x0800_0000
-;; @0025                               v56 = iadd.i64 v45, v117  ; v117 = 0x0800_0000
-;; @0025                               v57 = iadd.i64 v46, v117  ; v117 = 0x0800_0000
+;; @0025                               call fn1(v0, v45, v46, v113)  ; v113 = 0x0800_0000
+;; @0025                               v58 = isub.i64 v47, v113  ; v113 = 0x0800_0000
+;; @0025                               v59 = icmp ugt v58, v113  ; v113 = 0x0800_0000
+;; @0025                               v56 = iadd.i64 v45, v113  ; v113 = 0x0800_0000
+;; @0025                               v57 = iadd.i64 v46, v113  ; v113 = 0x0800_0000
 ;; @0025                               brif v59, block4(v56, v57, v58, v63), block5(v56, v57, v58, v63)
 ;;
 ;;                                 block7:
@@ -105,13 +104,13 @@
 ;; @0025                               jump block13(v79)
 ;;
 ;;                                 block13(v83: i64):
-;;                                     v112 = iconst.i64 0x0800_0000
-;;                                     v113 = isub.i64 v67, v112  ; v112 = 0x0800_0000
-;;                                     v114 = isub.i64 v68, v112  ; v112 = 0x0800_0000
-;; @0025                               call fn1(v0, v113, v114, v112)  ; v112 = 0x0800_0000
-;;                                     v115 = isub.i64 v69, v112  ; v112 = 0x0800_0000
-;;                                     v116 = icmp ugt v115, v112  ; v112 = 0x0800_0000
-;; @0025                               brif v116, block11(v113, v114, v115, v83), block12(v113, v114, v115, v83)
+;;                                     v108 = iconst.i64 0x0800_0000
+;;                                     v109 = isub.i64 v67, v108  ; v108 = 0x0800_0000
+;;                                     v110 = isub.i64 v68, v108  ; v108 = 0x0800_0000
+;; @0025                               call fn1(v0, v109, v110, v108)  ; v108 = 0x0800_0000
+;;                                     v111 = isub.i64 v69, v108  ; v108 = 0x0800_0000
+;;                                     v112 = icmp ugt v111, v108  ; v108 = 0x0800_0000
+;; @0025                               brif v112, block11(v109, v110, v111, v83), block12(v109, v110, v111, v83)
 ;;
 ;;                                 block12(v84: i64, v85: i64, v86: i64, v96: i64):
 ;; @0025                               v87 = isub v84, v86

--- a/tests/disas/memory-copy-epochs.wat
+++ b/tests/disas/memory-copy-epochs.wat
@@ -31,104 +31,104 @@
 ;; @001e                               brif v10, block3, block2(v9)
 ;;
 ;;                                 block3 cold:
-;; @001e                               v12 = call fn0(v0)
-;; @001e                               jump block2(v12)
+;; @001e                               v11 = call fn0(v0)
+;; @001e                               jump block2(v11)
 ;;
-;;                                 block2(v65: i64):
-;; @0025                               v17 = load.i64 notrap aligned v0+64
-;; @0025                               v18 = uextend.i64 v2
-;; @0025                               v19 = uextend.i64 v4
-;; @0025                               v22 = iadd v18, v19
-;; @0025                               v23 = icmp ugt v22, v17
-;; @0025                               trapnz v23, heap_oob
-;; @0025                               v31 = uextend.i64 v3
-;; @0025                               v35 = iadd v31, v19
-;; @0025                               v36 = icmp ugt v35, v17
-;; @0025                               trapnz v36, heap_oob
-;; @0025                               v24 = load.i64 notrap aligned readonly can_move v0+56
-;; @0025                               v41 = iadd v24, v31
-;; @0025                               v28 = iadd v24, v18
-;; @0025                               v45 = icmp ugt v41, v28
-;; @0025                               brif v45, block6, block7
+;;                                 block2(v62: i64):
+;; @0025                               v16 = load.i64 notrap aligned v0+64
+;; @0025                               v17 = uextend.i64 v2
+;; @0025                               v18 = uextend.i64 v4
+;; @0025                               v21 = iadd v17, v18
+;; @0025                               v22 = icmp ugt v21, v16
+;; @0025                               trapnz v22, heap_oob
+;; @0025                               v30 = uextend.i64 v3
+;; @0025                               v34 = iadd v30, v18
+;; @0025                               v35 = icmp ugt v34, v16
+;; @0025                               trapnz v35, heap_oob
+;; @0025                               v23 = load.i64 notrap aligned readonly can_move v0+56
+;; @0025                               v40 = iadd v23, v30
+;; @0025                               v27 = iadd v23, v17
+;; @0025                               v43 = icmp ugt v40, v27
+;; @0025                               brif v43, block6, block7
 ;;
-;;                                 block4(v47: i64, v48: i64, v49: i64, v52: i64):
-;; @0025                               v51 = load.i64 notrap aligned v6
-;; @0025                               v53 = icmp uge v51, v52
-;; @0025                               brif v53, block9, block8(v52)
+;;                                 block4(v45: i64, v46: i64, v47: i64, v50: i64):
+;; @0025                               v49 = load.i64 notrap aligned v6
+;; @0025                               v51 = icmp uge v49, v50
+;; @0025                               brif v51, block9, block8(v50)
 ;;
-;;                                 block5(v93: i64, v94: i64, v95: i64, v99: i64):
-;; @0025                               v98 = load.i64 notrap aligned v6
-;; @0025                               v101 = icmp uge v98, v99
-;; @0025                               brif v101, block17, block16
+;;                                 block5(v89: i64, v90: i64, v91: i64, v95: i64):
+;; @0025                               v94 = load.i64 notrap aligned v6
+;; @0025                               v97 = icmp uge v94, v95
+;; @0025                               brif v97, block17, block16
 ;;
 ;;                                 block6:
-;;                                     v122 = iconst.i64 0x0800_0000
-;;                                     v123 = icmp.i64 ugt v19, v122  ; v122 = 0x0800_0000
-;; @0025                               brif v123, block4(v28, v41, v19, v65), block5(v28, v41, v19, v65)
+;;                                     v117 = iconst.i64 0x0800_0000
+;;                                     v118 = icmp.i64 ugt v18, v117  ; v117 = 0x0800_0000
+;; @0025                               brif v118, block4(v27, v40, v18, v62), block5(v27, v40, v18, v62)
 ;;
 ;;                                 block9 cold:
-;; @0025                               v55 = load.i64 notrap aligned v8+8
-;; @0025                               v56 = icmp.i64 uge v51, v55
-;; @0025                               brif v56, block10, block8(v55)
+;; @0025                               v53 = load.i64 notrap aligned v8+8
+;; @0025                               v54 = icmp.i64 uge v49, v53
+;; @0025                               brif v54, block10, block8(v53)
 ;;
 ;;                                 block10 cold:
-;; @0025                               v58 = call fn0(v0)
-;; @0025                               jump block8(v58)
+;; @0025                               v55 = call fn0(v0)
+;; @0025                               jump block8(v55)
 ;;
-;;                                 block8(v66: i64):
-;; @0025                               call fn1(v0, v47, v48, v122)  ; v122 = 0x0800_0000
-;; @0025                               v61 = isub.i64 v49, v122  ; v122 = 0x0800_0000
-;; @0025                               v62 = icmp ugt v61, v122  ; v122 = 0x0800_0000
-;; @0025                               v59 = iadd.i64 v47, v122  ; v122 = 0x0800_0000
-;; @0025                               v60 = iadd.i64 v48, v122  ; v122 = 0x0800_0000
-;; @0025                               brif v62, block4(v59, v60, v61, v66), block5(v59, v60, v61, v66)
+;;                                 block8(v63: i64):
+;; @0025                               call fn1(v0, v45, v46, v117)  ; v117 = 0x0800_0000
+;; @0025                               v58 = isub.i64 v47, v117  ; v117 = 0x0800_0000
+;; @0025                               v59 = icmp ugt v58, v117  ; v117 = 0x0800_0000
+;; @0025                               v56 = iadd.i64 v45, v117  ; v117 = 0x0800_0000
+;; @0025                               v57 = iadd.i64 v46, v117  ; v117 = 0x0800_0000
+;; @0025                               brif v59, block4(v56, v57, v58, v63), block5(v56, v57, v58, v63)
 ;;
 ;;                                 block7:
-;; @0025                               v44 = iconst.i64 0x0800_0000
-;; @0025                               v69 = icmp.i64 ugt v19, v44  ; v44 = 0x0800_0000
-;; @0025                               v67 = iadd.i64 v28, v19
-;; @0025                               v68 = iadd.i64 v41, v19
-;; @0025                               brif v69, block11(v67, v68, v19, v65), block12(v67, v68, v19, v65)
+;; @0025                               v42 = iconst.i64 0x0800_0000
+;; @0025                               v66 = icmp.i64 ugt v18, v42  ; v42 = 0x0800_0000
+;; @0025                               v64 = iadd.i64 v27, v18
+;; @0025                               v65 = iadd.i64 v40, v18
+;; @0025                               brif v66, block11(v64, v65, v18, v62), block12(v64, v65, v18, v62)
 ;;
-;;                                 block11(v70: i64, v71: i64, v72: i64, v77: i64):
-;; @0025                               v76 = load.i64 notrap aligned v6
-;; @0025                               v78 = icmp uge v76, v77
-;; @0025                               brif v78, block14, block13(v77)
+;;                                 block11(v67: i64, v68: i64, v69: i64, v74: i64):
+;; @0025                               v73 = load.i64 notrap aligned v6
+;; @0025                               v75 = icmp uge v73, v74
+;; @0025                               brif v75, block14, block13(v74)
 ;;
 ;;                                 block14 cold:
-;; @0025                               v80 = load.i64 notrap aligned v8+8
-;; @0025                               v81 = icmp.i64 uge v76, v80
-;; @0025                               brif v81, block15, block13(v80)
+;; @0025                               v77 = load.i64 notrap aligned v8+8
+;; @0025                               v78 = icmp.i64 uge v73, v77
+;; @0025                               brif v78, block15, block13(v77)
 ;;
 ;;                                 block15 cold:
-;; @0025                               v83 = call fn0(v0)
-;; @0025                               jump block13(v83)
+;; @0025                               v79 = call fn0(v0)
+;; @0025                               jump block13(v79)
 ;;
-;;                                 block13(v87: i64):
-;;                                     v117 = iconst.i64 0x0800_0000
-;;                                     v118 = isub.i64 v70, v117  ; v117 = 0x0800_0000
-;;                                     v119 = isub.i64 v71, v117  ; v117 = 0x0800_0000
-;; @0025                               call fn1(v0, v118, v119, v117)  ; v117 = 0x0800_0000
-;;                                     v120 = isub.i64 v72, v117  ; v117 = 0x0800_0000
-;;                                     v121 = icmp ugt v120, v117  ; v117 = 0x0800_0000
-;; @0025                               brif v121, block11(v118, v119, v120, v87), block12(v118, v119, v120, v87)
+;;                                 block13(v83: i64):
+;;                                     v112 = iconst.i64 0x0800_0000
+;;                                     v113 = isub.i64 v67, v112  ; v112 = 0x0800_0000
+;;                                     v114 = isub.i64 v68, v112  ; v112 = 0x0800_0000
+;; @0025                               call fn1(v0, v113, v114, v112)  ; v112 = 0x0800_0000
+;;                                     v115 = isub.i64 v69, v112  ; v112 = 0x0800_0000
+;;                                     v116 = icmp ugt v115, v112  ; v112 = 0x0800_0000
+;; @0025                               brif v116, block11(v113, v114, v115, v83), block12(v113, v114, v115, v83)
 ;;
-;;                                 block12(v88: i64, v89: i64, v90: i64, v100: i64):
-;; @0025                               v91 = isub v88, v90
-;; @0025                               v92 = isub v89, v90
-;; @0025                               jump block5(v91, v92, v90, v100)
+;;                                 block12(v84: i64, v85: i64, v86: i64, v96: i64):
+;; @0025                               v87 = isub v84, v86
+;; @0025                               v88 = isub v85, v86
+;; @0025                               jump block5(v87, v88, v86, v96)
 ;;
 ;;                                 block17 cold:
-;; @0025                               v103 = load.i64 notrap aligned v8+8
-;; @0025                               v104 = icmp.i64 uge v98, v103
-;; @0025                               brif v104, block18, block16
+;; @0025                               v99 = load.i64 notrap aligned v8+8
+;; @0025                               v100 = icmp.i64 uge v94, v99
+;; @0025                               brif v100, block18, block16
 ;;
 ;;                                 block18 cold:
-;; @0025                               v106 = call fn0(v0)
+;; @0025                               v101 = call fn0(v0)
 ;; @0025                               jump block16
 ;;
 ;;                                 block16:
-;; @0025                               call fn1(v0, v93, v94, v95)
+;; @0025                               call fn1(v0, v89, v90, v91)
 ;; @0029                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/memory-copy-fuel.wat
+++ b/tests/disas/memory-copy-fuel.wat
@@ -13,9 +13,8 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
-;;     gv5 = load.i64 notrap aligned gv3+64
-;;     gv6 = load.i64 notrap aligned readonly can_move gv3+56
+;;     gv4 = load.i64 notrap aligned gv3+64
+;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     sig0 = (i64 vmctx) -> i8 tail
 ;;     sig1 = (i64 vmctx, i64, i64, i64) tail
 ;;     fn0 = colocated u805306368:12 sig0
@@ -32,8 +31,8 @@
 ;; @001e                               brif v10, block2, block3(v8)
 ;;
 ;;                                 block2:
-;;                                     v120 = iadd.i64 v6, v7  ; v7 = 1
-;; @001e                               store notrap aligned v120, v5
+;;                                     v110 = iadd.i64 v6, v7  ; v7 = 1
+;; @001e                               store notrap aligned v110, v5
 ;; @001e                               v12 = call fn0(v0)
 ;; @001e                               v14 = load.i64 notrap aligned v5
 ;; @001e                               jump block3(v14)
@@ -56,37 +55,37 @@
 ;; @0025                               brif v49, block6, block7
 ;;
 ;;                                 block4(v51: i64, v52: i64, v53: i64, v54: i64):
-;; @0025                               v55 = iadd v54, v130  ; v130 = 0x0800_0000
-;;                                     v134 = iconst.i64 0
-;;                                     v135 = icmp sge v55, v134  ; v134 = 0
-;; @0025                               brif v135, block8, block9(v55)
+;; @0025                               v55 = iadd v54, v120  ; v120 = 0x0800_0000
+;;                                     v124 = iconst.i64 0
+;;                                     v125 = icmp sge v55, v124  ; v124 = 0
+;; @0025                               brif v125, block8, block9(v55)
 ;;
 ;;                                 block5(v91: i64, v92: i64, v93: i64, v94: i64):
 ;; @0025                               v96 = iadd v94, v93
-;;                                     v137 = iconst.i64 0
-;;                                     v138 = icmp sge v96, v137  ; v137 = 0
-;; @0025                               brif v138, block14, block15(v96)
+;;                                     v127 = iconst.i64 0
+;;                                     v128 = icmp sge v96, v127  ; v127 = 0
+;; @0025                               brif v128, block14, block15(v96)
 ;;
 ;;                                 block6:
-;;                                     v130 = iconst.i64 0x0800_0000
-;;                                     v131 = icmp.i64 ugt v21, v130  ; v130 = 0x0800_0000
-;;                                     v132 = iconst.i64 4
-;;                                     v133 = iadd.i64 v45, v132  ; v132 = 4
-;; @0025                               brif v131, block4(v30, v43, v21, v133), block5(v30, v43, v21, v133)
+;;                                     v120 = iconst.i64 0x0800_0000
+;;                                     v121 = icmp.i64 ugt v21, v120  ; v120 = 0x0800_0000
+;;                                     v122 = iconst.i64 4
+;;                                     v123 = iadd.i64 v45, v122  ; v122 = 4
+;; @0025                               brif v121, block4(v30, v43, v21, v123), block5(v30, v43, v21, v123)
 ;;
 ;;                                 block8:
-;;                                     v136 = iadd.i64 v54, v130  ; v130 = 0x0800_0000
-;; @0025                               store notrap aligned v136, v5
+;;                                     v126 = iadd.i64 v54, v120  ; v120 = 0x0800_0000
+;; @0025                               store notrap aligned v126, v5
 ;; @0025                               v59 = call fn0(v0)
 ;; @0025                               v61 = load.i64 notrap aligned v5
 ;; @0025                               jump block9(v61)
 ;;
 ;;                                 block9(v66: i64):
-;; @0025                               call fn1(v0, v51, v52, v130)  ; v130 = 0x0800_0000
-;; @0025                               v64 = isub.i64 v53, v130  ; v130 = 0x0800_0000
-;; @0025                               v65 = icmp ugt v64, v130  ; v130 = 0x0800_0000
-;; @0025                               v62 = iadd.i64 v51, v130  ; v130 = 0x0800_0000
-;; @0025                               v63 = iadd.i64 v52, v130  ; v130 = 0x0800_0000
+;; @0025                               call fn1(v0, v51, v52, v120)  ; v120 = 0x0800_0000
+;; @0025                               v64 = isub.i64 v53, v120  ; v120 = 0x0800_0000
+;; @0025                               v65 = icmp ugt v64, v120  ; v120 = 0x0800_0000
+;; @0025                               v62 = iadd.i64 v51, v120  ; v120 = 0x0800_0000
+;; @0025                               v63 = iadd.i64 v52, v120  ; v120 = 0x0800_0000
 ;; @0025                               brif v65, block4(v62, v63, v64, v66), block5(v62, v63, v64, v66)
 ;;
 ;;                                 block7:
@@ -99,26 +98,26 @@
 ;; @0025                               brif v69, block10(v67, v68, v21, v47), block11(v67, v68, v21, v47)
 ;;
 ;;                                 block10(v70: i64, v71: i64, v72: i64, v75: i64):
-;;                                     v121 = iconst.i64 0x0800_0000
-;;                                     v122 = iadd v75, v121  ; v121 = 0x0800_0000
-;;                                     v123 = iconst.i64 0
-;;                                     v124 = icmp sge v122, v123  ; v123 = 0
-;; @0025                               brif v124, block12, block13(v122)
+;;                                     v111 = iconst.i64 0x0800_0000
+;;                                     v112 = iadd v75, v111  ; v111 = 0x0800_0000
+;;                                     v113 = iconst.i64 0
+;;                                     v114 = icmp sge v112, v113  ; v113 = 0
+;; @0025                               brif v114, block12, block13(v112)
 ;;
 ;;                                 block12:
-;; @0025                               store.i64 notrap aligned v122, v5
+;; @0025                               store.i64 notrap aligned v112, v5
 ;; @0025                               v80 = call fn0(v0)
 ;; @0025                               v82 = load.i64 notrap aligned v5
 ;; @0025                               jump block13(v82)
 ;;
 ;;                                 block13(v85: i64):
-;;                                     v125 = iconst.i64 0x0800_0000
-;;                                     v126 = isub.i64 v70, v125  ; v125 = 0x0800_0000
-;;                                     v127 = isub.i64 v71, v125  ; v125 = 0x0800_0000
-;; @0025                               call fn1(v0, v126, v127, v125)  ; v125 = 0x0800_0000
-;;                                     v128 = isub.i64 v72, v125  ; v125 = 0x0800_0000
-;;                                     v129 = icmp ugt v128, v125  ; v125 = 0x0800_0000
-;; @0025                               brif v129, block10(v126, v127, v128, v85), block11(v126, v127, v128, v85)
+;;                                     v115 = iconst.i64 0x0800_0000
+;;                                     v116 = isub.i64 v70, v115  ; v115 = 0x0800_0000
+;;                                     v117 = isub.i64 v71, v115  ; v115 = 0x0800_0000
+;; @0025                               call fn1(v0, v116, v117, v115)  ; v115 = 0x0800_0000
+;;                                     v118 = isub.i64 v72, v115  ; v115 = 0x0800_0000
+;;                                     v119 = icmp ugt v118, v115  ; v115 = 0x0800_0000
+;; @0025                               brif v119, block10(v116, v117, v118, v85), block11(v116, v117, v118, v85)
 ;;
 ;;                                 block11(v86: i64, v87: i64, v88: i64, v95: i64):
 ;; @0025                               v89 = isub v86, v88

--- a/tests/disas/memory-copy-fuel.wat
+++ b/tests/disas/memory-copy-fuel.wat
@@ -32,110 +32,110 @@
 ;; @001e                               brif v10, block2, block3(v8)
 ;;
 ;;                                 block2:
-;;                                     v125 = iadd.i64 v6, v7  ; v7 = 1
-;; @001e                               store notrap aligned v125, v5
-;; @001e                               v13 = call fn0(v0)
-;; @001e                               v15 = load.i64 notrap aligned v5
-;; @001e                               jump block3(v15)
+;;                                     v120 = iadd.i64 v6, v7  ; v7 = 1
+;; @001e                               store notrap aligned v120, v5
+;; @001e                               v12 = call fn0(v0)
+;; @001e                               v14 = load.i64 notrap aligned v5
+;; @001e                               jump block3(v14)
 ;;
-;;                                 block3(v47: i64):
-;; @0025                               v20 = load.i64 notrap aligned v0+64
-;; @0025                               v21 = uextend.i64 v2
-;; @0025                               v22 = uextend.i64 v4
-;; @0025                               v25 = iadd v21, v22
-;; @0025                               v26 = icmp ugt v25, v20
-;; @0025                               trapnz v26, heap_oob
-;; @0025                               v34 = uextend.i64 v3
-;; @0025                               v38 = iadd v34, v22
-;; @0025                               v39 = icmp ugt v38, v20
-;; @0025                               trapnz v39, heap_oob
-;; @0025                               v27 = load.i64 notrap aligned readonly can_move v0+56
-;; @0025                               v44 = iadd v27, v34
-;; @0025                               v31 = iadd v27, v21
-;; @0025                               v51 = icmp ugt v44, v31
-;; @0025                               brif v51, block6, block7
+;;                                 block3(v45: i64):
+;; @0025                               v19 = load.i64 notrap aligned v0+64
+;; @0025                               v20 = uextend.i64 v2
+;; @0025                               v21 = uextend.i64 v4
+;; @0025                               v24 = iadd v20, v21
+;; @0025                               v25 = icmp ugt v24, v19
+;; @0025                               trapnz v25, heap_oob
+;; @0025                               v33 = uextend.i64 v3
+;; @0025                               v37 = iadd v33, v21
+;; @0025                               v38 = icmp ugt v37, v19
+;; @0025                               trapnz v38, heap_oob
+;; @0025                               v26 = load.i64 notrap aligned readonly can_move v0+56
+;; @0025                               v43 = iadd v26, v33
+;; @0025                               v30 = iadd v26, v20
+;; @0025                               v49 = icmp ugt v43, v30
+;; @0025                               brif v49, block6, block7
 ;;
-;;                                 block4(v53: i64, v54: i64, v55: i64, v56: i64):
-;; @0025                               v57 = iadd v56, v135  ; v135 = 0x0800_0000
-;;                                     v139 = iconst.i64 0
-;;                                     v140 = icmp sge v57, v139  ; v139 = 0
-;; @0025                               brif v140, block8, block9(v57)
+;;                                 block4(v51: i64, v52: i64, v53: i64, v54: i64):
+;; @0025                               v55 = iadd v54, v130  ; v130 = 0x0800_0000
+;;                                     v134 = iconst.i64 0
+;;                                     v135 = icmp sge v55, v134  ; v134 = 0
+;; @0025                               brif v135, block8, block9(v55)
 ;;
-;;                                 block5(v95: i64, v96: i64, v97: i64, v98: i64):
-;; @0025                               v100 = iadd v98, v97
-;;                                     v142 = iconst.i64 0
-;;                                     v143 = icmp sge v100, v142  ; v142 = 0
-;; @0025                               brif v143, block14, block15(v100)
+;;                                 block5(v91: i64, v92: i64, v93: i64, v94: i64):
+;; @0025                               v96 = iadd v94, v93
+;;                                     v137 = iconst.i64 0
+;;                                     v138 = icmp sge v96, v137  ; v137 = 0
+;; @0025                               brif v138, block14, block15(v96)
 ;;
 ;;                                 block6:
-;;                                     v135 = iconst.i64 0x0800_0000
-;;                                     v136 = icmp.i64 ugt v22, v135  ; v135 = 0x0800_0000
-;;                                     v137 = iconst.i64 4
-;;                                     v138 = iadd.i64 v47, v137  ; v137 = 4
-;; @0025                               brif v136, block4(v31, v44, v22, v138), block5(v31, v44, v22, v138)
+;;                                     v130 = iconst.i64 0x0800_0000
+;;                                     v131 = icmp.i64 ugt v21, v130  ; v130 = 0x0800_0000
+;;                                     v132 = iconst.i64 4
+;;                                     v133 = iadd.i64 v45, v132  ; v132 = 4
+;; @0025                               brif v131, block4(v30, v43, v21, v133), block5(v30, v43, v21, v133)
 ;;
 ;;                                 block8:
-;;                                     v141 = iadd.i64 v56, v135  ; v135 = 0x0800_0000
-;; @0025                               store notrap aligned v141, v5
-;; @0025                               v62 = call fn0(v0)
-;; @0025                               v64 = load.i64 notrap aligned v5
-;; @0025                               jump block9(v64)
+;;                                     v136 = iadd.i64 v54, v130  ; v130 = 0x0800_0000
+;; @0025                               store notrap aligned v136, v5
+;; @0025                               v59 = call fn0(v0)
+;; @0025                               v61 = load.i64 notrap aligned v5
+;; @0025                               jump block9(v61)
 ;;
-;;                                 block9(v69: i64):
-;; @0025                               call fn1(v0, v53, v54, v135)  ; v135 = 0x0800_0000
-;; @0025                               v67 = isub.i64 v55, v135  ; v135 = 0x0800_0000
-;; @0025                               v68 = icmp ugt v67, v135  ; v135 = 0x0800_0000
-;; @0025                               v65 = iadd.i64 v53, v135  ; v135 = 0x0800_0000
-;; @0025                               v66 = iadd.i64 v54, v135  ; v135 = 0x0800_0000
-;; @0025                               brif v68, block4(v65, v66, v67, v69), block5(v65, v66, v67, v69)
+;;                                 block9(v66: i64):
+;; @0025                               call fn1(v0, v51, v52, v130)  ; v130 = 0x0800_0000
+;; @0025                               v64 = isub.i64 v53, v130  ; v130 = 0x0800_0000
+;; @0025                               v65 = icmp ugt v64, v130  ; v130 = 0x0800_0000
+;; @0025                               v62 = iadd.i64 v51, v130  ; v130 = 0x0800_0000
+;; @0025                               v63 = iadd.i64 v52, v130  ; v130 = 0x0800_0000
+;; @0025                               brif v65, block4(v62, v63, v64, v66), block5(v62, v63, v64, v66)
 ;;
 ;;                                 block7:
-;; @0025                               v50 = iconst.i64 0x0800_0000
-;; @0025                               v72 = icmp.i64 ugt v22, v50  ; v50 = 0x0800_0000
-;; @0025                               v70 = iadd.i64 v31, v22
-;; @0025                               v71 = iadd.i64 v44, v22
-;; @0025                               v48 = iconst.i64 4
-;; @0025                               v49 = iadd.i64 v47, v48  ; v48 = 4
-;; @0025                               brif v72, block10(v70, v71, v22, v49), block11(v70, v71, v22, v49)
+;; @0025                               v48 = iconst.i64 0x0800_0000
+;; @0025                               v69 = icmp.i64 ugt v21, v48  ; v48 = 0x0800_0000
+;; @0025                               v67 = iadd.i64 v30, v21
+;; @0025                               v68 = iadd.i64 v43, v21
+;; @0025                               v46 = iconst.i64 4
+;; @0025                               v47 = iadd.i64 v45, v46  ; v46 = 4
+;; @0025                               brif v69, block10(v67, v68, v21, v47), block11(v67, v68, v21, v47)
 ;;
-;;                                 block10(v73: i64, v74: i64, v75: i64, v78: i64):
-;;                                     v126 = iconst.i64 0x0800_0000
-;;                                     v127 = iadd v78, v126  ; v126 = 0x0800_0000
-;;                                     v128 = iconst.i64 0
-;;                                     v129 = icmp sge v127, v128  ; v128 = 0
-;; @0025                               brif v129, block12, block13(v127)
+;;                                 block10(v70: i64, v71: i64, v72: i64, v75: i64):
+;;                                     v121 = iconst.i64 0x0800_0000
+;;                                     v122 = iadd v75, v121  ; v121 = 0x0800_0000
+;;                                     v123 = iconst.i64 0
+;;                                     v124 = icmp sge v122, v123  ; v123 = 0
+;; @0025                               brif v124, block12, block13(v122)
 ;;
 ;;                                 block12:
-;; @0025                               store.i64 notrap aligned v127, v5
-;; @0025                               v84 = call fn0(v0)
-;; @0025                               v86 = load.i64 notrap aligned v5
-;; @0025                               jump block13(v86)
+;; @0025                               store.i64 notrap aligned v122, v5
+;; @0025                               v80 = call fn0(v0)
+;; @0025                               v82 = load.i64 notrap aligned v5
+;; @0025                               jump block13(v82)
 ;;
-;;                                 block13(v89: i64):
-;;                                     v130 = iconst.i64 0x0800_0000
-;;                                     v131 = isub.i64 v73, v130  ; v130 = 0x0800_0000
-;;                                     v132 = isub.i64 v74, v130  ; v130 = 0x0800_0000
-;; @0025                               call fn1(v0, v131, v132, v130)  ; v130 = 0x0800_0000
-;;                                     v133 = isub.i64 v75, v130  ; v130 = 0x0800_0000
-;;                                     v134 = icmp ugt v133, v130  ; v130 = 0x0800_0000
-;; @0025                               brif v134, block10(v131, v132, v133, v89), block11(v131, v132, v133, v89)
+;;                                 block13(v85: i64):
+;;                                     v125 = iconst.i64 0x0800_0000
+;;                                     v126 = isub.i64 v70, v125  ; v125 = 0x0800_0000
+;;                                     v127 = isub.i64 v71, v125  ; v125 = 0x0800_0000
+;; @0025                               call fn1(v0, v126, v127, v125)  ; v125 = 0x0800_0000
+;;                                     v128 = isub.i64 v72, v125  ; v125 = 0x0800_0000
+;;                                     v129 = icmp ugt v128, v125  ; v125 = 0x0800_0000
+;; @0025                               brif v129, block10(v126, v127, v128, v85), block11(v126, v127, v128, v85)
 ;;
-;;                                 block11(v90: i64, v91: i64, v92: i64, v99: i64):
-;; @0025                               v93 = isub v90, v92
-;; @0025                               v94 = isub v91, v92
-;; @0025                               jump block5(v93, v94, v92, v99)
+;;                                 block11(v86: i64, v87: i64, v88: i64, v95: i64):
+;; @0025                               v89 = isub v86, v88
+;; @0025                               v90 = isub v87, v88
+;; @0025                               jump block5(v89, v90, v88, v95)
 ;;
 ;;                                 block14:
-;; @0025                               store.i64 notrap aligned v100, v5
-;; @0025                               v105 = call fn0(v0)
-;; @0025                               v107 = load.i64 notrap aligned v5
-;; @0025                               jump block15(v107)
+;; @0025                               store.i64 notrap aligned v96, v5
+;; @0025                               v100 = call fn0(v0)
+;; @0025                               v102 = load.i64 notrap aligned v5
+;; @0025                               jump block15(v102)
 ;;
-;;                                 block15(v109: i64):
-;; @0025                               call fn1(v0, v95, v96, v97)
+;;                                 block15(v104: i64):
+;; @0025                               call fn1(v0, v91, v92, v93)
 ;; @0029                               jump block1
 ;;
 ;;                                 block1:
-;; @0029                               store.i64 notrap aligned v109, v5
+;; @0029                               store.i64 notrap aligned v104, v5
 ;; @0029                               return
 ;; }

--- a/tests/disas/passive-data.wat
+++ b/tests/disas/passive-data.wat
@@ -38,20 +38,20 @@
 ;; @003d                               v15 = iconst.i64 1
 ;; @003d                               v16 = imul v14, v15  ; v15 = 1
 ;; @003d                               v17 = iadd v13, v16
-;; @003d                               v19 = load.i32 notrap aligned v0+152
-;; @003d                               v20 = uextend.i64 v19
-;; @003d                               v21 = uextend.i64 v3
-;; @003d                               v22 = uextend.i64 v4
-;; @003d                               v23 = iconst.i64 1
-;; @003d                               v24 = imul v22, v23  ; v23 = 1
-;; @003d                               v25 = iadd v21, v24
-;; @003d                               v26 = icmp ugt v25, v20
-;; @003d                               trapnz v26, heap_oob
-;; @003d                               v28 = load.i64 notrap aligned v0+144
-;; @003d                               v29 = uextend.i64 v3
-;; @003d                               v30 = iadd v28, v29
-;; @003d                               v31 = uextend.i64 v4
-;; @003d                               call fn0(v0, v17, v30, v31)
+;; @003d                               v18 = load.i32 notrap aligned v0+152
+;; @003d                               v19 = uextend.i64 v18
+;; @003d                               v20 = uextend.i64 v3
+;; @003d                               v21 = uextend.i64 v4
+;; @003d                               v22 = iconst.i64 1
+;; @003d                               v23 = imul v21, v22  ; v22 = 1
+;; @003d                               v24 = iadd v20, v23
+;; @003d                               v25 = icmp ugt v24, v19
+;; @003d                               trapnz v25, heap_oob
+;; @003d                               v26 = load.i64 notrap aligned v0+144
+;; @003d                               v27 = uextend.i64 v3
+;; @003d                               v28 = iadd v26, v27
+;; @003d                               v29 = uextend.i64 v4
+;; @003d                               call fn0(v0, v17, v28, v29)
 ;; @0041                               jump block1
 ;;
 ;;                                 block1:
@@ -62,12 +62,11 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @0044                               v3 = iconst.i32 0
-;; @0044                               store notrap aligned v3, v0+152  ; v3 = 0
+;; @0044                               v2 = iconst.i32 0
+;; @0044                               store notrap aligned v2, v0+152  ; v2 = 0
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/readonly-funcrefs.wat
+++ b/tests/disas/readonly-funcrefs.wat
@@ -60,18 +60,18 @@
 ;;
 ;;                                 block2 cold:
 ;; @0031                               v16 = iconst.i32 0
-;; @0031                               v19 = call fn0(v0, v16, v5)  ; v16 = 0
-;; @0031                               jump block3(v19)
+;; @0031                               v18 = call fn0(v0, v16, v5)  ; v16 = 0
+;; @0031                               jump block3(v18)
 ;;
 ;;                                 block3(v15: i64):
-;; @0031                               v23 = load.i32 user7 aligned readonly v15+16
-;; @0031                               v21 = load.i64 notrap aligned readonly can_move v0+40
-;; @0031                               v22 = load.i32 notrap aligned readonly can_move v21
-;; @0031                               v24 = icmp eq v23, v22
-;; @0031                               trapz v24, user8
-;; @0031                               v26 = load.i64 notrap aligned readonly v15+8
-;; @0031                               v27 = load.i64 notrap aligned readonly v15+24
-;; @0031                               call_indirect sig0, v26(v27, v0)
+;; @0031                               v21 = load.i32 user7 aligned readonly v15+16
+;; @0031                               v19 = load.i64 notrap aligned readonly can_move v0+40
+;; @0031                               v20 = load.i32 notrap aligned readonly can_move v19
+;; @0031                               v22 = icmp eq v21, v20
+;; @0031                               trapz v22, user8
+;; @0031                               v24 = load.i64 notrap aligned readonly v15+8
+;; @0031                               v25 = load.i64 notrap aligned readonly v15+24
+;; @0031                               call_indirect sig0, v24(v25, v0)
 ;; @0034                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/stack-switching/resume-suspend-data-passing.wat
+++ b/tests/disas/stack-switching/resume-suspend-data-passing.wat
@@ -42,97 +42,96 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
 ;; @003c                               v3 = iconst.i32 10
-;; @0044                               v33 = iconst.i64 120
-;; @0044                               v36 = stack_addr.i64 ss0
-;; @0044                               v42 = iconst.i64 16
-;; @0044                               v39 = iconst.i64 0
-;; @0044                               v51 = iconst.i64 80
-;; @0044                               v54 = iconst.i64 -24
-;;                                     v70 = iconst.i64 0x0002_0000_0000
+;; @0044                               v31 = iconst.i64 120
+;; @0044                               v34 = stack_addr.i64 ss0
+;; @0044                               v40 = iconst.i64 16
+;; @0044                               v37 = iconst.i64 0
+;; @0044                               v49 = iconst.i64 80
+;; @0044                               v52 = iconst.i64 -24
+;;                                     v68 = iconst.i64 0x0002_0000_0000
 ;; @0040                               jump block2(v3)  ; v3 = 10
 ;;
 ;;                                 block2(v4: i32):
-;; @0044                               v9 = load.i64 notrap aligned v0+8
-;; @0044                               v10 = load.i64 notrap aligned v9+88
-;; @0044                               v11 = load.i64 notrap aligned v9+96
-;; @0044                               v14 = iconst.i64 1
-;; @0044                               v18 = iconst.i64 24
+;; @0044                               v7 = load.i64 notrap aligned v0+8
+;; @0044                               v8 = load.i64 notrap aligned v7+88
+;; @0044                               v9 = load.i64 notrap aligned v7+96
+;; @0044                               v12 = iconst.i64 1
+;; @0044                               v16 = iconst.i64 24
 ;; @003a                               v2 = iconst.i32 0
-;; @0044                               jump block4(v10, v11, v4)
+;; @0044                               jump block4(v8, v9, v4)
 ;;
-;;                                 block4(v12: i64, v13: i64, v64: i32):
-;;                                     v73 = iconst.i64 1
-;;                                     v74 = icmp eq v12, v73  ; v73 = 1
-;; @0044                               trapnz v74, user22
+;;                                 block4(v10: i64, v11: i64, v62: i32):
+;;                                     v71 = iconst.i64 1
+;;                                     v72 = icmp eq v10, v71  ; v71 = 1
+;; @0044                               trapnz v72, user22
 ;; @0044                               jump block5
 ;;
 ;;                                 block5:
-;; @0044                               v16 = load.i64 notrap aligned v13+48
-;; @0044                               v17 = load.i64 notrap aligned v13+56
-;;                                     v75 = iconst.i64 24
-;;                                     v76 = iadd v17, v75  ; v75 = 24
-;; @0044                               v20 = load.i64 notrap aligned v76+8
-;; @0044                               v21 = load.i32 notrap aligned v17+40
-;;                                     v77 = iconst.i32 0
-;;                                     v67 = iconst.i32 3
-;; @0044                               v6 = iconst.i64 48
-;; @0044                               v7 = iadd.i64 v0, v6  ; v6 = 48
-;; @0044                               v31 = iconst.i32 1
-;; @0044                               jump block6(v77)  ; v77 = 0
+;; @0044                               v14 = load.i64 notrap aligned v11+48
+;; @0044                               v15 = load.i64 notrap aligned v11+56
+;;                                     v73 = iconst.i64 24
+;;                                     v74 = iadd v15, v73  ; v73 = 24
+;; @0044                               v18 = load.i64 notrap aligned v74+8
+;; @0044                               v19 = load.i32 notrap aligned v15+40
+;;                                     v75 = iconst.i32 0
+;;                                     v65 = iconst.i32 3
+;; @0044                               v5 = iconst.i64 48
+;; @0044                               v6 = iadd.i64 v0, v5  ; v5 = 48
+;; @0044                               v29 = iconst.i32 1
+;; @0044                               jump block6(v75)  ; v75 = 0
 ;;
-;;                                 block6(v23: i32):
-;; @0044                               v24 = icmp ult v23, v21
-;; @0044                               brif v24, block7, block4(v16, v17, v64)
+;;                                 block6(v21: i32):
+;; @0044                               v22 = icmp ult v21, v19
+;; @0044                               brif v22, block7, block4(v14, v15, v62)
 ;;
 ;;                                 block7:
-;;                                     v78 = iconst.i32 3
-;;                                     v79 = ishl.i32 v23, v78  ; v78 = 3
-;; @0044                               v27 = uextend.i64 v79
-;; @0044                               v28 = iadd.i64 v20, v27
-;; @0044                               v29 = load.i64 notrap aligned v28
-;;                                     v80 = iadd.i64 v0, v6  ; v6 = 48
-;;                                     v81 = icmp eq v29, v80
-;;                                     v82 = iconst.i32 1
-;;                                     v83 = iadd.i32 v23, v82  ; v82 = 1
-;; @0044                               brif v81, block8, block6(v83)
+;;                                     v76 = iconst.i32 3
+;;                                     v77 = ishl.i32 v21, v76  ; v76 = 3
+;; @0044                               v25 = uextend.i64 v77
+;; @0044                               v26 = iadd.i64 v18, v25
+;; @0044                               v27 = load.i64 notrap aligned v26
+;;                                     v78 = iadd.i64 v0, v5  ; v5 = 48
+;;                                     v79 = icmp eq v27, v78
+;;                                     v80 = iconst.i32 1
+;;                                     v81 = iadd.i32 v21, v80  ; v80 = 1
+;; @0044                               brif v79, block8, block6(v81)
 ;;
 ;;                                 block8:
-;; @0044                               store.i64 notrap aligned v13, v11+64
-;;                                     v84 = iconst.i32 1
-;;                                     v85 = iconst.i64 120
-;;                                     v86 = iadd.i64 v11, v85  ; v85 = 120
-;; @0044                               store notrap aligned v84, v86+4  ; v84 = 1
-;; @0044                               store.i64 notrap aligned v36, v86+8
-;; @0044                               store.i32 notrap aligned v4, v36
-;; @0044                               store notrap aligned v84, v86  ; v84 = 1
-;;                                     v87 = iconst.i32 3
-;;                                     v88 = iconst.i64 16
-;;                                     v89 = iadd.i64 v11, v88  ; v88 = 16
-;; @0044                               store notrap aligned v87, v89  ; v87 = 3
-;;                                     v90 = iconst.i64 0
-;; @0044                               store notrap aligned v90, v13+48  ; v90 = 0
-;; @0044                               store notrap aligned v90, v13+56  ; v90 = 0
-;;                                     v91 = iconst.i64 80
-;;                                     v92 = iadd.i64 v13, v91  ; v91 = 80
-;; @0044                               v53 = load.i64 notrap aligned v92
-;;                                     v93 = iconst.i64 -24
-;;                                     v94 = iadd v53, v93  ; v93 = -24
-;; @0044                               v49 = uextend.i64 v23
-;;                                     v95 = iconst.i64 0x0002_0000_0000
-;;                                     v96 = bor v49, v95  ; v95 = 0x0002_0000_0000
-;; @0044                               v56 = stack_switch v94, v94, v96
-;; @0044                               v59 = load.i64 notrap aligned v86+8
-;;                                     v97 = iconst.i32 0
-;; @0044                               store notrap aligned v97, v86  ; v97 = 0
-;; @0044                               store notrap aligned v97, v86+4  ; v97 = 0
-;; @0044                               store notrap aligned v90, v86+8  ; v90 = 0
-;;                                     v98 = isub.i32 v64, v84  ; v84 = 1
-;; @004d                               brif v98, block2(v98), block10
+;; @0044                               store.i64 notrap aligned v11, v9+64
+;;                                     v82 = iconst.i32 1
+;;                                     v83 = iconst.i64 120
+;;                                     v84 = iadd.i64 v9, v83  ; v83 = 120
+;; @0044                               store notrap aligned v82, v84+4  ; v82 = 1
+;; @0044                               store.i64 notrap aligned v34, v84+8
+;; @0044                               store.i32 notrap aligned v4, v34
+;; @0044                               store notrap aligned v82, v84  ; v82 = 1
+;;                                     v85 = iconst.i32 3
+;;                                     v86 = iconst.i64 16
+;;                                     v87 = iadd.i64 v9, v86  ; v86 = 16
+;; @0044                               store notrap aligned v85, v87  ; v85 = 3
+;;                                     v88 = iconst.i64 0
+;; @0044                               store notrap aligned v88, v11+48  ; v88 = 0
+;; @0044                               store notrap aligned v88, v11+56  ; v88 = 0
+;;                                     v89 = iconst.i64 80
+;;                                     v90 = iadd.i64 v11, v89  ; v89 = 80
+;; @0044                               v51 = load.i64 notrap aligned v90
+;;                                     v91 = iconst.i64 -24
+;;                                     v92 = iadd v51, v91  ; v91 = -24
+;; @0044                               v47 = uextend.i64 v21
+;;                                     v93 = iconst.i64 0x0002_0000_0000
+;;                                     v94 = bor v47, v93  ; v93 = 0x0002_0000_0000
+;; @0044                               v54 = stack_switch v92, v92, v94
+;; @0044                               v57 = load.i64 notrap aligned v84+8
+;;                                     v95 = iconst.i32 0
+;; @0044                               store notrap aligned v95, v84  ; v95 = 0
+;; @0044                               store notrap aligned v95, v84+4  ; v95 = 0
+;; @0044                               store notrap aligned v88, v84+8  ; v88 = 0
+;;                                     v96 = isub.i32 v62, v82  ; v82 = 1
+;; @004d                               brif v96, block2(v96), block10
 ;;
 ;;                                 block10:
 ;; @004f                               jump block3
@@ -149,7 +148,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, i32) -> i64 tail
 ;;     sig1 = (i64 vmctx, i64, i32, i32) -> i64 tail
 ;;     fn0 = colocated u805306368:6 sig0
@@ -158,154 +156,154 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64):
 ;; @0056                               v2 = iconst.i32 0
-;; @0056                               v4 = call fn0(v0, v2)  ; v2 = 0
-;; @0058                               trapz v4, user16
-;; @0058                               v8 = call fn1(v0, v4, v2, v2)  ; v2 = 0, v2 = 0
-;; @0058                               v9 = load.i64 notrap aligned v8+72
-;; @0058                               v11 = uextend.i128 v9
-;; @0058                               v12 = iconst.i64 64
-;;                                     v121 = ishl v11, v12  ; v12 = 64
-;; @0058                               v10 = uextend.i128 v8
-;; @0058                               v15 = bor v121, v10
-;; @0062                               v27 = iconst.i64 1
-;; @0062                               v33 = iconst.i64 0
-;; @0062                               v34 = iconst.i64 2
-;; @0062                               v38 = iconst.i32 1
-;; @0062                               v39 = iconst.i64 16
-;; @0062                               v41 = iconst.i32 2
-;; @0062                               v53 = iconst.i64 24
-;; @0062                               v56 = stack_addr.i64 ss0
-;; @0062                               v58 = iconst.i64 48
-;; @0062                               v59 = iadd v0, v58  ; v58 = 48
-;; @0062                               v66 = iconst.i64 80
-;; @0062                               v69 = iconst.i64 -24
-;;                                     v125 = iconst.i64 0x0001_0000_0000
-;; @0062                               v64 = iconst.i64 32
-;; @005c                               jump block2(v15)
+;; @0056                               v3 = call fn0(v0, v2)  ; v2 = 0
+;; @0058                               trapz v3, user16
+;; @0058                               v6 = call fn1(v0, v3, v2, v2)  ; v2 = 0, v2 = 0
+;; @0058                               v7 = load.i64 notrap aligned v6+72
+;; @0058                               v9 = uextend.i128 v7
+;; @0058                               v10 = iconst.i64 64
+;;                                     v117 = ishl v9, v10  ; v10 = 64
+;; @0058                               v8 = uextend.i128 v6
+;; @0058                               v13 = bor v117, v8
+;; @0062                               v24 = iconst.i64 1
+;; @0062                               v30 = iconst.i64 0
+;; @0062                               v31 = iconst.i64 2
+;; @0062                               v35 = iconst.i32 1
+;; @0062                               v36 = iconst.i64 16
+;; @0062                               v38 = iconst.i32 2
+;; @0062                               v50 = iconst.i64 24
+;; @0062                               v53 = stack_addr.i64 ss0
+;; @0062                               v54 = iconst.i64 48
+;; @0062                               v55 = iadd v0, v54  ; v54 = 48
+;; @0062                               v62 = iconst.i64 80
+;; @0062                               v65 = iconst.i64 -24
+;;                                     v121 = iconst.i64 0x0001_0000_0000
+;; @0062                               v60 = iconst.i64 32
+;; @005c                               jump block2(v13)
 ;;
-;;                                 block2(v18: i128):
+;;                                 block2(v16: i128):
 ;; @0062                               jump block5
 ;;
 ;;                                 block5:
-;; @0062                               v20 = ireduce.i64 v18
-;; @0062                               trapz v20, user16
-;; @0062                               v25 = load.i64 notrap aligned v20+72
-;;                                     v128 = iconst.i64 64
-;;                                     v129 = ushr.i128 v18, v128  ; v128 = 64
-;; @0062                               v24 = ireduce.i64 v129
-;; @0062                               v26 = icmp eq v25, v24
-;; @0062                               trapz v26, user23
-;;                                     v130 = iconst.i64 1
-;;                                     v131 = iadd v25, v130  ; v130 = 1
-;; @0062                               store notrap aligned v131, v20+72
-;; @0062                               v29 = load.i64 notrap aligned v20+64
-;; @0062                               v30 = load.i64 notrap aligned v0+8
-;; @0062                               v31 = load.i64 notrap aligned v30+88
-;; @0062                               v32 = load.i64 notrap aligned v30+96
-;; @0062                               store notrap aligned v31, v29+48
-;; @0062                               store notrap aligned v32, v29+56
-;;                                     v132 = iconst.i64 0
-;; @0062                               store notrap aligned v132, v20+64  ; v132 = 0
-;; @0062                               v35 = load.i64 notrap aligned v0+8
-;;                                     v133 = iconst.i64 2
-;; @0062                               store notrap aligned v133, v35+88  ; v133 = 2
-;; @0062                               store notrap aligned v20, v35+96
-;;                                     v134 = iconst.i32 1
-;;                                     v135 = iconst.i64 16
-;;                                     v136 = iadd v20, v135  ; v135 = 16
-;; @0062                               store notrap aligned v134, v136  ; v134 = 1
-;;                                     v137 = iconst.i32 2
-;;                                     v138 = iadd v32, v135  ; v135 = 16
-;; @0062                               store notrap aligned v137, v138  ; v137 = 2
-;; @0062                               v44 = load.i64 notrap aligned readonly v0+8
-;; @0062                               v47 = load.i64 notrap aligned v44+72
-;; @0062                               store notrap aligned v47, v32+8
-;; @0062                               v48 = load.i64 notrap aligned v44+24
-;; @0062                               store notrap aligned v48, v32
-;; @0062                               v51 = load.i64 notrap aligned v20
-;; @0062                               store notrap aligned v51, v44+24
-;; @0062                               v52 = load.i64 notrap aligned v20+8
-;; @0062                               store notrap aligned v52, v44+72
-;;                                     v139 = iconst.i64 24
-;;                                     v140 = iadd v32, v139  ; v139 = 24
-;; @0062                               store notrap aligned v134, v140+4  ; v134 = 1
-;; @0062                               store.i64 notrap aligned v56, v140+8
-;;                                     v141 = iadd.i64 v0, v58  ; v58 = 48
-;; @0062                               store notrap aligned v141, v56
-;; @0062                               store notrap aligned v134, v140  ; v134 = 1
-;; @0062                               store notrap aligned v134, v32+40  ; v134 = 1
-;;                                     v142 = iconst.i64 80
-;;                                     v143 = iadd v29, v142  ; v142 = 80
-;; @0062                               v68 = load.i64 notrap aligned v143
-;;                                     v144 = iconst.i64 -24
-;;                                     v145 = iadd v68, v144  ; v144 = -24
-;;                                     v146 = iconst.i64 0x0001_0000_0000
-;; @0062                               v71 = stack_switch v145, v145, v146  ; v146 = 0x0001_0000_0000
-;; @0062                               v72 = load.i64 notrap aligned v0+8
-;; @0062                               v73 = load.i64 notrap aligned v72+88
-;; @0062                               v74 = load.i64 notrap aligned v72+96
-;; @0062                               store notrap aligned v31, v72+88
-;; @0062                               store notrap aligned v32, v72+96
-;; @0062                               store notrap aligned v134, v138  ; v134 = 1
-;;                                     v147 = iconst.i32 0
-;; @0062                               store notrap aligned v147, v140  ; v147 = 0
-;; @0062                               store notrap aligned v147, v140+4  ; v147 = 0
-;; @0062                               store notrap aligned v132, v140+8  ; v132 = 0
-;; @0062                               store notrap aligned v132, v32+40  ; v132 = 0
-;;                                     v148 = iconst.i64 32
-;;                                     v149 = ushr v71, v148  ; v148 = 32
-;; @0062                               brif v149, block7, block6
+;; @0062                               v17 = ireduce.i64 v16
+;; @0062                               trapz v17, user16
+;; @0062                               v22 = load.i64 notrap aligned v17+72
+;;                                     v124 = iconst.i64 64
+;;                                     v125 = ushr.i128 v16, v124  ; v124 = 64
+;; @0062                               v21 = ireduce.i64 v125
+;; @0062                               v23 = icmp eq v22, v21
+;; @0062                               trapz v23, user23
+;;                                     v126 = iconst.i64 1
+;;                                     v127 = iadd v22, v126  ; v126 = 1
+;; @0062                               store notrap aligned v127, v17+72
+;; @0062                               v26 = load.i64 notrap aligned v17+64
+;; @0062                               v27 = load.i64 notrap aligned v0+8
+;; @0062                               v28 = load.i64 notrap aligned v27+88
+;; @0062                               v29 = load.i64 notrap aligned v27+96
+;; @0062                               store notrap aligned v28, v26+48
+;; @0062                               store notrap aligned v29, v26+56
+;;                                     v128 = iconst.i64 0
+;; @0062                               store notrap aligned v128, v17+64  ; v128 = 0
+;; @0062                               v32 = load.i64 notrap aligned v0+8
+;;                                     v129 = iconst.i64 2
+;; @0062                               store notrap aligned v129, v32+88  ; v129 = 2
+;; @0062                               store notrap aligned v17, v32+96
+;;                                     v130 = iconst.i32 1
+;;                                     v131 = iconst.i64 16
+;;                                     v132 = iadd v17, v131  ; v131 = 16
+;; @0062                               store notrap aligned v130, v132  ; v130 = 1
+;;                                     v133 = iconst.i32 2
+;;                                     v134 = iadd v29, v131  ; v131 = 16
+;; @0062                               store notrap aligned v133, v134  ; v133 = 2
+;; @0062                               v41 = load.i64 notrap aligned readonly v0+8
+;; @0062                               v44 = load.i64 notrap aligned v41+72
+;; @0062                               store notrap aligned v44, v29+8
+;; @0062                               v45 = load.i64 notrap aligned v41+24
+;; @0062                               store notrap aligned v45, v29
+;; @0062                               v48 = load.i64 notrap aligned v17
+;; @0062                               store notrap aligned v48, v41+24
+;; @0062                               v49 = load.i64 notrap aligned v17+8
+;; @0062                               store notrap aligned v49, v41+72
+;;                                     v135 = iconst.i64 24
+;;                                     v136 = iadd v29, v135  ; v135 = 24
+;; @0062                               store notrap aligned v130, v136+4  ; v130 = 1
+;; @0062                               store.i64 notrap aligned v53, v136+8
+;;                                     v137 = iadd.i64 v0, v54  ; v54 = 48
+;; @0062                               store notrap aligned v137, v53
+;; @0062                               store notrap aligned v130, v136  ; v130 = 1
+;; @0062                               store notrap aligned v130, v29+40  ; v130 = 1
+;;                                     v138 = iconst.i64 80
+;;                                     v139 = iadd v26, v138  ; v138 = 80
+;; @0062                               v64 = load.i64 notrap aligned v139
+;;                                     v140 = iconst.i64 -24
+;;                                     v141 = iadd v64, v140  ; v140 = -24
+;;                                     v142 = iconst.i64 0x0001_0000_0000
+;; @0062                               v67 = stack_switch v141, v141, v142  ; v142 = 0x0001_0000_0000
+;; @0062                               v68 = load.i64 notrap aligned v0+8
+;; @0062                               v69 = load.i64 notrap aligned v68+88
+;; @0062                               v70 = load.i64 notrap aligned v68+96
+;; @0062                               store notrap aligned v28, v68+88
+;; @0062                               store notrap aligned v29, v68+96
+;; @0062                               store notrap aligned v130, v134  ; v130 = 1
+;;                                     v143 = iconst.i32 0
+;; @0062                               store notrap aligned v143, v136  ; v143 = 0
+;; @0062                               store notrap aligned v143, v136+4  ; v143 = 0
+;; @0062                               store notrap aligned v128, v136+8  ; v128 = 0
+;; @0062                               store notrap aligned v128, v29+40  ; v128 = 0
+;;                                     v144 = iconst.i64 32
+;;                                     v145 = ushr v67, v144  ; v144 = 32
+;; @0062                               brif v145, block7, block6
 ;;
 ;;                                 block7:
-;; @0062                               v88 = load.i64 notrap aligned v44+72
-;; @0062                               store notrap aligned v88, v74+8
-;; @0062                               v91 = load.i64 notrap aligned v32
-;; @0062                               store notrap aligned v91, v44+24
-;; @0062                               v92 = load.i64 notrap aligned v32+8
-;; @0062                               store notrap aligned v92, v44+72
-;; @0062                               v94 = load.i64 notrap aligned v74+72
+;; @0062                               v84 = load.i64 notrap aligned v41+72
+;; @0062                               store notrap aligned v84, v70+8
+;; @0062                               v87 = load.i64 notrap aligned v29
+;; @0062                               store notrap aligned v87, v41+24
+;; @0062                               v88 = load.i64 notrap aligned v29+8
+;; @0062                               store notrap aligned v88, v41+72
+;; @0062                               v90 = load.i64 notrap aligned v70+72
 ;; @0062                               jump block8
 ;;
 ;;                                 block9 cold:
 ;; @0062                               trap user12
 ;;
 ;;                                 block10:
-;; @0062                               v101 = iconst.i64 120
-;; @0062                               v102 = iadd.i64 v74, v101  ; v101 = 120
-;; @0062                               v103 = load.i64 notrap aligned v102+8
-;; @0062                               v104 = load.i32 notrap aligned v103
-;;                                     v154 = iconst.i32 0
-;; @0062                               store notrap aligned v154, v102  ; v154 = 0
+;; @0062                               v97 = iconst.i64 120
+;; @0062                               v98 = iadd.i64 v70, v97  ; v97 = 120
+;; @0062                               v99 = load.i64 notrap aligned v98+8
+;; @0062                               v100 = load.i32 notrap aligned v99
+;;                                     v150 = iconst.i32 0
+;; @0062                               store notrap aligned v150, v98  ; v150 = 0
 ;; @0062                               jump block4
 ;;
 ;;                                 block8:
-;; @0062                               v93 = ireduce.i32 v71
-;; @0062                               br_table v93, block9, [block10]
+;; @0062                               v89 = ireduce.i32 v67
+;; @0062                               br_table v89, block9, [block10]
 ;;
 ;;                                 block6:
-;; @0062                               v108 = load.i64 notrap aligned v32
-;; @0062                               store notrap aligned v108, v44+24
-;; @0062                               v109 = load.i64 notrap aligned v32+8
-;; @0062                               store notrap aligned v109, v44+72
-;; @0062                               v112 = iconst.i32 4
-;;                                     v150 = iconst.i64 16
-;;                                     v151 = iadd.i64 v74, v150  ; v150 = 16
-;; @0062                               store notrap aligned v112, v151  ; v112 = 4
-;; @0062                               v115 = iconst.i64 104
-;; @0062                               v116 = iadd.i64 v74, v115  ; v115 = 104
-;; @0062                               v117 = load.i64 notrap aligned v116+8
-;;                                     v152 = iconst.i32 0
-;; @0062                               store notrap aligned v152, v116  ; v152 = 0
-;; @0062                               store notrap aligned v152, v116+4  ; v152 = 0
-;;                                     v153 = iconst.i64 0
-;; @0062                               store notrap aligned v153, v116+8  ; v153 = 0
+;; @0062                               v104 = load.i64 notrap aligned v29
+;; @0062                               store notrap aligned v104, v41+24
+;; @0062                               v105 = load.i64 notrap aligned v29+8
+;; @0062                               store notrap aligned v105, v41+72
+;; @0062                               v108 = iconst.i32 4
+;;                                     v146 = iconst.i64 16
+;;                                     v147 = iadd.i64 v70, v146  ; v146 = 16
+;; @0062                               store notrap aligned v108, v147  ; v108 = 4
+;; @0062                               v111 = iconst.i64 104
+;; @0062                               v112 = iadd.i64 v70, v111  ; v111 = 104
+;; @0062                               v113 = load.i64 notrap aligned v112+8
+;;                                     v148 = iconst.i32 0
+;; @0062                               store notrap aligned v148, v112  ; v148 = 0
+;; @0062                               store notrap aligned v148, v112+4  ; v148 = 0
+;;                                     v149 = iconst.i64 0
+;; @0062                               store notrap aligned v149, v112+8  ; v149 = 0
 ;; @0068                               return
 ;;
 ;;                                 block4:
-;; @0062                               v96 = uextend.i128 v94
-;;                                     v155 = iconst.i64 64
-;;                                     v156 = ishl v96, v155  ; v155 = 64
-;; @0062                               v95 = uextend.i128 v74
-;; @0062                               v100 = bor v156, v95
-;; @006d                               jump block2(v100)
+;; @0062                               v92 = uextend.i128 v90
+;;                                     v151 = iconst.i64 64
+;;                                     v152 = ishl v92, v151  ; v151 = 64
+;; @0062                               v91 = uextend.i128 v70
+;; @0062                               v96 = bor v152, v91
+;; @006d                               jump block2(v96)
 ;; }

--- a/tests/disas/stack-switching/resume-suspend.wat
+++ b/tests/disas/stack-switching/resume-suspend.wat
@@ -26,79 +26,78 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @003b                               v6 = load.i64 notrap aligned v0+8
-;; @003b                               v7 = load.i64 notrap aligned v6+88
-;; @003b                               v8 = load.i64 notrap aligned v6+96
-;; @003b                               v11 = iconst.i64 1
-;; @003b                               v15 = iconst.i64 24
-;; @003b                               v19 = iconst.i32 0
-;; @003b                               jump block2(v7, v8)
+;; @003b                               v4 = load.i64 notrap aligned v0+8
+;; @003b                               v5 = load.i64 notrap aligned v4+88
+;; @003b                               v6 = load.i64 notrap aligned v4+96
+;; @003b                               v9 = iconst.i64 1
+;; @003b                               v13 = iconst.i64 24
+;; @003b                               v17 = iconst.i32 0
+;; @003b                               jump block2(v5, v6)
 ;;
-;;                                 block2(v9: i64, v10: i64):
-;;                                     v62 = iconst.i64 1
-;;                                     v63 = icmp eq v9, v62  ; v62 = 1
-;; @003b                               trapnz v63, user22
+;;                                 block2(v7: i64, v8: i64):
+;;                                     v60 = iconst.i64 1
+;;                                     v61 = icmp eq v7, v60  ; v60 = 1
+;; @003b                               trapnz v61, user22
 ;; @003b                               jump block3
 ;;
 ;;                                 block3:
-;; @003b                               v13 = load.i64 notrap aligned v10+48
-;; @003b                               v14 = load.i64 notrap aligned v10+56
-;;                                     v64 = iconst.i64 24
-;;                                     v65 = iadd v14, v64  ; v64 = 24
-;; @003b                               v17 = load.i64 notrap aligned v65+8
-;; @003b                               v18 = load.i32 notrap aligned v14+40
-;;                                     v66 = iconst.i32 0
-;;                                     v56 = iconst.i32 3
-;; @003b                               v3 = iconst.i64 48
-;; @003b                               v4 = iadd.i64 v0, v3  ; v3 = 48
-;; @003b                               v28 = iconst.i32 1
-;; @003b                               jump block4(v66)  ; v66 = 0
+;; @003b                               v11 = load.i64 notrap aligned v8+48
+;; @003b                               v12 = load.i64 notrap aligned v8+56
+;;                                     v62 = iconst.i64 24
+;;                                     v63 = iadd v12, v62  ; v62 = 24
+;; @003b                               v15 = load.i64 notrap aligned v63+8
+;; @003b                               v16 = load.i32 notrap aligned v12+40
+;;                                     v64 = iconst.i32 0
+;;                                     v54 = iconst.i32 3
+;; @003b                               v2 = iconst.i64 48
+;; @003b                               v3 = iadd.i64 v0, v2  ; v2 = 48
+;; @003b                               v26 = iconst.i32 1
+;; @003b                               jump block4(v64)  ; v64 = 0
 ;;
-;;                                 block4(v20: i32):
-;; @003b                               v21 = icmp ult v20, v18
-;; @003b                               brif v21, block5, block2(v13, v14)
+;;                                 block4(v18: i32):
+;; @003b                               v19 = icmp ult v18, v16
+;; @003b                               brif v19, block5, block2(v11, v12)
 ;;
 ;;                                 block5:
-;;                                     v67 = iconst.i32 3
-;;                                     v68 = ishl.i32 v20, v67  ; v67 = 3
-;; @003b                               v24 = uextend.i64 v68
-;; @003b                               v25 = iadd.i64 v17, v24
-;; @003b                               v26 = load.i64 notrap aligned v25
-;;                                     v69 = iadd.i64 v0, v3  ; v3 = 48
-;;                                     v70 = icmp eq v26, v69
-;;                                     v71 = iconst.i32 1
-;;                                     v72 = iadd.i32 v20, v71  ; v71 = 1
-;; @003b                               brif v70, block6, block4(v72)
+;;                                     v65 = iconst.i32 3
+;;                                     v66 = ishl.i32 v18, v65  ; v65 = 3
+;; @003b                               v22 = uextend.i64 v66
+;; @003b                               v23 = iadd.i64 v15, v22
+;; @003b                               v24 = load.i64 notrap aligned v23
+;;                                     v67 = iadd.i64 v0, v2  ; v2 = 48
+;;                                     v68 = icmp eq v24, v67
+;;                                     v69 = iconst.i32 1
+;;                                     v70 = iadd.i32 v18, v69  ; v69 = 1
+;; @003b                               brif v68, block6, block4(v70)
 ;;
 ;;                                 block6:
-;; @003b                               store.i64 notrap aligned v10, v8+64
-;;                                     v73 = iconst.i32 3
-;; @003b                               v35 = iconst.i64 16
-;; @003b                               v36 = iadd.i64 v8, v35  ; v35 = 16
-;; @003b                               store notrap aligned v73, v36  ; v73 = 3
-;; @003b                               v32 = iconst.i64 0
-;; @003b                               store notrap aligned v32, v10+48  ; v32 = 0
-;; @003b                               store notrap aligned v32, v10+56  ; v32 = 0
-;; @003b                               v44 = iconst.i64 80
-;; @003b                               v45 = iadd.i64 v10, v44  ; v44 = 80
-;; @003b                               v46 = load.i64 notrap aligned v45
-;; @003b                               v47 = iconst.i64 -24
-;; @003b                               v48 = iadd v46, v47  ; v47 = -24
-;; @003b                               v42 = uextend.i64 v20
-;;                                     v59 = iconst.i64 0x0002_0000_0000
-;;                                     v60 = bor v42, v59  ; v59 = 0x0002_0000_0000
-;; @003b                               v49 = stack_switch v48, v48, v60
-;; @003b                               v30 = iconst.i64 120
-;; @003b                               v31 = iadd.i64 v8, v30  ; v30 = 120
-;; @003b                               v52 = load.i64 notrap aligned v31+8
-;;                                     v74 = iconst.i32 0
-;; @003b                               store notrap aligned v74, v31  ; v74 = 0
-;; @003b                               store notrap aligned v74, v31+4  ; v74 = 0
-;; @003b                               store notrap aligned v32, v31+8  ; v32 = 0
+;; @003b                               store.i64 notrap aligned v8, v6+64
+;;                                     v71 = iconst.i32 3
+;; @003b                               v33 = iconst.i64 16
+;; @003b                               v34 = iadd.i64 v6, v33  ; v33 = 16
+;; @003b                               store notrap aligned v71, v34  ; v71 = 3
+;; @003b                               v30 = iconst.i64 0
+;; @003b                               store notrap aligned v30, v8+48  ; v30 = 0
+;; @003b                               store notrap aligned v30, v8+56  ; v30 = 0
+;; @003b                               v42 = iconst.i64 80
+;; @003b                               v43 = iadd.i64 v8, v42  ; v42 = 80
+;; @003b                               v44 = load.i64 notrap aligned v43
+;; @003b                               v45 = iconst.i64 -24
+;; @003b                               v46 = iadd v44, v45  ; v45 = -24
+;; @003b                               v40 = uextend.i64 v18
+;;                                     v57 = iconst.i64 0x0002_0000_0000
+;;                                     v58 = bor v40, v57  ; v57 = 0x0002_0000_0000
+;; @003b                               v47 = stack_switch v46, v46, v58
+;; @003b                               v28 = iconst.i64 120
+;; @003b                               v29 = iadd.i64 v6, v28  ; v28 = 120
+;; @003b                               v50 = load.i64 notrap aligned v29+8
+;;                                     v72 = iconst.i32 0
+;; @003b                               store notrap aligned v72, v29  ; v72 = 0
+;; @003b                               store notrap aligned v72, v29+4  ; v72 = 0
+;; @003b                               store notrap aligned v30, v29+8  ; v30 = 0
 ;; @003d                               jump block1
 ;;
 ;;                                 block1:
@@ -110,7 +109,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, i32) -> i64 tail
 ;;     sig1 = (i64 vmctx, i64, i32, i32) -> i64 tail
 ;;     fn0 = colocated u805306368:6 sig0
@@ -119,143 +117,143 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64):
 ;; @0043                               v9 = iconst.i32 0
-;; @0043                               v11 = call fn0(v0, v9)  ; v9 = 0
-;; @0045                               trapz v11, user16
-;; @0045                               v15 = call fn1(v0, v11, v9, v9)  ; v9 = 0, v9 = 0
-;; @0045                               v16 = load.i64 notrap aligned v15+72
+;; @0043                               v10 = call fn0(v0, v9)  ; v9 = 0
+;; @0045                               trapz v10, user16
+;; @0045                               v13 = call fn1(v0, v10, v9, v9)  ; v9 = 0, v9 = 0
+;; @0045                               v14 = load.i64 notrap aligned v13+72
 ;; @004e                               jump block3
 ;;
 ;;                                 block3:
-;; @0045                               v18 = uextend.i128 v16
+;; @0045                               v16 = uextend.i128 v14
 ;; @0040                               v5 = iconst.i64 64
-;;                                     v134 = ishl v18, v5  ; v5 = 64
-;;                                     v136 = ireduce.i64 v134
-;;                                     v138 = bor v136, v15
-;; @004e                               trapz v138, user16
-;; @004e                               v30 = load.i64 notrap aligned v138+72
-;; @0045                               v17 = uextend.i128 v15
-;; @0045                               v22 = bor v134, v17
-;;                                     v140 = ushr v22, v5  ; v5 = 64
-;; @004e                               v29 = ireduce.i64 v140
-;; @004e                               v31 = icmp eq v30, v29
-;; @004e                               trapz v31, user23
-;; @004e                               v32 = iconst.i64 1
-;; @004e                               v33 = iadd v30, v32  ; v32 = 1
-;; @004e                               store notrap aligned v33, v138+72
-;; @004e                               v34 = load.i64 notrap aligned v138+64
-;; @004e                               v35 = load.i64 notrap aligned v0+8
-;; @004e                               v36 = load.i64 notrap aligned v35+88
-;; @004e                               v37 = load.i64 notrap aligned v35+96
-;; @004e                               store notrap aligned v36, v34+48
-;; @004e                               store notrap aligned v37, v34+56
+;;                                     v130 = ishl v16, v5  ; v5 = 64
+;;                                     v132 = ireduce.i64 v130
+;;                                     v134 = bor v132, v13
+;; @004e                               trapz v134, user16
+;; @004e                               v27 = load.i64 notrap aligned v134+72
+;; @0045                               v15 = uextend.i128 v13
+;; @0045                               v20 = bor v130, v15
+;;                                     v136 = ushr v20, v5  ; v5 = 64
+;; @004e                               v26 = ireduce.i64 v136
+;; @004e                               v28 = icmp eq v27, v26
+;; @004e                               trapz v28, user23
+;; @004e                               v29 = iconst.i64 1
+;; @004e                               v30 = iadd v27, v29  ; v29 = 1
+;; @004e                               store notrap aligned v30, v134+72
+;; @004e                               v31 = load.i64 notrap aligned v134+64
+;; @004e                               v32 = load.i64 notrap aligned v0+8
+;; @004e                               v33 = load.i64 notrap aligned v32+88
+;; @004e                               v34 = load.i64 notrap aligned v32+96
+;; @004e                               store notrap aligned v33, v31+48
+;; @004e                               store notrap aligned v34, v31+56
 ;; @0040                               v2 = iconst.i64 0
-;; @004e                               store notrap aligned v2, v138+64  ; v2 = 0
-;; @004e                               v40 = load.i64 notrap aligned v0+8
-;; @004e                               v39 = iconst.i64 2
-;; @004e                               store notrap aligned v39, v40+88  ; v39 = 2
-;; @004e                               store notrap aligned v138, v40+96
-;; @004e                               v43 = iconst.i32 1
-;; @004e                               v44 = iconst.i64 16
-;; @004e                               v45 = iadd v138, v44  ; v44 = 16
-;; @004e                               store notrap aligned v43, v45  ; v43 = 1
-;; @004e                               v46 = iconst.i32 2
-;; @004e                               v48 = iadd v37, v44  ; v44 = 16
-;; @004e                               store notrap aligned v46, v48  ; v46 = 2
-;; @004e                               v49 = load.i64 notrap aligned readonly v0+8
-;; @004e                               v52 = load.i64 notrap aligned v49+72
-;; @004e                               store notrap aligned v52, v37+8
-;; @004e                               v53 = load.i64 notrap aligned v49+24
-;; @004e                               store notrap aligned v53, v37
-;; @004e                               v56 = load.i64 notrap aligned v138
-;; @004e                               store notrap aligned v56, v49+24
-;; @004e                               v57 = load.i64 notrap aligned v138+8
-;; @004e                               store notrap aligned v57, v49+72
-;; @004e                               v58 = iconst.i64 24
-;; @004e                               v59 = iadd v37, v58  ; v58 = 24
-;; @004e                               store notrap aligned v43, v59+4  ; v43 = 1
-;; @004e                               v61 = stack_addr.i64 ss0
-;; @004e                               store notrap aligned v61, v59+8
-;; @004e                               v63 = iconst.i64 48
-;; @004e                               v64 = iadd.i64 v0, v63  ; v63 = 48
-;; @004e                               store notrap aligned v64, v61
-;; @004e                               store notrap aligned v43, v59  ; v43 = 1
-;; @004e                               store notrap aligned v43, v37+40  ; v43 = 1
-;; @004e                               v71 = iconst.i64 80
-;; @004e                               v72 = iadd v34, v71  ; v71 = 80
-;; @004e                               v73 = load.i64 notrap aligned v72
-;; @004e                               v74 = iconst.i64 -24
-;; @004e                               v75 = iadd v73, v74  ; v74 = -24
-;;                                     v142 = iconst.i64 0x0001_0000_0000
-;; @004e                               v76 = stack_switch v75, v75, v142  ; v142 = 0x0001_0000_0000
-;; @004e                               v77 = load.i64 notrap aligned v0+8
-;; @004e                               v78 = load.i64 notrap aligned v77+88
-;; @004e                               v79 = load.i64 notrap aligned v77+96
-;; @004e                               store notrap aligned v36, v77+88
-;; @004e                               store notrap aligned v37, v77+96
-;; @004e                               store notrap aligned v43, v48  ; v43 = 1
-;;                                     v145 = iconst.i32 0
-;; @004e                               store notrap aligned v145, v59  ; v145 = 0
-;; @004e                               store notrap aligned v145, v59+4  ; v145 = 0
-;; @004e                               store notrap aligned v2, v59+8  ; v2 = 0
-;; @004e                               store notrap aligned v2, v37+40  ; v2 = 0
-;; @004e                               v69 = iconst.i64 32
-;; @004e                               v88 = ushr v76, v69  ; v69 = 32
-;; @004e                               brif v88, block5, block4
+;; @004e                               store notrap aligned v2, v134+64  ; v2 = 0
+;; @004e                               v37 = load.i64 notrap aligned v0+8
+;; @004e                               v36 = iconst.i64 2
+;; @004e                               store notrap aligned v36, v37+88  ; v36 = 2
+;; @004e                               store notrap aligned v134, v37+96
+;; @004e                               v40 = iconst.i32 1
+;; @004e                               v41 = iconst.i64 16
+;; @004e                               v42 = iadd v134, v41  ; v41 = 16
+;; @004e                               store notrap aligned v40, v42  ; v40 = 1
+;; @004e                               v43 = iconst.i32 2
+;; @004e                               v45 = iadd v34, v41  ; v41 = 16
+;; @004e                               store notrap aligned v43, v45  ; v43 = 2
+;; @004e                               v46 = load.i64 notrap aligned readonly v0+8
+;; @004e                               v49 = load.i64 notrap aligned v46+72
+;; @004e                               store notrap aligned v49, v34+8
+;; @004e                               v50 = load.i64 notrap aligned v46+24
+;; @004e                               store notrap aligned v50, v34
+;; @004e                               v53 = load.i64 notrap aligned v134
+;; @004e                               store notrap aligned v53, v46+24
+;; @004e                               v54 = load.i64 notrap aligned v134+8
+;; @004e                               store notrap aligned v54, v46+72
+;; @004e                               v55 = iconst.i64 24
+;; @004e                               v56 = iadd v34, v55  ; v55 = 24
+;; @004e                               store notrap aligned v40, v56+4  ; v40 = 1
+;; @004e                               v58 = stack_addr.i64 ss0
+;; @004e                               store notrap aligned v58, v56+8
+;; @004e                               v59 = iconst.i64 48
+;; @004e                               v60 = iadd.i64 v0, v59  ; v59 = 48
+;; @004e                               store notrap aligned v60, v58
+;; @004e                               store notrap aligned v40, v56  ; v40 = 1
+;; @004e                               store notrap aligned v40, v34+40  ; v40 = 1
+;; @004e                               v67 = iconst.i64 80
+;; @004e                               v68 = iadd v31, v67  ; v67 = 80
+;; @004e                               v69 = load.i64 notrap aligned v68
+;; @004e                               v70 = iconst.i64 -24
+;; @004e                               v71 = iadd v69, v70  ; v70 = -24
+;;                                     v138 = iconst.i64 0x0001_0000_0000
+;; @004e                               v72 = stack_switch v71, v71, v138  ; v138 = 0x0001_0000_0000
+;; @004e                               v73 = load.i64 notrap aligned v0+8
+;; @004e                               v74 = load.i64 notrap aligned v73+88
+;; @004e                               v75 = load.i64 notrap aligned v73+96
+;; @004e                               store notrap aligned v33, v73+88
+;; @004e                               store notrap aligned v34, v73+96
+;; @004e                               store notrap aligned v40, v45  ; v40 = 1
+;;                                     v141 = iconst.i32 0
+;; @004e                               store notrap aligned v141, v56  ; v141 = 0
+;; @004e                               store notrap aligned v141, v56+4  ; v141 = 0
+;; @004e                               store notrap aligned v2, v56+8  ; v2 = 0
+;; @004e                               store notrap aligned v2, v34+40  ; v2 = 0
+;; @004e                               v65 = iconst.i64 32
+;; @004e                               v84 = ushr v72, v65  ; v65 = 32
+;; @004e                               brif v84, block5, block4
 ;;
 ;;                                 block5:
-;; @004e                               v93 = load.i64 notrap aligned v49+72
-;; @004e                               store notrap aligned v93, v79+8
-;; @004e                               v96 = load.i64 notrap aligned v37
-;; @004e                               store notrap aligned v96, v49+24
-;; @004e                               v97 = load.i64 notrap aligned v37+8
-;; @004e                               store notrap aligned v97, v49+72
-;; @004e                               v99 = load.i64 notrap aligned v79+72
+;; @004e                               v89 = load.i64 notrap aligned v46+72
+;; @004e                               store notrap aligned v89, v75+8
+;; @004e                               v92 = load.i64 notrap aligned v34
+;; @004e                               store notrap aligned v92, v46+24
+;; @004e                               v93 = load.i64 notrap aligned v34+8
+;; @004e                               store notrap aligned v93, v46+72
+;; @004e                               v95 = load.i64 notrap aligned v75+72
 ;; @004e                               jump block6
 ;;
 ;;                                 block7 cold:
 ;; @004e                               trap user12
 ;;
 ;;                                 block8:
-;; @004e                               v106 = iconst.i64 120
-;; @004e                               v107 = iadd.i64 v79, v106  ; v106 = 120
-;; @004e                               v108 = load.i64 notrap aligned v107+8
-;;                                     v153 = iconst.i32 0
-;; @004e                               store notrap aligned v153, v107  ; v153 = 0
-;; @004e                               v101 = uextend.i128 v99
-;;                                     v154 = iconst.i64 64
-;;                                     v155 = ishl v101, v154  ; v154 = 64
-;; @004e                               v100 = uextend.i128 v79
-;; @004e                               v105 = bor v155, v100
-;; @004e                               jump block2(v105)
+;; @004e                               v102 = iconst.i64 120
+;; @004e                               v103 = iadd.i64 v75, v102  ; v102 = 120
+;; @004e                               v104 = load.i64 notrap aligned v103+8
+;;                                     v149 = iconst.i32 0
+;; @004e                               store notrap aligned v149, v103  ; v149 = 0
+;; @004e                               v97 = uextend.i128 v95
+;;                                     v150 = iconst.i64 64
+;;                                     v151 = ishl v97, v150  ; v150 = 64
+;; @004e                               v96 = uextend.i128 v75
+;; @004e                               v101 = bor v151, v96
+;; @004e                               jump block2(v101)
 ;;
 ;;                                 block6:
-;; @004e                               v98 = ireduce.i32 v76
-;; @004e                               br_table v98, block7, [block8]
+;; @004e                               v94 = ireduce.i32 v72
+;; @004e                               br_table v94, block7, [block8]
 ;;
 ;;                                 block4:
-;; @004e                               v112 = load.i64 notrap aligned v37
-;; @004e                               store notrap aligned v112, v49+24
-;; @004e                               v113 = load.i64 notrap aligned v37+8
-;; @004e                               store notrap aligned v113, v49+72
-;; @004e                               v116 = iconst.i32 4
-;;                                     v146 = iconst.i64 16
-;;                                     v147 = iadd.i64 v79, v146  ; v146 = 16
-;; @004e                               store notrap aligned v116, v147  ; v116 = 4
-;; @004e                               v119 = iconst.i64 104
-;; @004e                               v120 = iadd.i64 v79, v119  ; v119 = 104
-;; @004e                               v121 = load.i64 notrap aligned v120+8
-;;                                     v148 = iconst.i32 0
-;; @004e                               store notrap aligned v148, v120  ; v148 = 0
-;; @004e                               store notrap aligned v148, v120+4  ; v148 = 0
-;;                                     v149 = iconst.i64 0
-;; @004e                               store notrap aligned v149, v120+8  ; v149 = 0
-;;                                     v150 = uextend.i128 v149  ; v149 = 0
-;;                                     v151 = iconst.i64 64
-;;                                     v152 = ishl v150, v151  ; v151 = 64
-;; @0040                               v8 = bor v152, v150
+;; @004e                               v108 = load.i64 notrap aligned v34
+;; @004e                               store notrap aligned v108, v46+24
+;; @004e                               v109 = load.i64 notrap aligned v34+8
+;; @004e                               store notrap aligned v109, v46+72
+;; @004e                               v112 = iconst.i32 4
+;;                                     v142 = iconst.i64 16
+;;                                     v143 = iadd.i64 v75, v142  ; v142 = 16
+;; @004e                               store notrap aligned v112, v143  ; v112 = 4
+;; @004e                               v115 = iconst.i64 104
+;; @004e                               v116 = iadd.i64 v75, v115  ; v115 = 104
+;; @004e                               v117 = load.i64 notrap aligned v116+8
+;;                                     v144 = iconst.i32 0
+;; @004e                               store notrap aligned v144, v116  ; v144 = 0
+;; @004e                               store notrap aligned v144, v116+4  ; v144 = 0
+;;                                     v145 = iconst.i64 0
+;; @004e                               store notrap aligned v145, v116+8  ; v145 = 0
+;;                                     v146 = uextend.i128 v145  ; v145 = 0
+;;                                     v147 = iconst.i64 64
+;;                                     v148 = ishl v146, v147  ; v147 = 64
+;; @0040                               v8 = bor v148, v146
 ;; @0056                               jump block2(v8)
 ;;
-;;                                 block2(v23: i128):
+;;                                 block2(v21: i128):
 ;; @0058                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/stack-switching/symmetric-switch.wat
+++ b/tests/disas/stack-switching/symmetric-switch.wat
@@ -30,7 +30,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, i32) -> i64 tail
 ;;     sig1 = (i64 vmctx, i64, i32, i32) -> i64 tail
 ;;     fn0 = colocated u805306368:6 sig0
@@ -39,188 +38,188 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64):
 ;; @003a                               v2 = iconst.i32 1
-;; @003a                               v4 = call fn0(v0, v2)  ; v2 = 1
-;; @003c                               trapz v4, user16
-;; @003c                               v5 = iconst.i32 1
-;; @003c                               v6 = iconst.i32 0
-;; @003c                               v8 = call fn1(v0, v4, v5, v6)  ; v5 = 1, v6 = 0
-;; @003c                               v9 = load.i64 notrap aligned v8+72
-;; @003c                               v10 = uextend.i128 v8
-;; @003c                               v11 = uextend.i128 v9
-;; @003c                               v12 = iconst.i64 64
-;; @003c                               v13 = uextend.i128 v12  ; v12 = 64
-;; @003c                               v14 = ishl v11, v13
-;; @003c                               v15 = bor v14, v10
-;; @003e                               v17 = ireduce.i64 v15
-;; @003e                               v18 = iconst.i64 64
-;; @003e                               v19 = uextend.i128 v18  ; v18 = 64
-;; @003e                               v20 = ushr v15, v19
-;; @003e                               v21 = ireduce.i64 v20
-;; @003e                               trapz v17, user16
-;; @003e                               v22 = load.i64 notrap aligned v17+72
-;; @003e                               v23 = icmp eq v22, v21
-;; @003e                               trapz v23, user23
-;; @003e                               v24 = iconst.i64 1
-;; @003e                               v25 = iadd v22, v24  ; v24 = 1
-;; @003e                               store notrap aligned v25, v17+72
-;; @003e                               v27 = iconst.i64 48
-;; @003e                               v28 = iadd v0, v27  ; v27 = 48
-;; @003e                               v29 = load.i64 notrap aligned v0+8
-;; @003e                               v30 = load.i64 notrap aligned v29+88
-;; @003e                               v31 = load.i64 notrap aligned v29+96
-;; @003e                               jump block2(v30, v31)
+;; @003a                               v3 = call fn0(v0, v2)  ; v2 = 1
+;; @003c                               trapz v3, user16
+;; @003c                               v4 = iconst.i32 1
+;; @003c                               v5 = iconst.i32 0
+;; @003c                               v6 = call fn1(v0, v3, v4, v5)  ; v4 = 1, v5 = 0
+;; @003c                               v7 = load.i64 notrap aligned v6+72
+;; @003c                               v8 = uextend.i128 v6
+;; @003c                               v9 = uextend.i128 v7
+;; @003c                               v10 = iconst.i64 64
+;; @003c                               v11 = uextend.i128 v10  ; v10 = 64
+;; @003c                               v12 = ishl v9, v11
+;; @003c                               v13 = bor v12, v8
+;; @003e                               v14 = ireduce.i64 v13
+;; @003e                               v15 = iconst.i64 64
+;; @003e                               v16 = uextend.i128 v15  ; v15 = 64
+;; @003e                               v17 = ushr v13, v16
+;; @003e                               v18 = ireduce.i64 v17
+;; @003e                               trapz v14, user16
+;; @003e                               v19 = load.i64 notrap aligned v14+72
+;; @003e                               v20 = icmp eq v19, v18
+;; @003e                               trapz v20, user23
+;; @003e                               v21 = iconst.i64 1
+;; @003e                               v22 = iadd v19, v21  ; v21 = 1
+;; @003e                               store notrap aligned v22, v14+72
+;; @003e                               v23 = iconst.i64 48
+;; @003e                               v24 = iadd v0, v23  ; v23 = 48
+;; @003e                               v25 = load.i64 notrap aligned v0+8
+;; @003e                               v26 = load.i64 notrap aligned v25+88
+;; @003e                               v27 = load.i64 notrap aligned v25+96
+;; @003e                               jump block2(v26, v27)
 ;;
-;;                                 block2(v32: i64, v33: i64):
-;; @003e                               v34 = iconst.i64 1
-;; @003e                               v35 = icmp eq v32, v34  ; v34 = 1
-;; @003e                               trapnz v35, user22
+;;                                 block2(v28: i64, v29: i64):
+;; @003e                               v30 = iconst.i64 1
+;; @003e                               v31 = icmp eq v28, v30  ; v30 = 1
+;; @003e                               trapnz v31, user22
 ;; @003e                               jump block3
 ;;
 ;;                                 block3:
-;; @003e                               v36 = load.i64 notrap aligned v33+48
-;; @003e                               v37 = load.i64 notrap aligned v33+56
-;; @003e                               v38 = iconst.i64 24
-;; @003e                               v39 = iadd v37, v38  ; v38 = 24
-;; @003e                               v40 = load.i64 notrap aligned v39+8
-;; @003e                               v41 = load.i32 notrap aligned v37+40
-;; @003e                               v42 = load.i32 notrap aligned v39
-;; @003e                               jump block4(v41)
+;; @003e                               v32 = load.i64 notrap aligned v29+48
+;; @003e                               v33 = load.i64 notrap aligned v29+56
+;; @003e                               v34 = iconst.i64 24
+;; @003e                               v35 = iadd v33, v34  ; v34 = 24
+;; @003e                               v36 = load.i64 notrap aligned v35+8
+;; @003e                               v37 = load.i32 notrap aligned v33+40
+;; @003e                               v38 = load.i32 notrap aligned v35
+;; @003e                               jump block4(v37)
 ;;
-;;                                 block4(v43: i32):
-;; @003e                               v44 = icmp ult v43, v42
-;; @003e                               brif v44, block5, block2(v36, v37)
+;;                                 block4(v39: i32):
+;; @003e                               v40 = icmp ult v39, v38
+;; @003e                               brif v40, block5, block2(v32, v33)
 ;;
 ;;                                 block5:
-;; @003e                               v45 = iconst.i32 8
-;; @003e                               v46 = imul.i32 v43, v45  ; v45 = 8
-;; @003e                               v47 = uextend.i64 v46
-;; @003e                               v48 = iadd.i64 v40, v47
-;; @003e                               v49 = load.i64 notrap aligned v48
-;; @003e                               v50 = icmp eq v49, v28
-;; @003e                               v51 = iconst.i32 1
-;; @003e                               v52 = iadd.i32 v43, v51  ; v51 = 1
-;; @003e                               brif v50, block6, block4(v52)
+;; @003e                               v41 = iconst.i32 8
+;; @003e                               v42 = imul.i32 v39, v41  ; v41 = 8
+;; @003e                               v43 = uextend.i64 v42
+;; @003e                               v44 = iadd.i64 v36, v43
+;; @003e                               v45 = load.i64 notrap aligned v44
+;; @003e                               v46 = icmp eq v45, v24
+;; @003e                               v47 = iconst.i32 1
+;; @003e                               v48 = iadd.i32 v39, v47  ; v47 = 1
+;; @003e                               brif v46, block6, block4(v48)
 ;;
 ;;                                 block6:
-;; @003e                               store.i64 notrap aligned v33, v31+64
-;; @003e                               v53 = iconst.i64 120
-;; @003e                               v54 = iadd.i64 v31, v53  ; v53 = 120
-;; @003e                               v55 = iconst.i64 0
-;; @003e                               v56 = iadd.i64 v31, v55  ; v55 = 0
-;; @003e                               v57 = iconst.i32 3
-;; @003e                               v58 = iconst.i64 16
-;; @003e                               v59 = iadd v56, v58  ; v58 = 16
-;; @003e                               store notrap aligned v57, v59  ; v57 = 3
-;; @003e                               v60 = iconst.i64 0
-;; @003e                               v61 = iconst.i64 0
-;; @003e                               store notrap aligned v60, v33+48  ; v60 = 0
-;; @003e                               store notrap aligned v61, v33+56  ; v61 = 0
-;; @003e                               v62 = load.i64 notrap aligned readonly v0+8
-;; @003e                               v63 = iconst.i64 0
-;; @003e                               v64 = iadd v56, v63  ; v63 = 0
-;; @003e                               v65 = load.i64 notrap aligned v62+72
-;; @003e                               store notrap aligned v65, v64+8
-;; @003e                               v66 = load.i64 notrap aligned v31+72
-;; @003e                               v67 = uextend.i128 v31
-;; @003e                               v68 = uextend.i128 v66
-;; @003e                               v69 = iconst.i64 64
-;; @003e                               v70 = uextend.i128 v69  ; v69 = 64
-;; @003e                               v71 = ishl v68, v70
-;; @003e                               v72 = bor v71, v67
-;; @003e                               v74 = iconst.i64 0
-;; @003e                               v75 = iadd.i64 v17, v74  ; v74 = 0
-;; @003e                               v76 = iconst.i64 16
-;; @003e                               v77 = iadd v75, v76  ; v76 = 16
-;; @003e                               v78 = load.i32 notrap aligned v77
-;; @003e                               v79 = iconst.i32 0
-;; @003e                               v80 = icmp ne v78, v79  ; v79 = 0
-;; @003e                               brif v80, block9, block8
+;; @003e                               store.i64 notrap aligned v29, v27+64
+;; @003e                               v49 = iconst.i64 120
+;; @003e                               v50 = iadd.i64 v27, v49  ; v49 = 120
+;; @003e                               v51 = iconst.i64 0
+;; @003e                               v52 = iadd.i64 v27, v51  ; v51 = 0
+;; @003e                               v53 = iconst.i32 3
+;; @003e                               v54 = iconst.i64 16
+;; @003e                               v55 = iadd v52, v54  ; v54 = 16
+;; @003e                               store notrap aligned v53, v55  ; v53 = 3
+;; @003e                               v56 = iconst.i64 0
+;; @003e                               v57 = iconst.i64 0
+;; @003e                               store notrap aligned v56, v29+48  ; v56 = 0
+;; @003e                               store notrap aligned v57, v29+56  ; v57 = 0
+;; @003e                               v58 = load.i64 notrap aligned readonly v0+8
+;; @003e                               v59 = iconst.i64 0
+;; @003e                               v60 = iadd v52, v59  ; v59 = 0
+;; @003e                               v61 = load.i64 notrap aligned v58+72
+;; @003e                               store notrap aligned v61, v60+8
+;; @003e                               v62 = load.i64 notrap aligned v27+72
+;; @003e                               v63 = uextend.i128 v27
+;; @003e                               v64 = uextend.i128 v62
+;; @003e                               v65 = iconst.i64 64
+;; @003e                               v66 = uextend.i128 v65  ; v65 = 64
+;; @003e                               v67 = ishl v64, v66
+;; @003e                               v68 = bor v67, v63
+;; @003e                               v70 = iconst.i64 0
+;; @003e                               v71 = iadd.i64 v14, v70  ; v70 = 0
+;; @003e                               v72 = iconst.i64 16
+;; @003e                               v73 = iadd v71, v72  ; v72 = 16
+;; @003e                               v74 = load.i32 notrap aligned v73
+;; @003e                               v75 = iconst.i32 0
+;; @003e                               v76 = icmp ne v74, v75  ; v75 = 0
+;; @003e                               brif v76, block9, block8
 ;;
 ;;                                 block8:
-;; @003e                               v81 = iconst.i64 104
-;; @003e                               v82 = iadd.i64 v17, v81  ; v81 = 104
-;; @003e                               v83 = load.i64 notrap aligned v82+8
-;; @003e                               v84 = load.i32 notrap aligned v82
-;; @003e                               v85 = iconst.i32 1
-;; @003e                               v86 = iadd v84, v85  ; v85 = 1
-;; @003e                               store notrap aligned v86, v82
-;; @003e                               v87 = uextend.i64 v84
-;; @003e                               v88 = iconst.i64 16
-;; @003e                               v89 = imul v87, v88  ; v88 = 16
-;; @003e                               v90 = iadd v83, v89
-;; @003e                               jump block10(v90)
+;; @003e                               v77 = iconst.i64 104
+;; @003e                               v78 = iadd.i64 v14, v77  ; v77 = 104
+;; @003e                               v79 = load.i64 notrap aligned v78+8
+;; @003e                               v80 = load.i32 notrap aligned v78
+;; @003e                               v81 = iconst.i32 1
+;; @003e                               v82 = iadd v80, v81  ; v81 = 1
+;; @003e                               store notrap aligned v82, v78
+;; @003e                               v83 = uextend.i64 v80
+;; @003e                               v84 = iconst.i64 16
+;; @003e                               v85 = imul v83, v84  ; v84 = 16
+;; @003e                               v86 = iadd v79, v85
+;; @003e                               jump block10(v86)
 ;;
 ;;                                 block9:
-;; @003e                               v91 = iconst.i64 120
-;; @003e                               v92 = iadd.i64 v17, v91  ; v91 = 120
-;; @003e                               v93 = load.i64 notrap aligned v92+8
-;; @003e                               v94 = load.i32 notrap aligned v92
-;; @003e                               v95 = iconst.i32 1
-;; @003e                               v96 = iadd v94, v95  ; v95 = 1
-;; @003e                               store notrap aligned v96, v92
-;; @003e                               v97 = uextend.i64 v94
-;; @003e                               v98 = iconst.i64 16
-;; @003e                               v99 = imul v97, v98  ; v98 = 16
-;; @003e                               v100 = iadd v93, v99
-;; @003e                               jump block10(v100)
+;; @003e                               v87 = iconst.i64 120
+;; @003e                               v88 = iadd.i64 v14, v87  ; v87 = 120
+;; @003e                               v89 = load.i64 notrap aligned v88+8
+;; @003e                               v90 = load.i32 notrap aligned v88
+;; @003e                               v91 = iconst.i32 1
+;; @003e                               v92 = iadd v90, v91  ; v91 = 1
+;; @003e                               store notrap aligned v92, v88
+;; @003e                               v93 = uextend.i64 v90
+;; @003e                               v94 = iconst.i64 16
+;; @003e                               v95 = imul v93, v94  ; v94 = 16
+;; @003e                               v96 = iadd v89, v95
+;; @003e                               jump block10(v96)
 ;;
-;;                                 block10(v73: i64):
-;; @003e                               store.i128 notrap aligned v72, v73
-;; @003e                               v101 = iconst.i64 0
-;; @003e                               v102 = iadd.i64 v17, v101  ; v101 = 0
-;; @003e                               v103 = iconst.i32 1
-;; @003e                               v104 = iconst.i64 16
-;; @003e                               v105 = iadd v102, v104  ; v104 = 16
-;; @003e                               store notrap aligned v103, v105  ; v103 = 1
-;; @003e                               v106 = load.i64 notrap aligned v17+64
-;; @003e                               store.i64 notrap aligned v36, v106+48
-;; @003e                               store.i64 notrap aligned v37, v106+56
-;; @003e                               v107 = iconst.i64 2
-;; @003e                               v108 = load.i64 notrap aligned v0+8
-;; @003e                               store notrap aligned v107, v108+88  ; v107 = 2
-;; @003e                               store.i64 notrap aligned v17, v108+96
-;; @003e                               v109 = iconst.i64 0
-;; @003e                               v110 = iadd v102, v109  ; v109 = 0
+;;                                 block10(v69: i64):
+;; @003e                               store.i128 notrap aligned v68, v69
+;; @003e                               v97 = iconst.i64 0
+;; @003e                               v98 = iadd.i64 v14, v97  ; v97 = 0
+;; @003e                               v99 = iconst.i32 1
+;; @003e                               v100 = iconst.i64 16
+;; @003e                               v101 = iadd v98, v100  ; v100 = 16
+;; @003e                               store notrap aligned v99, v101  ; v99 = 1
+;; @003e                               v102 = load.i64 notrap aligned v14+64
+;; @003e                               store.i64 notrap aligned v32, v102+48
+;; @003e                               store.i64 notrap aligned v33, v102+56
+;; @003e                               v103 = iconst.i64 2
+;; @003e                               v104 = load.i64 notrap aligned v0+8
+;; @003e                               store notrap aligned v103, v104+88  ; v103 = 2
+;; @003e                               store.i64 notrap aligned v14, v104+96
+;; @003e                               v105 = iconst.i64 0
+;; @003e                               v106 = iadd v98, v105  ; v105 = 0
+;; @003e                               v107 = load.i64 notrap aligned v106
+;; @003e                               store notrap aligned v107, v58+24
+;; @003e                               v108 = load.i64 notrap aligned v106+8
+;; @003e                               store notrap aligned v108, v58+72
+;; @003e                               v109 = iconst.i64 80
+;; @003e                               v110 = iadd.i64 v29, v109  ; v109 = 80
 ;; @003e                               v111 = load.i64 notrap aligned v110
-;; @003e                               store notrap aligned v111, v62+24
-;; @003e                               v112 = load.i64 notrap aligned v110+8
-;; @003e                               store notrap aligned v112, v62+72
-;; @003e                               v113 = iconst.i64 80
-;; @003e                               v114 = iadd.i64 v33, v113  ; v113 = 80
-;; @003e                               v115 = load.i64 notrap aligned v114
-;; @003e                               v116 = iconst.i64 -24
-;; @003e                               v117 = iadd v115, v116  ; v116 = -24
-;; @003e                               v118 = iconst.i64 80
-;; @003e                               v119 = iadd v106, v118  ; v118 = 80
-;; @003e                               v120 = load.i64 notrap aligned v119
-;; @003e                               v121 = iconst.i64 -24
-;; @003e                               v122 = iadd v120, v121  ; v121 = -24
-;; @003e                               v123 = stack_addr.i64 ss0
-;; @003e                               v124 = load.i64 notrap aligned v122
-;; @003e                               store notrap aligned v124, v123
-;; @003e                               v125 = load.i64 notrap aligned v117
-;; @003e                               store notrap aligned v125, v122
-;; @003e                               v126 = load.i64 notrap aligned v122+8
-;; @003e                               store notrap aligned v126, v123+8
-;; @003e                               v127 = load.i64 notrap aligned v117+8
-;; @003e                               store notrap aligned v127, v122+8
-;; @003e                               v128 = load.i64 notrap aligned v122+16
-;; @003e                               store notrap aligned v128, v123+16
-;; @003e                               v129 = load.i64 notrap aligned v117+16
-;; @003e                               store notrap aligned v129, v122+16
-;; @003e                               v130 = iconst.i64 3
-;; @003e                               v131 = iconst.i64 32
-;; @003e                               v132 = ishl v130, v131  ; v130 = 3, v131 = 32
-;; @003e                               v133 = stack_switch v117, v123, v132
-;; @003e                               v134 = iconst.i64 120
-;; @003e                               v135 = iadd.i64 v31, v134  ; v134 = 120
-;; @003e                               v136 = load.i64 notrap aligned v135+8
-;; @003e                               v137 = iconst.i32 0
-;; @003e                               store notrap aligned v137, v135  ; v137 = 0
-;; @003e                               v138 = iconst.i32 0
-;; @003e                               store notrap aligned v138, v135+4  ; v138 = 0
-;; @003e                               v139 = iconst.i64 0
-;; @003e                               store notrap aligned v139, v135+8  ; v139 = 0
+;; @003e                               v112 = iconst.i64 -24
+;; @003e                               v113 = iadd v111, v112  ; v112 = -24
+;; @003e                               v114 = iconst.i64 80
+;; @003e                               v115 = iadd v102, v114  ; v114 = 80
+;; @003e                               v116 = load.i64 notrap aligned v115
+;; @003e                               v117 = iconst.i64 -24
+;; @003e                               v118 = iadd v116, v117  ; v117 = -24
+;; @003e                               v119 = stack_addr.i64 ss0
+;; @003e                               v120 = load.i64 notrap aligned v118
+;; @003e                               store notrap aligned v120, v119
+;; @003e                               v121 = load.i64 notrap aligned v113
+;; @003e                               store notrap aligned v121, v118
+;; @003e                               v122 = load.i64 notrap aligned v118+8
+;; @003e                               store notrap aligned v122, v119+8
+;; @003e                               v123 = load.i64 notrap aligned v113+8
+;; @003e                               store notrap aligned v123, v118+8
+;; @003e                               v124 = load.i64 notrap aligned v118+16
+;; @003e                               store notrap aligned v124, v119+16
+;; @003e                               v125 = load.i64 notrap aligned v113+16
+;; @003e                               store notrap aligned v125, v118+16
+;; @003e                               v126 = iconst.i64 3
+;; @003e                               v127 = iconst.i64 32
+;; @003e                               v128 = ishl v126, v127  ; v126 = 3, v127 = 32
+;; @003e                               v129 = stack_switch v113, v119, v128
+;; @003e                               v130 = iconst.i64 120
+;; @003e                               v131 = iadd.i64 v27, v130  ; v130 = 120
+;; @003e                               v132 = load.i64 notrap aligned v131+8
+;; @003e                               v133 = iconst.i32 0
+;; @003e                               store notrap aligned v133, v131  ; v133 = 0
+;; @003e                               v134 = iconst.i32 0
+;; @003e                               store notrap aligned v134, v131+4  ; v134 = 0
+;; @003e                               v135 = iconst.i64 0
+;; @003e                               store notrap aligned v135, v131+8  ; v135 = 0
 ;; @0041                               jump block1
 ;;
 ;;                                 block1:
@@ -245,7 +244,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, i32) -> i64 tail
 ;;     sig1 = (i64 vmctx, i64, i32, i32) -> i64 tail
 ;;     fn0 = colocated u805306368:6 sig0
@@ -254,163 +252,163 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64):
 ;; @0047                               v2 = iconst.i32 0
-;; @0047                               v4 = call fn0(v0, v2)  ; v2 = 0
-;; @0049                               trapz v4, user16
+;; @0047                               v3 = call fn0(v0, v2)  ; v2 = 0
+;; @0049                               trapz v3, user16
+;; @0049                               v4 = iconst.i32 0
 ;; @0049                               v5 = iconst.i32 0
-;; @0049                               v6 = iconst.i32 0
-;; @0049                               v8 = call fn1(v0, v4, v5, v6)  ; v5 = 0, v6 = 0
-;; @0049                               v9 = load.i64 notrap aligned v8+72
-;; @0049                               v10 = uextend.i128 v8
-;; @0049                               v11 = uextend.i128 v9
-;; @0049                               v12 = iconst.i64 64
-;; @0049                               v13 = uextend.i128 v12  ; v12 = 64
-;; @0049                               v14 = ishl v11, v13
-;; @0049                               v15 = bor v14, v10
+;; @0049                               v6 = call fn1(v0, v3, v4, v5)  ; v4 = 0, v5 = 0
+;; @0049                               v7 = load.i64 notrap aligned v6+72
+;; @0049                               v8 = uextend.i128 v6
+;; @0049                               v9 = uextend.i128 v7
+;; @0049                               v10 = iconst.i64 64
+;; @0049                               v11 = uextend.i128 v10  ; v10 = 64
+;; @0049                               v12 = ishl v9, v11
+;; @0049                               v13 = bor v12, v8
 ;; @004b                               jump block2
 ;;
 ;;                                 block2:
-;; @004b                               v17 = ireduce.i64 v15
-;; @004b                               v18 = iconst.i64 64
-;; @004b                               v19 = uextend.i128 v18  ; v18 = 64
-;; @004b                               v20 = ushr.i128 v15, v19
-;; @004b                               v21 = ireduce.i64 v20
-;; @004b                               trapz v17, user16
-;; @004b                               v22 = load.i64 notrap aligned v17+72
-;; @004b                               v23 = icmp eq v22, v21
-;; @004b                               trapz v23, user23
-;; @004b                               v24 = iconst.i64 1
-;; @004b                               v25 = iadd v22, v24  ; v24 = 1
-;; @004b                               store notrap aligned v25, v17+72
-;; @004b                               v26 = load.i64 notrap aligned v17+64
-;; @004b                               v27 = load.i64 notrap aligned v0+8
-;; @004b                               v28 = load.i64 notrap aligned v27+88
-;; @004b                               v29 = load.i64 notrap aligned v27+96
-;; @004b                               store notrap aligned v28, v26+48
-;; @004b                               store notrap aligned v29, v26+56
+;; @004b                               v14 = ireduce.i64 v13
+;; @004b                               v15 = iconst.i64 64
+;; @004b                               v16 = uextend.i128 v15  ; v15 = 64
+;; @004b                               v17 = ushr.i128 v13, v16
+;; @004b                               v18 = ireduce.i64 v17
+;; @004b                               trapz v14, user16
+;; @004b                               v19 = load.i64 notrap aligned v14+72
+;; @004b                               v20 = icmp eq v19, v18
+;; @004b                               trapz v20, user23
+;; @004b                               v21 = iconst.i64 1
+;; @004b                               v22 = iadd v19, v21  ; v21 = 1
+;; @004b                               store notrap aligned v22, v14+72
+;; @004b                               v23 = load.i64 notrap aligned v14+64
+;; @004b                               v24 = load.i64 notrap aligned v0+8
+;; @004b                               v25 = load.i64 notrap aligned v24+88
+;; @004b                               v26 = load.i64 notrap aligned v24+96
+;; @004b                               store notrap aligned v25, v23+48
+;; @004b                               store notrap aligned v26, v23+56
+;; @004b                               v27 = iconst.i64 0
+;; @004b                               store notrap aligned v27, v14+64  ; v27 = 0
+;; @004b                               v28 = iconst.i64 2
+;; @004b                               v29 = load.i64 notrap aligned v0+8
+;; @004b                               store notrap aligned v28, v29+88  ; v28 = 2
+;; @004b                               store notrap aligned v14, v29+96
 ;; @004b                               v30 = iconst.i64 0
-;; @004b                               store notrap aligned v30, v17+64  ; v30 = 0
-;; @004b                               v31 = iconst.i64 2
-;; @004b                               v32 = load.i64 notrap aligned v0+8
-;; @004b                               store notrap aligned v31, v32+88  ; v31 = 2
-;; @004b                               store notrap aligned v17, v32+96
-;; @004b                               v33 = iconst.i64 0
-;; @004b                               v34 = iadd v17, v33  ; v33 = 0
-;; @004b                               v35 = iconst.i32 1
+;; @004b                               v31 = iadd v14, v30  ; v30 = 0
+;; @004b                               v32 = iconst.i32 1
+;; @004b                               v33 = iconst.i64 16
+;; @004b                               v34 = iadd v31, v33  ; v33 = 16
+;; @004b                               store notrap aligned v32, v34  ; v32 = 1
+;; @004b                               v35 = iconst.i32 2
 ;; @004b                               v36 = iconst.i64 16
-;; @004b                               v37 = iadd v34, v36  ; v36 = 16
-;; @004b                               store notrap aligned v35, v37  ; v35 = 1
-;; @004b                               v38 = iconst.i32 2
-;; @004b                               v39 = iconst.i64 16
-;; @004b                               v40 = iadd v29, v39  ; v39 = 16
-;; @004b                               store notrap aligned v38, v40  ; v38 = 2
-;; @004b                               v41 = load.i64 notrap aligned readonly v0+8
-;; @004b                               v42 = iconst.i64 0
-;; @004b                               v43 = iadd v29, v42  ; v42 = 0
-;; @004b                               v44 = load.i64 notrap aligned v41+72
-;; @004b                               store notrap aligned v44, v43+8
-;; @004b                               v45 = load.i64 notrap aligned v41+24
-;; @004b                               store notrap aligned v45, v43
-;; @004b                               v46 = iconst.i64 0
-;; @004b                               v47 = iadd v34, v46  ; v46 = 0
-;; @004b                               v48 = load.i64 notrap aligned v47
-;; @004b                               store notrap aligned v48, v41+24
-;; @004b                               v49 = load.i64 notrap aligned v47+8
-;; @004b                               store notrap aligned v49, v41+72
-;; @004b                               v50 = iconst.i64 24
-;; @004b                               v51 = iadd v29, v50  ; v50 = 24
-;; @004b                               v52 = iconst.i32 1
-;; @004b                               v53 = stack_addr.i64 ss0
-;; @004b                               store notrap aligned v52, v51+4  ; v52 = 1
-;; @004b                               store notrap aligned v53, v51+8
-;; @004b                               v55 = iconst.i64 48
-;; @004b                               v56 = iadd.i64 v0, v55  ; v55 = 48
-;; @004b                               v57 = iconst.i32 1
-;; @004b                               v58 = load.i64 notrap aligned v51+8
-;; @004b                               store notrap aligned v56, v58
-;; @004b                               store notrap aligned v57, v51  ; v57 = 1
-;; @004b                               v59 = iconst.i32 0
-;; @004b                               store notrap aligned v59, v29+40  ; v59 = 0
-;; @004b                               v60 = iconst.i64 1
-;; @004b                               v61 = iconst.i64 32
-;; @004b                               v62 = ishl v60, v61  ; v60 = 1, v61 = 32
-;; @004b                               v63 = iconst.i64 80
-;; @004b                               v64 = iadd v26, v63  ; v63 = 80
-;; @004b                               v65 = load.i64 notrap aligned v64
-;; @004b                               v66 = iconst.i64 -24
-;; @004b                               v67 = iadd v65, v66  ; v66 = -24
-;; @004b                               v68 = stack_switch v67, v67, v62
-;; @004b                               v69 = load.i64 notrap aligned v0+8
-;; @004b                               v70 = load.i64 notrap aligned v69+88
-;; @004b                               v71 = load.i64 notrap aligned v69+96
-;; @004b                               v72 = load.i64 notrap aligned v0+8
-;; @004b                               store notrap aligned v28, v72+88
-;; @004b                               store notrap aligned v29, v72+96
-;; @004b                               v73 = iconst.i32 1
-;; @004b                               v74 = iconst.i64 16
-;; @004b                               v75 = iadd v29, v74  ; v74 = 16
-;; @004b                               store notrap aligned v73, v75  ; v73 = 1
-;; @004b                               v76 = iconst.i32 0
-;; @004b                               store notrap aligned v76, v51  ; v76 = 0
-;; @004b                               v77 = iconst.i32 0
-;; @004b                               store notrap aligned v77, v51+4  ; v77 = 0
-;; @004b                               v78 = iconst.i64 0
-;; @004b                               store notrap aligned v78, v51+8  ; v78 = 0
-;; @004b                               store notrap aligned v30, v29+40  ; v30 = 0
-;; @004b                               v79 = iconst.i64 32
-;; @004b                               v80 = ushr v68, v79  ; v79 = 32
-;; @004b                               brif v80, block4, block3
+;; @004b                               v37 = iadd v26, v36  ; v36 = 16
+;; @004b                               store notrap aligned v35, v37  ; v35 = 2
+;; @004b                               v38 = load.i64 notrap aligned readonly v0+8
+;; @004b                               v39 = iconst.i64 0
+;; @004b                               v40 = iadd v26, v39  ; v39 = 0
+;; @004b                               v41 = load.i64 notrap aligned v38+72
+;; @004b                               store notrap aligned v41, v40+8
+;; @004b                               v42 = load.i64 notrap aligned v38+24
+;; @004b                               store notrap aligned v42, v40
+;; @004b                               v43 = iconst.i64 0
+;; @004b                               v44 = iadd v31, v43  ; v43 = 0
+;; @004b                               v45 = load.i64 notrap aligned v44
+;; @004b                               store notrap aligned v45, v38+24
+;; @004b                               v46 = load.i64 notrap aligned v44+8
+;; @004b                               store notrap aligned v46, v38+72
+;; @004b                               v47 = iconst.i64 24
+;; @004b                               v48 = iadd v26, v47  ; v47 = 24
+;; @004b                               v49 = iconst.i32 1
+;; @004b                               v50 = stack_addr.i64 ss0
+;; @004b                               store notrap aligned v49, v48+4  ; v49 = 1
+;; @004b                               store notrap aligned v50, v48+8
+;; @004b                               v51 = iconst.i64 48
+;; @004b                               v52 = iadd.i64 v0, v51  ; v51 = 48
+;; @004b                               v53 = iconst.i32 1
+;; @004b                               v54 = load.i64 notrap aligned v48+8
+;; @004b                               store notrap aligned v52, v54
+;; @004b                               store notrap aligned v53, v48  ; v53 = 1
+;; @004b                               v55 = iconst.i32 0
+;; @004b                               store notrap aligned v55, v26+40  ; v55 = 0
+;; @004b                               v56 = iconst.i64 1
+;; @004b                               v57 = iconst.i64 32
+;; @004b                               v58 = ishl v56, v57  ; v56 = 1, v57 = 32
+;; @004b                               v59 = iconst.i64 80
+;; @004b                               v60 = iadd v23, v59  ; v59 = 80
+;; @004b                               v61 = load.i64 notrap aligned v60
+;; @004b                               v62 = iconst.i64 -24
+;; @004b                               v63 = iadd v61, v62  ; v62 = -24
+;; @004b                               v64 = stack_switch v63, v63, v58
+;; @004b                               v65 = load.i64 notrap aligned v0+8
+;; @004b                               v66 = load.i64 notrap aligned v65+88
+;; @004b                               v67 = load.i64 notrap aligned v65+96
+;; @004b                               v68 = load.i64 notrap aligned v0+8
+;; @004b                               store notrap aligned v25, v68+88
+;; @004b                               store notrap aligned v26, v68+96
+;; @004b                               v69 = iconst.i32 1
+;; @004b                               v70 = iconst.i64 16
+;; @004b                               v71 = iadd v26, v70  ; v70 = 16
+;; @004b                               store notrap aligned v69, v71  ; v69 = 1
+;; @004b                               v72 = iconst.i32 0
+;; @004b                               store notrap aligned v72, v48  ; v72 = 0
+;; @004b                               v73 = iconst.i32 0
+;; @004b                               store notrap aligned v73, v48+4  ; v73 = 0
+;; @004b                               v74 = iconst.i64 0
+;; @004b                               store notrap aligned v74, v48+8  ; v74 = 0
+;; @004b                               store notrap aligned v27, v26+40  ; v27 = 0
+;; @004b                               v75 = iconst.i64 32
+;; @004b                               v76 = ushr v64, v75  ; v75 = 32
+;; @004b                               brif v76, block4, block3
 ;;
 ;;                                 block4:
-;; @004b                               v81 = iconst.i64 0
-;; @004b                               v82 = iadd.i64 v71, v81  ; v81 = 0
-;; @004b                               v83 = iconst.i64 0
-;; @004b                               v84 = iadd v82, v83  ; v83 = 0
-;; @004b                               v85 = load.i64 notrap aligned v41+72
-;; @004b                               store notrap aligned v85, v84+8
-;; @004b                               v86 = iconst.i64 0
-;; @004b                               v87 = iadd.i64 v29, v86  ; v86 = 0
-;; @004b                               v88 = load.i64 notrap aligned v87
-;; @004b                               store notrap aligned v88, v41+24
-;; @004b                               v89 = load.i64 notrap aligned v87+8
-;; @004b                               store notrap aligned v89, v41+72
-;; @004b                               v90 = ireduce.i32 v68
-;; @004b                               v91 = load.i64 notrap aligned v71+72
-;; @004b                               v92 = uextend.i128 v71
-;; @004b                               v93 = uextend.i128 v91
-;; @004b                               v94 = iconst.i64 64
-;; @004b                               v95 = uextend.i128 v94  ; v94 = 64
-;; @004b                               v96 = ishl v93, v95
-;; @004b                               v97 = bor v96, v92
+;; @004b                               v77 = iconst.i64 0
+;; @004b                               v78 = iadd.i64 v67, v77  ; v77 = 0
+;; @004b                               v79 = iconst.i64 0
+;; @004b                               v80 = iadd v78, v79  ; v79 = 0
+;; @004b                               v81 = load.i64 notrap aligned v38+72
+;; @004b                               store notrap aligned v81, v80+8
+;; @004b                               v82 = iconst.i64 0
+;; @004b                               v83 = iadd.i64 v26, v82  ; v82 = 0
+;; @004b                               v84 = load.i64 notrap aligned v83
+;; @004b                               store notrap aligned v84, v38+24
+;; @004b                               v85 = load.i64 notrap aligned v83+8
+;; @004b                               store notrap aligned v85, v38+72
+;; @004b                               v86 = ireduce.i32 v64
+;; @004b                               v87 = load.i64 notrap aligned v67+72
+;; @004b                               v88 = uextend.i128 v67
+;; @004b                               v89 = uextend.i128 v87
+;; @004b                               v90 = iconst.i64 64
+;; @004b                               v91 = uextend.i128 v90  ; v90 = 64
+;; @004b                               v92 = ishl v89, v91
+;; @004b                               v93 = bor v92, v88
 ;; @004b                               jump block5
 ;;
 ;;                                 block6 cold:
 ;; @004b                               trap user12
 ;;
 ;;                                 block5:
-;; @004b                               br_table v90, block6, []
+;; @004b                               br_table v86, block6, []
 ;;
 ;;                                 block3:
+;; @004b                               v94 = iconst.i64 0
+;; @004b                               v95 = iadd.i64 v26, v94  ; v94 = 0
+;; @004b                               v96 = load.i64 notrap aligned v95
+;; @004b                               store notrap aligned v96, v38+24
+;; @004b                               v97 = load.i64 notrap aligned v95+8
+;; @004b                               store notrap aligned v97, v38+72
 ;; @004b                               v98 = iconst.i64 0
-;; @004b                               v99 = iadd.i64 v29, v98  ; v98 = 0
-;; @004b                               v100 = load.i64 notrap aligned v99
-;; @004b                               store notrap aligned v100, v41+24
-;; @004b                               v101 = load.i64 notrap aligned v99+8
-;; @004b                               store notrap aligned v101, v41+72
-;; @004b                               v102 = iconst.i64 0
-;; @004b                               v103 = iadd.i64 v71, v102  ; v102 = 0
-;; @004b                               v104 = iconst.i32 4
-;; @004b                               v105 = iconst.i64 16
-;; @004b                               v106 = iadd v103, v105  ; v105 = 16
-;; @004b                               store notrap aligned v104, v106  ; v104 = 4
-;; @004b                               v107 = iconst.i64 104
-;; @004b                               v108 = iadd.i64 v71, v107  ; v107 = 104
-;; @004b                               v109 = load.i64 notrap aligned v108+8
-;; @004b                               v110 = iconst.i32 0
-;; @004b                               store notrap aligned v110, v108  ; v110 = 0
-;; @004b                               v111 = iconst.i32 0
-;; @004b                               store notrap aligned v111, v108+4  ; v111 = 0
-;; @004b                               v112 = iconst.i64 0
-;; @004b                               store notrap aligned v112, v108+8  ; v112 = 0
+;; @004b                               v99 = iadd.i64 v67, v98  ; v98 = 0
+;; @004b                               v100 = iconst.i32 4
+;; @004b                               v101 = iconst.i64 16
+;; @004b                               v102 = iadd v99, v101  ; v101 = 16
+;; @004b                               store notrap aligned v100, v102  ; v100 = 4
+;; @004b                               v103 = iconst.i64 104
+;; @004b                               v104 = iadd.i64 v67, v103  ; v103 = 104
+;; @004b                               v105 = load.i64 notrap aligned v104+8
+;; @004b                               v106 = iconst.i32 0
+;; @004b                               store notrap aligned v106, v104  ; v106 = 0
+;; @004b                               v107 = iconst.i32 0
+;; @004b                               store notrap aligned v107, v104+4  ; v107 = 0
+;; @004b                               v108 = iconst.i64 0
+;; @004b                               store notrap aligned v108, v104+8  ; v108 = 0
 ;; @0050                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/startup-data-active.wat
+++ b/tests/disas/startup-data-active.wat
@@ -42,19 +42,19 @@
 ;;     fn0 = colocated u805306368:1 sig0
 ;;
 ;; block0(v0: i64, v1: i64):
-;;     v3 = load.i64 notrap aligned v0+112
-;;     v4 = iconst.i64 0
-;;     v5 = icmp eq v3, v4  ; v4 = 0
-;;     brif v5, block2, block1
+;;     v2 = load.i64 notrap aligned v0+112
+;;     v3 = iconst.i64 0
+;;     v4 = icmp eq v2, v3  ; v3 = 0
+;;     brif v4, block2, block1
 ;;
 ;; block1:
-;;     v8 = load.i32 notrap aligned v0+120
-;;     v11 = load.i64 notrap aligned v0+64
-;;     v13 = uextend.i64 v8
-;;     v17 = icmp ugt v13, v11
-;;     trapnz v17, heap_oob
-;;     v18 = load.i64 notrap aligned readonly can_move v0+56
-;;     call fn0(v0, v18, v3, v13)
+;;     v6 = load.i32 notrap aligned v0+120
+;;     v9 = load.i64 notrap aligned v0+64
+;;     v11 = uextend.i64 v6
+;;     v15 = icmp ugt v11, v9
+;;     trapnz v15, heap_oob
+;;     v16 = load.i64 notrap aligned readonly can_move v0+56
+;;     call fn0(v0, v16, v2, v11)
 ;;     jump block2
 ;;
 ;; block2:

--- a/tests/disas/startup-passive-segment.wat
+++ b/tests/disas/startup-passive-segment.wat
@@ -34,18 +34,17 @@
 ;;
 ;; function u2415919104:0(i64 vmctx, i64) tail {
 ;;     region0 = 2147483648 "GcHeap"
-;;     gv0 = vmctx
 ;;     sig0 = (i64 vmctx, i32) -> i64 tail
 ;;     fn0 = colocated u805306368:4 sig0
 ;;
 ;; block0(v0: i64, v1: i64):
-;;     v3 = iconst.i32 0
-;;     v4 = call fn0(v0, v3)  ; v3 = 0
-;;     v6 = iconst.i32 1
-;;     store user2 little region0 v6, v4  ; v6 = 1
-;;     v25 = iconst.i32 3
-;;     v17 = iconst.i64 16
-;;     v18 = iadd v4, v17  ; v17 = 16
-;;     store user2 little region0 v25, v18  ; v25 = 3
+;;     v2 = iconst.i32 0
+;;     v3 = call fn0(v0, v2)  ; v2 = 0
+;;     v5 = iconst.i32 1
+;;     store user2 little region0 v5, v3  ; v5 = 1
+;;     v24 = iconst.i32 3
+;;     v16 = iconst.i64 16
+;;     v17 = iadd v3, v16  ; v16 = 16
+;;     store user2 little region0 v24, v17  ; v24 = 3
 ;;     return
 ;; }

--- a/tests/disas/table-copy.wat
+++ b/tests/disas/table-copy.wat
@@ -77,8 +77,8 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):
-;; @0090                               v111 = load.i64 notrap aligned readonly can_move v0+48
-;; @0090                               v7 = load.i64 notrap aligned v111+8
+;; @0090                               v109 = load.i64 notrap aligned readonly can_move v0+48
+;; @0090                               v7 = load.i64 notrap aligned v109+8
 ;; @0090                               v8 = ireduce.i32 v7
 ;; @0090                               v9 = uextend.i64 v8
 ;; @0090                               v10 = uextend.i64 v3
@@ -88,8 +88,8 @@
 ;; @0090                               v14 = iadd v10, v13
 ;; @0090                               v15 = icmp ugt v14, v9
 ;; @0090                               trapnz v15, user6
-;; @0090                               v109 = load.i64 notrap aligned readonly can_move v0+48
-;; @0090                               v16 = load.i64 notrap aligned v109
+;; @0090                               v107 = load.i64 notrap aligned readonly can_move v0+48
+;; @0090                               v16 = load.i64 notrap aligned v107
 ;; @0090                               v17 = uextend.i64 v3
 ;; @0090                               v18 = iconst.i64 8
 ;; @0090                               v19 = imul v17, v18  ; v18 = 8
@@ -142,61 +142,61 @@
 ;; @0090                               v62 = band v60, v61  ; v61 = -2
 ;; @0090                               brif v60, block7(v62), block6
 ;;
-;;                                 block4(v77: i64, v78: i64, v79: i32):
-;; @0090                               v80 = iconst.i64 8
-;; @0090                               v81 = isub v77, v80  ; v80 = 8
-;; @0090                               v82 = iconst.i64 8
-;; @0090                               v83 = isub v78, v82  ; v82 = 8
-;; @0090                               v84 = iconst.i32 1
-;; @0090                               v85 = isub v79, v84  ; v84 = 1
-;; @0090                               v86 = iconst.i32 6
-;; @0090                               v87 = icmp uge v85, v86  ; v86 = 6
-;; @0090                               v88 = uextend.i64 v85
-;; @0090                               v89 = load.i64 notrap aligned readonly can_move v0+72
-;; @0090                               v90 = iconst.i64 3
-;; @0090                               v91 = ishl v88, v90  ; v90 = 3
-;; @0090                               v92 = iadd v89, v91
-;; @0090                               v93 = iconst.i64 0
-;; @0090                               v94 = select_spectre_guard v87, v93, v92  ; v93 = 0
-;; @0090                               v95 = load.i64 user6 aligned region0 v94
-;; @0090                               v96 = iconst.i64 -2
-;; @0090                               v97 = band v95, v96  ; v96 = -2
-;; @0090                               brif v95, block9(v97), block8
+;;                                 block4(v76: i64, v77: i64, v78: i32):
+;; @0090                               v79 = iconst.i64 8
+;; @0090                               v80 = isub v76, v79  ; v79 = 8
+;; @0090                               v81 = iconst.i64 8
+;; @0090                               v82 = isub v77, v81  ; v81 = 8
+;; @0090                               v83 = iconst.i32 1
+;; @0090                               v84 = isub v78, v83  ; v83 = 1
+;; @0090                               v85 = iconst.i32 6
+;; @0090                               v86 = icmp uge v84, v85  ; v85 = 6
+;; @0090                               v87 = uextend.i64 v84
+;; @0090                               v88 = load.i64 notrap aligned readonly can_move v0+72
+;; @0090                               v89 = iconst.i64 3
+;; @0090                               v90 = ishl v87, v89  ; v89 = 3
+;; @0090                               v91 = iadd v88, v90
+;; @0090                               v92 = iconst.i64 0
+;; @0090                               v93 = select_spectre_guard v86, v92, v91  ; v92 = 0
+;; @0090                               v94 = load.i64 user6 aligned region0 v93
+;; @0090                               v95 = iconst.i64 -2
+;; @0090                               v96 = band v94, v95  ; v95 = -2
+;; @0090                               brif v94, block9(v96), block8
 ;;
 ;;                                 block5:
 ;; @0094                               jump block1
 ;;
 ;;                                 block6 cold:
 ;; @0090                               v64 = iconst.i32 1
-;; @0090                               v66 = uextend.i64 v50
-;; @0090                               v67 = call fn0(v0, v64, v66)  ; v64 = 1
-;; @0090                               jump block7(v67)
+;; @0090                               v65 = uextend.i64 v50
+;; @0090                               v66 = call fn0(v0, v64, v65)  ; v64 = 1
+;; @0090                               jump block7(v66)
 ;;
 ;;                                 block7(v63: i64):
-;; @0090                               v68 = iconst.i64 1
-;; @0090                               v69 = bor v63, v68  ; v68 = 1
-;; @0090                               store notrap aligned v69, v48
-;; @0090                               v70 = iconst.i64 8
-;; @0090                               v71 = iadd.i64 v48, v70  ; v70 = 8
-;; @0090                               v72 = iconst.i64 8
-;; @0090                               v73 = iadd.i64 v49, v72  ; v72 = 8
-;; @0090                               v74 = iconst.i32 1
-;; @0090                               v75 = iadd.i32 v50, v74  ; v74 = 1
-;; @0090                               v76 = icmp eq v73, v45
-;; @0090                               brif v76, block5, block3(v71, v73, v75)
+;; @0090                               v67 = iconst.i64 1
+;; @0090                               v68 = bor v63, v67  ; v67 = 1
+;; @0090                               store notrap aligned v68, v48
+;; @0090                               v69 = iconst.i64 8
+;; @0090                               v70 = iadd.i64 v48, v69  ; v69 = 8
+;; @0090                               v71 = iconst.i64 8
+;; @0090                               v72 = iadd.i64 v49, v71  ; v71 = 8
+;; @0090                               v73 = iconst.i32 1
+;; @0090                               v74 = iadd.i32 v50, v73  ; v73 = 1
+;; @0090                               v75 = icmp eq v72, v45
+;; @0090                               brif v75, block5, block3(v70, v72, v74)
 ;;
 ;;                                 block8 cold:
-;; @0090                               v99 = iconst.i32 1
-;; @0090                               v101 = uextend.i64 v85
-;; @0090                               v102 = call fn0(v0, v99, v101)  ; v99 = 1
-;; @0090                               jump block9(v102)
+;; @0090                               v98 = iconst.i32 1
+;; @0090                               v99 = uextend.i64 v84
+;; @0090                               v100 = call fn0(v0, v98, v99)  ; v98 = 1
+;; @0090                               jump block9(v100)
 ;;
-;;                                 block9(v98: i64):
-;; @0090                               v103 = iconst.i64 1
-;; @0090                               v104 = bor v98, v103  ; v103 = 1
-;; @0090                               store notrap aligned v104, v81
-;; @0090                               v105 = icmp.i64 eq v83, v33
-;; @0090                               brif v105, block5, block4(v81, v83, v85)
+;;                                 block9(v97: i64):
+;; @0090                               v101 = iconst.i64 1
+;; @0090                               v102 = bor v97, v101  ; v101 = 1
+;; @0090                               store notrap aligned v102, v80
+;; @0090                               v103 = icmp.i64 eq v82, v33
+;; @0090                               brif v103, block5, block4(v80, v82, v84)
 ;;
 ;;                                 block1:
 ;; @0094                               return v2
@@ -231,8 +231,8 @@
 ;; @009f                               v17 = iconst.i64 8
 ;; @009f                               v18 = imul v16, v17  ; v17 = 8
 ;; @009f                               v19 = iadd v15, v18
-;; @009f                               v118 = load.i64 notrap aligned readonly can_move v0+48
-;; @009f                               v20 = load.i64 notrap aligned v118+8
+;; @009f                               v116 = load.i64 notrap aligned readonly can_move v0+48
+;; @009f                               v20 = load.i64 notrap aligned v116+8
 ;; @009f                               v21 = ireduce.i32 v20
 ;; @009f                               v22 = uextend.i64 v21
 ;; @009f                               v23 = uextend.i64 v4
@@ -242,8 +242,8 @@
 ;; @009f                               v27 = iadd v23, v26
 ;; @009f                               v28 = icmp ugt v27, v22
 ;; @009f                               trapnz v28, user6
-;; @009f                               v116 = load.i64 notrap aligned readonly can_move v0+48
-;; @009f                               v29 = load.i64 notrap aligned v116
+;; @009f                               v114 = load.i64 notrap aligned readonly can_move v0+48
+;; @009f                               v29 = load.i64 notrap aligned v114
 ;; @009f                               v30 = uextend.i64 v4
 ;; @009f                               v31 = iconst.i64 8
 ;; @009f                               v32 = imul v30, v31  ; v31 = 8
@@ -268,13 +268,13 @@
 ;; @009f                               brif v39, block3(v19, v33, v4), block4(v44, v45, v47)
 ;;
 ;;                                 block3(v48: i64, v49: i64, v50: i32):
-;; @009f                               v114 = load.i64 notrap aligned readonly can_move v0+48
-;; @009f                               v51 = load.i64 notrap aligned v114+8
+;; @009f                               v112 = load.i64 notrap aligned readonly can_move v0+48
+;; @009f                               v51 = load.i64 notrap aligned v112+8
 ;; @009f                               v52 = ireduce.i32 v51
 ;; @009f                               v53 = icmp uge v50, v52
 ;; @009f                               v54 = uextend.i64 v50
-;; @009f                               v112 = load.i64 notrap aligned readonly can_move v0+48
-;; @009f                               v55 = load.i64 notrap aligned v112
+;; @009f                               v110 = load.i64 notrap aligned readonly can_move v0+48
+;; @009f                               v55 = load.i64 notrap aligned v110
 ;; @009f                               v56 = iconst.i64 3
 ;; @009f                               v57 = ishl v54, v56  ; v56 = 3
 ;; @009f                               v58 = iadd v55, v57
@@ -285,64 +285,64 @@
 ;; @009f                               v63 = band v61, v62  ; v62 = -2
 ;; @009f                               brif v61, block7(v63), block6
 ;;
-;;                                 block4(v78: i64, v79: i64, v80: i32):
-;; @009f                               v81 = iconst.i64 8
-;; @009f                               v82 = isub v78, v81  ; v81 = 8
-;; @009f                               v83 = iconst.i64 8
-;; @009f                               v84 = isub v79, v83  ; v83 = 8
-;; @009f                               v85 = iconst.i32 1
-;; @009f                               v86 = isub v80, v85  ; v85 = 1
-;; @009f                               v110 = load.i64 notrap aligned readonly can_move v0+48
-;; @009f                               v87 = load.i64 notrap aligned v110+8
-;; @009f                               v88 = ireduce.i32 v87
-;; @009f                               v89 = icmp uge v86, v88
-;; @009f                               v90 = uextend.i64 v86
+;;                                 block4(v77: i64, v78: i64, v79: i32):
+;; @009f                               v80 = iconst.i64 8
+;; @009f                               v81 = isub v77, v80  ; v80 = 8
+;; @009f                               v82 = iconst.i64 8
+;; @009f                               v83 = isub v78, v82  ; v82 = 8
+;; @009f                               v84 = iconst.i32 1
+;; @009f                               v85 = isub v79, v84  ; v84 = 1
 ;; @009f                               v108 = load.i64 notrap aligned readonly can_move v0+48
-;; @009f                               v91 = load.i64 notrap aligned v108
-;; @009f                               v92 = iconst.i64 3
-;; @009f                               v93 = ishl v90, v92  ; v92 = 3
-;; @009f                               v94 = iadd v91, v93
-;; @009f                               v95 = iconst.i64 0
-;; @009f                               v96 = select_spectre_guard v89, v95, v94  ; v95 = 0
-;; @009f                               v97 = load.i64 user6 aligned region0 v96
-;; @009f                               v98 = iconst.i64 -2
-;; @009f                               v99 = band v97, v98  ; v98 = -2
-;; @009f                               brif v97, block9(v99), block8
+;; @009f                               v86 = load.i64 notrap aligned v108+8
+;; @009f                               v87 = ireduce.i32 v86
+;; @009f                               v88 = icmp uge v85, v87
+;; @009f                               v89 = uextend.i64 v85
+;; @009f                               v106 = load.i64 notrap aligned readonly can_move v0+48
+;; @009f                               v90 = load.i64 notrap aligned v106
+;; @009f                               v91 = iconst.i64 3
+;; @009f                               v92 = ishl v89, v91  ; v91 = 3
+;; @009f                               v93 = iadd v90, v92
+;; @009f                               v94 = iconst.i64 0
+;; @009f                               v95 = select_spectre_guard v88, v94, v93  ; v94 = 0
+;; @009f                               v96 = load.i64 user6 aligned region0 v95
+;; @009f                               v97 = iconst.i64 -2
+;; @009f                               v98 = band v96, v97  ; v97 = -2
+;; @009f                               brif v96, block9(v98), block8
 ;;
 ;;                                 block5:
 ;; @00a3                               jump block1
 ;;
 ;;                                 block6 cold:
 ;; @009f                               v65 = iconst.i32 0
-;; @009f                               v67 = uextend.i64 v50
-;; @009f                               v68 = call fn0(v0, v65, v67)  ; v65 = 0
-;; @009f                               jump block7(v68)
+;; @009f                               v66 = uextend.i64 v50
+;; @009f                               v67 = call fn0(v0, v65, v66)  ; v65 = 0
+;; @009f                               jump block7(v67)
 ;;
 ;;                                 block7(v64: i64):
-;; @009f                               v69 = iconst.i64 1
-;; @009f                               v70 = bor v64, v69  ; v69 = 1
-;; @009f                               store notrap aligned v70, v48
-;; @009f                               v71 = iconst.i64 8
-;; @009f                               v72 = iadd.i64 v48, v71  ; v71 = 8
-;; @009f                               v73 = iconst.i64 8
-;; @009f                               v74 = iadd.i64 v49, v73  ; v73 = 8
-;; @009f                               v75 = iconst.i32 1
-;; @009f                               v76 = iadd.i32 v50, v75  ; v75 = 1
-;; @009f                               v77 = icmp eq v74, v45
-;; @009f                               brif v77, block5, block3(v72, v74, v76)
+;; @009f                               v68 = iconst.i64 1
+;; @009f                               v69 = bor v64, v68  ; v68 = 1
+;; @009f                               store notrap aligned v69, v48
+;; @009f                               v70 = iconst.i64 8
+;; @009f                               v71 = iadd.i64 v48, v70  ; v70 = 8
+;; @009f                               v72 = iconst.i64 8
+;; @009f                               v73 = iadd.i64 v49, v72  ; v72 = 8
+;; @009f                               v74 = iconst.i32 1
+;; @009f                               v75 = iadd.i32 v50, v74  ; v74 = 1
+;; @009f                               v76 = icmp eq v73, v45
+;; @009f                               brif v76, block5, block3(v71, v73, v75)
 ;;
 ;;                                 block8 cold:
-;; @009f                               v101 = iconst.i32 0
-;; @009f                               v103 = uextend.i64 v86
-;; @009f                               v104 = call fn0(v0, v101, v103)  ; v101 = 0
-;; @009f                               jump block9(v104)
+;; @009f                               v100 = iconst.i32 0
+;; @009f                               v101 = uextend.i64 v85
+;; @009f                               v102 = call fn0(v0, v100, v101)  ; v100 = 0
+;; @009f                               jump block9(v102)
 ;;
-;;                                 block9(v100: i64):
-;; @009f                               v105 = iconst.i64 1
-;; @009f                               v106 = bor v100, v105  ; v105 = 1
-;; @009f                               store notrap aligned v106, v82
-;; @009f                               v107 = icmp.i64 eq v84, v33
-;; @009f                               brif v107, block5, block4(v82, v84, v86)
+;;                                 block9(v99: i64):
+;; @009f                               v103 = iconst.i64 1
+;; @009f                               v104 = bor v99, v103  ; v103 = 1
+;; @009f                               store notrap aligned v104, v81
+;; @009f                               v105 = icmp.i64 eq v83, v33
+;; @009f                               brif v105, block5, block4(v81, v83, v85)
 ;;
 ;;                                 block1:
 ;; @00a3                               return v2

--- a/tests/disas/typed-funcrefs.wat
+++ b/tests/disas/typed-funcrefs.wat
@@ -140,8 +140,8 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):
 ;; @0048                               v12 = load.i64 notrap aligned readonly can_move v0+48
-;;                                     v67 = iconst.i64 8
-;; @0048                               v15 = iadd v12, v67  ; v67 = 8
+;;                                     v65 = iconst.i64 8
+;; @0048                               v15 = iadd v12, v65  ; v65 = 8
 ;; @0048                               v18 = load.i64 user6 aligned region0 v15
 ;; @0048                               v19 = iconst.i64 -2
 ;; @0048                               v20 = band v18, v19  ; v19 = -2
@@ -149,36 +149,36 @@
 ;;
 ;;                                 block2 cold:
 ;; @003c                               v7 = iconst.i32 0
-;;                                     v66 = iconst.i64 1
-;; @0048                               v25 = call fn0(v0, v7, v66)  ; v7 = 0, v66 = 1
-;; @0048                               jump block3(v25)
+;;                                     v64 = iconst.i64 1
+;; @0048                               v24 = call fn0(v0, v7, v64)  ; v7 = 0, v64 = 1
+;; @0048                               jump block3(v24)
 ;;
 ;;                                 block3(v21: i64):
-;; @004a                               v26 = load.i64 user16 aligned readonly v21+8
-;; @004a                               v27 = load.i64 notrap aligned readonly v21+24
-;; @004a                               v28 = call_indirect sig1, v26(v27, v0, v2, v3, v4, v5)
-;;                                     v74 = iconst.i64 16
-;; @005b                               v42 = iadd.i64 v12, v74  ; v74 = 16
-;; @005b                               v45 = load.i64 user6 aligned region0 v42
-;;                                     v75 = iconst.i64 -2
-;;                                     v76 = band v45, v75  ; v75 = -2
-;; @005b                               brif v45, block5(v76), block4
+;; @004a                               v25 = load.i64 user16 aligned readonly v21+8
+;; @004a                               v26 = load.i64 notrap aligned readonly v21+24
+;; @004a                               v27 = call_indirect sig1, v25(v26, v0, v2, v3, v4, v5)
+;;                                     v72 = iconst.i64 16
+;; @005b                               v41 = iadd.i64 v12, v72  ; v72 = 16
+;; @005b                               v44 = load.i64 user6 aligned region0 v41
+;;                                     v73 = iconst.i64 -2
+;;                                     v74 = band v44, v73  ; v73 = -2
+;; @005b                               brif v44, block5(v74), block4
 ;;
 ;;                                 block4 cold:
-;;                                     v77 = iconst.i32 0
-;;                                     v73 = iconst.i64 2
-;; @005b                               v52 = call fn0(v0, v77, v73)  ; v77 = 0, v73 = 2
-;; @005b                               jump block5(v52)
+;;                                     v75 = iconst.i32 0
+;;                                     v71 = iconst.i64 2
+;; @005b                               v50 = call fn0(v0, v75, v71)  ; v75 = 0, v71 = 2
+;; @005b                               jump block5(v50)
 ;;
-;;                                 block5(v48: i64):
-;; @005d                               v53 = load.i64 user16 aligned readonly v48+8
-;; @005d                               v54 = load.i64 notrap aligned readonly v48+24
-;; @005d                               v55 = call_indirect sig1, v53(v54, v0, v2, v3, v4, v5)
+;;                                 block5(v47: i64):
+;; @005d                               v51 = load.i64 user16 aligned readonly v47+8
+;; @005d                               v52 = load.i64 notrap aligned readonly v47+24
+;; @005d                               v53 = call_indirect sig1, v51(v52, v0, v2, v3, v4, v5)
 ;; @0066                               jump block1
 ;;
 ;;                                 block1:
-;; @0061                               v57 = iadd.i32 v55, v28
-;; @0066                               return v57
+;; @0061                               v55 = iadd.i32 v53, v27
+;; @0066                               return v55
 ;; }
 ;;
 ;; function u0:2(i64 vmctx, i64, i32, i32, i32, i32) -> i32 tail {
@@ -195,8 +195,8 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):
 ;; @0075                               v12 = load.i64 notrap aligned readonly can_move v0+48
-;;                                     v67 = iconst.i64 8
-;; @0075                               v15 = iadd v12, v67  ; v67 = 8
+;;                                     v65 = iconst.i64 8
+;; @0075                               v15 = iadd v12, v65  ; v65 = 8
 ;; @0075                               v18 = load.i64 user6 aligned region0 v15
 ;; @0075                               v19 = iconst.i64 -2
 ;; @0075                               v20 = band v18, v19  ; v19 = -2
@@ -204,36 +204,36 @@
 ;;
 ;;                                 block2 cold:
 ;; @0069                               v7 = iconst.i32 0
-;;                                     v66 = iconst.i64 1
-;; @0075                               v25 = call fn0(v0, v7, v66)  ; v7 = 0, v66 = 1
-;; @0075                               jump block3(v25)
+;;                                     v64 = iconst.i64 1
+;; @0075                               v24 = call fn0(v0, v7, v64)  ; v7 = 0, v64 = 1
+;; @0075                               jump block3(v24)
 ;;
 ;;                                 block3(v21: i64):
-;; @0075                               v26 = load.i64 user7 aligned readonly v21+8
-;; @0075                               v27 = load.i64 notrap aligned readonly v21+24
-;; @0075                               v28 = call_indirect sig0, v26(v27, v0, v2, v3, v4, v5)
-;;                                     v74 = iconst.i64 16
-;; @0087                               v42 = iadd.i64 v12, v74  ; v74 = 16
-;; @0087                               v45 = load.i64 user6 aligned region0 v42
-;;                                     v75 = iconst.i64 -2
-;;                                     v76 = band v45, v75  ; v75 = -2
-;; @0087                               brif v45, block5(v76), block4
+;; @0075                               v25 = load.i64 user7 aligned readonly v21+8
+;; @0075                               v26 = load.i64 notrap aligned readonly v21+24
+;; @0075                               v27 = call_indirect sig0, v25(v26, v0, v2, v3, v4, v5)
+;;                                     v72 = iconst.i64 16
+;; @0087                               v41 = iadd.i64 v12, v72  ; v72 = 16
+;; @0087                               v44 = load.i64 user6 aligned region0 v41
+;;                                     v73 = iconst.i64 -2
+;;                                     v74 = band v44, v73  ; v73 = -2
+;; @0087                               brif v44, block5(v74), block4
 ;;
 ;;                                 block4 cold:
-;;                                     v77 = iconst.i32 0
-;;                                     v73 = iconst.i64 2
-;; @0087                               v52 = call fn0(v0, v77, v73)  ; v77 = 0, v73 = 2
-;; @0087                               jump block5(v52)
+;;                                     v75 = iconst.i32 0
+;;                                     v71 = iconst.i64 2
+;; @0087                               v50 = call fn0(v0, v75, v71)  ; v75 = 0, v71 = 2
+;; @0087                               jump block5(v50)
 ;;
-;;                                 block5(v48: i64):
-;; @0087                               v53 = load.i64 user7 aligned readonly v48+8
-;; @0087                               v54 = load.i64 notrap aligned readonly v48+24
-;; @0087                               v55 = call_indirect sig0, v53(v54, v0, v2, v3, v4, v5)
+;;                                 block5(v47: i64):
+;; @0087                               v51 = load.i64 user7 aligned readonly v47+8
+;; @0087                               v52 = load.i64 notrap aligned readonly v47+24
+;; @0087                               v53 = call_indirect sig0, v51(v52, v0, v2, v3, v4, v5)
 ;; @0091                               jump block1
 ;;
 ;;                                 block1:
-;; @008c                               v57 = iadd.i32 v55, v28
-;; @0091                               return v57
+;; @008c                               v55 = iadd.i32 v53, v27
+;; @0091                               return v55
 ;; }
 ;;
 ;; function u0:3(i64 vmctx, i64, i32, i32, i32, i32) -> i32 tail {

--- a/tests/disas/x64-simd-round-without-sse41.wat
+++ b/tests/disas/x64-simd-round-without-sse41.wat
@@ -15,7 +15,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, f32) -> f32 tail
 ;;     fn0 = colocated u805306368:28 sig0
 ;;     const0 = 0x00000000000000000000000000000000
@@ -23,31 +22,30 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
 ;; @0023                               v4 = bitcast.f32x4 little v2
-;; @0023                               v6 = vconst.f32x4 const0
-;; @0023                               v7 = extractlane v4, 0
-;; @0023                               v8 = call fn0(v0, v7)
-;; @0023                               v9 = insertlane v6, v8, 0  ; v6 = const0
-;; @0023                               v10 = extractlane v4, 1
-;; @0023                               v11 = call fn0(v0, v10)
-;; @0023                               v12 = insertlane v9, v11, 1
-;; @0023                               v13 = extractlane v4, 2
-;; @0023                               v14 = call fn0(v0, v13)
-;; @0023                               v15 = insertlane v12, v14, 2
-;; @0023                               v16 = extractlane v4, 3
-;; @0023                               v17 = call fn0(v0, v16)
-;; @0023                               v18 = insertlane v15, v17, 3
-;; @0025                               v19 = bitcast.i8x16 little v18
+;; @0023                               v5 = vconst.f32x4 const0
+;; @0023                               v6 = extractlane v4, 0
+;; @0023                               v7 = call fn0(v0, v6)
+;; @0023                               v8 = insertlane v5, v7, 0  ; v5 = const0
+;; @0023                               v9 = extractlane v4, 1
+;; @0023                               v10 = call fn0(v0, v9)
+;; @0023                               v11 = insertlane v8, v10, 1
+;; @0023                               v12 = extractlane v4, 2
+;; @0023                               v13 = call fn0(v0, v12)
+;; @0023                               v14 = insertlane v11, v13, 2
+;; @0023                               v15 = extractlane v4, 3
+;; @0023                               v16 = call fn0(v0, v15)
+;; @0023                               v17 = insertlane v14, v16, 3
+;; @0025                               v18 = bitcast.i8x16 little v17
 ;; @0025                               jump block1
 ;;
 ;;                                 block1:
-;; @0025                               return v19
+;; @0025                               return v18
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i8x16) -> i8x16 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, f32) -> f32 tail
 ;;     fn0 = colocated u805306368:30 sig0
 ;;     const0 = 0x00000000000000000000000000000000
@@ -55,31 +53,30 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
 ;; @002a                               v4 = bitcast.f32x4 little v2
-;; @002a                               v6 = vconst.f32x4 const0
-;; @002a                               v7 = extractlane v4, 0
-;; @002a                               v8 = call fn0(v0, v7)
-;; @002a                               v9 = insertlane v6, v8, 0  ; v6 = const0
-;; @002a                               v10 = extractlane v4, 1
-;; @002a                               v11 = call fn0(v0, v10)
-;; @002a                               v12 = insertlane v9, v11, 1
-;; @002a                               v13 = extractlane v4, 2
-;; @002a                               v14 = call fn0(v0, v13)
-;; @002a                               v15 = insertlane v12, v14, 2
-;; @002a                               v16 = extractlane v4, 3
-;; @002a                               v17 = call fn0(v0, v16)
-;; @002a                               v18 = insertlane v15, v17, 3
-;; @002c                               v19 = bitcast.i8x16 little v18
+;; @002a                               v5 = vconst.f32x4 const0
+;; @002a                               v6 = extractlane v4, 0
+;; @002a                               v7 = call fn0(v0, v6)
+;; @002a                               v8 = insertlane v5, v7, 0  ; v5 = const0
+;; @002a                               v9 = extractlane v4, 1
+;; @002a                               v10 = call fn0(v0, v9)
+;; @002a                               v11 = insertlane v8, v10, 1
+;; @002a                               v12 = extractlane v4, 2
+;; @002a                               v13 = call fn0(v0, v12)
+;; @002a                               v14 = insertlane v11, v13, 2
+;; @002a                               v15 = extractlane v4, 3
+;; @002a                               v16 = call fn0(v0, v15)
+;; @002a                               v17 = insertlane v14, v16, 3
+;; @002c                               v18 = bitcast.i8x16 little v17
 ;; @002c                               jump block1
 ;;
 ;;                                 block1:
-;; @002c                               return v19
+;; @002c                               return v18
 ;; }
 ;;
 ;; function u0:2(i64 vmctx, i64, i8x16) -> i8x16 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, f32) -> f32 tail
 ;;     fn0 = colocated u805306368:32 sig0
 ;;     const0 = 0x00000000000000000000000000000000
@@ -87,31 +84,30 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
 ;; @0031                               v4 = bitcast.f32x4 little v2
-;; @0031                               v6 = vconst.f32x4 const0
-;; @0031                               v7 = extractlane v4, 0
-;; @0031                               v8 = call fn0(v0, v7)
-;; @0031                               v9 = insertlane v6, v8, 0  ; v6 = const0
-;; @0031                               v10 = extractlane v4, 1
-;; @0031                               v11 = call fn0(v0, v10)
-;; @0031                               v12 = insertlane v9, v11, 1
-;; @0031                               v13 = extractlane v4, 2
-;; @0031                               v14 = call fn0(v0, v13)
-;; @0031                               v15 = insertlane v12, v14, 2
-;; @0031                               v16 = extractlane v4, 3
-;; @0031                               v17 = call fn0(v0, v16)
-;; @0031                               v18 = insertlane v15, v17, 3
-;; @0033                               v19 = bitcast.i8x16 little v18
+;; @0031                               v5 = vconst.f32x4 const0
+;; @0031                               v6 = extractlane v4, 0
+;; @0031                               v7 = call fn0(v0, v6)
+;; @0031                               v8 = insertlane v5, v7, 0  ; v5 = const0
+;; @0031                               v9 = extractlane v4, 1
+;; @0031                               v10 = call fn0(v0, v9)
+;; @0031                               v11 = insertlane v8, v10, 1
+;; @0031                               v12 = extractlane v4, 2
+;; @0031                               v13 = call fn0(v0, v12)
+;; @0031                               v14 = insertlane v11, v13, 2
+;; @0031                               v15 = extractlane v4, 3
+;; @0031                               v16 = call fn0(v0, v15)
+;; @0031                               v17 = insertlane v14, v16, 3
+;; @0033                               v18 = bitcast.i8x16 little v17
 ;; @0033                               jump block1
 ;;
 ;;                                 block1:
-;; @0033                               return v19
+;; @0033                               return v18
 ;; }
 ;;
 ;; function u0:3(i64 vmctx, i64, i8x16) -> i8x16 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, f32) -> f32 tail
 ;;     fn0 = colocated u805306368:34 sig0
 ;;     const0 = 0x00000000000000000000000000000000
@@ -119,31 +115,30 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
 ;; @0038                               v4 = bitcast.f32x4 little v2
-;; @0038                               v6 = vconst.f32x4 const0
-;; @0038                               v7 = extractlane v4, 0
-;; @0038                               v8 = call fn0(v0, v7)
-;; @0038                               v9 = insertlane v6, v8, 0  ; v6 = const0
-;; @0038                               v10 = extractlane v4, 1
-;; @0038                               v11 = call fn0(v0, v10)
-;; @0038                               v12 = insertlane v9, v11, 1
-;; @0038                               v13 = extractlane v4, 2
-;; @0038                               v14 = call fn0(v0, v13)
-;; @0038                               v15 = insertlane v12, v14, 2
-;; @0038                               v16 = extractlane v4, 3
-;; @0038                               v17 = call fn0(v0, v16)
-;; @0038                               v18 = insertlane v15, v17, 3
-;; @003a                               v19 = bitcast.i8x16 little v18
+;; @0038                               v5 = vconst.f32x4 const0
+;; @0038                               v6 = extractlane v4, 0
+;; @0038                               v7 = call fn0(v0, v6)
+;; @0038                               v8 = insertlane v5, v7, 0  ; v5 = const0
+;; @0038                               v9 = extractlane v4, 1
+;; @0038                               v10 = call fn0(v0, v9)
+;; @0038                               v11 = insertlane v8, v10, 1
+;; @0038                               v12 = extractlane v4, 2
+;; @0038                               v13 = call fn0(v0, v12)
+;; @0038                               v14 = insertlane v11, v13, 2
+;; @0038                               v15 = extractlane v4, 3
+;; @0038                               v16 = call fn0(v0, v15)
+;; @0038                               v17 = insertlane v14, v16, 3
+;; @003a                               v18 = bitcast.i8x16 little v17
 ;; @003a                               jump block1
 ;;
 ;;                                 block1:
-;; @003a                               return v19
+;; @003a                               return v18
 ;; }
 ;;
 ;; function u0:4(i64 vmctx, i64, i8x16) -> i8x16 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, f64) -> f64 tail
 ;;     fn0 = colocated u805306368:29 sig0
 ;;     const0 = 0x00000000000000000000000000000000
@@ -151,25 +146,24 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
 ;; @003f                               v4 = bitcast.f64x2 little v2
-;; @003f                               v6 = vconst.f64x2 const0
-;; @003f                               v7 = extractlane v4, 0
-;; @003f                               v8 = call fn0(v0, v7)
-;; @003f                               v9 = insertlane v6, v8, 0  ; v6 = const0
-;; @003f                               v10 = extractlane v4, 1
-;; @003f                               v11 = call fn0(v0, v10)
-;; @003f                               v12 = insertlane v9, v11, 1
-;; @0041                               v13 = bitcast.i8x16 little v12
+;; @003f                               v5 = vconst.f64x2 const0
+;; @003f                               v6 = extractlane v4, 0
+;; @003f                               v7 = call fn0(v0, v6)
+;; @003f                               v8 = insertlane v5, v7, 0  ; v5 = const0
+;; @003f                               v9 = extractlane v4, 1
+;; @003f                               v10 = call fn0(v0, v9)
+;; @003f                               v11 = insertlane v8, v10, 1
+;; @0041                               v12 = bitcast.i8x16 little v11
 ;; @0041                               jump block1
 ;;
 ;;                                 block1:
-;; @0041                               return v13
+;; @0041                               return v12
 ;; }
 ;;
 ;; function u0:5(i64 vmctx, i64, i8x16) -> i8x16 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, f64) -> f64 tail
 ;;     fn0 = colocated u805306368:31 sig0
 ;;     const0 = 0x00000000000000000000000000000000
@@ -177,25 +171,24 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
 ;; @0046                               v4 = bitcast.f64x2 little v2
-;; @0046                               v6 = vconst.f64x2 const0
-;; @0046                               v7 = extractlane v4, 0
-;; @0046                               v8 = call fn0(v0, v7)
-;; @0046                               v9 = insertlane v6, v8, 0  ; v6 = const0
-;; @0046                               v10 = extractlane v4, 1
-;; @0046                               v11 = call fn0(v0, v10)
-;; @0046                               v12 = insertlane v9, v11, 1
-;; @0048                               v13 = bitcast.i8x16 little v12
+;; @0046                               v5 = vconst.f64x2 const0
+;; @0046                               v6 = extractlane v4, 0
+;; @0046                               v7 = call fn0(v0, v6)
+;; @0046                               v8 = insertlane v5, v7, 0  ; v5 = const0
+;; @0046                               v9 = extractlane v4, 1
+;; @0046                               v10 = call fn0(v0, v9)
+;; @0046                               v11 = insertlane v8, v10, 1
+;; @0048                               v12 = bitcast.i8x16 little v11
 ;; @0048                               jump block1
 ;;
 ;;                                 block1:
-;; @0048                               return v13
+;; @0048                               return v12
 ;; }
 ;;
 ;; function u0:6(i64 vmctx, i64, i8x16) -> i8x16 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, f64) -> f64 tail
 ;;     fn0 = colocated u805306368:33 sig0
 ;;     const0 = 0x00000000000000000000000000000000
@@ -203,25 +196,24 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
 ;; @004d                               v4 = bitcast.f64x2 little v2
-;; @004d                               v6 = vconst.f64x2 const0
-;; @004d                               v7 = extractlane v4, 0
-;; @004d                               v8 = call fn0(v0, v7)
-;; @004d                               v9 = insertlane v6, v8, 0  ; v6 = const0
-;; @004d                               v10 = extractlane v4, 1
-;; @004d                               v11 = call fn0(v0, v10)
-;; @004d                               v12 = insertlane v9, v11, 1
-;; @004f                               v13 = bitcast.i8x16 little v12
+;; @004d                               v5 = vconst.f64x2 const0
+;; @004d                               v6 = extractlane v4, 0
+;; @004d                               v7 = call fn0(v0, v6)
+;; @004d                               v8 = insertlane v5, v7, 0  ; v5 = const0
+;; @004d                               v9 = extractlane v4, 1
+;; @004d                               v10 = call fn0(v0, v9)
+;; @004d                               v11 = insertlane v8, v10, 1
+;; @004f                               v12 = bitcast.i8x16 little v11
 ;; @004f                               jump block1
 ;;
 ;;                                 block1:
-;; @004f                               return v13
+;; @004f                               return v12
 ;; }
 ;;
 ;; function u0:7(i64 vmctx, i64, i8x16) -> i8x16 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, f64) -> f64 tail
 ;;     fn0 = colocated u805306368:35 sig0
 ;;     const0 = 0x00000000000000000000000000000000
@@ -229,18 +221,18 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
 ;; @0054                               v4 = bitcast.f64x2 little v2
-;; @0054                               v6 = vconst.f64x2 const0
-;; @0054                               v7 = extractlane v4, 0
-;; @0054                               v8 = call fn0(v0, v7)
-;; @0054                               v9 = insertlane v6, v8, 0  ; v6 = const0
-;; @0054                               v10 = extractlane v4, 1
-;; @0054                               v11 = call fn0(v0, v10)
-;; @0054                               v12 = insertlane v9, v11, 1
-;; @0057                               v13 = bitcast.i8x16 little v12
+;; @0054                               v5 = vconst.f64x2 const0
+;; @0054                               v6 = extractlane v4, 0
+;; @0054                               v7 = call fn0(v0, v6)
+;; @0054                               v8 = insertlane v5, v7, 0  ; v5 = const0
+;; @0054                               v9 = extractlane v4, 1
+;; @0054                               v10 = call fn0(v0, v9)
+;; @0054                               v11 = insertlane v8, v10, 1
+;; @0057                               v12 = bitcast.i8x16 little v11
 ;; @0057                               jump block1
 ;;
 ;;                                 block1:
-;; @0057                               return v13
+;; @0057                               return v12
 ;; }
 ;;
 ;; function u0:8(i64 vmctx, i64, i8x16) -> i8x16 tail {


### PR DESCRIPTION
See each commit for details.