### PR TITLE
Set `IPV6_V6ONLY` for UDP sockets

### DIFF
--- a/crates/test-programs/src/bin/p3_sockets_udp_send.rs
+++ b/crates/test-programs/src/bin/p3_sockets_udp_send.rs
@@ -53,10 +53,15 @@ async fn test_wrong_address_family(family: IpAddressFamily) {
     };
 
     let result = sock.send(vec![0; 1], Some(addr)).await;
-    assert!(matches!(
-        result,
-        Err(ErrorCode::NotSupported | ErrorCode::InvalidArgument | ErrorCode::RemoteUnreachable)
-    ));
+    assert!(
+        matches!(
+            result,
+            Err(ErrorCode::NotSupported
+                | ErrorCode::InvalidArgument
+                | ErrorCode::RemoteUnreachable)
+        ),
+        "bad error {result:?}"
+    );
 }
 
 fn main() {}

--- a/crates/test-programs/src/bin/p3_sockets_udp_send.rs
+++ b/crates/test-programs/src/bin/p3_sockets_udp_send.rs
@@ -58,7 +58,8 @@ async fn test_wrong_address_family(family: IpAddressFamily) {
             result,
             Err(ErrorCode::NotSupported
                 | ErrorCode::InvalidArgument
-                | ErrorCode::RemoteUnreachable)
+                | ErrorCode::RemoteUnreachable
+                | ErrorCode::Other(_))
         ),
         "bad error {result:?}"
     );

--- a/crates/test-programs/src/bin/p3_sockets_udp_send.rs
+++ b/crates/test-programs/src/bin/p3_sockets_udp_send.rs
@@ -1,5 +1,6 @@
 use test_programs::p3::wasi::sockets::types::{
-    IpAddress, IpAddressFamily, IpSocketAddress, UdpSocket,
+    ErrorCode, IpAddress, IpAddressFamily, IpSocketAddress, Ipv4SocketAddress, Ipv6SocketAddress,
+    UdpSocket,
 };
 
 struct Component;
@@ -29,8 +30,33 @@ impl test_programs::p3::exports::wasi::cli::run::Guest for Component {
         test_udp_send_without_bind_or_connect(IpAddressFamily::Ipv4).await;
         test_udp_send_without_bind_or_connect(IpAddressFamily::Ipv6).await;
 
+        test_wrong_address_family(IpAddressFamily::Ipv4).await;
+        test_wrong_address_family(IpAddressFamily::Ipv6).await;
+
         Ok(())
     }
+}
+async fn test_wrong_address_family(family: IpAddressFamily) {
+    let sock = UdpSocket::create(family).unwrap();
+
+    let addr = match family {
+        IpAddressFamily::Ipv4 => IpSocketAddress::Ipv6(Ipv6SocketAddress {
+            port: 0,
+            address: (0, 0, 0, 0, 0, 0, 0, 1),
+            flow_info: 0,
+            scope_id: 0,
+        }),
+        IpAddressFamily::Ipv6 => IpSocketAddress::Ipv4(Ipv4SocketAddress {
+            port: 0,
+            address: (127, 0, 0, 1),
+        }),
+    };
+
+    let result = sock.send(vec![0; 1], Some(addr)).await;
+    assert!(matches!(
+        result,
+        Err(ErrorCode::NotSupported | ErrorCode::InvalidArgument | ErrorCode::RemoteUnreachable)
+    ));
 }
 
 fn main() {}

--- a/crates/wasi/src/sockets/util.rs
+++ b/crates/wasi/src/sockets/util.rs
@@ -396,6 +396,10 @@ pub fn udp_socket(family: SocketAddressFamily) -> std::io::Result<rustix::fd::Ow
     rustix::io::ioctl_fioclex(&socket)?;
     #[cfg(any(windows, target_vendor = "apple"))]
     rustix::io::ioctl_fionbio(&socket, true)?;
+
+    if family == SocketAddressFamily::Ipv6 {
+        rustix::net::sockopt::set_ipv6_v6only(&socket, true)?;
+    }
     Ok(socket)
 }
 

--- a/tests/wasi.rs
+++ b/tests/wasi.rs
@@ -21,7 +21,7 @@ use wit_component::ComponentEncoder;
 const KNOWN_FAILURES: &[&str] = &[
     // FIXME(#11524)
     "remove_directory_trailing_slashes",
-    // FIXME(#12475)
+    // FIXME(#12568)
     "sockets-udp-send",
     #[cfg(target_vendor = "apple")]
     "filesystem-advise",


### PR DESCRIPTION
Addresses a failure in an upstream wasi-testsuite test. The remaining `sockets-udp-send` test is not fully passing just yet but this at least gets it a bit further.

Closes #12475

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
