### PR TITLE
Enable the Wasm GC proposal by default

### DIFF
--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -1033,11 +1033,9 @@ impl Config {
     /// Note that the function references proposal depends on the typed function
     /// references proposal.
     ///
-    /// This feature is `true` by default, unless Wasmtime was not built with
-    /// the `gc` cargo feature.
+    /// This feature is `true` by default.
     ///
     /// [proposal]: https://github.com/WebAssembly/gc
-    #[cfg(feature = "gc")]
     pub fn wasm_gc(&mut self, enable: bool) -> &mut Self {
         self.wasm_features(WasmFeatures::GC, enable);
         self
@@ -2436,6 +2434,7 @@ impl Config {
         features |= WasmFeatures::EXTENDED_CONST;
         features |= WasmFeatures::MEMORY64;
         features |= WasmFeatures::FUNCTION_REFERENCES;
+        features |= WasmFeatures::GC;
         // NB: if you add a feature above this line please double-check
         // https://docs.wasmtime.dev/stability-wasm-proposals.html
         // to ensure all requirements are met and/or update the documentation
@@ -2444,7 +2443,6 @@ impl Config {
         // Set some features to their conditionally-enabled defaults depending
         // on crate compile-time features.
         features.set(WasmFeatures::GC_TYPES, cfg!(feature = "gc"));
-        features.set(WasmFeatures::GC, cfg!(feature = "gc"));
         features.set(WasmFeatures::THREADS, cfg!(feature = "threads"));
         features.set(
             WasmFeatures::COMPONENT_MODEL,

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -1004,7 +1004,7 @@ impl Config {
     /// Note that the function references proposal depends on the reference
     /// types proposal.
     ///
-    /// This feature is `false` by default.
+    /// This feature is `true` by default.
     ///
     /// [proposal]: https://github.com/WebAssembly/function-references
     #[cfg(feature = "gc")]
@@ -1033,10 +1033,8 @@ impl Config {
     /// Note that the function references proposal depends on the typed function
     /// references proposal.
     ///
-    /// This feature is `false` by default.
-    ///
-    /// **Warning: Wasmtime's implementation of the GC proposal is still in
-    /// progress and generally not ready for primetime.**
+    /// This feature is `true` by default, unless Wasmtime was not built with
+    /// the `gc` cargo feature.
     ///
     /// [proposal]: https://github.com/WebAssembly/gc
     #[cfg(feature = "gc")]
@@ -2437,6 +2435,7 @@ impl Config {
         features |= WasmFeatures::TAIL_CALL;
         features |= WasmFeatures::EXTENDED_CONST;
         features |= WasmFeatures::MEMORY64;
+        features |= WasmFeatures::FUNCTION_REFERENCES;
         // NB: if you add a feature above this line please double-check
         // https://docs.wasmtime.dev/stability-wasm-proposals.html
         // to ensure all requirements are met and/or update the documentation
@@ -2445,6 +2444,7 @@ impl Config {
         // Set some features to their conditionally-enabled defaults depending
         // on crate compile-time features.
         features.set(WasmFeatures::GC_TYPES, cfg!(feature = "gc"));
+        features.set(WasmFeatures::GC, cfg!(feature = "gc"));
         features.set(WasmFeatures::THREADS, cfg!(feature = "threads"));
         features.set(
             WasmFeatures::COMPONENT_MODEL,

--- a/docs/stability-tiers.md
+++ b/docs/stability-tiers.md
@@ -40,6 +40,8 @@ For explanations of what each tier means see below.
 | WebAssembly Proposal | [`tail-call`]                              |
 | WebAssembly Proposal | [`extended-const`]                         |
 | WebAssembly Proposal | [`memory64`]                               |
+| WebAssembly Proposal | [`function-references`]                    |
+| WebAssembly Proposal | [`gc`]                                     |
 | WASI Proposal        | [`wasi-io`]                                |
 | WASI Proposal        | [`wasi-clocks`]                            |
 | WASI Proposal        | [`wasi-filesystem`]                        |
@@ -58,6 +60,9 @@ For explanations of what each tier means see below.
 [`bulk-memory`]: https://github.com/WebAssembly/bulk-memory-operations/blob/master/proposals/bulk-memory-operations/Overview.md
 [`extended-const`]: https://github.com/WebAssembly/extended-const
 [`reference-types`]: https://github.com/WebAssembly/reference-types/blob/master/proposals/reference-types/Overview.md
+[`memory64`]: https://github.com/WebAssembly/memory64/blob/master/proposals/memory64/Overview.md
+[`function-references`]: https://github.com/WebAssembly/function-references/blob/main/proposals/function-references/Overview.md
+[`gc`]: https://github.com/WebAssembly/gc
 [`simd`]: https://github.com/WebAssembly/simd/blob/master/proposals/simd/SIMD.md
 [`wasi-clocks`]: https://github.com/WebAssembly/wasi-clocks
 [`wasi-filesystem`]: https://github.com/WebAssembly/wasi-filesystem
@@ -82,20 +87,16 @@ For explanations of what each tier means see below.
 | Target               | Support for `#![no_std]`   | Support beyond CI checks    |
 | WebAssembly Proposal | [`custom-page-sizes`]      | Unstable wasm proposal      |
 | WebAssembly Proposal | [`exception-handling`]     | fuzzing, dependence on GC   |
-| WebAssembly Proposal | [`function-references`]    | production quality          |
-| WebAssembly Proposal | [`gc`]                     | production quality          |
 | WebAssembly Proposal | [`threads`]                | fuzzing, API quality        |
 | WebAssembly Proposal | [`wide-arithmetic`]        | Unstable wasm proposal      |
 | Execution Backend    | Pulley                     | More time fuzzing/baking    |
 | Embedding API        | C++                        | Full-time maintainer        |
 
-[`memory64`]: https://github.com/WebAssembly/memory64/blob/master/proposals/memory64/Overview.md
 [`custom-page-sizes`]: https://github.com/WebAssembly/custom-page-sizes
 [`multi-memory`]: https://github.com/WebAssembly/multi-memory/blob/master/proposals/multi-memory/Overview.md
 [`threads`]: https://github.com/WebAssembly/threads
 [`component-model`]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/Explainer.md
 [`relaxed-simd`]: https://github.com/WebAssembly/relaxed-simd/blob/main/proposals/relaxed-simd/Overview.md
-[`function-references`]: https://github.com/WebAssembly/function-references/blob/main/proposals/function-references/Overview.md
 [`wide-arithmetic`]: https://github.com/WebAssembly/wide-arithmetic/blob/main/proposals/wide-arithmetic/Overview.md
 [`exception-handling`]: https://github.com/WebAssembly/exception-handling
 [`stack-switching`]: https://github.com/WebAssembly/stack-switching
@@ -133,7 +134,6 @@ For explanations of what each tier means see below.
 [`wasi-config`]: https://github.com/WebAssembly/wasi-config
 [`wasi-keyvalue`]: https://github.com/WebAssembly/wasi-keyvalue
 [`wasi-tls`]: https://github.com/WebAssembly/wasi-tls
-[`gc`]: https://github.com/WebAssembly/gc
 
 [^1]: This is intended to encompass features that Cranelift supports as a
 general-purpose code generator such as integer value types other than `i32` and

--- a/docs/stability-wasm-proposals.md
+++ b/docs/stability-wasm-proposals.md
@@ -32,6 +32,8 @@ The emoji legend is:
 | [`tail-call`]            | ✅      | ✅    | ✅       | ✅     | ✅  | ✅    |
 | [`extended-const`]       | ✅      | ✅    | ✅       | ✅     | ✅  | ✅    |
 | [`memory64`]             | ✅      | ✅    | ✅       | ✅     | ✅  | ✅    |
+| [`function-references`]  | ✅      | ✅    | ✅       | ✅     | ✅  | ✅    |
+| [`gc`]                   | ✅      | ✅    | ✅       | ✅     | ✅  | ✅    |
 
 [^1]: The `component-model` proposal is not at phase 4 in the standardization
     process but it is still enabled-by-default in Wasmtime.
@@ -48,20 +50,11 @@ The emoji legend is:
 |--------------------------|---------|-------|----------|--------|-----|--------|
 | [`custom-page-sizes`]    | ❌      | ✅    | ✅       | ✅     | ✅  | ✅     |
 | [`exception-handling`]   | ✅      | ✅    | ✅       | ✅     | ✅  | ✅     |
-| [`function-references`]  | ✅      | ✅    | ✅       | 🚧     | ✅  | ❌     |
-| [`gc`] [^5]              | ✅      | ✅    | 🚧[^6]   | ✅     | ✅  | ✅     |
 | [`threads`]              | ✅      | ✅    | 🚧[^8]   | ❌[^4] | ✅  | ✅     |
 | [`wide-arithmetic`]      | ❌      | ✅    | ✅       | ✅     | ✅  | ✅     |
 
 [^4]: Fuzzing with threads is an open implementation question that is expected
     to get fleshed out as the [`shared-everything-threads`] proposal advances.
-[^5]: There is also a [tracking
-    issue](https://github.com/bytecodealliance/wasmtime/issues/5032) for the
-    GC proposal.
-[^6]: The implementation of Wasm GC is feature complete from a specification
-    perspective, however a number of quality-of-implementation tasks
-    [remain](https://github.com/bytecodealliance/wasmtime/issues/13216) that
-    we'd like to resolve before promoting Wasm GC to tier 1.
 [^8]: There are [known
     issues](https://github.com/bytecodealliance/wasmtime/issues/4245) with
     shared memories and the implementation/API in Wasmtime, for example they


### PR DESCRIPTION
And also the function references proposal, which was effectively folded into the GC proposal.

Resolves https://github.com/bytecodealliance/wasmtime/issues/13216

Resolves https://github.com/bytecodealliance/wasmtime/issues/5032

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
