### PR TITLE
Add bounds-checked unsafe intrinsics

### DIFF
--- a/crates/cranelift/src/compiler/component.rs
+++ b/crates/cranelift/src/compiler/component.rs
@@ -1541,31 +1541,29 @@ impl<'a> TrampolineCompiler<'a> {
     /// `VMComponentContext` if it's otherwise unused.
     fn load_vm_store_context(&mut self) -> ir::Value {
         let caller_vmctx = self.abi_load_params()[1];
-        let vmctx_region = self
-            .builder
-            .func
-            .dfg
-            .alias_regions
-            .insert(ir::AliasRegionData {
-                user_id: 2,
-                description: "vmctx".into(),
-            });
+        let offset = self.offsets.ptr.vmctx_store_context();
+        let region = self.builder.func.dfg.alias_regions.insert(
+            AliasRegionKey::Vm {
+                ty: VmType::VMContext,
+                offset: offset.into(),
+            }
+            .into(),
+        );
         self.builder.ins().load(
             self.isa.pointer_type(),
             ir::MemFlagsData::trusted()
                 .with_readonly()
-                .with_alias_region(Some(vmctx_region))
+                .with_alias_region(Some(region))
                 .with_can_move(),
             caller_vmctx,
-            i32::from(self.offsets.ptr.vmctx_store_context()),
+            i32::from(offset),
         )
     }
 }
 
-// Helper structure to implement `TranslateTrap`. This isn't possible to do
-// natively for `TrampolineCompiler` because it stores `FunctionBuilder`
-// internally. This differs from `FuncEnvironment` for core wasm which stores it
-// externally, hence the slightly different idioms to bridge here.
+// XXX: we can't implement this for `TrampolineCompiler` directly because it
+// stores `FunctionBuilder` internally, but this needs to take the builder as an
+// argument.
 struct TrapTranslator<'a> {
     compiler: &'a Compiler,
     vmctx: ir::Value,
@@ -1576,9 +1574,11 @@ impl TranslateTrap for TrapTranslator<'_> {
     fn compiler(&self) -> &Compiler {
         self.compiler
     }
+
     fn vmctx_val(&mut self, _: &mut FuncCursor<'_>) -> ir::Value {
         self.vmctx
     }
+
     fn builtin_funcref(
         &mut self,
         builder: &mut FunctionBuilder<'_>,
@@ -1586,6 +1586,58 @@ impl TranslateTrap for TrapTranslator<'_> {
     ) -> ir::FuncRef {
         self.builtins.load_builtin(builder.func, index)
     }
+}
+
+fn checked_native_addr<T: TranslateTrap>(
+    traps: &mut T,
+    builder: &mut FunctionBuilder<'_>,
+    isa: &(dyn TargetIsa + 'static),
+    base_address: ir::Value,
+    offset: ir::Value,
+    length: ir::Value,
+    size: u32,
+) -> Result<ir::Value> {
+    debug_assert_eq!(builder.func.dfg.value_type(base_address), ir::types::I64);
+    debug_assert_eq!(builder.func.dfg.value_type(offset), ir::types::I64);
+    debug_assert_eq!(builder.func.dfg.value_type(length), ir::types::I64);
+
+    // Compute `offset + size`, trapping if it either overflows or is greater
+    // than `length`.
+    let size = builder.ins().iconst(ir::types::I64, i64::from(size));
+    let (end, overflow) = builder.ins().uadd_overflow(offset, size);
+    let too_big = builder.ins().icmp(IntCC::UnsignedGreaterThan, end, length);
+    let oob = builder.ins().bor(overflow, too_big);
+
+    // Compute the native address `base_address + offset`, truncating to the
+    // target's pointer width on 32-bit architectures.
+    let addr = builder.ins().iadd(base_address, offset);
+    let addr = match isa.pointer_bits() {
+        32 => builder.ins().ireduce(ir::types::I32, addr),
+        64 => addr,
+        p => bail!("unsupported architecture: no support for {p}-bit pointers"),
+    };
+
+    let addr =
+        // When Spectre mitigations are enabled, replace the address with NULL
+        // on the out-of-bounds path. The subsequent access only happens on the
+        // in-bounds path (we will have trapped otherwise), but this guards
+        // against the bounds-check branch being mispredicted and the access
+        // being performed speculatively against an out-of-bounds address.
+        if isa.flags().enable_heap_access_spectre_mitigation() {
+            let pointer_type = isa.pointer_type();
+            let null = builder.ins().iconst(pointer_type, 0);
+            let addr = builder.ins().select_spectre_guard(oob, null, addr);
+            traps.trapz(builder, addr, ir::TrapCode::HEAP_OUT_OF_BOUNDS);
+            addr
+        }
+        // Otherwise, when Spectre mitigations are disabled, just conditionally
+        // trap on the out-of-bounds condition directly.
+        else {
+            traps.trapnz(builder, oob, ir::TrapCode::HEAP_OUT_OF_BOUNDS);
+            addr
+        };
+
+    Ok(addr)
 }
 
 impl ComponentCompiler for Compiler {
@@ -2099,9 +2151,12 @@ impl TrampolineCompiler<'_> {
 
         // Bounds-check the access and compute its native address, trapping if
         // it is out of bounds.
-        let addr = UnsafeIntrinsicCompiler::checked_native_addr(
-            &mut self.builder.cursor(),
-            self.isa,
+        let isa = self.isa;
+        let (mut traps, builder) = self.traps();
+        let addr = checked_native_addr(
+            &mut traps,
+            builder,
+            isa,
             base_address,
             offset,
             length,
@@ -2109,16 +2164,15 @@ impl TrampolineCompiler<'_> {
         )?;
 
         // Do the load!
-        let mut value = self
-            .builder
+        let mut value = builder
             .ins()
             .load(clif_ty, ir::MemFlagsData::trusted(), addr, 0);
 
         // Zero-extend the loaded value to the Wasm result type, if necessary.
-        let wasm_clif_ty = crate::value_type(self.isa, wasm_ty);
+        let wasm_clif_ty = crate::value_type(isa, wasm_ty);
         if clif_ty != wasm_clif_ty {
             assert!(clif_ty.bytes() < wasm_clif_ty.bytes());
-            value = self.builder.ins().uextend(wasm_clif_ty, value);
+            value = builder.ins().uextend(wasm_clif_ty, value);
         }
 
         self.abi_store_results(&[value]);
@@ -2154,9 +2208,12 @@ impl TrampolineCompiler<'_> {
 
         // Bounds-check the access and compute its native address, trapping if
         // it is out of bounds.
-        let addr = UnsafeIntrinsicCompiler::checked_native_addr(
-            &mut self.builder.cursor(),
-            self.isa,
+        let isa = self.isa;
+        let (mut traps, builder) = self.traps();
+        let addr = checked_native_addr(
+            &mut traps,
+            builder,
+            isa,
             base_address,
             offset,
             length,
@@ -2164,14 +2221,14 @@ impl TrampolineCompiler<'_> {
         )?;
 
         // Truncate the value to the access type, if necessary.
-        let wasm_ty = crate::value_type(self.isa, wasm_ty);
+        let wasm_ty = crate::value_type(isa, wasm_ty);
         if clif_ty != wasm_ty {
             assert!(clif_ty.bytes() < wasm_ty.bytes());
-            value = self.builder.ins().ireduce(clif_ty, value);
+            value = builder.ins().ireduce(clif_ty, value);
         }
 
         // Do the store!
-        self.builder
+        builder
             .ins()
             .store(ir::MemFlagsData::trusted(), value, addr, 0);
 
@@ -2234,13 +2291,14 @@ impl TrampolineCompiler<'_> {
 /// This type itself is more of a context type of sorts where it maintains
 /// little-to-no state and instead just weaves together all that's necessary for
 /// translating an intrinsic.
-pub struct UnsafeIntrinsicCompiler<'a> {
+pub struct UnsafeIntrinsicCompiler<'a, 'b, T: TranslateTrap> {
     pub isa: &'a (dyn TargetIsa + 'static),
-    pub cursor: FuncCursor<'a>,
-    pub ptr: &'a (dyn PtrSize + 'static),
+    pub builder: &'a mut FunctionBuilder<'b>,
+    pub ptr: u8,
+    pub traps: &'a mut T,
 }
 
-impl<'a> UnsafeIntrinsicCompiler<'a> {
+impl<T: TranslateTrap> UnsafeIntrinsicCompiler<'_, '_, T> {
     /// Translates the `intrinsic` provided which is provided `params` as
     /// arguments.
     ///
@@ -2292,29 +2350,28 @@ impl<'a> UnsafeIntrinsicCompiler<'a> {
                 // Load the `*mut VMStoreContext` out of our vmctx.
                 let store_ctx = self.load_vm_store_context(params);
 
-                let vmctx_region = self
-                    .cursor
-                    .func
-                    .dfg
-                    .alias_regions
-                    .insert(ir::AliasRegionData {
-                        user_id: 2,
-                        description: "vmctx".into(),
-                    });
                 // Load the `*mut T` out of the `VMStoreContext`.
-                let data_address = self.cursor.ins().load(
+                let offset = self.ptr.vmstore_context_store_data();
+                let region = self.builder.func.dfg.alias_regions.insert(
+                    AliasRegionKey::Vm {
+                        ty: VmType::VMStoreContext,
+                        offset: offset.into(),
+                    }
+                    .into(),
+                );
+                let data_address = self.builder.ins().load(
                     pointer_type,
                     ir::MemFlagsData::trusted()
                         .with_readonly()
-                        .with_alias_region(Some(vmctx_region))
+                        .with_alias_region(Some(region))
                         .with_can_move(),
                     store_ctx,
-                    i32::from(self.ptr.vmstore_context_store_data()),
+                    i32::from(offset),
                 );
 
                 // Zero-extend the address if we are on a 32-bit architecture.
                 let data_address = match pointer_type.bits() {
-                    32 => self.cursor.ins().uextend(ir::types::I64, data_address),
+                    32 => self.builder.ins().uextend(ir::types::I64, data_address),
                     64 => data_address,
                     p => bail!("unsupported architecture: no support for {p}-bit pointers"),
                 };
@@ -2348,16 +2405,16 @@ impl<'a> UnsafeIntrinsicCompiler<'a> {
         };
 
         // Truncate the pointer, if necessary.
-        debug_assert_eq!(self.cursor.func.dfg.value_type(pointer), ir::types::I64);
+        debug_assert_eq!(self.builder.func.dfg.value_type(pointer), ir::types::I64);
         let pointer = match self.isa.pointer_bits() {
-            32 => self.cursor.ins().ireduce(ir::types::I32, pointer),
+            32 => self.builder.ins().ireduce(ir::types::I32, pointer),
             64 => pointer,
             p => bail!("unsupported architecture: no support for {p}-bit pointers"),
         };
 
         // Do the load!
         let mut value = self
-            .cursor
+            .builder
             .ins()
             .load(clif_ty, ir::MemFlagsData::trusted(), pointer, 0);
 
@@ -2370,7 +2427,7 @@ impl<'a> UnsafeIntrinsicCompiler<'a> {
             assert!(clif_ty.bytes() < wasm_clif_ty.bytes());
             // NB: all of our unsafe intrinsics for native loads are
             // unsigned, so we always zero-extend.
-            value = self.cursor.ins().uextend(wasm_clif_ty, value);
+            value = self.builder.ins().uextend(wasm_clif_ty, value);
         }
 
         Ok(value)
@@ -2392,9 +2449,9 @@ impl<'a> UnsafeIntrinsicCompiler<'a> {
         };
 
         // Truncate the pointer, if necessary.
-        debug_assert_eq!(self.cursor.func.dfg.value_type(pointer), ir::types::I64);
+        debug_assert_eq!(self.builder.func.dfg.value_type(pointer), ir::types::I64);
         let pointer = match self.isa.pointer_bits() {
-            32 => self.cursor.ins().ireduce(ir::types::I32, pointer),
+            32 => self.builder.ins().ireduce(ir::types::I32, pointer),
             64 => pointer,
             p => bail!("unsupported architecture: no support for {p}-bit pointers"),
         };
@@ -2406,11 +2463,11 @@ impl<'a> UnsafeIntrinsicCompiler<'a> {
         let wasm_ty = crate::value_type(self.isa, wasm_ty);
         if clif_ty != wasm_ty {
             assert!(clif_ty.bytes() < wasm_ty.bytes());
-            value = self.cursor.ins().ireduce(clif_ty, value);
+            value = self.builder.ins().ireduce(clif_ty, value);
         }
 
         // Do the store!
-        self.cursor
+        self.builder
             .ins()
             .store(ir::MemFlagsData::trusted(), value, pointer, 0);
 
@@ -2437,8 +2494,9 @@ impl<'a> UnsafeIntrinsicCompiler<'a> {
 
         // Bounds-check the access and compute its native address, trapping if
         // it is out of bounds.
-        let addr = Self::checked_native_addr(
-            &mut self.cursor,
+        let addr = checked_native_addr(
+            self.traps,
+            self.builder,
             self.isa,
             base_address,
             offset,
@@ -2448,7 +2506,7 @@ impl<'a> UnsafeIntrinsicCompiler<'a> {
 
         // Do the load!
         let mut value = self
-            .cursor
+            .builder
             .ins()
             .load(clif_ty, ir::MemFlagsData::trusted(), addr, 0);
 
@@ -2456,7 +2514,7 @@ impl<'a> UnsafeIntrinsicCompiler<'a> {
         let wasm_clif_ty = crate::value_type(self.isa, wasm_ty);
         if clif_ty != wasm_clif_ty {
             assert!(clif_ty.bytes() < wasm_clif_ty.bytes());
-            value = self.cursor.ins().uextend(wasm_clif_ty, value);
+            value = self.builder.ins().uextend(wasm_clif_ty, value);
         }
 
         Ok(value)
@@ -2495,8 +2553,9 @@ impl<'a> UnsafeIntrinsicCompiler<'a> {
 
         // Bounds-check the access and compute its native address, trapping if
         // it is out of bounds.
-        let addr = Self::checked_native_addr(
-            &mut self.cursor,
+        let addr = checked_native_addr(
+            self.traps,
+            self.builder,
             self.isa,
             base_address,
             offset,
@@ -2508,84 +2567,15 @@ impl<'a> UnsafeIntrinsicCompiler<'a> {
         let wasm_ty = crate::value_type(self.isa, wasm_ty);
         if clif_ty != wasm_ty {
             assert!(clif_ty.bytes() < wasm_ty.bytes());
-            value = self.cursor.ins().ireduce(clif_ty, value);
+            value = self.builder.ins().ireduce(clif_ty, value);
         }
 
         // Do the store!
-        self.cursor
+        self.builder
             .ins()
             .store(ir::MemFlagsData::trusted(), value, addr, 0);
 
         Ok(())
-    }
-
-    /// Emit the bounds check and native-address computation shared by the
-    /// checked native load and store intrinsics.
-    ///
-    /// Given the `base_address`, `offset`, and `length` `i64` arguments and the
-    /// `size` (in bytes) of the access, this traps with a heap-out-of-bounds
-    /// trap if `offset + size > length` or if that addition overflows.
-    /// Otherwise it returns the pointer-typed native address `base_address +
-    /// offset` to access.
-    ///
-    /// When the target enables Spectre mitigations for heap accesses, the
-    /// returned address is additionally guarded with a `select_spectre_guard`
-    /// instruction so that speculative execution cannot use an out-of-bounds
-    /// address even if the preceding bounds-check branch is mispredicted.
-    fn checked_native_addr(
-        cursor: &mut FuncCursor<'_>,
-        isa: &(dyn TargetIsa + 'static),
-        base_address: ir::Value,
-        offset: ir::Value,
-        length: ir::Value,
-        size: u32,
-    ) -> Result<ir::Value> {
-        debug_assert_eq!(cursor.func.dfg.value_type(base_address), ir::types::I64);
-        debug_assert_eq!(cursor.func.dfg.value_type(offset), ir::types::I64);
-        debug_assert_eq!(cursor.func.dfg.value_type(length), ir::types::I64);
-
-        // Compute `offset + size`, trapping if it either overflows or is
-        // greater than `length`.
-        let size = cursor.ins().iconst(ir::types::I64, i64::from(size));
-        let (end, overflow) = cursor.ins().uadd_overflow(offset, size);
-        let too_big = cursor.ins().icmp(IntCC::UnsignedGreaterThan, end, length);
-        let oob = cursor.ins().bor(overflow, too_big);
-
-        // Compute the native address `base_address + offset`, truncating to the
-        // target's pointer width on 32-bit architectures.
-        let addr = cursor.ins().iadd(base_address, offset);
-        let addr = match isa.pointer_bits() {
-            32 => cursor.ins().ireduce(ir::types::I32, addr),
-            64 => addr,
-            p => bail!("unsupported architecture: no support for {p}-bit pointers"),
-        };
-
-        let addr =
-            // When Spectre mitigations are enabled, replace the address with
-            // NULL on the out-of-bounds path. The subsequent access only
-            // happens on the in-bounds path (we will have trapped otherwise),
-            // but this guards against the bounds-check branch being
-            // mispredicted and the access being performed speculatively against
-            // an out-of-bounds address.
-            if isa.flags().enable_heap_access_spectre_mitigation() {
-                let pointer_type = isa.pointer_type();
-                let null = cursor.ins().iconst(pointer_type, 0);
-                let addr = cursor.ins().select_spectre_guard(oob, null, addr);
-                cursor
-                    .ins()
-                    .trapz(addr, ir::TrapCode::HEAP_OUT_OF_BOUNDS);
-                addr
-            }
-            // Otherwise, when Spectre mitigations are disabled, just conditionally
-            // trap on the out-of-bounds condition directly.
-            else {
-                cursor
-                    .ins()
-                    .trapnz(oob, ir::TrapCode::HEAP_OUT_OF_BOUNDS);
-                addr
-            };
-
-        Ok(addr)
     }
 
     fn translate_context_intrinsic(
@@ -2612,7 +2602,7 @@ impl<'a> UnsafeIntrinsicCompiler<'a> {
         let vmstore_context = self.load_vm_store_context(params);
         match intrinsic {
             UnsafeIntrinsic::ContextGetI32_0 | UnsafeIntrinsic::ContextGetI32_1 => {
-                let context = self.cursor.ins().load(
+                let context = self.builder.ins().load(
                     ty,
                     MemFlagsData::trusted(),
                     vmstore_context,
@@ -2622,7 +2612,7 @@ impl<'a> UnsafeIntrinsicCompiler<'a> {
             }
             UnsafeIntrinsic::ContextSetI32_0 | UnsafeIntrinsic::ContextSetI32_1 => {
                 let new_context = params[2];
-                self.cursor.ins().store(
+                self.builder.ins().store(
                     MemFlagsData::trusted(),
                     new_context,
                     vmstore_context,
@@ -2645,23 +2635,22 @@ impl<'a> UnsafeIntrinsicCompiler<'a> {
     /// `VMComponentContext` if it's otherwise unused.
     fn load_vm_store_context(&mut self, params: &[ir::Value]) -> ir::Value {
         let caller_vmctx = params[1];
-        let vmctx_region = self
-            .cursor
-            .func
-            .dfg
-            .alias_regions
-            .insert(ir::AliasRegionData {
-                user_id: 2,
-                description: "vmctx".into(),
-            });
-        self.cursor.ins().load(
+        let offset = self.ptr.vmctx_store_context();
+        let region = self.builder.func.dfg.alias_regions.insert(
+            AliasRegionKey::Vm {
+                ty: VmType::VMContext,
+                offset: offset.into(),
+            }
+            .into(),
+        );
+        self.builder.ins().load(
             self.isa.pointer_type(),
             ir::MemFlagsData::trusted()
                 .with_readonly()
-                .with_alias_region(Some(vmctx_region))
+                .with_alias_region(Some(region))
                 .with_can_move(),
             caller_vmctx,
-            i32::from(self.ptr.vmctx_store_context()),
+            i32::from(offset),
         )
     }
 }

--- a/crates/cranelift/src/compiler/component.rs
+++ b/crates/cranelift/src/compiler/component.rs
@@ -1718,6 +1718,18 @@ impl ComponentCompiler for Compiler {
             | UnsafeIntrinsic::U16NativeStore
             | UnsafeIntrinsic::U32NativeStore
             | UnsafeIntrinsic::U64NativeStore => c.translate_store_intrinsic(intrinsic)?,
+            UnsafeIntrinsic::U8CheckedNativeLoad
+            | UnsafeIntrinsic::U16CheckedNativeLoad
+            | UnsafeIntrinsic::U32CheckedNativeLoad
+            | UnsafeIntrinsic::U64CheckedNativeLoad => {
+                c.translate_checked_load_intrinsic(intrinsic)?
+            }
+            UnsafeIntrinsic::U8CheckedNativeStore
+            | UnsafeIntrinsic::U16CheckedNativeStore
+            | UnsafeIntrinsic::U32CheckedNativeStore
+            | UnsafeIntrinsic::U64CheckedNativeStore => {
+                c.translate_checked_store_intrinsic(intrinsic)?
+            }
             UnsafeIntrinsic::StoreDataAddress => {
                 let [callee_vmctx, _caller_vmctx] = *c.abi_load_params() else {
                     unreachable!()
@@ -2067,6 +2079,163 @@ impl TrampolineCompiler<'_> {
         Ok(())
     }
 
+    fn translate_checked_load_intrinsic(&mut self, intrinsic: UnsafeIntrinsic) -> Result<()> {
+        debug_assert_eq!(
+            intrinsic.core_params(),
+            &[WasmValType::I64, WasmValType::I64, WasmValType::I64]
+        );
+        debug_assert_eq!(intrinsic.core_results().len(), 1);
+
+        let wasm_ty = intrinsic.core_results()[0];
+        let clif_ty = unsafe_intrinsic_clif_results(intrinsic)[0];
+
+        let [_callee_vmctx, _caller_vmctx, base_address, offset, length] = *self.abi_load_params()
+        else {
+            unreachable!()
+        };
+
+        // Bounds-check the access and compute its native address, trapping if
+        // it is out of bounds.
+        let addr = self.checked_native_addr(base_address, offset, length, clif_ty.bytes())?;
+
+        // Do the load!
+        let mut value = self
+            .builder
+            .ins()
+            .load(clif_ty, ir::MemFlagsData::trusted(), addr, 0);
+
+        // Zero-extend the loaded value to the Wasm result type, if necessary.
+        let wasm_clif_ty = crate::value_type(self.isa, wasm_ty);
+        if clif_ty != wasm_clif_ty {
+            assert!(clif_ty.bytes() < wasm_clif_ty.bytes());
+            value = self.builder.ins().uextend(wasm_clif_ty, value);
+        }
+
+        self.abi_store_results(&[value]);
+        Ok(())
+    }
+
+    fn translate_checked_store_intrinsic(&mut self, intrinsic: UnsafeIntrinsic) -> Result<()> {
+        debug_assert!(intrinsic.core_results().is_empty());
+        debug_assert!(matches!(
+            intrinsic.core_params(),
+            [
+                WasmValType::I64,
+                WasmValType::I64,
+                WasmValType::I64,
+                _value_ty
+            ]
+        ));
+
+        let wasm_ty = intrinsic.core_params()[3];
+        let clif_ty = unsafe_intrinsic_clif_params(intrinsic)[3];
+
+        let [
+            _callee_vmctx,
+            _caller_vmctx,
+            base_address,
+            offset,
+            length,
+            mut value,
+        ] = *self.abi_load_params()
+        else {
+            unreachable!()
+        };
+
+        // Bounds-check the access and compute its native address, trapping if
+        // it is out of bounds.
+        let addr = self.checked_native_addr(base_address, offset, length, clif_ty.bytes())?;
+
+        // Truncate the value to the access type, if necessary.
+        let wasm_ty = crate::value_type(self.isa, wasm_ty);
+        if clif_ty != wasm_ty {
+            assert!(clif_ty.bytes() < wasm_ty.bytes());
+            value = self.builder.ins().ireduce(clif_ty, value);
+        }
+
+        // Do the store!
+        self.builder
+            .ins()
+            .store(ir::MemFlagsData::trusted(), value, addr, 0);
+
+        self.abi_store_results(&[]);
+        Ok(())
+    }
+
+    /// Emit the bounds check and native-address computation shared by the
+    /// checked native load and store intrinsics.
+    ///
+    /// Given the `base_address`, `offset`, and `length` `i64` arguments and the
+    /// `size` (in bytes) of the access, this traps with a heap-out-of-bounds
+    /// trap if `offset + size > length` or if that addition overflows.
+    /// Otherwise it returns the pointer-typed native address `base_address +
+    /// offset` to access.
+    ///
+    /// When the target enables Spectre mitigations for heap accesses, the
+    /// returned address is additionally guarded with a `select_spectre_guard`
+    /// instruction so that speculative execution cannot use an out-of-bounds
+    /// address even if the preceding bounds-check branch is mispredicted.
+    fn checked_native_addr(
+        &mut self,
+        base_address: ir::Value,
+        offset: ir::Value,
+        length: ir::Value,
+        size: u32,
+    ) -> Result<ir::Value> {
+        debug_assert_eq!(
+            self.builder.func.dfg.value_type(base_address),
+            ir::types::I64
+        );
+        debug_assert_eq!(self.builder.func.dfg.value_type(offset), ir::types::I64);
+        debug_assert_eq!(self.builder.func.dfg.value_type(length), ir::types::I64);
+
+        // Compute `offset + size`, trapping if it either overflows or is
+        // greater than `length`.
+        let size = self.builder.ins().iconst(ir::types::I64, i64::from(size));
+        let (end, overflow) = self.builder.ins().uadd_overflow(offset, size);
+        let too_big = self
+            .builder
+            .ins()
+            .icmp(IntCC::UnsignedGreaterThan, end, length);
+        let oob = self.builder.ins().bor(overflow, too_big);
+
+        // Compute the native address `base_address + offset`, truncating to the
+        // target's pointer width on 32-bit architectures.
+        let addr = self.builder.ins().iadd(base_address, offset);
+        let addr = match self.isa.pointer_bits() {
+            32 => self.builder.ins().ireduce(ir::types::I32, addr),
+            64 => addr,
+            p => bail!("unsupported architecture: no support for {p}-bit pointers"),
+        };
+
+        let addr =
+            // When Spectre mitigations are enabled, replace the address with
+            // NULL on the out-of-bounds path. The subsequent access only
+            // happens on the in-bounds path (we will have trapped otherwise),
+            // but this guards against the bounds-check branch being
+            // mispredicted and the access being performed speculatively against
+            // an out-of-bounds address.
+            if self.isa.flags().enable_heap_access_spectre_mitigation() {
+                let pointer_type = self.isa.pointer_type();
+                let null = self.builder.ins().iconst(pointer_type, 0);
+                let addr = self.builder.ins().select_spectre_guard(oob, null, addr);
+                self.builder
+                    .ins()
+                    .trapz(addr, ir::TrapCode::HEAP_OUT_OF_BOUNDS);
+                addr
+            }
+            // Otherwise, when Specter mitigations are disabled, just conditionally
+            // trap on the out-of-bounds condition directly.
+            else {
+                self.builder
+                    .ins()
+                    .trapnz(oob, ir::TrapCode::HEAP_OUT_OF_BOUNDS);
+                addr
+            };
+
+        Ok(addr)
+    }
+
     fn translate_context_intrinsic(&mut self, intrinsic: UnsafeIntrinsic) -> Result<()> {
         let ty = match intrinsic {
             UnsafeIntrinsic::ContextGetI32_0
@@ -2158,6 +2327,22 @@ impl<'a> UnsafeIntrinsicCompiler<'a> {
                 self.translate_store_intrinsic(intrinsic, params)?;
                 None
             }
+
+            UnsafeIntrinsic::U8CheckedNativeLoad
+            | UnsafeIntrinsic::U16CheckedNativeLoad
+            | UnsafeIntrinsic::U32CheckedNativeLoad
+            | UnsafeIntrinsic::U64CheckedNativeLoad => {
+                Some(self.translate_checked_load_intrinsic(intrinsic, params)?)
+            }
+
+            UnsafeIntrinsic::U8CheckedNativeStore
+            | UnsafeIntrinsic::U16CheckedNativeStore
+            | UnsafeIntrinsic::U32CheckedNativeStore
+            | UnsafeIntrinsic::U64CheckedNativeStore => {
+                self.translate_checked_store_intrinsic(intrinsic, params)?;
+                None
+            }
+
             UnsafeIntrinsic::StoreDataAddress => {
                 let pointer_type = self.isa.pointer_type();
 
@@ -2287,6 +2472,151 @@ impl<'a> UnsafeIntrinsicCompiler<'a> {
             .store(ir::MemFlagsData::trusted(), value, pointer, 0);
 
         Ok(())
+    }
+
+    fn translate_checked_load_intrinsic(
+        &mut self,
+        intrinsic: UnsafeIntrinsic,
+        params: &[ir::Value],
+    ) -> Result<ir::Value> {
+        debug_assert_eq!(
+            intrinsic.core_params(),
+            &[WasmValType::I64, WasmValType::I64, WasmValType::I64]
+        );
+        debug_assert_eq!(intrinsic.core_results().len(), 1);
+
+        let wasm_ty = intrinsic.core_results()[0];
+        let clif_ty = unsafe_intrinsic_clif_results(intrinsic)[0];
+
+        let [_callee_vmctx, _caller_vmctx, base_address, offset, length] = *params else {
+            unreachable!()
+        };
+
+        // Bounds-check the access and compute its native address, trapping if
+        // it is out of bounds.
+        let addr = self.checked_native_addr(base_address, offset, length, clif_ty.bytes())?;
+
+        // Do the load!
+        let mut value = self
+            .cursor
+            .ins()
+            .load(clif_ty, ir::MemFlagsData::trusted(), addr, 0);
+
+        // Zero-extend the loaded value to the Wasm result type, if necessary.
+        let wasm_clif_ty = crate::value_type(self.isa, wasm_ty);
+        if clif_ty != wasm_clif_ty {
+            assert!(clif_ty.bytes() < wasm_clif_ty.bytes());
+            value = self.cursor.ins().uextend(wasm_clif_ty, value);
+        }
+
+        Ok(value)
+    }
+
+    fn translate_checked_store_intrinsic(
+        &mut self,
+        intrinsic: UnsafeIntrinsic,
+        params: &[ir::Value],
+    ) -> Result<()> {
+        debug_assert!(intrinsic.core_results().is_empty());
+        debug_assert!(matches!(
+            intrinsic.core_params(),
+            [
+                WasmValType::I64,
+                WasmValType::I64,
+                WasmValType::I64,
+                _value_ty
+            ]
+        ));
+
+        let wasm_ty = intrinsic.core_params()[3];
+        let clif_ty = unsafe_intrinsic_clif_params(intrinsic)[3];
+
+        let [
+            _callee_vmctx,
+            _caller_vmctx,
+            base_address,
+            offset,
+            length,
+            mut value,
+        ] = *params
+        else {
+            unreachable!()
+        };
+
+        // Bounds-check the access and compute its native address, trapping if
+        // it is out of bounds.
+        let addr = self.checked_native_addr(base_address, offset, length, clif_ty.bytes())?;
+
+        // Truncate the value to the access type, if necessary.
+        let wasm_ty = crate::value_type(self.isa, wasm_ty);
+        if clif_ty != wasm_ty {
+            assert!(clif_ty.bytes() < wasm_ty.bytes());
+            value = self.cursor.ins().ireduce(clif_ty, value);
+        }
+
+        // Do the store!
+        self.cursor
+            .ins()
+            .store(ir::MemFlagsData::trusted(), value, addr, 0);
+
+        Ok(())
+    }
+
+    /// Emit the bounds check and native-address computation shared by the
+    /// checked native load and store intrinsics.
+    ///
+    /// See [`TrampolineCompiler::checked_native_addr`] for details; this is the
+    /// equivalent for the inlined translation path.
+    fn checked_native_addr(
+        &mut self,
+        base_address: ir::Value,
+        offset: ir::Value,
+        length: ir::Value,
+        size: u32,
+    ) -> Result<ir::Value> {
+        debug_assert_eq!(
+            self.cursor.func.dfg.value_type(base_address),
+            ir::types::I64
+        );
+        debug_assert_eq!(self.cursor.func.dfg.value_type(offset), ir::types::I64);
+        debug_assert_eq!(self.cursor.func.dfg.value_type(length), ir::types::I64);
+
+        // Compute `offset + size`, trapping if it either overflows or is
+        // greater than `length`.
+        let size = self.cursor.ins().iconst(ir::types::I64, i64::from(size));
+        let (end, overflow) = self.cursor.ins().uadd_overflow(offset, size);
+        let too_big = self
+            .cursor
+            .ins()
+            .icmp(IntCC::UnsignedGreaterThan, end, length);
+        let oob = self.cursor.ins().bor(overflow, too_big);
+        self.cursor
+            .ins()
+            .trapnz(oob, ir::TrapCode::HEAP_OUT_OF_BOUNDS);
+
+        // Compute the native address `base_address + offset`, truncating to the
+        // target's pointer width on 32-bit architectures.
+        let addr = self.cursor.ins().iadd(base_address, offset);
+        let addr = match self.isa.pointer_bits() {
+            32 => self.cursor.ins().ireduce(ir::types::I32, addr),
+            64 => addr,
+            p => bail!("unsupported architecture: no support for {p}-bit pointers"),
+        };
+
+        // When Spectre mitigations are enabled, replace the address with NULL
+        // on the out-of-bounds path. The subsequent access only happens on the
+        // in-bounds path (we trapped above otherwise), but this guards against
+        // the bounds-check branch being mispredicted and the access being
+        // performed speculatively against an out-of-bounds address.
+        let addr = if self.isa.flags().enable_heap_access_spectre_mitigation() {
+            let pointer_type = self.isa.pointer_type();
+            let null = self.cursor.ins().iconst(pointer_type, 0);
+            self.cursor.ins().select_spectre_guard(oob, null, addr)
+        } else {
+            addr
+        };
+
+        Ok(addr)
     }
 
     fn translate_context_intrinsic(

--- a/crates/cranelift/src/compiler/component.rs
+++ b/crates/cranelift/src/compiler/component.rs
@@ -2091,12 +2091,22 @@ impl TrampolineCompiler<'_> {
 
         let [_callee_vmctx, _caller_vmctx, base_address, offset, length] = *self.abi_load_params()
         else {
-            unreachable!()
+            unreachable!(
+                "should've been caught by validation: wrong number of params for checked load \
+                 intrinsic"
+            )
         };
 
         // Bounds-check the access and compute its native address, trapping if
         // it is out of bounds.
-        let addr = self.checked_native_addr(base_address, offset, length, clif_ty.bytes())?;
+        let addr = UnsafeIntrinsicCompiler::checked_native_addr(
+            &mut self.builder.cursor(),
+            self.isa,
+            base_address,
+            offset,
+            length,
+            clif_ty.bytes(),
+        )?;
 
         // Do the load!
         let mut value = self
@@ -2144,7 +2154,14 @@ impl TrampolineCompiler<'_> {
 
         // Bounds-check the access and compute its native address, trapping if
         // it is out of bounds.
-        let addr = self.checked_native_addr(base_address, offset, length, clif_ty.bytes())?;
+        let addr = UnsafeIntrinsicCompiler::checked_native_addr(
+            &mut self.builder.cursor(),
+            self.isa,
+            base_address,
+            offset,
+            length,
+            clif_ty.bytes(),
+        )?;
 
         // Truncate the value to the access type, if necessary.
         let wasm_ty = crate::value_type(self.isa, wasm_ty);
@@ -2160,80 +2177,6 @@ impl TrampolineCompiler<'_> {
 
         self.abi_store_results(&[]);
         Ok(())
-    }
-
-    /// Emit the bounds check and native-address computation shared by the
-    /// checked native load and store intrinsics.
-    ///
-    /// Given the `base_address`, `offset`, and `length` `i64` arguments and the
-    /// `size` (in bytes) of the access, this traps with a heap-out-of-bounds
-    /// trap if `offset + size > length` or if that addition overflows.
-    /// Otherwise it returns the pointer-typed native address `base_address +
-    /// offset` to access.
-    ///
-    /// When the target enables Spectre mitigations for heap accesses, the
-    /// returned address is additionally guarded with a `select_spectre_guard`
-    /// instruction so that speculative execution cannot use an out-of-bounds
-    /// address even if the preceding bounds-check branch is mispredicted.
-    fn checked_native_addr(
-        &mut self,
-        base_address: ir::Value,
-        offset: ir::Value,
-        length: ir::Value,
-        size: u32,
-    ) -> Result<ir::Value> {
-        debug_assert_eq!(
-            self.builder.func.dfg.value_type(base_address),
-            ir::types::I64
-        );
-        debug_assert_eq!(self.builder.func.dfg.value_type(offset), ir::types::I64);
-        debug_assert_eq!(self.builder.func.dfg.value_type(length), ir::types::I64);
-
-        // Compute `offset + size`, trapping if it either overflows or is
-        // greater than `length`.
-        let size = self.builder.ins().iconst(ir::types::I64, i64::from(size));
-        let (end, overflow) = self.builder.ins().uadd_overflow(offset, size);
-        let too_big = self
-            .builder
-            .ins()
-            .icmp(IntCC::UnsignedGreaterThan, end, length);
-        let oob = self.builder.ins().bor(overflow, too_big);
-
-        // Compute the native address `base_address + offset`, truncating to the
-        // target's pointer width on 32-bit architectures.
-        let addr = self.builder.ins().iadd(base_address, offset);
-        let addr = match self.isa.pointer_bits() {
-            32 => self.builder.ins().ireduce(ir::types::I32, addr),
-            64 => addr,
-            p => bail!("unsupported architecture: no support for {p}-bit pointers"),
-        };
-
-        let addr =
-            // When Spectre mitigations are enabled, replace the address with
-            // NULL on the out-of-bounds path. The subsequent access only
-            // happens on the in-bounds path (we will have trapped otherwise),
-            // but this guards against the bounds-check branch being
-            // mispredicted and the access being performed speculatively against
-            // an out-of-bounds address.
-            if self.isa.flags().enable_heap_access_spectre_mitigation() {
-                let pointer_type = self.isa.pointer_type();
-                let null = self.builder.ins().iconst(pointer_type, 0);
-                let addr = self.builder.ins().select_spectre_guard(oob, null, addr);
-                self.builder
-                    .ins()
-                    .trapz(addr, ir::TrapCode::HEAP_OUT_OF_BOUNDS);
-                addr
-            }
-            // Otherwise, when Specter mitigations are disabled, just conditionally
-            // trap on the out-of-bounds condition directly.
-            else {
-                self.builder
-                    .ins()
-                    .trapnz(oob, ir::TrapCode::HEAP_OUT_OF_BOUNDS);
-                addr
-            };
-
-        Ok(addr)
     }
 
     fn translate_context_intrinsic(&mut self, intrinsic: UnsafeIntrinsic) -> Result<()> {
@@ -2494,7 +2437,14 @@ impl<'a> UnsafeIntrinsicCompiler<'a> {
 
         // Bounds-check the access and compute its native address, trapping if
         // it is out of bounds.
-        let addr = self.checked_native_addr(base_address, offset, length, clif_ty.bytes())?;
+        let addr = Self::checked_native_addr(
+            &mut self.cursor,
+            self.isa,
+            base_address,
+            offset,
+            length,
+            clif_ty.bytes(),
+        )?;
 
         // Do the load!
         let mut value = self
@@ -2545,7 +2495,14 @@ impl<'a> UnsafeIntrinsicCompiler<'a> {
 
         // Bounds-check the access and compute its native address, trapping if
         // it is out of bounds.
-        let addr = self.checked_native_addr(base_address, offset, length, clif_ty.bytes())?;
+        let addr = Self::checked_native_addr(
+            &mut self.cursor,
+            self.isa,
+            base_address,
+            offset,
+            length,
+            clif_ty.bytes(),
+        )?;
 
         // Truncate the value to the access type, if necessary.
         let wasm_ty = crate::value_type(self.isa, wasm_ty);
@@ -2565,56 +2522,68 @@ impl<'a> UnsafeIntrinsicCompiler<'a> {
     /// Emit the bounds check and native-address computation shared by the
     /// checked native load and store intrinsics.
     ///
-    /// See [`TrampolineCompiler::checked_native_addr`] for details; this is the
-    /// equivalent for the inlined translation path.
+    /// Given the `base_address`, `offset`, and `length` `i64` arguments and the
+    /// `size` (in bytes) of the access, this traps with a heap-out-of-bounds
+    /// trap if `offset + size > length` or if that addition overflows.
+    /// Otherwise it returns the pointer-typed native address `base_address +
+    /// offset` to access.
+    ///
+    /// When the target enables Spectre mitigations for heap accesses, the
+    /// returned address is additionally guarded with a `select_spectre_guard`
+    /// instruction so that speculative execution cannot use an out-of-bounds
+    /// address even if the preceding bounds-check branch is mispredicted.
     fn checked_native_addr(
-        &mut self,
+        cursor: &mut FuncCursor<'_>,
+        isa: &(dyn TargetIsa + 'static),
         base_address: ir::Value,
         offset: ir::Value,
         length: ir::Value,
         size: u32,
     ) -> Result<ir::Value> {
-        debug_assert_eq!(
-            self.cursor.func.dfg.value_type(base_address),
-            ir::types::I64
-        );
-        debug_assert_eq!(self.cursor.func.dfg.value_type(offset), ir::types::I64);
-        debug_assert_eq!(self.cursor.func.dfg.value_type(length), ir::types::I64);
+        debug_assert_eq!(cursor.func.dfg.value_type(base_address), ir::types::I64);
+        debug_assert_eq!(cursor.func.dfg.value_type(offset), ir::types::I64);
+        debug_assert_eq!(cursor.func.dfg.value_type(length), ir::types::I64);
 
         // Compute `offset + size`, trapping if it either overflows or is
         // greater than `length`.
-        let size = self.cursor.ins().iconst(ir::types::I64, i64::from(size));
-        let (end, overflow) = self.cursor.ins().uadd_overflow(offset, size);
-        let too_big = self
-            .cursor
-            .ins()
-            .icmp(IntCC::UnsignedGreaterThan, end, length);
-        let oob = self.cursor.ins().bor(overflow, too_big);
-        self.cursor
-            .ins()
-            .trapnz(oob, ir::TrapCode::HEAP_OUT_OF_BOUNDS);
+        let size = cursor.ins().iconst(ir::types::I64, i64::from(size));
+        let (end, overflow) = cursor.ins().uadd_overflow(offset, size);
+        let too_big = cursor.ins().icmp(IntCC::UnsignedGreaterThan, end, length);
+        let oob = cursor.ins().bor(overflow, too_big);
 
         // Compute the native address `base_address + offset`, truncating to the
         // target's pointer width on 32-bit architectures.
-        let addr = self.cursor.ins().iadd(base_address, offset);
-        let addr = match self.isa.pointer_bits() {
-            32 => self.cursor.ins().ireduce(ir::types::I32, addr),
+        let addr = cursor.ins().iadd(base_address, offset);
+        let addr = match isa.pointer_bits() {
+            32 => cursor.ins().ireduce(ir::types::I32, addr),
             64 => addr,
             p => bail!("unsupported architecture: no support for {p}-bit pointers"),
         };
 
-        // When Spectre mitigations are enabled, replace the address with NULL
-        // on the out-of-bounds path. The subsequent access only happens on the
-        // in-bounds path (we trapped above otherwise), but this guards against
-        // the bounds-check branch being mispredicted and the access being
-        // performed speculatively against an out-of-bounds address.
-        let addr = if self.isa.flags().enable_heap_access_spectre_mitigation() {
-            let pointer_type = self.isa.pointer_type();
-            let null = self.cursor.ins().iconst(pointer_type, 0);
-            self.cursor.ins().select_spectre_guard(oob, null, addr)
-        } else {
-            addr
-        };
+        let addr =
+            // When Spectre mitigations are enabled, replace the address with
+            // NULL on the out-of-bounds path. The subsequent access only
+            // happens on the in-bounds path (we will have trapped otherwise),
+            // but this guards against the bounds-check branch being
+            // mispredicted and the access being performed speculatively against
+            // an out-of-bounds address.
+            if isa.flags().enable_heap_access_spectre_mitigation() {
+                let pointer_type = isa.pointer_type();
+                let null = cursor.ins().iconst(pointer_type, 0);
+                let addr = cursor.ins().select_spectre_guard(oob, null, addr);
+                cursor
+                    .ins()
+                    .trapz(addr, ir::TrapCode::HEAP_OUT_OF_BOUNDS);
+                addr
+            }
+            // Otherwise, when Spectre mitigations are disabled, just conditionally
+            // trap on the out-of-bounds condition directly.
+            else {
+                cursor
+                    .ins()
+                    .trapnz(oob, ir::TrapCode::HEAP_OUT_OF_BOUNDS);
+                addr
+            };
 
         Ok(addr)
     }

--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -2087,13 +2087,18 @@ impl<'a, 'func, 'module_env> Call<'a, 'func, 'module_env> {
                     .env
                     .get_or_create_imported_func_ref(self.builder.func, callee_index);
                 if self.can_directly_inline_unsafe_intrinsic(*abi) {
-                    let result = super::compiler::component::UnsafeIntrinsicCompiler {
-                        cursor: self.builder.cursor(),
-                        isa: self.env.isa,
-                        ptr: &self.env.offsets.ptr,
-                    }
-                    .translate(*intrinsic, &real_call_args)
-                    .unwrap();
+                    let isa = self.env.compiler.isa();
+                    let ptr = self.env.offsets.ptr;
+                    let mut intrinsic_compiler =
+                        super::compiler::component::UnsafeIntrinsicCompiler {
+                            builder: self.builder,
+                            isa,
+                            ptr,
+                            traps: self.env,
+                        };
+                    let result = intrinsic_compiler
+                        .translate(*intrinsic, &real_call_args)
+                        .unwrap();
                     Ok(result.into_iter().collect())
                 } else {
                     Ok(self.direct_call_inst(callee, &real_call_args))

--- a/crates/environ/src/component/intrinsic.rs
+++ b/crates/environ/src/component/intrinsic.rs
@@ -23,6 +23,18 @@ macro_rules! for_each_unsafe_intrinsic {
             "u64-native-load" => U64NativeLoad : u64_native_load(address: u64) -> u64;
             "u64-native-store" => U64NativeStore : u64_native_store(address: u64, value: u64);
 
+            "u8-checked-native-load" => U8CheckedNativeLoad : u8_checked_native_load(base_address: u64, offset: u64, length: u64) -> u8;
+            "u8-checked-native-store" => U8CheckedNativeStore : u8_checked_native_store(base_address: u64, offset: u64, length: u64, value: u8);
+
+            "u16-checked-native-load" => U16CheckedNativeLoad : u16_checked_native_load(base_address: u64, offset: u64, length: u64) -> u16;
+            "u16-checked-native-store" => U16CheckedNativeStore : u16_checked_native_store(base_address: u64, offset: u64, length: u64, value: u16);
+
+            "u32-checked-native-load" => U32CheckedNativeLoad : u32_checked_native_load(base_address: u64, offset: u64, length: u64) -> u32;
+            "u32-checked-native-store" => U32CheckedNativeStore : u32_checked_native_store(base_address: u64, offset: u64, length: u64, value: u32);
+
+            "u64-checked-native-load" => U64CheckedNativeLoad : u64_checked_native_load(base_address: u64, offset: u64, length: u64) -> u64;
+            "u64-checked-native-store" => U64CheckedNativeStore : u64_checked_native_store(base_address: u64, offset: u64, length: u64, value: u64);
+
             "context-get-i32-0" => ContextGetI32_0 : context_get_i32_0() -> u32;
             "context-set-i32-0" => ContextSetI32_0 : context_set_i32_0(val: u32);
             "context-get-i32-1" => ContextGetI32_1 : context_get_i32_1() -> u32;

--- a/crates/wasmtime/src/compile/code_builder.rs
+++ b/crates/wasmtime/src/compile/code_builder.rs
@@ -309,17 +309,25 @@ impl<'a> CodeBuilder<'a> {
     ///
     /// # Intrinsics
     ///
-    /// | Name                 | Parameters   | Results |
-    /// |----------------------|--------------|---------|
-    /// | `u8-native-load`     | `u64`        | `u8`    |
-    /// | `u16-native-load`    | `u64`        | `u16`   |
-    /// | `u32-native-load`    | `u64`        | `u32`   |
-    /// | `u64-native-load`    | `u64`        | `u64`   |
-    /// | `u8-native-store`    | `u64`, `u8`  | -       |
-    /// | `u16-native-load`    | `u64`, `u16` | -       |
-    /// | `u32-native-load`    | `u64`, `u32` | -       |
-    /// | `u64-native-load`    | `u64`, `u64` | -       |
-    /// | `store-data-address` | -            | `u64`   |
+    /// | Name                       | Parameters                  | Results |
+    /// |----------------------------|-----------------------------|---------|
+    /// | `u8-native-load`           | `u64`                       | `u8`    |
+    /// | `u16-native-load`          | `u64`                       | `u16`   |
+    /// | `u32-native-load`          | `u64`                       | `u32`   |
+    /// | `u64-native-load`          | `u64`                       | `u64`   |
+    /// | `u8-native-store`          | `u64`, `u8`                 | -       |
+    /// | `u16-native-store`         | `u64`, `u16`                | -       |
+    /// | `u32-native-store`         | `u64`, `u32`                | -       |
+    /// | `u64-native-store`         | `u64`, `u64`                | -       |
+    /// | `u8-checked-native-load`   | `u64`, `u64`, `u64`         | `u8`    |
+    /// | `u16-checked-native-load`  | `u64`, `u64`, `u64`         | `u16`   |
+    /// | `u32-checked-native-load`  | `u64`, `u64`, `u64`         | `u32`   |
+    /// | `u64-checked-native-load`  | `u64`, `u64`, `u64`         | `u64`   |
+    /// | `u8-checked-native-store`  | `u64`, `u64`, `u64`, `u8`   | -       |
+    /// | `u16-checked-native-store` | `u64`, `u64`, `u64`, `u16`  | -       |
+    /// | `u32-checked-native-store` | `u64`, `u64`, `u64`, `u32`  | -       |
+    /// | `u64-checked-native-store` | `u64`, `u64`, `u64`, `u64`  | -       |
+    /// | `store-data-address`       | -                           | `u64`   |
     ///
     /// ## `*-native-load`
     ///
@@ -330,6 +338,38 @@ impl<'a> CodeBuilder<'a> {
     ///
     /// These intrinsics perform an unsandboxed, unsynchronized store to native
     /// memory, using the native endianness.
+    ///
+    /// ## `*-checked-native-load`
+    ///
+    /// These intrinsics perform a bounds-checked version of the corresponding
+    /// `*-native-load` intrinsic. Their parameters are a `base_address`, an
+    /// `offset`, and a `length` (in bytes) describing a region of native
+    /// memory, and they load from `base_address + offset`.
+    ///
+    /// Before performing the load, they check that the access is in bounds. If
+    /// `offset + SIZE > length` -- where `SIZE` is the byte width of the access
+    /// (e.g. `4` for `u32-checked-native-load`) -- or if that addition
+    /// overflows, then the intrinsic raises a trap and the load is *not*
+    /// performed. Otherwise the load is performed exactly as the corresponding
+    /// unchecked `*-native-load` intrinsic would, against the address
+    /// `base_address + offset`.
+    ///
+    /// Note that the bounds check is performed against the given `length`
+    /// argument; it is the caller's responsibility to pass a `length` that
+    /// actually describes a valid region of memory beginning at `base_address`.
+    /// When the access is in bounds, the resulting `base_address + offset`
+    /// access must still uphold all of the safety invariants described above
+    /// for the unchecked intrinsics.
+    ///
+    /// ## `*-checked-native-store`
+    ///
+    /// These intrinsics perform a bounds-checked version of the corresponding
+    /// `*-native-store` intrinsic. Their parameters are a `base_address`, an
+    /// `offset`, a `length` (in bytes), and a `value`. They perform the same
+    /// bounds check as the `*-checked-native-load` intrinsics -- trapping,
+    /// without storing anything, if `offset + SIZE > length` or if that
+    /// addition overflows -- and otherwise store `value` to `base_address +
+    /// offset`.
     ///
     /// ## `store-data-address`
     ///

--- a/tests/all/intrinsics.rs
+++ b/tests/all/intrinsics.rs
@@ -698,8 +698,6 @@ fn checked_native_loads_and_stores(spectre: bool, inlining: bool) -> Result<()> 
     });
 
     if spectre {
-        // Spectre heap mitigations require signals-based traps.
-        config.signals_based_traps(true);
         unsafe {
             config.cranelift_flag_set("enable_heap_access_spectre_mitigation", "true");
         }
@@ -709,7 +707,24 @@ fn checked_native_loads_and_stores(spectre: bool, inlining: bool) -> Result<()> 
         }
     }
 
-    let engine = Engine::new(&config)?;
+    let engine = match Engine::new(&config) {
+        Ok(engine) => engine,
+
+        // Some build configurations don't support signals-based traps, which
+        // means that we cannot test checked intrinsics with Spectre mitigations
+        // on them, as Spectre mitigations require signals-based traps.
+        Err(e)
+            if spectre
+                && e.to_string().contains(
+                    "when signals-based traps are disabled then spectre mitigations \
+                     must also be disabled",
+                ) =>
+        {
+            return Ok(());
+        }
+
+        Err(e) => return Err(e),
+    };
 
     // A few distinct values, used for the initial buffer contents (`KNOWN*`)
     // and the values written by the store intrinsic (`STORED*`).

--- a/tests/all/intrinsics.rs
+++ b/tests/all/intrinsics.rs
@@ -697,15 +697,27 @@ fn checked_native_loads_and_stores(spectre: bool, inlining: bool) -> Result<()> 
         Inlining::No
     });
 
-    // Safety: this setting is safe to toggle.
-    unsafe {
-        config.cranelift_flag_set(
-            "enable_heap_access_spectre_mitigation",
-            if spectre { "true" } else { "false" },
-        );
+    if spectre {
+        // Spectre heap mitigations require signals-based traps.
+        config.signals_based_traps(true);
+        unsafe {
+            config.cranelift_flag_set("enable_heap_access_spectre_mitigation", "true");
+        }
+    } else {
+        unsafe {
+            config.cranelift_flag_set("enable_heap_access_spectre_mitigation", "false");
+        }
     }
 
-    let engine = Engine::new(&config)?;
+    let Ok(engine) = Engine::new(&config) else {
+        // Some platforms don't support all the knobs we are tuning here. Warn
+        // and ignore.
+        eprintln!(
+            "Warning: could not create engine with `spectre = {spectre}` and \
+             `inlining = {inlining}` on this platform; ignoring."
+        );
+        return Ok(());
+    };
 
     // A few distinct values, used for the initial buffer contents (`KNOWN*`)
     // and the values written by the store intrinsic (`STORED*`).

--- a/tests/all/intrinsics.rs
+++ b/tests/all/intrinsics.rs
@@ -709,15 +709,7 @@ fn checked_native_loads_and_stores(spectre: bool, inlining: bool) -> Result<()> 
         }
     }
 
-    let Ok(engine) = Engine::new(&config) else {
-        // Some platforms don't support all the knobs we are tuning here. Warn
-        // and ignore.
-        eprintln!(
-            "Warning: could not create engine with `spectre = {spectre}` and \
-             `inlining = {inlining}` on this platform; ignoring."
-        );
-        return Ok(());
-    };
+    let engine = Engine::new(&config)?;
 
     // A few distinct values, used for the initial buffer contents (`KNOWN*`)
     // and the values written by the store intrinsic (`STORED*`).
@@ -946,6 +938,9 @@ fn checked_native_loads_and_stores(spectre: bool, inlining: bool) -> Result<()> 
 
 #[test]
 #[cfg_attr(miri, ignore)]
+// These tests require signals-based traps, and we can't always enable that on
+// 32-bit architectures.
+#[cfg(target_pointer_width = "64")]
 fn checked_native_loads_and_stores_with_spectre_mitigations() -> Result<()> {
     checked_native_loads_and_stores(true, false)?;
     checked_native_loads_and_stores(true, true)?;

--- a/tests/all/intrinsics.rs
+++ b/tests/all/intrinsics.rs
@@ -627,6 +627,327 @@ fn store_data_address() -> Result<()> {
     Ok(())
 }
 
+/// A 16-byte buffer aligned to 8 bytes so that aligned native accesses of any
+/// of our intrinsic widths (`u8`/`u16`/`u32`/`u64`) are well-defined.
+#[repr(align(8))]
+struct AlignedBuf([u8; 16]);
+
+/// Get the native-endian byte encoding of `x` truncated to the given intrinsic
+/// width.
+fn ne_bytes(comp_ty: &str, x: u64) -> Vec<u8> {
+    match comp_ty {
+        "u8" => (x as u8).to_ne_bytes().to_vec(),
+        "u16" => (x as u16).to_ne_bytes().to_vec(),
+        "u32" => (x as u32).to_ne_bytes().to_vec(),
+        "u64" => x.to_ne_bytes().to_vec(),
+        _ => unreachable!(),
+    }
+}
+
+/// Truncate `x` to the given intrinsic width, zero-extended back into a `u64`
+/// (matching what a checked load of that width returns).
+fn mask(comp_ty: &str, x: u64) -> u64 {
+    match comp_ty {
+        "u8" => x as u8 as u64,
+        "u16" => x as u16 as u64,
+        "u32" => x as u32 as u64,
+        "u64" => x,
+        _ => unreachable!(),
+    }
+}
+
+fn val_to_u64(v: &component::Val) -> u64 {
+    match v {
+        component::Val::U8(x) => u64::from(*x),
+        component::Val::U16(x) => u64::from(*x),
+        component::Val::U32(x) => u64::from(*x),
+        component::Val::U64(x) => *x,
+        other => panic!("unexpected result value: {other:?}"),
+    }
+}
+
+fn val_of_width(comp_ty: &str, x: u64) -> component::Val {
+    match comp_ty {
+        "u8" => component::Val::U8(x as u8),
+        "u16" => component::Val::U16(x as u16),
+        "u32" => component::Val::U32(x as u32),
+        "u64" => component::Val::U64(x),
+        _ => unreachable!(),
+    }
+}
+
+/// Exercise the bounds-checked native load/store intrinsics, both the
+/// non-trapping (in-bounds) and trapping (out-of-bounds and overflowing) cases,
+/// for every access width.
+///
+/// The functional behavior must be identical regardless of whether Spectre
+/// mitigations are enabled; `spectre` controls the
+/// `enable_heap_access_spectre_mitigation` Cranelift setting so that we cover
+/// both code paths. (The actual codegen difference is checked by the `disas`
+/// filetests.)
+///
+/// `inlining` controls whether the intrinsics are inlined into their callers,
+/// which is a separate code path in the compiler (the trampoline compiler
+/// versus the inlined-intrinsic compiler); we cover both.
+fn checked_native_loads_and_stores(spectre: bool, inlining: bool) -> Result<()> {
+    let mut config = Config::new();
+    config.compiler_inlining(if inlining {
+        Inlining::Yes
+    } else {
+        Inlining::No
+    });
+
+    // Safety: this setting is safe to toggle.
+    unsafe {
+        config.cranelift_flag_set(
+            "enable_heap_access_spectre_mitigation",
+            if spectre { "true" } else { "false" },
+        );
+    }
+
+    let engine = Engine::new(&config)?;
+
+    // A few distinct values, used for the initial buffer contents (`KNOWN*`)
+    // and the values written by the store intrinsic (`STORED*`).
+    const KNOWN: u64 = 0x1122_3344_5566_7788;
+    const KNOWN2: u64 = 0x99aa_bbcc_ddee_ff00;
+    const STORED: u64 = 0xa5b6_c7d8_e9fa_0b1c;
+    const STORED2: u64 = 0x0102_0304_0506_0708;
+
+    for (comp_ty, core_ty, size) in [
+        ("u8", "i32", 1),
+        ("u16", "i32", 2),
+        ("u32", "i32", 4),
+        ("u64", "i64", 8),
+    ] {
+        let wat = format!(
+            r#"
+                (component
+                    ;; Import the unsafe intrinsics.
+                    (import "unsafe-intrinsics"
+                        (instance $intrinsics
+                            (export "{comp_ty}-checked-native-load"
+                                (func (param "base" u64) (param "offset" u64) (param "length" u64)
+                                      (result {comp_ty})))
+                            (export "{comp_ty}-checked-native-store"
+                                (func (param "base" u64) (param "offset" u64) (param "length" u64)
+                                      (param "value" {comp_ty})))
+                        )
+                    )
+
+                    ;; Lower them to core functions.
+                    (core func $load' (canon lower (func $intrinsics "{comp_ty}-checked-native-load")))
+                    (core func $store' (canon lower (func $intrinsics "{comp_ty}-checked-native-store")))
+
+                    ;; Define a core module that imports them and exports functions that wrap them.
+                    (core module $m
+                        (import "" "load" (func $load (param i64 i64 i64) (result {core_ty})))
+                        (import "" "store" (func $store (param i64 i64 i64 {core_ty})))
+
+                        (func (export "load") (param $base i64) (param $offset i64) (param $length i64)
+                                              (result {core_ty})
+                            (call $load (local.get $base)
+                                        (local.get $offset)
+                                        (local.get $length))
+                        )
+
+                        (func (export "store") (param $base i64) (param $offset i64) (param $length i64)
+                                               (param $value {core_ty})
+                            (call $store (local.get $base)
+                                         (local.get $offset)
+                                         (local.get $length)
+                                         (local.get $value))
+                        )
+                    )
+
+                    ;; Instantiate that core module.
+                    (core instance $i
+                        (instantiate $m
+                            (with "" (instance (export "load" (func $load'))
+                                               (export "store" (func $store'))))
+                        )
+                    )
+
+                    ;; Export lifted versions of the core instance's wrapper functions.
+                    (func (export "load") (param "base" u64)
+                                          (param "offset" u64)
+                                          (param "length" u64)
+                                          (result {comp_ty})
+                        (canon lift (core func $i "load"))
+                    )
+                    (func (export "store") (param "base" u64)
+                                           (param "offset" u64)
+                                           (param "length" u64)
+                                           (param "value" {comp_ty})
+                        (canon lift (core func $i "store"))
+                    )
+                )
+            "#
+        );
+
+        let mut code_builder = CodeBuilder::new(&engine);
+        code_builder.wasm_binary_or_text(wat.as_bytes(), None)?;
+        unsafe {
+            code_builder.expose_unsafe_intrinsics("unsafe-intrinsics");
+        }
+        let component = code_builder.compile_component()?;
+        let linker = component::Linker::new(&engine);
+
+        // Allocate a host buffer that Wasm will access directly via the
+        // intrinsics. We tell the intrinsics its length so they can bounds
+        // check accesses against it.
+        let data = Arc::new(UnsafeCell::new(AlignedBuf([0; 16])));
+        let base_ptr = data.get().cast::<u8>();
+        let base = base_ptr as usize as u64;
+        let length: u64 = 16;
+        // The last offset at which a `size`-byte access is in bounds.
+        let boundary: u64 = length - size;
+
+        // Initialize known values at the start of the buffer and at the last
+        // in-bounds slot.
+        unsafe {
+            let bytes = ne_bytes(comp_ty, KNOWN);
+            std::ptr::copy_nonoverlapping(bytes.as_ptr(), base_ptr, bytes.len());
+            let bytes = ne_bytes(comp_ty, KNOWN2);
+            std::ptr::copy_nonoverlapping(
+                bytes.as_ptr(),
+                base_ptr.add(usize::try_from(boundary).unwrap()),
+                bytes.len(),
+            );
+        }
+
+        // Each call uses a fresh store and instance because a trap leaves the
+        // instance unusable.
+        let call_load = |offset: u64, len: u64| -> Result<u64> {
+            let mut store = Store::new(&engine, ());
+            let instance = linker.instantiate(&mut store, &component)?;
+            let func = instance.get_func(&mut store, "load").unwrap();
+            let mut results = [component::Val::Bool(false)];
+            func.call(
+                &mut store,
+                &[
+                    component::Val::U64(base),
+                    component::Val::U64(offset),
+                    component::Val::U64(len),
+                ],
+                &mut results,
+            )?;
+            Ok(val_to_u64(&results[0]))
+        };
+        let call_store = |offset: u64, len: u64, value: u64| -> Result<()> {
+            let mut store = Store::new(&engine, ());
+            let instance = linker.instantiate(&mut store, &component)?;
+            let func = instance.get_func(&mut store, "store").unwrap();
+            func.call(
+                &mut store,
+                &[
+                    component::Val::U64(base),
+                    component::Val::U64(offset),
+                    component::Val::U64(len),
+                    val_of_width(comp_ty, value),
+                ],
+                &mut [],
+            )?;
+            Ok(())
+        };
+        let assert_oob = |result: Result<u64>, what: &str| {
+            let err = result.err().unwrap_or_else(|| {
+                panic!("expected a trap for {what} (spectre={spectre}, inlining={inlining}, ty={comp_ty})")
+            });
+            match err.downcast::<Trap>() {
+                Ok(trap) => assert_eq!(
+                    trap,
+                    Trap::MemoryOutOfBounds,
+                    "wrong trap for {what} (spectre={spectre}, inlining={inlining}, ty={comp_ty})"
+                ),
+                Err(e) => panic!(
+                    "expected a Trap for {what} (spectre={spectre}, inlining={inlining}, ty={comp_ty}), got: {e:?}"
+                ),
+            }
+        };
+
+        // Non-trapping loads.
+
+        // A load at offset 0 reads the value we wrote there.
+        assert_eq!(call_load(0, length)?, mask(comp_ty, KNOWN));
+        // A load at the very last in-bounds offset is allowed.
+        assert_eq!(call_load(boundary, length)?, mask(comp_ty, KNOWN2));
+
+        // Trapping loads.
+
+        // One byte past the last in-bounds offset traps.
+        assert_oob(call_load(boundary + 1, length), "load one past the end");
+        // An offset equal to the length traps.
+        assert_oob(call_load(length, length), "load at offset == length");
+        // The `length` argument is what is checked, not the underlying
+        // allocation: shrinking it makes otherwise-valid offsets trap.
+        assert_oob(call_load(size, size), "load past a shortened length");
+        // A huge offset whose `offset + size` does not overflow but exceeds the
+        // length still traps (and must not wrap around to an in-bounds access).
+        assert_oob(call_load(u64::MAX - 100, length), "load at a huge offset");
+        // An offset whose `offset + size` overflows traps.
+        assert_oob(
+            call_load(u64::MAX, length),
+            "load whose offset + size overflows",
+        );
+
+        // Non-trapping stores.
+
+        // Store at offset 0 and at the last in-bounds offset, then read the
+        // values back out of the host buffer.
+        call_store(0, length, STORED)?;
+        call_store(boundary, length, STORED2)?;
+        let buf = unsafe { (*data.get()).0 };
+        let size = usize::try_from(size).unwrap();
+        let boundary = usize::try_from(boundary).unwrap();
+        assert_eq!(&buf[..size], &ne_bytes(comp_ty, STORED)[..]);
+        assert_eq!(&buf[boundary..], &ne_bytes(comp_ty, STORED2)[..]);
+
+        // Trapping stores.
+
+        // All of these must trap and leave the buffer unmodified.
+        assert_oob(
+            call_store(boundary as u64 + 1, length, !STORED).map(|()| 0),
+            "store one past the end",
+        );
+        assert_oob(
+            call_store(length, length, !STORED).map(|()| 0),
+            "store at offset == length",
+        );
+        assert_oob(
+            call_store(size as u64, size as u64, !STORED).map(|()| 0),
+            "store past a shortened length",
+        );
+        assert_oob(
+            call_store(u64::MAX, length, !STORED).map(|()| 0),
+            "store whose offset + size overflows",
+        );
+
+        // Confirm the failed stores did not corrupt the buffer.
+        let buf = unsafe { (*data.get()).0 };
+        assert_eq!(&buf[..size], &ne_bytes(comp_ty, STORED)[..]);
+        assert_eq!(&buf[boundary..], &ne_bytes(comp_ty, STORED2)[..]);
+    }
+
+    Ok(())
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn checked_native_loads_and_stores_with_spectre_mitigations() -> Result<()> {
+    checked_native_loads_and_stores(true, false)?;
+    checked_native_loads_and_stores(true, true)?;
+    Ok(())
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn checked_native_loads_and_stores_without_spectre_mitigations() -> Result<()> {
+    checked_native_loads_and_stores(false, false)?;
+    checked_native_loads_and_stores(false, true)?;
+    Ok(())
+}
+
 #[test]
 #[cfg_attr(miri, ignore)]
 fn other_import_name() -> Result<()> {

--- a/tests/disas/component-model/checked-intrinsics-inlined-no-spectre.wat
+++ b/tests/disas/component-model/checked-intrinsics-inlined-no-spectre.wat
@@ -48,9 +48,13 @@
     )
 )
 ;; function u0:0(i64 vmctx, i64, i64, i64) tail {
-;;     region0 = 2 "vmctx"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 72 "VMContext+0x48"
+;;     region2 = 268435560 "VMStoreContext+0x68"
+;;     region3 = 104 "VMContext+0x68"
+;;     region4 = 136 "VMContext+0x88"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, i64) -> i64 tail
@@ -68,7 +72,7 @@
 ;; @01b0                               v15 = bor v13, v14
 ;; @01b0                               trapnz v15, heap_oob
 ;; @01aa                               v7 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @01aa                               v8 = load.i64 notrap aligned readonly can_move region0 v7+104
+;; @01aa                               v8 = load.i64 notrap aligned readonly can_move region2 v7+104
 ;; @01b0                               v16 = iadd v8, v2
 ;; @01b0                               v17 = load.i32 notrap aligned v16
 ;; @01bf                               v27, v28 = uadd_overflow v2, v11  ; v11 = 4

--- a/tests/disas/component-model/checked-intrinsics-inlined-no-spectre.wat
+++ b/tests/disas/component-model/checked-intrinsics-inlined-no-spectre.wat
@@ -1,0 +1,85 @@
+;;! target = "x86_64"
+;;! test = "optimize"
+;;! filter = "wasm[0]--function"
+;;! flags = "-C inlining=y -C cranelift-enable_heap_access_spectre_mitigation=false"
+;;! unsafe_intrinsics = "unsafe-intrinsics"
+
+;; Same as `checked-intrinsics-inlined.wat`, but with Spectre mitigations
+;; disabled. The bounds check should still trap on out-of-bounds or overflow,
+;; but there should be no `select_spectre_guard` guarding the address.
+
+(component
+    (import "unsafe-intrinsics"
+        (instance $intrinsics
+            (export "store-data-address" (func (result u64)))
+            (export "u32-checked-native-load"
+                (func (param "base" u64) (param "offset" u64) (param "length" u64) (result u32)))
+            (export "u32-checked-native-store"
+                (func (param "base" u64) (param "offset" u64) (param "length" u64) (param "value" u32)))
+        )
+    )
+
+    (core func $sda' (canon lower (func $intrinsics "store-data-address")))
+    (core func $load' (canon lower (func $intrinsics "u32-checked-native-load")))
+    (core func $store' (canon lower (func $intrinsics "u32-checked-native-store")))
+
+    (core module $m
+        (import "" "store-data-address" (func $sda (result i64)))
+        (import "" "u32-checked-native-load" (func $load (param i64 i64 i64) (result i32)))
+        (import "" "u32-checked-native-store" (func $store (param i64 i64 i64 i32)))
+        (func (export "f") (param $offset i64) (param $length i64)
+            (local $x i32)
+            (local.set $x (call $load (call $sda) (local.get $offset) (local.get $length)))
+            (call $store (call $sda) (local.get $offset) (local.get $length)
+                         (i32.add (local.get $x) (i32.const 1)))
+        )
+    )
+
+    (core instance $i
+        (instantiate $m
+            (with "" (instance (export "store-data-address" (func $sda'))
+                               (export "u32-checked-native-load" (func $load'))
+                               (export "u32-checked-native-store" (func $store'))))
+        )
+    )
+
+    (func (export "f") (param "offset" u64) (param "length" u64)
+      (canon lift (core func $i "f"))
+    )
+)
+;; function u0:0(i64 vmctx, i64, i64, i64) tail {
+;;     region0 = 2 "vmctx"
+;;     gv0 = vmctx
+;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv3 = vmctx
+;;     sig0 = (i64 vmctx, i64) -> i64 tail
+;;     sig1 = (i64 vmctx, i64, i64, i64, i64) -> i32 tail
+;;     sig2 = (i64 vmctx, i64, i64, i64, i64, i32) tail
+;;     fn0 = colocated u2147483648:0 sig0
+;;     fn1 = colocated u2147483648:13 sig1
+;;     fn2 = colocated u2147483648:14 sig2
+;;     stack_limit = gv2
+;;
+;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i64):
+;; @01b0                               v11 = iconst.i64 4
+;; @01b0                               v12, v13 = uadd_overflow v2, v11  ; v11 = 4
+;; @01b0                               v14 = icmp ugt v12, v3
+;; @01b0                               v15 = bor v13, v14
+;; @01b0                               trapnz v15, heap_oob
+;; @01aa                               v7 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @01aa                               v8 = load.i64 notrap aligned readonly can_move region0 v7+104
+;; @01b0                               v16 = iadd v8, v2
+;; @01b0                               v17 = load.i32 notrap aligned v16
+;; @01bf                               v27, v28 = uadd_overflow v2, v11  ; v11 = 4
+;; @01bf                               v29 = icmp ugt v27, v3
+;; @01bf                               v30 = bor v28, v29
+;; @01bf                               trapnz v30, heap_oob
+;; @01bc                               v22 = iconst.i32 1
+;; @01be                               v23 = iadd v17, v22  ; v22 = 1
+;; @01bf                               store notrap aligned v23, v16
+;; @01c1                               jump block1
+;;
+;;                                 block1:
+;; @01c1                               return
+;; }

--- a/tests/disas/component-model/checked-intrinsics-inlined.wat
+++ b/tests/disas/component-model/checked-intrinsics-inlined.wat
@@ -67,20 +67,20 @@
 ;; @01b0                               v12, v13 = uadd_overflow v2, v11  ; v11 = 4
 ;; @01b0                               v14 = icmp ugt v12, v3
 ;; @01b0                               v15 = bor v13, v14
-;; @01b0                               trapnz v15, heap_oob
 ;; @01b0                               v17 = iconst.i64 0
 ;; @01aa                               v7 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @01aa                               v8 = load.i64 notrap aligned readonly can_move region0 v7+104
 ;; @01b0                               v16 = iadd v8, v2
 ;; @01b0                               v18 = select_spectre_guard v15, v17, v16  ; v17 = 0
+;; @01b0                               trapz v18, heap_oob
 ;; @01b0                               v19 = load.i32 notrap aligned v18
 ;; @01bf                               v29, v30 = uadd_overflow v2, v11  ; v11 = 4
 ;; @01bf                               v31 = icmp ugt v29, v3
 ;; @01bf                               v32 = bor v30, v31
-;; @01bf                               trapnz v32, heap_oob
+;; @01bf                               v35 = select_spectre_guard v32, v17, v16  ; v17 = 0
+;; @01bf                               trapz v35, heap_oob
 ;; @01bc                               v24 = iconst.i32 1
 ;; @01be                               v25 = iadd v19, v24  ; v24 = 1
-;; @01bf                               v35 = select_spectre_guard v32, v17, v16  ; v17 = 0
 ;; @01bf                               store notrap aligned v25, v35
 ;; @01c1                               jump block1
 ;;

--- a/tests/disas/component-model/checked-intrinsics-inlined.wat
+++ b/tests/disas/component-model/checked-intrinsics-inlined.wat
@@ -1,0 +1,89 @@
+;;! target = "x86_64"
+;;! test = "optimize"
+;;! filter = "wasm[0]--function"
+;;! flags = "-C inlining=y"
+;;! unsafe_intrinsics = "unsafe-intrinsics"
+
+;; Test the bounds-checked native load/store intrinsics, inlined into their
+;; caller, with Spectre mitigations enabled (the default). The bounds check
+;; should trap on out-of-bounds or overflow and additionally guard the computed
+;; address with a `select_spectre_guard`.
+
+(component
+    (import "unsafe-intrinsics"
+        (instance $intrinsics
+            (export "store-data-address" (func (result u64)))
+            (export "u32-checked-native-load"
+                (func (param "base" u64) (param "offset" u64) (param "length" u64) (result u32)))
+            (export "u32-checked-native-store"
+                (func (param "base" u64) (param "offset" u64) (param "length" u64) (param "value" u32)))
+        )
+    )
+
+    (core func $sda' (canon lower (func $intrinsics "store-data-address")))
+    (core func $load' (canon lower (func $intrinsics "u32-checked-native-load")))
+    (core func $store' (canon lower (func $intrinsics "u32-checked-native-store")))
+
+    (core module $m
+        (import "" "store-data-address" (func $sda (result i64)))
+        (import "" "u32-checked-native-load" (func $load (param i64 i64 i64) (result i32)))
+        (import "" "u32-checked-native-store" (func $store (param i64 i64 i64 i32)))
+        (func (export "f") (param $offset i64) (param $length i64)
+            (local $x i32)
+            (local.set $x (call $load (call $sda) (local.get $offset) (local.get $length)))
+            (call $store (call $sda) (local.get $offset) (local.get $length)
+                         (i32.add (local.get $x) (i32.const 1)))
+        )
+    )
+
+    (core instance $i
+        (instantiate $m
+            (with "" (instance (export "store-data-address" (func $sda'))
+                               (export "u32-checked-native-load" (func $load'))
+                               (export "u32-checked-native-store" (func $store'))))
+        )
+    )
+
+    (func (export "f") (param "offset" u64) (param "length" u64)
+      (canon lift (core func $i "f"))
+    )
+)
+;; function u0:0(i64 vmctx, i64, i64, i64) tail {
+;;     region0 = 2 "vmctx"
+;;     gv0 = vmctx
+;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv3 = vmctx
+;;     sig0 = (i64 vmctx, i64) -> i64 tail
+;;     sig1 = (i64 vmctx, i64, i64, i64, i64) -> i32 tail
+;;     sig2 = (i64 vmctx, i64, i64, i64, i64, i32) tail
+;;     fn0 = colocated u2147483648:0 sig0
+;;     fn1 = colocated u2147483648:13 sig1
+;;     fn2 = colocated u2147483648:14 sig2
+;;     stack_limit = gv2
+;;
+;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i64):
+;; @01b0                               v11 = iconst.i64 4
+;; @01b0                               v12, v13 = uadd_overflow v2, v11  ; v11 = 4
+;; @01b0                               v14 = icmp ugt v12, v3
+;; @01b0                               v15 = bor v13, v14
+;; @01b0                               trapnz v15, heap_oob
+;; @01b0                               v17 = iconst.i64 0
+;; @01aa                               v7 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @01aa                               v8 = load.i64 notrap aligned readonly can_move region0 v7+104
+;; @01b0                               v16 = iadd v8, v2
+;; @01b0                               v18 = select_spectre_guard v15, v17, v16  ; v17 = 0
+;; @01b0                               v19 = load.i32 notrap aligned v18
+;; @01bf                               v29, v30 = uadd_overflow v2, v11  ; v11 = 4
+;; @01bf                               v31 = icmp ugt v29, v3
+;; @01bf                               v32 = bor v30, v31
+;; @01bf                               trapnz v32, heap_oob
+;; @01bc                               v24 = iconst.i32 1
+;; @01be                               v25 = iadd v19, v24  ; v24 = 1
+;; @01bf                               v35 = select_spectre_guard v32, v17, v16  ; v17 = 0
+;; @01bf                               store notrap aligned v25, v35
+;; @01c1                               jump block1
+;;
+;;                                 block1:
+;; @01c1                               return
+;; }

--- a/tests/disas/component-model/checked-intrinsics-inlined.wat
+++ b/tests/disas/component-model/checked-intrinsics-inlined.wat
@@ -49,9 +49,13 @@
     )
 )
 ;; function u0:0(i64 vmctx, i64, i64, i64) tail {
-;;     region0 = 2 "vmctx"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 72 "VMContext+0x48"
+;;     region2 = 268435560 "VMStoreContext+0x68"
+;;     region3 = 104 "VMContext+0x68"
+;;     region4 = 136 "VMContext+0x88"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, i64) -> i64 tail
@@ -69,7 +73,7 @@
 ;; @01b0                               v15 = bor v13, v14
 ;; @01b0                               v17 = iconst.i64 0
 ;; @01aa                               v7 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @01aa                               v8 = load.i64 notrap aligned readonly can_move region0 v7+104
+;; @01aa                               v8 = load.i64 notrap aligned readonly can_move region2 v7+104
 ;; @01b0                               v16 = iadd v8, v2
 ;; @01b0                               v18 = select_spectre_guard v15, v17, v16  ; v17 = 0
 ;; @01b0                               trapz v18, heap_oob

--- a/tests/disas/component-model/checked-intrinsics-trampoline.wat
+++ b/tests/disas/component-model/checked-intrinsics-trampoline.wat
@@ -1,0 +1,60 @@
+;;! target = "x86_64"
+;;! test = "optimize"
+;;! filter = "unsafe-intrinsics-wasm-call"
+;;! unsafe_intrinsics = "unsafe-intrinsics"
+
+;; Test the standalone (non-inlined) trampolines for the bounds-checked native
+;; load/store intrinsics, with Spectre mitigations enabled (the default).
+
+(component
+    (import "unsafe-intrinsics"
+        (instance $intrinsics
+            (export "u32-checked-native-load"
+                (func (param "base" u64) (param "offset" u64) (param "length" u64) (result u32)))
+            (export "u32-checked-native-store"
+                (func (param "base" u64) (param "offset" u64) (param "length" u64) (param "value" u32)))
+        )
+    )
+
+    (core func $load' (canon lower (func $intrinsics "u32-checked-native-load")))
+    (core func $store' (canon lower (func $intrinsics "u32-checked-native-store")))
+
+    (core module $m
+        (import "" "u32-checked-native-load" (func $load (param i64 i64 i64) (result i32)))
+        (import "" "u32-checked-native-store" (func $store (param i64 i64 i64 i32)))
+    )
+
+    (core instance $i
+        (instantiate $m
+            (with "" (instance (export "u32-checked-native-load" (func $load'))
+                               (export "u32-checked-native-store" (func $store'))))
+        )
+    )
+)
+;; function u0:0(i64 vmctx, i64, i64, i64, i64) -> i32 tail {
+;; block0(v0: i64, v1: i64, v2: i64, v3: i64, v4: i64):
+;;     v5 = iconst.i64 4
+;;     v6, v7 = uadd_overflow v3, v5  ; v5 = 4
+;;     v8 = icmp ugt v6, v4
+;;     v9 = bor v7, v8
+;;     v11 = iconst.i64 0
+;;     v10 = iadd v2, v3
+;;     v12 = select_spectre_guard v9, v11, v10  ; v11 = 0
+;;     trapz v12, heap_oob
+;;     v13 = load.i32 notrap aligned v12
+;;     return v13
+;; }
+;;
+;; function u0:0(i64 vmctx, i64, i64, i64, i64, i32) tail {
+;; block0(v0: i64, v1: i64, v2: i64, v3: i64, v4: i64, v5: i32):
+;;     v6 = iconst.i64 4
+;;     v7, v8 = uadd_overflow v3, v6  ; v6 = 4
+;;     v9 = icmp ugt v7, v4
+;;     v10 = bor v8, v9
+;;     v12 = iconst.i64 0
+;;     v11 = iadd v2, v3
+;;     v13 = select_spectre_guard v10, v12, v11  ; v12 = 0
+;;     trapz v13, heap_oob
+;;     store notrap aligned v5, v13
+;;     return
+;; }

--- a/tests/disas/component-model/inlining-and-unsafe-intrinsics.wat
+++ b/tests/disas/component-model/inlining-and-unsafe-intrinsics.wat
@@ -45,7 +45,7 @@
 ;; function u0:0(i64 vmctx, i64) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 72 "VMContext+0x48"
-;;     region2 = 2 "vmctx"
+;;     region2 = 268435560 "VMStoreContext+0x68"
 ;;     region3 = 104 "VMContext+0x68"
 ;;     region4 = 136 "VMContext+0x88"
 ;;     gv0 = vmctx
@@ -61,7 +61,7 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @0153                               v5 = load.i64 notrap aligned readonly can_move region2 v0+8
+;; @0153                               v5 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @0153                               v6 = load.i64 notrap aligned readonly can_move region2 v5+104
 ;; @0155                               v9 = load.i8 notrap aligned v6
 ;;                                     v22 = iconst.i8 1

--- a/tests/disas/riscv64-component-builtins.wat
+++ b/tests/disas/riscv64-component-builtins.wat
@@ -11,7 +11,7 @@
 )
 
 ;; function u0:0(i64 vmctx, i64, i32) tail {
-;;     region0 = 2 "vmctx"
+;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 16 "VMContext+0x10"
 ;;     sig0 = (i64 sext, i32 sext, i32 sext, i32 sext) -> i64 sext system_v
 ;;     sig1 = (i64 sext vmctx) system_v


### PR DESCRIPTION
These intrinsics are similar to the unchecked versions, but instead of taking a raw address, take a base, offset, and length. They do a bounds check first, and trap on out-of-bounds accesses or perform the actual in-bounds access. When Spectre mitigations are enabled, their bounds check has Spectre mitigations applied.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
