### PR TITLE
Always use the vmctx alias region for all loads from within the vmctx

### DIFF
--- a/crates/cranelift/src/alias_region_key.rs
+++ b/crates/cranelift/src/alias_region_key.rs
@@ -4,6 +4,18 @@ use wasmtime_environ::{
     DefinedGlobalIndex, DefinedMemoryIndex, DefinedTableIndex, StaticModuleIndex,
 };
 
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+pub(crate) enum VmType {
+    VMContext,
+    VMStoreContext,
+
+    #[allow(
+        dead_code,
+        reason = "used when tagging `VMMemoryDefinition` fields in upcoming commits"
+    )]
+    VMMemoryDefinition,
+}
+
 /// A key that uniquely identifies an alias region across an entire compilation.
 ///
 /// This is used to assign stable `user_id`s to `AliasRegionData` entries so
@@ -13,16 +25,12 @@ use wasmtime_environ::{
 /// `[ kind: 4 bits | data: 28 bits ]`
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
 pub(crate) enum AliasRegionKey {
-    /// A `VMContext` field access.
-    VMContext {
-        /// The offset of the `VMContext` field being accessed (or the base
-        /// of the array for `VMContext` array fields).
-        offset: u32,
-    },
-
-    /// A `VMStoreContext` field access.
-    VMStoreContext {
-        /// The offset of the `VMStoreContext` field being accessed.
+    /// An access of a field within a VM data structure of type `ty`.
+    Vm {
+        /// The type of VM data structure being accessed.
+        ty: VmType,
+        /// The offset of the accessed field *within* the `ty` structure (or
+        /// the base offset of the array, for array fields).
         offset: u32,
     },
 
@@ -63,10 +71,6 @@ pub(crate) enum AliasRegionKey {
     },
 
     /// A GC heap access.
-    #[allow(
-        dead_code,
-        reason = "easier not to cfg off; exact feature set is wonky in workspace"
-    )]
     GcHeap,
 }
 
@@ -97,18 +101,20 @@ impl AliasRegionKey {
     const IMPORTED_GLOBAL_KIND: u32 = Self::new_kind(0b0110);
     const DEFINED_GLOBAL_KIND: u32 = Self::new_kind(0b0111);
     const GC_HEAP_KIND: u32 = Self::new_kind(0b1000);
+    const VM_MEMORY_DEFINITION_KIND: u32 = Self::new_kind(0b1001);
 
     /// Encode this key into a raw `u32` suitable for use as an
     /// `AliasRegionData::user_id`.
     pub(crate) fn into_raw(self) -> u32 {
         match self {
-            AliasRegionKey::VMContext { offset } => {
+            AliasRegionKey::Vm { ty, offset } => {
                 debug_assert_eq!(offset & Self::KIND_MASK, 0);
-                Self::VM_CONTEXT_KIND | (offset & Self::OFFSET_MASK)
-            }
-            AliasRegionKey::VMStoreContext { offset } => {
-                debug_assert_eq!(offset & Self::KIND_MASK, 0);
-                Self::VM_STORE_CONTEXT_KIND | (offset & Self::OFFSET_MASK)
+                let kind = match ty {
+                    VmType::VMContext => Self::VM_CONTEXT_KIND,
+                    VmType::VMStoreContext => Self::VM_STORE_CONTEXT_KIND,
+                    VmType::VMMemoryDefinition => Self::VM_MEMORY_DEFINITION_KIND,
+                };
+                kind | (offset & Self::OFFSET_MASK)
             }
             AliasRegionKey::PublicMemory => Self::IMPORTED_MEMORY_KIND,
             AliasRegionKey::DefinedMemory { module, index } => {
@@ -149,8 +155,7 @@ impl AliasRegionKey {
 impl fmt::Debug for AliasRegionKey {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            AliasRegionKey::VMContext { offset } => write!(f, "VMContext+{offset:#x}"),
-            AliasRegionKey::VMStoreContext { offset } => write!(f, "VMStoreContext+{offset:#x}"),
+            AliasRegionKey::Vm { ty, offset } => write!(f, "{ty:?}+{offset:#x}"),
             AliasRegionKey::PublicMemory => write!(f, "PublicMemory"),
             AliasRegionKey::DefinedMemory { module, index } => {
                 write!(f, "DefinedMemory({module:?}, {index:?})")

--- a/crates/cranelift/src/compiler.rs
+++ b/crates/cranelift/src/compiler.rs
@@ -1,4 +1,5 @@
 use crate::TRAP_INTERNAL_ASSERT;
+use crate::alias_region_key::{AliasRegionKey, VmType};
 use crate::debug::DwarfSectionRelocTarget;
 use crate::func_environ::FuncEnvironment;
 use crate::translate::FuncTranslator;
@@ -227,11 +228,13 @@ impl Compiler {
             wasmtime_environ::VMCONTEXT_MAGIC,
         );
         let ptr = isa.pointer_bytes();
+        let store_ctx_offset = ptr.vmcontext_store_context();
+        let region = vmctx_alias_region(builder.func, store_ctx_offset.into());
         let vm_store_context = builder.ins().load(
             pointer_type,
-            MemFlagsData::trusted(),
+            MemFlagsData::trusted().with_alias_region(Some(region)),
             caller_vmctx,
-            i32::from(ptr.vmcontext_store_context()),
+            i32::from(store_ctx_offset),
         );
         save_last_wasm_exit_fp_and_pc(&mut builder, pointer_type, &ptr, vm_store_context);
 
@@ -263,11 +266,15 @@ impl Compiler {
         // Increment the "execution version" on the VMStoreContext if
         // guest debugging is enabled.
         if self.tunables.debug_guest {
+            let store_ctx_offset = ptr_size.vmctx_store_context();
+            let region = vmctx_alias_region(builder.func, store_ctx_offset.into());
             let vmstore_ctx_ptr = builder.ins().load(
                 pointer_type,
-                MemFlagsData::trusted().with_readonly(),
+                MemFlagsData::trusted()
+                    .with_readonly()
+                    .with_alias_region(Some(region)),
                 caller_vmctx,
-                i32::from(ptr_size.vmctx_store_context()),
+                i32::from(store_ctx_offset),
             );
             let old_version = builder.ins().load(
                 ir::types::I64,
@@ -335,11 +342,13 @@ impl Compiler {
         // additionally perform the "routine of the exit trampoline" of saving
         // fp/pc/etc.
         self.debug_assert_vmctx_kind(&mut builder, vmctx, wasmtime_environ::VMCONTEXT_MAGIC);
+        let store_ctx_offset = ptr_size.vmcontext_store_context();
+        let region = vmctx_alias_region(builder.func, store_ctx_offset.into());
         let vm_store_context = builder.ins().load(
             pointer_type,
-            MemFlagsData::trusted(),
+            MemFlagsData::trusted().with_alias_region(Some(region)),
             vmctx,
-            ptr_size.vmcontext_store_context(),
+            store_ctx_offset,
         );
         save_last_wasm_exit_fp_and_pc(&mut builder, pointer_type, &ptr_size, vm_store_context);
 
@@ -533,11 +542,19 @@ impl wasmtime_environ::Compiler for Compiler {
             let vmctx = context
                 .func
                 .create_global_value(ir::GlobalValueData::VMContext);
+            let interrupts_region = vmctx_alias_region(
+                &mut context.func,
+                func_env.offsets.ptr.vmctx_store_context().into(),
+            );
             let interrupts_flags = context
                 .func
                 .dfg
                 .mem_flags
-                .insert(MemFlagsData::trusted().with_readonly())
+                .insert(
+                    MemFlagsData::trusted()
+                        .with_readonly()
+                        .with_alias_region(Some(interrupts_region)),
+                )
                 .unwrap();
             let interrupts_ptr = context.func.create_global_value(ir::GlobalValueData::Load {
                 base: vmctx,
@@ -1327,11 +1344,13 @@ impl Compiler {
         // base pointer of the array and then load the entry of the array that
         // corresponds to this builtin.
         let mem_flags = ir::MemFlagsData::trusted().with_readonly();
+        let builtins_offset = ptr_size.vmcontext_builtin_functions();
+        let region = vmctx_alias_region(builder.func, builtins_offset.into());
         let array_addr = builder.ins().load(
             pointer_type,
-            mem_flags,
+            mem_flags.with_alias_region(Some(region)),
             vmctx,
-            i32::from(ptr_size.vmcontext_builtin_functions()),
+            i32::from(builtins_offset),
         );
         let body_offset = i32::try_from(builtin.index() * pointer_type.bytes()).unwrap();
         let func_addr = builder
@@ -1762,6 +1781,21 @@ fn clif_to_env_breakpoints(
     Ok(())
 }
 
+/// Insert (deduplicated) an alias region for the `VMContext` field at `offset`.
+///
+/// This is the trampoline-side equivalent of
+/// `FuncEnvironment::vmctx_alias_region`, for the trampoline compilers that do
+/// not have a `FuncEnvironment` on hand.
+fn vmctx_alias_region(func: &mut ir::Function, offset: u32) -> ir::AliasRegion {
+    func.dfg.alias_regions.insert(
+        AliasRegionKey::Vm {
+            ty: VmType::VMContext,
+            offset,
+        }
+        .into(),
+    )
+}
+
 fn save_last_wasm_entry_context(
     builder: &mut FunctionBuilder,
     pointer_type: ir::Type,
@@ -1771,9 +1805,10 @@ fn save_last_wasm_entry_context(
     block: ir::Block,
 ) {
     // First we need to get the `VMStoreContext`.
+    let region = vmctx_alias_region(builder.func, vm_store_context_offset);
     let vm_store_context = builder.ins().load(
         pointer_type,
-        MemFlagsData::trusted(),
+        MemFlagsData::trusted().with_alias_region(Some(region)),
         vmctx,
         i32::try_from(vm_store_context_offset).unwrap(),
     );

--- a/crates/cranelift/src/compiler/component.rs
+++ b/crates/cranelift/src/compiler/component.rs
@@ -1,6 +1,6 @@
 //! Compilation support for the component model.
 
-use crate::alias_region_key::AliasRegionKey;
+use crate::alias_region_key::{AliasRegionKey, VmType};
 use crate::func_environ::BuiltinFunctions;
 use crate::trap::TranslateTrap;
 use crate::{TRAP_CANNOT_LEAVE_COMPONENT, TRAP_INTERNAL_ASSERT, compiler::Compiler};
@@ -1726,13 +1726,15 @@ impl ComponentCompiler for Compiler {
 
                 // Load the `*mut VMStoreContext` out of our vmctx.
                 let vmctx_region = c.builder.func.dfg.alias_regions.insert(
-                    AliasRegionKey::VMContext {
+                    AliasRegionKey::Vm {
+                        ty: VmType::VMContext,
                         offset: c.offsets.vm_store_context(),
                     }
                     .into(),
                 );
                 let store_ctx_region = c.builder.func.dfg.alias_regions.insert(
-                    AliasRegionKey::VMStoreContext {
+                    AliasRegionKey::Vm {
+                        ty: VmType::VMStoreContext,
                         offset: u32::from(c.offsets.ptr.vmstore_context_store_data()),
                     }
                     .into(),

--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -1,7 +1,7 @@
 mod gc;
 pub(crate) mod stack_switching;
 
-use crate::alias_region_key::AliasRegionKey;
+use crate::alias_region_key::{AliasRegionKey, VmType};
 use crate::compiler::Compiler;
 use crate::translate::{
     FuncTranslationStacks, GlobalVariable, Heap, HeapData, MemoryKind, StructFieldsVec, TableData,
@@ -438,7 +438,13 @@ impl<'module_environment> FuncEnvironment<'module_environment> {
         func: &mut Function,
         offset: u32,
     ) -> ir::AliasRegion {
-        self.alias_region(func, AliasRegionKey::VMContext { offset })
+        self.alias_region(
+            func,
+            AliasRegionKey::Vm {
+                ty: VmType::VMContext,
+                offset,
+            },
+        )
     }
 
     fn get_memory_atomic_wait(&mut self, func: &mut Function, ty: ir::Type) -> ir::FuncRef {
@@ -461,10 +467,16 @@ impl<'module_environment> FuncEnvironment<'module_environment> {
             (vmctx, offset)
         } else {
             let from_offset = self.offsets.vmctx_vmglobal_import_from(index);
+            let region = self.vmctx_alias_region(func, from_offset);
             let global_flags = func
                 .dfg
                 .mem_flags
-                .insert(MemFlagsData::trusted().with_readonly().with_can_move())
+                .insert(
+                    MemFlagsData::trusted()
+                        .with_readonly()
+                        .with_can_move()
+                        .with_alias_region(Some(region)),
+                )
                 .unwrap();
             let global = func.create_global_value(ir::GlobalValueData::Load {
                 base: vmctx,
@@ -492,10 +504,16 @@ impl<'module_environment> FuncEnvironment<'module_environment> {
 
         let offset = self.offsets.ptr.vmctx_store_context();
         let base = self.vmctx(func);
+        let region = self.vmctx_alias_region(func, offset.into());
         let ptr_flags = func
             .dfg
             .mem_flags
-            .insert(ir::MemFlagsData::trusted().with_readonly().with_can_move())
+            .insert(
+                ir::MemFlagsData::trusted()
+                    .with_readonly()
+                    .with_can_move()
+                    .with_alias_region(Some(region)),
+            )
             .unwrap();
         let ptr = func.create_global_value(ir::GlobalValueData::Load {
             base,
@@ -510,13 +528,17 @@ impl<'module_environment> FuncEnvironment<'module_environment> {
     /// Get the `*mut VMStoreContext` value for our `VMContext`.
     fn get_vmstore_context_ptr(&mut self, builder: &mut FunctionBuilder) -> ir::Value {
         let pointer_type = self.pointer_type();
-        let offset = i32::from(self.offsets.ptr.vmctx_store_context());
+        let offset = self.offsets.ptr.vmctx_store_context();
         let vmctx = self.vmctx_val(&mut builder.cursor());
+        let region = self.vmctx_alias_region(builder.func, offset.into());
         builder.ins().load(
             pointer_type,
-            ir::MemFlagsData::trusted().with_readonly().with_can_move(),
+            ir::MemFlagsData::trusted()
+                .with_readonly()
+                .with_can_move()
+                .with_alias_region(Some(region)),
             vmctx,
-            offset,
+            i32::from(offset),
         )
     }
 
@@ -816,10 +838,14 @@ impl<'module_environment> FuncEnvironment<'module_environment> {
     fn epoch_ptr(&mut self, builder: &mut FunctionBuilder<'_>) -> ir::Value {
         let pointer_type = self.pointer_type();
         let base = self.vmctx_val(&mut builder.cursor());
-        let offset = i32::from(self.offsets.ptr.vmctx_epoch_ptr());
-        let epoch_ptr = builder
-            .ins()
-            .load(pointer_type, ir::MemFlagsData::trusted(), base, offset);
+        let offset = self.offsets.ptr.vmctx_epoch_ptr();
+        let region = self.vmctx_alias_region(builder.func, offset.into());
+        let epoch_ptr = builder.ins().load(
+            pointer_type,
+            ir::MemFlagsData::trusted().with_alias_region(Some(region)),
+            base,
+            i32::from(offset),
+        );
         epoch_ptr
     }
 
@@ -1129,6 +1155,8 @@ impl<'module_environment> FuncEnvironment<'module_environment> {
         flags: ir::MemFlagsData,
     ) -> ir::GlobalValue {
         let vmctx = self.vmctx(func);
+        let region = self.vmctx_alias_region(func, offset);
+        let flags = flags.with_alias_region(Some(region));
         self.global_load(func, vmctx, offset, flags)
     }
 
@@ -1219,11 +1247,13 @@ impl<'module_environment> FuncEnvironment<'module_environment> {
         let mem_flags = ir::MemFlagsData::trusted().with_readonly().with_can_move();
 
         // Load the base pointer of the array of `VMSharedTypeIndex`es.
+        let type_ids_offset = self.offsets.ptr.vmctx_type_ids_array();
+        let region = self.vmctx_alias_region(pos.func, type_ids_offset.into());
         let shared_indices = pos.ins().load(
             pointer_type,
-            mem_flags,
+            mem_flags.with_alias_region(Some(region)),
             vmctx,
-            i32::from(self.offsets.ptr.vmctx_type_ids_array()),
+            i32::from(type_ids_offset),
         );
 
         // Calculate the offset in that array for this type's entry.
@@ -1793,10 +1823,16 @@ impl FuncEnvironment<'_> {
                 (vmctx, base_offset, current_elements_offset)
             } else {
                 let from_offset = self.offsets.vmctx_vmtable_from(index);
+                let region = self.vmctx_alias_region(func, from_offset);
                 let table_flags = func
                     .dfg
                     .mem_flags
-                    .insert(MemFlagsData::trusted().with_readonly().with_can_move())
+                    .insert(
+                        MemFlagsData::trusted()
+                            .with_readonly()
+                            .with_can_move()
+                            .with_alias_region(Some(region)),
+                    )
                     .unwrap();
                 let table = func.create_global_value(ir::GlobalValueData::Load {
                     base: vmctx,
@@ -1899,15 +1935,21 @@ impl FuncEnvironment<'_> {
             let vmctx_tag_index_offset = self.offsets.vmctx_vmtag_import_index(tag_index);
             let vmctx = self.vmctx_val(&mut builder.cursor());
             let pointer_type = self.pointer_type();
+            let vmctx_region = self.vmctx_alias_region(builder.func, vmctx_tag_vmctx_offset);
             let from_vmctx = builder.ins().load(
                 pointer_type,
-                MemFlagsData::trusted().with_readonly(),
+                MemFlagsData::trusted()
+                    .with_readonly()
+                    .with_alias_region(Some(vmctx_region)),
                 vmctx,
                 i32::try_from(vmctx_tag_vmctx_offset).unwrap(),
             );
+            let index_region = self.vmctx_alias_region(builder.func, vmctx_tag_index_offset);
             let index = builder.ins().load(
                 I32,
-                MemFlagsData::trusted().with_readonly(),
+                MemFlagsData::trusted()
+                    .with_readonly()
+                    .with_alias_region(Some(index_region)),
                 vmctx,
                 i32::try_from(vmctx_tag_index_offset).unwrap(),
             );
@@ -2009,20 +2051,24 @@ impl<'a, 'func, 'module_env> Call<'a, 'func, 'module_env> {
         let mem_flags = ir::MemFlagsData::trusted().with_readonly().with_can_move();
 
         // Load the callee address.
-        let body_offset = i32::try_from(
-            self.env
-                .offsets
-                .vmctx_vmfunction_import_wasm_call(callee_index),
-        )
-        .unwrap();
+        let wasm_call_offset = self
+            .env
+            .offsets
+            .vmctx_vmfunction_import_wasm_call(callee_index);
+        let body_offset = i32::try_from(wasm_call_offset).unwrap();
 
         // First append the callee vmctx address.
-        let vmctx_offset =
-            i32::try_from(self.env.offsets.vmctx_vmfunction_import_vmctx(callee_index)).unwrap();
-        let callee_vmctx = self
-            .builder
-            .ins()
-            .load(pointer_type, mem_flags, base, vmctx_offset);
+        let vmctx_import_offset = self.env.offsets.vmctx_vmfunction_import_vmctx(callee_index);
+        let vmctx_offset = i32::try_from(vmctx_import_offset).unwrap();
+        let vmctx_region = self
+            .env
+            .vmctx_alias_region(self.builder.func, vmctx_import_offset);
+        let callee_vmctx = self.builder.ins().load(
+            pointer_type,
+            mem_flags.with_alias_region(Some(vmctx_region)),
+            base,
+            vmctx_offset,
+        );
         real_call_args.push(callee_vmctx);
         real_call_args.push(caller_vmctx);
 
@@ -2071,10 +2117,15 @@ impl<'a, 'func, 'module_env> Call<'a, 'func, 'module_env> {
             // and with different functions. Either way, we have to do the
             // indirect call.
             None => {
-                let func_addr = self
-                    .builder
-                    .ins()
-                    .load(pointer_type, mem_flags, base, body_offset);
+                let wasm_call_region = self
+                    .env
+                    .vmctx_alias_region(self.builder.func, wasm_call_offset);
+                let func_addr = self.builder.ins().load(
+                    pointer_type,
+                    mem_flags.with_alias_region(Some(wasm_call_region)),
+                    base,
+                    body_offset,
+                );
                 Ok(self.indirect_call_inst(sig_ref, func_addr, &real_call_args))
             }
         }
@@ -3406,19 +3457,21 @@ impl FuncEnvironment<'_> {
             None => {
                 let vmimport = self.offsets.vmctx_vmmemory_import(index);
 
+                let vmctx_offset = vmimport + u32::from(self.offsets.vmmemory_import_vmctx());
+                let vmctx_region = self.vmctx_alias_region(pos.func, vmctx_offset);
                 let vmctx = pos.ins().load(
                     self.isa.pointer_type(),
-                    ir::MemFlagsData::trusted(),
+                    ir::MemFlagsData::trusted().with_alias_region(Some(vmctx_region)),
                     cur_vmctx,
-                    i32::try_from(vmimport + u32::from(self.offsets.vmmemory_import_vmctx()))
-                        .unwrap(),
+                    i32::try_from(vmctx_offset).unwrap(),
                 );
+                let index_offset = vmimport + u32::from(self.offsets.vmmemory_import_index());
+                let index_region = self.vmctx_alias_region(pos.func, index_offset);
                 let index = pos.ins().load(
                     ir::types::I32,
-                    ir::MemFlagsData::trusted(),
+                    ir::MemFlagsData::trusted().with_alias_region(Some(index_region)),
                     cur_vmctx,
-                    i32::try_from(vmimport + u32::from(self.offsets.vmmemory_import_index()))
-                        .unwrap(),
+                    i32::try_from(index_offset).unwrap(),
                 );
                 (vmctx, index)
             }
@@ -3442,19 +3495,21 @@ impl FuncEnvironment<'_> {
             None => {
                 let vmimport = self.offsets.vmctx_vmtable_import(index);
 
+                let vmctx_offset = vmimport + u32::from(self.offsets.vmtable_import_vmctx());
+                let vmctx_region = self.vmctx_alias_region(pos.func, vmctx_offset);
                 let vmctx = pos.ins().load(
                     self.isa.pointer_type(),
-                    ir::MemFlagsData::trusted(),
+                    ir::MemFlagsData::trusted().with_alias_region(Some(vmctx_region)),
                     cur_vmctx,
-                    i32::try_from(vmimport + u32::from(self.offsets.vmtable_import_vmctx()))
-                        .unwrap(),
+                    i32::try_from(vmctx_offset).unwrap(),
                 );
+                let index_offset = vmimport + u32::from(self.offsets.vmtable_import_index());
+                let index_region = self.vmctx_alias_region(pos.func, index_offset);
                 let index = pos.ins().load(
                     ir::types::I32,
-                    ir::MemFlagsData::trusted(),
+                    ir::MemFlagsData::trusted().with_alias_region(Some(index_region)),
                     cur_vmctx,
-                    i32::try_from(vmimport + u32::from(self.offsets.vmtable_import_index()))
-                        .unwrap(),
+                    i32::try_from(index_offset).unwrap(),
                 );
                 (vmctx, index)
             }
@@ -3504,11 +3559,14 @@ impl FuncEnvironment<'_> {
         match self.module.defined_memory_index(index) {
             Some(def_index) => {
                 if is_shared {
-                    let offset =
-                        i32::try_from(self.offsets.vmctx_vmmemory_pointer(def_index)).unwrap();
-                    let vmmemory_ptr =
-                        pos.ins()
-                            .load(pointer_type, ir::MemFlagsData::trusted(), base, offset);
+                    let ptr_offset = self.offsets.vmctx_vmmemory_pointer(def_index);
+                    let region = self.vmctx_alias_region(pos.func, ptr_offset);
+                    let vmmemory_ptr = pos.ins().load(
+                        pointer_type,
+                        ir::MemFlagsData::trusted().with_alias_region(Some(region)),
+                        base,
+                        i32::try_from(ptr_offset).unwrap(),
+                    );
                     let vmmemory_definition_offset =
                         i64::from(self.offsets.ptr.vmmemory_definition_current_length());
                     let vmmemory_definition_ptr = pos
@@ -3537,10 +3595,14 @@ impl FuncEnvironment<'_> {
                 }
             }
             None => {
-                let offset = i32::try_from(self.offsets.vmctx_vmmemory_import_from(index)).unwrap();
-                let vmmemory_ptr =
-                    pos.ins()
-                        .load(pointer_type, ir::MemFlagsData::trusted(), base, offset);
+                let from_offset = self.offsets.vmctx_vmmemory_import_from(index);
+                let region = self.vmctx_alias_region(pos.func, from_offset);
+                let vmmemory_ptr = pos.ins().load(
+                    pointer_type,
+                    ir::MemFlagsData::trusted().with_alias_region(Some(region)),
+                    base,
+                    i32::try_from(from_offset).unwrap(),
+                );
                 if is_shared {
                     let vmmemory_definition_offset =
                         i64::from(self.offsets.ptr.vmmemory_definition_current_length());

--- a/crates/cranelift/src/func_environ/stack_switching/instructions.rs
+++ b/crates/cranelift/src/func_environ/stack_switching/instructions.rs
@@ -919,12 +919,15 @@ pub(crate) fn tag_address<'a>(
         let offset = i32::try_from(env.offsets.vmctx_vmtag_definition(def_index)).unwrap();
         builder.ins().iadd_imm_s(vmctx, i64::from(offset))
     } else {
-        let offset = i32::try_from(env.offsets.vmctx_vmtag_import_from(tag_index)).unwrap();
+        let from_offset = env.offsets.vmctx_vmtag_import_from(tag_index);
+        let region = env.vmctx_alias_region(builder.func, from_offset);
         builder.ins().load(
             pointer_type,
-            ir::MemFlagsData::trusted().with_readonly(),
+            ir::MemFlagsData::trusted()
+                .with_readonly()
+                .with_alias_region(Some(region)),
             vmctx,
-            ir::immediates::Offset32::new(offset),
+            ir::immediates::Offset32::new(i32::try_from(from_offset).unwrap()),
         )
     }
 }
@@ -941,9 +944,10 @@ pub fn vmctx_load_stack_chain<'a>(
 
     // First we need to get the `VMStoreContext`.
     let vm_store_context_offset = env.offsets.ptr.vmctx_store_context();
+    let region = env.vmctx_alias_region(builder.func, vm_store_context_offset.into());
     let vm_store_context = builder.ins().load(
         env.pointer_type(),
-        MemFlagsData::trusted(),
+        MemFlagsData::trusted().with_alias_region(Some(region)),
         vmctx,
         vm_store_context_offset,
     );
@@ -969,9 +973,10 @@ pub fn vmctx_store_stack_chain<'a>(
 
     // First we need to get the `VMStoreContext`.
     let vm_store_context_offset = env.offsets.ptr.vmctx_store_context();
+    let region = env.vmctx_alias_region(builder.func, vm_store_context_offset.into());
     let vm_store_context = builder.ins().load(
         env.pointer_type(),
-        MemFlagsData::trusted(),
+        MemFlagsData::trusted().with_alias_region(Some(region)),
         vmctx,
         vm_store_context_offset,
     );
@@ -997,13 +1002,18 @@ pub fn vmctx_load_vm_runtime_limits_ptr<'a>(
     vmctx: ir::Value,
 ) -> ir::Value {
     let pointer_type = env.pointer_type();
-    let offset = i32::from(env.offsets.ptr.vmctx_store_context());
+    let store_ctx_offset = env.offsets.ptr.vmctx_store_context();
+    let region = env.vmctx_alias_region(builder.func, store_ctx_offset.into());
 
     // The *pointer* to the VMRuntimeLimits does not change within the
     // same function, allowing us to set the `read_only` flag.
-    let flags = ir::MemFlagsData::trusted().with_readonly();
+    let flags = ir::MemFlagsData::trusted()
+        .with_readonly()
+        .with_alias_region(Some(region));
 
-    builder.ins().load(pointer_type, flags, vmctx, offset)
+    builder
+        .ins()
+        .load(pointer_type, flags, vmctx, i32::from(store_ctx_offset))
 }
 
 /// This function generates code that searches for a handler for `tag_address`,

--- a/tests/disas/alias-region-globals.wat
+++ b/tests/disas/alias-region-globals.wat
@@ -15,19 +15,21 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 1610612736 "PublicGlobal"
-;;     region1 = 1879048192 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 48 "VMContext+0x30"
+;;     region2 = 1610612736 "PublicGlobal"
+;;     region3 = 1879048192 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+48
+;;     gv4 = load.i64 notrap aligned readonly can_move region1 gv3+48
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0039                               v4 = load.i64 notrap aligned readonly can_move v0+48
-;; @0039                               store notrap aligned region0 v2, v4
-;; @003d                               store notrap aligned region1 v2, v0+80
+;; @0039                               v4 = load.i64 notrap aligned readonly can_move region1 v0+48
+;; @0039                               store notrap aligned region2 v2, v4
+;; @003d                               store notrap aligned region3 v2, v0+80
 ;; @0041                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/alias-region-memories.wat
+++ b/tests/disas/alias-region-memories.wat
@@ -15,13 +15,15 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32) -> i32 tail {
-;;     region0 = 536870912 "PublicMemory"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 48 "VMContext+0x30"
+;;     region2 = 536870912 "PublicMemory"
+;;     region3 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+48
+;;     gv4 = load.i64 notrap aligned readonly can_move region1 gv3+48
 ;;     gv5 = load.i64 notrap aligned gv4+8
 ;;     gv6 = load.i64 notrap aligned readonly can_move gv4
 ;;     gv7 = load.i64 notrap aligned gv3+88
@@ -29,14 +31,14 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
-;; @003b                               v18 = load.i64 notrap aligned readonly can_move v0+48
+;; @003b                               v18 = load.i64 notrap aligned readonly can_move region1 v0+48
 ;; @003b                               v6 = load.i64 notrap aligned readonly can_move v18
 ;; @003b                               v5 = uextend.i64 v2
 ;; @003b                               v7 = iadd v6, v5
-;; @003b                               store little region0 v3, v7
+;; @003b                               store little region2 v3, v7
 ;; @0042                               v9 = load.i64 notrap aligned readonly can_move v0+80
 ;; @0042                               v10 = iadd v9, v5
-;; @0042                               store little region1 v3, v10
+;; @0042                               store little region3 v3, v10
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/alias-region-tables.wat
+++ b/tests/disas/alias-region-tables.wat
@@ -16,13 +16,16 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32, i64) -> i32 tail {
-;;     region0 = 1073741824 "PublicTable"
-;;     region1 = 1342177280 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 48 "VMContext+0x30"
+;;     region2 = 1073741824 "PublicTable"
+;;     region3 = 1342177280 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
+;;     region4 = 40 "VMContext+0x28"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+48
+;;     gv4 = load.i64 notrap aligned readonly can_move region1 gv3+48
 ;;     gv5 = load.i64 notrap aligned gv4
 ;;     gv6 = load.i64 notrap aligned gv4+8
 ;;     gv7 = load.i64 notrap aligned gv3+72
@@ -33,7 +36,7 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i64):
-;; @0043                               v62 = load.i64 notrap aligned readonly can_move v0+48
+;; @0043                               v62 = load.i64 notrap aligned readonly can_move region1 v0+48
 ;; @0043                               v5 = load.i64 notrap aligned v62+8
 ;; @0043                               v9 = load.i64 notrap aligned v62
 ;; @0043                               v15 = iconst.i64 1
@@ -46,14 +49,14 @@
 ;; @0043                               v11 = ishl v8, v10  ; v10 = 3
 ;; @0043                               v12 = iadd v9, v11
 ;; @0043                               v14 = select_spectre_guard v7, v13, v12  ; v13 = 0
-;; @0043                               store user6 aligned region0 v16, v14
+;; @0043                               store user6 aligned region2 v16, v14
 ;; @0049                               v17 = load.i64 notrap aligned v0+80
 ;; @0049                               v21 = load.i64 notrap aligned v0+72
 ;; @0049                               v18 = ireduce.i32 v17
 ;; @0049                               v19 = icmp uge v2, v18
 ;; @0049                               v24 = iadd v21, v11
 ;; @0049                               v26 = select_spectre_guard v19, v13, v24  ; v13 = 0
-;; @0049                               store user6 aligned region1 v16, v26
+;; @0049                               store user6 aligned region3 v16, v26
 ;; @004d                               v40 = iconst.i64 -2
 ;; @004d                               v41 = band v16, v40  ; v40 = -2
 ;; @004d                               brif v16, block3(v41), block2
@@ -65,7 +68,7 @@
 ;;
 ;;                                 block3(v42: i64):
 ;; @004d                               v48 = load.i32 user7 aligned readonly v42+16
-;; @004d                               v46 = load.i64 notrap aligned readonly can_move v0+40
+;; @004d                               v46 = load.i64 notrap aligned readonly can_move region4 v0+40
 ;; @004d                               v47 = load.i32 notrap aligned readonly can_move v46
 ;; @004d                               v49 = icmp eq v48, v47
 ;; @004d                               trapz v49, user8

--- a/tests/disas/arith.wat
+++ b/tests/disas/arith.wat
@@ -15,8 +15,9 @@
 )
 
 ;; function u0:0(i64 vmctx, i64) tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     stack_limit = gv2
 ;;

--- a/tests/disas/array-copy-anyref.wat
+++ b/tests/disas/array-copy-anyref.wat
@@ -10,25 +10,26 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32, i32, i32, i32) tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32, v6: i32):
 ;; @002b                               trapz v2, user16
-;; @002b                               v109 = load.i64 notrap aligned readonly can_move v0+8
+;; @002b                               v109 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @002b                               v8 = load.i64 notrap aligned readonly can_move v109+32
 ;; @002b                               v7 = uextend.i64 v2
 ;; @002b                               v9 = iadd v8, v7
 ;; @002b                               v10 = iconst.i64 16
 ;; @002b                               v11 = iadd v9, v10  ; v10 = 16
-;; @002b                               v12 = load.i32 user2 readonly region0 v11
+;; @002b                               v12 = load.i32 user2 readonly region1 v11
 ;; @002b                               v14 = uextend.i64 v3
 ;; @002b                               v15 = uextend.i64 v6
 ;; @002b                               v18 = iadd v14, v15
@@ -39,7 +40,7 @@
 ;; @002b                               v30 = uextend.i64 v4
 ;; @002b                               v32 = iadd v8, v30
 ;; @002b                               v34 = iadd v32, v10  ; v10 = 16
-;; @002b                               v35 = load.i32 user2 readonly region0 v34
+;; @002b                               v35 = load.i32 user2 readonly region1 v34
 ;; @002b                               v37 = uextend.i64 v5
 ;; @002b                               v41 = iadd v37, v15
 ;; @002b                               v36 = uextend.i64 v35
@@ -74,8 +75,8 @@
 ;; @002b                               brif v72, block3(v29, v52, v5), block4(v77, v78, v80)
 ;;
 ;;                                 block3(v81: i64, v82: i64, v83: i32):
-;; @002b                               v86 = load.i32 user2 little region0 v82
-;; @002b                               store user2 little region0 v86, v81
+;; @002b                               v86 = load.i32 user2 little region1 v82
+;; @002b                               store user2 little region1 v86, v81
 ;;                                     v125 = iconst.i64 4
 ;;                                     v126 = iadd v82, v125  ; v125 = 4
 ;; @002b                               v93 = icmp eq v126, v78
@@ -87,9 +88,9 @@
 ;;                                 block4(v94: i64, v95: i64, v96: i32):
 ;;                                     v120 = iconst.i64 4
 ;;                                     v121 = isub v95, v120  ; v120 = 4
-;; @002b                               v105 = load.i32 user2 little region0 v121
+;; @002b                               v105 = load.i32 user2 little region1 v121
 ;;                                     v122 = isub v94, v120  ; v120 = 4
-;; @002b                               store user2 little region0 v105, v122
+;; @002b                               store user2 little region1 v105, v122
 ;; @002b                               v106 = icmp eq v121, v52
 ;;                                     v123 = iconst.i32 1
 ;;                                     v124 = isub v96, v123  ; v123 = 1

--- a/tests/disas/array-copy-i64.wat
+++ b/tests/disas/array-copy-i64.wat
@@ -10,12 +10,13 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32, i32, i32, i32) tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i64, i64, i64) tail
@@ -24,13 +25,13 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32, v6: i32):
 ;; @002b                               trapz v2, user16
-;; @002b                               v74 = load.i64 notrap aligned readonly can_move v0+8
+;; @002b                               v74 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @002b                               v8 = load.i64 notrap aligned readonly can_move v74+32
 ;; @002b                               v7 = uextend.i64 v2
 ;; @002b                               v9 = iadd v8, v7
 ;; @002b                               v10 = iconst.i64 16
 ;; @002b                               v11 = iadd v9, v10  ; v10 = 16
-;; @002b                               v12 = load.i32 user2 readonly region0 v11
+;; @002b                               v12 = load.i32 user2 readonly region1 v11
 ;; @002b                               v14 = uextend.i64 v3
 ;; @002b                               v15 = uextend.i64 v6
 ;; @002b                               v18 = iadd v14, v15
@@ -41,7 +42,7 @@
 ;; @002b                               v30 = uextend.i64 v4
 ;; @002b                               v32 = iadd v8, v30
 ;; @002b                               v34 = iadd v32, v10  ; v10 = 16
-;; @002b                               v35 = load.i32 user2 readonly region0 v34
+;; @002b                               v35 = load.i32 user2 readonly region1 v34
 ;; @002b                               v37 = uextend.i64 v5
 ;; @002b                               v41 = iadd v37, v15
 ;; @002b                               v36 = uextend.i64 v35

--- a/tests/disas/array-copy-i8.wat
+++ b/tests/disas/array-copy-i8.wat
@@ -10,12 +10,13 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32, i32, i32, i32) tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i64, i64, i64) tail
@@ -24,13 +25,13 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32, v6: i32):
 ;; @002b                               trapz v2, user16
-;; @002b                               v74 = load.i64 notrap aligned readonly can_move v0+8
+;; @002b                               v74 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @002b                               v8 = load.i64 notrap aligned readonly can_move v74+32
 ;; @002b                               v7 = uextend.i64 v2
 ;; @002b                               v9 = iadd v8, v7
 ;; @002b                               v10 = iconst.i64 16
 ;; @002b                               v11 = iadd v9, v10  ; v10 = 16
-;; @002b                               v12 = load.i32 user2 readonly region0 v11
+;; @002b                               v12 = load.i32 user2 readonly region1 v11
 ;; @002b                               v14 = uextend.i64 v3
 ;; @002b                               v15 = uextend.i64 v6
 ;; @002b                               v18 = iadd v14, v15
@@ -41,7 +42,7 @@
 ;; @002b                               v30 = uextend.i64 v4
 ;; @002b                               v32 = iadd v8, v30
 ;; @002b                               v34 = iadd v32, v10  ; v10 = 16
-;; @002b                               v35 = load.i32 user2 readonly region0 v34
+;; @002b                               v35 = load.i32 user2 readonly region1 v34
 ;; @002b                               v37 = uextend.i64 v5
 ;; @002b                               v41 = iadd v37, v15
 ;; @002b                               v36 = uextend.i64 v35

--- a/tests/disas/array-copy-inline.wat
+++ b/tests/disas/array-copy-inline.wat
@@ -16,25 +16,26 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32, i32, i32) tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):
 ;; @002a                               trapz v2, user16
-;; @002a                               v77 = load.i64 notrap aligned readonly can_move v0+8
+;; @002a                               v77 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @002a                               v8 = load.i64 notrap aligned readonly can_move v77+32
 ;; @002a                               v7 = uextend.i64 v2
 ;; @002a                               v9 = iadd v8, v7
 ;; @002a                               v10 = iconst.i64 16
 ;; @002a                               v11 = iadd v9, v10  ; v10 = 16
-;; @002a                               v12 = load.i32 user2 readonly region0 v11
+;; @002a                               v12 = load.i32 user2 readonly region1 v11
 ;; @002a                               v14 = uextend.i64 v3
 ;;                                     v79 = iconst.i64 7
 ;; @002a                               v18 = iadd v14, v79  ; v79 = 7
@@ -45,7 +46,7 @@
 ;; @002a                               v30 = uextend.i64 v4
 ;; @002a                               v32 = iadd v8, v30
 ;; @002a                               v34 = iadd v32, v10  ; v10 = 16
-;; @002a                               v35 = load.i32 user2 readonly region0 v34
+;; @002a                               v35 = load.i32 user2 readonly region1 v34
 ;; @002a                               v37 = uextend.i64 v5
 ;; @002a                               v41 = iadd v37, v79  ; v79 = 7
 ;; @002a                               v36 = uextend.i64 v35

--- a/tests/disas/array-fill-anyref.wat
+++ b/tests/disas/array-fill-anyref.wat
@@ -18,25 +18,26 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32, i32, i32) tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):
 ;; @0030                               trapz v2, user16
-;; @0030                               v46 = load.i64 notrap aligned readonly can_move v0+8
+;; @0030                               v46 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @0030                               v7 = load.i64 notrap aligned readonly can_move v46+32
 ;; @0030                               v6 = uextend.i64 v2
 ;; @0030                               v8 = iadd v7, v6
 ;; @0030                               v9 = iconst.i64 16
 ;; @0030                               v10 = iadd v8, v9  ; v9 = 16
-;; @0030                               v11 = load.i32 user2 readonly region0 v10
+;; @0030                               v11 = load.i32 user2 readonly region1 v10
 ;; @0030                               v13 = uextend.i64 v3
 ;; @0030                               v14 = uextend.i64 v5
 ;; @0030                               v17 = iadd v13, v14
@@ -61,7 +62,7 @@
 ;; @0030                               brif v41, block3, block2(v28)
 ;;
 ;;                                 block2(v42: i64):
-;; @0030                               store.i32 user2 little region0 v4, v42
+;; @0030                               store.i32 user2 little region1 v4, v42
 ;;                                     v55 = iconst.i64 4
 ;;                                     v56 = iadd v42, v55  ; v55 = 4
 ;; @0030                               v45 = icmp eq v56, v39
@@ -75,25 +76,26 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32, i32, i32) tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
 ;; @003e                               trapz v2, user16
-;; @003e                               v46 = load.i64 notrap aligned readonly can_move v0+8
+;; @003e                               v46 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @003e                               v7 = load.i64 notrap aligned readonly can_move v46+32
 ;; @003e                               v6 = uextend.i64 v2
 ;; @003e                               v8 = iadd v7, v6
 ;; @003e                               v9 = iconst.i64 16
 ;; @003e                               v10 = iadd v8, v9  ; v9 = 16
-;; @003e                               v11 = load.i32 user2 readonly region0 v10
+;; @003e                               v11 = load.i32 user2 readonly region1 v10
 ;; @003e                               v13 = uextend.i64 v3
 ;; @003e                               v14 = uextend.i64 v4
 ;; @003e                               v17 = iadd v13, v14
@@ -120,7 +122,7 @@
 ;;
 ;;                                 block2(v42: i64):
 ;;                                     v55 = iconst.i32 0
-;; @003e                               store user2 little region0 v55, v42  ; v55 = 0
+;; @003e                               store user2 little region1 v55, v42  ; v55 = 0
 ;;                                     v56 = iconst.i64 4
 ;;                                     v57 = iadd v42, v56  ; v56 = 4
 ;; @003e                               v45 = icmp eq v57, v39
@@ -134,25 +136,26 @@
 ;; }
 ;;
 ;; function u0:2(i64 vmctx, i64, i32, i32, i32) tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
 ;; @004e                               trapz v2, user16
-;; @004e                               v50 = load.i64 notrap aligned readonly can_move v0+8
+;; @004e                               v50 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @004e                               v11 = load.i64 notrap aligned readonly can_move v50+32
 ;; @004e                               v10 = uextend.i64 v2
 ;; @004e                               v12 = iadd v11, v10
 ;; @004e                               v13 = iconst.i64 16
 ;; @004e                               v14 = iadd v12, v13  ; v13 = 16
-;; @004e                               v15 = load.i32 user2 readonly region0 v14
+;; @004e                               v15 = load.i32 user2 readonly region1 v14
 ;; @004e                               v17 = uextend.i64 v3
 ;; @004e                               v18 = uextend.i64 v4
 ;; @004e                               v21 = iadd v17, v18
@@ -179,7 +182,7 @@
 ;;
 ;;                                 block2(v46: i64):
 ;;                                     v65 = iconst.i32 -1
-;; @004e                               store user2 little region0 v65, v46  ; v65 = -1
+;; @004e                               store user2 little region1 v65, v46  ; v65 = -1
 ;;                                     v66 = iconst.i64 4
 ;;                                     v67 = iadd v46, v66  ; v66 = 4
 ;; @004e                               v49 = icmp eq v67, v43

--- a/tests/disas/array-fill-externref.wat
+++ b/tests/disas/array-fill-externref.wat
@@ -14,25 +14,26 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32, i32, i32) tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):
 ;; @002f                               trapz v2, user16
-;; @002f                               v46 = load.i64 notrap aligned readonly can_move v0+8
+;; @002f                               v46 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @002f                               v7 = load.i64 notrap aligned readonly can_move v46+32
 ;; @002f                               v6 = uextend.i64 v2
 ;; @002f                               v8 = iadd v7, v6
 ;; @002f                               v9 = iconst.i64 16
 ;; @002f                               v10 = iadd v8, v9  ; v9 = 16
-;; @002f                               v11 = load.i32 user2 readonly region0 v10
+;; @002f                               v11 = load.i32 user2 readonly region1 v10
 ;; @002f                               v13 = uextend.i64 v3
 ;; @002f                               v14 = uextend.i64 v5
 ;; @002f                               v17 = iadd v13, v14
@@ -57,7 +58,7 @@
 ;; @002f                               brif v41, block3, block2(v28)
 ;;
 ;;                                 block2(v42: i64):
-;; @002f                               store.i32 user2 little region0 v4, v42
+;; @002f                               store.i32 user2 little region1 v4, v42
 ;;                                     v55 = iconst.i64 4
 ;;                                     v56 = iadd v42, v55  ; v55 = 4
 ;; @002f                               v45 = icmp eq v56, v39
@@ -71,25 +72,26 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32, i32, i32) tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
 ;; @003d                               trapz v2, user16
-;; @003d                               v46 = load.i64 notrap aligned readonly can_move v0+8
+;; @003d                               v46 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @003d                               v7 = load.i64 notrap aligned readonly can_move v46+32
 ;; @003d                               v6 = uextend.i64 v2
 ;; @003d                               v8 = iadd v7, v6
 ;; @003d                               v9 = iconst.i64 16
 ;; @003d                               v10 = iadd v8, v9  ; v9 = 16
-;; @003d                               v11 = load.i32 user2 readonly region0 v10
+;; @003d                               v11 = load.i32 user2 readonly region1 v10
 ;; @003d                               v13 = uextend.i64 v3
 ;; @003d                               v14 = uextend.i64 v4
 ;; @003d                               v17 = iadd v13, v14
@@ -116,7 +118,7 @@
 ;;
 ;;                                 block2(v42: i64):
 ;;                                     v55 = iconst.i32 0
-;; @003d                               store user2 little region0 v55, v42  ; v55 = 0
+;; @003d                               store user2 little region1 v55, v42  ; v55 = 0
 ;;                                     v56 = iconst.i64 4
 ;;                                     v57 = iadd v42, v56  ; v56 = 4
 ;; @003d                               v45 = icmp eq v57, v39

--- a/tests/disas/array-fill-f32.wat
+++ b/tests/disas/array-fill-f32.wat
@@ -18,25 +18,26 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32, f32, i32) tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: f32, v5: i32):
 ;; @0030                               trapz v2, user16
-;; @0030                               v46 = load.i64 notrap aligned readonly can_move v0+8
+;; @0030                               v46 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @0030                               v7 = load.i64 notrap aligned readonly can_move v46+32
 ;; @0030                               v6 = uextend.i64 v2
 ;; @0030                               v8 = iadd v7, v6
 ;; @0030                               v9 = iconst.i64 16
 ;; @0030                               v10 = iadd v8, v9  ; v9 = 16
-;; @0030                               v11 = load.i32 user2 readonly region0 v10
+;; @0030                               v11 = load.i32 user2 readonly region1 v10
 ;; @0030                               v13 = uextend.i64 v3
 ;; @0030                               v14 = uextend.i64 v5
 ;; @0030                               v17 = iadd v13, v14
@@ -61,7 +62,7 @@
 ;; @0030                               brif v41, block3, block2(v28)
 ;;
 ;;                                 block2(v42: i64):
-;; @0030                               store.f32 user2 little region0 v4, v42
+;; @0030                               store.f32 user2 little region1 v4, v42
 ;;                                     v55 = iconst.i64 4
 ;;                                     v56 = iadd v42, v55  ; v55 = 4
 ;; @0030                               v45 = icmp eq v56, v39
@@ -75,12 +76,13 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32, i32, i32) tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i64, i32, i64) tail
@@ -89,13 +91,13 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
 ;; @0041                               trapz v2, user16
-;; @0041                               v40 = load.i64 notrap aligned readonly can_move v0+8
+;; @0041                               v40 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @0041                               v7 = load.i64 notrap aligned readonly can_move v40+32
 ;; @0041                               v6 = uextend.i64 v2
 ;; @0041                               v8 = iadd v7, v6
 ;; @0041                               v9 = iconst.i64 16
 ;; @0041                               v10 = iadd v8, v9  ; v9 = 16
-;; @0041                               v11 = load.i32 user2 readonly region0 v10
+;; @0041                               v11 = load.i32 user2 readonly region1 v10
 ;; @0041                               v13 = uextend.i64 v3
 ;; @0041                               v14 = uextend.i64 v4
 ;; @0041                               v17 = iadd v13, v14
@@ -122,25 +124,26 @@
 ;; }
 ;;
 ;; function u0:2(i64 vmctx, i64, i32, i32, i32) tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
 ;; @0052                               trapz v2, user16
-;; @0052                               v46 = load.i64 notrap aligned readonly can_move v0+8
+;; @0052                               v46 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @0052                               v7 = load.i64 notrap aligned readonly can_move v46+32
 ;; @0052                               v6 = uextend.i64 v2
 ;; @0052                               v8 = iadd v7, v6
 ;; @0052                               v9 = iconst.i64 16
 ;; @0052                               v10 = iadd v8, v9  ; v9 = 16
-;; @0052                               v11 = load.i32 user2 readonly region0 v10
+;; @0052                               v11 = load.i32 user2 readonly region1 v10
 ;; @0052                               v13 = uextend.i64 v3
 ;; @0052                               v14 = uextend.i64 v4
 ;; @0052                               v17 = iadd v13, v14
@@ -167,7 +170,7 @@
 ;;
 ;;                                 block2(v42: i64):
 ;;                                     v55 = f32const 0x1.000000p0
-;; @0052                               store user2 little region0 v55, v42  ; v55 = 0x1.000000p0
+;; @0052                               store user2 little region1 v55, v42  ; v55 = 0x1.000000p0
 ;;                                     v56 = iconst.i64 4
 ;;                                     v57 = iadd v42, v56  ; v56 = 4
 ;; @0052                               v45 = icmp eq v57, v39

--- a/tests/disas/array-fill-f64.wat
+++ b/tests/disas/array-fill-f64.wat
@@ -18,25 +18,26 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32, f64, i32) tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: f64, v5: i32):
 ;; @0030                               trapz v2, user16
-;; @0030                               v46 = load.i64 notrap aligned readonly can_move v0+8
+;; @0030                               v46 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @0030                               v7 = load.i64 notrap aligned readonly can_move v46+32
 ;; @0030                               v6 = uextend.i64 v2
 ;; @0030                               v8 = iadd v7, v6
 ;; @0030                               v9 = iconst.i64 16
 ;; @0030                               v10 = iadd v8, v9  ; v9 = 16
-;; @0030                               v11 = load.i32 user2 readonly region0 v10
+;; @0030                               v11 = load.i32 user2 readonly region1 v10
 ;; @0030                               v13 = uextend.i64 v3
 ;; @0030                               v14 = uextend.i64 v5
 ;; @0030                               v17 = iadd v13, v14
@@ -61,7 +62,7 @@
 ;; @0030                               brif v41, block3, block2(v28)
 ;;
 ;;                                 block2(v42: i64):
-;; @0030                               store.f64 user2 little region0 v4, v42
+;; @0030                               store.f64 user2 little region1 v4, v42
 ;;                                     v55 = iconst.i64 8
 ;;                                     v56 = iadd v42, v55  ; v55 = 8
 ;; @0030                               v45 = icmp eq v56, v39
@@ -75,12 +76,13 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32, i32, i32) tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i64, i32, i64) tail
@@ -89,13 +91,13 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
 ;; @0045                               trapz v2, user16
-;; @0045                               v40 = load.i64 notrap aligned readonly can_move v0+8
+;; @0045                               v40 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @0045                               v7 = load.i64 notrap aligned readonly can_move v40+32
 ;; @0045                               v6 = uextend.i64 v2
 ;; @0045                               v8 = iadd v7, v6
 ;; @0045                               v9 = iconst.i64 16
 ;; @0045                               v10 = iadd v8, v9  ; v9 = 16
-;; @0045                               v11 = load.i32 user2 readonly region0 v10
+;; @0045                               v11 = load.i32 user2 readonly region1 v10
 ;; @0045                               v13 = uextend.i64 v3
 ;; @0045                               v14 = uextend.i64 v4
 ;; @0045                               v17 = iadd v13, v14
@@ -122,25 +124,26 @@
 ;; }
 ;;
 ;; function u0:2(i64 vmctx, i64, i32, i32, i32) tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
 ;; @005a                               trapz v2, user16
-;; @005a                               v46 = load.i64 notrap aligned readonly can_move v0+8
+;; @005a                               v46 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @005a                               v7 = load.i64 notrap aligned readonly can_move v46+32
 ;; @005a                               v6 = uextend.i64 v2
 ;; @005a                               v8 = iadd v7, v6
 ;; @005a                               v9 = iconst.i64 16
 ;; @005a                               v10 = iadd v8, v9  ; v9 = 16
-;; @005a                               v11 = load.i32 user2 readonly region0 v10
+;; @005a                               v11 = load.i32 user2 readonly region1 v10
 ;; @005a                               v13 = uextend.i64 v3
 ;; @005a                               v14 = uextend.i64 v4
 ;; @005a                               v17 = iadd v13, v14
@@ -167,7 +170,7 @@
 ;;
 ;;                                 block2(v42: i64):
 ;;                                     v55 = f64const 0x1.0000000000000p0
-;; @005a                               store user2 little region0 v55, v42  ; v55 = 0x1.0000000000000p0
+;; @005a                               store user2 little region1 v55, v42  ; v55 = 0x1.0000000000000p0
 ;;                                     v56 = iconst.i64 8
 ;;                                     v57 = iadd v42, v56  ; v56 = 8
 ;; @005a                               v45 = icmp eq v57, v39

--- a/tests/disas/array-fill-funcref.wat
+++ b/tests/disas/array-fill-funcref.wat
@@ -21,12 +21,13 @@
   (elem declare func $hi)
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32, i64, i32) tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i64) -> i64 tail
@@ -35,13 +36,13 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i64, v5: i32):
 ;; @003b                               trapz v2, user16
-;; @003b                               v48 = load.i64 notrap aligned readonly can_move v0+8
+;; @003b                               v48 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @003b                               v7 = load.i64 notrap aligned readonly can_move v48+32
 ;; @003b                               v6 = uextend.i64 v2
 ;; @003b                               v8 = iadd v7, v6
 ;; @003b                               v9 = iconst.i64 16
 ;; @003b                               v10 = iadd v8, v9  ; v9 = 16
-;; @003b                               v11 = load.i32 user2 readonly region0 v10
+;; @003b                               v11 = load.i32 user2 readonly region1 v10
 ;; @003b                               v13 = uextend.i64 v3
 ;; @003b                               v14 = uextend.i64 v5
 ;; @003b                               v17 = iadd v13, v14
@@ -82,12 +83,13 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32, i32, i32) tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i64) -> i64 tail
@@ -96,13 +98,13 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
 ;; @0049                               trapz v2, user16
-;; @0049                               v48 = load.i64 notrap aligned readonly can_move v0+8
+;; @0049                               v48 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @0049                               v7 = load.i64 notrap aligned readonly can_move v48+32
 ;; @0049                               v6 = uextend.i64 v2
 ;; @0049                               v8 = iadd v7, v6
 ;; @0049                               v9 = iconst.i64 16
 ;; @0049                               v10 = iadd v8, v9  ; v9 = 16
-;; @0049                               v11 = load.i32 user2 readonly region0 v10
+;; @0049                               v11 = load.i32 user2 readonly region1 v10
 ;; @0049                               v13 = uextend.i64 v3
 ;; @0049                               v14 = uextend.i64 v4
 ;; @0049                               v17 = iadd v13, v14
@@ -144,12 +146,13 @@
 ;;
 ;; function u0:2(i64 vmctx, i64, i32, i32, i32) tail {
 ;;     ss0 = explicit_slot 4, align = 4
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32) -> i64 tail
@@ -165,13 +168,13 @@
 ;; @0053                               v6 = call fn0(v0, v5), stack_map=[i32 @ ss0+0]  ; v5 = 3
 ;;                                     v54 = load.i32 notrap v55
 ;; @0057                               trapz v54, user16
-;; @0057                               v56 = load.i64 notrap aligned readonly can_move v0+8
+;; @0057                               v56 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @0057                               v8 = load.i64 notrap aligned readonly can_move v56+32
 ;; @0057                               v7 = uextend.i64 v54
 ;; @0057                               v9 = iadd v8, v7
 ;; @0057                               v10 = iconst.i64 16
 ;; @0057                               v11 = iadd v9, v10  ; v10 = 16
-;; @0057                               v12 = load.i32 user2 readonly region0 v11
+;; @0057                               v12 = load.i32 user2 readonly region1 v11
 ;; @0057                               v14 = uextend.i64 v3
 ;; @0057                               v15 = uextend.i64 v4
 ;; @0057                               v18 = iadd v14, v15
@@ -212,8 +215,9 @@
 ;; }
 ;;
 ;; function u0:3(i64 vmctx, i64) tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     stack_limit = gv2
 ;;

--- a/tests/disas/array-fill-i16.wat
+++ b/tests/disas/array-fill-i16.wat
@@ -22,25 +22,26 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32, i32, i32) tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):
 ;; @0031                               trapz v2, user16
-;; @0031                               v46 = load.i64 notrap aligned readonly can_move v0+8
+;; @0031                               v46 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @0031                               v7 = load.i64 notrap aligned readonly can_move v46+32
 ;; @0031                               v6 = uextend.i64 v2
 ;; @0031                               v8 = iadd v7, v6
 ;; @0031                               v9 = iconst.i64 16
 ;; @0031                               v10 = iadd v8, v9  ; v9 = 16
-;; @0031                               v11 = load.i32 user2 readonly region0 v10
+;; @0031                               v11 = load.i32 user2 readonly region1 v10
 ;; @0031                               v13 = uextend.i64 v3
 ;; @0031                               v14 = uextend.i64 v5
 ;; @0031                               v17 = iadd v13, v14
@@ -65,7 +66,7 @@
 ;; @0031                               brif v41, block3, block2(v28)
 ;;
 ;;                                 block2(v42: i64):
-;; @0031                               istore16.i32 user2 little region0 v4, v42
+;; @0031                               istore16.i32 user2 little region1 v4, v42
 ;;                                     v58 = iconst.i64 2
 ;;                                     v59 = iadd v42, v58  ; v58 = 2
 ;; @0031                               v45 = icmp eq v59, v39
@@ -79,12 +80,13 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32, i32, i32) tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i64, i32, i64) tail
@@ -93,13 +95,13 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
 ;; @003f                               trapz v2, user16
-;; @003f                               v40 = load.i64 notrap aligned readonly can_move v0+8
+;; @003f                               v40 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @003f                               v7 = load.i64 notrap aligned readonly can_move v40+32
 ;; @003f                               v6 = uextend.i64 v2
 ;; @003f                               v8 = iadd v7, v6
 ;; @003f                               v9 = iconst.i64 16
 ;; @003f                               v10 = iadd v8, v9  ; v9 = 16
-;; @003f                               v11 = load.i32 user2 readonly region0 v10
+;; @003f                               v11 = load.i32 user2 readonly region1 v10
 ;; @003f                               v13 = uextend.i64 v3
 ;; @003f                               v14 = uextend.i64 v4
 ;; @003f                               v17 = iadd v13, v14
@@ -126,12 +128,13 @@
 ;; }
 ;;
 ;; function u0:2(i64 vmctx, i64, i32, i32, i32) tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i64, i32, i64) tail
@@ -140,13 +143,13 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
 ;; @004d                               trapz v2, user16
-;; @004d                               v40 = load.i64 notrap aligned readonly can_move v0+8
+;; @004d                               v40 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @004d                               v7 = load.i64 notrap aligned readonly can_move v40+32
 ;; @004d                               v6 = uextend.i64 v2
 ;; @004d                               v8 = iadd v7, v6
 ;; @004d                               v9 = iconst.i64 16
 ;; @004d                               v10 = iadd v8, v9  ; v9 = 16
-;; @004d                               v11 = load.i32 user2 readonly region0 v10
+;; @004d                               v11 = load.i32 user2 readonly region1 v10
 ;; @004d                               v13 = uextend.i64 v3
 ;; @004d                               v14 = uextend.i64 v4
 ;; @004d                               v17 = iadd v13, v14
@@ -173,25 +176,26 @@
 ;; }
 ;;
 ;; function u0:3(i64 vmctx, i64, i32, i32, i32) tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
 ;; @005d                               trapz v2, user16
-;; @005d                               v46 = load.i64 notrap aligned readonly can_move v0+8
+;; @005d                               v46 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @005d                               v7 = load.i64 notrap aligned readonly can_move v46+32
 ;; @005d                               v6 = uextend.i64 v2
 ;; @005d                               v8 = iadd v7, v6
 ;; @005d                               v9 = iconst.i64 16
 ;; @005d                               v10 = iadd v8, v9  ; v9 = 16
-;; @005d                               v11 = load.i32 user2 readonly region0 v10
+;; @005d                               v11 = load.i32 user2 readonly region1 v10
 ;; @005d                               v13 = uextend.i64 v3
 ;; @005d                               v14 = uextend.i64 v4
 ;; @005d                               v17 = iadd v13, v14
@@ -218,7 +222,7 @@
 ;;
 ;;                                 block2(v42: i64):
 ;;                                     v58 = iconst.i32 0xdead
-;; @005d                               istore16 user2 little region0 v58, v42  ; v58 = 0xdead
+;; @005d                               istore16 user2 little region1 v58, v42  ; v58 = 0xdead
 ;;                                     v59 = iconst.i64 2
 ;;                                     v60 = iadd v42, v59  ; v59 = 2
 ;; @005d                               v45 = icmp eq v60, v39

--- a/tests/disas/array-fill-i31ref.wat
+++ b/tests/disas/array-fill-i31ref.wat
@@ -18,25 +18,26 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32, i32, i32) tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):
 ;; @0030                               trapz v2, user16
-;; @0030                               v46 = load.i64 notrap aligned readonly can_move v0+8
+;; @0030                               v46 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @0030                               v7 = load.i64 notrap aligned readonly can_move v46+32
 ;; @0030                               v6 = uextend.i64 v2
 ;; @0030                               v8 = iadd v7, v6
 ;; @0030                               v9 = iconst.i64 16
 ;; @0030                               v10 = iadd v8, v9  ; v9 = 16
-;; @0030                               v11 = load.i32 user2 readonly region0 v10
+;; @0030                               v11 = load.i32 user2 readonly region1 v10
 ;; @0030                               v13 = uextend.i64 v3
 ;; @0030                               v14 = uextend.i64 v5
 ;; @0030                               v17 = iadd v13, v14
@@ -61,7 +62,7 @@
 ;; @0030                               brif v41, block3, block2(v28)
 ;;
 ;;                                 block2(v42: i64):
-;; @0030                               store.i32 user2 little region0 v4, v42
+;; @0030                               store.i32 user2 little region1 v4, v42
 ;;                                     v55 = iconst.i64 4
 ;;                                     v56 = iadd v42, v55  ; v55 = 4
 ;; @0030                               v45 = icmp eq v56, v39
@@ -75,25 +76,26 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32, i32, i32) tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
 ;; @003e                               trapz v2, user16
-;; @003e                               v46 = load.i64 notrap aligned readonly can_move v0+8
+;; @003e                               v46 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @003e                               v7 = load.i64 notrap aligned readonly can_move v46+32
 ;; @003e                               v6 = uextend.i64 v2
 ;; @003e                               v8 = iadd v7, v6
 ;; @003e                               v9 = iconst.i64 16
 ;; @003e                               v10 = iadd v8, v9  ; v9 = 16
-;; @003e                               v11 = load.i32 user2 readonly region0 v10
+;; @003e                               v11 = load.i32 user2 readonly region1 v10
 ;; @003e                               v13 = uextend.i64 v3
 ;; @003e                               v14 = uextend.i64 v4
 ;; @003e                               v17 = iadd v13, v14
@@ -120,7 +122,7 @@
 ;;
 ;;                                 block2(v42: i64):
 ;;                                     v55 = iconst.i32 0
-;; @003e                               store user2 little region0 v55, v42  ; v55 = 0
+;; @003e                               store user2 little region1 v55, v42  ; v55 = 0
 ;;                                     v56 = iconst.i64 4
 ;;                                     v57 = iadd v42, v56  ; v56 = 4
 ;; @003e                               v45 = icmp eq v57, v39
@@ -134,25 +136,26 @@
 ;; }
 ;;
 ;; function u0:2(i64 vmctx, i64, i32, i32, i32) tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
 ;; @004e                               trapz v2, user16
-;; @004e                               v50 = load.i64 notrap aligned readonly can_move v0+8
+;; @004e                               v50 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @004e                               v11 = load.i64 notrap aligned readonly can_move v50+32
 ;; @004e                               v10 = uextend.i64 v2
 ;; @004e                               v12 = iadd v11, v10
 ;; @004e                               v13 = iconst.i64 16
 ;; @004e                               v14 = iadd v12, v13  ; v13 = 16
-;; @004e                               v15 = load.i32 user2 readonly region0 v14
+;; @004e                               v15 = load.i32 user2 readonly region1 v14
 ;; @004e                               v17 = uextend.i64 v3
 ;; @004e                               v18 = uextend.i64 v4
 ;; @004e                               v21 = iadd v17, v18
@@ -179,7 +182,7 @@
 ;;
 ;;                                 block2(v46: i64):
 ;;                                     v65 = iconst.i32 -1
-;; @004e                               store user2 little region0 v65, v46  ; v65 = -1
+;; @004e                               store user2 little region1 v65, v46  ; v65 = -1
 ;;                                     v66 = iconst.i64 4
 ;;                                     v67 = iadd v46, v66  ; v66 = 4
 ;; @004e                               v49 = icmp eq v67, v43

--- a/tests/disas/array-fill-i32.wat
+++ b/tests/disas/array-fill-i32.wat
@@ -22,25 +22,26 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32, i32, i32) tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):
 ;; @0031                               trapz v2, user16
-;; @0031                               v46 = load.i64 notrap aligned readonly can_move v0+8
+;; @0031                               v46 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @0031                               v7 = load.i64 notrap aligned readonly can_move v46+32
 ;; @0031                               v6 = uextend.i64 v2
 ;; @0031                               v8 = iadd v7, v6
 ;; @0031                               v9 = iconst.i64 16
 ;; @0031                               v10 = iadd v8, v9  ; v9 = 16
-;; @0031                               v11 = load.i32 user2 readonly region0 v10
+;; @0031                               v11 = load.i32 user2 readonly region1 v10
 ;; @0031                               v13 = uextend.i64 v3
 ;; @0031                               v14 = uextend.i64 v5
 ;; @0031                               v17 = iadd v13, v14
@@ -65,7 +66,7 @@
 ;; @0031                               brif v41, block3, block2(v28)
 ;;
 ;;                                 block2(v42: i64):
-;; @0031                               store.i32 user2 little region0 v4, v42
+;; @0031                               store.i32 user2 little region1 v4, v42
 ;;                                     v55 = iconst.i64 4
 ;;                                     v56 = iadd v42, v55  ; v55 = 4
 ;; @0031                               v45 = icmp eq v56, v39
@@ -79,12 +80,13 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32, i32, i32) tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i64, i32, i64) tail
@@ -93,13 +95,13 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
 ;; @003f                               trapz v2, user16
-;; @003f                               v40 = load.i64 notrap aligned readonly can_move v0+8
+;; @003f                               v40 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @003f                               v7 = load.i64 notrap aligned readonly can_move v40+32
 ;; @003f                               v6 = uextend.i64 v2
 ;; @003f                               v8 = iadd v7, v6
 ;; @003f                               v9 = iconst.i64 16
 ;; @003f                               v10 = iadd v8, v9  ; v9 = 16
-;; @003f                               v11 = load.i32 user2 readonly region0 v10
+;; @003f                               v11 = load.i32 user2 readonly region1 v10
 ;; @003f                               v13 = uextend.i64 v3
 ;; @003f                               v14 = uextend.i64 v4
 ;; @003f                               v17 = iadd v13, v14
@@ -126,12 +128,13 @@
 ;; }
 ;;
 ;; function u0:2(i64 vmctx, i64, i32, i32, i32) tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i64, i32, i64) tail
@@ -140,13 +143,13 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
 ;; @004d                               trapz v2, user16
-;; @004d                               v40 = load.i64 notrap aligned readonly can_move v0+8
+;; @004d                               v40 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @004d                               v7 = load.i64 notrap aligned readonly can_move v40+32
 ;; @004d                               v6 = uextend.i64 v2
 ;; @004d                               v8 = iadd v7, v6
 ;; @004d                               v9 = iconst.i64 16
 ;; @004d                               v10 = iadd v8, v9  ; v9 = 16
-;; @004d                               v11 = load.i32 user2 readonly region0 v10
+;; @004d                               v11 = load.i32 user2 readonly region1 v10
 ;; @004d                               v13 = uextend.i64 v3
 ;; @004d                               v14 = uextend.i64 v4
 ;; @004d                               v17 = iadd v13, v14
@@ -173,25 +176,26 @@
 ;; }
 ;;
 ;; function u0:3(i64 vmctx, i64, i32, i32, i32) tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
 ;; @005d                               trapz v2, user16
-;; @005d                               v46 = load.i64 notrap aligned readonly can_move v0+8
+;; @005d                               v46 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @005d                               v7 = load.i64 notrap aligned readonly can_move v46+32
 ;; @005d                               v6 = uextend.i64 v2
 ;; @005d                               v8 = iadd v7, v6
 ;; @005d                               v9 = iconst.i64 16
 ;; @005d                               v10 = iadd v8, v9  ; v9 = 16
-;; @005d                               v11 = load.i32 user2 readonly region0 v10
+;; @005d                               v11 = load.i32 user2 readonly region1 v10
 ;; @005d                               v13 = uextend.i64 v3
 ;; @005d                               v14 = uextend.i64 v4
 ;; @005d                               v17 = iadd v13, v14
@@ -218,7 +222,7 @@
 ;;
 ;;                                 block2(v42: i64):
 ;;                                     v55 = iconst.i32 0xdead
-;; @005d                               store user2 little region0 v55, v42  ; v55 = 0xdead
+;; @005d                               store user2 little region1 v55, v42  ; v55 = 0xdead
 ;;                                     v56 = iconst.i64 4
 ;;                                     v57 = iadd v42, v56  ; v56 = 4
 ;; @005d                               v45 = icmp eq v57, v39

--- a/tests/disas/array-fill-i64.wat
+++ b/tests/disas/array-fill-i64.wat
@@ -22,25 +22,26 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32, i64, i32) tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i64, v5: i32):
 ;; @0031                               trapz v2, user16
-;; @0031                               v46 = load.i64 notrap aligned readonly can_move v0+8
+;; @0031                               v46 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @0031                               v7 = load.i64 notrap aligned readonly can_move v46+32
 ;; @0031                               v6 = uextend.i64 v2
 ;; @0031                               v8 = iadd v7, v6
 ;; @0031                               v9 = iconst.i64 16
 ;; @0031                               v10 = iadd v8, v9  ; v9 = 16
-;; @0031                               v11 = load.i32 user2 readonly region0 v10
+;; @0031                               v11 = load.i32 user2 readonly region1 v10
 ;; @0031                               v13 = uextend.i64 v3
 ;; @0031                               v14 = uextend.i64 v5
 ;; @0031                               v17 = iadd v13, v14
@@ -65,7 +66,7 @@
 ;; @0031                               brif v41, block3, block2(v28)
 ;;
 ;;                                 block2(v42: i64):
-;; @0031                               store.i64 user2 little region0 v4, v42
+;; @0031                               store.i64 user2 little region1 v4, v42
 ;;                                     v55 = iconst.i64 8
 ;;                                     v56 = iadd v42, v55  ; v55 = 8
 ;; @0031                               v45 = icmp eq v56, v39
@@ -79,12 +80,13 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32, i32, i32) tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i64, i32, i64) tail
@@ -93,13 +95,13 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
 ;; @003f                               trapz v2, user16
-;; @003f                               v40 = load.i64 notrap aligned readonly can_move v0+8
+;; @003f                               v40 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @003f                               v7 = load.i64 notrap aligned readonly can_move v40+32
 ;; @003f                               v6 = uextend.i64 v2
 ;; @003f                               v8 = iadd v7, v6
 ;; @003f                               v9 = iconst.i64 16
 ;; @003f                               v10 = iadd v8, v9  ; v9 = 16
-;; @003f                               v11 = load.i32 user2 readonly region0 v10
+;; @003f                               v11 = load.i32 user2 readonly region1 v10
 ;; @003f                               v13 = uextend.i64 v3
 ;; @003f                               v14 = uextend.i64 v4
 ;; @003f                               v17 = iadd v13, v14
@@ -126,12 +128,13 @@
 ;; }
 ;;
 ;; function u0:2(i64 vmctx, i64, i32, i32, i32) tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i64, i32, i64) tail
@@ -140,13 +143,13 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
 ;; @004d                               trapz v2, user16
-;; @004d                               v40 = load.i64 notrap aligned readonly can_move v0+8
+;; @004d                               v40 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @004d                               v7 = load.i64 notrap aligned readonly can_move v40+32
 ;; @004d                               v6 = uextend.i64 v2
 ;; @004d                               v8 = iadd v7, v6
 ;; @004d                               v9 = iconst.i64 16
 ;; @004d                               v10 = iadd v8, v9  ; v9 = 16
-;; @004d                               v11 = load.i32 user2 readonly region0 v10
+;; @004d                               v11 = load.i32 user2 readonly region1 v10
 ;; @004d                               v13 = uextend.i64 v3
 ;; @004d                               v14 = uextend.i64 v4
 ;; @004d                               v17 = iadd v13, v14
@@ -173,25 +176,26 @@
 ;; }
 ;;
 ;; function u0:3(i64 vmctx, i64, i32, i32, i32) tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
 ;; @005b                               trapz v2, user16
-;; @005b                               v46 = load.i64 notrap aligned readonly can_move v0+8
+;; @005b                               v46 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @005b                               v7 = load.i64 notrap aligned readonly can_move v46+32
 ;; @005b                               v6 = uextend.i64 v2
 ;; @005b                               v8 = iadd v7, v6
 ;; @005b                               v9 = iconst.i64 16
 ;; @005b                               v10 = iadd v8, v9  ; v9 = 16
-;; @005b                               v11 = load.i32 user2 readonly region0 v10
+;; @005b                               v11 = load.i32 user2 readonly region1 v10
 ;; @005b                               v13 = uextend.i64 v3
 ;; @005b                               v14 = uextend.i64 v4
 ;; @005b                               v17 = iadd v13, v14
@@ -218,7 +222,7 @@
 ;;
 ;;                                 block2(v42: i64):
 ;;                                     v55 = iconst.i64 1
-;; @005b                               store user2 little region0 v55, v42  ; v55 = 1
+;; @005b                               store user2 little region1 v55, v42  ; v55 = 1
 ;;                                     v56 = iconst.i64 8
 ;;                                     v57 = iadd v42, v56  ; v56 = 8
 ;; @005b                               v45 = icmp eq v57, v39

--- a/tests/disas/basic-wat-test.wat
+++ b/tests/disas/basic-wat-test.wat
@@ -10,9 +10,10 @@
     i32.add))
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) -> i32 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -23,11 +24,11 @@
 ;; @0021                               v5 = uextend.i64 v2
 ;; @0021                               v6 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0021                               v7 = iadd v6, v5
-;; @0021                               v8 = load.i32 little region0 v7
+;; @0021                               v8 = load.i32 little region1 v7
 ;; @0026                               v9 = uextend.i64 v3
 ;; @0026                               v10 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0026                               v11 = iadd v10, v9
-;; @0026                               v12 = load.i32 little region0 v11
+;; @0026                               v12 = load.i32 little region1 v11
 ;; @0029                               v13 = iadd v8, v12
 ;; @002a                               jump block1
 ;;

--- a/tests/disas/bounds-check.wat
+++ b/tests/disas/bounds-check.wat
@@ -25,9 +25,10 @@
   (export "store" (func $store))
 )
 ;; function u0:0(i64 vmctx, i64, i32) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -39,17 +40,17 @@
 ;; @002c                               v5 = load.i64 notrap aligned readonly can_move v0+56
 ;; @002c                               v4 = uextend.i64 v2
 ;; @002c                               v6 = iadd v5, v4
-;; @002c                               istore8 little region0 v3, v6  ; v3 = 0
+;; @002c                               istore8 little region1 v3, v6  ; v3 = 0
 ;; @0033                               v11 = iconst.i64 0x07ff_ffff
 ;; @0033                               v12 = iadd v6, v11  ; v11 = 0x07ff_ffff
-;; @0033                               istore8 little region0 v3, v12  ; v3 = 0
+;; @0033                               istore8 little region1 v3, v12  ; v3 = 0
 ;; @003d                               v15 = load.i64 notrap aligned v0+64
 ;; @003d                               v16 = icmp ugt v4, v15
 ;; @003d                               v21 = iconst.i64 0
 ;; @003d                               v19 = iconst.i64 0xffff_ffff
 ;; @003d                               v20 = iadd v6, v19  ; v19 = 0xffff_ffff
 ;; @003d                               v22 = select_spectre_guard v16, v21, v20  ; v21 = 0
-;; @003d                               istore8 little region0 v3, v22  ; v3 = 0
+;; @003d                               istore8 little region1 v3, v22  ; v3 = 0
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/br_table.wat
+++ b/tests/disas/br_table.wat
@@ -32,8 +32,9 @@
 )
 
 ;; function u0:0(i64 vmctx, i64) -> i32 tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     stack_limit = gv2
 ;;
@@ -68,8 +69,9 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64) -> i32 tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     stack_limit = gv2
 ;;
@@ -104,8 +106,9 @@
 ;; }
 ;;
 ;; function u0:2(i64 vmctx, i64) -> i32 tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     stack_limit = gv2
 ;;
@@ -128,8 +131,9 @@
 ;; }
 ;;
 ;; function u0:3(i64 vmctx, i64) -> i32 tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     stack_limit = gv2
 ;;

--- a/tests/disas/branch-hinting-disabled.wat
+++ b/tests/disas/branch-hinting-disabled.wat
@@ -28,8 +28,9 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     stack_limit = gv2
 ;;
@@ -52,8 +53,9 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     stack_limit = gv2
 ;;

--- a/tests/disas/branch-hinting.wat
+++ b/tests/disas/branch-hinting.wat
@@ -73,8 +73,9 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     stack_limit = gv2
 ;;
@@ -94,8 +95,9 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     stack_limit = gv2
 ;;
@@ -115,8 +117,9 @@
 ;; }
 ;;
 ;; function u0:2(i64 vmctx, i64, i32) -> i32 tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     stack_limit = gv2
 ;;
@@ -139,8 +142,9 @@
 ;; }
 ;;
 ;; function u0:3(i64 vmctx, i64, i32) -> i32 tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     stack_limit = gv2
 ;;
@@ -163,9 +167,10 @@
 ;; }
 ;;
 ;; function u0:4(i64 vmctx, i64, i32) tail {
-;;     region0 = 1879048192 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 1879048192 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     stack_limit = gv2
@@ -175,12 +180,12 @@
 ;;
 ;;                                 block2:
 ;; @009b                               v3 = iconst.i32 1
-;; @009d                               store notrap aligned region0 v3, v0+48  ; v3 = 1
+;; @009d                               store notrap aligned region1 v3, v0+48  ; v3 = 1
 ;; @009f                               jump block3
 ;;
 ;;                                 block4 cold:
 ;; @00a0                               v5 = iconst.i32 2
-;; @00a2                               store notrap aligned region0 v5, v0+48  ; v5 = 2
+;; @00a2                               store notrap aligned region1 v5, v0+48  ; v5 = 2
 ;; @00a4                               jump block3
 ;;
 ;;                                 block3:

--- a/tests/disas/byteswap.wat
+++ b/tests/disas/byteswap.wat
@@ -72,8 +72,9 @@
 )
 
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     stack_limit = gv2
 ;;
@@ -86,8 +87,9 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i64 tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     stack_limit = gv2
 ;;

--- a/tests/disas/call-indirect-with-gc.wat
+++ b/tests/disas/call-indirect-with-gc.wat
@@ -10,9 +10,11 @@
 )
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) -> i32 tail {
-;;     region0 = 1073741824 "PublicTable"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 1073741824 "PublicTable"
+;;     region2 = 40 "VMContext+0x28"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+48
@@ -33,7 +35,7 @@
 ;; @0035                               v11 = ishl v8, v10  ; v10 = 3
 ;; @0035                               v12 = iadd v9, v11
 ;; @0035                               v14 = select_spectre_guard v7, v13, v12  ; v13 = 0
-;; @0035                               v15 = load.i64 user6 aligned region0 v14
+;; @0035                               v15 = load.i64 user6 aligned region1 v14
 ;; @0035                               v16 = iconst.i64 -2
 ;; @0035                               v17 = band v15, v16  ; v16 = -2
 ;; @0035                               brif v15, block3(v17), block2
@@ -45,7 +47,7 @@
 ;;
 ;;                                 block3(v18: i64):
 ;; @0035                               v24 = load.i32 user7 aligned readonly v18+16
-;; @0035                               v22 = load.i64 notrap aligned readonly can_move v0+40
+;; @0035                               v22 = load.i64 notrap aligned readonly can_move region2 v0+40
 ;; @0035                               v23 = load.i32 notrap aligned readonly can_move v22+4
 ;; @0035                               v25 = icmp eq v24, v23
 ;; @0035                               trapz v25, user8

--- a/tests/disas/call-indirect-without-gc.wat
+++ b/tests/disas/call-indirect-without-gc.wat
@@ -10,9 +10,11 @@
 )
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) -> i32 tail {
-;;     region0 = 1073741824 "PublicTable"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 1073741824 "PublicTable"
+;;     region2 = 40 "VMContext+0x28"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+48
@@ -33,7 +35,7 @@
 ;; @0035                               v11 = ishl v8, v10  ; v10 = 3
 ;; @0035                               v12 = iadd v9, v11
 ;; @0035                               v14 = select_spectre_guard v7, v13, v12  ; v13 = 0
-;; @0035                               v15 = load.i64 user6 aligned region0 v14
+;; @0035                               v15 = load.i64 user6 aligned region1 v14
 ;; @0035                               v16 = iconst.i64 -2
 ;; @0035                               v17 = band v15, v16  ; v16 = -2
 ;; @0035                               brif v15, block3(v17), block2
@@ -45,7 +47,7 @@
 ;;
 ;;                                 block3(v18: i64):
 ;; @0035                               v24 = load.i32 user7 aligned readonly v18+16
-;; @0035                               v22 = load.i64 notrap aligned readonly can_move v0+40
+;; @0035                               v22 = load.i64 notrap aligned readonly can_move region2 v0+40
 ;; @0035                               v23 = load.i32 notrap aligned readonly can_move v22+4
 ;; @0035                               v25 = icmp eq v24, v23
 ;; @0035                               trapz v25, user8

--- a/tests/disas/call-indirect.wat
+++ b/tests/disas/call-indirect.wat
@@ -8,9 +8,11 @@
 )
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) -> i32 tail {
-;;     region0 = 1073741824 "PublicTable"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 1073741824 "PublicTable"
+;;     region2 = 40 "VMContext+0x28"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+48
@@ -31,7 +33,7 @@
 ;; @0035                               v12 = iadd v9, v11
 ;; @0035                               v13 = iconst.i64 0
 ;; @0035                               v14 = select_spectre_guard v7, v13, v12  ; v13 = 0
-;; @0035                               v15 = load.i64 user6 aligned region0 v14
+;; @0035                               v15 = load.i64 user6 aligned region1 v14
 ;; @0035                               v16 = iconst.i64 -2
 ;; @0035                               v17 = band v15, v16  ; v16 = -2
 ;; @0035                               brif v15, block3(v17), block2
@@ -43,7 +45,7 @@
 ;; @0035                               jump block3(v21)
 ;;
 ;;                                 block3(v18: i64):
-;; @0035                               v22 = load.i64 notrap aligned readonly can_move v0+40
+;; @0035                               v22 = load.i64 notrap aligned readonly can_move region2 v0+40
 ;; @0035                               v23 = load.i32 notrap aligned readonly can_move v22+4
 ;; @0035                               v24 = load.i32 user7 aligned readonly v18+16
 ;; @0035                               v25 = icmp eq v24, v23

--- a/tests/disas/call-simd.wat
+++ b/tests/disas/call-simd.wat
@@ -16,8 +16,9 @@
 )
 
 ;; function u0:0(i64 vmctx, i64) tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     sig0 = (i64 vmctx, i64, i8x16, i8x16) -> i8x16 tail
 ;;     fn0 = colocated u0:1 sig0
@@ -35,8 +36,9 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i8x16, i8x16) -> i8x16 tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     stack_limit = gv2
 ;;

--- a/tests/disas/call.wat
+++ b/tests/disas/call.wat
@@ -12,8 +12,9 @@
 )
 
 ;; function u0:0(i64 vmctx, i64) tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     sig0 = (i64 vmctx, i64) -> i32 tail
 ;;     fn0 = colocated u0:1 sig0
@@ -30,8 +31,9 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64) -> i32 tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     stack_limit = gv2
 ;;

--- a/tests/disas/component-model/direct-adapter-calls-inlining.wat
+++ b/tests/disas/component-model/direct-adapter-calls-inlining.wat
@@ -55,19 +55,25 @@
 )
 
 ;; function u1:0(i64 vmctx, i64) -> i32 tail {
-;;     region0 = 1610612736 "PublicGlobal"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 72 "VMContext+0x48"
+;;     region2 = 136 "VMContext+0x88"
+;;     region3 = 112 "VMContext+0x70"
+;;     region4 = 1610612736 "PublicGlobal"
+;;     region5 = 104 "VMContext+0x68"
+;;     region6 = 88 "VMContext+0x58"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = vmctx
-;;     gv5 = load.i64 notrap aligned readonly gv4+8
+;;     gv5 = load.i64 notrap aligned readonly region0 gv4+8
 ;;     gv6 = load.i64 notrap aligned gv5+24
 ;;     gv7 = vmctx
-;;     gv8 = load.i64 notrap aligned readonly can_move gv7+136
-;;     gv9 = load.i64 notrap aligned readonly can_move gv7+112
+;;     gv8 = load.i64 notrap aligned readonly can_move region2 gv7+136
+;;     gv9 = load.i64 notrap aligned readonly can_move region3 gv7+112
 ;;     gv10 = vmctx
-;;     gv11 = load.i64 notrap aligned readonly gv10+8
+;;     gv11 = load.i64 notrap aligned readonly region0 gv10+8
 ;;     gv12 = load.i64 notrap aligned gv11+24
 ;;     sig0 = (i64 vmctx, i64, i32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i64, i32) tail
@@ -80,9 +86,9 @@
 ;; @00ee                               jump block2
 ;;
 ;;                                 block2:
-;; @00ee                               v5 = load.i64 notrap aligned readonly can_move v0+72
-;;                                     v12 = load.i64 notrap aligned readonly can_move v5+136
-;;                                     v13 = load.i32 notrap aligned region0 v12
+;; @00ee                               v5 = load.i64 notrap aligned readonly can_move region1 v0+72
+;;                                     v12 = load.i64 notrap aligned readonly can_move region2 v5+136
+;;                                     v13 = load.i32 notrap aligned region4 v12
 ;;                                     v14 = iconst.i32 1
 ;;                                     v15 = band v13, v14  ; v14 = 1
 ;;                                     v11 = iconst.i32 0
@@ -90,21 +96,21 @@
 ;;                                     brif v17, block4, block5
 ;;
 ;;                                 block4:
-;;                                     v21 = load.i64 notrap aligned readonly can_move v5+88
-;;                                     v20 = load.i64 notrap aligned readonly can_move v5+104
+;;                                     v21 = load.i64 notrap aligned readonly can_move region6 v5+88
+;;                                     v20 = load.i64 notrap aligned readonly can_move region5 v5+104
 ;;                                     v19 = iconst.i32 23
 ;;                                     call_indirect sig1, v21(v20, v5, v19)  ; v19 = 23
 ;;                                     trap user12
 ;;
 ;;                                 block5:
-;;                                     v22 = load.i64 notrap aligned readonly can_move v5+112
-;;                                     v23 = load.i32 notrap aligned region0 v22
+;;                                     v22 = load.i64 notrap aligned readonly can_move region3 v5+112
+;;                                     v23 = load.i32 notrap aligned region4 v22
 ;;                                     v24 = iconst.i32 -2
 ;;                                     v25 = band v23, v24  ; v24 = -2
-;;                                     store notrap aligned region0 v25, v22
+;;                                     store notrap aligned region4 v25, v22
 ;;                                     v55 = iconst.i32 1
 ;;                                     v56 = bor v23, v55  ; v55 = 1
-;;                                     store notrap aligned region0 v56, v22
+;;                                     store notrap aligned region4 v56, v22
 ;;                                     jump block6
 ;;
 ;;                                 block6:
@@ -114,13 +120,13 @@
 ;;                                     jump block8
 ;;
 ;;                                 block8:
-;;                                     v36 = load.i32 notrap aligned region0 v12
+;;                                     v36 = load.i32 notrap aligned region4 v12
 ;;                                     v57 = iconst.i32 -2
 ;;                                     v58 = band v36, v57  ; v57 = -2
-;;                                     store notrap aligned region0 v58, v12
+;;                                     store notrap aligned region4 v58, v12
 ;;                                     v59 = iconst.i32 1
 ;;                                     v60 = bor v36, v59  ; v59 = 1
-;;                                     store notrap aligned region0 v60, v12
+;;                                     store notrap aligned region4 v60, v12
 ;;                                     jump block3
 ;;
 ;;                                 block3:

--- a/tests/disas/component-model/direct-adapter-calls.wat
+++ b/tests/disas/component-model/direct-adapter-calls.wat
@@ -58,8 +58,9 @@
 )
 
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     stack_limit = gv2
 ;;
@@ -73,8 +74,10 @@
 ;; }
 ;;
 ;; function u1:0(i64 vmctx, i64) -> i32 tail {
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 72 "VMContext+0x48"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, i64, i32) -> i32 tail
@@ -82,7 +85,7 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @00ee                               v5 = load.i64 notrap aligned readonly can_move v0+72
+;; @00ee                               v5 = load.i64 notrap aligned readonly can_move region1 v0+72
 ;; @00eb                               v3 = iconst.i32 1234
 ;; @00ee                               v6 = call fn0(v5, v0, v3)  ; v3 = 1234
 ;; @00f0                               jump block1
@@ -92,21 +95,27 @@
 ;; }
 ;;
 ;; function u2:0(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 1610612736 "PublicGlobal"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 136 "VMContext+0x88"
+;;     region2 = 1610612736 "PublicGlobal"
+;;     region3 = 104 "VMContext+0x68"
+;;     region4 = 88 "VMContext+0x58"
+;;     region5 = 112 "VMContext+0x70"
+;;     region6 = 72 "VMContext+0x48"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+136
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+112
+;;     gv4 = load.i64 notrap aligned readonly can_move region1 gv3+136
+;;     gv5 = load.i64 notrap aligned readonly can_move region5 gv3+112
 ;;     sig0 = (i64 vmctx, i64, i32) tail
 ;;     sig1 = (i64 vmctx, i64, i32) -> i32 tail
 ;;     fn0 = colocated u0:0 sig1
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0077                               v5 = load.i64 notrap aligned readonly can_move v0+136
-;; @0077                               v6 = load.i32 notrap aligned region0 v5
+;; @0077                               v5 = load.i64 notrap aligned readonly can_move region1 v0+136
+;; @0077                               v6 = load.i32 notrap aligned region2 v5
 ;; @0079                               v7 = iconst.i32 1
 ;; @007b                               v8 = band v6, v7  ; v7 = 1
 ;; @0075                               v4 = iconst.i32 0
@@ -114,28 +123,28 @@
 ;; @007d                               brif v10, block2, block3
 ;;
 ;;                                 block2:
-;; @0081                               v15 = load.i64 notrap aligned readonly can_move v0+88
-;; @0081                               v14 = load.i64 notrap aligned readonly can_move v0+104
+;; @0081                               v15 = load.i64 notrap aligned readonly can_move region4 v0+88
+;; @0081                               v14 = load.i64 notrap aligned readonly can_move region3 v0+104
 ;; @007f                               v12 = iconst.i32 23
 ;; @0081                               call_indirect sig0, v15(v14, v0, v12)  ; v12 = 23
 ;; @0083                               trap user12
 ;;
 ;;                                 block3:
-;; @0085                               v16 = load.i64 notrap aligned readonly can_move v0+112
-;; @0085                               v17 = load.i32 notrap aligned region0 v16
+;; @0085                               v16 = load.i64 notrap aligned readonly can_move region5 v0+112
+;; @0085                               v17 = load.i32 notrap aligned region2 v16
 ;; @0087                               v18 = iconst.i32 -2
 ;; @0089                               v19 = band v17, v18  ; v18 = -2
-;; @008a                               store notrap aligned region0 v19, v16
+;; @008a                               store notrap aligned region2 v19, v16
 ;;                                     v52 = iconst.i32 1
 ;;                                     v53 = bor v17, v52  ; v52 = 1
-;; @0093                               store notrap aligned region0 v53, v16
-;; @0095                               v27 = load.i64 notrap aligned readonly can_move v0+72
+;; @0093                               store notrap aligned region2 v53, v16
+;; @0095                               v27 = load.i64 notrap aligned readonly can_move region6 v0+72
 ;; @0095                               v28 = call fn0(v27, v0, v2)
-;; @0099                               v30 = load.i32 notrap aligned region0 v5
+;; @0099                               v30 = load.i32 notrap aligned region2 v5
 ;; @009d                               v32 = band v30, v18  ; v18 = -2
-;; @009e                               store notrap aligned region0 v32, v5
+;; @009e                               store notrap aligned region2 v32, v5
 ;;                                     v54 = bor v30, v52  ; v52 = 1
-;; @00a7                               store notrap aligned region0 v54, v5
+;; @00a7                               store notrap aligned region2 v54, v5
 ;; @00a9                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/component-model/exported-module-makes-adapters-indirect.wat
+++ b/tests/disas/component-model/exported-module-makes-adapters-indirect.wat
@@ -59,16 +59,19 @@
 )
 
 ;; function u1:0(i64 vmctx, i64) -> i32 tail {
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 72 "VMContext+0x48"
+;;     region2 = 56 "VMContext+0x38"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, i64, i32) -> i32 tail
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @00ee                               v6 = load.i64 notrap aligned readonly can_move v0+56
-;; @00ee                               v5 = load.i64 notrap aligned readonly can_move v0+72
+;; @00ee                               v6 = load.i64 notrap aligned readonly can_move region2 v0+56
+;; @00ee                               v5 = load.i64 notrap aligned readonly can_move region1 v0+72
 ;; @00eb                               v3 = iconst.i32 1234
 ;; @00ee                               v7 = call_indirect sig0, v6(v5, v0, v3)  ; v3 = 1234
 ;; @00f0                               jump block1

--- a/tests/disas/component-model/inlining-and-unsafe-intrinsics.wat
+++ b/tests/disas/component-model/inlining-and-unsafe-intrinsics.wat
@@ -43,9 +43,13 @@
 )
 
 ;; function u0:0(i64 vmctx, i64) tail {
-;;     region0 = 2 "vmctx"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 72 "VMContext+0x48"
+;;     region2 = 2 "vmctx"
+;;     region3 = 104 "VMContext+0x68"
+;;     region4 = 136 "VMContext+0x88"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, i64) -> i64 tail
@@ -57,8 +61,8 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @0153                               v5 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0153                               v6 = load.i64 notrap aligned readonly can_move region0 v5+104
+;; @0153                               v5 = load.i64 notrap aligned readonly can_move region2 v0+8
+;; @0153                               v6 = load.i64 notrap aligned readonly can_move region2 v5+104
 ;; @0155                               v9 = load.i8 notrap aligned v6
 ;;                                     v22 = iconst.i8 1
 ;;                                     v23 = iadd v9, v22  ; v22 = 1

--- a/tests/disas/component-model/inlining-bug.wat
+++ b/tests/disas/component-model/inlining-bug.wat
@@ -35,16 +35,19 @@
 )
 
 ;; function u2:0(i64 vmctx, i64) -> i32 tail {
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 72 "VMContext+0x48"
+;;     region2 = 104 "VMContext+0x68"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = vmctx
-;;     gv5 = load.i64 notrap aligned readonly gv4+8
+;;     gv5 = load.i64 notrap aligned readonly region0 gv4+8
 ;;     gv6 = load.i64 notrap aligned gv5+24
 ;;     gv7 = vmctx
 ;;     gv8 = vmctx
-;;     gv9 = load.i64 notrap aligned readonly gv8+8
+;;     gv9 = load.i64 notrap aligned readonly region0 gv8+8
 ;;     gv10 = load.i64 notrap aligned gv9+24
 ;;     sig0 = (i64 vmctx, i64) -> i32 tail
 ;;     sig1 = (i64 vmctx, i64) -> i32 tail
@@ -61,8 +64,8 @@
 ;;                                     jump block4
 ;;
 ;;                                 block4:
-;; @00d4                               v4 = load.i64 notrap aligned readonly can_move v0+72
-;;                                     v10 = load.i64 notrap aligned readonly can_move v4+104
+;; @00d4                               v4 = load.i64 notrap aligned readonly can_move region1 v0+72
+;;                                     v10 = load.i64 notrap aligned readonly can_move region2 v4+104
 ;;                                     call fn2(v10, v10)
 ;;                                     jump block5
 ;;

--- a/tests/disas/component-model/inlining-fuzz-bug.wat
+++ b/tests/disas/component-model/inlining-fuzz-bug.wat
@@ -38,19 +38,22 @@
 )
 
 ;; function u2:0(i64 vmctx, i64) -> i32 tail {
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 72 "VMContext+0x48"
+;;     region2 = 104 "VMContext+0x68"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = vmctx
-;;     gv5 = load.i64 notrap aligned readonly gv4+8
+;;     gv5 = load.i64 notrap aligned readonly region0 gv4+8
 ;;     gv6 = load.i64 notrap aligned gv5+24
 ;;     gv7 = vmctx
 ;;     gv8 = vmctx
-;;     gv9 = load.i64 notrap aligned readonly gv8+8
+;;     gv9 = load.i64 notrap aligned readonly region0 gv8+8
 ;;     gv10 = load.i64 notrap aligned gv9+24
 ;;     gv11 = vmctx
-;;     gv12 = load.i64 notrap aligned readonly gv11+8
+;;     gv12 = load.i64 notrap aligned readonly region0 gv11+8
 ;;     gv13 = load.i64 notrap aligned gv12+24
 ;;     sig0 = (i64 vmctx, i64) -> i32 tail
 ;;     sig1 = (i64 vmctx, i64) -> i32 tail

--- a/tests/disas/component-model/issue-11458.wat
+++ b/tests/disas/component-model/issue-11458.wat
@@ -20,12 +20,14 @@
 )
 
 ;; function u1:0(i64 vmctx, i64, i32) -> i32 tail {
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 72 "VMContext+0x48"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = vmctx
-;;     gv5 = load.i64 notrap aligned readonly gv4+8
+;;     gv5 = load.i64 notrap aligned readonly region0 gv4+8
 ;;     gv6 = load.i64 notrap aligned gv5+24
 ;;     sig0 = (i64 vmctx, i64, i32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i64, i32) -> i32 tail
@@ -37,7 +39,7 @@
 ;; @006f                               jump block2
 ;;
 ;;                                 block2:
-;; @006f                               v6 = load.i64 notrap aligned readonly can_move v0+72
+;; @006f                               v6 = load.i64 notrap aligned readonly can_move region1 v0+72
 ;;                                     v10 = iconst.i32 1
 ;;                                     v12 = call fn1(v6, v6, v10)  ; v10 = 1
 ;;                                     jump block4

--- a/tests/disas/component-model/multiple-instantiations-makes-adapters-indirect.wat
+++ b/tests/disas/component-model/multiple-instantiations-makes-adapters-indirect.wat
@@ -65,16 +65,19 @@
 )
 
 ;; function u1:0(i64 vmctx, i64) -> i32 tail {
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 72 "VMContext+0x48"
+;;     region2 = 56 "VMContext+0x38"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, i64, i32) -> i32 tail
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @00ee                               v6 = load.i64 notrap aligned readonly can_move v0+56
-;; @00ee                               v5 = load.i64 notrap aligned readonly can_move v0+72
+;; @00ee                               v6 = load.i64 notrap aligned readonly can_move region2 v0+56
+;; @00ee                               v5 = load.i64 notrap aligned readonly can_move region1 v0+72
 ;; @00eb                               v3 = iconst.i32 1234
 ;; @00ee                               v7 = call_indirect sig0, v6(v5, v0, v3)  ; v3 = 1234
 ;; @00f0                               jump block1

--- a/tests/disas/conditional-traps.wat
+++ b/tests/disas/conditional-traps.wat
@@ -22,8 +22,9 @@
 )
 
 ;; function u0:0(i64 vmctx, i64, i32) tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     stack_limit = gv2
 ;;
@@ -39,8 +40,9 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     stack_limit = gv2
 ;;

--- a/tests/disas/dead-code.wat
+++ b/tests/disas/dead-code.wat
@@ -22,8 +22,9 @@
     i32.const 42)
 )
 ;; function u0:0(i64 vmctx, i64, i32) tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     stack_limit = gv2
 ;;
@@ -47,8 +48,9 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     stack_limit = gv2
 ;;
@@ -60,8 +62,9 @@
 ;; }
 ;;
 ;; function u0:2(i64 vmctx, i64) tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     stack_limit = gv2
 ;;
@@ -73,8 +76,9 @@
 ;; }
 ;;
 ;; function u0:3(i64 vmctx, i64, i32) -> i32 tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     stack_limit = gv2
 ;;

--- a/tests/disas/duplicate-function-types.wat
+++ b/tests/disas/duplicate-function-types.wat
@@ -17,12 +17,15 @@
 )
 
 ;; function u0:0(i64 vmctx, i64, i32) -> i32, i32 tail {
-;;     region0 = 1073741824 "PublicTable"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 48 "VMContext+0x30"
+;;     region2 = 1073741824 "PublicTable"
+;;     region3 = 40 "VMContext+0x28"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+48
+;;     gv4 = load.i64 notrap aligned readonly can_move region1 gv3+48
 ;;     gv5 = load.i64 notrap aligned gv4
 ;;     gv6 = load.i64 notrap aligned gv4+8
 ;;     sig0 = (i64 vmctx, i64) -> i32 tail
@@ -31,19 +34,19 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @002d                               v62 = load.i64 notrap aligned readonly can_move v0+48
+;; @002d                               v62 = load.i64 notrap aligned readonly can_move region1 v0+48
 ;; @002d                               v5 = load.i64 notrap aligned v62+8
 ;; @002d                               v6 = ireduce.i32 v5
 ;; @002d                               v7 = icmp uge v2, v6
 ;; @002d                               v8 = uextend.i64 v2
-;; @002d                               v60 = load.i64 notrap aligned readonly can_move v0+48
+;; @002d                               v60 = load.i64 notrap aligned readonly can_move region1 v0+48
 ;; @002d                               v9 = load.i64 notrap aligned v60
 ;; @002d                               v10 = iconst.i64 3
 ;; @002d                               v11 = ishl v8, v10  ; v10 = 3
 ;; @002d                               v12 = iadd v9, v11
 ;; @002d                               v13 = iconst.i64 0
 ;; @002d                               v14 = select_spectre_guard v7, v13, v12  ; v13 = 0
-;; @002d                               v15 = load.i64 user6 aligned region0 v14
+;; @002d                               v15 = load.i64 user6 aligned region2 v14
 ;; @002d                               v16 = iconst.i64 -2
 ;; @002d                               v17 = band v15, v16  ; v16 = -2
 ;; @002d                               brif v15, block3(v17), block2
@@ -55,7 +58,7 @@
 ;; @002d                               jump block3(v21)
 ;;
 ;;                                 block3(v18: i64):
-;; @002d                               v22 = load.i64 notrap aligned readonly can_move v0+40
+;; @002d                               v22 = load.i64 notrap aligned readonly can_move region3 v0+40
 ;; @002d                               v23 = load.i32 notrap aligned readonly can_move v22
 ;; @002d                               v24 = load.i32 user7 aligned readonly v18+16
 ;; @002d                               v25 = icmp eq v24, v23
@@ -64,19 +67,19 @@
 ;; @002d                               v27 = load.i64 notrap aligned readonly v18+8
 ;; @002d                               v28 = load.i64 notrap aligned readonly v18+24
 ;; @002d                               v29 = call_indirect sig0, v27(v28, v0)
-;; @0032                               v58 = load.i64 notrap aligned readonly can_move v0+48
+;; @0032                               v58 = load.i64 notrap aligned readonly can_move region1 v0+48
 ;; @0032                               v31 = load.i64 notrap aligned v58+8
 ;; @0032                               v32 = ireduce.i32 v31
 ;; @0032                               v33 = icmp.i32 uge v2, v32
 ;; @0032                               v34 = uextend.i64 v2
-;; @0032                               v56 = load.i64 notrap aligned readonly can_move v0+48
+;; @0032                               v56 = load.i64 notrap aligned readonly can_move region1 v0+48
 ;; @0032                               v35 = load.i64 notrap aligned v56
 ;; @0032                               v36 = iconst.i64 3
 ;; @0032                               v37 = ishl v34, v36  ; v36 = 3
 ;; @0032                               v38 = iadd v35, v37
 ;; @0032                               v39 = iconst.i64 0
 ;; @0032                               v40 = select_spectre_guard v33, v39, v38  ; v39 = 0
-;; @0032                               v41 = load.i64 user6 aligned region0 v40
+;; @0032                               v41 = load.i64 user6 aligned region2 v40
 ;; @0032                               v42 = iconst.i64 -2
 ;; @0032                               v43 = band v41, v42  ; v42 = -2
 ;; @0032                               brif v41, block5(v43), block4
@@ -88,7 +91,7 @@
 ;; @0032                               jump block5(v47)
 ;;
 ;;                                 block5(v44: i64):
-;; @0032                               v48 = load.i64 notrap aligned readonly can_move v0+40
+;; @0032                               v48 = load.i64 notrap aligned readonly can_move region3 v0+40
 ;; @0032                               v49 = load.i32 notrap aligned readonly can_move v48
 ;; @0032                               v50 = load.i32 user7 aligned readonly v44+16
 ;; @0032                               v51 = icmp eq v50, v49

--- a/tests/disas/duplicate-loads-dynamic-memory.wat
+++ b/tests/disas/duplicate-loads-dynamic-memory.wat
@@ -23,9 +23,10 @@
 )
 
 ;; function u0:0(i64 vmctx, i64, i32) -> i32, i32 tail {
-;;     region0 = 536870912 "PublicMemory"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 536870912 "PublicMemory"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -40,7 +41,7 @@
 ;; @0057                               v10 = iconst.i64 0
 ;; @0057                               v9 = iadd v8, v5
 ;; @0057                               v11 = select_spectre_guard v7, v10, v9  ; v10 = 0
-;; @0057                               v12 = load.i32 little region0 v11
+;; @0057                               v12 = load.i32 little region1 v11
 ;; @005f                               jump block1
 ;;
 ;;                                 block1:
@@ -48,9 +49,10 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32, i32 tail {
-;;     region0 = 536870912 "PublicMemory"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 536870912 "PublicMemory"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -67,7 +69,7 @@
 ;; @0064                               v10 = iconst.i64 1234
 ;; @0064                               v11 = iadd v9, v10  ; v10 = 1234
 ;; @0064                               v13 = select_spectre_guard v7, v12, v11  ; v12 = 0
-;; @0064                               v14 = load.i32 little region0 v13
+;; @0064                               v14 = load.i32 little region1 v13
 ;; @006e                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/duplicate-loads-static-memory.wat
+++ b/tests/disas/duplicate-loads-static-memory.wat
@@ -18,9 +18,10 @@
 )
 
 ;; function u0:0(i64 vmctx, i64, i32) -> i32, i32 tail {
-;;     region0 = 536870912 "PublicMemory"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 536870912 "PublicMemory"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -31,7 +32,7 @@
 ;; @0057                               v6 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0057                               v5 = uextend.i64 v2
 ;; @0057                               v7 = iadd v6, v5
-;; @0057                               v8 = load.i32 little region0 v7
+;; @0057                               v8 = load.i32 little region1 v7
 ;; @005f                               jump block1
 ;;
 ;;                                 block1:
@@ -39,9 +40,10 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32, i32 tail {
-;;     region0 = 536870912 "PublicMemory"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 536870912 "PublicMemory"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -54,7 +56,7 @@
 ;; @0064                               v7 = iadd v6, v5
 ;; @0064                               v8 = iconst.i64 1234
 ;; @0064                               v9 = iadd v7, v8  ; v8 = 1234
-;; @0064                               v10 = load.i32 little region0 v9
+;; @0064                               v10 = load.i32 little region1 v9
 ;; @006e                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/dynamic-memory-no-spectre-access-same-index-different-offsets.wat
+++ b/tests/disas/dynamic-memory-no-spectre-access-same-index-different-offsets.wat
@@ -36,9 +36,10 @@
 )
 
 ;; function u0:0(i64 vmctx, i64, i32) -> i32, i32, i32 tail {
-;;     region0 = 536870912 "PublicMemory"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 536870912 "PublicMemory"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -52,17 +53,17 @@
 ;; @0047                               trapnz v8, heap_oob
 ;; @0047                               v9 = load.i64 notrap aligned can_move v0+56
 ;; @0047                               v10 = iadd v9, v6
-;; @0047                               v11 = load.i32 little region0 v10
+;; @0047                               v11 = load.i32 little region1 v10
 ;; @004c                               v17 = iconst.i64 4
 ;; @004c                               v18 = iadd v10, v17  ; v17 = 4
-;; @004c                               v19 = load.i32 little region0 v18
+;; @004c                               v19 = load.i32 little region1 v18
 ;; @0051                               v21 = iconst.i64 0x0010_0003
 ;; @0051                               v22 = uadd_overflow_trap v6, v21, heap_oob  ; v21 = 0x0010_0003
 ;; @0051                               v24 = icmp ugt v22, v7
 ;; @0051                               trapnz v24, heap_oob
 ;; @0051                               v27 = iconst.i64 0x000f_ffff
 ;; @0051                               v28 = iadd v10, v27  ; v27 = 0x000f_ffff
-;; @0051                               v29 = load.i32 little region0 v28
+;; @0051                               v29 = load.i32 little region1 v28
 ;; @0056                               jump block1
 ;;
 ;;                                 block1:
@@ -70,9 +71,10 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32, i32, i32, i32) tail {
-;;     region0 = 536870912 "PublicMemory"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 536870912 "PublicMemory"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -86,17 +88,17 @@
 ;; @005d                               trapnz v8, heap_oob
 ;; @005d                               v9 = load.i64 notrap aligned can_move v0+56
 ;; @005d                               v10 = iadd v9, v6
-;; @005d                               store little region0 v3, v10
+;; @005d                               store little region1 v3, v10
 ;; @0064                               v16 = iconst.i64 4
 ;; @0064                               v17 = iadd v10, v16  ; v16 = 4
-;; @0064                               store little region0 v4, v17
+;; @0064                               store little region1 v4, v17
 ;; @006b                               v19 = iconst.i64 0x0010_0003
 ;; @006b                               v20 = uadd_overflow_trap v6, v19, heap_oob  ; v19 = 0x0010_0003
 ;; @006b                               v22 = icmp ugt v20, v7
 ;; @006b                               trapnz v22, heap_oob
 ;; @006b                               v25 = iconst.i64 0x000f_ffff
 ;; @006b                               v26 = iadd v10, v25  ; v25 = 0x000f_ffff
-;; @006b                               store little region0 v5, v26
+;; @006b                               store little region1 v5, v26
 ;; @0070                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/dynamic-memory-yes-spectre-access-same-index-different-offsets.wat
+++ b/tests/disas/dynamic-memory-yes-spectre-access-same-index-different-offsets.wat
@@ -32,9 +32,10 @@
 )
 
 ;; function u0:0(i64 vmctx, i64, i32) -> i32, i32, i32 tail {
-;;     region0 = 536870912 "PublicMemory"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 536870912 "PublicMemory"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -49,18 +50,18 @@
 ;; @0047                               v11 = iconst.i64 0
 ;; @0047                               v10 = iadd v9, v6
 ;; @0047                               v12 = select_spectre_guard v8, v11, v10  ; v11 = 0
-;; @0047                               v13 = load.i32 little region0 v12
+;; @0047                               v13 = load.i32 little region1 v12
 ;; @004c                               v19 = iconst.i64 4
 ;; @004c                               v20 = iadd v10, v19  ; v19 = 4
 ;; @004c                               v22 = select_spectre_guard v8, v11, v20  ; v11 = 0
-;; @004c                               v23 = load.i32 little region0 v22
+;; @004c                               v23 = load.i32 little region1 v22
 ;; @0051                               v25 = iconst.i64 0x0010_0003
 ;; @0051                               v26 = uadd_overflow_trap v6, v25, heap_oob  ; v25 = 0x0010_0003
 ;; @0051                               v28 = icmp ugt v26, v7
 ;; @0051                               v31 = iconst.i64 0x000f_ffff
 ;; @0051                               v32 = iadd v10, v31  ; v31 = 0x000f_ffff
 ;; @0051                               v34 = select_spectre_guard v28, v11, v32  ; v11 = 0
-;; @0051                               v35 = load.i32 little region0 v34
+;; @0051                               v35 = load.i32 little region1 v34
 ;; @0056                               jump block1
 ;;
 ;;                                 block1:
@@ -68,9 +69,10 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32, i32, i32, i32) tail {
-;;     region0 = 536870912 "PublicMemory"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 536870912 "PublicMemory"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -85,18 +87,18 @@
 ;; @005d                               v11 = iconst.i64 0
 ;; @005d                               v10 = iadd v9, v6
 ;; @005d                               v12 = select_spectre_guard v8, v11, v10  ; v11 = 0
-;; @005d                               store little region0 v3, v12
+;; @005d                               store little region1 v3, v12
 ;; @0064                               v18 = iconst.i64 4
 ;; @0064                               v19 = iadd v10, v18  ; v18 = 4
 ;; @0064                               v21 = select_spectre_guard v8, v11, v19  ; v11 = 0
-;; @0064                               store little region0 v4, v21
+;; @0064                               store little region1 v4, v21
 ;; @006b                               v23 = iconst.i64 0x0010_0003
 ;; @006b                               v24 = uadd_overflow_trap v6, v23, heap_oob  ; v23 = 0x0010_0003
 ;; @006b                               v26 = icmp ugt v24, v7
 ;; @006b                               v29 = iconst.i64 0x000f_ffff
 ;; @006b                               v30 = iadd v10, v29  ; v29 = 0x000f_ffff
 ;; @006b                               v32 = select_spectre_guard v26, v11, v30  ; v11 = 0
-;; @006b                               store little region0 v5, v32
+;; @006b                               store little region1 v5, v32
 ;; @0070                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/epoch-interruption.wat
+++ b/tests/disas/epoch-interruption.wat
@@ -5,17 +5,19 @@
 (module (func (loop (br 0))))
 
 ;; function u0:0(i64 vmctx, i64) tail {
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 24 "VMContext+0x18"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     sig0 = (i64 vmctx) -> i64 tail
 ;;     fn0 = colocated u805306368:13 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @0016                               v2 = load.i64 notrap aligned v0+24
+;; @0016                               v2 = load.i64 notrap aligned region1 v0+24
 ;; @0016                               v3 = load.i64 notrap aligned v2
-;; @0016                               v4 = load.i64 notrap aligned readonly can_move v0+8
+;; @0016                               v4 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @0016                               v5 = load.i64 notrap aligned v4+8
 ;; @0016                               v6 = icmp uge v3, v5
 ;; @0016                               brif v6, block3, block2(v5)

--- a/tests/disas/f32-load.wat
+++ b/tests/disas/f32-load.wat
@@ -7,9 +7,10 @@
     f32.load))
 
 ;; function u0:0(i64 vmctx, i64, i32) -> f32 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -20,7 +21,7 @@
 ;; @002e                               v4 = uextend.i64 v2
 ;; @002e                               v5 = load.i64 notrap aligned readonly can_move v0+56
 ;; @002e                               v6 = iadd v5, v4
-;; @002e                               v7 = load.f32 little region0 v6
+;; @002e                               v7 = load.f32 little region1 v6
 ;; @0031                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/f32-store.wat
+++ b/tests/disas/f32-store.wat
@@ -10,9 +10,10 @@
     f32.store))
 
 ;; function u0:0(i64 vmctx, i64, i32, f32) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -23,7 +24,7 @@
 ;; @0031                               v4 = uextend.i64 v2
 ;; @0031                               v5 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0031                               v6 = iadd v5, v4
-;; @0031                               store little region0 v3, v6
+;; @0031                               store little region1 v3, v6
 ;; @0034                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/f64-load.wat
+++ b/tests/disas/f64-load.wat
@@ -9,9 +9,10 @@
     f64.load))
 
 ;; function u0:0(i64 vmctx, i64, i32) -> f64 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -22,7 +23,7 @@
 ;; @002e                               v4 = uextend.i64 v2
 ;; @002e                               v5 = load.i64 notrap aligned readonly can_move v0+56
 ;; @002e                               v6 = iadd v5, v4
-;; @002e                               v7 = load.f64 little region0 v6
+;; @002e                               v7 = load.f64 little region1 v6
 ;; @0031                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/f64-store.wat
+++ b/tests/disas/f64-store.wat
@@ -10,9 +10,10 @@
     f64.store))
 
 ;; function u0:0(i64 vmctx, i64, i32, f64) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -23,7 +24,7 @@
 ;; @0031                               v4 = uextend.i64 v2
 ;; @0031                               v5 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0031                               v6 = iadd v5, v4
-;; @0031                               store little region0 v3, v6
+;; @0031                               store little region1 v3, v6
 ;; @0034                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/fac-multi-value.wat
+++ b/tests/disas/fac-multi-value.wat
@@ -21,8 +21,9 @@
 )
 
 ;; function u0:0(i64 vmctx, i64, i64) -> i64, i64 tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     stack_limit = gv2
 ;;
@@ -34,8 +35,9 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i64, i64) -> i64, i64, i64 tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     stack_limit = gv2
 ;;
@@ -47,8 +49,9 @@
 ;; }
 ;;
 ;; function u0:2(i64 vmctx, i64, i64) -> i64 tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     sig0 = (i64 vmctx, i64, i64, i64) -> i64, i64, i64 tail
 ;;     sig1 = (i64 vmctx, i64, i64) -> i64, i64 tail

--- a/tests/disas/fibonacci.wat
+++ b/tests/disas/fibonacci.wat
@@ -24,9 +24,10 @@
 )
 
 ;; function u0:0(i64 vmctx, i64) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -58,7 +59,7 @@
 ;; @005a                               v17 = uextend.i64 v16  ; v16 = 0
 ;; @005a                               v18 = load.i64 notrap aligned readonly can_move v0+56
 ;; @005a                               v19 = iadd v18, v17
-;; @005a                               store.i32 little region0 v11, v19
+;; @005a                               store.i32 little region1 v11, v19
 ;; @005d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/fixed-size-memory.wat
+++ b/tests/disas/fixed-size-memory.wat
@@ -21,9 +21,10 @@
     i32.load8_u offset=0))
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -37,7 +38,7 @@
 ;; @0041                               trapnz v6, heap_oob
 ;; @0041                               v7 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0041                               v8 = iadd v7, v4
-;; @0041                               istore8 little region0 v3, v8
+;; @0041                               istore8 little region1 v3, v8
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -45,9 +46,10 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -61,7 +63,7 @@
 ;; @0049                               trapnz v6, heap_oob
 ;; @0049                               v7 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0049                               v8 = iadd v7, v4
-;; @0049                               v9 = uload8.i32 little region0 v8
+;; @0049                               v9 = uload8.i32 little region1 v8
 ;; @004c                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/foo.wat
+++ b/tests/disas/foo.wat
@@ -15,15 +15,18 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32) -> i32, i32 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
-;;     region1 = 1073741824 "PublicTable"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 72 "VMContext+0x48"
+;;     region3 = 1073741824 "PublicTable"
+;;     region4 = 40 "VMContext+0x28"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
-;;     gv6 = load.i64 notrap aligned readonly can_move gv3+72
+;;     gv6 = load.i64 notrap aligned readonly can_move region2 gv3+72
 ;;     gv7 = load.i64 notrap aligned gv6
 ;;     gv8 = load.i64 notrap aligned gv6+8
 ;;     sig0 = (i64 vmctx, i64, i32) -> i32 tail
@@ -35,8 +38,8 @@
 ;; @0040                               v7 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0040                               v6 = uextend.i64 v3
 ;; @0040                               v8 = iadd v7, v6
-;; @0040                               v9 = load.i32 little region0 v8
-;; @0043                               v73 = load.i64 notrap aligned readonly can_move v0+72
+;; @0040                               v9 = load.i32 little region1 v8
+;; @0043                               v73 = load.i64 notrap aligned readonly can_move region2 v0+72
 ;; @0043                               v10 = load.i64 notrap aligned v73+8
 ;; @0043                               v14 = load.i64 notrap aligned v73
 ;; @0043                               v11 = ireduce.i32 v10
@@ -47,7 +50,7 @@
 ;; @0043                               v16 = ishl v13, v15  ; v15 = 3
 ;; @0043                               v17 = iadd v14, v16
 ;; @0043                               v19 = select_spectre_guard v12, v18, v17  ; v18 = 0
-;; @0043                               v20 = load.i64 user6 aligned region1 v19
+;; @0043                               v20 = load.i64 user6 aligned region3 v19
 ;; @0043                               v21 = iconst.i64 -2
 ;; @0043                               v22 = band v20, v21  ; v21 = -2
 ;; @0043                               brif v20, block3(v22), block2
@@ -59,14 +62,14 @@
 ;;
 ;;                                 block3(v23: i64):
 ;; @0043                               v29 = load.i32 user7 aligned readonly v23+16
-;; @0043                               v27 = load.i64 notrap aligned readonly can_move v0+40
+;; @0043                               v27 = load.i64 notrap aligned readonly can_move region4 v0+40
 ;; @0043                               v28 = load.i32 notrap aligned readonly can_move v27+4
 ;; @0043                               v30 = icmp eq v29, v28
 ;; @0043                               trapz v30, user8
 ;; @0043                               v32 = load.i64 notrap aligned readonly v23+8
 ;; @0043                               v33 = load.i64 notrap aligned readonly v23+24
 ;; @0043                               v34 = call_indirect sig0, v32(v33, v0, v2)
-;; @004a                               v40 = load.i32 little region0 v8
+;; @004a                               v40 = load.i32 little region1 v8
 ;; @004d                               v41 = load.i64 notrap aligned v73+8
 ;; @004d                               v45 = load.i64 notrap aligned v73
 ;; @004d                               v42 = ireduce.i32 v41
@@ -77,7 +80,7 @@
 ;; @004d                               v48 = iadd v45, v77
 ;;                                     v78 = iconst.i64 0
 ;;                                     v79 = select_spectre_guard v43, v78, v48  ; v78 = 0
-;; @004d                               v51 = load.i64 user6 aligned region1 v79
+;; @004d                               v51 = load.i64 user6 aligned region3 v79
 ;;                                     v80 = iconst.i64 -2
 ;;                                     v81 = band v51, v80  ; v80 = -2
 ;; @004d                               brif v51, block5(v81), block4

--- a/tests/disas/gc/array-copy-with-fuel.wat
+++ b/tests/disas/gc/array-copy-with-fuel.wat
@@ -12,12 +12,13 @@
 ;; function u0:0(i64 vmctx, i64, i32, i32, i32, i32, i32) tail {
 ;;     ss0 = explicit_slot 4, align = 4
 ;;     ss1 = explicit_slot 4, align = 4
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx) -> i8 tail
@@ -29,7 +30,7 @@
 ;;                                     store notrap v2, v179
 ;;                                     v180 = stack_addr.i64 ss1
 ;;                                     store notrap v4, v180
-;; @0020                               v7 = load.i64 notrap aligned readonly can_move v0+8
+;; @0020                               v7 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @0020                               v8 = load.i64 notrap aligned v7
 ;; @0020                               v9 = iconst.i64 1
 ;; @0020                               v10 = iadd v8, v9  ; v9 = 1
@@ -52,7 +53,7 @@
 ;; @002b                               v24 = iadd v23, v22
 ;; @002b                               v25 = iconst.i64 16
 ;; @002b                               v26 = iadd v24, v25  ; v25 = 16
-;; @002b                               v27 = load.i32 user2 readonly region0 v26
+;; @002b                               v27 = load.i32 user2 readonly region1 v26
 ;; @002b                               v29 = uextend.i64 v3
 ;; @002b                               v30 = uextend.i64 v6
 ;; @002b                               v33 = iadd v29, v30
@@ -64,7 +65,7 @@
 ;; @002b                               v45 = uextend.i64 v172
 ;; @002b                               v47 = iadd v23, v45
 ;; @002b                               v49 = iadd v47, v25  ; v25 = 16
-;; @002b                               v50 = load.i32 user2 readonly region0 v49
+;; @002b                               v50 = load.i32 user2 readonly region1 v49
 ;; @002b                               v52 = uextend.i64 v5
 ;; @002b                               v56 = iadd v52, v30
 ;; @002b                               v51 = uextend.i64 v50
@@ -131,8 +132,8 @@
 ;; @002b                               jump block9(v112)
 ;;
 ;;                                 block9(v143: i64):
-;; @002b                               v113 = load.i32 user2 little region0 v100
-;; @002b                               store user2 little region0 v113, v99
+;; @002b                               v113 = load.i32 user2 little region1 v100
+;; @002b                               store user2 little region1 v113, v99
 ;;                                     v148 = load.i32 notrap v179
 ;;                                     v150 = load.i32 notrap v180
 ;;                                     v208 = iconst.i64 4
@@ -152,9 +153,9 @@
 ;;                                 block11(v144: i64):
 ;;                                     v199 = iconst.i64 4
 ;;                                     v200 = isub.i64 v122, v199  ; v199 = 4
-;; @002b                               v141 = load.i32 user2 little region0 v200
+;; @002b                               v141 = load.i32 user2 little region1 v200
 ;;                                     v201 = isub.i64 v121, v199  ; v199 = 4
-;; @002b                               store user2 little region0 v141, v201
+;; @002b                               store user2 little region1 v141, v201
 ;;                                     v154 = load.i32 notrap v180
 ;;                                     v156 = load.i32 notrap v179
 ;; @002b                               v142 = icmp eq v200, v67

--- a/tests/disas/gc/array-fill-i8.wat
+++ b/tests/disas/gc/array-fill-i8.wat
@@ -10,12 +10,13 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32, i32, i32) tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i64, i32, i64) tail
@@ -24,13 +25,13 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):
 ;; @0027                               trapz v2, user16
-;; @0027                               v39 = load.i64 notrap aligned readonly can_move v0+8
+;; @0027                               v39 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @0027                               v7 = load.i64 notrap aligned readonly can_move v39+32
 ;; @0027                               v6 = uextend.i64 v2
 ;; @0027                               v8 = iadd v7, v6
 ;; @0027                               v9 = iconst.i64 16
 ;; @0027                               v10 = iadd v8, v9  ; v9 = 16
-;; @0027                               v11 = load.i32 user2 readonly region0 v10
+;; @0027                               v11 = load.i32 user2 readonly region1 v10
 ;; @0027                               v13 = uextend.i64 v3
 ;; @0027                               v14 = uextend.i64 v5
 ;; @0027                               v17 = iadd v13, v14

--- a/tests/disas/gc/array-init-data.wat
+++ b/tests/disas/gc/array-init-data.wat
@@ -14,12 +14,13 @@
     array.init_data $a $passive)
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32, i32, i32) tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i64, i64, i64) tail
@@ -28,13 +29,13 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):
 ;; @002a                               trapz v2, user16
-;; @002a                               v52 = load.i64 notrap aligned readonly can_move v0+8
+;; @002a                               v52 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @002a                               v7 = load.i64 notrap aligned readonly can_move v52+32
 ;; @002a                               v6 = uextend.i64 v2
 ;; @002a                               v8 = iadd v7, v6
 ;; @002a                               v9 = iconst.i64 16
 ;; @002a                               v10 = iadd v8, v9  ; v9 = 16
-;; @002a                               v11 = load.i32 user2 readonly region0 v10
+;; @002a                               v11 = load.i32 user2 readonly region1 v10
 ;; @002a                               v13 = uextend.i64 v3
 ;; @002a                               v14 = uextend.i64 v5
 ;; @002a                               v17 = iadd v13, v14

--- a/tests/disas/gc/array-new-data.wat
+++ b/tests/disas/gc/array-new-data.wat
@@ -77,13 +77,15 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) -> i32 tail {
 ;;     ss0 = explicit_slot 4, align = 4
-;;     region0 = 32 "VMContext+0x20"
-;;     region1 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 40 "VMContext+0x28"
+;;     region2 = 32 "VMContext+0x20"
+;;     region3 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
@@ -126,13 +128,13 @@
 ;;                                     v126 = iconst.i32 -16
 ;;                                     v127 = band v123, v126  ; v126 = -16
 ;;                                     v129 = iadd.i32 v25, v127
-;; @0025                               store notrap aligned region0 v129, v24
+;; @0025                               store notrap aligned region2 v129, v24
 ;;                                     v143 = iconst.i32 -1476395002
-;;                                     v144 = load.i64 notrap aligned readonly can_move v0+8
+;;                                     v144 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;;                                     v145 = load.i64 notrap aligned readonly can_move v144+32
 ;; @0025                               v49 = iadd v145, v32
 ;; @0025                               store notrap aligned v143, v49  ; v143 = -1476395002
-;;                                     v146 = load.i64 notrap aligned readonly can_move v0+40
+;;                                     v146 = load.i64 notrap aligned readonly can_move region1 v0+40
 ;;                                     v147 = load.i32 notrap aligned readonly can_move v146
 ;; @0025                               store notrap aligned v147, v49+4
 ;;                                     v148 = band.i64 v30, v29  ; v29 = -16
@@ -141,11 +143,11 @@
 ;;
 ;;                                 block3 cold:
 ;; @0025                               v36 = iconst.i32 -1476395002
-;; @0025                               v37 = load.i64 notrap aligned readonly can_move v0+40
+;; @0025                               v37 = load.i64 notrap aligned readonly can_move region1 v0+40
 ;; @0025                               v38 = load.i32 notrap aligned readonly can_move v37
 ;; @0025                               v39 = iconst.i32 16
 ;; @0025                               v40 = call fn0(v0, v36, v38, v23, v39)  ; v36 = -1476395002, v39 = 16
-;; @0025                               v41 = load.i64 notrap aligned readonly can_move v0+8
+;; @0025                               v41 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @0025                               v42 = load.i64 notrap aligned readonly can_move v41+32
 ;; @0025                               v43 = uextend.i64 v40
 ;; @0025                               v44 = iadd v42, v43
@@ -156,14 +158,14 @@
 ;;                                     store notrap v53, v112
 ;; @0025                               v55 = iconst.i64 16
 ;; @0025                               v56 = iadd v54, v55  ; v55 = 16
-;; @0025                               store.i32 user2 region1 v3, v56
+;; @0025                               store.i32 user2 region3 v3, v56
 ;; @0025                               trapz v53, user16
-;;                                     v149 = load.i64 notrap aligned readonly can_move v0+8
+;;                                     v149 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;;                                     v150 = load.i64 notrap aligned readonly can_move v149+32
 ;; @0025                               v58 = uextend.i64 v53
 ;; @0025                               v60 = iadd v150, v58
 ;; @0025                               v62 = iadd v60, v55  ; v55 = 16
-;; @0025                               v63 = load.i32 user2 readonly region1 v62
+;; @0025                               v63 = load.i32 user2 readonly region3 v62
 ;; @0025                               v64 = uextend.i64 v63
 ;; @0025                               v70 = icmp.i64 ugt v8, v64
 ;; @0025                               trapnz v70, user17

--- a/tests/disas/gc/array-new-default-anyref.wat
+++ b/tests/disas/gc/array-new-default-anyref.wat
@@ -10,13 +10,15 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 32 "VMContext+0x20"
-;;     region1 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 40 "VMContext+0x28"
+;;     region2 = 32 "VMContext+0x20"
+;;     region3 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
@@ -54,13 +56,13 @@
 ;;                                     v109 = iconst.i32 -16
 ;;                                     v110 = band v106, v109  ; v109 = -16
 ;;                                     v112 = iadd.i32 v13, v110
-;; @001f                               store notrap aligned region0 v112, v12
+;; @001f                               store notrap aligned region2 v112, v12
 ;;                                     v128 = iconst.i32 -1476394994
-;;                                     v129 = load.i64 notrap aligned readonly can_move v0+8
+;;                                     v129 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;;                                     v130 = load.i64 notrap aligned readonly can_move v129+32
 ;; @001f                               v37 = iadd v130, v20
 ;; @001f                               store notrap aligned v128, v37  ; v128 = -1476394994
-;;                                     v131 = load.i64 notrap aligned readonly can_move v0+40
+;;                                     v131 = load.i64 notrap aligned readonly can_move region1 v0+40
 ;;                                     v132 = load.i32 notrap aligned readonly can_move v131
 ;; @001f                               store notrap aligned v132, v37+4
 ;;                                     v133 = band.i64 v18, v17  ; v17 = -16
@@ -69,11 +71,11 @@
 ;;
 ;;                                 block3 cold:
 ;; @001f                               v24 = iconst.i32 -1476394994
-;; @001f                               v25 = load.i64 notrap aligned readonly can_move v0+40
+;; @001f                               v25 = load.i64 notrap aligned readonly can_move region1 v0+40
 ;; @001f                               v26 = load.i32 notrap aligned readonly can_move v25
 ;; @001f                               v27 = iconst.i32 16
 ;; @001f                               v28 = call fn0(v0, v24, v26, v11, v27)  ; v24 = -1476394994, v27 = 16
-;; @001f                               v29 = load.i64 notrap aligned readonly can_move v0+8
+;; @001f                               v29 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @001f                               v30 = load.i64 notrap aligned readonly can_move v29+32
 ;; @001f                               v31 = uextend.i64 v28
 ;; @001f                               v32 = iadd v30, v31
@@ -82,14 +84,14 @@
 ;;                                 block4(v41: i32, v42: i64):
 ;; @001f                               v43 = iconst.i64 16
 ;; @001f                               v44 = iadd v42, v43  ; v43 = 16
-;; @001f                               store.i32 user2 region1 v2, v44
+;; @001f                               store.i32 user2 region3 v2, v44
 ;; @001f                               trapz v41, user16
-;;                                     v134 = load.i64 notrap aligned readonly can_move v0+8
+;;                                     v134 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;;                                     v135 = load.i64 notrap aligned readonly can_move v134+32
 ;; @001f                               v47 = uextend.i64 v41
 ;; @001f                               v49 = iadd v135, v47
 ;; @001f                               v51 = iadd v49, v43  ; v43 = 16
-;; @001f                               v52 = load.i32 user2 readonly region1 v51
+;; @001f                               v52 = load.i32 user2 readonly region3 v51
 ;; @001f                               v53 = uextend.i64 v52
 ;; @001f                               v59 = icmp.i64 ugt v5, v53
 ;; @001f                               trapnz v59, user17
@@ -109,7 +111,7 @@
 ;;
 ;;                                 block5(v83: i64):
 ;;                                     v136 = iconst.i32 0
-;; @001f                               store user2 little region1 v136, v83  ; v136 = 0
+;; @001f                               store user2 little region3 v136, v83  ; v136 = 0
 ;;                                     v137 = iconst.i64 4
 ;;                                     v138 = iadd v83, v137  ; v137 = 4
 ;; @001f                               v86 = icmp eq v138, v80

--- a/tests/disas/gc/array-new-default-exnref.wat
+++ b/tests/disas/gc/array-new-default-exnref.wat
@@ -10,13 +10,15 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 32 "VMContext+0x20"
-;;     region1 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 40 "VMContext+0x28"
+;;     region2 = 32 "VMContext+0x20"
+;;     region3 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
@@ -54,13 +56,13 @@
 ;;                                     v109 = iconst.i32 -16
 ;;                                     v110 = band v106, v109  ; v109 = -16
 ;;                                     v112 = iadd.i32 v13, v110
-;; @001f                               store notrap aligned region0 v112, v12
+;; @001f                               store notrap aligned region2 v112, v12
 ;;                                     v128 = iconst.i32 -1476394994
-;;                                     v129 = load.i64 notrap aligned readonly can_move v0+8
+;;                                     v129 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;;                                     v130 = load.i64 notrap aligned readonly can_move v129+32
 ;; @001f                               v37 = iadd v130, v20
 ;; @001f                               store notrap aligned v128, v37  ; v128 = -1476394994
-;;                                     v131 = load.i64 notrap aligned readonly can_move v0+40
+;;                                     v131 = load.i64 notrap aligned readonly can_move region1 v0+40
 ;;                                     v132 = load.i32 notrap aligned readonly can_move v131
 ;; @001f                               store notrap aligned v132, v37+4
 ;;                                     v133 = band.i64 v18, v17  ; v17 = -16
@@ -69,11 +71,11 @@
 ;;
 ;;                                 block3 cold:
 ;; @001f                               v24 = iconst.i32 -1476394994
-;; @001f                               v25 = load.i64 notrap aligned readonly can_move v0+40
+;; @001f                               v25 = load.i64 notrap aligned readonly can_move region1 v0+40
 ;; @001f                               v26 = load.i32 notrap aligned readonly can_move v25
 ;; @001f                               v27 = iconst.i32 16
 ;; @001f                               v28 = call fn0(v0, v24, v26, v11, v27)  ; v24 = -1476394994, v27 = 16
-;; @001f                               v29 = load.i64 notrap aligned readonly can_move v0+8
+;; @001f                               v29 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @001f                               v30 = load.i64 notrap aligned readonly can_move v29+32
 ;; @001f                               v31 = uextend.i64 v28
 ;; @001f                               v32 = iadd v30, v31
@@ -82,14 +84,14 @@
 ;;                                 block4(v41: i32, v42: i64):
 ;; @001f                               v43 = iconst.i64 16
 ;; @001f                               v44 = iadd v42, v43  ; v43 = 16
-;; @001f                               store.i32 user2 region1 v2, v44
+;; @001f                               store.i32 user2 region3 v2, v44
 ;; @001f                               trapz v41, user16
-;;                                     v134 = load.i64 notrap aligned readonly can_move v0+8
+;;                                     v134 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;;                                     v135 = load.i64 notrap aligned readonly can_move v134+32
 ;; @001f                               v47 = uextend.i64 v41
 ;; @001f                               v49 = iadd v135, v47
 ;; @001f                               v51 = iadd v49, v43  ; v43 = 16
-;; @001f                               v52 = load.i32 user2 readonly region1 v51
+;; @001f                               v52 = load.i32 user2 readonly region3 v51
 ;; @001f                               v53 = uextend.i64 v52
 ;; @001f                               v59 = icmp.i64 ugt v5, v53
 ;; @001f                               trapnz v59, user17
@@ -109,7 +111,7 @@
 ;;
 ;;                                 block5(v83: i64):
 ;;                                     v136 = iconst.i32 0
-;; @001f                               store user2 little region1 v136, v83  ; v136 = 0
+;; @001f                               store user2 little region3 v136, v83  ; v136 = 0
 ;;                                     v137 = iconst.i64 4
 ;;                                     v138 = iadd v83, v137  ; v137 = 4
 ;; @001f                               v86 = icmp eq v138, v80

--- a/tests/disas/gc/array-new-default-externref.wat
+++ b/tests/disas/gc/array-new-default-externref.wat
@@ -10,13 +10,15 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 32 "VMContext+0x20"
-;;     region1 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 40 "VMContext+0x28"
+;;     region2 = 32 "VMContext+0x20"
+;;     region3 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
@@ -54,13 +56,13 @@
 ;;                                     v109 = iconst.i32 -16
 ;;                                     v110 = band v106, v109  ; v109 = -16
 ;;                                     v112 = iadd.i32 v13, v110
-;; @001f                               store notrap aligned region0 v112, v12
+;; @001f                               store notrap aligned region2 v112, v12
 ;;                                     v128 = iconst.i32 -1476394994
-;;                                     v129 = load.i64 notrap aligned readonly can_move v0+8
+;;                                     v129 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;;                                     v130 = load.i64 notrap aligned readonly can_move v129+32
 ;; @001f                               v37 = iadd v130, v20
 ;; @001f                               store notrap aligned v128, v37  ; v128 = -1476394994
-;;                                     v131 = load.i64 notrap aligned readonly can_move v0+40
+;;                                     v131 = load.i64 notrap aligned readonly can_move region1 v0+40
 ;;                                     v132 = load.i32 notrap aligned readonly can_move v131
 ;; @001f                               store notrap aligned v132, v37+4
 ;;                                     v133 = band.i64 v18, v17  ; v17 = -16
@@ -69,11 +71,11 @@
 ;;
 ;;                                 block3 cold:
 ;; @001f                               v24 = iconst.i32 -1476394994
-;; @001f                               v25 = load.i64 notrap aligned readonly can_move v0+40
+;; @001f                               v25 = load.i64 notrap aligned readonly can_move region1 v0+40
 ;; @001f                               v26 = load.i32 notrap aligned readonly can_move v25
 ;; @001f                               v27 = iconst.i32 16
 ;; @001f                               v28 = call fn0(v0, v24, v26, v11, v27)  ; v24 = -1476394994, v27 = 16
-;; @001f                               v29 = load.i64 notrap aligned readonly can_move v0+8
+;; @001f                               v29 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @001f                               v30 = load.i64 notrap aligned readonly can_move v29+32
 ;; @001f                               v31 = uextend.i64 v28
 ;; @001f                               v32 = iadd v30, v31
@@ -82,14 +84,14 @@
 ;;                                 block4(v41: i32, v42: i64):
 ;; @001f                               v43 = iconst.i64 16
 ;; @001f                               v44 = iadd v42, v43  ; v43 = 16
-;; @001f                               store.i32 user2 region1 v2, v44
+;; @001f                               store.i32 user2 region3 v2, v44
 ;; @001f                               trapz v41, user16
-;;                                     v134 = load.i64 notrap aligned readonly can_move v0+8
+;;                                     v134 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;;                                     v135 = load.i64 notrap aligned readonly can_move v134+32
 ;; @001f                               v47 = uextend.i64 v41
 ;; @001f                               v49 = iadd v135, v47
 ;; @001f                               v51 = iadd v49, v43  ; v43 = 16
-;; @001f                               v52 = load.i32 user2 readonly region1 v51
+;; @001f                               v52 = load.i32 user2 readonly region3 v51
 ;; @001f                               v53 = uextend.i64 v52
 ;; @001f                               v59 = icmp.i64 ugt v5, v53
 ;; @001f                               trapnz v59, user17
@@ -109,7 +111,7 @@
 ;;
 ;;                                 block5(v83: i64):
 ;;                                     v136 = iconst.i32 0
-;; @001f                               store user2 little region1 v136, v83  ; v136 = 0
+;; @001f                               store user2 little region3 v136, v83  ; v136 = 0
 ;;                                     v137 = iconst.i64 4
 ;;                                     v138 = iadd v83, v137  ; v137 = 4
 ;; @001f                               v86 = icmp eq v138, v80

--- a/tests/disas/gc/array-new-default-f32.wat
+++ b/tests/disas/gc/array-new-default-f32.wat
@@ -11,13 +11,15 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     ss0 = explicit_slot 4, align = 4
-;;     region0 = 32 "VMContext+0x20"
-;;     region1 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 40 "VMContext+0x28"
+;;     region2 = 32 "VMContext+0x20"
+;;     region3 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
@@ -57,13 +59,13 @@
 ;;                                     v112 = iconst.i32 -16
 ;;                                     v113 = band v109, v112  ; v112 = -16
 ;;                                     v115 = iadd.i32 v13, v113
-;; @001f                               store notrap aligned region0 v115, v12
+;; @001f                               store notrap aligned region2 v115, v12
 ;;                                     v131 = iconst.i32 -1476395002
-;;                                     v132 = load.i64 notrap aligned readonly can_move v0+8
+;;                                     v132 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;;                                     v133 = load.i64 notrap aligned readonly can_move v132+32
 ;; @001f                               v37 = iadd v133, v20
 ;; @001f                               store notrap aligned v131, v37  ; v131 = -1476395002
-;;                                     v134 = load.i64 notrap aligned readonly can_move v0+40
+;;                                     v134 = load.i64 notrap aligned readonly can_move region1 v0+40
 ;;                                     v135 = load.i32 notrap aligned readonly can_move v134
 ;; @001f                               store notrap aligned v135, v37+4
 ;;                                     v136 = band.i64 v18, v17  ; v17 = -16
@@ -72,11 +74,11 @@
 ;;
 ;;                                 block3 cold:
 ;; @001f                               v24 = iconst.i32 -1476395002
-;; @001f                               v25 = load.i64 notrap aligned readonly can_move v0+40
+;; @001f                               v25 = load.i64 notrap aligned readonly can_move region1 v0+40
 ;; @001f                               v26 = load.i32 notrap aligned readonly can_move v25
 ;; @001f                               v27 = iconst.i32 16
 ;; @001f                               v28 = call fn0(v0, v24, v26, v11, v27)  ; v24 = -1476395002, v27 = 16
-;; @001f                               v29 = load.i64 notrap aligned readonly can_move v0+8
+;; @001f                               v29 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @001f                               v30 = load.i64 notrap aligned readonly can_move v29+32
 ;; @001f                               v31 = uextend.i64 v28
 ;; @001f                               v32 = iadd v30, v31
@@ -87,14 +89,14 @@
 ;;                                     store notrap v41, v89
 ;; @001f                               v43 = iconst.i64 16
 ;; @001f                               v44 = iadd v42, v43  ; v43 = 16
-;; @001f                               store.i32 user2 region1 v2, v44
+;; @001f                               store.i32 user2 region3 v2, v44
 ;; @001f                               trapz v41, user16
-;;                                     v137 = load.i64 notrap aligned readonly can_move v0+8
+;;                                     v137 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;;                                     v138 = load.i64 notrap aligned readonly can_move v137+32
 ;; @001f                               v47 = uextend.i64 v41
 ;; @001f                               v49 = iadd v138, v47
 ;; @001f                               v51 = iadd v49, v43  ; v43 = 16
-;; @001f                               v52 = load.i32 user2 readonly region1 v51
+;; @001f                               v52 = load.i32 user2 readonly region3 v51
 ;; @001f                               v53 = uextend.i64 v52
 ;; @001f                               v59 = icmp.i64 ugt v5, v53
 ;; @001f                               trapnz v59, user17

--- a/tests/disas/gc/array-new-default-f64.wat
+++ b/tests/disas/gc/array-new-default-f64.wat
@@ -11,13 +11,15 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     ss0 = explicit_slot 4, align = 4
-;;     region0 = 32 "VMContext+0x20"
-;;     region1 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 40 "VMContext+0x28"
+;;     region2 = 32 "VMContext+0x20"
+;;     region3 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
@@ -57,13 +59,13 @@
 ;;                                     v112 = iconst.i32 -16
 ;;                                     v113 = band v109, v112  ; v112 = -16
 ;;                                     v115 = iadd.i32 v13, v113
-;; @001f                               store notrap aligned region0 v115, v12
+;; @001f                               store notrap aligned region2 v115, v12
 ;;                                     v131 = iconst.i32 -1476395002
-;;                                     v132 = load.i64 notrap aligned readonly can_move v0+8
+;;                                     v132 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;;                                     v133 = load.i64 notrap aligned readonly can_move v132+32
 ;; @001f                               v37 = iadd v133, v20
 ;; @001f                               store notrap aligned v131, v37  ; v131 = -1476395002
-;;                                     v134 = load.i64 notrap aligned readonly can_move v0+40
+;;                                     v134 = load.i64 notrap aligned readonly can_move region1 v0+40
 ;;                                     v135 = load.i32 notrap aligned readonly can_move v134
 ;; @001f                               store notrap aligned v135, v37+4
 ;;                                     v136 = band.i64 v18, v17  ; v17 = -16
@@ -72,11 +74,11 @@
 ;;
 ;;                                 block3 cold:
 ;; @001f                               v24 = iconst.i32 -1476395002
-;; @001f                               v25 = load.i64 notrap aligned readonly can_move v0+40
+;; @001f                               v25 = load.i64 notrap aligned readonly can_move region1 v0+40
 ;; @001f                               v26 = load.i32 notrap aligned readonly can_move v25
 ;; @001f                               v27 = iconst.i32 16
 ;; @001f                               v28 = call fn0(v0, v24, v26, v11, v27)  ; v24 = -1476395002, v27 = 16
-;; @001f                               v29 = load.i64 notrap aligned readonly can_move v0+8
+;; @001f                               v29 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @001f                               v30 = load.i64 notrap aligned readonly can_move v29+32
 ;; @001f                               v31 = uextend.i64 v28
 ;; @001f                               v32 = iadd v30, v31
@@ -87,14 +89,14 @@
 ;;                                     store notrap v41, v89
 ;; @001f                               v43 = iconst.i64 16
 ;; @001f                               v44 = iadd v42, v43  ; v43 = 16
-;; @001f                               store.i32 user2 region1 v2, v44
+;; @001f                               store.i32 user2 region3 v2, v44
 ;; @001f                               trapz v41, user16
-;;                                     v137 = load.i64 notrap aligned readonly can_move v0+8
+;;                                     v137 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;;                                     v138 = load.i64 notrap aligned readonly can_move v137+32
 ;; @001f                               v47 = uextend.i64 v41
 ;; @001f                               v49 = iadd v138, v47
 ;; @001f                               v51 = iadd v49, v43  ; v43 = 16
-;; @001f                               v52 = load.i32 user2 readonly region1 v51
+;; @001f                               v52 = load.i32 user2 readonly region3 v51
 ;; @001f                               v53 = uextend.i64 v52
 ;; @001f                               v59 = icmp.i64 ugt v5, v53
 ;; @001f                               trapnz v59, user17

--- a/tests/disas/gc/array-new-default-funcref.wat
+++ b/tests/disas/gc/array-new-default-funcref.wat
@@ -11,13 +11,15 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     ss0 = explicit_slot 4, align = 4
-;;     region0 = 32 "VMContext+0x20"
-;;     region1 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 40 "VMContext+0x28"
+;;     region2 = 32 "VMContext+0x20"
+;;     region3 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
@@ -57,13 +59,13 @@
 ;;                                     v120 = iconst.i32 -16
 ;;                                     v121 = band v117, v120  ; v120 = -16
 ;;                                     v123 = iadd.i32 v13, v121
-;; @001f                               store notrap aligned region0 v123, v12
+;; @001f                               store notrap aligned region2 v123, v12
 ;;                                     v138 = iconst.i32 -1476395002
-;;                                     v139 = load.i64 notrap aligned readonly can_move v0+8
+;;                                     v139 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;;                                     v140 = load.i64 notrap aligned readonly can_move v139+32
 ;; @001f                               v37 = iadd v140, v20
 ;; @001f                               store notrap aligned v138, v37  ; v138 = -1476395002
-;;                                     v141 = load.i64 notrap aligned readonly can_move v0+40
+;;                                     v141 = load.i64 notrap aligned readonly can_move region1 v0+40
 ;;                                     v142 = load.i32 notrap aligned readonly can_move v141
 ;; @001f                               store notrap aligned v142, v37+4
 ;;                                     v143 = band.i64 v18, v17  ; v17 = -16
@@ -72,11 +74,11 @@
 ;;
 ;;                                 block3 cold:
 ;; @001f                               v24 = iconst.i32 -1476395002
-;; @001f                               v25 = load.i64 notrap aligned readonly can_move v0+40
+;; @001f                               v25 = load.i64 notrap aligned readonly can_move region1 v0+40
 ;; @001f                               v26 = load.i32 notrap aligned readonly can_move v25
 ;; @001f                               v27 = iconst.i32 16
 ;; @001f                               v28 = call fn0(v0, v24, v26, v11, v27)  ; v24 = -1476395002, v27 = 16
-;; @001f                               v29 = load.i64 notrap aligned readonly can_move v0+8
+;; @001f                               v29 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @001f                               v30 = load.i64 notrap aligned readonly can_move v29+32
 ;; @001f                               v31 = uextend.i64 v28
 ;; @001f                               v32 = iadd v30, v31
@@ -87,14 +89,14 @@
 ;;                                     store notrap v41, v97
 ;; @001f                               v43 = iconst.i64 16
 ;; @001f                               v44 = iadd v42, v43  ; v43 = 16
-;; @001f                               store.i32 user2 region1 v2, v44
+;; @001f                               store.i32 user2 region3 v2, v44
 ;; @001f                               trapz v41, user16
-;;                                     v144 = load.i64 notrap aligned readonly can_move v0+8
+;;                                     v144 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;;                                     v145 = load.i64 notrap aligned readonly can_move v144+32
 ;; @001f                               v47 = uextend.i64 v41
 ;; @001f                               v49 = iadd v145, v47
 ;; @001f                               v51 = iadd v49, v43  ; v43 = 16
-;; @001f                               v52 = load.i32 user2 readonly region1 v51
+;; @001f                               v52 = load.i32 user2 readonly region3 v51
 ;; @001f                               v53 = uextend.i64 v52
 ;; @001f                               v59 = icmp.i64 ugt v5, v53
 ;; @001f                               trapnz v59, user17

--- a/tests/disas/gc/array-new-default-i16.wat
+++ b/tests/disas/gc/array-new-default-i16.wat
@@ -11,13 +11,15 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     ss0 = explicit_slot 4, align = 4
-;;     region0 = 32 "VMContext+0x20"
-;;     region1 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 40 "VMContext+0x28"
+;;     region2 = 32 "VMContext+0x20"
+;;     region3 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
@@ -56,13 +58,13 @@
 ;;                                     v117 = iconst.i32 -16
 ;;                                     v118 = band v114, v117  ; v117 = -16
 ;;                                     v120 = iadd.i32 v13, v118
-;; @001f                               store notrap aligned region0 v120, v12
+;; @001f                               store notrap aligned region2 v120, v12
 ;;                                     v141 = iconst.i32 -1476395002
-;;                                     v142 = load.i64 notrap aligned readonly can_move v0+8
+;;                                     v142 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;;                                     v143 = load.i64 notrap aligned readonly can_move v142+32
 ;; @001f                               v37 = iadd v143, v20
 ;; @001f                               store notrap aligned v141, v37  ; v141 = -1476395002
-;;                                     v144 = load.i64 notrap aligned readonly can_move v0+40
+;;                                     v144 = load.i64 notrap aligned readonly can_move region1 v0+40
 ;;                                     v145 = load.i32 notrap aligned readonly can_move v144
 ;; @001f                               store notrap aligned v145, v37+4
 ;;                                     v146 = band.i64 v18, v17  ; v17 = -16
@@ -71,11 +73,11 @@
 ;;
 ;;                                 block3 cold:
 ;; @001f                               v24 = iconst.i32 -1476395002
-;; @001f                               v25 = load.i64 notrap aligned readonly can_move v0+40
+;; @001f                               v25 = load.i64 notrap aligned readonly can_move region1 v0+40
 ;; @001f                               v26 = load.i32 notrap aligned readonly can_move v25
 ;; @001f                               v27 = iconst.i32 16
 ;; @001f                               v28 = call fn0(v0, v24, v26, v11, v27)  ; v24 = -1476395002, v27 = 16
-;; @001f                               v29 = load.i64 notrap aligned readonly can_move v0+8
+;; @001f                               v29 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @001f                               v30 = load.i64 notrap aligned readonly can_move v29+32
 ;; @001f                               v31 = uextend.i64 v28
 ;; @001f                               v32 = iadd v30, v31
@@ -86,14 +88,14 @@
 ;;                                     store notrap v41, v89
 ;; @001f                               v43 = iconst.i64 16
 ;; @001f                               v44 = iadd v42, v43  ; v43 = 16
-;; @001f                               store.i32 user2 region1 v2, v44
+;; @001f                               store.i32 user2 region3 v2, v44
 ;; @001f                               trapz v41, user16
-;;                                     v147 = load.i64 notrap aligned readonly can_move v0+8
+;;                                     v147 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;;                                     v148 = load.i64 notrap aligned readonly can_move v147+32
 ;; @001f                               v47 = uextend.i64 v41
 ;; @001f                               v49 = iadd v148, v47
 ;; @001f                               v51 = iadd v49, v43  ; v43 = 16
-;; @001f                               v52 = load.i32 user2 readonly region1 v51
+;; @001f                               v52 = load.i32 user2 readonly region3 v51
 ;; @001f                               v53 = uextend.i64 v52
 ;; @001f                               v59 = icmp.i64 ugt v5, v53
 ;; @001f                               trapnz v59, user17

--- a/tests/disas/gc/array-new-default-i32.wat
+++ b/tests/disas/gc/array-new-default-i32.wat
@@ -11,13 +11,15 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     ss0 = explicit_slot 4, align = 4
-;;     region0 = 32 "VMContext+0x20"
-;;     region1 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 40 "VMContext+0x28"
+;;     region2 = 32 "VMContext+0x20"
+;;     region3 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
@@ -57,13 +59,13 @@
 ;;                                     v112 = iconst.i32 -16
 ;;                                     v113 = band v109, v112  ; v112 = -16
 ;;                                     v115 = iadd.i32 v13, v113
-;; @001f                               store notrap aligned region0 v115, v12
+;; @001f                               store notrap aligned region2 v115, v12
 ;;                                     v131 = iconst.i32 -1476395002
-;;                                     v132 = load.i64 notrap aligned readonly can_move v0+8
+;;                                     v132 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;;                                     v133 = load.i64 notrap aligned readonly can_move v132+32
 ;; @001f                               v37 = iadd v133, v20
 ;; @001f                               store notrap aligned v131, v37  ; v131 = -1476395002
-;;                                     v134 = load.i64 notrap aligned readonly can_move v0+40
+;;                                     v134 = load.i64 notrap aligned readonly can_move region1 v0+40
 ;;                                     v135 = load.i32 notrap aligned readonly can_move v134
 ;; @001f                               store notrap aligned v135, v37+4
 ;;                                     v136 = band.i64 v18, v17  ; v17 = -16
@@ -72,11 +74,11 @@
 ;;
 ;;                                 block3 cold:
 ;; @001f                               v24 = iconst.i32 -1476395002
-;; @001f                               v25 = load.i64 notrap aligned readonly can_move v0+40
+;; @001f                               v25 = load.i64 notrap aligned readonly can_move region1 v0+40
 ;; @001f                               v26 = load.i32 notrap aligned readonly can_move v25
 ;; @001f                               v27 = iconst.i32 16
 ;; @001f                               v28 = call fn0(v0, v24, v26, v11, v27)  ; v24 = -1476395002, v27 = 16
-;; @001f                               v29 = load.i64 notrap aligned readonly can_move v0+8
+;; @001f                               v29 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @001f                               v30 = load.i64 notrap aligned readonly can_move v29+32
 ;; @001f                               v31 = uextend.i64 v28
 ;; @001f                               v32 = iadd v30, v31
@@ -87,14 +89,14 @@
 ;;                                     store notrap v41, v89
 ;; @001f                               v43 = iconst.i64 16
 ;; @001f                               v44 = iadd v42, v43  ; v43 = 16
-;; @001f                               store.i32 user2 region1 v2, v44
+;; @001f                               store.i32 user2 region3 v2, v44
 ;; @001f                               trapz v41, user16
-;;                                     v137 = load.i64 notrap aligned readonly can_move v0+8
+;;                                     v137 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;;                                     v138 = load.i64 notrap aligned readonly can_move v137+32
 ;; @001f                               v47 = uextend.i64 v41
 ;; @001f                               v49 = iadd v138, v47
 ;; @001f                               v51 = iadd v49, v43  ; v43 = 16
-;; @001f                               v52 = load.i32 user2 readonly region1 v51
+;; @001f                               v52 = load.i32 user2 readonly region3 v51
 ;; @001f                               v53 = uextend.i64 v52
 ;; @001f                               v59 = icmp.i64 ugt v5, v53
 ;; @001f                               trapnz v59, user17

--- a/tests/disas/gc/array-new-default-i64.wat
+++ b/tests/disas/gc/array-new-default-i64.wat
@@ -11,13 +11,15 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     ss0 = explicit_slot 4, align = 4
-;;     region0 = 32 "VMContext+0x20"
-;;     region1 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 40 "VMContext+0x28"
+;;     region2 = 32 "VMContext+0x20"
+;;     region3 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
@@ -57,13 +59,13 @@
 ;;                                     v112 = iconst.i32 -16
 ;;                                     v113 = band v109, v112  ; v112 = -16
 ;;                                     v115 = iadd.i32 v13, v113
-;; @001f                               store notrap aligned region0 v115, v12
+;; @001f                               store notrap aligned region2 v115, v12
 ;;                                     v130 = iconst.i32 -1476395002
-;;                                     v131 = load.i64 notrap aligned readonly can_move v0+8
+;;                                     v131 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;;                                     v132 = load.i64 notrap aligned readonly can_move v131+32
 ;; @001f                               v37 = iadd v132, v20
 ;; @001f                               store notrap aligned v130, v37  ; v130 = -1476395002
-;;                                     v133 = load.i64 notrap aligned readonly can_move v0+40
+;;                                     v133 = load.i64 notrap aligned readonly can_move region1 v0+40
 ;;                                     v134 = load.i32 notrap aligned readonly can_move v133
 ;; @001f                               store notrap aligned v134, v37+4
 ;;                                     v135 = band.i64 v18, v17  ; v17 = -16
@@ -72,11 +74,11 @@
 ;;
 ;;                                 block3 cold:
 ;; @001f                               v24 = iconst.i32 -1476395002
-;; @001f                               v25 = load.i64 notrap aligned readonly can_move v0+40
+;; @001f                               v25 = load.i64 notrap aligned readonly can_move region1 v0+40
 ;; @001f                               v26 = load.i32 notrap aligned readonly can_move v25
 ;; @001f                               v27 = iconst.i32 16
 ;; @001f                               v28 = call fn0(v0, v24, v26, v11, v27)  ; v24 = -1476395002, v27 = 16
-;; @001f                               v29 = load.i64 notrap aligned readonly can_move v0+8
+;; @001f                               v29 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @001f                               v30 = load.i64 notrap aligned readonly can_move v29+32
 ;; @001f                               v31 = uextend.i64 v28
 ;; @001f                               v32 = iadd v30, v31
@@ -87,14 +89,14 @@
 ;;                                     store notrap v41, v89
 ;; @001f                               v43 = iconst.i64 16
 ;; @001f                               v44 = iadd v42, v43  ; v43 = 16
-;; @001f                               store.i32 user2 region1 v2, v44
+;; @001f                               store.i32 user2 region3 v2, v44
 ;; @001f                               trapz v41, user16
-;;                                     v136 = load.i64 notrap aligned readonly can_move v0+8
+;;                                     v136 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;;                                     v137 = load.i64 notrap aligned readonly can_move v136+32
 ;; @001f                               v47 = uextend.i64 v41
 ;; @001f                               v49 = iadd v137, v47
 ;; @001f                               v51 = iadd v49, v43  ; v43 = 16
-;; @001f                               v52 = load.i32 user2 readonly region1 v51
+;; @001f                               v52 = load.i32 user2 readonly region3 v51
 ;; @001f                               v53 = uextend.i64 v52
 ;; @001f                               v59 = icmp.i64 ugt v5, v53
 ;; @001f                               trapnz v59, user17

--- a/tests/disas/gc/array-new-default-i8.wat
+++ b/tests/disas/gc/array-new-default-i8.wat
@@ -11,13 +11,15 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     ss0 = explicit_slot 4, align = 4
-;;     region0 = 32 "VMContext+0x20"
-;;     region1 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 40 "VMContext+0x28"
+;;     region2 = 32 "VMContext+0x20"
+;;     region3 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
@@ -53,13 +55,13 @@
 ;;                                     v102 = iconst.i32 -16
 ;;                                     v103 = band v99, v102  ; v102 = -16
 ;;                                     v105 = iadd.i32 v13, v103
-;; @001f                               store notrap aligned region0 v105, v12
+;; @001f                               store notrap aligned region2 v105, v12
 ;;                                     v119 = iconst.i32 -1476395002
-;;                                     v120 = load.i64 notrap aligned readonly can_move v0+8
+;;                                     v120 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;;                                     v121 = load.i64 notrap aligned readonly can_move v120+32
 ;; @001f                               v37 = iadd v121, v20
 ;; @001f                               store notrap aligned v119, v37  ; v119 = -1476395002
-;;                                     v122 = load.i64 notrap aligned readonly can_move v0+40
+;;                                     v122 = load.i64 notrap aligned readonly can_move region1 v0+40
 ;;                                     v123 = load.i32 notrap aligned readonly can_move v122
 ;; @001f                               store notrap aligned v123, v37+4
 ;;                                     v124 = band.i64 v18, v17  ; v17 = -16
@@ -68,11 +70,11 @@
 ;;
 ;;                                 block3 cold:
 ;; @001f                               v24 = iconst.i32 -1476395002
-;; @001f                               v25 = load.i64 notrap aligned readonly can_move v0+40
+;; @001f                               v25 = load.i64 notrap aligned readonly can_move region1 v0+40
 ;; @001f                               v26 = load.i32 notrap aligned readonly can_move v25
 ;; @001f                               v27 = iconst.i32 16
 ;; @001f                               v28 = call fn0(v0, v24, v26, v11, v27)  ; v24 = -1476395002, v27 = 16
-;; @001f                               v29 = load.i64 notrap aligned readonly can_move v0+8
+;; @001f                               v29 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @001f                               v30 = load.i64 notrap aligned readonly can_move v29+32
 ;; @001f                               v31 = uextend.i64 v28
 ;; @001f                               v32 = iadd v30, v31
@@ -83,14 +85,14 @@
 ;;                                     store notrap v41, v88
 ;; @001f                               v43 = iconst.i64 16
 ;; @001f                               v44 = iadd v42, v43  ; v43 = 16
-;; @001f                               store.i32 user2 region1 v2, v44
+;; @001f                               store.i32 user2 region3 v2, v44
 ;; @001f                               trapz v41, user16
-;;                                     v125 = load.i64 notrap aligned readonly can_move v0+8
+;;                                     v125 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;;                                     v126 = load.i64 notrap aligned readonly can_move v125+32
 ;; @001f                               v47 = uextend.i64 v41
 ;; @001f                               v49 = iadd v126, v47
 ;; @001f                               v51 = iadd v49, v43  ; v43 = 16
-;; @001f                               v52 = load.i32 user2 readonly region1 v51
+;; @001f                               v52 = load.i32 user2 readonly region3 v51
 ;; @001f                               v53 = uextend.i64 v52
 ;; @001f                               v59 = icmp.i64 ugt v5, v53
 ;; @001f                               trapnz v59, user17

--- a/tests/disas/gc/call-indirect-final-type.wat
+++ b/tests/disas/gc/call-indirect-final-type.wat
@@ -16,9 +16,11 @@
     (return_call_indirect (type $f) (local.get 0) (local.get 1)))
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32) -> i32 tail {
-;;     region0 = 1342177280 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 1342177280 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
+;;     region2 = 40 "VMContext+0x28"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+48
@@ -39,7 +41,7 @@
 ;; @002b                               v11 = ishl v8, v10  ; v10 = 3
 ;; @002b                               v12 = iadd v9, v11
 ;; @002b                               v14 = select_spectre_guard v7, v13, v12  ; v13 = 0
-;; @002b                               v15 = load.i64 user6 aligned region0 v14
+;; @002b                               v15 = load.i64 user6 aligned region1 v14
 ;; @002b                               v16 = iconst.i64 -2
 ;; @002b                               v17 = band v15, v16  ; v16 = -2
 ;; @002b                               brif v15, block3(v17), block2
@@ -51,7 +53,7 @@
 ;;
 ;;                                 block3(v18: i64):
 ;; @002b                               v24 = load.i32 user7 aligned readonly v18+16
-;; @002b                               v22 = load.i64 notrap aligned readonly can_move v0+40
+;; @002b                               v22 = load.i64 notrap aligned readonly can_move region2 v0+40
 ;; @002b                               v23 = load.i32 notrap aligned readonly can_move v22
 ;; @002b                               v25 = icmp eq v24, v23
 ;; @002b                               trapz v25, user8
@@ -65,9 +67,11 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32, i32) -> i32 tail {
-;;     region0 = 1342177280 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 1342177280 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
+;;     region2 = 40 "VMContext+0x28"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+48
@@ -88,7 +92,7 @@
 ;; @0035                               v11 = ishl v8, v10  ; v10 = 3
 ;; @0035                               v12 = iadd v9, v11
 ;; @0035                               v14 = select_spectre_guard v7, v13, v12  ; v13 = 0
-;; @0035                               v15 = load.i64 user6 aligned region0 v14
+;; @0035                               v15 = load.i64 user6 aligned region1 v14
 ;; @0035                               v16 = iconst.i64 -2
 ;; @0035                               v17 = band v15, v16  ; v16 = -2
 ;; @0035                               brif v15, block3(v17), block2
@@ -100,7 +104,7 @@
 ;;
 ;;                                 block3(v18: i64):
 ;; @0035                               v24 = load.i32 user7 aligned readonly v18+16
-;; @0035                               v22 = load.i64 notrap aligned readonly can_move v0+40
+;; @0035                               v22 = load.i64 notrap aligned readonly can_move region2 v0+40
 ;; @0035                               v23 = load.i32 notrap aligned readonly can_move v22
 ;; @0035                               v25 = icmp eq v24, v23
 ;; @0035                               trapz v25, user8

--- a/tests/disas/gc/copying/array-fill.wat
+++ b/tests/disas/gc/copying/array-fill.wat
@@ -9,25 +9,26 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32, i64, i32) tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i64, v5: i32):
 ;; @0027                               trapz v2, user16
-;; @0027                               v46 = load.i64 notrap aligned readonly can_move v0+8
+;; @0027                               v46 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @0027                               v7 = load.i64 notrap aligned readonly can_move v46+32
 ;; @0027                               v6 = uextend.i64 v2
 ;; @0027                               v8 = iadd v7, v6
 ;; @0027                               v9 = iconst.i64 16
 ;; @0027                               v10 = iadd v8, v9  ; v9 = 16
-;; @0027                               v11 = load.i32 user2 readonly region0 v10
+;; @0027                               v11 = load.i32 user2 readonly region1 v10
 ;; @0027                               v13 = uextend.i64 v3
 ;; @0027                               v14 = uextend.i64 v5
 ;; @0027                               v17 = iadd v13, v14
@@ -52,7 +53,7 @@
 ;; @0027                               brif v41, block3, block2(v28)
 ;;
 ;;                                 block2(v42: i64):
-;; @0027                               store.i64 user2 little region0 v4, v42
+;; @0027                               store.i64 user2 little region1 v4, v42
 ;;                                     v55 = iconst.i64 8
 ;;                                     v56 = iadd v42, v55  ; v55 = 8
 ;; @0027                               v45 = icmp eq v56, v39

--- a/tests/disas/gc/copying/array-get-s.wat
+++ b/tests/disas/gc/copying/array-get-s.wat
@@ -9,25 +9,26 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32) -> i32 tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0022                               trapz v2, user16
-;; @0022                               v34 = load.i64 notrap aligned readonly can_move v0+8
+;; @0022                               v34 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @0022                               v6 = load.i64 notrap aligned readonly can_move v34+32
 ;; @0022                               v5 = uextend.i64 v2
 ;; @0022                               v7 = iadd v6, v5
 ;; @0022                               v8 = iconst.i64 16
 ;; @0022                               v9 = iadd v7, v8  ; v8 = 16
-;; @0022                               v10 = load.i32 user2 readonly region0 v9
+;; @0022                               v10 = load.i32 user2 readonly region1 v9
 ;; @0022                               v11 = icmp ult v3, v10
 ;; @0022                               trapz v11, user17
 ;; @0022                               v13 = uextend.i64 v10
@@ -43,7 +44,7 @@
 ;; @0022                               v27 = isub v19, v22
 ;; @0022                               v28 = uextend.i64 v27
 ;; @0022                               v29 = isub v26, v28
-;; @0022                               v30 = load.i8 user2 little region0 v29
+;; @0022                               v30 = load.i8 user2 little region1 v29
 ;; @0025                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/copying/array-get-u.wat
+++ b/tests/disas/gc/copying/array-get-u.wat
@@ -9,25 +9,26 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32) -> i32 tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0022                               trapz v2, user16
-;; @0022                               v34 = load.i64 notrap aligned readonly can_move v0+8
+;; @0022                               v34 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @0022                               v6 = load.i64 notrap aligned readonly can_move v34+32
 ;; @0022                               v5 = uextend.i64 v2
 ;; @0022                               v7 = iadd v6, v5
 ;; @0022                               v8 = iconst.i64 16
 ;; @0022                               v9 = iadd v7, v8  ; v8 = 16
-;; @0022                               v10 = load.i32 user2 readonly region0 v9
+;; @0022                               v10 = load.i32 user2 readonly region1 v9
 ;; @0022                               v11 = icmp ult v3, v10
 ;; @0022                               trapz v11, user17
 ;; @0022                               v13 = uextend.i64 v10
@@ -43,7 +44,7 @@
 ;; @0022                               v27 = isub v19, v22
 ;; @0022                               v28 = uextend.i64 v27
 ;; @0022                               v29 = isub v26, v28
-;; @0022                               v30 = load.i8 user2 little region0 v29
+;; @0022                               v30 = load.i8 user2 little region1 v29
 ;; @0025                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/copying/array-get.wat
+++ b/tests/disas/gc/copying/array-get.wat
@@ -9,25 +9,26 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32) -> i64 tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0022                               trapz v2, user16
-;; @0022                               v33 = load.i64 notrap aligned readonly can_move v0+8
+;; @0022                               v33 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @0022                               v6 = load.i64 notrap aligned readonly can_move v33+32
 ;; @0022                               v5 = uextend.i64 v2
 ;; @0022                               v7 = iadd v6, v5
 ;; @0022                               v8 = iconst.i64 16
 ;; @0022                               v9 = iadd v7, v8  ; v8 = 16
-;; @0022                               v10 = load.i32 user2 readonly region0 v9
+;; @0022                               v10 = load.i32 user2 readonly region1 v9
 ;; @0022                               v11 = icmp ult v3, v10
 ;; @0022                               trapz v11, user17
 ;; @0022                               v13 = uextend.i64 v10
@@ -48,7 +49,7 @@
 ;; @0022                               v27 = isub v19, v22
 ;; @0022                               v28 = uextend.i64 v27
 ;; @0022                               v29 = isub v26, v28
-;; @0022                               v30 = load.i64 user2 little region0 v29
+;; @0022                               v30 = load.i64 user2 little region1 v29
 ;; @0025                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/copying/array-len.wat
+++ b/tests/disas/gc/copying/array-len.wat
@@ -9,25 +9,26 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @001f                               trapz v2, user16
-;; @001f                               v10 = load.i64 notrap aligned readonly can_move v0+8
+;; @001f                               v10 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @001f                               v5 = load.i64 notrap aligned readonly can_move v10+32
 ;; @001f                               v4 = uextend.i64 v2
 ;; @001f                               v6 = iadd v5, v4
 ;; @001f                               v7 = iconst.i64 16
 ;; @001f                               v8 = iadd v6, v7  ; v7 = 16
-;; @001f                               v9 = load.i32 user2 readonly region0 v8
+;; @001f                               v9 = load.i32 user2 readonly region1 v8
 ;; @0021                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/copying/array-new-fixed-of-gc-refs.wat
+++ b/tests/disas/gc/copying/array-new-fixed-of-gc-refs.wat
@@ -12,13 +12,15 @@
 ;;     ss0 = explicit_slot 4, align = 4
 ;;     ss1 = explicit_slot 4, align = 4
 ;;     ss2 = explicit_slot 4, align = 4
-;;     region0 = 32 "VMContext+0x20"
-;;     region1 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 40 "VMContext+0x28"
+;;     region2 = 32 "VMContext+0x20"
+;;     region3 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
@@ -45,13 +47,13 @@
 ;;                                 block2:
 ;;                                     v266 = iconst.i32 32
 ;;                                     v172 = iadd.i32 v16, v266  ; v266 = 32
-;; @0025                               store notrap aligned region0 v172, v15
+;; @0025                               store notrap aligned region2 v172, v15
 ;;                                     v267 = iconst.i32 -1476394994
-;;                                     v268 = load.i64 notrap aligned readonly can_move v0+8
+;;                                     v268 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;;                                     v269 = load.i64 notrap aligned readonly can_move v268+32
 ;; @0025                               v40 = iadd v269, v23
 ;; @0025                               store notrap aligned v267, v40  ; v267 = -1476394994
-;;                                     v270 = load.i64 notrap aligned readonly can_move v0+40
+;;                                     v270 = load.i64 notrap aligned readonly can_move region1 v0+40
 ;;                                     v271 = load.i32 notrap aligned readonly can_move v270
 ;; @0025                               store notrap aligned v271, v40+4
 ;;                                     v272 = iconst.i64 32
@@ -60,12 +62,12 @@
 ;;
 ;;                                 block3 cold:
 ;; @0025                               v27 = iconst.i32 -1476394994
-;; @0025                               v28 = load.i64 notrap aligned readonly can_move v0+40
+;; @0025                               v28 = load.i64 notrap aligned readonly can_move region1 v0+40
 ;; @0025                               v29 = load.i32 notrap aligned readonly can_move v28
 ;;                                     v158 = iconst.i32 32
 ;; @0025                               v30 = iconst.i32 16
 ;; @0025                               v31 = call fn0(v0, v27, v29, v158, v30), stack_map=[i32 @ ss2+0, i32 @ ss1+0, i32 @ ss0+0]  ; v27 = -1476394994, v158 = 32, v30 = 16
-;; @0025                               v32 = load.i64 notrap aligned readonly can_move v0+8
+;; @0025                               v32 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @0025                               v33 = load.i64 notrap aligned readonly can_move v32+32
 ;; @0025                               v34 = uextend.i64 v31
 ;; @0025                               v35 = iadd v33, v34
@@ -75,14 +77,14 @@
 ;; @0025                               v6 = iconst.i32 3
 ;; @0025                               v46 = iconst.i64 16
 ;; @0025                               v47 = iadd v45, v46  ; v46 = 16
-;; @0025                               store user2 region1 v6, v47  ; v6 = 3
+;; @0025                               store user2 region3 v6, v47  ; v6 = 3
 ;; @0025                               trapz v44, user16
-;;                                     v273 = load.i64 notrap aligned readonly can_move v0+8
+;;                                     v273 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;;                                     v274 = load.i64 notrap aligned readonly can_move v273+32
 ;; @0025                               v49 = uextend.i64 v44
 ;; @0025                               v51 = iadd v274, v49
 ;; @0025                               v53 = iadd v51, v46  ; v46 = 16
-;; @0025                               v54 = load.i32 user2 readonly region1 v53
+;; @0025                               v54 = load.i32 user2 readonly region3 v53
 ;; @0025                               trapz v54, user17
 ;; @0025                               v57 = uextend.i64 v54
 ;;                                     v149 = iconst.i64 2
@@ -101,8 +103,8 @@
 ;; @0025                               v71 = isub v63, v7  ; v7 = 20
 ;; @0025                               v72 = uextend.i64 v71
 ;; @0025                               v73 = isub v70, v72
-;; @0025                               store user2 little region1 v131, v73
-;; @0025                               v80 = load.i32 user2 readonly region1 v53
+;; @0025                               store user2 little region3 v131, v73
+;; @0025                               v80 = load.i32 user2 readonly region3 v53
 ;; @0025                               v74 = iconst.i32 1
 ;;                                     v205 = icmp ugt v80, v74  ; v74 = 1
 ;; @0025                               trapz v205, user17
@@ -120,8 +122,8 @@
 ;; @0025                               v97 = isub v89, v227  ; v227 = 24
 ;; @0025                               v98 = uextend.i64 v97
 ;; @0025                               v99 = isub v96, v98
-;; @0025                               store user2 little region1 v129, v99
-;; @0025                               v106 = load.i32 user2 readonly region1 v53
+;; @0025                               store user2 little region3 v129, v99
+;; @0025                               v106 = load.i32 user2 readonly region3 v53
 ;;                                     v233 = icmp ugt v106, v187  ; v187 = 2
 ;; @0025                               trapz v233, user17
 ;; @0025                               v109 = uextend.i64 v106
@@ -138,7 +140,7 @@
 ;; @0025                               v123 = isub v115, v260  ; v260 = 28
 ;; @0025                               v124 = uextend.i64 v123
 ;; @0025                               v125 = isub v122, v124
-;; @0025                               store user2 little region1 v127, v125
+;; @0025                               store user2 little region3 v127, v125
 ;; @0029                               jump block1(v44)
 ;;
 ;;                                 block1(v5: i32):

--- a/tests/disas/gc/copying/array-new-fixed.wat
+++ b/tests/disas/gc/copying/array-new-fixed.wat
@@ -9,13 +9,15 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i64, i64, i64) -> i32 tail {
-;;     region0 = 32 "VMContext+0x20"
-;;     region1 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 40 "VMContext+0x28"
+;;     region2 = 32 "VMContext+0x20"
+;;     region3 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
@@ -36,13 +38,13 @@
 ;;                                 block2:
 ;;                                     v254 = iconst.i32 48
 ;;                                     v162 = iadd.i32 v16, v254  ; v254 = 48
-;; @0025                               store notrap aligned region0 v162, v15
+;; @0025                               store notrap aligned region2 v162, v15
 ;;                                     v255 = iconst.i32 -1476395002
-;;                                     v256 = load.i64 notrap aligned readonly can_move v0+8
+;;                                     v256 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;;                                     v257 = load.i64 notrap aligned readonly can_move v256+32
 ;; @0025                               v40 = iadd v257, v23
 ;; @0025                               store notrap aligned v255, v40  ; v255 = -1476395002
-;;                                     v258 = load.i64 notrap aligned readonly can_move v0+40
+;;                                     v258 = load.i64 notrap aligned readonly can_move region1 v0+40
 ;;                                     v259 = load.i32 notrap aligned readonly can_move v258
 ;; @0025                               store notrap aligned v259, v40+4
 ;;                                     v260 = iconst.i64 48
@@ -51,12 +53,12 @@
 ;;
 ;;                                 block3 cold:
 ;; @0025                               v27 = iconst.i32 -1476395002
-;; @0025                               v28 = load.i64 notrap aligned readonly can_move v0+40
+;; @0025                               v28 = load.i64 notrap aligned readonly can_move region1 v0+40
 ;; @0025                               v29 = load.i32 notrap aligned readonly can_move v28
 ;;                                     v147 = iconst.i32 48
 ;; @0025                               v30 = iconst.i32 16
 ;; @0025                               v31 = call fn0(v0, v27, v29, v147, v30)  ; v27 = -1476395002, v147 = 48, v30 = 16
-;; @0025                               v32 = load.i64 notrap aligned readonly can_move v0+8
+;; @0025                               v32 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @0025                               v33 = load.i64 notrap aligned readonly can_move v32+32
 ;; @0025                               v34 = uextend.i64 v31
 ;; @0025                               v35 = iadd v33, v34
@@ -66,14 +68,14 @@
 ;; @0025                               v6 = iconst.i32 3
 ;; @0025                               v46 = iconst.i64 16
 ;; @0025                               v47 = iadd v45, v46  ; v46 = 16
-;; @0025                               store user2 region1 v6, v47  ; v6 = 3
+;; @0025                               store user2 region3 v6, v47  ; v6 = 3
 ;; @0025                               trapz v44, user16
-;;                                     v261 = load.i64 notrap aligned readonly can_move v0+8
+;;                                     v261 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;;                                     v262 = load.i64 notrap aligned readonly can_move v261+32
 ;; @0025                               v49 = uextend.i64 v44
 ;; @0025                               v51 = iadd v262, v49
 ;; @0025                               v53 = iadd v51, v46  ; v46 = 16
-;; @0025                               v54 = load.i32 user2 readonly region1 v53
+;; @0025                               v54 = load.i32 user2 readonly region3 v53
 ;; @0025                               trapz v54, user17
 ;; @0025                               v57 = uextend.i64 v54
 ;;                                     v138 = iconst.i64 3
@@ -90,8 +92,8 @@
 ;; @0025                               v71 = isub v63, v7  ; v7 = 24
 ;; @0025                               v72 = uextend.i64 v71
 ;; @0025                               v73 = isub v70, v72
-;; @0025                               store.i64 user2 little region1 v2, v73
-;; @0025                               v80 = load.i32 user2 readonly region1 v53
+;; @0025                               store.i64 user2 little region3 v2, v73
+;; @0025                               v80 = load.i32 user2 readonly region3 v53
 ;; @0025                               v74 = iconst.i32 1
 ;;                                     v194 = icmp ugt v80, v74  ; v74 = 1
 ;; @0025                               trapz v194, user17
@@ -108,8 +110,8 @@
 ;; @0025                               v97 = isub v89, v216  ; v216 = 32
 ;; @0025                               v98 = uextend.i64 v97
 ;; @0025                               v99 = isub v96, v98
-;; @0025                               store.i64 user2 little region1 v3, v99
-;; @0025                               v106 = load.i32 user2 readonly region1 v53
+;; @0025                               store.i64 user2 little region3 v3, v99
+;; @0025                               v106 = load.i32 user2 readonly region3 v53
 ;; @0025                               v100 = iconst.i32 2
 ;;                                     v222 = icmp ugt v106, v100  ; v100 = 2
 ;; @0025                               trapz v222, user17
@@ -126,7 +128,7 @@
 ;; @0025                               v123 = isub v115, v248  ; v248 = 40
 ;; @0025                               v124 = uextend.i64 v123
 ;; @0025                               v125 = isub v122, v124
-;; @0025                               store.i64 user2 little region1 v4, v125
+;; @0025                               store.i64 user2 little region3 v4, v125
 ;; @0029                               jump block1(v44)
 ;;
 ;;                                 block1(v5: i32):

--- a/tests/disas/gc/copying/array-new.wat
+++ b/tests/disas/gc/copying/array-new.wat
@@ -9,13 +9,15 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i64, i32) -> i32 tail {
-;;     region0 = 32 "VMContext+0x20"
-;;     region1 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 40 "VMContext+0x28"
+;;     region2 = 32 "VMContext+0x20"
+;;     region3 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
@@ -53,13 +55,13 @@
 ;;                                     v109 = iconst.i32 -16
 ;;                                     v110 = band v106, v109  ; v109 = -16
 ;;                                     v112 = iadd.i32 v14, v110
-;; @0022                               store notrap aligned region0 v112, v13
+;; @0022                               store notrap aligned region2 v112, v13
 ;;                                     v128 = iconst.i32 -1476395002
-;;                                     v129 = load.i64 notrap aligned readonly can_move v0+8
+;;                                     v129 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;;                                     v130 = load.i64 notrap aligned readonly can_move v129+32
 ;; @0022                               v38 = iadd v130, v21
 ;; @0022                               store notrap aligned v128, v38  ; v128 = -1476395002
-;;                                     v131 = load.i64 notrap aligned readonly can_move v0+40
+;;                                     v131 = load.i64 notrap aligned readonly can_move region1 v0+40
 ;;                                     v132 = load.i32 notrap aligned readonly can_move v131
 ;; @0022                               store notrap aligned v132, v38+4
 ;;                                     v133 = band.i64 v19, v18  ; v18 = -16
@@ -68,11 +70,11 @@
 ;;
 ;;                                 block3 cold:
 ;; @0022                               v25 = iconst.i32 -1476395002
-;; @0022                               v26 = load.i64 notrap aligned readonly can_move v0+40
+;; @0022                               v26 = load.i64 notrap aligned readonly can_move region1 v0+40
 ;; @0022                               v27 = load.i32 notrap aligned readonly can_move v26
 ;; @0022                               v28 = iconst.i32 16
 ;; @0022                               v29 = call fn0(v0, v25, v27, v12, v28)  ; v25 = -1476395002, v28 = 16
-;; @0022                               v30 = load.i64 notrap aligned readonly can_move v0+8
+;; @0022                               v30 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @0022                               v31 = load.i64 notrap aligned readonly can_move v30+32
 ;; @0022                               v32 = uextend.i64 v29
 ;; @0022                               v33 = iadd v31, v32
@@ -81,14 +83,14 @@
 ;;                                 block4(v42: i32, v43: i64):
 ;; @0022                               v44 = iconst.i64 16
 ;; @0022                               v45 = iadd v43, v44  ; v44 = 16
-;; @0022                               store.i32 user2 region1 v3, v45
+;; @0022                               store.i32 user2 region3 v3, v45
 ;; @0022                               trapz v42, user16
-;;                                     v134 = load.i64 notrap aligned readonly can_move v0+8
+;;                                     v134 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;;                                     v135 = load.i64 notrap aligned readonly can_move v134+32
 ;; @0022                               v47 = uextend.i64 v42
 ;; @0022                               v49 = iadd v135, v47
 ;; @0022                               v51 = iadd v49, v44  ; v44 = 16
-;; @0022                               v52 = load.i32 user2 readonly region1 v51
+;; @0022                               v52 = load.i32 user2 readonly region3 v51
 ;; @0022                               v53 = uextend.i64 v52
 ;; @0022                               v59 = icmp.i64 ugt v6, v53
 ;; @0022                               trapnz v59, user17
@@ -106,7 +108,7 @@
 ;; @0022                               brif v82, block6, block5(v65)
 ;;
 ;;                                 block5(v83: i64):
-;; @0022                               store.i64 user2 little region1 v2, v83
+;; @0022                               store.i64 user2 little region3 v2, v83
 ;;                                     v136 = iconst.i64 8
 ;;                                     v137 = iadd v83, v136  ; v136 = 8
 ;; @0022                               v86 = icmp eq v137, v80

--- a/tests/disas/gc/copying/array-set.wat
+++ b/tests/disas/gc/copying/array-set.wat
@@ -9,25 +9,26 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32, i64) tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i64):
 ;; @0024                               trapz v2, user16
-;; @0024                               v32 = load.i64 notrap aligned readonly can_move v0+8
+;; @0024                               v32 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @0024                               v6 = load.i64 notrap aligned readonly can_move v32+32
 ;; @0024                               v5 = uextend.i64 v2
 ;; @0024                               v7 = iadd v6, v5
 ;; @0024                               v8 = iconst.i64 16
 ;; @0024                               v9 = iadd v7, v8  ; v8 = 16
-;; @0024                               v10 = load.i32 user2 readonly region0 v9
+;; @0024                               v10 = load.i32 user2 readonly region1 v9
 ;; @0024                               v11 = icmp ult v3, v10
 ;; @0024                               trapz v11, user17
 ;; @0024                               v13 = uextend.i64 v10
@@ -48,7 +49,7 @@
 ;; @0024                               v27 = isub v19, v22
 ;; @0024                               v28 = uextend.i64 v27
 ;; @0024                               v29 = isub v26, v28
-;; @0024                               store user2 little region0 v4, v29
+;; @0024                               store user2 little region1 v4, v29
 ;; @0027                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/copying/br-on-cast-fail.wat
+++ b/tests/disas/gc/copying/br-on-cast-fail.wat
@@ -16,12 +16,18 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32) tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 40 "VMContext+0x28"
+;;     region2 = 2147483648 "GcHeap"
+;;     region3 = 72 "VMContext+0x48"
+;;     region4 = 56 "VMContext+0x38"
+;;     region5 = 104 "VMContext+0x68"
+;;     region6 = 88 "VMContext+0x58"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i64) tail
@@ -39,14 +45,14 @@
 ;; @002e                               brif v9, block5(v30), block4  ; v30 = 0
 ;;
 ;;                                 block4:
-;; @002e                               v28 = load.i64 notrap aligned readonly can_move v0+8
+;; @002e                               v28 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @002e                               v14 = load.i64 notrap aligned readonly can_move v28+32
 ;; @002e                               v13 = uextend.i64 v2
 ;; @002e                               v15 = iadd v14, v13
 ;; @002e                               v16 = iconst.i64 4
 ;; @002e                               v17 = iadd v15, v16  ; v16 = 4
-;; @002e                               v18 = load.i32 user2 readonly region0 v17
-;; @002e                               v11 = load.i64 notrap aligned readonly can_move v0+40
+;; @002e                               v18 = load.i32 user2 readonly region2 v17
+;; @002e                               v11 = load.i64 notrap aligned readonly can_move region1 v0+40
 ;; @002e                               v12 = load.i32 notrap aligned readonly can_move v11
 ;; @002e                               v19 = icmp eq v18, v12
 ;; @002e                               v20 = uextend.i32 v19
@@ -56,14 +62,14 @@
 ;; @002e                               brif v21, block6, block2
 ;;
 ;;                                 block6:
-;; @0034                               v24 = load.i64 notrap aligned readonly can_move v0+56
-;; @0034                               v23 = load.i64 notrap aligned readonly can_move v0+72
+;; @0034                               v24 = load.i64 notrap aligned readonly can_move region4 v0+56
+;; @0034                               v23 = load.i64 notrap aligned readonly can_move region3 v0+72
 ;; @0034                               call_indirect sig0, v24(v23, v0)
 ;; @0036                               return
 ;;
 ;;                                 block2:
-;; @0038                               v27 = load.i64 notrap aligned readonly can_move v0+88
-;; @0038                               v26 = load.i64 notrap aligned readonly can_move v0+104
+;; @0038                               v27 = load.i64 notrap aligned readonly can_move region6 v0+88
+;; @0038                               v26 = load.i64 notrap aligned readonly can_move region5 v0+104
 ;; @0038                               call_indirect sig0, v27(v26, v0)
 ;; @003a                               return
 ;; }

--- a/tests/disas/gc/copying/br-on-cast.wat
+++ b/tests/disas/gc/copying/br-on-cast.wat
@@ -16,12 +16,18 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32) tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 40 "VMContext+0x28"
+;;     region2 = 2147483648 "GcHeap"
+;;     region3 = 72 "VMContext+0x48"
+;;     region4 = 56 "VMContext+0x38"
+;;     region5 = 104 "VMContext+0x68"
+;;     region6 = 88 "VMContext+0x58"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i64) tail
@@ -39,14 +45,14 @@
 ;; @002f                               brif v9, block5(v30), block4  ; v30 = 0
 ;;
 ;;                                 block4:
-;; @002f                               v28 = load.i64 notrap aligned readonly can_move v0+8
+;; @002f                               v28 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @002f                               v14 = load.i64 notrap aligned readonly can_move v28+32
 ;; @002f                               v13 = uextend.i64 v2
 ;; @002f                               v15 = iadd v14, v13
 ;; @002f                               v16 = iconst.i64 4
 ;; @002f                               v17 = iadd v15, v16  ; v16 = 4
-;; @002f                               v18 = load.i32 user2 readonly region0 v17
-;; @002f                               v11 = load.i64 notrap aligned readonly can_move v0+40
+;; @002f                               v18 = load.i32 user2 readonly region2 v17
+;; @002f                               v11 = load.i64 notrap aligned readonly can_move region1 v0+40
 ;; @002f                               v12 = load.i32 notrap aligned readonly can_move v11
 ;; @002f                               v19 = icmp eq v18, v12
 ;; @002f                               v20 = uextend.i32 v19
@@ -56,14 +62,14 @@
 ;; @002f                               brif v21, block2, block6
 ;;
 ;;                                 block6:
-;; @0035                               v24 = load.i64 notrap aligned readonly can_move v0+56
-;; @0035                               v23 = load.i64 notrap aligned readonly can_move v0+72
+;; @0035                               v24 = load.i64 notrap aligned readonly can_move region4 v0+56
+;; @0035                               v23 = load.i64 notrap aligned readonly can_move region3 v0+72
 ;; @0035                               call_indirect sig0, v24(v23, v0)
 ;; @0037                               return
 ;;
 ;;                                 block2:
-;; @0039                               v27 = load.i64 notrap aligned readonly can_move v0+88
-;; @0039                               v26 = load.i64 notrap aligned readonly can_move v0+104
+;; @0039                               v27 = load.i64 notrap aligned readonly can_move region6 v0+88
+;; @0039                               v26 = load.i64 notrap aligned readonly can_move region5 v0+104
 ;; @0039                               call_indirect sig0, v27(v26, v0)
 ;; @003b                               return
 ;; }

--- a/tests/disas/gc/copying/call-indirect-and-subtyping.wat
+++ b/tests/disas/gc/copying/call-indirect-and-subtyping.wat
@@ -16,9 +16,11 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32) tail {
-;;     region0 = 1342177280 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 1342177280 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
+;;     region2 = 40 "VMContext+0x28"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned readonly can_move gv3+112
@@ -39,7 +41,7 @@
 ;; @005c                               v8 = ishl v5, v7  ; v7 = 3
 ;; @005c                               v9 = iadd v6, v8
 ;; @005c                               v11 = select_spectre_guard v4, v10, v9  ; v10 = 0
-;; @005c                               v12 = load.i64 user6 aligned region0 v11
+;; @005c                               v12 = load.i64 user6 aligned region1 v11
 ;; @005c                               v13 = iconst.i64 -2
 ;; @005c                               v14 = band v12, v13  ; v13 = -2
 ;; @005c                               brif v12, block3(v14), block2
@@ -51,7 +53,7 @@
 ;;
 ;;                                 block3(v15: i64):
 ;; @005c                               v21 = load.i32 user7 aligned readonly v15+16
-;; @005c                               v19 = load.i64 notrap aligned readonly can_move v0+40
+;; @005c                               v19 = load.i64 notrap aligned readonly can_move region2 v0+40
 ;; @005c                               v20 = load.i32 notrap aligned readonly can_move v19
 ;; @005c                               v22 = icmp eq v21, v20
 ;; @005c                               v23 = uextend.i32 v22

--- a/tests/disas/gc/copying/externref-globals.wat
+++ b/tests/disas/gc/copying/externref-globals.wat
@@ -11,8 +11,9 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64) -> i32 tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     stack_limit = gv2
@@ -28,8 +29,9 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     stack_limit = gv2

--- a/tests/disas/gc/copying/funcref-in-gc-heap-get.wat
+++ b/tests/disas/gc/copying/funcref-in-gc-heap-get.wat
@@ -9,12 +9,13 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i64 tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32) -> i64 tail
@@ -23,13 +24,13 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0020                               trapz v2, user16
-;; @0020                               v12 = load.i64 notrap aligned readonly can_move v0+8
+;; @0020                               v12 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @0020                               v5 = load.i64 notrap aligned readonly can_move v12+32
 ;; @0020                               v4 = uextend.i64 v2
 ;; @0020                               v6 = iadd v5, v4
 ;; @0020                               v7 = iconst.i64 16
 ;; @0020                               v8 = iadd v6, v7  ; v7 = 16
-;; @0020                               v10 = load.i32 user2 little region0 v8
+;; @0020                               v10 = load.i32 user2 little region1 v8
 ;; @0020                               v9 = iconst.i32 -1
 ;; @0020                               v11 = call fn0(v0, v10, v9)  ; v9 = -1
 ;; @0024                               jump block1

--- a/tests/disas/gc/copying/funcref-in-gc-heap-new.wat
+++ b/tests/disas/gc/copying/funcref-in-gc-heap-new.wat
@@ -10,10 +10,12 @@
 )
 ;; function u0:0(i64 vmctx, i64, i64) -> i32 tail {
 ;;     ss0 = explicit_slot 4, align = 4
-;;     region0 = 32 "VMContext+0x20"
-;;     region1 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 40 "VMContext+0x28"
+;;     region2 = 32 "VMContext+0x20"
+;;     region3 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i64) -> i64 tail
@@ -35,13 +37,13 @@
 ;;                                 block2:
 ;;                                     v59 = iconst.i32 32
 ;;                                     v57 = iadd.i32 v6, v59  ; v59 = 32
-;; @0020                               store notrap aligned region0 v57, v5
+;; @0020                               store notrap aligned region2 v57, v5
 ;;                                     v60 = iconst.i32 -1342177278
-;;                                     v61 = load.i64 notrap aligned readonly can_move v0+8
+;;                                     v61 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;;                                     v62 = load.i64 notrap aligned readonly can_move v61+32
 ;; @0020                               v30 = iadd v62, v13
 ;; @0020                               store notrap aligned v60, v30  ; v60 = -1342177278
-;;                                     v63 = load.i64 notrap aligned readonly can_move v0+40
+;;                                     v63 = load.i64 notrap aligned readonly can_move region1 v0+40
 ;;                                     v64 = load.i32 notrap aligned readonly can_move v63
 ;; @0020                               store notrap aligned v64, v30+4
 ;;                                     v65 = iconst.i64 32
@@ -50,12 +52,12 @@
 ;;
 ;;                                 block3 cold:
 ;; @0020                               v17 = iconst.i32 -1342177278
-;; @0020                               v18 = load.i64 notrap aligned readonly can_move v0+40
+;; @0020                               v18 = load.i64 notrap aligned readonly can_move region1 v0+40
 ;; @0020                               v19 = load.i32 notrap aligned readonly can_move v18
 ;; @0020                               v4 = iconst.i32 32
 ;; @0020                               v20 = iconst.i32 16
 ;; @0020                               v21 = call fn0(v0, v17, v19, v4, v20)  ; v17 = -1342177278, v4 = 32, v20 = 16
-;; @0020                               v22 = load.i64 notrap aligned readonly can_move v0+8
+;; @0020                               v22 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @0020                               v23 = load.i64 notrap aligned readonly can_move v22+32
 ;; @0020                               v24 = uextend.i64 v21
 ;; @0020                               v25 = iadd v23, v24
@@ -68,7 +70,7 @@
 ;; @0020                               v39 = ireduce.i32 v38
 ;; @0020                               v36 = iconst.i64 16
 ;; @0020                               v37 = iadd v35, v36  ; v36 = 16
-;; @0020                               store user2 little region1 v39, v37
+;; @0020                               store user2 little region3 v39, v37
 ;;                                     v41 = load.i32 notrap v42
 ;; @0023                               jump block1
 ;;

--- a/tests/disas/gc/copying/funcref-in-gc-heap-set.wat
+++ b/tests/disas/gc/copying/funcref-in-gc-heap-set.wat
@@ -9,12 +9,13 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32, i64) tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i64) -> i64 tail
@@ -25,13 +26,13 @@
 ;; @0022                               trapz v2, user16
 ;; @0022                               v9 = call fn0(v0, v3)
 ;; @0022                               v10 = ireduce.i32 v9
-;; @0022                               v11 = load.i64 notrap aligned readonly can_move v0+8
+;; @0022                               v11 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @0022                               v5 = load.i64 notrap aligned readonly can_move v11+32
 ;; @0022                               v4 = uextend.i64 v2
 ;; @0022                               v6 = iadd v5, v4
 ;; @0022                               v7 = iconst.i64 16
 ;; @0022                               v8 = iadd v6, v7  ; v7 = 16
-;; @0022                               store user2 little region0 v10, v8
+;; @0022                               store user2 little region1 v10, v8
 ;; @0026                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/copying/i31ref-globals.wat
+++ b/tests/disas/gc/copying/i31ref-globals.wat
@@ -11,8 +11,9 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64) -> i32 tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     stack_limit = gv2
@@ -28,8 +29,9 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     stack_limit = gv2

--- a/tests/disas/gc/copying/multiple-array-get.wat
+++ b/tests/disas/gc/copying/multiple-array-get.wat
@@ -10,25 +10,26 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32, i32) -> i64, i64 tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
 ;; @0024                               trapz v2, user16
-;; @0024                               v65 = load.i64 notrap aligned readonly can_move v0+8
+;; @0024                               v65 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @0024                               v8 = load.i64 notrap aligned readonly can_move v65+32
 ;; @0024                               v7 = uextend.i64 v2
 ;; @0024                               v9 = iadd v8, v7
 ;; @0024                               v10 = iconst.i64 16
 ;; @0024                               v11 = iadd v9, v10  ; v10 = 16
-;; @0024                               v12 = load.i32 user2 readonly region0 v11
+;; @0024                               v12 = load.i32 user2 readonly region1 v11
 ;; @0024                               v13 = icmp ult v3, v12
 ;; @0024                               trapz v13, user17
 ;; @0024                               v15 = uextend.i64 v12
@@ -49,7 +50,7 @@
 ;; @0024                               v29 = isub v21, v24
 ;; @0024                               v30 = uextend.i64 v29
 ;; @0024                               v31 = isub v28, v30
-;; @0024                               v32 = load.i64 user2 little region0 v31
+;; @0024                               v32 = load.i64 user2 little region1 v31
 ;; @002b                               v39 = icmp ult v4, v12
 ;; @002b                               trapz v39, user17
 ;;                                     v86 = ishl v4, v77  ; v77 = 3
@@ -57,7 +58,7 @@
 ;; @002b                               v55 = isub v21, v50
 ;; @002b                               v56 = uextend.i64 v55
 ;; @002b                               v57 = isub v28, v56
-;; @002b                               v58 = load.i64 user2 little region0 v57
+;; @002b                               v58 = load.i64 user2 little region1 v57
 ;; @002e                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/copying/multiple-struct-get.wat
+++ b/tests/disas/gc/copying/multiple-struct-get.wat
@@ -11,28 +11,29 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> f32, i32 tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0023                               trapz v2, user16
-;; @0023                               v20 = load.i64 notrap aligned readonly can_move v0+8
+;; @0023                               v20 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @0023                               v6 = load.i64 notrap aligned readonly can_move v20+32
 ;; @0023                               v5 = uextend.i64 v2
 ;; @0023                               v7 = iadd v6, v5
 ;; @0023                               v8 = iconst.i64 16
 ;; @0023                               v9 = iadd v7, v8  ; v8 = 16
-;; @0023                               v10 = load.f32 user2 little region0 v9
+;; @0023                               v10 = load.f32 user2 little region1 v9
 ;; @0029                               v14 = iconst.i64 20
 ;; @0029                               v15 = iadd v7, v14  ; v14 = 20
-;; @0029                               v16 = load.i8 user2 little region0 v15
+;; @0029                               v16 = load.i8 user2 little region1 v15
 ;; @002d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/copying/ref-cast.wat
+++ b/tests/disas/gc/copying/ref-cast.wat
@@ -8,12 +8,14 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 40 "VMContext+0x28"
+;;     region2 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
@@ -30,14 +32,14 @@
 ;; @001e                               brif v9, block4(v24), block3  ; v24 = 0
 ;;
 ;;                                 block3:
-;; @001e                               v22 = load.i64 notrap aligned readonly can_move v0+8
+;; @001e                               v22 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @001e                               v14 = load.i64 notrap aligned readonly can_move v22+32
 ;; @001e                               v13 = uextend.i64 v2
 ;; @001e                               v15 = iadd v14, v13
 ;; @001e                               v16 = iconst.i64 4
 ;; @001e                               v17 = iadd v15, v16  ; v16 = 4
-;; @001e                               v18 = load.i32 user2 readonly region0 v17
-;; @001e                               v11 = load.i64 notrap aligned readonly can_move v0+40
+;; @001e                               v18 = load.i32 user2 readonly region2 v17
+;; @001e                               v11 = load.i64 notrap aligned readonly can_move region1 v0+40
 ;; @001e                               v12 = load.i32 notrap aligned readonly can_move v11
 ;; @001e                               v19 = icmp eq v18, v12
 ;; @001e                               v20 = uextend.i32 v19

--- a/tests/disas/gc/copying/ref-is-null.wat
+++ b/tests/disas/gc/copying/ref-is-null.wat
@@ -10,8 +10,9 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     stack_limit = gv2
 ;;
@@ -26,8 +27,9 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     stack_limit = gv2
 ;;

--- a/tests/disas/gc/copying/ref-test-any.wat
+++ b/tests/disas/gc/copying/ref-test-any.wat
@@ -10,8 +10,9 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     stack_limit = gv2
 ;;
@@ -26,8 +27,9 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     stack_limit = gv2
 ;;

--- a/tests/disas/gc/copying/ref-test-array.wat
+++ b/tests/disas/gc/copying/ref-test-array.wat
@@ -7,12 +7,13 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
@@ -29,11 +30,11 @@
 ;; @001b                               brif v9, block4(v24), block3  ; v24 = 0
 ;;
 ;;                                 block3:
-;; @001b                               v22 = load.i64 notrap aligned readonly can_move v0+8
+;; @001b                               v22 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @001b                               v12 = load.i64 notrap aligned readonly can_move v22+32
 ;; @001b                               v11 = uextend.i64 v2
 ;; @001b                               v13 = iadd v12, v11
-;; @001b                               v16 = load.i32 user2 readonly region0 v13
+;; @001b                               v16 = load.i32 user2 readonly region1 v13
 ;; @001b                               v17 = iconst.i32 -1476395008
 ;; @001b                               v18 = band v16, v17  ; v17 = -1476395008
 ;; @001b                               v19 = icmp eq v18, v17  ; v17 = -1476395008

--- a/tests/disas/gc/copying/ref-test-concrete-func-type.wat
+++ b/tests/disas/gc/copying/ref-test-concrete-func-type.wat
@@ -8,9 +8,11 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i64) -> i32 tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 40 "VMContext+0x28"
+;;     region2 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     stack_limit = gv2
 ;;
@@ -24,8 +26,8 @@
 ;; @0020                               jump block3
 ;;
 ;;                                 block3:
-;; @0020                               v10 = load.i32 user2 readonly region0 v2+16
-;; @0020                               v8 = load.i64 notrap aligned readonly can_move v0+40
+;; @0020                               v10 = load.i32 user2 readonly region2 v2+16
+;; @0020                               v8 = load.i64 notrap aligned readonly can_move region1 v0+40
 ;; @0020                               v9 = load.i32 notrap aligned readonly can_move v8
 ;; @0020                               v11 = icmp eq v10, v9
 ;; @0020                               v12 = uextend.i32 v11

--- a/tests/disas/gc/copying/ref-test-concrete-type.wat
+++ b/tests/disas/gc/copying/ref-test-concrete-type.wat
@@ -8,12 +8,14 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 40 "VMContext+0x28"
+;;     region2 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
@@ -30,14 +32,14 @@
 ;; @001d                               brif v9, block4(v24), block3  ; v24 = 0
 ;;
 ;;                                 block3:
-;; @001d                               v22 = load.i64 notrap aligned readonly can_move v0+8
+;; @001d                               v22 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @001d                               v14 = load.i64 notrap aligned readonly can_move v22+32
 ;; @001d                               v13 = uextend.i64 v2
 ;; @001d                               v15 = iadd v14, v13
 ;; @001d                               v16 = iconst.i64 4
 ;; @001d                               v17 = iadd v15, v16  ; v16 = 4
-;; @001d                               v18 = load.i32 user2 readonly region0 v17
-;; @001d                               v11 = load.i64 notrap aligned readonly can_move v0+40
+;; @001d                               v18 = load.i32 user2 readonly region2 v17
+;; @001d                               v11 = load.i64 notrap aligned readonly can_move region1 v0+40
 ;; @001d                               v12 = load.i32 notrap aligned readonly can_move v11
 ;; @001d                               v19 = icmp eq v18, v12
 ;; @001d                               v20 = uextend.i32 v19

--- a/tests/disas/gc/copying/ref-test-eq.wat
+++ b/tests/disas/gc/copying/ref-test-eq.wat
@@ -7,12 +7,13 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
@@ -28,11 +29,11 @@
 ;; @001b                               brif v9, block4(v8), block3  ; v8 = 1
 ;;
 ;;                                 block3:
-;; @001b                               v22 = load.i64 notrap aligned readonly can_move v0+8
+;; @001b                               v22 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @001b                               v12 = load.i64 notrap aligned readonly can_move v22+32
 ;; @001b                               v11 = uextend.i64 v2
 ;; @001b                               v13 = iadd v12, v11
-;; @001b                               v16 = load.i32 user2 readonly region0 v13
+;; @001b                               v16 = load.i32 user2 readonly region1 v13
 ;; @001b                               v17 = iconst.i32 -1610612736
 ;; @001b                               v18 = band v16, v17  ; v17 = -1610612736
 ;; @001b                               v19 = icmp eq v18, v17  ; v17 = -1610612736

--- a/tests/disas/gc/copying/ref-test-i31.wat
+++ b/tests/disas/gc/copying/ref-test-i31.wat
@@ -7,8 +7,9 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     stack_limit = gv2
 ;;

--- a/tests/disas/gc/copying/ref-test-none.wat
+++ b/tests/disas/gc/copying/ref-test-none.wat
@@ -10,8 +10,9 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     stack_limit = gv2
 ;;
@@ -24,8 +25,9 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     stack_limit = gv2
 ;;

--- a/tests/disas/gc/copying/ref-test-struct.wat
+++ b/tests/disas/gc/copying/ref-test-struct.wat
@@ -7,12 +7,13 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
@@ -29,11 +30,11 @@
 ;; @001b                               brif v9, block4(v24), block3  ; v24 = 0
 ;;
 ;;                                 block3:
-;; @001b                               v22 = load.i64 notrap aligned readonly can_move v0+8
+;; @001b                               v22 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @001b                               v12 = load.i64 notrap aligned readonly can_move v22+32
 ;; @001b                               v11 = uextend.i64 v2
 ;; @001b                               v13 = iadd v12, v11
-;; @001b                               v16 = load.i32 user2 readonly region0 v13
+;; @001b                               v16 = load.i32 user2 readonly region1 v13
 ;; @001b                               v17 = iconst.i32 -1342177280
 ;; @001b                               v18 = band v16, v17  ; v17 = -1342177280
 ;; @001b                               v19 = icmp eq v18, v17  ; v17 = -1342177280

--- a/tests/disas/gc/copying/struct-get.wat
+++ b/tests/disas/gc/copying/struct-get.wat
@@ -23,25 +23,26 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> f32 tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0033                               trapz v2, user16
-;; @0033                               v10 = load.i64 notrap aligned readonly can_move v0+8
+;; @0033                               v10 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @0033                               v5 = load.i64 notrap aligned readonly can_move v10+32
 ;; @0033                               v4 = uextend.i64 v2
 ;; @0033                               v6 = iadd v5, v4
 ;; @0033                               v7 = iconst.i64 16
 ;; @0033                               v8 = iadd v6, v7  ; v7 = 16
-;; @0033                               v9 = load.f32 user2 little region0 v8
+;; @0033                               v9 = load.f32 user2 little region1 v8
 ;; @0037                               jump block1
 ;;
 ;;                                 block1:
@@ -49,25 +50,26 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @003c                               trapz v2, user16
-;; @003c                               v11 = load.i64 notrap aligned readonly can_move v0+8
+;; @003c                               v11 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @003c                               v5 = load.i64 notrap aligned readonly can_move v11+32
 ;; @003c                               v4 = uextend.i64 v2
 ;; @003c                               v6 = iadd v5, v4
 ;; @003c                               v7 = iconst.i64 20
 ;; @003c                               v8 = iadd v6, v7  ; v7 = 20
-;; @003c                               v9 = load.i8 user2 little region0 v8
+;; @003c                               v9 = load.i8 user2 little region1 v8
 ;; @0040                               jump block1
 ;;
 ;;                                 block1:
@@ -76,25 +78,26 @@
 ;; }
 ;;
 ;; function u0:2(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0045                               trapz v2, user16
-;; @0045                               v11 = load.i64 notrap aligned readonly can_move v0+8
+;; @0045                               v11 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @0045                               v5 = load.i64 notrap aligned readonly can_move v11+32
 ;; @0045                               v4 = uextend.i64 v2
 ;; @0045                               v6 = iadd v5, v4
 ;; @0045                               v7 = iconst.i64 20
 ;; @0045                               v8 = iadd v6, v7  ; v7 = 20
-;; @0045                               v9 = load.i8 user2 little region0 v8
+;; @0045                               v9 = load.i8 user2 little region1 v8
 ;; @0049                               jump block1
 ;;
 ;;                                 block1:
@@ -103,25 +106,26 @@
 ;; }
 ;;
 ;; function u0:3(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @004e                               trapz v2, user16
-;; @004e                               v10 = load.i64 notrap aligned readonly can_move v0+8
+;; @004e                               v10 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @004e                               v5 = load.i64 notrap aligned readonly can_move v10+32
 ;; @004e                               v4 = uextend.i64 v2
 ;; @004e                               v6 = iadd v5, v4
 ;; @004e                               v7 = iconst.i64 24
 ;; @004e                               v8 = iadd v6, v7  ; v7 = 24
-;; @004e                               v9 = load.i32 user2 little region0 v8
+;; @004e                               v9 = load.i32 user2 little region1 v8
 ;; @0052                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/copying/struct-new-default.wat
+++ b/tests/disas/gc/copying/struct-new-default.wat
@@ -11,10 +11,12 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64) -> i32 tail {
-;;     region0 = 32 "VMContext+0x20"
-;;     region1 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 40 "VMContext+0x28"
+;;     region2 = 32 "VMContext+0x20"
+;;     region3 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
 ;;     fn0 = colocated u805306368:24 sig0
@@ -34,13 +36,13 @@
 ;;                                 block2:
 ;;                                     v60 = iconst.i32 32
 ;;                                     v58 = iadd.i32 v8, v60  ; v60 = 32
-;; @0021                               store notrap aligned region0 v58, v7
+;; @0021                               store notrap aligned region2 v58, v7
 ;;                                     v61 = iconst.i32 -1342177246
-;;                                     v62 = load.i64 notrap aligned readonly can_move v0+8
+;;                                     v62 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;;                                     v63 = load.i64 notrap aligned readonly can_move v62+32
 ;; @0021                               v32 = iadd v63, v15
 ;; @0021                               store notrap aligned v61, v32  ; v61 = -1342177246
-;;                                     v64 = load.i64 notrap aligned readonly can_move v0+40
+;;                                     v64 = load.i64 notrap aligned readonly can_move region1 v0+40
 ;;                                     v65 = load.i32 notrap aligned readonly can_move v64
 ;; @0021                               store notrap aligned v65, v32+4
 ;;                                     v66 = iconst.i64 32
@@ -49,12 +51,12 @@
 ;;
 ;;                                 block3 cold:
 ;; @0021                               v19 = iconst.i32 -1342177246
-;; @0021                               v20 = load.i64 notrap aligned readonly can_move v0+40
+;; @0021                               v20 = load.i64 notrap aligned readonly can_move region1 v0+40
 ;; @0021                               v21 = load.i32 notrap aligned readonly can_move v20
 ;; @0021                               v6 = iconst.i32 32
 ;; @0021                               v22 = iconst.i32 16
 ;; @0021                               v23 = call fn0(v0, v19, v21, v6, v22)  ; v19 = -1342177246, v6 = 32, v22 = 16
-;; @0021                               v24 = load.i64 notrap aligned readonly can_move v0+8
+;; @0021                               v24 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @0021                               v25 = load.i64 notrap aligned readonly can_move v24+32
 ;; @0021                               v26 = uextend.i64 v23
 ;; @0021                               v27 = iadd v25, v26
@@ -64,14 +66,14 @@
 ;; @0021                               v3 = f32const 0.0
 ;; @0021                               v38 = iconst.i64 16
 ;; @0021                               v39 = iadd v37, v38  ; v38 = 16
-;; @0021                               store user2 little region1 v3, v39  ; v3 = 0.0
+;; @0021                               store user2 little region3 v3, v39  ; v3 = 0.0
 ;; @0021                               v4 = iconst.i32 0
 ;; @0021                               v40 = iconst.i64 20
 ;; @0021                               v41 = iadd v37, v40  ; v40 = 20
-;; @0021                               istore8 user2 little region1 v4, v41  ; v4 = 0
+;; @0021                               istore8 user2 little region3 v4, v41  ; v4 = 0
 ;; @0021                               v42 = iconst.i64 24
 ;; @0021                               v43 = iadd v37, v42  ; v42 = 24
-;; @0021                               store user2 little region1 v4, v43  ; v4 = 0
+;; @0021                               store user2 little region3 v4, v43  ; v4 = 0
 ;; @0024                               jump block1(v36)
 ;;
 ;;                                 block1(v2: i32):

--- a/tests/disas/gc/copying/struct-new.wat
+++ b/tests/disas/gc/copying/struct-new.wat
@@ -12,10 +12,12 @@
 )
 ;; function u0:0(i64 vmctx, i64, f32, i32, i32) -> i32 tail {
 ;;     ss0 = explicit_slot 4, align = 4
-;;     region0 = 32 "VMContext+0x20"
-;;     region1 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 40 "VMContext+0x28"
+;;     region2 = 32 "VMContext+0x20"
+;;     region3 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
 ;;     fn0 = colocated u805306368:24 sig0
@@ -37,13 +39,13 @@
 ;;                                 block2:
 ;;                                     v63 = iconst.i32 32
 ;;                                     v61 = iadd.i32 v8, v63  ; v63 = 32
-;; @002a                               store notrap aligned region0 v61, v7
+;; @002a                               store notrap aligned region2 v61, v7
 ;;                                     v64 = iconst.i32 -1342177246
-;;                                     v65 = load.i64 notrap aligned readonly can_move v0+8
+;;                                     v65 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;;                                     v66 = load.i64 notrap aligned readonly can_move v65+32
 ;; @002a                               v32 = iadd v66, v15
 ;; @002a                               store notrap aligned v64, v32  ; v64 = -1342177246
-;;                                     v67 = load.i64 notrap aligned readonly can_move v0+40
+;;                                     v67 = load.i64 notrap aligned readonly can_move region1 v0+40
 ;;                                     v68 = load.i32 notrap aligned readonly can_move v67
 ;; @002a                               store notrap aligned v68, v32+4
 ;;                                     v69 = iconst.i64 32
@@ -52,12 +54,12 @@
 ;;
 ;;                                 block3 cold:
 ;; @002a                               v19 = iconst.i32 -1342177246
-;; @002a                               v20 = load.i64 notrap aligned readonly can_move v0+40
+;; @002a                               v20 = load.i64 notrap aligned readonly can_move region1 v0+40
 ;; @002a                               v21 = load.i32 notrap aligned readonly can_move v20
 ;; @002a                               v6 = iconst.i32 32
 ;; @002a                               v22 = iconst.i32 16
 ;; @002a                               v23 = call fn0(v0, v19, v21, v6, v22), stack_map=[i32 @ ss0+0]  ; v19 = -1342177246, v6 = 32, v22 = 16
-;; @002a                               v24 = load.i64 notrap aligned readonly can_move v0+8
+;; @002a                               v24 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @002a                               v25 = load.i64 notrap aligned readonly can_move v24+32
 ;; @002a                               v26 = uextend.i64 v23
 ;; @002a                               v27 = iadd v25, v26
@@ -66,14 +68,14 @@
 ;;                                 block4(v36: i32, v37: i64):
 ;; @002a                               v38 = iconst.i64 16
 ;; @002a                               v39 = iadd v37, v38  ; v38 = 16
-;; @002a                               store.f32 user2 little region1 v2, v39
+;; @002a                               store.f32 user2 little region3 v2, v39
 ;; @002a                               v40 = iconst.i64 20
 ;; @002a                               v41 = iadd v37, v40  ; v40 = 20
-;; @002a                               istore8.i32 user2 little region1 v3, v41
+;; @002a                               istore8.i32 user2 little region3 v3, v41
 ;;                                     v45 = load.i32 notrap v46
 ;; @002a                               v42 = iconst.i64 24
 ;; @002a                               v43 = iadd v37, v42  ; v42 = 24
-;; @002a                               store user2 little region1 v45, v43
+;; @002a                               store user2 little region3 v45, v43
 ;; @002d                               jump block1(v36)
 ;;
 ;;                                 block1(v5: i32):

--- a/tests/disas/gc/copying/struct-set.wat
+++ b/tests/disas/gc/copying/struct-set.wat
@@ -19,25 +19,26 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32, f32) tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: f32):
 ;; @0034                               trapz v2, user16
-;; @0034                               v9 = load.i64 notrap aligned readonly can_move v0+8
+;; @0034                               v9 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @0034                               v5 = load.i64 notrap aligned readonly can_move v9+32
 ;; @0034                               v4 = uextend.i64 v2
 ;; @0034                               v6 = iadd v5, v4
 ;; @0034                               v7 = iconst.i64 16
 ;; @0034                               v8 = iadd v6, v7  ; v7 = 16
-;; @0034                               store user2 little region0 v3, v8
+;; @0034                               store user2 little region1 v3, v8
 ;; @0038                               jump block1
 ;;
 ;;                                 block1:
@@ -45,25 +46,26 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32, i32) tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @003f                               trapz v2, user16
-;; @003f                               v9 = load.i64 notrap aligned readonly can_move v0+8
+;; @003f                               v9 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @003f                               v5 = load.i64 notrap aligned readonly can_move v9+32
 ;; @003f                               v4 = uextend.i64 v2
 ;; @003f                               v6 = iadd v5, v4
 ;; @003f                               v7 = iconst.i64 20
 ;; @003f                               v8 = iadd v6, v7  ; v7 = 20
-;; @003f                               istore8 user2 little region0 v3, v8
+;; @003f                               istore8 user2 little region1 v3, v8
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -71,25 +73,26 @@
 ;; }
 ;;
 ;; function u0:2(i64 vmctx, i64, i32, i32) tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @004a                               trapz v2, user16
-;; @004a                               v9 = load.i64 notrap aligned readonly can_move v0+8
+;; @004a                               v9 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @004a                               v5 = load.i64 notrap aligned readonly can_move v9+32
 ;; @004a                               v4 = uextend.i64 v2
 ;; @004a                               v6 = iadd v5, v4
 ;; @004a                               v7 = iconst.i64 24
 ;; @004a                               v8 = iadd v6, v7  ; v7 = 24
-;; @004a                               store user2 little region0 v3, v8
+;; @004a                               store user2 little region1 v3, v8
 ;; @004e                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/copying/v128-fields.wat
+++ b/tests/disas/gc/copying/v128-fields.wat
@@ -11,25 +11,26 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i8x16 tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0022                               trapz v2, user16
-;; @0022                               v19 = load.i64 notrap aligned readonly can_move v0+8
+;; @0022                               v19 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @0022                               v5 = load.i64 notrap aligned readonly can_move v19+32
 ;; @0022                               v4 = uextend.i64 v2
 ;; @0022                               v6 = iadd v5, v4
 ;; @0022                               v7 = iconst.i64 16
 ;; @0022                               v8 = iadd v6, v7  ; v7 = 16
-;; @0022                               v9 = load.i8x16 user2 little region0 v8
+;; @0022                               v9 = load.i8x16 user2 little region1 v8
 ;; @002e                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/drc/array-fill.wat
+++ b/tests/disas/gc/drc/array-fill.wat
@@ -10,25 +10,26 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32, i64, i32) tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i64, v5: i32):
 ;; @0027                               trapz v2, user16
-;; @0027                               v46 = load.i64 notrap aligned readonly can_move v0+8
+;; @0027                               v46 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @0027                               v7 = load.i64 notrap aligned readonly can_move v46+32
 ;; @0027                               v6 = uextend.i64 v2
 ;; @0027                               v8 = iadd v7, v6
 ;; @0027                               v9 = iconst.i64 24
 ;; @0027                               v10 = iadd v8, v9  ; v9 = 24
-;; @0027                               v11 = load.i32 user2 readonly region0 v10
+;; @0027                               v11 = load.i32 user2 readonly region1 v10
 ;; @0027                               v13 = uextend.i64 v3
 ;; @0027                               v14 = uextend.i64 v5
 ;; @0027                               v17 = iadd v13, v14
@@ -53,7 +54,7 @@
 ;; @0027                               brif v41, block3, block2(v28)
 ;;
 ;;                                 block2(v42: i64):
-;; @0027                               store.i64 user2 little region0 v4, v42
+;; @0027                               store.i64 user2 little region1 v4, v42
 ;;                                     v55 = iconst.i64 8
 ;;                                     v56 = iadd v42, v55  ; v55 = 8
 ;; @0027                               v45 = icmp eq v56, v39

--- a/tests/disas/gc/drc/array-get-s.wat
+++ b/tests/disas/gc/drc/array-get-s.wat
@@ -10,25 +10,26 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32) -> i32 tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0022                               trapz v2, user16
-;; @0022                               v34 = load.i64 notrap aligned readonly can_move v0+8
+;; @0022                               v34 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @0022                               v6 = load.i64 notrap aligned readonly can_move v34+32
 ;; @0022                               v5 = uextend.i64 v2
 ;; @0022                               v7 = iadd v6, v5
 ;; @0022                               v8 = iconst.i64 24
 ;; @0022                               v9 = iadd v7, v8  ; v8 = 24
-;; @0022                               v10 = load.i32 user2 readonly region0 v9
+;; @0022                               v10 = load.i32 user2 readonly region1 v9
 ;; @0022                               v11 = icmp ult v3, v10
 ;; @0022                               trapz v11, user17
 ;; @0022                               v13 = uextend.i64 v10
@@ -44,7 +45,7 @@
 ;; @0022                               v27 = isub v19, v22
 ;; @0022                               v28 = uextend.i64 v27
 ;; @0022                               v29 = isub v26, v28
-;; @0022                               v30 = load.i8 user2 little region0 v29
+;; @0022                               v30 = load.i8 user2 little region1 v29
 ;; @0025                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/drc/array-get-u.wat
+++ b/tests/disas/gc/drc/array-get-u.wat
@@ -10,25 +10,26 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32) -> i32 tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0022                               trapz v2, user16
-;; @0022                               v34 = load.i64 notrap aligned readonly can_move v0+8
+;; @0022                               v34 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @0022                               v6 = load.i64 notrap aligned readonly can_move v34+32
 ;; @0022                               v5 = uextend.i64 v2
 ;; @0022                               v7 = iadd v6, v5
 ;; @0022                               v8 = iconst.i64 24
 ;; @0022                               v9 = iadd v7, v8  ; v8 = 24
-;; @0022                               v10 = load.i32 user2 readonly region0 v9
+;; @0022                               v10 = load.i32 user2 readonly region1 v9
 ;; @0022                               v11 = icmp ult v3, v10
 ;; @0022                               trapz v11, user17
 ;; @0022                               v13 = uextend.i64 v10
@@ -44,7 +45,7 @@
 ;; @0022                               v27 = isub v19, v22
 ;; @0022                               v28 = uextend.i64 v27
 ;; @0022                               v29 = isub v26, v28
-;; @0022                               v30 = load.i8 user2 little region0 v29
+;; @0022                               v30 = load.i8 user2 little region1 v29
 ;; @0025                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/drc/array-get.wat
+++ b/tests/disas/gc/drc/array-get.wat
@@ -10,25 +10,26 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32) -> i64 tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0022                               trapz v2, user16
-;; @0022                               v33 = load.i64 notrap aligned readonly can_move v0+8
+;; @0022                               v33 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @0022                               v6 = load.i64 notrap aligned readonly can_move v33+32
 ;; @0022                               v5 = uextend.i64 v2
 ;; @0022                               v7 = iadd v6, v5
 ;; @0022                               v8 = iconst.i64 24
 ;; @0022                               v9 = iadd v7, v8  ; v8 = 24
-;; @0022                               v10 = load.i32 user2 readonly region0 v9
+;; @0022                               v10 = load.i32 user2 readonly region1 v9
 ;; @0022                               v11 = icmp ult v3, v10
 ;; @0022                               trapz v11, user17
 ;; @0022                               v13 = uextend.i64 v10
@@ -49,7 +50,7 @@
 ;; @0022                               v27 = isub v19, v22
 ;; @0022                               v28 = uextend.i64 v27
 ;; @0022                               v29 = isub v26, v28
-;; @0022                               v30 = load.i64 user2 little region0 v29
+;; @0022                               v30 = load.i64 user2 little region1 v29
 ;; @0025                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/drc/array-len.wat
+++ b/tests/disas/gc/drc/array-len.wat
@@ -10,25 +10,26 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @001f                               trapz v2, user16
-;; @001f                               v10 = load.i64 notrap aligned readonly can_move v0+8
+;; @001f                               v10 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @001f                               v5 = load.i64 notrap aligned readonly can_move v10+32
 ;; @001f                               v4 = uextend.i64 v2
 ;; @001f                               v6 = iadd v5, v4
 ;; @001f                               v7 = iconst.i64 24
 ;; @001f                               v8 = iadd v6, v7  ; v7 = 24
-;; @001f                               v9 = load.i32 user2 readonly region0 v8
+;; @001f                               v9 = load.i32 user2 readonly region1 v8
 ;; @0021                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/drc/array-new-fixed-of-gc-refs.wat
+++ b/tests/disas/gc/drc/array-new-fixed-of-gc-refs.wat
@@ -13,12 +13,14 @@
 ;;     ss0 = explicit_slot 4, align = 4
 ;;     ss1 = explicit_slot 4, align = 4
 ;;     ss2 = explicit_slot 4, align = 4
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 40 "VMContext+0x28"
+;;     region2 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
@@ -33,19 +35,19 @@
 ;;                                     v193 = stack_addr.i64 ss0
 ;;                                     store notrap v4, v193
 ;; @0025                               v15 = iconst.i32 -1476395008
-;; @0025                               v16 = load.i64 notrap aligned readonly can_move v0+40
+;; @0025                               v16 = load.i64 notrap aligned readonly can_move region1 v0+40
 ;; @0025                               v17 = load.i32 notrap aligned readonly can_move v16
 ;;                                     v229 = iconst.i32 40
 ;; @0025                               v18 = iconst.i32 8
 ;; @0025                               v19 = call fn0(v0, v15, v17, v229, v18), stack_map=[i32 @ ss2+0, i32 @ ss1+0, i32 @ ss0+0]  ; v15 = -1476395008, v229 = 40, v18 = 8
 ;; @0025                               v6 = iconst.i32 3
-;; @0025                               v20 = load.i64 notrap aligned readonly can_move v0+8
+;; @0025                               v20 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @0025                               v21 = load.i64 notrap aligned readonly can_move v20+32
 ;; @0025                               v22 = uextend.i64 v19
 ;; @0025                               v23 = iadd v21, v22
 ;; @0025                               v24 = iconst.i64 24
 ;; @0025                               v25 = iadd v23, v24  ; v24 = 24
-;; @0025                               store user2 region0 v6, v25  ; v6 = 3
+;; @0025                               store user2 region2 v6, v25  ; v6 = 3
 ;; @0025                               trapz v19, user16
 ;; @0025                               v45 = uadd_overflow_trap v19, v229, user2  ; v229 = 40
 ;;                                     v190 = load.i32 notrap v191
@@ -63,10 +65,10 @@
 ;; @0025                               v60 = iadd.i64 v21, v58
 ;; @0025                               v61 = iconst.i64 8
 ;; @0025                               v62 = iadd v60, v61  ; v61 = 8
-;; @0025                               v63 = load.i64 user2 region0 v62
+;; @0025                               v63 = load.i64 user2 region2 v62
 ;; @0025                               v64 = iconst.i64 1
 ;; @0025                               v65 = iadd v63, v64  ; v64 = 1
-;; @0025                               store user2 region0 v65, v62
+;; @0025                               store user2 region2 v65, v62
 ;; @0025                               jump block3
 ;;
 ;;                                 block3:
@@ -75,9 +77,9 @@
 ;; @0025                               v48 = iadd.i64 v21, v46
 ;;                                     v219 = iconst.i64 12
 ;; @0025                               v51 = isub v48, v219  ; v219 = 12
-;; @0025                               store user2 little region0 v182, v51
+;; @0025                               store user2 little region2 v182, v51
 ;;                                     v322 = iadd.i64 v23, v24  ; v24 = 24
-;; @0025                               v77 = load.i32 user2 readonly region0 v322
+;; @0025                               v77 = load.i32 user2 readonly region2 v322
 ;;                                     v323 = iconst.i32 1
 ;;                                     v324 = icmp ugt v77, v323  ; v323 = 1
 ;; @0025                               trapz v324, user17
@@ -106,10 +108,10 @@
 ;; @0025                               v105 = iadd.i64 v21, v103
 ;;                                     v328 = iconst.i64 8
 ;; @0025                               v107 = iadd v105, v328  ; v328 = 8
-;; @0025                               v108 = load.i64 user2 region0 v107
+;; @0025                               v108 = load.i64 user2 region2 v107
 ;;                                     v329 = iconst.i64 1
 ;; @0025                               v110 = iadd v108, v329  ; v329 = 1
-;; @0025                               store user2 region0 v110, v107
+;; @0025                               store user2 region2 v110, v107
 ;; @0025                               jump block5
 ;;
 ;;                                 block5:
@@ -120,9 +122,9 @@
 ;; @0025                               v94 = isub.i32 v86, v284  ; v284 = 32
 ;; @0025                               v95 = uextend.i64 v94
 ;; @0025                               v96 = isub v93, v95
-;; @0025                               store user2 little region0 v172, v96
+;; @0025                               store user2 little region2 v172, v96
 ;;                                     v330 = iadd.i64 v23, v24  ; v24 = 24
-;; @0025                               v122 = load.i32 user2 readonly region0 v330
+;; @0025                               v122 = load.i32 user2 readonly region2 v330
 ;;                                     v331 = iconst.i32 2
 ;;                                     v332 = icmp ugt v122, v331  ; v331 = 2
 ;; @0025                               trapz v332, user17
@@ -151,10 +153,10 @@
 ;; @0025                               v150 = iadd.i64 v21, v148
 ;;                                     v343 = iconst.i64 8
 ;; @0025                               v152 = iadd v150, v343  ; v343 = 8
-;; @0025                               v153 = load.i64 user2 region0 v152
+;; @0025                               v153 = load.i64 user2 region2 v152
 ;;                                     v344 = iconst.i64 1
 ;; @0025                               v155 = iadd v153, v344  ; v344 = 1
-;; @0025                               store user2 region0 v155, v152
+;; @0025                               store user2 region2 v155, v152
 ;; @0025                               jump block7
 ;;
 ;;                                 block7:
@@ -165,7 +167,7 @@
 ;; @0025                               v139 = isub.i32 v131, v316  ; v316 = 36
 ;; @0025                               v140 = uextend.i64 v139
 ;; @0025                               v141 = isub v138, v140
-;; @0025                               store user2 little region0 v162, v141
+;; @0025                               store user2 little region2 v162, v141
 ;; @0029                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/drc/array-new-fixed.wat
+++ b/tests/disas/gc/drc/array-new-fixed.wat
@@ -10,12 +10,14 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i64, i64, i64) -> i32 tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 40 "VMContext+0x28"
+;;     region2 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
@@ -24,26 +26,26 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i64, v4: i64):
 ;; @0025                               v15 = iconst.i32 -1476395008
-;; @0025                               v16 = load.i64 notrap aligned readonly can_move v0+40
+;; @0025                               v16 = load.i64 notrap aligned readonly can_move region1 v0+40
 ;; @0025                               v17 = load.i32 notrap aligned readonly can_move v16
 ;;                                     v126 = iconst.i32 56
 ;; @0025                               v18 = iconst.i32 8
 ;; @0025                               v19 = call fn0(v0, v15, v17, v126, v18)  ; v15 = -1476395008, v126 = 56, v18 = 8
 ;; @0025                               v6 = iconst.i32 3
-;; @0025                               v20 = load.i64 notrap aligned readonly can_move v0+8
+;; @0025                               v20 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @0025                               v21 = load.i64 notrap aligned readonly can_move v20+32
 ;; @0025                               v22 = uextend.i64 v19
 ;; @0025                               v23 = iadd v21, v22
 ;;                                     v117 = iconst.i64 24
 ;; @0025                               v25 = iadd v23, v117  ; v117 = 24
-;; @0025                               store user2 region0 v6, v25  ; v6 = 3
+;; @0025                               store user2 region2 v6, v25  ; v6 = 3
 ;; @0025                               trapz v19, user16
 ;; @0025                               v45 = uadd_overflow_trap v19, v126, user2  ; v126 = 56
 ;; @0025                               v46 = uextend.i64 v45
 ;; @0025                               v48 = iadd v21, v46
 ;; @0025                               v51 = isub v48, v117  ; v117 = 24
-;; @0025                               store user2 little region0 v2, v51
-;; @0025                               v58 = load.i32 user2 readonly region0 v25
+;; @0025                               store user2 little region2 v2, v51
+;; @0025                               v58 = load.i32 user2 readonly region2 v25
 ;; @0025                               v52 = iconst.i32 1
 ;;                                     v157 = icmp ugt v58, v52  ; v52 = 1
 ;; @0025                               trapz v157, user17
@@ -63,8 +65,8 @@
 ;; @0025                               v75 = isub v67, v179  ; v179 = 40
 ;; @0025                               v76 = uextend.i64 v75
 ;; @0025                               v77 = isub v74, v76
-;; @0025                               store user2 little region0 v3, v77
-;; @0025                               v84 = load.i32 user2 readonly region0 v25
+;; @0025                               store user2 little region2 v3, v77
+;; @0025                               v84 = load.i32 user2 readonly region2 v25
 ;; @0025                               v78 = iconst.i32 2
 ;;                                     v185 = icmp ugt v84, v78  ; v78 = 2
 ;; @0025                               trapz v185, user17
@@ -81,7 +83,7 @@
 ;; @0025                               v101 = isub v93, v212  ; v212 = 48
 ;; @0025                               v102 = uextend.i64 v101
 ;; @0025                               v103 = isub v100, v102
-;; @0025                               store user2 little region0 v4, v103
+;; @0025                               store user2 little region2 v4, v103
 ;; @0029                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/drc/array-new.wat
+++ b/tests/disas/gc/drc/array-new.wat
@@ -10,12 +10,14 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i64, i32) -> i32 tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 40 "VMContext+0x28"
+;;     region2 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
@@ -34,17 +36,17 @@
 ;;                                     v75 = ishl v3, v74  ; v74 = 3
 ;; @0022                               v12 = uadd_overflow_trap v5, v75, user18  ; v5 = 32
 ;; @0022                               v13 = iconst.i32 -1476395008
-;; @0022                               v14 = load.i64 notrap aligned readonly can_move v0+40
+;; @0022                               v14 = load.i64 notrap aligned readonly can_move region1 v0+40
 ;; @0022                               v15 = load.i32 notrap aligned readonly can_move v14
 ;;                                     v72 = iconst.i32 8
 ;; @0022                               v17 = call fn0(v0, v13, v15, v12, v72)  ; v13 = -1476395008, v72 = 8
-;; @0022                               v18 = load.i64 notrap aligned readonly can_move v0+8
+;; @0022                               v18 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @0022                               v19 = load.i64 notrap aligned readonly can_move v18+32
 ;; @0022                               v20 = uextend.i64 v17
 ;; @0022                               v21 = iadd v19, v20
 ;; @0022                               v22 = iconst.i64 24
 ;; @0022                               v23 = iadd v21, v22  ; v22 = 24
-;; @0022                               store user2 region0 v3, v23
+;; @0022                               store user2 region2 v3, v23
 ;; @0022                               trapz v17, user16
 ;; @0022                               v54 = load.i64 notrap aligned v18+40
 ;; @0022                               v43 = iadd v21, v9  ; v9 = 32
@@ -59,7 +61,7 @@
 ;; @0022                               brif v60, block3, block2(v43)
 ;;
 ;;                                 block2(v61: i64):
-;; @0022                               store.i64 user2 little region0 v2, v61
+;; @0022                               store.i64 user2 little region2 v2, v61
 ;;                                     v93 = iconst.i64 8
 ;;                                     v94 = iadd v61, v93  ; v93 = 8
 ;; @0022                               v64 = icmp eq v94, v58

--- a/tests/disas/gc/drc/array-set.wat
+++ b/tests/disas/gc/drc/array-set.wat
@@ -10,25 +10,26 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32, i64) tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i64):
 ;; @0024                               trapz v2, user16
-;; @0024                               v32 = load.i64 notrap aligned readonly can_move v0+8
+;; @0024                               v32 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @0024                               v6 = load.i64 notrap aligned readonly can_move v32+32
 ;; @0024                               v5 = uextend.i64 v2
 ;; @0024                               v7 = iadd v6, v5
 ;; @0024                               v8 = iconst.i64 24
 ;; @0024                               v9 = iadd v7, v8  ; v8 = 24
-;; @0024                               v10 = load.i32 user2 readonly region0 v9
+;; @0024                               v10 = load.i32 user2 readonly region1 v9
 ;; @0024                               v11 = icmp ult v3, v10
 ;; @0024                               trapz v11, user17
 ;; @0024                               v13 = uextend.i64 v10
@@ -49,7 +50,7 @@
 ;; @0024                               v27 = isub v19, v22
 ;; @0024                               v28 = uextend.i64 v27
 ;; @0024                               v29 = isub v26, v28
-;; @0024                               store user2 little region0 v4, v29
+;; @0024                               store user2 little region1 v4, v29
 ;; @0027                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/drc/br-on-cast-fail.wat
+++ b/tests/disas/gc/drc/br-on-cast-fail.wat
@@ -17,12 +17,18 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32) tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 40 "VMContext+0x28"
+;;     region2 = 2147483648 "GcHeap"
+;;     region3 = 72 "VMContext+0x48"
+;;     region4 = 56 "VMContext+0x38"
+;;     region5 = 104 "VMContext+0x68"
+;;     region6 = 88 "VMContext+0x58"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i64) tail
@@ -40,14 +46,14 @@
 ;; @002e                               brif v9, block5(v30), block4  ; v30 = 0
 ;;
 ;;                                 block4:
-;; @002e                               v28 = load.i64 notrap aligned readonly can_move v0+8
+;; @002e                               v28 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @002e                               v14 = load.i64 notrap aligned readonly can_move v28+32
 ;; @002e                               v13 = uextend.i64 v2
 ;; @002e                               v15 = iadd v14, v13
 ;; @002e                               v16 = iconst.i64 4
 ;; @002e                               v17 = iadd v15, v16  ; v16 = 4
-;; @002e                               v18 = load.i32 user2 readonly region0 v17
-;; @002e                               v11 = load.i64 notrap aligned readonly can_move v0+40
+;; @002e                               v18 = load.i32 user2 readonly region2 v17
+;; @002e                               v11 = load.i64 notrap aligned readonly can_move region1 v0+40
 ;; @002e                               v12 = load.i32 notrap aligned readonly can_move v11
 ;; @002e                               v19 = icmp eq v18, v12
 ;; @002e                               v20 = uextend.i32 v19
@@ -57,14 +63,14 @@
 ;; @002e                               brif v21, block6, block2
 ;;
 ;;                                 block6:
-;; @0034                               v24 = load.i64 notrap aligned readonly can_move v0+56
-;; @0034                               v23 = load.i64 notrap aligned readonly can_move v0+72
+;; @0034                               v24 = load.i64 notrap aligned readonly can_move region4 v0+56
+;; @0034                               v23 = load.i64 notrap aligned readonly can_move region3 v0+72
 ;; @0034                               call_indirect sig0, v24(v23, v0)
 ;; @0036                               return
 ;;
 ;;                                 block2:
-;; @0038                               v27 = load.i64 notrap aligned readonly can_move v0+88
-;; @0038                               v26 = load.i64 notrap aligned readonly can_move v0+104
+;; @0038                               v27 = load.i64 notrap aligned readonly can_move region6 v0+88
+;; @0038                               v26 = load.i64 notrap aligned readonly can_move region5 v0+104
 ;; @0038                               call_indirect sig0, v27(v26, v0)
 ;; @003a                               return
 ;; }

--- a/tests/disas/gc/drc/br-on-cast.wat
+++ b/tests/disas/gc/drc/br-on-cast.wat
@@ -17,12 +17,18 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32) tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 40 "VMContext+0x28"
+;;     region2 = 2147483648 "GcHeap"
+;;     region3 = 72 "VMContext+0x48"
+;;     region4 = 56 "VMContext+0x38"
+;;     region5 = 104 "VMContext+0x68"
+;;     region6 = 88 "VMContext+0x58"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i64) tail
@@ -40,14 +46,14 @@
 ;; @002f                               brif v9, block5(v30), block4  ; v30 = 0
 ;;
 ;;                                 block4:
-;; @002f                               v28 = load.i64 notrap aligned readonly can_move v0+8
+;; @002f                               v28 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @002f                               v14 = load.i64 notrap aligned readonly can_move v28+32
 ;; @002f                               v13 = uextend.i64 v2
 ;; @002f                               v15 = iadd v14, v13
 ;; @002f                               v16 = iconst.i64 4
 ;; @002f                               v17 = iadd v15, v16  ; v16 = 4
-;; @002f                               v18 = load.i32 user2 readonly region0 v17
-;; @002f                               v11 = load.i64 notrap aligned readonly can_move v0+40
+;; @002f                               v18 = load.i32 user2 readonly region2 v17
+;; @002f                               v11 = load.i64 notrap aligned readonly can_move region1 v0+40
 ;; @002f                               v12 = load.i32 notrap aligned readonly can_move v11
 ;; @002f                               v19 = icmp eq v18, v12
 ;; @002f                               v20 = uextend.i32 v19
@@ -57,14 +63,14 @@
 ;; @002f                               brif v21, block2, block6
 ;;
 ;;                                 block6:
-;; @0035                               v24 = load.i64 notrap aligned readonly can_move v0+56
-;; @0035                               v23 = load.i64 notrap aligned readonly can_move v0+72
+;; @0035                               v24 = load.i64 notrap aligned readonly can_move region4 v0+56
+;; @0035                               v23 = load.i64 notrap aligned readonly can_move region3 v0+72
 ;; @0035                               call_indirect sig0, v24(v23, v0)
 ;; @0037                               return
 ;;
 ;;                                 block2:
-;; @0039                               v27 = load.i64 notrap aligned readonly can_move v0+88
-;; @0039                               v26 = load.i64 notrap aligned readonly can_move v0+104
+;; @0039                               v27 = load.i64 notrap aligned readonly can_move region6 v0+88
+;; @0039                               v26 = load.i64 notrap aligned readonly can_move region5 v0+104
 ;; @0039                               call_indirect sig0, v27(v26, v0)
 ;; @003b                               return
 ;; }

--- a/tests/disas/gc/drc/call-indirect-and-subtyping.wat
+++ b/tests/disas/gc/drc/call-indirect-and-subtyping.wat
@@ -17,9 +17,11 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32) tail {
-;;     region0 = 1342177280 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 1342177280 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
+;;     region2 = 40 "VMContext+0x28"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned readonly can_move gv3+112
@@ -40,7 +42,7 @@
 ;; @005c                               v8 = ishl v5, v7  ; v7 = 3
 ;; @005c                               v9 = iadd v6, v8
 ;; @005c                               v11 = select_spectre_guard v4, v10, v9  ; v10 = 0
-;; @005c                               v12 = load.i64 user6 aligned region0 v11
+;; @005c                               v12 = load.i64 user6 aligned region1 v11
 ;; @005c                               v13 = iconst.i64 -2
 ;; @005c                               v14 = band v12, v13  ; v13 = -2
 ;; @005c                               brif v12, block3(v14), block2
@@ -52,7 +54,7 @@
 ;;
 ;;                                 block3(v15: i64):
 ;; @005c                               v21 = load.i32 user7 aligned readonly v15+16
-;; @005c                               v19 = load.i64 notrap aligned readonly can_move v0+40
+;; @005c                               v19 = load.i64 notrap aligned readonly can_move region2 v0+40
 ;; @005c                               v20 = load.i32 notrap aligned readonly can_move v19
 ;; @005c                               v22 = icmp eq v21, v20
 ;; @005c                               v23 = uextend.i32 v22

--- a/tests/disas/gc/drc/externref-globals.wat
+++ b/tests/disas/gc/drc/externref-globals.wat
@@ -14,13 +14,14 @@
 
 ;; function u0:0(i64 vmctx, i64) -> i32 tail {
 ;;     ss0 = explicit_slot 4, align = 4
-;;     region0 = 2147483648 "GcHeap"
-;;     region1 = 32 "VMContext+0x20"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 2147483648 "GcHeap"
+;;     region2 = 32 "VMContext+0x20"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx) -> i8 tail
@@ -42,31 +43,31 @@
 ;; @0034                               brif v12, block4, block2
 ;;
 ;;                                 block2:
-;; @0034                               v90 = load.i64 notrap aligned readonly can_move v0+8
+;; @0034                               v90 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @0034                               v14 = load.i64 notrap aligned readonly can_move v90+32
 ;; @0034                               v13 = uextend.i64 v6
 ;; @0034                               v15 = iadd v14, v13
-;; @0034                               v16 = load.i32 user2 region0 v15
+;; @0034                               v16 = load.i32 user2 region1 v15
 ;; @0034                               v17 = iconst.i32 2
 ;; @0034                               v18 = band v16, v17  ; v17 = 2
 ;; @0034                               brif v18, block4, block3
 ;;
 ;;                                 block3:
-;; @0034                               v20 = load.i64 notrap aligned readonly can_move region1 v0+32
-;; @0034                               v21 = load.i32 user2 region0 v20
+;; @0034                               v20 = load.i64 notrap aligned readonly can_move region2 v0+32
+;; @0034                               v21 = load.i32 user2 region1 v20
 ;; @0034                               v25 = iconst.i64 16
 ;; @0034                               v26 = iadd.i64 v15, v25  ; v25 = 16
-;; @0034                               store user2 region0 v21, v26
+;; @0034                               store user2 region1 v21, v26
 ;;                                     v92 = iconst.i32 2
 ;;                                     v93 = bor.i32 v16, v92  ; v92 = 2
-;; @0034                               store user2 region0 v93, v15
+;; @0034                               store user2 region1 v93, v15
 ;; @0034                               v35 = iconst.i64 8
 ;; @0034                               v36 = iadd.i64 v15, v35  ; v35 = 8
-;; @0034                               v37 = load.i64 user2 region0 v36
+;; @0034                               v37 = load.i64 user2 region1 v36
 ;; @0034                               v38 = iconst.i64 1
 ;; @0034                               v39 = iadd v37, v38  ; v38 = 1
-;; @0034                               store user2 region0 v39, v36
-;; @0034                               store.i32 user2 region0 v6, v20
+;; @0034                               store user2 region1 v39, v36
+;; @0034                               store.i32 user2 region1 v6, v20
 ;; @0034                               v47 = load.i32 notrap aligned v20+4
 ;;                                     v94 = iconst.i32 1
 ;;                                     v95 = iadd v47, v94  ; v94 = 1
@@ -94,12 +95,13 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32) tail
@@ -119,16 +121,16 @@
 ;; @003b                               brif v12, block3, block2
 ;;
 ;;                                 block2:
-;; @003b                               v53 = load.i64 notrap aligned readonly can_move v0+8
+;; @003b                               v53 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @003b                               v14 = load.i64 notrap aligned readonly can_move v53+32
 ;; @003b                               v13 = uextend.i64 v2
 ;; @003b                               v15 = iadd v14, v13
 ;; @003b                               v16 = iconst.i64 8
 ;; @003b                               v17 = iadd v15, v16  ; v16 = 8
-;; @003b                               v18 = load.i64 user2 region0 v17
+;; @003b                               v18 = load.i64 user2 region1 v17
 ;; @003b                               v19 = iconst.i64 1
 ;; @003b                               v20 = iadd v18, v19  ; v19 = 1
-;; @003b                               store user2 region0 v20, v17
+;; @003b                               store user2 region1 v20, v17
 ;; @003b                               jump block3
 ;;
 ;;                                 block3:
@@ -143,13 +145,13 @@
 ;; @003b                               brif v31, block7, block4
 ;;
 ;;                                 block4:
-;;                                     v72 = load.i64 notrap aligned readonly can_move v0+8
+;;                                     v72 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;;                                     v73 = load.i64 notrap aligned readonly can_move v72+32
 ;; @003b                               v32 = uextend.i64 v6
 ;; @003b                               v34 = iadd v73, v32
 ;;                                     v74 = iconst.i64 8
 ;; @003b                               v36 = iadd v34, v74  ; v74 = 8
-;; @003b                               v37 = load.i64 user2 region0 v36
+;; @003b                               v37 = load.i64 user2 region1 v36
 ;;                                     v75 = iconst.i64 1
 ;;                                     v65 = icmp eq v37, v75  ; v75 = 1
 ;; @003b                               brif v65, block5, block6
@@ -162,7 +164,7 @@
 ;; @003b                               v38 = iconst.i64 -1
 ;; @003b                               v39 = iadd.i64 v37, v38  ; v38 = -1
 ;;                                     v76 = iadd.i64 v34, v74  ; v74 = 8
-;; @003b                               store user2 region0 v39, v76
+;; @003b                               store user2 region1 v39, v76
 ;; @003b                               jump block7
 ;;
 ;;                                 block7:

--- a/tests/disas/gc/drc/funcref-in-gc-heap-get.wat
+++ b/tests/disas/gc/drc/funcref-in-gc-heap-get.wat
@@ -10,12 +10,13 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i64 tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32) -> i64 tail
@@ -24,13 +25,13 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0020                               trapz v2, user16
-;; @0020                               v12 = load.i64 notrap aligned readonly can_move v0+8
+;; @0020                               v12 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @0020                               v5 = load.i64 notrap aligned readonly can_move v12+32
 ;; @0020                               v4 = uextend.i64 v2
 ;; @0020                               v6 = iadd v5, v4
 ;; @0020                               v7 = iconst.i64 24
 ;; @0020                               v8 = iadd v6, v7  ; v7 = 24
-;; @0020                               v10 = load.i32 user2 little region0 v8
+;; @0020                               v10 = load.i32 user2 little region1 v8
 ;; @0020                               v9 = iconst.i32 -1
 ;; @0020                               v11 = call fn0(v0, v10, v9)  ; v9 = -1
 ;; @0024                               jump block1

--- a/tests/disas/gc/drc/funcref-in-gc-heap-new.wat
+++ b/tests/disas/gc/drc/funcref-in-gc-heap-new.wat
@@ -11,9 +11,11 @@
 )
 ;; function u0:0(i64 vmctx, i64, i64) -> i32 tail {
 ;;     ss0 = explicit_slot 4, align = 4
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 40 "VMContext+0x28"
+;;     region2 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i64) -> i64 tail
@@ -23,7 +25,7 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @0020                               v5 = iconst.i32 -1342177280
-;; @0020                               v6 = load.i64 notrap aligned readonly can_move v0+40
+;; @0020                               v6 = load.i64 notrap aligned readonly can_move region1 v0+40
 ;; @0020                               v7 = load.i32 notrap aligned readonly can_move v6
 ;; @0020                               v4 = iconst.i32 32
 ;; @0020                               v8 = iconst.i32 8
@@ -32,13 +34,13 @@
 ;;                                     store notrap v9, v22
 ;; @0020                               v16 = call fn1(v0, v2), stack_map=[i32 @ ss0+0]
 ;; @0020                               v17 = ireduce.i32 v16
-;; @0020                               v10 = load.i64 notrap aligned readonly can_move v0+8
+;; @0020                               v10 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @0020                               v11 = load.i64 notrap aligned readonly can_move v10+32
 ;; @0020                               v12 = uextend.i64 v9
 ;; @0020                               v13 = iadd v11, v12
 ;; @0020                               v14 = iconst.i64 24
 ;; @0020                               v15 = iadd v13, v14  ; v14 = 24
-;; @0020                               store user2 little region0 v17, v15
+;; @0020                               store user2 little region2 v17, v15
 ;;                                     v19 = load.i32 notrap v22
 ;; @0023                               jump block1
 ;;

--- a/tests/disas/gc/drc/funcref-in-gc-heap-set.wat
+++ b/tests/disas/gc/drc/funcref-in-gc-heap-set.wat
@@ -10,12 +10,13 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32, i64) tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i64) -> i64 tail
@@ -26,13 +27,13 @@
 ;; @0022                               trapz v2, user16
 ;; @0022                               v9 = call fn0(v0, v3)
 ;; @0022                               v10 = ireduce.i32 v9
-;; @0022                               v11 = load.i64 notrap aligned readonly can_move v0+8
+;; @0022                               v11 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @0022                               v5 = load.i64 notrap aligned readonly can_move v11+32
 ;; @0022                               v4 = uextend.i64 v2
 ;; @0022                               v6 = iadd v5, v4
 ;; @0022                               v7 = iconst.i64 24
 ;; @0022                               v8 = iadd v6, v7  ; v7 = 24
-;; @0022                               store user2 little region0 v10, v8
+;; @0022                               store user2 little region1 v10, v8
 ;; @0026                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/drc/i31ref-globals.wat
+++ b/tests/disas/gc/drc/i31ref-globals.wat
@@ -13,8 +13,9 @@
 )
 
 ;; function u0:0(i64 vmctx, i64) -> i32 tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     stack_limit = gv2
@@ -30,8 +31,9 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     stack_limit = gv2

--- a/tests/disas/gc/drc/multiple-array-get.wat
+++ b/tests/disas/gc/drc/multiple-array-get.wat
@@ -11,25 +11,26 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32, i32) -> i64, i64 tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
 ;; @0024                               trapz v2, user16
-;; @0024                               v65 = load.i64 notrap aligned readonly can_move v0+8
+;; @0024                               v65 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @0024                               v8 = load.i64 notrap aligned readonly can_move v65+32
 ;; @0024                               v7 = uextend.i64 v2
 ;; @0024                               v9 = iadd v8, v7
 ;; @0024                               v10 = iconst.i64 24
 ;; @0024                               v11 = iadd v9, v10  ; v10 = 24
-;; @0024                               v12 = load.i32 user2 readonly region0 v11
+;; @0024                               v12 = load.i32 user2 readonly region1 v11
 ;; @0024                               v13 = icmp ult v3, v12
 ;; @0024                               trapz v13, user17
 ;; @0024                               v15 = uextend.i64 v12
@@ -50,7 +51,7 @@
 ;; @0024                               v29 = isub v21, v24
 ;; @0024                               v30 = uextend.i64 v29
 ;; @0024                               v31 = isub v28, v30
-;; @0024                               v32 = load.i64 user2 little region0 v31
+;; @0024                               v32 = load.i64 user2 little region1 v31
 ;; @002b                               v39 = icmp ult v4, v12
 ;; @002b                               trapz v39, user17
 ;;                                     v86 = ishl v4, v77  ; v77 = 3
@@ -58,7 +59,7 @@
 ;; @002b                               v55 = isub v21, v50
 ;; @002b                               v56 = uextend.i64 v55
 ;; @002b                               v57 = isub v28, v56
-;; @002b                               v58 = load.i64 user2 little region0 v57
+;; @002b                               v58 = load.i64 user2 little region1 v57
 ;; @002e                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/drc/multiple-struct-get.wat
+++ b/tests/disas/gc/drc/multiple-struct-get.wat
@@ -12,28 +12,29 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> f32, i32 tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0023                               trapz v2, user16
-;; @0023                               v20 = load.i64 notrap aligned readonly can_move v0+8
+;; @0023                               v20 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @0023                               v6 = load.i64 notrap aligned readonly can_move v20+32
 ;; @0023                               v5 = uextend.i64 v2
 ;; @0023                               v7 = iadd v6, v5
 ;; @0023                               v8 = iconst.i64 24
 ;; @0023                               v9 = iadd v7, v8  ; v8 = 24
-;; @0023                               v10 = load.f32 user2 little region0 v9
+;; @0023                               v10 = load.f32 user2 little region1 v9
 ;; @0029                               v14 = iconst.i64 28
 ;; @0029                               v15 = iadd v7, v14  ; v14 = 28
-;; @0029                               v16 = load.i8 user2 little region0 v15
+;; @0029                               v16 = load.i8 user2 little region1 v15
 ;; @002d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/drc/ref-cast.wat
+++ b/tests/disas/gc/drc/ref-cast.wat
@@ -9,12 +9,14 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 40 "VMContext+0x28"
+;;     region2 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
@@ -31,14 +33,14 @@
 ;; @001e                               brif v9, block4(v24), block3  ; v24 = 0
 ;;
 ;;                                 block3:
-;; @001e                               v22 = load.i64 notrap aligned readonly can_move v0+8
+;; @001e                               v22 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @001e                               v14 = load.i64 notrap aligned readonly can_move v22+32
 ;; @001e                               v13 = uextend.i64 v2
 ;; @001e                               v15 = iadd v14, v13
 ;; @001e                               v16 = iconst.i64 4
 ;; @001e                               v17 = iadd v15, v16  ; v16 = 4
-;; @001e                               v18 = load.i32 user2 readonly region0 v17
-;; @001e                               v11 = load.i64 notrap aligned readonly can_move v0+40
+;; @001e                               v18 = load.i32 user2 readonly region2 v17
+;; @001e                               v11 = load.i64 notrap aligned readonly can_move region1 v0+40
 ;; @001e                               v12 = load.i32 notrap aligned readonly can_move v11
 ;; @001e                               v19 = icmp eq v18, v12
 ;; @001e                               v20 = uextend.i32 v19

--- a/tests/disas/gc/drc/ref-is-null.wat
+++ b/tests/disas/gc/drc/ref-is-null.wat
@@ -11,8 +11,9 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     stack_limit = gv2
 ;;
@@ -27,8 +28,9 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     stack_limit = gv2
 ;;

--- a/tests/disas/gc/drc/ref-test-any.wat
+++ b/tests/disas/gc/drc/ref-test-any.wat
@@ -11,8 +11,9 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     stack_limit = gv2
 ;;
@@ -27,8 +28,9 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     stack_limit = gv2
 ;;

--- a/tests/disas/gc/drc/ref-test-array.wat
+++ b/tests/disas/gc/drc/ref-test-array.wat
@@ -8,12 +8,13 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
@@ -30,11 +31,11 @@
 ;; @001b                               brif v9, block4(v24), block3  ; v24 = 0
 ;;
 ;;                                 block3:
-;; @001b                               v22 = load.i64 notrap aligned readonly can_move v0+8
+;; @001b                               v22 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @001b                               v12 = load.i64 notrap aligned readonly can_move v22+32
 ;; @001b                               v11 = uextend.i64 v2
 ;; @001b                               v13 = iadd v12, v11
-;; @001b                               v16 = load.i32 user2 readonly region0 v13
+;; @001b                               v16 = load.i32 user2 readonly region1 v13
 ;; @001b                               v17 = iconst.i32 -1476395008
 ;; @001b                               v18 = band v16, v17  ; v17 = -1476395008
 ;; @001b                               v19 = icmp eq v18, v17  ; v17 = -1476395008

--- a/tests/disas/gc/drc/ref-test-concrete-func-type.wat
+++ b/tests/disas/gc/drc/ref-test-concrete-func-type.wat
@@ -9,9 +9,11 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i64) -> i32 tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 40 "VMContext+0x28"
+;;     region2 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     stack_limit = gv2
 ;;
@@ -25,8 +27,8 @@
 ;; @0020                               jump block3
 ;;
 ;;                                 block3:
-;; @0020                               v10 = load.i32 user2 readonly region0 v2+16
-;; @0020                               v8 = load.i64 notrap aligned readonly can_move v0+40
+;; @0020                               v10 = load.i32 user2 readonly region2 v2+16
+;; @0020                               v8 = load.i64 notrap aligned readonly can_move region1 v0+40
 ;; @0020                               v9 = load.i32 notrap aligned readonly can_move v8
 ;; @0020                               v11 = icmp eq v10, v9
 ;; @0020                               v12 = uextend.i32 v11

--- a/tests/disas/gc/drc/ref-test-concrete-type.wat
+++ b/tests/disas/gc/drc/ref-test-concrete-type.wat
@@ -9,12 +9,14 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 40 "VMContext+0x28"
+;;     region2 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
@@ -31,14 +33,14 @@
 ;; @001d                               brif v9, block4(v24), block3  ; v24 = 0
 ;;
 ;;                                 block3:
-;; @001d                               v22 = load.i64 notrap aligned readonly can_move v0+8
+;; @001d                               v22 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @001d                               v14 = load.i64 notrap aligned readonly can_move v22+32
 ;; @001d                               v13 = uextend.i64 v2
 ;; @001d                               v15 = iadd v14, v13
 ;; @001d                               v16 = iconst.i64 4
 ;; @001d                               v17 = iadd v15, v16  ; v16 = 4
-;; @001d                               v18 = load.i32 user2 readonly region0 v17
-;; @001d                               v11 = load.i64 notrap aligned readonly can_move v0+40
+;; @001d                               v18 = load.i32 user2 readonly region2 v17
+;; @001d                               v11 = load.i64 notrap aligned readonly can_move region1 v0+40
 ;; @001d                               v12 = load.i32 notrap aligned readonly can_move v11
 ;; @001d                               v19 = icmp eq v18, v12
 ;; @001d                               v20 = uextend.i32 v19

--- a/tests/disas/gc/drc/ref-test-eq.wat
+++ b/tests/disas/gc/drc/ref-test-eq.wat
@@ -8,12 +8,13 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
@@ -29,11 +30,11 @@
 ;; @001b                               brif v9, block4(v8), block3  ; v8 = 1
 ;;
 ;;                                 block3:
-;; @001b                               v22 = load.i64 notrap aligned readonly can_move v0+8
+;; @001b                               v22 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @001b                               v12 = load.i64 notrap aligned readonly can_move v22+32
 ;; @001b                               v11 = uextend.i64 v2
 ;; @001b                               v13 = iadd v12, v11
-;; @001b                               v16 = load.i32 user2 readonly region0 v13
+;; @001b                               v16 = load.i32 user2 readonly region1 v13
 ;; @001b                               v17 = iconst.i32 -1610612736
 ;; @001b                               v18 = band v16, v17  ; v17 = -1610612736
 ;; @001b                               v19 = icmp eq v18, v17  ; v17 = -1610612736

--- a/tests/disas/gc/drc/ref-test-i31.wat
+++ b/tests/disas/gc/drc/ref-test-i31.wat
@@ -8,8 +8,9 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     stack_limit = gv2
 ;;

--- a/tests/disas/gc/drc/ref-test-none.wat
+++ b/tests/disas/gc/drc/ref-test-none.wat
@@ -11,8 +11,9 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     stack_limit = gv2
 ;;
@@ -25,8 +26,9 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     stack_limit = gv2
 ;;

--- a/tests/disas/gc/drc/ref-test-struct.wat
+++ b/tests/disas/gc/drc/ref-test-struct.wat
@@ -8,12 +8,13 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
@@ -30,11 +31,11 @@
 ;; @001b                               brif v9, block4(v24), block3  ; v24 = 0
 ;;
 ;;                                 block3:
-;; @001b                               v22 = load.i64 notrap aligned readonly can_move v0+8
+;; @001b                               v22 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @001b                               v12 = load.i64 notrap aligned readonly can_move v22+32
 ;; @001b                               v11 = uextend.i64 v2
 ;; @001b                               v13 = iadd v12, v11
-;; @001b                               v16 = load.i32 user2 readonly region0 v13
+;; @001b                               v16 = load.i32 user2 readonly region1 v13
 ;; @001b                               v17 = iconst.i32 -1342177280
 ;; @001b                               v18 = band v16, v17  ; v17 = -1342177280
 ;; @001b                               v19 = icmp eq v18, v17  ; v17 = -1342177280

--- a/tests/disas/gc/drc/struct-get.wat
+++ b/tests/disas/gc/drc/struct-get.wat
@@ -24,25 +24,26 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> f32 tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0033                               trapz v2, user16
-;; @0033                               v10 = load.i64 notrap aligned readonly can_move v0+8
+;; @0033                               v10 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @0033                               v5 = load.i64 notrap aligned readonly can_move v10+32
 ;; @0033                               v4 = uextend.i64 v2
 ;; @0033                               v6 = iadd v5, v4
 ;; @0033                               v7 = iconst.i64 24
 ;; @0033                               v8 = iadd v6, v7  ; v7 = 24
-;; @0033                               v9 = load.f32 user2 little region0 v8
+;; @0033                               v9 = load.f32 user2 little region1 v8
 ;; @0037                               jump block1
 ;;
 ;;                                 block1:
@@ -50,25 +51,26 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @003c                               trapz v2, user16
-;; @003c                               v11 = load.i64 notrap aligned readonly can_move v0+8
+;; @003c                               v11 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @003c                               v5 = load.i64 notrap aligned readonly can_move v11+32
 ;; @003c                               v4 = uextend.i64 v2
 ;; @003c                               v6 = iadd v5, v4
 ;; @003c                               v7 = iconst.i64 28
 ;; @003c                               v8 = iadd v6, v7  ; v7 = 28
-;; @003c                               v9 = load.i8 user2 little region0 v8
+;; @003c                               v9 = load.i8 user2 little region1 v8
 ;; @0040                               jump block1
 ;;
 ;;                                 block1:
@@ -77,25 +79,26 @@
 ;; }
 ;;
 ;; function u0:2(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0045                               trapz v2, user16
-;; @0045                               v11 = load.i64 notrap aligned readonly can_move v0+8
+;; @0045                               v11 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @0045                               v5 = load.i64 notrap aligned readonly can_move v11+32
 ;; @0045                               v4 = uextend.i64 v2
 ;; @0045                               v6 = iadd v5, v4
 ;; @0045                               v7 = iconst.i64 28
 ;; @0045                               v8 = iadd v6, v7  ; v7 = 28
-;; @0045                               v9 = load.i8 user2 little region0 v8
+;; @0045                               v9 = load.i8 user2 little region1 v8
 ;; @0049                               jump block1
 ;;
 ;;                                 block1:
@@ -105,13 +108,14 @@
 ;;
 ;; function u0:3(i64 vmctx, i64, i32) -> i32 tail {
 ;;     ss0 = explicit_slot 4, align = 4
-;;     region0 = 2147483648 "GcHeap"
-;;     region1 = 32 "VMContext+0x20"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 2147483648 "GcHeap"
+;;     region2 = 32 "VMContext+0x20"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx) -> i8 tail
@@ -120,13 +124,13 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @004e                               trapz v2, user16
-;; @004e                               v95 = load.i64 notrap aligned readonly can_move v0+8
+;; @004e                               v95 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @004e                               v5 = load.i64 notrap aligned readonly can_move v95+32
 ;; @004e                               v4 = uextend.i64 v2
 ;; @004e                               v6 = iadd v5, v4
 ;; @004e                               v7 = iconst.i64 32
 ;; @004e                               v8 = iadd v6, v7  ; v7 = 32
-;; @004e                               v9 = load.i32 user2 little region0 v8
+;; @004e                               v9 = load.i32 user2 little region1 v8
 ;;                                     v84 = stack_addr.i64 ss0
 ;;                                     store notrap v9, v84
 ;; @004e                               v10 = iconst.i32 1
@@ -140,27 +144,27 @@
 ;;                                 block2:
 ;; @004e                               v16 = uextend.i64 v9
 ;; @004e                               v18 = iadd.i64 v5, v16
-;; @004e                               v19 = load.i32 user2 region0 v18
+;; @004e                               v19 = load.i32 user2 region1 v18
 ;; @004e                               v20 = iconst.i32 2
 ;; @004e                               v21 = band v19, v20  ; v20 = 2
 ;; @004e                               brif v21, block4, block3
 ;;
 ;;                                 block3:
-;; @004e                               v23 = load.i64 notrap aligned readonly can_move region1 v0+32
-;; @004e                               v24 = load.i32 user2 region0 v23
+;; @004e                               v23 = load.i64 notrap aligned readonly can_move region2 v0+32
+;; @004e                               v24 = load.i32 user2 region1 v23
 ;; @004e                               v28 = iconst.i64 16
 ;; @004e                               v29 = iadd.i64 v18, v28  ; v28 = 16
-;; @004e                               store user2 region0 v24, v29
+;; @004e                               store user2 region1 v24, v29
 ;;                                     v97 = iconst.i32 2
 ;;                                     v98 = bor.i32 v19, v97  ; v97 = 2
-;; @004e                               store user2 region0 v98, v18
+;; @004e                               store user2 region1 v98, v18
 ;; @004e                               v38 = iconst.i64 8
 ;; @004e                               v39 = iadd.i64 v18, v38  ; v38 = 8
-;; @004e                               v40 = load.i64 user2 region0 v39
+;; @004e                               v40 = load.i64 user2 region1 v39
 ;; @004e                               v41 = iconst.i64 1
 ;; @004e                               v42 = iadd v40, v41  ; v41 = 1
-;; @004e                               store user2 region0 v42, v39
-;; @004e                               store.i32 user2 region0 v9, v23
+;; @004e                               store user2 region1 v42, v39
+;; @004e                               store.i32 user2 region1 v9, v23
 ;; @004e                               v50 = load.i32 notrap aligned v23+4
 ;;                                     v99 = iconst.i32 1
 ;;                                     v100 = iadd v50, v99  ; v99 = 1

--- a/tests/disas/gc/drc/struct-new-default.wat
+++ b/tests/disas/gc/drc/struct-new-default.wat
@@ -12,12 +12,14 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64) -> i32 tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 40 "VMContext+0x28"
+;;     region2 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
@@ -26,30 +28,30 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64):
 ;; @0021                               v7 = iconst.i32 -1342177280
-;; @0021                               v8 = load.i64 notrap aligned readonly can_move v0+40
+;; @0021                               v8 = load.i64 notrap aligned readonly can_move region1 v0+40
 ;; @0021                               v9 = load.i32 notrap aligned readonly can_move v8
 ;; @0021                               v6 = iconst.i32 40
 ;; @0021                               v10 = iconst.i32 8
 ;; @0021                               v11 = call fn0(v0, v7, v9, v6, v10)  ; v7 = -1342177280, v6 = 40, v10 = 8
 ;; @0021                               v3 = f32const 0.0
-;; @0021                               v12 = load.i64 notrap aligned readonly can_move v0+8
+;; @0021                               v12 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @0021                               v13 = load.i64 notrap aligned readonly can_move v12+32
 ;; @0021                               v14 = uextend.i64 v11
 ;; @0021                               v15 = iadd v13, v14
 ;; @0021                               v16 = iconst.i64 24
 ;; @0021                               v17 = iadd v15, v16  ; v16 = 24
-;; @0021                               store user2 little region0 v3, v17  ; v3 = 0.0
+;; @0021                               store user2 little region2 v3, v17  ; v3 = 0.0
 ;; @0021                               v4 = iconst.i32 0
 ;; @0021                               v18 = iconst.i64 28
 ;; @0021                               v19 = iadd v15, v18  ; v18 = 28
-;; @0021                               istore8 user2 little region0 v4, v19  ; v4 = 0
+;; @0021                               istore8 user2 little region2 v4, v19  ; v4 = 0
 ;;                                     jump block3
 ;;
 ;;                                 block3:
 ;;                                     v62 = iconst.i32 0
 ;; @0021                               v20 = iconst.i64 32
 ;; @0021                               v21 = iadd.i64 v15, v20  ; v20 = 32
-;; @0021                               store user2 little region0 v62, v21  ; v62 = 0
+;; @0021                               store user2 little region2 v62, v21  ; v62 = 0
 ;; @0024                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/drc/struct-new.wat
+++ b/tests/disas/gc/drc/struct-new.wat
@@ -13,12 +13,14 @@
 )
 ;; function u0:0(i64 vmctx, i64, f32, i32, i32) -> i32 tail {
 ;;     ss0 = explicit_slot 4, align = 4
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 40 "VMContext+0x28"
+;;     region2 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
@@ -29,21 +31,21 @@
 ;;                                     v51 = stack_addr.i64 ss0
 ;;                                     store notrap v4, v51
 ;; @002a                               v7 = iconst.i32 -1342177280
-;; @002a                               v8 = load.i64 notrap aligned readonly can_move v0+40
+;; @002a                               v8 = load.i64 notrap aligned readonly can_move region1 v0+40
 ;; @002a                               v9 = load.i32 notrap aligned readonly can_move v8
 ;; @002a                               v6 = iconst.i32 40
 ;; @002a                               v10 = iconst.i32 8
 ;; @002a                               v11 = call fn0(v0, v7, v9, v6, v10), stack_map=[i32 @ ss0+0]  ; v7 = -1342177280, v6 = 40, v10 = 8
-;; @002a                               v12 = load.i64 notrap aligned readonly can_move v0+8
+;; @002a                               v12 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @002a                               v13 = load.i64 notrap aligned readonly can_move v12+32
 ;; @002a                               v14 = uextend.i64 v11
 ;; @002a                               v15 = iadd v13, v14
 ;; @002a                               v16 = iconst.i64 24
 ;; @002a                               v17 = iadd v15, v16  ; v16 = 24
-;; @002a                               store user2 little region0 v2, v17
+;; @002a                               store user2 little region2 v2, v17
 ;; @002a                               v18 = iconst.i64 28
 ;; @002a                               v19 = iadd v15, v18  ; v18 = 28
-;; @002a                               istore8 user2 little region0 v3, v19
+;; @002a                               istore8 user2 little region2 v3, v19
 ;;                                     v50 = load.i32 notrap v51
 ;; @002a                               v22 = iconst.i32 1
 ;; @002a                               v23 = band v50, v22  ; v22 = 1
@@ -58,16 +60,16 @@
 ;; @002a                               v30 = iadd.i64 v13, v28
 ;; @002a                               v31 = iconst.i64 8
 ;; @002a                               v32 = iadd v30, v31  ; v31 = 8
-;; @002a                               v33 = load.i64 user2 region0 v32
+;; @002a                               v33 = load.i64 user2 region2 v32
 ;; @002a                               v34 = iconst.i64 1
 ;; @002a                               v35 = iadd v33, v34  ; v34 = 1
-;; @002a                               store user2 region0 v35, v32
+;; @002a                               store user2 region2 v35, v32
 ;; @002a                               jump block3
 ;;
 ;;                                 block3:
 ;; @002a                               v20 = iconst.i64 32
 ;; @002a                               v21 = iadd.i64 v15, v20  ; v20 = 32
-;; @002a                               store.i32 user2 little region0 v50, v21
+;; @002a                               store.i32 user2 little region2 v50, v21
 ;; @002d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/drc/struct-set.wat
+++ b/tests/disas/gc/drc/struct-set.wat
@@ -20,25 +20,26 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32, f32) tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: f32):
 ;; @0034                               trapz v2, user16
-;; @0034                               v9 = load.i64 notrap aligned readonly can_move v0+8
+;; @0034                               v9 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @0034                               v5 = load.i64 notrap aligned readonly can_move v9+32
 ;; @0034                               v4 = uextend.i64 v2
 ;; @0034                               v6 = iadd v5, v4
 ;; @0034                               v7 = iconst.i64 24
 ;; @0034                               v8 = iadd v6, v7  ; v7 = 24
-;; @0034                               store user2 little region0 v3, v8
+;; @0034                               store user2 little region1 v3, v8
 ;; @0038                               jump block1
 ;;
 ;;                                 block1:
@@ -46,25 +47,26 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32, i32) tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @003f                               trapz v2, user16
-;; @003f                               v9 = load.i64 notrap aligned readonly can_move v0+8
+;; @003f                               v9 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @003f                               v5 = load.i64 notrap aligned readonly can_move v9+32
 ;; @003f                               v4 = uextend.i64 v2
 ;; @003f                               v6 = iadd v5, v4
 ;; @003f                               v7 = iconst.i64 28
 ;; @003f                               v8 = iadd v6, v7  ; v7 = 28
-;; @003f                               istore8 user2 little region0 v3, v8
+;; @003f                               istore8 user2 little region1 v3, v8
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -72,12 +74,13 @@
 ;; }
 ;;
 ;; function u0:2(i64 vmctx, i64, i32, i32) tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32) tail
@@ -86,13 +89,13 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @004a                               trapz v2, user16
-;; @004a                               v58 = load.i64 notrap aligned readonly can_move v0+8
+;; @004a                               v58 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @004a                               v5 = load.i64 notrap aligned readonly can_move v58+32
 ;; @004a                               v4 = uextend.i64 v2
 ;; @004a                               v6 = iadd v5, v4
 ;; @004a                               v7 = iconst.i64 32
 ;; @004a                               v8 = iadd v6, v7  ; v7 = 32
-;; @004a                               v9 = load.i32 user2 little region0 v8
+;; @004a                               v9 = load.i32 user2 little region1 v8
 ;; @004a                               v10 = iconst.i32 1
 ;; @004a                               v11 = band v3, v10  ; v10 = 1
 ;; @004a                               v12 = iconst.i32 0
@@ -106,15 +109,15 @@
 ;; @004a                               v18 = iadd.i64 v5, v16
 ;; @004a                               v19 = iconst.i64 8
 ;; @004a                               v20 = iadd v18, v19  ; v19 = 8
-;; @004a                               v21 = load.i64 user2 region0 v20
+;; @004a                               v21 = load.i64 user2 region1 v20
 ;; @004a                               v22 = iconst.i64 1
 ;; @004a                               v23 = iadd v21, v22  ; v22 = 1
-;; @004a                               store user2 region0 v23, v20
+;; @004a                               store user2 region1 v23, v20
 ;; @004a                               jump block3
 ;;
 ;;                                 block3:
 ;;                                     v72 = iadd.i64 v6, v7  ; v7 = 32
-;; @004a                               store.i32 user2 little region0 v3, v72
+;; @004a                               store.i32 user2 little region1 v3, v72
 ;;                                     v73 = iconst.i32 1
 ;;                                     v74 = band.i32 v9, v73  ; v73 = 1
 ;;                                     v75 = iconst.i32 0
@@ -128,7 +131,7 @@
 ;; @004a                               v37 = iadd.i64 v5, v35
 ;;                                     v77 = iconst.i64 8
 ;; @004a                               v39 = iadd v37, v77  ; v77 = 8
-;; @004a                               v40 = load.i64 user2 region0 v39
+;; @004a                               v40 = load.i64 user2 region1 v39
 ;;                                     v78 = iconst.i64 1
 ;;                                     v70 = icmp eq v40, v78  ; v78 = 1
 ;; @004a                               brif v70, block5, block6
@@ -141,7 +144,7 @@
 ;; @004a                               v41 = iconst.i64 -1
 ;; @004a                               v42 = iadd.i64 v40, v41  ; v41 = -1
 ;;                                     v79 = iadd.i64 v37, v77  ; v77 = 8
-;; @004a                               store user2 region0 v42, v79
+;; @004a                               store user2 region1 v42, v79
 ;; @004a                               jump block7
 ;;
 ;;                                 block7:

--- a/tests/disas/gc/null/array-fill.wat
+++ b/tests/disas/gc/null/array-fill.wat
@@ -10,25 +10,26 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32, i64, i32) tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i64, v5: i32):
 ;; @0027                               trapz v2, user16
-;; @0027                               v46 = load.i64 notrap aligned readonly can_move v0+8
+;; @0027                               v46 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @0027                               v7 = load.i64 notrap aligned readonly can_move v46+32
 ;; @0027                               v6 = uextend.i64 v2
 ;; @0027                               v8 = iadd v7, v6
 ;; @0027                               v9 = iconst.i64 8
 ;; @0027                               v10 = iadd v8, v9  ; v9 = 8
-;; @0027                               v11 = load.i32 user2 readonly region0 v10
+;; @0027                               v11 = load.i32 user2 readonly region1 v10
 ;; @0027                               v13 = uextend.i64 v3
 ;; @0027                               v14 = uextend.i64 v5
 ;; @0027                               v17 = iadd v13, v14
@@ -52,7 +53,7 @@
 ;; @0027                               brif v41, block3, block2(v28)
 ;;
 ;;                                 block2(v42: i64):
-;; @0027                               store.i64 user2 little region0 v4, v42
+;; @0027                               store.i64 user2 little region1 v4, v42
 ;;                                     v55 = iconst.i64 8
 ;;                                     v56 = iadd v42, v55  ; v55 = 8
 ;; @0027                               v45 = icmp eq v56, v39

--- a/tests/disas/gc/null/array-get-s.wat
+++ b/tests/disas/gc/null/array-get-s.wat
@@ -10,25 +10,26 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32) -> i32 tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0022                               trapz v2, user16
-;; @0022                               v34 = load.i64 notrap aligned readonly can_move v0+8
+;; @0022                               v34 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @0022                               v6 = load.i64 notrap aligned readonly can_move v34+32
 ;; @0022                               v5 = uextend.i64 v2
 ;; @0022                               v7 = iadd v6, v5
 ;; @0022                               v8 = iconst.i64 8
 ;; @0022                               v9 = iadd v7, v8  ; v8 = 8
-;; @0022                               v10 = load.i32 user2 readonly region0 v9
+;; @0022                               v10 = load.i32 user2 readonly region1 v9
 ;; @0022                               v11 = icmp ult v3, v10
 ;; @0022                               trapz v11, user17
 ;; @0022                               v13 = uextend.i64 v10
@@ -44,7 +45,7 @@
 ;; @0022                               v27 = isub v19, v22
 ;; @0022                               v28 = uextend.i64 v27
 ;; @0022                               v29 = isub v26, v28
-;; @0022                               v30 = load.i8 user2 little region0 v29
+;; @0022                               v30 = load.i8 user2 little region1 v29
 ;; @0025                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/null/array-get-u.wat
+++ b/tests/disas/gc/null/array-get-u.wat
@@ -10,25 +10,26 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32) -> i32 tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0022                               trapz v2, user16
-;; @0022                               v34 = load.i64 notrap aligned readonly can_move v0+8
+;; @0022                               v34 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @0022                               v6 = load.i64 notrap aligned readonly can_move v34+32
 ;; @0022                               v5 = uextend.i64 v2
 ;; @0022                               v7 = iadd v6, v5
 ;; @0022                               v8 = iconst.i64 8
 ;; @0022                               v9 = iadd v7, v8  ; v8 = 8
-;; @0022                               v10 = load.i32 user2 readonly region0 v9
+;; @0022                               v10 = load.i32 user2 readonly region1 v9
 ;; @0022                               v11 = icmp ult v3, v10
 ;; @0022                               trapz v11, user17
 ;; @0022                               v13 = uextend.i64 v10
@@ -44,7 +45,7 @@
 ;; @0022                               v27 = isub v19, v22
 ;; @0022                               v28 = uextend.i64 v27
 ;; @0022                               v29 = isub v26, v28
-;; @0022                               v30 = load.i8 user2 little region0 v29
+;; @0022                               v30 = load.i8 user2 little region1 v29
 ;; @0025                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/null/array-get.wat
+++ b/tests/disas/gc/null/array-get.wat
@@ -10,25 +10,26 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32) -> i64 tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0022                               trapz v2, user16
-;; @0022                               v33 = load.i64 notrap aligned readonly can_move v0+8
+;; @0022                               v33 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @0022                               v6 = load.i64 notrap aligned readonly can_move v33+32
 ;; @0022                               v5 = uextend.i64 v2
 ;; @0022                               v7 = iadd v6, v5
 ;; @0022                               v8 = iconst.i64 8
 ;; @0022                               v9 = iadd v7, v8  ; v8 = 8
-;; @0022                               v10 = load.i32 user2 readonly region0 v9
+;; @0022                               v10 = load.i32 user2 readonly region1 v9
 ;; @0022                               v11 = icmp ult v3, v10
 ;; @0022                               trapz v11, user17
 ;; @0022                               v13 = uextend.i64 v10
@@ -49,7 +50,7 @@
 ;; @0022                               v27 = isub v19, v22
 ;; @0022                               v28 = uextend.i64 v27
 ;; @0022                               v29 = isub v26, v28
-;; @0022                               v30 = load.i64 user2 little region0 v29
+;; @0022                               v30 = load.i64 user2 little region1 v29
 ;; @0025                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/null/array-len.wat
+++ b/tests/disas/gc/null/array-len.wat
@@ -10,25 +10,26 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @001f                               trapz v2, user16
-;; @001f                               v10 = load.i64 notrap aligned readonly can_move v0+8
+;; @001f                               v10 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @001f                               v5 = load.i64 notrap aligned readonly can_move v10+32
 ;; @001f                               v4 = uextend.i64 v2
 ;; @001f                               v6 = iadd v5, v4
 ;; @001f                               v7 = iconst.i64 8
 ;; @001f                               v8 = iadd v6, v7  ; v7 = 8
-;; @001f                               v9 = load.i32 user2 readonly region0 v8
+;; @001f                               v9 = load.i32 user2 readonly region1 v8
 ;; @0021                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/null/array-new-fixed-of-gc-refs.wat
+++ b/tests/disas/gc/null/array-new-fixed-of-gc-refs.wat
@@ -13,13 +13,15 @@
 ;;     ss0 = explicit_slot 4, align = 4
 ;;     ss1 = explicit_slot 4, align = 4
 ;;     ss2 = explicit_slot 4, align = 4
-;;     region0 = 32 "VMContext+0x20"
-;;     region1 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 32 "VMContext+0x20"
+;;     region2 = 2147483648 "GcHeap"
+;;     region3 = 40 "VMContext+0x28"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i64) -> i8 tail
@@ -33,15 +35,15 @@
 ;;                                     store notrap v3, v127
 ;;                                     v128 = stack_addr.i64 ss0
 ;;                                     store notrap v4, v128
-;; @0025                               v18 = load.i64 notrap aligned readonly region0 v0+32
-;; @0025                               v19 = load.i32 user2 region1 v18
+;; @0025                               v18 = load.i64 notrap aligned readonly region1 v0+32
+;; @0025                               v19 = load.i32 user2 region2 v18
 ;;                                     v158 = iconst.i32 7
 ;; @0025                               v22 = uadd_overflow_trap v19, v158, user18  ; v158 = 7
 ;;                                     v164 = iconst.i32 -8
 ;; @0025                               v24 = band v22, v164  ; v164 = -8
 ;;                                     v151 = iconst.i32 24
 ;; @0025                               v25 = uadd_overflow_trap v24, v151, user18  ; v151 = 24
-;; @0025                               v27 = load.i64 notrap aligned readonly can_move v0+8
+;; @0025                               v27 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @0025                               v28 = load.i64 notrap aligned v27+40
 ;; @0025                               v26 = uextend.i64 v25
 ;; @0025                               v29 = icmp ule v26, v28
@@ -53,15 +55,15 @@
 ;;                                     v263 = band.i32 v22, v164  ; v164 = -8
 ;;                                     v264 = uextend.i64 v263
 ;; @0025                               v35 = iadd v33, v264
-;; @0025                               store user2 region1 v165, v35  ; v165 = -1476394984
-;; @0025                               v38 = load.i64 notrap aligned readonly can_move v0+40
+;; @0025                               store user2 region2 v165, v35  ; v165 = -1476394984
+;; @0025                               v38 = load.i64 notrap aligned readonly can_move region3 v0+40
 ;; @0025                               v39 = load.i32 notrap aligned readonly can_move v38
-;; @0025                               store user2 region1 v39, v35+4
-;; @0025                               store.i32 user2 region1 v25, v18
+;; @0025                               store user2 region2 v39, v35+4
+;; @0025                               store.i32 user2 region2 v25, v18
 ;; @0025                               v6 = iconst.i32 3
 ;; @0025                               v40 = iconst.i64 8
 ;; @0025                               v41 = iadd v35, v40  ; v40 = 8
-;; @0025                               store user2 region1 v6, v41  ; v6 = 3
+;; @0025                               store user2 region2 v6, v41  ; v6 = 3
 ;; @0025                               trapz v263, user16
 ;;                                     v265 = iconst.i32 24
 ;; @0025                               v61 = uadd_overflow_trap v263, v265, user2  ; v265 = 24
@@ -70,8 +72,8 @@
 ;; @0025                               v64 = iadd v33, v62
 ;;                                     v142 = iconst.i64 12
 ;; @0025                               v67 = isub v64, v142  ; v142 = 12
-;; @0025                               store user2 little region1 v125, v67
-;; @0025                               v74 = load.i32 user2 readonly region1 v41
+;; @0025                               store user2 little region2 v125, v67
+;; @0025                               v74 = load.i32 user2 readonly region2 v41
 ;; @0025                               v68 = iconst.i32 1
 ;;                                     v203 = icmp ugt v74, v68  ; v68 = 1
 ;; @0025                               trapz v203, user17
@@ -93,8 +95,8 @@
 ;; @0025                               v91 = isub v83, v225  ; v225 = 16
 ;; @0025                               v92 = uextend.i64 v91
 ;; @0025                               v93 = isub v90, v92
-;; @0025                               store user2 little region1 v123, v93
-;; @0025                               v100 = load.i32 user2 readonly region1 v41
+;; @0025                               store user2 little region2 v123, v93
+;; @0025                               v100 = load.i32 user2 readonly region2 v41
 ;;                                     v231 = icmp ugt v100, v182  ; v182 = 2
 ;; @0025                               trapz v231, user17
 ;; @0025                               v103 = uextend.i64 v100
@@ -111,7 +113,7 @@
 ;; @0025                               v117 = isub v109, v257  ; v257 = 20
 ;; @0025                               v118 = uextend.i64 v117
 ;; @0025                               v119 = isub v116, v118
-;; @0025                               store user2 little region1 v121, v119
+;; @0025                               store user2 little region2 v121, v119
 ;; @0029                               jump block1
 ;;
 ;;                                 block3 cold:

--- a/tests/disas/gc/null/array-new-fixed.wat
+++ b/tests/disas/gc/null/array-new-fixed.wat
@@ -10,13 +10,15 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i64, i64, i64) -> i32 tail {
-;;     region0 = 32 "VMContext+0x20"
-;;     region1 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 32 "VMContext+0x20"
+;;     region2 = 2147483648 "GcHeap"
+;;     region3 = 40 "VMContext+0x28"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i64) -> i8 tail
@@ -24,15 +26,15 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i64, v4: i64):
-;; @0025                               v18 = load.i64 notrap aligned readonly region0 v0+32
-;; @0025                               v19 = load.i32 user2 region1 v18
+;; @0025                               v18 = load.i64 notrap aligned readonly region1 v0+32
+;; @0025                               v19 = load.i32 user2 region2 v18
 ;;                                     v149 = iconst.i32 7
 ;; @0025                               v22 = uadd_overflow_trap v19, v149, user18  ; v149 = 7
 ;;                                     v155 = iconst.i32 -8
 ;; @0025                               v24 = band v22, v155  ; v155 = -8
 ;;                                     v142 = iconst.i32 40
 ;; @0025                               v25 = uadd_overflow_trap v24, v142, user18  ; v142 = 40
-;; @0025                               v27 = load.i64 notrap aligned readonly can_move v0+8
+;; @0025                               v27 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @0025                               v28 = load.i64 notrap aligned v27+40
 ;; @0025                               v26 = uextend.i64 v25
 ;; @0025                               v29 = icmp ule v26, v28
@@ -44,15 +46,15 @@
 ;;                                     v251 = band.i32 v22, v155  ; v155 = -8
 ;;                                     v252 = uextend.i64 v251
 ;; @0025                               v35 = iadd v33, v252
-;; @0025                               store user2 region1 v156, v35  ; v156 = -1476394968
-;; @0025                               v38 = load.i64 notrap aligned readonly can_move v0+40
+;; @0025                               store user2 region2 v156, v35  ; v156 = -1476394968
+;; @0025                               v38 = load.i64 notrap aligned readonly can_move region3 v0+40
 ;; @0025                               v39 = load.i32 notrap aligned readonly can_move v38
-;; @0025                               store user2 region1 v39, v35+4
-;; @0025                               store.i32 user2 region1 v25, v18
+;; @0025                               store user2 region2 v39, v35+4
+;; @0025                               store.i32 user2 region2 v25, v18
 ;; @0025                               v6 = iconst.i32 3
 ;; @0025                               v9 = iconst.i64 8
 ;; @0025                               v41 = iadd v35, v9  ; v9 = 8
-;; @0025                               store user2 region1 v6, v41  ; v6 = 3
+;; @0025                               store user2 region2 v6, v41  ; v6 = 3
 ;; @0025                               trapz v251, user16
 ;;                                     v253 = iconst.i32 40
 ;; @0025                               v61 = uadd_overflow_trap v251, v253, user2  ; v253 = 40
@@ -60,8 +62,8 @@
 ;; @0025                               v64 = iadd v33, v62
 ;;                                     v133 = iconst.i64 24
 ;; @0025                               v67 = isub v64, v133  ; v133 = 24
-;; @0025                               store.i64 user2 little region1 v2, v67
-;; @0025                               v74 = load.i32 user2 readonly region1 v41
+;; @0025                               store.i64 user2 little region2 v2, v67
+;; @0025                               v74 = load.i32 user2 readonly region2 v41
 ;; @0025                               v68 = iconst.i32 1
 ;;                                     v192 = icmp ugt v74, v68  ; v68 = 1
 ;; @0025                               trapz v192, user17
@@ -81,8 +83,8 @@
 ;; @0025                               v91 = isub v83, v141  ; v141 = 24
 ;; @0025                               v92 = uextend.i64 v91
 ;; @0025                               v93 = isub v90, v92
-;; @0025                               store.i64 user2 little region1 v3, v93
-;; @0025                               v100 = load.i32 user2 readonly region1 v41
+;; @0025                               store.i64 user2 little region2 v3, v93
+;; @0025                               v100 = load.i32 user2 readonly region2 v41
 ;; @0025                               v94 = iconst.i32 2
 ;;                                     v219 = icmp ugt v100, v94  ; v94 = 2
 ;; @0025                               trapz v219, user17
@@ -99,7 +101,7 @@
 ;; @0025                               v117 = isub v109, v245  ; v245 = 32
 ;; @0025                               v118 = uextend.i64 v117
 ;; @0025                               v119 = isub v116, v118
-;; @0025                               store.i64 user2 little region1 v4, v119
+;; @0025                               store.i64 user2 little region2 v4, v119
 ;; @0029                               jump block1
 ;;
 ;;                                 block3 cold:

--- a/tests/disas/gc/null/array-new.wat
+++ b/tests/disas/gc/null/array-new.wat
@@ -10,13 +10,15 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i64, i32) -> i32 tail {
-;;     region0 = 32 "VMContext+0x20"
-;;     region1 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 32 "VMContext+0x20"
+;;     region2 = 2147483648 "GcHeap"
+;;     region3 = 40 "VMContext+0x28"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i64) -> i8 tail
@@ -37,14 +39,14 @@
 ;; @0022                               v14 = iconst.i32 -67108864
 ;; @0022                               v15 = band v12, v14  ; v14 = -67108864
 ;; @0022                               trapnz v15, user18
-;; @0022                               v16 = load.i64 notrap aligned readonly region0 v0+32
-;; @0022                               v17 = load.i32 user2 region1 v16
+;; @0022                               v16 = load.i64 notrap aligned readonly region1 v0+32
+;; @0022                               v17 = load.i32 user2 region2 v16
 ;;                                     v94 = iconst.i32 7
 ;; @0022                               v20 = uadd_overflow_trap v17, v94, user18  ; v94 = 7
 ;;                                     v100 = iconst.i32 -8
 ;; @0022                               v22 = band v20, v100  ; v100 = -8
 ;; @0022                               v23 = uadd_overflow_trap v22, v12, user18
-;; @0022                               v25 = load.i64 notrap aligned readonly can_move v0+8
+;; @0022                               v25 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @0022                               v26 = load.i64 notrap aligned v25+40
 ;; @0022                               v24 = uextend.i64 v23
 ;; @0022                               v27 = icmp ule v24, v26
@@ -57,14 +59,14 @@
 ;;                                     v118 = band.i32 v20, v100  ; v100 = -8
 ;;                                     v119 = uextend.i64 v118
 ;; @0022                               v33 = iadd v31, v119
-;; @0022                               store user2 region1 v101, v33
-;; @0022                               v36 = load.i64 notrap aligned readonly can_move v0+40
+;; @0022                               store user2 region2 v101, v33
+;; @0022                               v36 = load.i64 notrap aligned readonly can_move region3 v0+40
 ;; @0022                               v37 = load.i32 notrap aligned readonly can_move v36
-;; @0022                               store user2 region1 v37, v33+4
-;; @0022                               store.i32 user2 region1 v23, v16
+;; @0022                               store user2 region2 v37, v33+4
+;; @0022                               store.i32 user2 region2 v23, v16
 ;; @0022                               v7 = iconst.i64 8
 ;; @0022                               v39 = iadd v33, v7  ; v7 = 8
-;; @0022                               store.i32 user2 region1 v3, v39
+;; @0022                               store.i32 user2 region2 v3, v39
 ;; @0022                               trapz v118, user16
 ;; @0022                               v70 = load.i64 notrap aligned v25+40
 ;; @0022                               v58 = iconst.i64 16
@@ -79,7 +81,7 @@
 ;; @0022                               brif v76, block5, block4(v59)
 ;;
 ;;                                 block4(v77: i64):
-;; @0022                               store.i64 user2 little region1 v2, v77
+;; @0022                               store.i64 user2 little region2 v2, v77
 ;;                                     v120 = iconst.i64 8
 ;;                                     v121 = iadd v77, v120  ; v120 = 8
 ;; @0022                               v80 = icmp eq v121, v74

--- a/tests/disas/gc/null/array-set.wat
+++ b/tests/disas/gc/null/array-set.wat
@@ -10,25 +10,26 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32, i64) tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i64):
 ;; @0024                               trapz v2, user16
-;; @0024                               v32 = load.i64 notrap aligned readonly can_move v0+8
+;; @0024                               v32 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @0024                               v6 = load.i64 notrap aligned readonly can_move v32+32
 ;; @0024                               v5 = uextend.i64 v2
 ;; @0024                               v7 = iadd v6, v5
 ;; @0024                               v8 = iconst.i64 8
 ;; @0024                               v9 = iadd v7, v8  ; v8 = 8
-;; @0024                               v10 = load.i32 user2 readonly region0 v9
+;; @0024                               v10 = load.i32 user2 readonly region1 v9
 ;; @0024                               v11 = icmp ult v3, v10
 ;; @0024                               trapz v11, user17
 ;; @0024                               v13 = uextend.i64 v10
@@ -49,7 +50,7 @@
 ;; @0024                               v27 = isub v19, v22
 ;; @0024                               v28 = uextend.i64 v27
 ;; @0024                               v29 = isub v26, v28
-;; @0024                               store user2 little region0 v4, v29
+;; @0024                               store user2 little region1 v4, v29
 ;; @0027                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/null/br-on-cast-fail.wat
+++ b/tests/disas/gc/null/br-on-cast-fail.wat
@@ -17,12 +17,18 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32) tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 40 "VMContext+0x28"
+;;     region2 = 2147483648 "GcHeap"
+;;     region3 = 72 "VMContext+0x48"
+;;     region4 = 56 "VMContext+0x38"
+;;     region5 = 104 "VMContext+0x68"
+;;     region6 = 88 "VMContext+0x58"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i64) tail
@@ -40,14 +46,14 @@
 ;; @002e                               brif v9, block5(v30), block4  ; v30 = 0
 ;;
 ;;                                 block4:
-;; @002e                               v28 = load.i64 notrap aligned readonly can_move v0+8
+;; @002e                               v28 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @002e                               v14 = load.i64 notrap aligned readonly can_move v28+32
 ;; @002e                               v13 = uextend.i64 v2
 ;; @002e                               v15 = iadd v14, v13
 ;; @002e                               v16 = iconst.i64 4
 ;; @002e                               v17 = iadd v15, v16  ; v16 = 4
-;; @002e                               v18 = load.i32 user2 readonly region0 v17
-;; @002e                               v11 = load.i64 notrap aligned readonly can_move v0+40
+;; @002e                               v18 = load.i32 user2 readonly region2 v17
+;; @002e                               v11 = load.i64 notrap aligned readonly can_move region1 v0+40
 ;; @002e                               v12 = load.i32 notrap aligned readonly can_move v11
 ;; @002e                               v19 = icmp eq v18, v12
 ;; @002e                               v20 = uextend.i32 v19
@@ -57,14 +63,14 @@
 ;; @002e                               brif v21, block6, block2
 ;;
 ;;                                 block6:
-;; @0034                               v24 = load.i64 notrap aligned readonly can_move v0+56
-;; @0034                               v23 = load.i64 notrap aligned readonly can_move v0+72
+;; @0034                               v24 = load.i64 notrap aligned readonly can_move region4 v0+56
+;; @0034                               v23 = load.i64 notrap aligned readonly can_move region3 v0+72
 ;; @0034                               call_indirect sig0, v24(v23, v0)
 ;; @0036                               return
 ;;
 ;;                                 block2:
-;; @0038                               v27 = load.i64 notrap aligned readonly can_move v0+88
-;; @0038                               v26 = load.i64 notrap aligned readonly can_move v0+104
+;; @0038                               v27 = load.i64 notrap aligned readonly can_move region6 v0+88
+;; @0038                               v26 = load.i64 notrap aligned readonly can_move region5 v0+104
 ;; @0038                               call_indirect sig0, v27(v26, v0)
 ;; @003a                               return
 ;; }

--- a/tests/disas/gc/null/br-on-cast.wat
+++ b/tests/disas/gc/null/br-on-cast.wat
@@ -17,12 +17,18 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32) tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 40 "VMContext+0x28"
+;;     region2 = 2147483648 "GcHeap"
+;;     region3 = 72 "VMContext+0x48"
+;;     region4 = 56 "VMContext+0x38"
+;;     region5 = 104 "VMContext+0x68"
+;;     region6 = 88 "VMContext+0x58"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i64) tail
@@ -40,14 +46,14 @@
 ;; @002f                               brif v9, block5(v30), block4  ; v30 = 0
 ;;
 ;;                                 block4:
-;; @002f                               v28 = load.i64 notrap aligned readonly can_move v0+8
+;; @002f                               v28 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @002f                               v14 = load.i64 notrap aligned readonly can_move v28+32
 ;; @002f                               v13 = uextend.i64 v2
 ;; @002f                               v15 = iadd v14, v13
 ;; @002f                               v16 = iconst.i64 4
 ;; @002f                               v17 = iadd v15, v16  ; v16 = 4
-;; @002f                               v18 = load.i32 user2 readonly region0 v17
-;; @002f                               v11 = load.i64 notrap aligned readonly can_move v0+40
+;; @002f                               v18 = load.i32 user2 readonly region2 v17
+;; @002f                               v11 = load.i64 notrap aligned readonly can_move region1 v0+40
 ;; @002f                               v12 = load.i32 notrap aligned readonly can_move v11
 ;; @002f                               v19 = icmp eq v18, v12
 ;; @002f                               v20 = uextend.i32 v19
@@ -57,14 +63,14 @@
 ;; @002f                               brif v21, block2, block6
 ;;
 ;;                                 block6:
-;; @0035                               v24 = load.i64 notrap aligned readonly can_move v0+56
-;; @0035                               v23 = load.i64 notrap aligned readonly can_move v0+72
+;; @0035                               v24 = load.i64 notrap aligned readonly can_move region4 v0+56
+;; @0035                               v23 = load.i64 notrap aligned readonly can_move region3 v0+72
 ;; @0035                               call_indirect sig0, v24(v23, v0)
 ;; @0037                               return
 ;;
 ;;                                 block2:
-;; @0039                               v27 = load.i64 notrap aligned readonly can_move v0+88
-;; @0039                               v26 = load.i64 notrap aligned readonly can_move v0+104
+;; @0039                               v27 = load.i64 notrap aligned readonly can_move region6 v0+88
+;; @0039                               v26 = load.i64 notrap aligned readonly can_move region5 v0+104
 ;; @0039                               call_indirect sig0, v27(v26, v0)
 ;; @003b                               return
 ;; }

--- a/tests/disas/gc/null/call-indirect-and-subtyping.wat
+++ b/tests/disas/gc/null/call-indirect-and-subtyping.wat
@@ -17,9 +17,11 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32) tail {
-;;     region0 = 1342177280 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 1342177280 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
+;;     region2 = 40 "VMContext+0x28"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned readonly can_move gv3+112
@@ -40,7 +42,7 @@
 ;; @005c                               v8 = ishl v5, v7  ; v7 = 3
 ;; @005c                               v9 = iadd v6, v8
 ;; @005c                               v11 = select_spectre_guard v4, v10, v9  ; v10 = 0
-;; @005c                               v12 = load.i64 user6 aligned region0 v11
+;; @005c                               v12 = load.i64 user6 aligned region1 v11
 ;; @005c                               v13 = iconst.i64 -2
 ;; @005c                               v14 = band v12, v13  ; v13 = -2
 ;; @005c                               brif v12, block3(v14), block2
@@ -52,7 +54,7 @@
 ;;
 ;;                                 block3(v15: i64):
 ;; @005c                               v21 = load.i32 user7 aligned readonly v15+16
-;; @005c                               v19 = load.i64 notrap aligned readonly can_move v0+40
+;; @005c                               v19 = load.i64 notrap aligned readonly can_move region2 v0+40
 ;; @005c                               v20 = load.i32 notrap aligned readonly can_move v19
 ;; @005c                               v22 = icmp eq v21, v20
 ;; @005c                               v23 = uextend.i32 v22

--- a/tests/disas/gc/null/externref-globals.wat
+++ b/tests/disas/gc/null/externref-globals.wat
@@ -13,8 +13,9 @@
 )
 
 ;; function u0:0(i64 vmctx, i64) -> i32 tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     stack_limit = gv2
@@ -30,8 +31,9 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     stack_limit = gv2

--- a/tests/disas/gc/null/funcref-in-gc-heap-get.wat
+++ b/tests/disas/gc/null/funcref-in-gc-heap-get.wat
@@ -10,12 +10,13 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i64 tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32) -> i64 tail
@@ -24,13 +25,13 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0020                               trapz v2, user16
-;; @0020                               v12 = load.i64 notrap aligned readonly can_move v0+8
+;; @0020                               v12 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @0020                               v5 = load.i64 notrap aligned readonly can_move v12+32
 ;; @0020                               v4 = uextend.i64 v2
 ;; @0020                               v6 = iadd v5, v4
 ;; @0020                               v7 = iconst.i64 8
 ;; @0020                               v8 = iadd v6, v7  ; v7 = 8
-;; @0020                               v10 = load.i32 user2 little region0 v8
+;; @0020                               v10 = load.i32 user2 little region1 v8
 ;; @0020                               v9 = iconst.i32 -1
 ;; @0020                               v11 = call fn0(v0, v10, v9)  ; v9 = -1
 ;; @0024                               jump block1

--- a/tests/disas/gc/null/funcref-in-gc-heap-new.wat
+++ b/tests/disas/gc/null/funcref-in-gc-heap-new.wat
@@ -10,10 +10,12 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i64) -> i32 tail {
-;;     region0 = 32 "VMContext+0x20"
-;;     region1 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 32 "VMContext+0x20"
+;;     region2 = 2147483648 "GcHeap"
+;;     region3 = 40 "VMContext+0x28"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     sig0 = (i64 vmctx, i64) -> i8 tail
 ;;     sig1 = (i64 vmctx, i64) -> i64 tail
@@ -22,15 +24,15 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0020                               v8 = load.i64 notrap aligned readonly region0 v0+32
-;; @0020                               v9 = load.i32 user2 region1 v8
+;; @0020                               v8 = load.i64 notrap aligned readonly region1 v0+32
+;; @0020                               v9 = load.i32 user2 region2 v8
 ;;                                     v40 = iconst.i32 7
 ;; @0020                               v12 = uadd_overflow_trap v9, v40, user18  ; v40 = 7
 ;;                                     v46 = iconst.i32 -8
 ;; @0020                               v14 = band v12, v46  ; v46 = -8
 ;; @0020                               v4 = iconst.i32 16
 ;; @0020                               v15 = uadd_overflow_trap v14, v4, user18  ; v4 = 16
-;; @0020                               v17 = load.i64 notrap aligned readonly can_move v0+8
+;; @0020                               v17 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @0020                               v18 = load.i64 notrap aligned v17+40
 ;; @0020                               v16 = uextend.i64 v15
 ;; @0020                               v19 = icmp ule v16, v18
@@ -42,16 +44,16 @@
 ;;                                     v53 = band.i32 v12, v46  ; v46 = -8
 ;;                                     v54 = uextend.i64 v53
 ;; @0020                               v25 = iadd v23, v54
-;; @0020                               store user2 region1 v47, v25  ; v47 = -1342177264
-;; @0020                               v28 = load.i64 notrap aligned readonly can_move v0+40
+;; @0020                               store user2 region2 v47, v25  ; v47 = -1342177264
+;; @0020                               v28 = load.i64 notrap aligned readonly can_move region3 v0+40
 ;; @0020                               v29 = load.i32 notrap aligned readonly can_move v28
-;; @0020                               store user2 region1 v29, v25+4
-;; @0020                               store.i32 user2 region1 v15, v8
+;; @0020                               store user2 region2 v29, v25+4
+;; @0020                               store.i32 user2 region2 v15, v8
 ;; @0020                               v32 = call fn1(v0, v2)
 ;; @0020                               v33 = ireduce.i32 v32
 ;; @0020                               v30 = iconst.i64 8
 ;; @0020                               v31 = iadd v25, v30  ; v30 = 8
-;; @0020                               store user2 little region1 v33, v31
+;; @0020                               store user2 little region2 v33, v31
 ;; @0023                               jump block1
 ;;
 ;;                                 block3 cold:

--- a/tests/disas/gc/null/funcref-in-gc-heap-set.wat
+++ b/tests/disas/gc/null/funcref-in-gc-heap-set.wat
@@ -10,12 +10,13 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32, i64) tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i64) -> i64 tail
@@ -26,13 +27,13 @@
 ;; @0022                               trapz v2, user16
 ;; @0022                               v9 = call fn0(v0, v3)
 ;; @0022                               v10 = ireduce.i32 v9
-;; @0022                               v11 = load.i64 notrap aligned readonly can_move v0+8
+;; @0022                               v11 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @0022                               v5 = load.i64 notrap aligned readonly can_move v11+32
 ;; @0022                               v4 = uextend.i64 v2
 ;; @0022                               v6 = iadd v5, v4
 ;; @0022                               v7 = iconst.i64 8
 ;; @0022                               v8 = iadd v6, v7  ; v7 = 8
-;; @0022                               store user2 little region0 v10, v8
+;; @0022                               store user2 little region1 v10, v8
 ;; @0026                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/null/i31ref-globals.wat
+++ b/tests/disas/gc/null/i31ref-globals.wat
@@ -13,8 +13,9 @@
 )
 
 ;; function u0:0(i64 vmctx, i64) -> i32 tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     stack_limit = gv2
@@ -30,8 +31,9 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     stack_limit = gv2

--- a/tests/disas/gc/null/multiple-array-get.wat
+++ b/tests/disas/gc/null/multiple-array-get.wat
@@ -11,25 +11,26 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32, i32) -> i64, i64 tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
 ;; @0024                               trapz v2, user16
-;; @0024                               v65 = load.i64 notrap aligned readonly can_move v0+8
+;; @0024                               v65 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @0024                               v8 = load.i64 notrap aligned readonly can_move v65+32
 ;; @0024                               v7 = uextend.i64 v2
 ;; @0024                               v9 = iadd v8, v7
 ;; @0024                               v10 = iconst.i64 8
 ;; @0024                               v11 = iadd v9, v10  ; v10 = 8
-;; @0024                               v12 = load.i32 user2 readonly region0 v11
+;; @0024                               v12 = load.i32 user2 readonly region1 v11
 ;; @0024                               v13 = icmp ult v3, v12
 ;; @0024                               trapz v13, user17
 ;; @0024                               v15 = uextend.i64 v12
@@ -50,7 +51,7 @@
 ;; @0024                               v29 = isub v21, v24
 ;; @0024                               v30 = uextend.i64 v29
 ;; @0024                               v31 = isub v28, v30
-;; @0024                               v32 = load.i64 user2 little region0 v31
+;; @0024                               v32 = load.i64 user2 little region1 v31
 ;; @002b                               v39 = icmp ult v4, v12
 ;; @002b                               trapz v39, user17
 ;;                                     v86 = ishl v4, v77  ; v77 = 3
@@ -58,7 +59,7 @@
 ;; @002b                               v55 = isub v21, v50
 ;; @002b                               v56 = uextend.i64 v55
 ;; @002b                               v57 = isub v28, v56
-;; @002b                               v58 = load.i64 user2 little region0 v57
+;; @002b                               v58 = load.i64 user2 little region1 v57
 ;; @002e                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/null/multiple-struct-get.wat
+++ b/tests/disas/gc/null/multiple-struct-get.wat
@@ -12,28 +12,29 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> f32, i32 tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0023                               trapz v2, user16
-;; @0023                               v20 = load.i64 notrap aligned readonly can_move v0+8
+;; @0023                               v20 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @0023                               v6 = load.i64 notrap aligned readonly can_move v20+32
 ;; @0023                               v5 = uextend.i64 v2
 ;; @0023                               v7 = iadd v6, v5
 ;; @0023                               v8 = iconst.i64 8
 ;; @0023                               v9 = iadd v7, v8  ; v8 = 8
-;; @0023                               v10 = load.f32 user2 little region0 v9
+;; @0023                               v10 = load.f32 user2 little region1 v9
 ;; @0029                               v14 = iconst.i64 12
 ;; @0029                               v15 = iadd v7, v14  ; v14 = 12
-;; @0029                               v16 = load.i8 user2 little region0 v15
+;; @0029                               v16 = load.i8 user2 little region1 v15
 ;; @002d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/null/ref-cast.wat
+++ b/tests/disas/gc/null/ref-cast.wat
@@ -9,12 +9,14 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 40 "VMContext+0x28"
+;;     region2 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
@@ -31,14 +33,14 @@
 ;; @001e                               brif v9, block4(v24), block3  ; v24 = 0
 ;;
 ;;                                 block3:
-;; @001e                               v22 = load.i64 notrap aligned readonly can_move v0+8
+;; @001e                               v22 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @001e                               v14 = load.i64 notrap aligned readonly can_move v22+32
 ;; @001e                               v13 = uextend.i64 v2
 ;; @001e                               v15 = iadd v14, v13
 ;; @001e                               v16 = iconst.i64 4
 ;; @001e                               v17 = iadd v15, v16  ; v16 = 4
-;; @001e                               v18 = load.i32 user2 readonly region0 v17
-;; @001e                               v11 = load.i64 notrap aligned readonly can_move v0+40
+;; @001e                               v18 = load.i32 user2 readonly region2 v17
+;; @001e                               v11 = load.i64 notrap aligned readonly can_move region1 v0+40
 ;; @001e                               v12 = load.i32 notrap aligned readonly can_move v11
 ;; @001e                               v19 = icmp eq v18, v12
 ;; @001e                               v20 = uextend.i32 v19

--- a/tests/disas/gc/null/ref-is-null.wat
+++ b/tests/disas/gc/null/ref-is-null.wat
@@ -11,8 +11,9 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     stack_limit = gv2
 ;;
@@ -27,8 +28,9 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     stack_limit = gv2
 ;;

--- a/tests/disas/gc/null/ref-test-any.wat
+++ b/tests/disas/gc/null/ref-test-any.wat
@@ -11,8 +11,9 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     stack_limit = gv2
 ;;
@@ -27,8 +28,9 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     stack_limit = gv2
 ;;

--- a/tests/disas/gc/null/ref-test-array.wat
+++ b/tests/disas/gc/null/ref-test-array.wat
@@ -8,12 +8,13 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
@@ -30,11 +31,11 @@
 ;; @001b                               brif v9, block4(v24), block3  ; v24 = 0
 ;;
 ;;                                 block3:
-;; @001b                               v22 = load.i64 notrap aligned readonly can_move v0+8
+;; @001b                               v22 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @001b                               v12 = load.i64 notrap aligned readonly can_move v22+32
 ;; @001b                               v11 = uextend.i64 v2
 ;; @001b                               v13 = iadd v12, v11
-;; @001b                               v16 = load.i32 user2 readonly region0 v13
+;; @001b                               v16 = load.i32 user2 readonly region1 v13
 ;; @001b                               v17 = iconst.i32 -1476395008
 ;; @001b                               v18 = band v16, v17  ; v17 = -1476395008
 ;; @001b                               v19 = icmp eq v18, v17  ; v17 = -1476395008

--- a/tests/disas/gc/null/ref-test-concrete-func-type.wat
+++ b/tests/disas/gc/null/ref-test-concrete-func-type.wat
@@ -9,9 +9,11 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i64) -> i32 tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 40 "VMContext+0x28"
+;;     region2 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     stack_limit = gv2
 ;;
@@ -25,8 +27,8 @@
 ;; @0020                               jump block3
 ;;
 ;;                                 block3:
-;; @0020                               v10 = load.i32 user2 readonly region0 v2+16
-;; @0020                               v8 = load.i64 notrap aligned readonly can_move v0+40
+;; @0020                               v10 = load.i32 user2 readonly region2 v2+16
+;; @0020                               v8 = load.i64 notrap aligned readonly can_move region1 v0+40
 ;; @0020                               v9 = load.i32 notrap aligned readonly can_move v8
 ;; @0020                               v11 = icmp eq v10, v9
 ;; @0020                               v12 = uextend.i32 v11

--- a/tests/disas/gc/null/ref-test-concrete-type.wat
+++ b/tests/disas/gc/null/ref-test-concrete-type.wat
@@ -9,12 +9,14 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 40 "VMContext+0x28"
+;;     region2 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
@@ -31,14 +33,14 @@
 ;; @001d                               brif v9, block4(v24), block3  ; v24 = 0
 ;;
 ;;                                 block3:
-;; @001d                               v22 = load.i64 notrap aligned readonly can_move v0+8
+;; @001d                               v22 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @001d                               v14 = load.i64 notrap aligned readonly can_move v22+32
 ;; @001d                               v13 = uextend.i64 v2
 ;; @001d                               v15 = iadd v14, v13
 ;; @001d                               v16 = iconst.i64 4
 ;; @001d                               v17 = iadd v15, v16  ; v16 = 4
-;; @001d                               v18 = load.i32 user2 readonly region0 v17
-;; @001d                               v11 = load.i64 notrap aligned readonly can_move v0+40
+;; @001d                               v18 = load.i32 user2 readonly region2 v17
+;; @001d                               v11 = load.i64 notrap aligned readonly can_move region1 v0+40
 ;; @001d                               v12 = load.i32 notrap aligned readonly can_move v11
 ;; @001d                               v19 = icmp eq v18, v12
 ;; @001d                               v20 = uextend.i32 v19

--- a/tests/disas/gc/null/ref-test-eq.wat
+++ b/tests/disas/gc/null/ref-test-eq.wat
@@ -8,12 +8,13 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
@@ -29,11 +30,11 @@
 ;; @001b                               brif v9, block4(v8), block3  ; v8 = 1
 ;;
 ;;                                 block3:
-;; @001b                               v22 = load.i64 notrap aligned readonly can_move v0+8
+;; @001b                               v22 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @001b                               v12 = load.i64 notrap aligned readonly can_move v22+32
 ;; @001b                               v11 = uextend.i64 v2
 ;; @001b                               v13 = iadd v12, v11
-;; @001b                               v16 = load.i32 user2 readonly region0 v13
+;; @001b                               v16 = load.i32 user2 readonly region1 v13
 ;; @001b                               v17 = iconst.i32 -1610612736
 ;; @001b                               v18 = band v16, v17  ; v17 = -1610612736
 ;; @001b                               v19 = icmp eq v18, v17  ; v17 = -1610612736

--- a/tests/disas/gc/null/ref-test-i31.wat
+++ b/tests/disas/gc/null/ref-test-i31.wat
@@ -8,8 +8,9 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     stack_limit = gv2
 ;;

--- a/tests/disas/gc/null/ref-test-none.wat
+++ b/tests/disas/gc/null/ref-test-none.wat
@@ -11,8 +11,9 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     stack_limit = gv2
 ;;
@@ -25,8 +26,9 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     stack_limit = gv2
 ;;

--- a/tests/disas/gc/null/ref-test-struct.wat
+++ b/tests/disas/gc/null/ref-test-struct.wat
@@ -8,12 +8,13 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
@@ -30,11 +31,11 @@
 ;; @001b                               brif v9, block4(v24), block3  ; v24 = 0
 ;;
 ;;                                 block3:
-;; @001b                               v22 = load.i64 notrap aligned readonly can_move v0+8
+;; @001b                               v22 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @001b                               v12 = load.i64 notrap aligned readonly can_move v22+32
 ;; @001b                               v11 = uextend.i64 v2
 ;; @001b                               v13 = iadd v12, v11
-;; @001b                               v16 = load.i32 user2 readonly region0 v13
+;; @001b                               v16 = load.i32 user2 readonly region1 v13
 ;; @001b                               v17 = iconst.i32 -1342177280
 ;; @001b                               v18 = band v16, v17  ; v17 = -1342177280
 ;; @001b                               v19 = icmp eq v18, v17  ; v17 = -1342177280

--- a/tests/disas/gc/null/struct-get-guard-pages.wat
+++ b/tests/disas/gc/null/struct-get-guard-pages.wat
@@ -24,25 +24,26 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> f32 tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0033                               trapz v2, user16
-;; @0033                               v10 = load.i64 notrap aligned readonly can_move v0+8
+;; @0033                               v10 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @0033                               v5 = load.i64 notrap aligned readonly can_move v10+32
 ;; @0033                               v4 = uextend.i64 v2
 ;; @0033                               v6 = iadd v5, v4
 ;; @0033                               v7 = iconst.i64 8
 ;; @0033                               v8 = iadd v6, v7  ; v7 = 8
-;; @0033                               v9 = load.f32 user2 little region0 v8
+;; @0033                               v9 = load.f32 user2 little region1 v8
 ;; @0037                               jump block1
 ;;
 ;;                                 block1:
@@ -50,25 +51,26 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @003c                               trapz v2, user16
-;; @003c                               v11 = load.i64 notrap aligned readonly can_move v0+8
+;; @003c                               v11 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @003c                               v5 = load.i64 notrap aligned readonly can_move v11+32
 ;; @003c                               v4 = uextend.i64 v2
 ;; @003c                               v6 = iadd v5, v4
 ;; @003c                               v7 = iconst.i64 12
 ;; @003c                               v8 = iadd v6, v7  ; v7 = 12
-;; @003c                               v9 = load.i8 user2 little region0 v8
+;; @003c                               v9 = load.i8 user2 little region1 v8
 ;; @0040                               jump block1
 ;;
 ;;                                 block1:
@@ -77,25 +79,26 @@
 ;; }
 ;;
 ;; function u0:2(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0045                               trapz v2, user16
-;; @0045                               v11 = load.i64 notrap aligned readonly can_move v0+8
+;; @0045                               v11 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @0045                               v5 = load.i64 notrap aligned readonly can_move v11+32
 ;; @0045                               v4 = uextend.i64 v2
 ;; @0045                               v6 = iadd v5, v4
 ;; @0045                               v7 = iconst.i64 12
 ;; @0045                               v8 = iadd v6, v7  ; v7 = 12
-;; @0045                               v9 = load.i8 user2 little region0 v8
+;; @0045                               v9 = load.i8 user2 little region1 v8
 ;; @0049                               jump block1
 ;;
 ;;                                 block1:
@@ -104,25 +107,26 @@
 ;; }
 ;;
 ;; function u0:3(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @004e                               trapz v2, user16
-;; @004e                               v10 = load.i64 notrap aligned readonly can_move v0+8
+;; @004e                               v10 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @004e                               v5 = load.i64 notrap aligned readonly can_move v10+32
 ;; @004e                               v4 = uextend.i64 v2
 ;; @004e                               v6 = iadd v5, v4
 ;; @004e                               v7 = iconst.i64 16
 ;; @004e                               v8 = iadd v6, v7  ; v7 = 16
-;; @004e                               v9 = load.i32 user2 little region0 v8
+;; @004e                               v9 = load.i32 user2 little region1 v8
 ;; @0052                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/null/struct-get-no-guard-pages.wat
+++ b/tests/disas/gc/null/struct-get-no-guard-pages.wat
@@ -24,12 +24,13 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> f32 tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
@@ -39,7 +40,7 @@
 ;; @0033                               v4 = uextend.i64 v2
 ;; @0033                               v5 = iconst.i64 24
 ;; @0033                               v6 = uadd_overflow_trap v4, v5, user2  ; v5 = 24
-;; @0033                               v18 = load.i64 notrap aligned readonly can_move v0+8
+;; @0033                               v18 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @0033                               v7 = load.i64 notrap aligned v18+40
 ;; @0033                               v9 = load.i64 notrap aligned v18+32
 ;; @0033                               v8 = icmp ugt v6, v7
@@ -48,7 +49,7 @@
 ;; @0033                               v12 = select_spectre_guard v8, v11, v10  ; v11 = 0
 ;; @0033                               v13 = iconst.i64 8
 ;; @0033                               v14 = iadd v12, v13  ; v13 = 8
-;; @0033                               v15 = load.f32 user2 little region0 v14
+;; @0033                               v15 = load.f32 user2 little region1 v14
 ;; @0037                               jump block1
 ;;
 ;;                                 block1:
@@ -56,12 +57,13 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
@@ -71,7 +73,7 @@
 ;; @003c                               v4 = uextend.i64 v2
 ;; @003c                               v5 = iconst.i64 24
 ;; @003c                               v6 = uadd_overflow_trap v4, v5, user2  ; v5 = 24
-;; @003c                               v19 = load.i64 notrap aligned readonly can_move v0+8
+;; @003c                               v19 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @003c                               v7 = load.i64 notrap aligned v19+40
 ;; @003c                               v9 = load.i64 notrap aligned v19+32
 ;; @003c                               v8 = icmp ugt v6, v7
@@ -80,7 +82,7 @@
 ;; @003c                               v12 = select_spectre_guard v8, v11, v10  ; v11 = 0
 ;; @003c                               v13 = iconst.i64 12
 ;; @003c                               v14 = iadd v12, v13  ; v13 = 12
-;; @003c                               v15 = load.i8 user2 little region0 v14
+;; @003c                               v15 = load.i8 user2 little region1 v14
 ;; @0040                               jump block1
 ;;
 ;;                                 block1:
@@ -89,12 +91,13 @@
 ;; }
 ;;
 ;; function u0:2(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
@@ -104,7 +107,7 @@
 ;; @0045                               v4 = uextend.i64 v2
 ;; @0045                               v5 = iconst.i64 24
 ;; @0045                               v6 = uadd_overflow_trap v4, v5, user2  ; v5 = 24
-;; @0045                               v19 = load.i64 notrap aligned readonly can_move v0+8
+;; @0045                               v19 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @0045                               v7 = load.i64 notrap aligned v19+40
 ;; @0045                               v9 = load.i64 notrap aligned v19+32
 ;; @0045                               v8 = icmp ugt v6, v7
@@ -113,7 +116,7 @@
 ;; @0045                               v12 = select_spectre_guard v8, v11, v10  ; v11 = 0
 ;; @0045                               v13 = iconst.i64 12
 ;; @0045                               v14 = iadd v12, v13  ; v13 = 12
-;; @0045                               v15 = load.i8 user2 little region0 v14
+;; @0045                               v15 = load.i8 user2 little region1 v14
 ;; @0049                               jump block1
 ;;
 ;;                                 block1:
@@ -122,12 +125,13 @@
 ;; }
 ;;
 ;; function u0:3(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
@@ -137,7 +141,7 @@
 ;; @004e                               v4 = uextend.i64 v2
 ;; @004e                               v5 = iconst.i64 24
 ;; @004e                               v6 = uadd_overflow_trap v4, v5, user2  ; v5 = 24
-;; @004e                               v18 = load.i64 notrap aligned readonly can_move v0+8
+;; @004e                               v18 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @004e                               v7 = load.i64 notrap aligned v18+40
 ;; @004e                               v9 = load.i64 notrap aligned v18+32
 ;; @004e                               v8 = icmp ugt v6, v7
@@ -146,7 +150,7 @@
 ;; @004e                               v12 = select_spectre_guard v8, v11, v10  ; v11 = 0
 ;; @004e                               v13 = iconst.i64 16
 ;; @004e                               v14 = iadd v12, v13  ; v13 = 16
-;; @004e                               v15 = load.i32 user2 little region0 v14
+;; @004e                               v15 = load.i32 user2 little region1 v14
 ;; @0052                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/null/struct-get.wat
+++ b/tests/disas/gc/null/struct-get.wat
@@ -24,25 +24,26 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> f32 tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0033                               trapz v2, user16
-;; @0033                               v10 = load.i64 notrap aligned readonly can_move v0+8
+;; @0033                               v10 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @0033                               v5 = load.i64 notrap aligned readonly can_move v10+32
 ;; @0033                               v4 = uextend.i64 v2
 ;; @0033                               v6 = iadd v5, v4
 ;; @0033                               v7 = iconst.i64 8
 ;; @0033                               v8 = iadd v6, v7  ; v7 = 8
-;; @0033                               v9 = load.f32 user2 little region0 v8
+;; @0033                               v9 = load.f32 user2 little region1 v8
 ;; @0037                               jump block1
 ;;
 ;;                                 block1:
@@ -50,25 +51,26 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @003c                               trapz v2, user16
-;; @003c                               v11 = load.i64 notrap aligned readonly can_move v0+8
+;; @003c                               v11 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @003c                               v5 = load.i64 notrap aligned readonly can_move v11+32
 ;; @003c                               v4 = uextend.i64 v2
 ;; @003c                               v6 = iadd v5, v4
 ;; @003c                               v7 = iconst.i64 12
 ;; @003c                               v8 = iadd v6, v7  ; v7 = 12
-;; @003c                               v9 = load.i8 user2 little region0 v8
+;; @003c                               v9 = load.i8 user2 little region1 v8
 ;; @0040                               jump block1
 ;;
 ;;                                 block1:
@@ -77,25 +79,26 @@
 ;; }
 ;;
 ;; function u0:2(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0045                               trapz v2, user16
-;; @0045                               v11 = load.i64 notrap aligned readonly can_move v0+8
+;; @0045                               v11 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @0045                               v5 = load.i64 notrap aligned readonly can_move v11+32
 ;; @0045                               v4 = uextend.i64 v2
 ;; @0045                               v6 = iadd v5, v4
 ;; @0045                               v7 = iconst.i64 12
 ;; @0045                               v8 = iadd v6, v7  ; v7 = 12
-;; @0045                               v9 = load.i8 user2 little region0 v8
+;; @0045                               v9 = load.i8 user2 little region1 v8
 ;; @0049                               jump block1
 ;;
 ;;                                 block1:
@@ -104,25 +107,26 @@
 ;; }
 ;;
 ;; function u0:3(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @004e                               trapz v2, user16
-;; @004e                               v10 = load.i64 notrap aligned readonly can_move v0+8
+;; @004e                               v10 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @004e                               v5 = load.i64 notrap aligned readonly can_move v10+32
 ;; @004e                               v4 = uextend.i64 v2
 ;; @004e                               v6 = iadd v5, v4
 ;; @004e                               v7 = iconst.i64 16
 ;; @004e                               v8 = iadd v6, v7  ; v7 = 16
-;; @004e                               v9 = load.i32 user2 little region0 v8
+;; @004e                               v9 = load.i32 user2 little region1 v8
 ;; @0052                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/null/struct-new-default.wat
+++ b/tests/disas/gc/null/struct-new-default.wat
@@ -12,25 +12,27 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64) -> i32 tail {
-;;     region0 = 32 "VMContext+0x20"
-;;     region1 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 32 "VMContext+0x20"
+;;     region2 = 2147483648 "GcHeap"
+;;     region3 = 40 "VMContext+0x28"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     sig0 = (i64 vmctx, i64) -> i8 tail
 ;;     fn0 = colocated u805306368:23 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @0021                               v10 = load.i64 notrap aligned readonly region0 v0+32
-;; @0021                               v11 = load.i32 user2 region1 v10
+;; @0021                               v10 = load.i64 notrap aligned readonly region1 v0+32
+;; @0021                               v11 = load.i32 user2 region2 v10
 ;;                                     v43 = iconst.i32 7
 ;; @0021                               v14 = uadd_overflow_trap v11, v43, user18  ; v43 = 7
 ;;                                     v49 = iconst.i32 -8
 ;; @0021                               v16 = band v14, v49  ; v49 = -8
 ;; @0021                               v6 = iconst.i32 24
 ;; @0021                               v17 = uadd_overflow_trap v16, v6, user18  ; v6 = 24
-;; @0021                               v19 = load.i64 notrap aligned readonly can_move v0+8
+;; @0021                               v19 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @0021                               v20 = load.i64 notrap aligned v19+40
 ;; @0021                               v18 = uextend.i64 v17
 ;; @0021                               v21 = icmp ule v18, v20
@@ -42,22 +44,22 @@
 ;;                                     v56 = band.i32 v14, v49  ; v49 = -8
 ;;                                     v57 = uextend.i64 v56
 ;; @0021                               v27 = iadd v25, v57
-;; @0021                               store user2 region1 v50, v27  ; v50 = -1342177256
-;; @0021                               v30 = load.i64 notrap aligned readonly can_move v0+40
+;; @0021                               store user2 region2 v50, v27  ; v50 = -1342177256
+;; @0021                               v30 = load.i64 notrap aligned readonly can_move region3 v0+40
 ;; @0021                               v31 = load.i32 notrap aligned readonly can_move v30
-;; @0021                               store user2 region1 v31, v27+4
-;; @0021                               store.i32 user2 region1 v17, v10
+;; @0021                               store user2 region2 v31, v27+4
+;; @0021                               store.i32 user2 region2 v17, v10
 ;; @0021                               v3 = f32const 0.0
 ;; @0021                               v32 = iconst.i64 8
 ;; @0021                               v33 = iadd v27, v32  ; v32 = 8
-;; @0021                               store user2 little region1 v3, v33  ; v3 = 0.0
+;; @0021                               store user2 little region2 v3, v33  ; v3 = 0.0
 ;; @0021                               v4 = iconst.i32 0
 ;; @0021                               v34 = iconst.i64 12
 ;; @0021                               v35 = iadd v27, v34  ; v34 = 12
-;; @0021                               istore8 user2 little region1 v4, v35  ; v4 = 0
+;; @0021                               istore8 user2 little region2 v4, v35  ; v4 = 0
 ;; @0021                               v36 = iconst.i64 16
 ;; @0021                               v37 = iadd v27, v36  ; v36 = 16
-;; @0021                               store user2 little region1 v4, v37  ; v4 = 0
+;; @0021                               store user2 little region2 v4, v37  ; v4 = 0
 ;; @0024                               jump block1
 ;;
 ;;                                 block3 cold:

--- a/tests/disas/gc/null/struct-new.wat
+++ b/tests/disas/gc/null/struct-new.wat
@@ -13,10 +13,12 @@
 )
 ;; function u0:0(i64 vmctx, i64, f32, i32, i32) -> i32 tail {
 ;;     ss0 = explicit_slot 4, align = 4
-;;     region0 = 32 "VMContext+0x20"
-;;     region1 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 32 "VMContext+0x20"
+;;     region2 = 2147483648 "GcHeap"
+;;     region3 = 40 "VMContext+0x28"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     sig0 = (i64 vmctx, i64) -> i8 tail
 ;;     fn0 = colocated u805306368:23 sig0
@@ -25,15 +27,15 @@
 ;;                                 block0(v0: i64, v1: i64, v2: f32, v3: i32, v4: i32):
 ;;                                     v40 = stack_addr.i64 ss0
 ;;                                     store notrap v4, v40
-;; @002a                               v10 = load.i64 notrap aligned readonly region0 v0+32
-;; @002a                               v11 = load.i32 user2 region1 v10
+;; @002a                               v10 = load.i64 notrap aligned readonly region1 v0+32
+;; @002a                               v11 = load.i32 user2 region2 v10
 ;;                                     v47 = iconst.i32 7
 ;; @002a                               v14 = uadd_overflow_trap v11, v47, user18  ; v47 = 7
 ;;                                     v53 = iconst.i32 -8
 ;; @002a                               v16 = band v14, v53  ; v53 = -8
 ;; @002a                               v6 = iconst.i32 24
 ;; @002a                               v17 = uadd_overflow_trap v16, v6, user18  ; v6 = 24
-;; @002a                               v19 = load.i64 notrap aligned readonly can_move v0+8
+;; @002a                               v19 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @002a                               v20 = load.i64 notrap aligned v19+40
 ;; @002a                               v18 = uextend.i64 v17
 ;; @002a                               v21 = icmp ule v18, v20
@@ -45,21 +47,21 @@
 ;;                                     v60 = band.i32 v14, v53  ; v53 = -8
 ;;                                     v61 = uextend.i64 v60
 ;; @002a                               v27 = iadd v25, v61
-;; @002a                               store user2 region1 v54, v27  ; v54 = -1342177256
-;; @002a                               v30 = load.i64 notrap aligned readonly can_move v0+40
+;; @002a                               store user2 region2 v54, v27  ; v54 = -1342177256
+;; @002a                               v30 = load.i64 notrap aligned readonly can_move region3 v0+40
 ;; @002a                               v31 = load.i32 notrap aligned readonly can_move v30
-;; @002a                               store user2 region1 v31, v27+4
-;; @002a                               store.i32 user2 region1 v17, v10
+;; @002a                               store user2 region2 v31, v27+4
+;; @002a                               store.i32 user2 region2 v17, v10
 ;; @002a                               v32 = iconst.i64 8
 ;; @002a                               v33 = iadd v27, v32  ; v32 = 8
-;; @002a                               store.f32 user2 little region1 v2, v33
+;; @002a                               store.f32 user2 little region2 v2, v33
 ;; @002a                               v34 = iconst.i64 12
 ;; @002a                               v35 = iadd v27, v34  ; v34 = 12
-;; @002a                               istore8.i32 user2 little region1 v3, v35
+;; @002a                               istore8.i32 user2 little region2 v3, v35
 ;;                                     v39 = load.i32 notrap v40
 ;; @002a                               v36 = iconst.i64 16
 ;; @002a                               v37 = iadd v27, v36  ; v36 = 16
-;; @002a                               store user2 little region1 v39, v37
+;; @002a                               store user2 little region2 v39, v37
 ;; @002d                               jump block1
 ;;
 ;;                                 block3 cold:

--- a/tests/disas/gc/null/struct-set.wat
+++ b/tests/disas/gc/null/struct-set.wat
@@ -20,25 +20,26 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32, f32) tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: f32):
 ;; @0034                               trapz v2, user16
-;; @0034                               v9 = load.i64 notrap aligned readonly can_move v0+8
+;; @0034                               v9 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @0034                               v5 = load.i64 notrap aligned readonly can_move v9+32
 ;; @0034                               v4 = uextend.i64 v2
 ;; @0034                               v6 = iadd v5, v4
 ;; @0034                               v7 = iconst.i64 8
 ;; @0034                               v8 = iadd v6, v7  ; v7 = 8
-;; @0034                               store user2 little region0 v3, v8
+;; @0034                               store user2 little region1 v3, v8
 ;; @0038                               jump block1
 ;;
 ;;                                 block1:
@@ -46,25 +47,26 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32, i32) tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @003f                               trapz v2, user16
-;; @003f                               v9 = load.i64 notrap aligned readonly can_move v0+8
+;; @003f                               v9 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @003f                               v5 = load.i64 notrap aligned readonly can_move v9+32
 ;; @003f                               v4 = uextend.i64 v2
 ;; @003f                               v6 = iadd v5, v4
 ;; @003f                               v7 = iconst.i64 12
 ;; @003f                               v8 = iadd v6, v7  ; v7 = 12
-;; @003f                               istore8 user2 little region0 v3, v8
+;; @003f                               istore8 user2 little region1 v3, v8
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -72,25 +74,26 @@
 ;; }
 ;;
 ;; function u0:2(i64 vmctx, i64, i32, i32) tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @004a                               trapz v2, user16
-;; @004a                               v9 = load.i64 notrap aligned readonly can_move v0+8
+;; @004a                               v9 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @004a                               v5 = load.i64 notrap aligned readonly can_move v9+32
 ;; @004a                               v4 = uextend.i64 v2
 ;; @004a                               v6 = iadd v5, v4
 ;; @004a                               v7 = iconst.i64 16
 ;; @004a                               v8 = iadd v6, v7  ; v7 = 16
-;; @004a                               store user2 little region0 v3, v8
+;; @004a                               store user2 little region1 v3, v8
 ;; @004e                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/null/v128-fields.wat
+++ b/tests/disas/gc/null/v128-fields.wat
@@ -12,25 +12,26 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i8x16 tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0022                               trapz v2, user16
-;; @0022                               v19 = load.i64 notrap aligned readonly can_move v0+8
+;; @0022                               v19 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @0022                               v5 = load.i64 notrap aligned readonly can_move v19+32
 ;; @0022                               v4 = uextend.i64 v2
 ;; @0022                               v6 = iadd v5, v4
 ;; @0022                               v7 = iconst.i64 16
 ;; @0022                               v8 = iadd v6, v7  ; v7 = 16
-;; @0022                               v9 = load.i8x16 user2 little region0 v8
+;; @0022                               v9 = load.i8x16 user2 little region1 v8
 ;; @002e                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/ref-test-cast-final-type.wat
+++ b/tests/disas/gc/ref-test-cast-final-type.wat
@@ -15,12 +15,14 @@
     (ref.cast (ref $s) (local.get 0)))
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 40 "VMContext+0x28"
+;;     region2 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
@@ -37,14 +39,14 @@
 ;; @0024                               brif v9, block4(v24), block3  ; v24 = 0
 ;;
 ;;                                 block3:
-;; @0024                               v22 = load.i64 notrap aligned readonly can_move v0+8
+;; @0024                               v22 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @0024                               v14 = load.i64 notrap aligned readonly can_move v22+32
 ;; @0024                               v13 = uextend.i64 v2
 ;; @0024                               v15 = iadd v14, v13
 ;; @0024                               v16 = iconst.i64 4
 ;; @0024                               v17 = iadd v15, v16  ; v16 = 4
-;; @0024                               v18 = load.i32 user2 readonly region0 v17
-;; @0024                               v11 = load.i64 notrap aligned readonly can_move v0+40
+;; @0024                               v18 = load.i32 user2 readonly region2 v17
+;; @0024                               v11 = load.i64 notrap aligned readonly can_move region1 v0+40
 ;; @0024                               v12 = load.i32 notrap aligned readonly can_move v11
 ;; @0024                               v19 = icmp eq v18, v12
 ;; @0024                               v20 = uextend.i32 v19
@@ -58,12 +60,14 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 40 "VMContext+0x28"
+;;     region2 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
@@ -80,14 +84,14 @@
 ;; @002c                               brif v9, block4(v24), block3  ; v24 = 0
 ;;
 ;;                                 block3:
-;; @002c                               v22 = load.i64 notrap aligned readonly can_move v0+8
+;; @002c                               v22 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @002c                               v14 = load.i64 notrap aligned readonly can_move v22+32
 ;; @002c                               v13 = uextend.i64 v2
 ;; @002c                               v15 = iadd v14, v13
 ;; @002c                               v16 = iconst.i64 4
 ;; @002c                               v17 = iadd v15, v16  ; v16 = 4
-;; @002c                               v18 = load.i32 user2 readonly region0 v17
-;; @002c                               v11 = load.i64 notrap aligned readonly can_move v0+40
+;; @002c                               v18 = load.i32 user2 readonly region2 v17
+;; @002c                               v11 = load.i64 notrap aligned readonly can_move region1 v0+40
 ;; @002c                               v12 = load.i32 notrap aligned readonly can_move v11
 ;; @002c                               v19 = icmp eq v18, v12
 ;; @002c                               v20 = uextend.i32 v19

--- a/tests/disas/gc/struct-new-default.wat
+++ b/tests/disas/gc/struct-new-default.wat
@@ -13,10 +13,12 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64) -> i32 tail {
-;;     region0 = 32 "VMContext+0x20"
-;;     region1 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 40 "VMContext+0x28"
+;;     region2 = 32 "VMContext+0x20"
+;;     region3 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
 ;;     fn0 = colocated u805306368:24 sig0
@@ -37,13 +39,13 @@
 ;;                                 block2:
 ;;                                     v63 = iconst.i32 48
 ;;                                     v61 = iadd.i32 v9, v63  ; v63 = 48
-;; @0023                               store notrap aligned region0 v61, v8
+;; @0023                               store notrap aligned region2 v61, v8
 ;;                                     v64 = iconst.i32 -1342177246
-;;                                     v65 = load.i64 notrap aligned readonly can_move v0+8
+;;                                     v65 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;;                                     v66 = load.i64 notrap aligned readonly can_move v65+32
 ;; @0023                               v33 = iadd v66, v16
 ;; @0023                               store notrap aligned v64, v33  ; v64 = -1342177246
-;;                                     v67 = load.i64 notrap aligned readonly can_move v0+40
+;;                                     v67 = load.i64 notrap aligned readonly can_move region1 v0+40
 ;;                                     v68 = load.i32 notrap aligned readonly can_move v67
 ;; @0023                               store notrap aligned v68, v33+4
 ;;                                     v69 = iconst.i64 48
@@ -52,12 +54,12 @@
 ;;
 ;;                                 block3 cold:
 ;; @0023                               v20 = iconst.i32 -1342177246
-;; @0023                               v21 = load.i64 notrap aligned readonly can_move v0+40
+;; @0023                               v21 = load.i64 notrap aligned readonly can_move region1 v0+40
 ;; @0023                               v22 = load.i32 notrap aligned readonly can_move v21
 ;; @0023                               v7 = iconst.i32 48
 ;; @0023                               v23 = iconst.i32 16
 ;; @0023                               v24 = call fn0(v0, v20, v22, v7, v23)  ; v20 = -1342177246, v7 = 48, v23 = 16
-;; @0023                               v25 = load.i64 notrap aligned readonly can_move v0+8
+;; @0023                               v25 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @0023                               v26 = load.i64 notrap aligned readonly can_move v25+32
 ;; @0023                               v27 = uextend.i64 v24
 ;; @0023                               v28 = iadd v26, v27
@@ -67,18 +69,18 @@
 ;; @0023                               v3 = f32const 0.0
 ;; @0023                               v39 = iconst.i64 16
 ;; @0023                               v40 = iadd v38, v39  ; v39 = 16
-;; @0023                               store user2 little region1 v3, v40  ; v3 = 0.0
+;; @0023                               store user2 little region3 v3, v40  ; v3 = 0.0
 ;; @0023                               v4 = iconst.i32 0
 ;; @0023                               v41 = iconst.i64 20
 ;; @0023                               v42 = iadd v38, v41  ; v41 = 20
-;; @0023                               istore8 user2 little region1 v4, v42  ; v4 = 0
+;; @0023                               istore8 user2 little region3 v4, v42  ; v4 = 0
 ;; @0023                               v43 = iconst.i64 24
 ;; @0023                               v44 = iadd v38, v43  ; v43 = 24
-;; @0023                               store user2 little region1 v4, v44  ; v4 = 0
+;; @0023                               store user2 little region3 v4, v44  ; v4 = 0
 ;; @0023                               v6 = vconst.i8x16 const0
 ;; @0023                               v45 = iconst.i64 32
 ;; @0023                               v46 = iadd v38, v45  ; v45 = 32
-;; @0023                               store user2 little region1 v6, v46  ; v6 = const0
+;; @0023                               store user2 little region3 v6, v46  ; v6 = const0
 ;; @0026                               jump block1(v37)
 ;;
 ;;                                 block1(v2: i32):

--- a/tests/disas/gc/struct-new.wat
+++ b/tests/disas/gc/struct-new.wat
@@ -13,10 +13,12 @@
 )
 ;; function u0:0(i64 vmctx, i64, f32, i32, i32) -> i32 tail {
 ;;     ss0 = explicit_slot 4, align = 4
-;;     region0 = 32 "VMContext+0x20"
-;;     region1 = 2147483648 "GcHeap"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 40 "VMContext+0x28"
+;;     region2 = 32 "VMContext+0x20"
+;;     region3 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
 ;;     fn0 = colocated u805306368:24 sig0
@@ -38,13 +40,13 @@
 ;;                                 block2:
 ;;                                     v63 = iconst.i32 32
 ;;                                     v61 = iadd.i32 v8, v63  ; v63 = 32
-;; @002a                               store notrap aligned region0 v61, v7
+;; @002a                               store notrap aligned region2 v61, v7
 ;;                                     v64 = iconst.i32 -1342177246
-;;                                     v65 = load.i64 notrap aligned readonly can_move v0+8
+;;                                     v65 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;;                                     v66 = load.i64 notrap aligned readonly can_move v65+32
 ;; @002a                               v32 = iadd v66, v15
 ;; @002a                               store notrap aligned v64, v32  ; v64 = -1342177246
-;;                                     v67 = load.i64 notrap aligned readonly can_move v0+40
+;;                                     v67 = load.i64 notrap aligned readonly can_move region1 v0+40
 ;;                                     v68 = load.i32 notrap aligned readonly can_move v67
 ;; @002a                               store notrap aligned v68, v32+4
 ;;                                     v69 = iconst.i64 32
@@ -53,12 +55,12 @@
 ;;
 ;;                                 block3 cold:
 ;; @002a                               v19 = iconst.i32 -1342177246
-;; @002a                               v20 = load.i64 notrap aligned readonly can_move v0+40
+;; @002a                               v20 = load.i64 notrap aligned readonly can_move region1 v0+40
 ;; @002a                               v21 = load.i32 notrap aligned readonly can_move v20
 ;; @002a                               v6 = iconst.i32 32
 ;; @002a                               v22 = iconst.i32 16
 ;; @002a                               v23 = call fn0(v0, v19, v21, v6, v22), stack_map=[i32 @ ss0+0]  ; v19 = -1342177246, v6 = 32, v22 = 16
-;; @002a                               v24 = load.i64 notrap aligned readonly can_move v0+8
+;; @002a                               v24 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @002a                               v25 = load.i64 notrap aligned readonly can_move v24+32
 ;; @002a                               v26 = uextend.i64 v23
 ;; @002a                               v27 = iadd v25, v26
@@ -67,14 +69,14 @@
 ;;                                 block4(v36: i32, v37: i64):
 ;; @002a                               v38 = iconst.i64 16
 ;; @002a                               v39 = iadd v37, v38  ; v38 = 16
-;; @002a                               store.f32 user2 little region1 v2, v39
+;; @002a                               store.f32 user2 little region3 v2, v39
 ;; @002a                               v40 = iconst.i64 20
 ;; @002a                               v41 = iadd v37, v40  ; v40 = 20
-;; @002a                               istore8.i32 user2 little region1 v3, v41
+;; @002a                               istore8.i32 user2 little region3 v3, v41
 ;;                                     v45 = load.i32 notrap v46
 ;; @002a                               v42 = iconst.i64 24
 ;; @002a                               v43 = iadd v37, v42  ; v42 = 24
-;; @002a                               store user2 little region1 v45, v43
+;; @002a                               store user2 little region3 v45, v43
 ;; @002d                               jump block1(v36)
 ;;
 ;;                                 block1(v5: i32):

--- a/tests/disas/gc/typed-select-and-stack-maps.wat
+++ b/tests/disas/gc/typed-select-and-stack-maps.wat
@@ -41,8 +41,13 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32, i32) tail {
 ;;     ss0 = explicit_slot 4, align = 4
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 104 "VMContext+0x68"
+;;     region2 = 88 "VMContext+0x58"
+;;     region3 = 72 "VMContext+0x48"
+;;     region4 = 56 "VMContext+0x38"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, i64) tail
@@ -53,12 +58,12 @@
 ;; @0049                               v5 = select v4, v2, v3
 ;;                                     v14 = stack_addr.i64 ss0
 ;;                                     store notrap v5, v14
-;; @004c                               v8 = load.i64 notrap aligned readonly can_move v0+88
-;; @004c                               v7 = load.i64 notrap aligned readonly can_move v0+104
+;; @004c                               v8 = load.i64 notrap aligned readonly can_move region2 v0+88
+;; @004c                               v7 = load.i64 notrap aligned readonly can_move region1 v0+104
 ;; @004c                               call_indirect sig0, v8(v7, v0), stack_map=[i32 @ ss0+0]
 ;;                                     v13 = load.i32 notrap v14
-;; @004e                               v11 = load.i64 notrap aligned readonly can_move v0+56
-;; @004e                               v10 = load.i64 notrap aligned readonly can_move v0+72
+;; @004e                               v11 = load.i64 notrap aligned readonly can_move region4 v0+56
+;; @004e                               v10 = load.i64 notrap aligned readonly can_move region3 v0+72
 ;; @004e                               call_indirect sig1, v11(v10, v0, v13)
 ;; @0050                               jump block1
 ;;
@@ -67,8 +72,13 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32, i32, i32) tail {
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 104 "VMContext+0x68"
+;;     region2 = 88 "VMContext+0x58"
+;;     region3 = 72 "VMContext+0x48"
+;;     region4 = 56 "VMContext+0x38"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, i64) tail
@@ -76,11 +86,11 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
-;; @005c                               v8 = load.i64 notrap aligned readonly can_move v0+88
-;; @005c                               v7 = load.i64 notrap aligned readonly can_move v0+104
+;; @005c                               v8 = load.i64 notrap aligned readonly can_move region2 v0+88
+;; @005c                               v7 = load.i64 notrap aligned readonly can_move region1 v0+104
 ;; @005c                               call_indirect sig0, v8(v7, v0)
-;; @005e                               v11 = load.i64 notrap aligned readonly can_move v0+56
-;; @005e                               v10 = load.i64 notrap aligned readonly can_move v0+72
+;; @005e                               v11 = load.i64 notrap aligned readonly can_move region4 v0+56
+;; @005e                               v10 = load.i64 notrap aligned readonly can_move region3 v0+72
 ;; @0059                               v5 = select v4, v2, v3
 ;; @005e                               call_indirect sig1, v11(v10, v0, v5)
 ;; @0060                               jump block1

--- a/tests/disas/global-get.wat
+++ b/tests/disas/global-get.wat
@@ -31,17 +31,19 @@
 )
 
 ;; function u0:0(i64 vmctx, i64) -> i32 tail {
-;;     region0 = 1610612736 "PublicGlobal"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 48 "VMContext+0x30"
+;;     region2 = 1610612736 "PublicGlobal"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+48
+;;     gv4 = load.i64 notrap aligned readonly can_move region1 gv3+48
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @003d                               v3 = load.i64 notrap aligned readonly can_move v0+48
-;; @003d                               v4 = load.i32 notrap aligned region0 v3
+;; @003d                               v3 = load.i64 notrap aligned readonly can_move region1 v0+48
+;; @003d                               v4 = load.i32 notrap aligned region2 v3
 ;; @003f                               jump block1
 ;;
 ;;                                 block1:
@@ -49,17 +51,19 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64) -> i32 tail {
-;;     region0 = 1610612736 "PublicGlobal"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 72 "VMContext+0x48"
+;;     region2 = 1610612736 "PublicGlobal"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+72
+;;     gv4 = load.i64 notrap aligned readonly can_move region1 gv3+72
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @0042                               v3 = load.i64 notrap aligned readonly can_move v0+72
-;; @0042                               v4 = load.i32 notrap aligned region0 v3
+;; @0042                               v3 = load.i64 notrap aligned readonly can_move region1 v0+72
+;; @0042                               v4 = load.i32 notrap aligned region2 v3
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -67,8 +71,9 @@
 ;; }
 ;;
 ;; function u0:2(i64 vmctx, i64) -> i32 tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     stack_limit = gv2
 ;;
@@ -81,15 +86,16 @@
 ;; }
 ;;
 ;; function u0:3(i64 vmctx, i64) -> i32 tail {
-;;     region0 = 1879048193 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(1))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 1879048193 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(1))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @004c                               v4 = load.i32 notrap aligned region0 v0+112
+;; @004c                               v4 = load.i32 notrap aligned region1 v0+112
 ;; @004e                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/globals.wat
+++ b/tests/disas/globals.wat
@@ -10,10 +10,11 @@
 )
 
 ;; function u0:0(i64 vmctx, i64) tail {
-;;     region0 = 1879048192 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(0))"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 1879048192 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(0))"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -23,11 +24,11 @@
 ;;                                 block0(v0: i64, v1: i64):
 ;; @0027                               v2 = iconst.i32 0
 ;; @0029                               v3 = iconst.i32 0
-;; @002b                               v5 = load.i32 notrap aligned region0 v0+80
+;; @002b                               v5 = load.i32 notrap aligned region1 v0+80
 ;; @002d                               v6 = uextend.i64 v3  ; v3 = 0
 ;; @002d                               v7 = load.i64 notrap aligned readonly can_move v0+56
 ;; @002d                               v8 = iadd v7, v6
-;; @002d                               store little region1 v5, v8
+;; @002d                               store little region2 v5, v8
 ;; @0030                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/i128-cmp.wat
+++ b/tests/disas/i128-cmp.wat
@@ -100,8 +100,9 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i64, i64, i64, i64) -> i32 tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     stack_limit = gv2
 ;;
@@ -117,8 +118,9 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i64, i64, i64, i64) -> i32 tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     stack_limit = gv2
 ;;
@@ -134,8 +136,9 @@
 ;; }
 ;;
 ;; function u0:2(i64 vmctx, i64, i64, i64, i64, i64) -> i32 tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     stack_limit = gv2
 ;;
@@ -151,8 +154,9 @@
 ;; }
 ;;
 ;; function u0:3(i64 vmctx, i64, i64, i64, i64, i64) -> i32 tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     stack_limit = gv2
 ;;
@@ -168,8 +172,9 @@
 ;; }
 ;;
 ;; function u0:4(i64 vmctx, i64, i64, i64, i64, i64) -> i32 tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     stack_limit = gv2
 ;;
@@ -185,8 +190,9 @@
 ;; }
 ;;
 ;; function u0:5(i64 vmctx, i64, i64, i64, i64, i64) -> i32 tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     stack_limit = gv2
 ;;
@@ -202,8 +208,9 @@
 ;; }
 ;;
 ;; function u0:6(i64 vmctx, i64, i64, i64, i64, i64) -> i32 tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     stack_limit = gv2
 ;;
@@ -219,8 +226,9 @@
 ;; }
 ;;
 ;; function u0:7(i64 vmctx, i64, i64, i64, i64, i64) -> i32 tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     stack_limit = gv2
 ;;

--- a/tests/disas/i32-load.wat
+++ b/tests/disas/i32-load.wat
@@ -9,9 +9,10 @@
     i32.load))
 
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -22,7 +23,7 @@
 ;; @002e                               v4 = uextend.i64 v2
 ;; @002e                               v5 = load.i64 notrap aligned readonly can_move v0+56
 ;; @002e                               v6 = iadd v5, v4
-;; @002e                               v7 = load.i32 little region0 v6
+;; @002e                               v7 = load.i32 little region1 v6
 ;; @0031                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/i32-load16-s.wat
+++ b/tests/disas/i32-load16-s.wat
@@ -9,9 +9,10 @@
     i32.load16_s))
 
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -22,7 +23,7 @@
 ;; @0032                               v4 = uextend.i64 v2
 ;; @0032                               v5 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0032                               v6 = iadd v5, v4
-;; @0032                               v7 = sload16.i32 little region0 v6
+;; @0032                               v7 = sload16.i32 little region1 v6
 ;; @0035                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/i32-load16-u.wat
+++ b/tests/disas/i32-load16-u.wat
@@ -9,9 +9,10 @@
     i32.load16_u))
 
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -22,7 +23,7 @@
 ;; @0032                               v4 = uextend.i64 v2
 ;; @0032                               v5 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0032                               v6 = iadd v5, v4
-;; @0032                               v7 = uload16.i32 little region0 v6
+;; @0032                               v7 = uload16.i32 little region1 v6
 ;; @0035                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/i32-load8-s.wat
+++ b/tests/disas/i32-load8-s.wat
@@ -9,9 +9,10 @@
     i32.load8_s))
 
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -22,7 +23,7 @@
 ;; @0031                               v4 = uextend.i64 v2
 ;; @0031                               v5 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0031                               v6 = iadd v5, v4
-;; @0031                               v7 = sload8.i32 little region0 v6
+;; @0031                               v7 = sload8.i32 little region1 v6
 ;; @0034                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/i32-load8-u.wat
+++ b/tests/disas/i32-load8-u.wat
@@ -9,9 +9,10 @@
     i32.load8_u))
 
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -22,7 +23,7 @@
 ;; @0031                               v4 = uextend.i64 v2
 ;; @0031                               v5 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0031                               v6 = iadd v5, v4
-;; @0031                               v7 = uload8.i32 little region0 v6
+;; @0031                               v7 = uload8.i32 little region1 v6
 ;; @0034                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/i32-store.wat
+++ b/tests/disas/i32-store.wat
@@ -10,9 +10,10 @@
     i32.store))
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -23,7 +24,7 @@
 ;; @0031                               v4 = uextend.i64 v2
 ;; @0031                               v5 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0031                               v6 = iadd v5, v4
-;; @0031                               store little region0 v3, v6
+;; @0031                               store little region1 v3, v6
 ;; @0034                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/i32-store16.wat
+++ b/tests/disas/i32-store16.wat
@@ -10,9 +10,10 @@
     i32.store16))
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -23,7 +24,7 @@
 ;; @0033                               v4 = uextend.i64 v2
 ;; @0033                               v5 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0033                               v6 = iadd v5, v4
-;; @0033                               istore16 little region0 v3, v6
+;; @0033                               istore16 little region1 v3, v6
 ;; @0036                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/i32-store8.wat
+++ b/tests/disas/i32-store8.wat
@@ -10,9 +10,10 @@
     i32.store8))
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -23,7 +24,7 @@
 ;; @0032                               v4 = uextend.i64 v2
 ;; @0032                               v5 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0032                               v6 = iadd v5, v4
-;; @0032                               istore8 little region0 v3, v6
+;; @0032                               istore8 little region1 v3, v6
 ;; @0035                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/i64-load.wat
+++ b/tests/disas/i64-load.wat
@@ -9,9 +9,10 @@
     i64.load))
 
 ;; function u0:0(i64 vmctx, i64, i32) -> i64 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -22,7 +23,7 @@
 ;; @002e                               v4 = uextend.i64 v2
 ;; @002e                               v5 = load.i64 notrap aligned readonly can_move v0+56
 ;; @002e                               v6 = iadd v5, v4
-;; @002e                               v7 = load.i64 little region0 v6
+;; @002e                               v7 = load.i64 little region1 v6
 ;; @0031                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/i64-load16-s.wat
+++ b/tests/disas/i64-load16-s.wat
@@ -9,9 +9,10 @@
     i64.load16_s))
 
 ;; function u0:0(i64 vmctx, i64, i32) -> i64 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -22,7 +23,7 @@
 ;; @0032                               v4 = uextend.i64 v2
 ;; @0032                               v5 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0032                               v6 = iadd v5, v4
-;; @0032                               v7 = sload16.i64 little region0 v6
+;; @0032                               v7 = sload16.i64 little region1 v6
 ;; @0035                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/i64-load16-u.wat
+++ b/tests/disas/i64-load16-u.wat
@@ -9,9 +9,10 @@
     i64.load16_u))
 
 ;; function u0:0(i64 vmctx, i64, i32) -> i64 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -22,7 +23,7 @@
 ;; @0032                               v4 = uextend.i64 v2
 ;; @0032                               v5 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0032                               v6 = iadd v5, v4
-;; @0032                               v7 = uload16.i64 little region0 v6
+;; @0032                               v7 = uload16.i64 little region1 v6
 ;; @0035                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/i64-load8-s.wat
+++ b/tests/disas/i64-load8-s.wat
@@ -9,9 +9,10 @@
     i64.load8_s))
 
 ;; function u0:0(i64 vmctx, i64, i32) -> i64 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -22,7 +23,7 @@
 ;; @0031                               v4 = uextend.i64 v2
 ;; @0031                               v5 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0031                               v6 = iadd v5, v4
-;; @0031                               v7 = sload8.i64 little region0 v6
+;; @0031                               v7 = sload8.i64 little region1 v6
 ;; @0034                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/i64-load8-u.wat
+++ b/tests/disas/i64-load8-u.wat
@@ -9,9 +9,10 @@
     i64.load8_u))
 
 ;; function u0:0(i64 vmctx, i64, i32) -> i64 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -22,7 +23,7 @@
 ;; @0031                               v4 = uextend.i64 v2
 ;; @0031                               v5 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0031                               v6 = iadd v5, v4
-;; @0031                               v7 = uload8.i64 little region0 v6
+;; @0031                               v7 = uload8.i64 little region1 v6
 ;; @0034                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/i64-store.wat
+++ b/tests/disas/i64-store.wat
@@ -10,9 +10,10 @@
     i64.store))
 
 ;; function u0:0(i64 vmctx, i64, i32, i64) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -23,7 +24,7 @@
 ;; @0031                               v4 = uextend.i64 v2
 ;; @0031                               v5 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0031                               v6 = iadd v5, v4
-;; @0031                               store little region0 v3, v6
+;; @0031                               store little region1 v3, v6
 ;; @0034                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/i64-store16.wat
+++ b/tests/disas/i64-store16.wat
@@ -10,9 +10,10 @@
     i64.store16))
 
 ;; function u0:0(i64 vmctx, i64, i32, i64) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -23,7 +24,7 @@
 ;; @0033                               v4 = uextend.i64 v2
 ;; @0033                               v5 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0033                               v6 = iadd v5, v4
-;; @0033                               istore16 little region0 v3, v6
+;; @0033                               istore16 little region1 v3, v6
 ;; @0036                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/i64-store32.wat
+++ b/tests/disas/i64-store32.wat
@@ -10,9 +10,10 @@
     i64.store32))
 
 ;; function u0:0(i64 vmctx, i64, i32, i64) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -23,7 +24,7 @@
 ;; @0033                               v4 = uextend.i64 v2
 ;; @0033                               v5 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0033                               v6 = iadd v5, v4
-;; @0033                               istore32 little region0 v3, v6
+;; @0033                               istore32 little region1 v3, v6
 ;; @0036                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/i64-store8.wat
+++ b/tests/disas/i64-store8.wat
@@ -10,9 +10,10 @@
     i64.store8))
 
 ;; function u0:0(i64 vmctx, i64, i32, i64) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -23,7 +24,7 @@
 ;; @0032                               v4 = uextend.i64 v2
 ;; @0032                               v5 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0032                               v6 = iadd v5, v4
-;; @0032                               istore8 little region0 v3, v6
+;; @0032                               istore8 little region1 v3, v6
 ;; @0035                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/icall-loop.wat
+++ b/tests/disas/icall-loop.wat
@@ -23,9 +23,11 @@
 )
 
 ;; function u0:0(i64 vmctx, i64, i32) tail {
-;;     region0 = 1342177280 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 1342177280 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
+;;     region2 = 40 "VMContext+0x28"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned readonly can_move gv3+48
@@ -46,12 +48,12 @@
 ;; @002b                               v12 = select_spectre_guard v5, v11, v10  ; v11 = 0
 ;; @002b                               v14 = iconst.i64 -2
 ;; @002b                               v17 = iconst.i32 0
-;; @002b                               v20 = load.i64 notrap aligned readonly can_move v0+40
+;; @002b                               v20 = load.i64 notrap aligned readonly can_move region2 v0+40
 ;; @002b                               v21 = load.i32 notrap aligned readonly can_move v20
 ;; @0027                               jump block2
 ;;
 ;;                                 block2:
-;; @002b                               v13 = load.i64 user6 aligned region0 v12
+;; @002b                               v13 = load.i64 user6 aligned region1 v12
 ;;                                     v30 = iconst.i64 -2
 ;;                                     v31 = band v13, v30  ; v30 = -2
 ;; @002b                               brif v13, block5(v31), block4
@@ -72,9 +74,11 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64) tail {
-;;     region0 = 1342177280 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 1342177280 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
+;;     region2 = 40 "VMContext+0x28"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned readonly can_move gv3+48
@@ -90,13 +94,13 @@
 ;; @0038                               v13 = iconst.i64 -2
 ;; @0038                               v16 = iconst.i32 0
 ;;                                     v34 = iconst.i64 1
-;; @0038                               v19 = load.i64 notrap aligned readonly can_move v0+40
+;; @0038                               v19 = load.i64 notrap aligned readonly can_move region2 v0+40
 ;; @0038                               v20 = load.i32 notrap aligned readonly can_move v19
 ;; @0034                               jump block2
 ;;
 ;;                                 block2:
 ;;                                     v36 = iadd.i64 v6, v35  ; v35 = 8
-;; @0038                               v12 = load.i64 user6 aligned region0 v36
+;; @0038                               v12 = load.i64 user6 aligned region1 v36
 ;;                                     v37 = iconst.i64 -2
 ;;                                     v38 = band v12, v37  ; v37 = -2
 ;; @0038                               brif v12, block5(v38), block4

--- a/tests/disas/icall-simd.wat
+++ b/tests/disas/icall-simd.wat
@@ -9,9 +9,11 @@
 )
 
 ;; function u0:0(i64 vmctx, i64, i32, i8x16) -> i8x16 tail {
-;;     region0 = 1342177280 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 1342177280 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
+;;     region2 = 40 "VMContext+0x28"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned readonly can_move gv3+48
@@ -30,7 +32,7 @@
 ;; @0033                               v11 = iadd v8, v10
 ;; @0033                               v12 = iconst.i64 0
 ;; @0033                               v13 = select_spectre_guard v6, v12, v11  ; v12 = 0
-;; @0033                               v14 = load.i64 user6 aligned region0 v13
+;; @0033                               v14 = load.i64 user6 aligned region1 v13
 ;; @0033                               v15 = iconst.i64 -2
 ;; @0033                               v16 = band v14, v15  ; v15 = -2
 ;; @0033                               brif v14, block3(v16), block2
@@ -42,7 +44,7 @@
 ;; @0033                               jump block3(v20)
 ;;
 ;;                                 block3(v17: i64):
-;; @0033                               v21 = load.i64 notrap aligned readonly can_move v0+40
+;; @0033                               v21 = load.i64 notrap aligned readonly can_move region2 v0+40
 ;; @0033                               v22 = load.i32 notrap aligned readonly can_move v21
 ;; @0033                               v23 = load.i32 user7 aligned readonly v17+16
 ;; @0033                               v24 = icmp eq v23, v22

--- a/tests/disas/icall.wat
+++ b/tests/disas/icall.wat
@@ -9,9 +9,11 @@
 )
 
 ;; function u0:0(i64 vmctx, i64, i32, f32) -> i32 tail {
-;;     region0 = 1342177280 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 1342177280 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
+;;     region2 = 40 "VMContext+0x28"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned readonly can_move gv3+48
@@ -30,7 +32,7 @@
 ;; @0033                               v11 = iadd v8, v10
 ;; @0033                               v12 = iconst.i64 0
 ;; @0033                               v13 = select_spectre_guard v6, v12, v11  ; v12 = 0
-;; @0033                               v14 = load.i64 user6 aligned region0 v13
+;; @0033                               v14 = load.i64 user6 aligned region1 v13
 ;; @0033                               v15 = iconst.i64 -2
 ;; @0033                               v16 = band v14, v15  ; v15 = -2
 ;; @0033                               brif v14, block3(v16), block2
@@ -42,7 +44,7 @@
 ;; @0033                               jump block3(v20)
 ;;
 ;;                                 block3(v17: i64):
-;; @0033                               v21 = load.i64 notrap aligned readonly can_move v0+40
+;; @0033                               v21 = load.i64 notrap aligned readonly can_move region2 v0+40
 ;; @0033                               v22 = load.i32 notrap aligned readonly can_move v21
 ;; @0033                               v23 = load.i32 user7 aligned readonly v17+16
 ;; @0033                               v24 = icmp eq v23, v22

--- a/tests/disas/idempotent-store.wat
+++ b/tests/disas/idempotent-store.wat
@@ -15,9 +15,10 @@
 )
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -28,7 +29,7 @@
 ;; @0029                               v5 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0029                               v4 = uextend.i64 v2
 ;; @0029                               v6 = iadd v5, v4
-;; @0029                               store little region0 v3, v6
+;; @0029                               store little region1 v3, v6
 ;; @0033                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/if-reachability-translation-0.wat
+++ b/tests/disas/if-reachability-translation-0.wat
@@ -14,8 +14,9 @@
     i32.const 0))
 
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     stack_limit = gv2
 ;;

--- a/tests/disas/if-reachability-translation-1.wat
+++ b/tests/disas/if-reachability-translation-1.wat
@@ -14,8 +14,9 @@
     i32.const 0))
 
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     stack_limit = gv2
 ;;

--- a/tests/disas/if-reachability-translation-2.wat
+++ b/tests/disas/if-reachability-translation-2.wat
@@ -14,8 +14,9 @@
     i32.const 0))
 
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     stack_limit = gv2
 ;;

--- a/tests/disas/if-reachability-translation-3.wat
+++ b/tests/disas/if-reachability-translation-3.wat
@@ -14,8 +14,9 @@
     i32.const 0))
 
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     stack_limit = gv2
 ;;

--- a/tests/disas/if-reachability-translation-4.wat
+++ b/tests/disas/if-reachability-translation-4.wat
@@ -14,8 +14,9 @@
     i32.const 0))
 
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     stack_limit = gv2
 ;;

--- a/tests/disas/if-reachability-translation-5.wat
+++ b/tests/disas/if-reachability-translation-5.wat
@@ -16,8 +16,9 @@
     i32.const 0))
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) -> i32 tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     stack_limit = gv2
 ;;

--- a/tests/disas/if-reachability-translation-6.wat
+++ b/tests/disas/if-reachability-translation-6.wat
@@ -16,8 +16,9 @@
     i32.const 0))
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) -> i32 tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     stack_limit = gv2
 ;;

--- a/tests/disas/if-unreachable-else-params-2.wat
+++ b/tests/disas/if-unreachable-else-params-2.wat
@@ -20,9 +20,10 @@
   (export "memory" (memory 0)))
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) -> f64 tail {
-;;     region0 = 536870912 "PublicMemory"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 536870912 "PublicMemory"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -38,7 +39,7 @@
 ;; @0058                               v7 = uextend.i64 v2
 ;; @0058                               v8 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0058                               v9 = iadd v8, v7
-;; @0058                               v10 = sload16.i64 little region0 v9
+;; @0058                               v10 = sload16.i64 little region1 v9
 ;; @005c                               jump block3
 ;;
 ;;                                 block3:

--- a/tests/disas/if-unreachable-else-params.wat
+++ b/tests/disas/if-unreachable-else-params.wat
@@ -43,9 +43,10 @@
   (export "memory" (memory 0)))
 
 ;; function u0:0(i64 vmctx, i64, i32) tail {
-;;     region0 = 536870912 "PublicMemory"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 536870912 "PublicMemory"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -63,7 +64,7 @@
 ;; @004b                               v7 = uextend.i64 v3  ; v3 = 35
 ;; @004b                               v8 = load.i64 notrap aligned readonly can_move v0+56
 ;; @004b                               v9 = iadd v8, v7
-;; @004b                               v10 = sload16.i64 little region0 v9
+;; @004b                               v10 = sload16.i64 little region1 v9
 ;; @004e                               trap user12
 ;;
 ;;                                 block6:

--- a/tests/disas/indirect-call-no-caching.wat
+++ b/tests/disas/indirect-call-no-caching.wat
@@ -21,8 +21,9 @@
 
  (elem (i32.const 1) func $f1 $f2 $f3))
 ;; function u0:0(i64 vmctx, i64) -> i32 tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     stack_limit = gv2
 ;;
@@ -35,8 +36,9 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64) -> i32 tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     stack_limit = gv2
 ;;
@@ -49,8 +51,9 @@
 ;; }
 ;;
 ;; function u0:2(i64 vmctx, i64) -> i32 tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     stack_limit = gv2
 ;;
@@ -63,9 +66,11 @@
 ;; }
 ;;
 ;; function u0:3(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 1342177280 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 1342177280 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
+;;     region2 = 40 "VMContext+0x28"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned readonly can_move gv3+48
@@ -84,7 +89,7 @@
 ;; @0050                               v10 = iadd v7, v9
 ;; @0050                               v11 = iconst.i64 0
 ;; @0050                               v12 = select_spectre_guard v5, v11, v10  ; v11 = 0
-;; @0050                               v13 = load.i64 user6 aligned region0 v12
+;; @0050                               v13 = load.i64 user6 aligned region1 v12
 ;; @0050                               v14 = iconst.i64 -2
 ;; @0050                               v15 = band v13, v14  ; v14 = -2
 ;; @0050                               brif v13, block3(v15), block2
@@ -96,7 +101,7 @@
 ;; @0050                               jump block3(v19)
 ;;
 ;;                                 block3(v16: i64):
-;; @0050                               v20 = load.i64 notrap aligned readonly can_move v0+40
+;; @0050                               v20 = load.i64 notrap aligned readonly can_move region2 v0+40
 ;; @0050                               v21 = load.i32 notrap aligned readonly can_move v20
 ;; @0050                               v22 = load.i32 user7 aligned readonly v16+16
 ;; @0050                               v23 = icmp eq v22, v21

--- a/tests/disas/intra-module-inlining.wat
+++ b/tests/disas/intra-module-inlining.wat
@@ -10,8 +10,9 @@
     (call 0)))
 
 ;; function u0:0(i64 vmctx, i64) -> i32 tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     stack_limit = gv2
 ;;
@@ -24,11 +25,12 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64) -> i32 tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly gv3+8
+;;     gv4 = load.i64 notrap aligned readonly region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned gv4+24
 ;;     sig0 = (i64 vmctx, i64) -> i32 tail
 ;;     fn0 = colocated u0:0 sig0

--- a/tests/disas/issue-10929-v128-icmp-egraphs.wat
+++ b/tests/disas/issue-10929-v128-icmp-egraphs.wat
@@ -11,8 +11,9 @@
     i8x16.ne)
 )
 ;; function u0:0(i64 vmctx, i64, i8x16) -> i8x16 tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     const0 = 0xffffffffffffffffffffffffffffffff
 ;;     stack_limit = gv2

--- a/tests/disas/issue-5696.wat
+++ b/tests/disas/issue-5696.wat
@@ -10,8 +10,9 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i64) -> i64 tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     stack_limit = gv2
 ;;

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0_offset.wat
@@ -19,9 +19,10 @@
     i32.load offset=0))
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -37,7 +38,7 @@
 ;; @0040                               trapnz v8, heap_oob
 ;; @0040                               v9 = load.i64 notrap aligned can_move v0+56
 ;; @0040                               v10 = iadd v9, v4
-;; @0040                               store little region0 v3, v10
+;; @0040                               store little region1 v3, v10
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -45,9 +46,10 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -63,7 +65,7 @@
 ;; @0048                               trapnz v8, heap_oob
 ;; @0048                               v9 = load.i64 notrap aligned can_move v0+56
 ;; @0048                               v10 = iadd v9, v4
-;; @0048                               v11 = load.i32 little region0 v10
+;; @0048                               v11 = load.i32 little region1 v10
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -19,9 +19,10 @@
     i32.load offset=0x1000))
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -39,7 +40,7 @@
 ;; @0040                               v10 = iadd v9, v4
 ;; @0040                               v11 = iconst.i64 4096
 ;; @0040                               v12 = iadd v10, v11  ; v11 = 4096
-;; @0040                               store little region0 v3, v12
+;; @0040                               store little region1 v3, v12
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -47,9 +48,10 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -67,7 +69,7 @@
 ;; @0049                               v10 = iadd v9, v4
 ;; @0049                               v11 = iconst.i64 4096
 ;; @0049                               v12 = iadd v10, v11  ; v11 = 4096
-;; @0049                               v13 = load.i32 little region0 v12
+;; @0049                               v13 = load.i32 little region1 v12
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -19,9 +19,10 @@
     i32.load offset=0xffff0000))
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -39,7 +40,7 @@
 ;; @0040                               v10 = iadd v9, v4
 ;; @0040                               v11 = iconst.i64 0xffff_0000
 ;; @0040                               v12 = iadd v10, v11  ; v11 = 0xffff_0000
-;; @0040                               store little region0 v3, v12
+;; @0040                               store little region1 v3, v12
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -47,9 +48,10 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -67,7 +69,7 @@
 ;; @004c                               v10 = iadd v9, v4
 ;; @004c                               v11 = iconst.i64 0xffff_0000
 ;; @004c                               v12 = iadd v10, v11  ; v11 = 0xffff_0000
-;; @004c                               v13 = load.i32 little region0 v12
+;; @004c                               v13 = load.i32 little region1 v12
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0_offset.wat
@@ -19,9 +19,10 @@
     i32.load8_u offset=0))
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -35,7 +36,7 @@
 ;; @0040                               trapnz v6, heap_oob
 ;; @0040                               v7 = load.i64 notrap aligned can_move v0+56
 ;; @0040                               v8 = iadd v7, v4
-;; @0040                               istore8 little region0 v3, v8
+;; @0040                               istore8 little region1 v3, v8
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -43,9 +44,10 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -59,7 +61,7 @@
 ;; @0048                               trapnz v6, heap_oob
 ;; @0048                               v7 = load.i64 notrap aligned can_move v0+56
 ;; @0048                               v8 = iadd v7, v4
-;; @0048                               v9 = uload8.i32 little region0 v8
+;; @0048                               v9 = uload8.i32 little region1 v8
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -19,9 +19,10 @@
     i32.load8_u offset=0x1000))
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -39,7 +40,7 @@
 ;; @0040                               v10 = iadd v9, v4
 ;; @0040                               v11 = iconst.i64 4096
 ;; @0040                               v12 = iadd v10, v11  ; v11 = 4096
-;; @0040                               istore8 little region0 v3, v12
+;; @0040                               istore8 little region1 v3, v12
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -47,9 +48,10 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -67,7 +69,7 @@
 ;; @0049                               v10 = iadd v9, v4
 ;; @0049                               v11 = iconst.i64 4096
 ;; @0049                               v12 = iadd v10, v11  ; v11 = 4096
-;; @0049                               v13 = uload8.i32 little region0 v12
+;; @0049                               v13 = uload8.i32 little region1 v12
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -19,9 +19,10 @@
     i32.load8_u offset=0xffff0000))
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -39,7 +40,7 @@
 ;; @0040                               v10 = iadd v9, v4
 ;; @0040                               v11 = iconst.i64 0xffff_0000
 ;; @0040                               v12 = iadd v10, v11  ; v11 = 0xffff_0000
-;; @0040                               istore8 little region0 v3, v12
+;; @0040                               istore8 little region1 v3, v12
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -47,9 +48,10 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -67,7 +69,7 @@
 ;; @004c                               v10 = iadd v9, v4
 ;; @004c                               v11 = iconst.i64 0xffff_0000
 ;; @004c                               v12 = iadd v10, v11  ; v11 = 0xffff_0000
-;; @004c                               v13 = uload8.i32 little region0 v12
+;; @004c                               v13 = uload8.i32 little region1 v12
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0_offset.wat
@@ -19,9 +19,10 @@
     i32.load offset=0))
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -38,7 +39,7 @@
 ;; @0040                               v10 = iadd v9, v4
 ;; @0040                               v11 = iconst.i64 0
 ;; @0040                               v12 = select_spectre_guard v8, v11, v10  ; v11 = 0
-;; @0040                               store little region0 v3, v12
+;; @0040                               store little region1 v3, v12
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -46,9 +47,10 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -65,7 +67,7 @@
 ;; @0048                               v10 = iadd v9, v4
 ;; @0048                               v11 = iconst.i64 0
 ;; @0048                               v12 = select_spectre_guard v8, v11, v10  ; v11 = 0
-;; @0048                               v13 = load.i32 little region0 v12
+;; @0048                               v13 = load.i32 little region1 v12
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -19,9 +19,10 @@
     i32.load offset=0x1000))
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -40,7 +41,7 @@
 ;; @0040                               v12 = iadd v10, v11  ; v11 = 4096
 ;; @0040                               v13 = iconst.i64 0
 ;; @0040                               v14 = select_spectre_guard v8, v13, v12  ; v13 = 0
-;; @0040                               store little region0 v3, v14
+;; @0040                               store little region1 v3, v14
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -48,9 +49,10 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -69,7 +71,7 @@
 ;; @0049                               v12 = iadd v10, v11  ; v11 = 4096
 ;; @0049                               v13 = iconst.i64 0
 ;; @0049                               v14 = select_spectre_guard v8, v13, v12  ; v13 = 0
-;; @0049                               v15 = load.i32 little region0 v14
+;; @0049                               v15 = load.i32 little region1 v14
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -19,9 +19,10 @@
     i32.load offset=0xffff0000))
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -40,7 +41,7 @@
 ;; @0040                               v12 = iadd v10, v11  ; v11 = 0xffff_0000
 ;; @0040                               v13 = iconst.i64 0
 ;; @0040                               v14 = select_spectre_guard v8, v13, v12  ; v13 = 0
-;; @0040                               store little region0 v3, v14
+;; @0040                               store little region1 v3, v14
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -48,9 +49,10 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -69,7 +71,7 @@
 ;; @004c                               v12 = iadd v10, v11  ; v11 = 0xffff_0000
 ;; @004c                               v13 = iconst.i64 0
 ;; @004c                               v14 = select_spectre_guard v8, v13, v12  ; v13 = 0
-;; @004c                               v15 = load.i32 little region0 v14
+;; @004c                               v15 = load.i32 little region1 v14
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0_offset.wat
@@ -19,9 +19,10 @@
     i32.load8_u offset=0))
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -36,7 +37,7 @@
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               v9 = iconst.i64 0
 ;; @0040                               v10 = select_spectre_guard v6, v9, v8  ; v9 = 0
-;; @0040                               istore8 little region0 v3, v10
+;; @0040                               istore8 little region1 v3, v10
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -44,9 +45,10 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -61,7 +63,7 @@
 ;; @0048                               v8 = iadd v7, v4
 ;; @0048                               v9 = iconst.i64 0
 ;; @0048                               v10 = select_spectre_guard v6, v9, v8  ; v9 = 0
-;; @0048                               v11 = uload8.i32 little region0 v10
+;; @0048                               v11 = uload8.i32 little region1 v10
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -19,9 +19,10 @@
     i32.load8_u offset=0x1000))
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -40,7 +41,7 @@
 ;; @0040                               v12 = iadd v10, v11  ; v11 = 4096
 ;; @0040                               v13 = iconst.i64 0
 ;; @0040                               v14 = select_spectre_guard v8, v13, v12  ; v13 = 0
-;; @0040                               istore8 little region0 v3, v14
+;; @0040                               istore8 little region1 v3, v14
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -48,9 +49,10 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -69,7 +71,7 @@
 ;; @0049                               v12 = iadd v10, v11  ; v11 = 4096
 ;; @0049                               v13 = iconst.i64 0
 ;; @0049                               v14 = select_spectre_guard v8, v13, v12  ; v13 = 0
-;; @0049                               v15 = uload8.i32 little region0 v14
+;; @0049                               v15 = uload8.i32 little region1 v14
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -19,9 +19,10 @@
     i32.load8_u offset=0xffff0000))
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -40,7 +41,7 @@
 ;; @0040                               v12 = iadd v10, v11  ; v11 = 0xffff_0000
 ;; @0040                               v13 = iconst.i64 0
 ;; @0040                               v14 = select_spectre_guard v8, v13, v12  ; v13 = 0
-;; @0040                               istore8 little region0 v3, v14
+;; @0040                               istore8 little region1 v3, v14
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -48,9 +49,10 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -69,7 +71,7 @@
 ;; @004c                               v12 = iadd v10, v11  ; v11 = 0xffff_0000
 ;; @004c                               v13 = iconst.i64 0
 ;; @004c                               v14 = select_spectre_guard v8, v13, v12  ; v13 = 0
-;; @004c                               v15 = uload8.i32 little region0 v14
+;; @004c                               v15 = uload8.i32 little region1 v14
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
@@ -19,9 +19,10 @@
     i32.load offset=0))
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -35,7 +36,7 @@
 ;; @0040                               trapnz v6, heap_oob
 ;; @0040                               v7 = load.i64 notrap aligned can_move v0+56
 ;; @0040                               v8 = iadd v7, v4
-;; @0040                               store little region0 v3, v8
+;; @0040                               store little region1 v3, v8
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -43,9 +44,10 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -59,7 +61,7 @@
 ;; @0048                               trapnz v6, heap_oob
 ;; @0048                               v7 = load.i64 notrap aligned can_move v0+56
 ;; @0048                               v8 = iadd v7, v4
-;; @0048                               v9 = load.i32 little region0 v8
+;; @0048                               v9 = load.i32 little region1 v8
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -19,9 +19,10 @@
     i32.load offset=0x1000))
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -37,7 +38,7 @@
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               v9 = iconst.i64 4096
 ;; @0040                               v10 = iadd v8, v9  ; v9 = 4096
-;; @0040                               store little region0 v3, v10
+;; @0040                               store little region1 v3, v10
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -45,9 +46,10 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -63,7 +65,7 @@
 ;; @0049                               v8 = iadd v7, v4
 ;; @0049                               v9 = iconst.i64 4096
 ;; @0049                               v10 = iadd v8, v9  ; v9 = 4096
-;; @0049                               v11 = load.i32 little region0 v10
+;; @0049                               v11 = load.i32 little region1 v10
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -19,9 +19,10 @@
     i32.load offset=0xffff0000))
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -37,7 +38,7 @@
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               v9 = iconst.i64 0xffff_0000
 ;; @0040                               v10 = iadd v8, v9  ; v9 = 0xffff_0000
-;; @0040                               store little region0 v3, v10
+;; @0040                               store little region1 v3, v10
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -45,9 +46,10 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -63,7 +65,7 @@
 ;; @004c                               v8 = iadd v7, v4
 ;; @004c                               v9 = iconst.i64 0xffff_0000
 ;; @004c                               v10 = iadd v8, v9  ; v9 = 0xffff_0000
-;; @004c                               v11 = load.i32 little region0 v10
+;; @004c                               v11 = load.i32 little region1 v10
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
@@ -19,9 +19,10 @@
     i32.load8_u offset=0))
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -35,7 +36,7 @@
 ;; @0040                               trapnz v6, heap_oob
 ;; @0040                               v7 = load.i64 notrap aligned can_move v0+56
 ;; @0040                               v8 = iadd v7, v4
-;; @0040                               istore8 little region0 v3, v8
+;; @0040                               istore8 little region1 v3, v8
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -43,9 +44,10 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -59,7 +61,7 @@
 ;; @0048                               trapnz v6, heap_oob
 ;; @0048                               v7 = load.i64 notrap aligned can_move v0+56
 ;; @0048                               v8 = iadd v7, v4
-;; @0048                               v9 = uload8.i32 little region0 v8
+;; @0048                               v9 = uload8.i32 little region1 v8
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -19,9 +19,10 @@
     i32.load8_u offset=0x1000))
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -37,7 +38,7 @@
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               v9 = iconst.i64 4096
 ;; @0040                               v10 = iadd v8, v9  ; v9 = 4096
-;; @0040                               istore8 little region0 v3, v10
+;; @0040                               istore8 little region1 v3, v10
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -45,9 +46,10 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -63,7 +65,7 @@
 ;; @0049                               v8 = iadd v7, v4
 ;; @0049                               v9 = iconst.i64 4096
 ;; @0049                               v10 = iadd v8, v9  ; v9 = 4096
-;; @0049                               v11 = uload8.i32 little region0 v10
+;; @0049                               v11 = uload8.i32 little region1 v10
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -19,9 +19,10 @@
     i32.load8_u offset=0xffff0000))
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -37,7 +38,7 @@
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               v9 = iconst.i64 0xffff_0000
 ;; @0040                               v10 = iadd v8, v9  ; v9 = 0xffff_0000
-;; @0040                               istore8 little region0 v3, v10
+;; @0040                               istore8 little region1 v3, v10
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -45,9 +46,10 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -63,7 +65,7 @@
 ;; @004c                               v8 = iadd v7, v4
 ;; @004c                               v9 = iconst.i64 0xffff_0000
 ;; @004c                               v10 = iadd v8, v9  ; v9 = 0xffff_0000
-;; @004c                               v11 = uload8.i32 little region0 v10
+;; @004c                               v11 = uload8.i32 little region1 v10
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
@@ -19,9 +19,10 @@
     i32.load offset=0))
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -36,7 +37,7 @@
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               v9 = iconst.i64 0
 ;; @0040                               v10 = select_spectre_guard v6, v9, v8  ; v9 = 0
-;; @0040                               store little region0 v3, v10
+;; @0040                               store little region1 v3, v10
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -44,9 +45,10 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -61,7 +63,7 @@
 ;; @0048                               v8 = iadd v7, v4
 ;; @0048                               v9 = iconst.i64 0
 ;; @0048                               v10 = select_spectre_guard v6, v9, v8  ; v9 = 0
-;; @0048                               v11 = load.i32 little region0 v10
+;; @0048                               v11 = load.i32 little region1 v10
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -19,9 +19,10 @@
     i32.load offset=0x1000))
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -38,7 +39,7 @@
 ;; @0040                               v10 = iadd v8, v9  ; v9 = 4096
 ;; @0040                               v11 = iconst.i64 0
 ;; @0040                               v12 = select_spectre_guard v6, v11, v10  ; v11 = 0
-;; @0040                               store little region0 v3, v12
+;; @0040                               store little region1 v3, v12
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -46,9 +47,10 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -65,7 +67,7 @@
 ;; @0049                               v10 = iadd v8, v9  ; v9 = 4096
 ;; @0049                               v11 = iconst.i64 0
 ;; @0049                               v12 = select_spectre_guard v6, v11, v10  ; v11 = 0
-;; @0049                               v13 = load.i32 little region0 v12
+;; @0049                               v13 = load.i32 little region1 v12
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -19,9 +19,10 @@
     i32.load offset=0xffff0000))
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -38,7 +39,7 @@
 ;; @0040                               v10 = iadd v8, v9  ; v9 = 0xffff_0000
 ;; @0040                               v11 = iconst.i64 0
 ;; @0040                               v12 = select_spectre_guard v6, v11, v10  ; v11 = 0
-;; @0040                               store little region0 v3, v12
+;; @0040                               store little region1 v3, v12
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -46,9 +47,10 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -65,7 +67,7 @@
 ;; @004c                               v10 = iadd v8, v9  ; v9 = 0xffff_0000
 ;; @004c                               v11 = iconst.i64 0
 ;; @004c                               v12 = select_spectre_guard v6, v11, v10  ; v11 = 0
-;; @004c                               v13 = load.i32 little region0 v12
+;; @004c                               v13 = load.i32 little region1 v12
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
@@ -19,9 +19,10 @@
     i32.load8_u offset=0))
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -36,7 +37,7 @@
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               v9 = iconst.i64 0
 ;; @0040                               v10 = select_spectre_guard v6, v9, v8  ; v9 = 0
-;; @0040                               istore8 little region0 v3, v10
+;; @0040                               istore8 little region1 v3, v10
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -44,9 +45,10 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -61,7 +63,7 @@
 ;; @0048                               v8 = iadd v7, v4
 ;; @0048                               v9 = iconst.i64 0
 ;; @0048                               v10 = select_spectre_guard v6, v9, v8  ; v9 = 0
-;; @0048                               v11 = uload8.i32 little region0 v10
+;; @0048                               v11 = uload8.i32 little region1 v10
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -19,9 +19,10 @@
     i32.load8_u offset=0x1000))
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -38,7 +39,7 @@
 ;; @0040                               v10 = iadd v8, v9  ; v9 = 4096
 ;; @0040                               v11 = iconst.i64 0
 ;; @0040                               v12 = select_spectre_guard v6, v11, v10  ; v11 = 0
-;; @0040                               istore8 little region0 v3, v12
+;; @0040                               istore8 little region1 v3, v12
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -46,9 +47,10 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -65,7 +67,7 @@
 ;; @0049                               v10 = iadd v8, v9  ; v9 = 4096
 ;; @0049                               v11 = iconst.i64 0
 ;; @0049                               v12 = select_spectre_guard v6, v11, v10  ; v11 = 0
-;; @0049                               v13 = uload8.i32 little region0 v12
+;; @0049                               v13 = uload8.i32 little region1 v12
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -19,9 +19,10 @@
     i32.load8_u offset=0xffff0000))
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -38,7 +39,7 @@
 ;; @0040                               v10 = iadd v8, v9  ; v9 = 0xffff_0000
 ;; @0040                               v11 = iconst.i64 0
 ;; @0040                               v12 = select_spectre_guard v6, v11, v10  ; v11 = 0
-;; @0040                               istore8 little region0 v3, v12
+;; @0040                               istore8 little region1 v3, v12
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -46,9 +47,10 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -65,7 +67,7 @@
 ;; @004c                               v10 = iadd v8, v9  ; v9 = 0xffff_0000
 ;; @004c                               v11 = iconst.i64 0
 ;; @004c                               v12 = select_spectre_guard v6, v11, v10  ; v11 = 0
-;; @004c                               v13 = uload8.i32 little region0 v12
+;; @004c                               v13 = uload8.i32 little region1 v12
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0_offset.wat
@@ -19,9 +19,10 @@
     i32.load offset=0))
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -36,7 +37,7 @@
 ;; @0040                               trapnz v7, heap_oob
 ;; @0040                               v8 = load.i64 notrap aligned can_move v0+56
 ;; @0040                               v9 = iadd v8, v2
-;; @0040                               store little region0 v3, v9
+;; @0040                               store little region1 v3, v9
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -44,9 +45,10 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -61,7 +63,7 @@
 ;; @0048                               trapnz v7, heap_oob
 ;; @0048                               v8 = load.i64 notrap aligned can_move v0+56
 ;; @0048                               v9 = iadd v8, v2
-;; @0048                               v10 = load.i32 little region0 v9
+;; @0048                               v10 = load.i32 little region1 v9
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -19,9 +19,10 @@
     i32.load offset=0x1000))
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -38,7 +39,7 @@
 ;; @0040                               v9 = iadd v8, v2
 ;; @0040                               v10 = iconst.i64 4096
 ;; @0040                               v11 = iadd v9, v10  ; v10 = 4096
-;; @0040                               store little region0 v3, v11
+;; @0040                               store little region1 v3, v11
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -46,9 +47,10 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -65,7 +67,7 @@
 ;; @0049                               v9 = iadd v8, v2
 ;; @0049                               v10 = iconst.i64 4096
 ;; @0049                               v11 = iadd v9, v10  ; v10 = 4096
-;; @0049                               v12 = load.i32 little region0 v11
+;; @0049                               v12 = load.i32 little region1 v11
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -19,9 +19,10 @@
     i32.load offset=0xffff0000))
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -38,7 +39,7 @@
 ;; @0040                               v9 = iadd v8, v2
 ;; @0040                               v10 = iconst.i64 0xffff_0000
 ;; @0040                               v11 = iadd v9, v10  ; v10 = 0xffff_0000
-;; @0040                               store little region0 v3, v11
+;; @0040                               store little region1 v3, v11
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -46,9 +47,10 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -65,7 +67,7 @@
 ;; @004c                               v9 = iadd v8, v2
 ;; @004c                               v10 = iconst.i64 0xffff_0000
 ;; @004c                               v11 = iadd v9, v10  ; v10 = 0xffff_0000
-;; @004c                               v12 = load.i32 little region0 v11
+;; @004c                               v12 = load.i32 little region1 v11
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0_offset.wat
@@ -19,9 +19,10 @@
     i32.load8_u offset=0))
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -34,7 +35,7 @@
 ;; @0040                               trapnz v5, heap_oob
 ;; @0040                               v6 = load.i64 notrap aligned can_move v0+56
 ;; @0040                               v7 = iadd v6, v2
-;; @0040                               istore8 little region0 v3, v7
+;; @0040                               istore8 little region1 v3, v7
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -42,9 +43,10 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -57,7 +59,7 @@
 ;; @0048                               trapnz v5, heap_oob
 ;; @0048                               v6 = load.i64 notrap aligned can_move v0+56
 ;; @0048                               v7 = iadd v6, v2
-;; @0048                               v8 = uload8.i32 little region0 v7
+;; @0048                               v8 = uload8.i32 little region1 v7
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -19,9 +19,10 @@
     i32.load8_u offset=0x1000))
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -38,7 +39,7 @@
 ;; @0040                               v9 = iadd v8, v2
 ;; @0040                               v10 = iconst.i64 4096
 ;; @0040                               v11 = iadd v9, v10  ; v10 = 4096
-;; @0040                               istore8 little region0 v3, v11
+;; @0040                               istore8 little region1 v3, v11
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -46,9 +47,10 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -65,7 +67,7 @@
 ;; @0049                               v9 = iadd v8, v2
 ;; @0049                               v10 = iconst.i64 4096
 ;; @0049                               v11 = iadd v9, v10  ; v10 = 4096
-;; @0049                               v12 = uload8.i32 little region0 v11
+;; @0049                               v12 = uload8.i32 little region1 v11
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -19,9 +19,10 @@
     i32.load8_u offset=0xffff0000))
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -38,7 +39,7 @@
 ;; @0040                               v9 = iadd v8, v2
 ;; @0040                               v10 = iconst.i64 0xffff_0000
 ;; @0040                               v11 = iadd v9, v10  ; v10 = 0xffff_0000
-;; @0040                               istore8 little region0 v3, v11
+;; @0040                               istore8 little region1 v3, v11
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -46,9 +47,10 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -65,7 +67,7 @@
 ;; @004c                               v9 = iadd v8, v2
 ;; @004c                               v10 = iconst.i64 0xffff_0000
 ;; @004c                               v11 = iadd v9, v10  ; v10 = 0xffff_0000
-;; @004c                               v12 = uload8.i32 little region0 v11
+;; @004c                               v12 = uload8.i32 little region1 v11
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0_offset.wat
@@ -19,9 +19,10 @@
     i32.load offset=0))
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -37,7 +38,7 @@
 ;; @0040                               v9 = iadd v8, v2
 ;; @0040                               v10 = iconst.i64 0
 ;; @0040                               v11 = select_spectre_guard v7, v10, v9  ; v10 = 0
-;; @0040                               store little region0 v3, v11
+;; @0040                               store little region1 v3, v11
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -45,9 +46,10 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -63,7 +65,7 @@
 ;; @0048                               v9 = iadd v8, v2
 ;; @0048                               v10 = iconst.i64 0
 ;; @0048                               v11 = select_spectre_guard v7, v10, v9  ; v10 = 0
-;; @0048                               v12 = load.i32 little region0 v11
+;; @0048                               v12 = load.i32 little region1 v11
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -19,9 +19,10 @@
     i32.load offset=0x1000))
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -39,7 +40,7 @@
 ;; @0040                               v11 = iadd v9, v10  ; v10 = 4096
 ;; @0040                               v12 = iconst.i64 0
 ;; @0040                               v13 = select_spectre_guard v7, v12, v11  ; v12 = 0
-;; @0040                               store little region0 v3, v13
+;; @0040                               store little region1 v3, v13
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -47,9 +48,10 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -67,7 +69,7 @@
 ;; @0049                               v11 = iadd v9, v10  ; v10 = 4096
 ;; @0049                               v12 = iconst.i64 0
 ;; @0049                               v13 = select_spectre_guard v7, v12, v11  ; v12 = 0
-;; @0049                               v14 = load.i32 little region0 v13
+;; @0049                               v14 = load.i32 little region1 v13
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -19,9 +19,10 @@
     i32.load offset=0xffff0000))
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -39,7 +40,7 @@
 ;; @0040                               v11 = iadd v9, v10  ; v10 = 0xffff_0000
 ;; @0040                               v12 = iconst.i64 0
 ;; @0040                               v13 = select_spectre_guard v7, v12, v11  ; v12 = 0
-;; @0040                               store little region0 v3, v13
+;; @0040                               store little region1 v3, v13
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -47,9 +48,10 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -67,7 +69,7 @@
 ;; @004c                               v11 = iadd v9, v10  ; v10 = 0xffff_0000
 ;; @004c                               v12 = iconst.i64 0
 ;; @004c                               v13 = select_spectre_guard v7, v12, v11  ; v12 = 0
-;; @004c                               v14 = load.i32 little region0 v13
+;; @004c                               v14 = load.i32 little region1 v13
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0_offset.wat
@@ -19,9 +19,10 @@
     i32.load8_u offset=0))
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -35,7 +36,7 @@
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 0
 ;; @0040                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0
-;; @0040                               istore8 little region0 v3, v9
+;; @0040                               istore8 little region1 v3, v9
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -43,9 +44,10 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -59,7 +61,7 @@
 ;; @0048                               v7 = iadd v6, v2
 ;; @0048                               v8 = iconst.i64 0
 ;; @0048                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0
-;; @0048                               v10 = uload8.i32 little region0 v9
+;; @0048                               v10 = uload8.i32 little region1 v9
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -19,9 +19,10 @@
     i32.load8_u offset=0x1000))
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -39,7 +40,7 @@
 ;; @0040                               v11 = iadd v9, v10  ; v10 = 4096
 ;; @0040                               v12 = iconst.i64 0
 ;; @0040                               v13 = select_spectre_guard v7, v12, v11  ; v12 = 0
-;; @0040                               istore8 little region0 v3, v13
+;; @0040                               istore8 little region1 v3, v13
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -47,9 +48,10 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -67,7 +69,7 @@
 ;; @0049                               v11 = iadd v9, v10  ; v10 = 4096
 ;; @0049                               v12 = iconst.i64 0
 ;; @0049                               v13 = select_spectre_guard v7, v12, v11  ; v12 = 0
-;; @0049                               v14 = uload8.i32 little region0 v13
+;; @0049                               v14 = uload8.i32 little region1 v13
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -19,9 +19,10 @@
     i32.load8_u offset=0xffff0000))
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -39,7 +40,7 @@
 ;; @0040                               v11 = iadd v9, v10  ; v10 = 0xffff_0000
 ;; @0040                               v12 = iconst.i64 0
 ;; @0040                               v13 = select_spectre_guard v7, v12, v11  ; v12 = 0
-;; @0040                               istore8 little region0 v3, v13
+;; @0040                               istore8 little region1 v3, v13
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -47,9 +48,10 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -67,7 +69,7 @@
 ;; @004c                               v11 = iadd v9, v10  ; v10 = 0xffff_0000
 ;; @004c                               v12 = iconst.i64 0
 ;; @004c                               v13 = select_spectre_guard v7, v12, v11  ; v12 = 0
-;; @004c                               v14 = uload8.i32 little region0 v13
+;; @004c                               v14 = uload8.i32 little region1 v13
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
@@ -19,9 +19,10 @@
     i32.load offset=0))
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -34,7 +35,7 @@
 ;; @0040                               trapnz v5, heap_oob
 ;; @0040                               v6 = load.i64 notrap aligned can_move v0+56
 ;; @0040                               v7 = iadd v6, v2
-;; @0040                               store little region0 v3, v7
+;; @0040                               store little region1 v3, v7
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -42,9 +43,10 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -57,7 +59,7 @@
 ;; @0048                               trapnz v5, heap_oob
 ;; @0048                               v6 = load.i64 notrap aligned can_move v0+56
 ;; @0048                               v7 = iadd v6, v2
-;; @0048                               v8 = load.i32 little region0 v7
+;; @0048                               v8 = load.i32 little region1 v7
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -19,9 +19,10 @@
     i32.load offset=0x1000))
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -36,7 +37,7 @@
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 4096
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 4096
-;; @0040                               store little region0 v3, v9
+;; @0040                               store little region1 v3, v9
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -44,9 +45,10 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -61,7 +63,7 @@
 ;; @0049                               v7 = iadd v6, v2
 ;; @0049                               v8 = iconst.i64 4096
 ;; @0049                               v9 = iadd v7, v8  ; v8 = 4096
-;; @0049                               v10 = load.i32 little region0 v9
+;; @0049                               v10 = load.i32 little region1 v9
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -19,9 +19,10 @@
     i32.load offset=0xffff0000))
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -36,7 +37,7 @@
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 0xffff_0000
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
-;; @0040                               store little region0 v3, v9
+;; @0040                               store little region1 v3, v9
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -44,9 +45,10 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -61,7 +63,7 @@
 ;; @004c                               v7 = iadd v6, v2
 ;; @004c                               v8 = iconst.i64 0xffff_0000
 ;; @004c                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
-;; @004c                               v10 = load.i32 little region0 v9
+;; @004c                               v10 = load.i32 little region1 v9
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
@@ -19,9 +19,10 @@
     i32.load8_u offset=0))
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -34,7 +35,7 @@
 ;; @0040                               trapnz v5, heap_oob
 ;; @0040                               v6 = load.i64 notrap aligned can_move v0+56
 ;; @0040                               v7 = iadd v6, v2
-;; @0040                               istore8 little region0 v3, v7
+;; @0040                               istore8 little region1 v3, v7
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -42,9 +43,10 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -57,7 +59,7 @@
 ;; @0048                               trapnz v5, heap_oob
 ;; @0048                               v6 = load.i64 notrap aligned can_move v0+56
 ;; @0048                               v7 = iadd v6, v2
-;; @0048                               v8 = uload8.i32 little region0 v7
+;; @0048                               v8 = uload8.i32 little region1 v7
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -19,9 +19,10 @@
     i32.load8_u offset=0x1000))
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -36,7 +37,7 @@
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 4096
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 4096
-;; @0040                               istore8 little region0 v3, v9
+;; @0040                               istore8 little region1 v3, v9
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -44,9 +45,10 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -61,7 +63,7 @@
 ;; @0049                               v7 = iadd v6, v2
 ;; @0049                               v8 = iconst.i64 4096
 ;; @0049                               v9 = iadd v7, v8  ; v8 = 4096
-;; @0049                               v10 = uload8.i32 little region0 v9
+;; @0049                               v10 = uload8.i32 little region1 v9
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -19,9 +19,10 @@
     i32.load8_u offset=0xffff0000))
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -36,7 +37,7 @@
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 0xffff_0000
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
-;; @0040                               istore8 little region0 v3, v9
+;; @0040                               istore8 little region1 v3, v9
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -44,9 +45,10 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -61,7 +63,7 @@
 ;; @004c                               v7 = iadd v6, v2
 ;; @004c                               v8 = iconst.i64 0xffff_0000
 ;; @004c                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
-;; @004c                               v10 = uload8.i32 little region0 v9
+;; @004c                               v10 = uload8.i32 little region1 v9
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
@@ -19,9 +19,10 @@
     i32.load offset=0))
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -35,7 +36,7 @@
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 0
 ;; @0040                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0
-;; @0040                               store little region0 v3, v9
+;; @0040                               store little region1 v3, v9
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -43,9 +44,10 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -59,7 +61,7 @@
 ;; @0048                               v7 = iadd v6, v2
 ;; @0048                               v8 = iconst.i64 0
 ;; @0048                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0
-;; @0048                               v10 = load.i32 little region0 v9
+;; @0048                               v10 = load.i32 little region1 v9
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -19,9 +19,10 @@
     i32.load offset=0x1000))
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -37,7 +38,7 @@
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 4096
 ;; @0040                               v10 = iconst.i64 0
 ;; @0040                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
-;; @0040                               store little region0 v3, v11
+;; @0040                               store little region1 v3, v11
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -45,9 +46,10 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -63,7 +65,7 @@
 ;; @0049                               v9 = iadd v7, v8  ; v8 = 4096
 ;; @0049                               v10 = iconst.i64 0
 ;; @0049                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
-;; @0049                               v12 = load.i32 little region0 v11
+;; @0049                               v12 = load.i32 little region1 v11
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -19,9 +19,10 @@
     i32.load offset=0xffff0000))
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -37,7 +38,7 @@
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
 ;; @0040                               v10 = iconst.i64 0
 ;; @0040                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
-;; @0040                               store little region0 v3, v11
+;; @0040                               store little region1 v3, v11
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -45,9 +46,10 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -63,7 +65,7 @@
 ;; @004c                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
 ;; @004c                               v10 = iconst.i64 0
 ;; @004c                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
-;; @004c                               v12 = load.i32 little region0 v11
+;; @004c                               v12 = load.i32 little region1 v11
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
@@ -19,9 +19,10 @@
     i32.load8_u offset=0))
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -35,7 +36,7 @@
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 0
 ;; @0040                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0
-;; @0040                               istore8 little region0 v3, v9
+;; @0040                               istore8 little region1 v3, v9
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -43,9 +44,10 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -59,7 +61,7 @@
 ;; @0048                               v7 = iadd v6, v2
 ;; @0048                               v8 = iconst.i64 0
 ;; @0048                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0
-;; @0048                               v10 = uload8.i32 little region0 v9
+;; @0048                               v10 = uload8.i32 little region1 v9
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -19,9 +19,10 @@
     i32.load8_u offset=0x1000))
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -37,7 +38,7 @@
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 4096
 ;; @0040                               v10 = iconst.i64 0
 ;; @0040                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
-;; @0040                               istore8 little region0 v3, v11
+;; @0040                               istore8 little region1 v3, v11
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -45,9 +46,10 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -63,7 +65,7 @@
 ;; @0049                               v9 = iadd v7, v8  ; v8 = 4096
 ;; @0049                               v10 = iconst.i64 0
 ;; @0049                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
-;; @0049                               v12 = uload8.i32 little region0 v11
+;; @0049                               v12 = uload8.i32 little region1 v11
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -19,9 +19,10 @@
     i32.load8_u offset=0xffff0000))
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -37,7 +38,7 @@
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
 ;; @0040                               v10 = iconst.i64 0
 ;; @0040                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
-;; @0040                               istore8 little region0 v3, v11
+;; @0040                               istore8 little region1 v3, v11
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -45,9 +46,10 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -63,7 +65,7 @@
 ;; @004c                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
 ;; @004c                               v10 = iconst.i64 0
 ;; @004c                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
-;; @004c                               v12 = uload8.i32 little region0 v11
+;; @004c                               v12 = uload8.i32 little region1 v11
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0_offset.wat
@@ -19,9 +19,10 @@
     i32.load offset=0))
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -35,7 +36,7 @@
 ;; @0040                               trapnz v6, heap_oob
 ;; @0040                               v7 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0040                               v8 = iadd v7, v4
-;; @0040                               store little region0 v3, v8
+;; @0040                               store little region1 v3, v8
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -43,9 +44,10 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -59,7 +61,7 @@
 ;; @0048                               trapnz v6, heap_oob
 ;; @0048                               v7 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0048                               v8 = iadd v7, v4
-;; @0048                               v9 = load.i32 little region0 v8
+;; @0048                               v9 = load.i32 little region1 v8
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -19,9 +19,10 @@
     i32.load offset=0x1000))
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -37,7 +38,7 @@
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               v9 = iconst.i64 4096
 ;; @0040                               v10 = iadd v8, v9  ; v9 = 4096
-;; @0040                               store little region0 v3, v10
+;; @0040                               store little region1 v3, v10
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -45,9 +46,10 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -63,7 +65,7 @@
 ;; @0049                               v8 = iadd v7, v4
 ;; @0049                               v9 = iconst.i64 4096
 ;; @0049                               v10 = iadd v8, v9  ; v9 = 4096
-;; @0049                               v11 = load.i32 little region0 v10
+;; @0049                               v11 = load.i32 little region1 v10
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -19,9 +19,10 @@
     i32.load offset=0xffff0000))
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -37,7 +38,7 @@
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               v9 = iconst.i64 0xffff_0000
 ;; @0040                               v10 = iadd v8, v9  ; v9 = 0xffff_0000
-;; @0040                               store little region0 v3, v10
+;; @0040                               store little region1 v3, v10
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -45,9 +46,10 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -63,7 +65,7 @@
 ;; @004c                               v8 = iadd v7, v4
 ;; @004c                               v9 = iconst.i64 0xffff_0000
 ;; @004c                               v10 = iadd v8, v9  ; v9 = 0xffff_0000
-;; @004c                               v11 = load.i32 little region0 v10
+;; @004c                               v11 = load.i32 little region1 v10
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0_offset.wat
@@ -19,9 +19,10 @@
     i32.load8_u offset=0))
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -32,7 +33,7 @@
 ;; @0040                               v4 = uextend.i64 v2
 ;; @0040                               v5 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0040                               v6 = iadd v5, v4
-;; @0040                               istore8 little region0 v3, v6
+;; @0040                               istore8 little region1 v3, v6
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -40,9 +41,10 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -53,7 +55,7 @@
 ;; @0048                               v4 = uextend.i64 v2
 ;; @0048                               v5 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0048                               v6 = iadd v5, v4
-;; @0048                               v7 = uload8.i32 little region0 v6
+;; @0048                               v7 = uload8.i32 little region1 v6
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -19,9 +19,10 @@
     i32.load8_u offset=0x1000))
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -37,7 +38,7 @@
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               v9 = iconst.i64 4096
 ;; @0040                               v10 = iadd v8, v9  ; v9 = 4096
-;; @0040                               istore8 little region0 v3, v10
+;; @0040                               istore8 little region1 v3, v10
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -45,9 +46,10 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -63,7 +65,7 @@
 ;; @0049                               v8 = iadd v7, v4
 ;; @0049                               v9 = iconst.i64 4096
 ;; @0049                               v10 = iadd v8, v9  ; v9 = 4096
-;; @0049                               v11 = uload8.i32 little region0 v10
+;; @0049                               v11 = uload8.i32 little region1 v10
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -19,9 +19,10 @@
     i32.load8_u offset=0xffff0000))
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -37,7 +38,7 @@
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               v9 = iconst.i64 0xffff_0000
 ;; @0040                               v10 = iadd v8, v9  ; v9 = 0xffff_0000
-;; @0040                               istore8 little region0 v3, v10
+;; @0040                               istore8 little region1 v3, v10
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -45,9 +46,10 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -63,7 +65,7 @@
 ;; @004c                               v8 = iadd v7, v4
 ;; @004c                               v9 = iconst.i64 0xffff_0000
 ;; @004c                               v10 = iadd v8, v9  ; v9 = 0xffff_0000
-;; @004c                               v11 = uload8.i32 little region0 v10
+;; @004c                               v11 = uload8.i32 little region1 v10
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0_offset.wat
@@ -19,9 +19,10 @@
     i32.load offset=0))
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -36,7 +37,7 @@
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               v9 = iconst.i64 0
 ;; @0040                               v10 = select_spectre_guard v6, v9, v8  ; v9 = 0
-;; @0040                               store little region0 v3, v10
+;; @0040                               store little region1 v3, v10
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -44,9 +45,10 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -61,7 +63,7 @@
 ;; @0048                               v8 = iadd v7, v4
 ;; @0048                               v9 = iconst.i64 0
 ;; @0048                               v10 = select_spectre_guard v6, v9, v8  ; v9 = 0
-;; @0048                               v11 = load.i32 little region0 v10
+;; @0048                               v11 = load.i32 little region1 v10
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -19,9 +19,10 @@
     i32.load offset=0x1000))
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -38,7 +39,7 @@
 ;; @0040                               v10 = iadd v8, v9  ; v9 = 4096
 ;; @0040                               v11 = iconst.i64 0
 ;; @0040                               v12 = select_spectre_guard v6, v11, v10  ; v11 = 0
-;; @0040                               store little region0 v3, v12
+;; @0040                               store little region1 v3, v12
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -46,9 +47,10 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -65,7 +67,7 @@
 ;; @0049                               v10 = iadd v8, v9  ; v9 = 4096
 ;; @0049                               v11 = iconst.i64 0
 ;; @0049                               v12 = select_spectre_guard v6, v11, v10  ; v11 = 0
-;; @0049                               v13 = load.i32 little region0 v12
+;; @0049                               v13 = load.i32 little region1 v12
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -19,9 +19,10 @@
     i32.load offset=0xffff0000))
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -38,7 +39,7 @@
 ;; @0040                               v10 = iadd v8, v9  ; v9 = 0xffff_0000
 ;; @0040                               v11 = iconst.i64 0
 ;; @0040                               v12 = select_spectre_guard v6, v11, v10  ; v11 = 0
-;; @0040                               store little region0 v3, v12
+;; @0040                               store little region1 v3, v12
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -46,9 +47,10 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -65,7 +67,7 @@
 ;; @004c                               v10 = iadd v8, v9  ; v9 = 0xffff_0000
 ;; @004c                               v11 = iconst.i64 0
 ;; @004c                               v12 = select_spectre_guard v6, v11, v10  ; v11 = 0
-;; @004c                               v13 = load.i32 little region0 v12
+;; @004c                               v13 = load.i32 little region1 v12
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i8_access_0_offset.wat
@@ -19,9 +19,10 @@
     i32.load8_u offset=0))
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -32,7 +33,7 @@
 ;; @0040                               v4 = uextend.i64 v2
 ;; @0040                               v5 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0040                               v6 = iadd v5, v4
-;; @0040                               istore8 little region0 v3, v6
+;; @0040                               istore8 little region1 v3, v6
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -40,9 +41,10 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -53,7 +55,7 @@
 ;; @0048                               v4 = uextend.i64 v2
 ;; @0048                               v5 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0048                               v6 = iadd v5, v4
-;; @0048                               v7 = uload8.i32 little region0 v6
+;; @0048                               v7 = uload8.i32 little region1 v6
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -19,9 +19,10 @@
     i32.load8_u offset=0x1000))
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -38,7 +39,7 @@
 ;; @0040                               v10 = iadd v8, v9  ; v9 = 4096
 ;; @0040                               v11 = iconst.i64 0
 ;; @0040                               v12 = select_spectre_guard v6, v11, v10  ; v11 = 0
-;; @0040                               istore8 little region0 v3, v12
+;; @0040                               istore8 little region1 v3, v12
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -46,9 +47,10 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -65,7 +67,7 @@
 ;; @0049                               v10 = iadd v8, v9  ; v9 = 4096
 ;; @0049                               v11 = iconst.i64 0
 ;; @0049                               v12 = select_spectre_guard v6, v11, v10  ; v11 = 0
-;; @0049                               v13 = uload8.i32 little region0 v12
+;; @0049                               v13 = uload8.i32 little region1 v12
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -19,9 +19,10 @@
     i32.load8_u offset=0xffff0000))
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -38,7 +39,7 @@
 ;; @0040                               v10 = iadd v8, v9  ; v9 = 0xffff_0000
 ;; @0040                               v11 = iconst.i64 0
 ;; @0040                               v12 = select_spectre_guard v6, v11, v10  ; v11 = 0
-;; @0040                               istore8 little region0 v3, v12
+;; @0040                               istore8 little region1 v3, v12
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -46,9 +47,10 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -65,7 +67,7 @@
 ;; @004c                               v10 = iadd v8, v9  ; v9 = 0xffff_0000
 ;; @004c                               v11 = iconst.i64 0
 ;; @004c                               v12 = select_spectre_guard v6, v11, v10  ; v11 = 0
-;; @004c                               v13 = uload8.i32 little region0 v12
+;; @004c                               v13 = uload8.i32 little region1 v12
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
@@ -19,9 +19,10 @@
     i32.load offset=0))
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -32,7 +33,7 @@
 ;; @0040                               v4 = uextend.i64 v2
 ;; @0040                               v5 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0040                               v6 = iadd v5, v4
-;; @0040                               store little region0 v3, v6
+;; @0040                               store little region1 v3, v6
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -40,9 +41,10 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -53,7 +55,7 @@
 ;; @0048                               v4 = uextend.i64 v2
 ;; @0048                               v5 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0048                               v6 = iadd v5, v4
-;; @0048                               v7 = load.i32 little region0 v6
+;; @0048                               v7 = load.i32 little region1 v6
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -19,9 +19,10 @@
     i32.load offset=0x1000))
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -34,7 +35,7 @@
 ;; @0040                               v6 = iadd v5, v4
 ;; @0040                               v7 = iconst.i64 4096
 ;; @0040                               v8 = iadd v6, v7  ; v7 = 4096
-;; @0040                               store little region0 v3, v8
+;; @0040                               store little region1 v3, v8
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -42,9 +43,10 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -57,7 +59,7 @@
 ;; @0049                               v6 = iadd v5, v4
 ;; @0049                               v7 = iconst.i64 4096
 ;; @0049                               v8 = iadd v6, v7  ; v7 = 4096
-;; @0049                               v9 = load.i32 little region0 v8
+;; @0049                               v9 = load.i32 little region1 v8
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -19,9 +19,10 @@
     i32.load offset=0xffff0000))
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -34,7 +35,7 @@
 ;; @0040                               v6 = iadd v5, v4
 ;; @0040                               v7 = iconst.i64 0xffff_0000
 ;; @0040                               v8 = iadd v6, v7  ; v7 = 0xffff_0000
-;; @0040                               store little region0 v3, v8
+;; @0040                               store little region1 v3, v8
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -42,9 +43,10 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -57,7 +59,7 @@
 ;; @004c                               v6 = iadd v5, v4
 ;; @004c                               v7 = iconst.i64 0xffff_0000
 ;; @004c                               v8 = iadd v6, v7  ; v7 = 0xffff_0000
-;; @004c                               v9 = load.i32 little region0 v8
+;; @004c                               v9 = load.i32 little region1 v8
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
@@ -19,9 +19,10 @@
     i32.load8_u offset=0))
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -32,7 +33,7 @@
 ;; @0040                               v4 = uextend.i64 v2
 ;; @0040                               v5 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0040                               v6 = iadd v5, v4
-;; @0040                               istore8 little region0 v3, v6
+;; @0040                               istore8 little region1 v3, v6
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -40,9 +41,10 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -53,7 +55,7 @@
 ;; @0048                               v4 = uextend.i64 v2
 ;; @0048                               v5 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0048                               v6 = iadd v5, v4
-;; @0048                               v7 = uload8.i32 little region0 v6
+;; @0048                               v7 = uload8.i32 little region1 v6
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -19,9 +19,10 @@
     i32.load8_u offset=0x1000))
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -34,7 +35,7 @@
 ;; @0040                               v6 = iadd v5, v4
 ;; @0040                               v7 = iconst.i64 4096
 ;; @0040                               v8 = iadd v6, v7  ; v7 = 4096
-;; @0040                               istore8 little region0 v3, v8
+;; @0040                               istore8 little region1 v3, v8
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -42,9 +43,10 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -57,7 +59,7 @@
 ;; @0049                               v6 = iadd v5, v4
 ;; @0049                               v7 = iconst.i64 4096
 ;; @0049                               v8 = iadd v6, v7  ; v7 = 4096
-;; @0049                               v9 = uload8.i32 little region0 v8
+;; @0049                               v9 = uload8.i32 little region1 v8
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -19,9 +19,10 @@
     i32.load8_u offset=0xffff0000))
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -34,7 +35,7 @@
 ;; @0040                               v6 = iadd v5, v4
 ;; @0040                               v7 = iconst.i64 0xffff_0000
 ;; @0040                               v8 = iadd v6, v7  ; v7 = 0xffff_0000
-;; @0040                               istore8 little region0 v3, v8
+;; @0040                               istore8 little region1 v3, v8
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -42,9 +43,10 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -57,7 +59,7 @@
 ;; @004c                               v6 = iadd v5, v4
 ;; @004c                               v7 = iconst.i64 0xffff_0000
 ;; @004c                               v8 = iadd v6, v7  ; v7 = 0xffff_0000
-;; @004c                               v9 = uload8.i32 little region0 v8
+;; @004c                               v9 = uload8.i32 little region1 v8
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
@@ -19,9 +19,10 @@
     i32.load offset=0))
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -32,7 +33,7 @@
 ;; @0040                               v4 = uextend.i64 v2
 ;; @0040                               v5 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0040                               v6 = iadd v5, v4
-;; @0040                               store little region0 v3, v6
+;; @0040                               store little region1 v3, v6
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -40,9 +41,10 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -53,7 +55,7 @@
 ;; @0048                               v4 = uextend.i64 v2
 ;; @0048                               v5 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0048                               v6 = iadd v5, v4
-;; @0048                               v7 = load.i32 little region0 v6
+;; @0048                               v7 = load.i32 little region1 v6
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -19,9 +19,10 @@
     i32.load offset=0x1000))
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -34,7 +35,7 @@
 ;; @0040                               v6 = iadd v5, v4
 ;; @0040                               v7 = iconst.i64 4096
 ;; @0040                               v8 = iadd v6, v7  ; v7 = 4096
-;; @0040                               store little region0 v3, v8
+;; @0040                               store little region1 v3, v8
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -42,9 +43,10 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -57,7 +59,7 @@
 ;; @0049                               v6 = iadd v5, v4
 ;; @0049                               v7 = iconst.i64 4096
 ;; @0049                               v8 = iadd v6, v7  ; v7 = 4096
-;; @0049                               v9 = load.i32 little region0 v8
+;; @0049                               v9 = load.i32 little region1 v8
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -19,9 +19,10 @@
     i32.load offset=0xffff0000))
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -34,7 +35,7 @@
 ;; @0040                               v6 = iadd v5, v4
 ;; @0040                               v7 = iconst.i64 0xffff_0000
 ;; @0040                               v8 = iadd v6, v7  ; v7 = 0xffff_0000
-;; @0040                               store little region0 v3, v8
+;; @0040                               store little region1 v3, v8
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -42,9 +43,10 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -57,7 +59,7 @@
 ;; @004c                               v6 = iadd v5, v4
 ;; @004c                               v7 = iconst.i64 0xffff_0000
 ;; @004c                               v8 = iadd v6, v7  ; v7 = 0xffff_0000
-;; @004c                               v9 = load.i32 little region0 v8
+;; @004c                               v9 = load.i32 little region1 v8
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
@@ -19,9 +19,10 @@
     i32.load8_u offset=0))
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -32,7 +33,7 @@
 ;; @0040                               v4 = uextend.i64 v2
 ;; @0040                               v5 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0040                               v6 = iadd v5, v4
-;; @0040                               istore8 little region0 v3, v6
+;; @0040                               istore8 little region1 v3, v6
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -40,9 +41,10 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -53,7 +55,7 @@
 ;; @0048                               v4 = uextend.i64 v2
 ;; @0048                               v5 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0048                               v6 = iadd v5, v4
-;; @0048                               v7 = uload8.i32 little region0 v6
+;; @0048                               v7 = uload8.i32 little region1 v6
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -19,9 +19,10 @@
     i32.load8_u offset=0x1000))
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -34,7 +35,7 @@
 ;; @0040                               v6 = iadd v5, v4
 ;; @0040                               v7 = iconst.i64 4096
 ;; @0040                               v8 = iadd v6, v7  ; v7 = 4096
-;; @0040                               istore8 little region0 v3, v8
+;; @0040                               istore8 little region1 v3, v8
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -42,9 +43,10 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -57,7 +59,7 @@
 ;; @0049                               v6 = iadd v5, v4
 ;; @0049                               v7 = iconst.i64 4096
 ;; @0049                               v8 = iadd v6, v7  ; v7 = 4096
-;; @0049                               v9 = uload8.i32 little region0 v8
+;; @0049                               v9 = uload8.i32 little region1 v8
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -19,9 +19,10 @@
     i32.load8_u offset=0xffff0000))
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -34,7 +35,7 @@
 ;; @0040                               v6 = iadd v5, v4
 ;; @0040                               v7 = iconst.i64 0xffff_0000
 ;; @0040                               v8 = iadd v6, v7  ; v7 = 0xffff_0000
-;; @0040                               istore8 little region0 v3, v8
+;; @0040                               istore8 little region1 v3, v8
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -42,9 +43,10 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -57,7 +59,7 @@
 ;; @004c                               v6 = iadd v5, v4
 ;; @004c                               v7 = iconst.i64 0xffff_0000
 ;; @004c                               v8 = iadd v6, v7  ; v7 = 0xffff_0000
-;; @004c                               v9 = uload8.i32 little region0 v8
+;; @004c                               v9 = uload8.i32 little region1 v8
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0_offset.wat
@@ -19,9 +19,10 @@
     i32.load offset=0))
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -34,7 +35,7 @@
 ;; @0040                               trapnz v5, heap_oob
 ;; @0040                               v6 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0040                               v7 = iadd v6, v2
-;; @0040                               store little region0 v3, v7
+;; @0040                               store little region1 v3, v7
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -42,9 +43,10 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -57,7 +59,7 @@
 ;; @0048                               trapnz v5, heap_oob
 ;; @0048                               v6 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0048                               v7 = iadd v6, v2
-;; @0048                               v8 = load.i32 little region0 v7
+;; @0048                               v8 = load.i32 little region1 v7
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -19,9 +19,10 @@
     i32.load offset=0x1000))
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -36,7 +37,7 @@
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 4096
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 4096
-;; @0040                               store little region0 v3, v9
+;; @0040                               store little region1 v3, v9
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -44,9 +45,10 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -61,7 +63,7 @@
 ;; @0049                               v7 = iadd v6, v2
 ;; @0049                               v8 = iconst.i64 4096
 ;; @0049                               v9 = iadd v7, v8  ; v8 = 4096
-;; @0049                               v10 = load.i32 little region0 v9
+;; @0049                               v10 = load.i32 little region1 v9
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -19,9 +19,10 @@
     i32.load offset=0xffff0000))
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -36,7 +37,7 @@
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 0xffff_0000
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
-;; @0040                               store little region0 v3, v9
+;; @0040                               store little region1 v3, v9
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -44,9 +45,10 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -61,7 +63,7 @@
 ;; @004c                               v7 = iadd v6, v2
 ;; @004c                               v8 = iconst.i64 0xffff_0000
 ;; @004c                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
-;; @004c                               v10 = load.i32 little region0 v9
+;; @004c                               v10 = load.i32 little region1 v9
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0_offset.wat
@@ -19,9 +19,10 @@
     i32.load8_u offset=0))
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -34,7 +35,7 @@
 ;; @0040                               trapnz v5, heap_oob
 ;; @0040                               v6 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0040                               v7 = iadd v6, v2
-;; @0040                               istore8 little region0 v3, v7
+;; @0040                               istore8 little region1 v3, v7
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -42,9 +43,10 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -57,7 +59,7 @@
 ;; @0048                               trapnz v5, heap_oob
 ;; @0048                               v6 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0048                               v7 = iadd v6, v2
-;; @0048                               v8 = uload8.i32 little region0 v7
+;; @0048                               v8 = uload8.i32 little region1 v7
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -19,9 +19,10 @@
     i32.load8_u offset=0x1000))
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -36,7 +37,7 @@
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 4096
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 4096
-;; @0040                               istore8 little region0 v3, v9
+;; @0040                               istore8 little region1 v3, v9
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -44,9 +45,10 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -61,7 +63,7 @@
 ;; @0049                               v7 = iadd v6, v2
 ;; @0049                               v8 = iconst.i64 4096
 ;; @0049                               v9 = iadd v7, v8  ; v8 = 4096
-;; @0049                               v10 = uload8.i32 little region0 v9
+;; @0049                               v10 = uload8.i32 little region1 v9
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -19,9 +19,10 @@
     i32.load8_u offset=0xffff0000))
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -36,7 +37,7 @@
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 0xffff_0000
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
-;; @0040                               istore8 little region0 v3, v9
+;; @0040                               istore8 little region1 v3, v9
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -44,9 +45,10 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -61,7 +63,7 @@
 ;; @004c                               v7 = iadd v6, v2
 ;; @004c                               v8 = iconst.i64 0xffff_0000
 ;; @004c                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
-;; @004c                               v10 = uload8.i32 little region0 v9
+;; @004c                               v10 = uload8.i32 little region1 v9
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0_offset.wat
@@ -19,9 +19,10 @@
     i32.load offset=0))
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -35,7 +36,7 @@
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 0
 ;; @0040                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0
-;; @0040                               store little region0 v3, v9
+;; @0040                               store little region1 v3, v9
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -43,9 +44,10 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -59,7 +61,7 @@
 ;; @0048                               v7 = iadd v6, v2
 ;; @0048                               v8 = iconst.i64 0
 ;; @0048                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0
-;; @0048                               v10 = load.i32 little region0 v9
+;; @0048                               v10 = load.i32 little region1 v9
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -19,9 +19,10 @@
     i32.load offset=0x1000))
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -37,7 +38,7 @@
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 4096
 ;; @0040                               v10 = iconst.i64 0
 ;; @0040                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
-;; @0040                               store little region0 v3, v11
+;; @0040                               store little region1 v3, v11
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -45,9 +46,10 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -63,7 +65,7 @@
 ;; @0049                               v9 = iadd v7, v8  ; v8 = 4096
 ;; @0049                               v10 = iconst.i64 0
 ;; @0049                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
-;; @0049                               v12 = load.i32 little region0 v11
+;; @0049                               v12 = load.i32 little region1 v11
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -19,9 +19,10 @@
     i32.load offset=0xffff0000))
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -37,7 +38,7 @@
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
 ;; @0040                               v10 = iconst.i64 0
 ;; @0040                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
-;; @0040                               store little region0 v3, v11
+;; @0040                               store little region1 v3, v11
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -45,9 +46,10 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -63,7 +65,7 @@
 ;; @004c                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
 ;; @004c                               v10 = iconst.i64 0
 ;; @004c                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
-;; @004c                               v12 = load.i32 little region0 v11
+;; @004c                               v12 = load.i32 little region1 v11
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0_offset.wat
@@ -19,9 +19,10 @@
     i32.load8_u offset=0))
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -35,7 +36,7 @@
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 0
 ;; @0040                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0
-;; @0040                               istore8 little region0 v3, v9
+;; @0040                               istore8 little region1 v3, v9
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -43,9 +44,10 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -59,7 +61,7 @@
 ;; @0048                               v7 = iadd v6, v2
 ;; @0048                               v8 = iconst.i64 0
 ;; @0048                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0
-;; @0048                               v10 = uload8.i32 little region0 v9
+;; @0048                               v10 = uload8.i32 little region1 v9
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -19,9 +19,10 @@
     i32.load8_u offset=0x1000))
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -37,7 +38,7 @@
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 4096
 ;; @0040                               v10 = iconst.i64 0
 ;; @0040                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
-;; @0040                               istore8 little region0 v3, v11
+;; @0040                               istore8 little region1 v3, v11
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -45,9 +46,10 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -63,7 +65,7 @@
 ;; @0049                               v9 = iadd v7, v8  ; v8 = 4096
 ;; @0049                               v10 = iconst.i64 0
 ;; @0049                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
-;; @0049                               v12 = uload8.i32 little region0 v11
+;; @0049                               v12 = uload8.i32 little region1 v11
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -19,9 +19,10 @@
     i32.load8_u offset=0xffff0000))
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -37,7 +38,7 @@
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
 ;; @0040                               v10 = iconst.i64 0
 ;; @0040                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
-;; @0040                               istore8 little region0 v3, v11
+;; @0040                               istore8 little region1 v3, v11
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -45,9 +46,10 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -63,7 +65,7 @@
 ;; @004c                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
 ;; @004c                               v10 = iconst.i64 0
 ;; @004c                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
-;; @004c                               v12 = uload8.i32 little region0 v11
+;; @004c                               v12 = uload8.i32 little region1 v11
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
@@ -19,9 +19,10 @@
     i32.load offset=0))
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -34,7 +35,7 @@
 ;; @0040                               trapnz v5, heap_oob
 ;; @0040                               v6 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0040                               v7 = iadd v6, v2
-;; @0040                               store little region0 v3, v7
+;; @0040                               store little region1 v3, v7
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -42,9 +43,10 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -57,7 +59,7 @@
 ;; @0048                               trapnz v5, heap_oob
 ;; @0048                               v6 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0048                               v7 = iadd v6, v2
-;; @0048                               v8 = load.i32 little region0 v7
+;; @0048                               v8 = load.i32 little region1 v7
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -19,9 +19,10 @@
     i32.load offset=0x1000))
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -36,7 +37,7 @@
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 4096
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 4096
-;; @0040                               store little region0 v3, v9
+;; @0040                               store little region1 v3, v9
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -44,9 +45,10 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -61,7 +63,7 @@
 ;; @0049                               v7 = iadd v6, v2
 ;; @0049                               v8 = iconst.i64 4096
 ;; @0049                               v9 = iadd v7, v8  ; v8 = 4096
-;; @0049                               v10 = load.i32 little region0 v9
+;; @0049                               v10 = load.i32 little region1 v9
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -19,9 +19,10 @@
     i32.load offset=0xffff0000))
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -36,7 +37,7 @@
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 0xffff_0000
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
-;; @0040                               store little region0 v3, v9
+;; @0040                               store little region1 v3, v9
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -44,9 +45,10 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -61,7 +63,7 @@
 ;; @004c                               v7 = iadd v6, v2
 ;; @004c                               v8 = iconst.i64 0xffff_0000
 ;; @004c                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
-;; @004c                               v10 = load.i32 little region0 v9
+;; @004c                               v10 = load.i32 little region1 v9
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
@@ -19,9 +19,10 @@
     i32.load8_u offset=0))
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -34,7 +35,7 @@
 ;; @0040                               trapnz v5, heap_oob
 ;; @0040                               v6 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0040                               v7 = iadd v6, v2
-;; @0040                               istore8 little region0 v3, v7
+;; @0040                               istore8 little region1 v3, v7
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -42,9 +43,10 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -57,7 +59,7 @@
 ;; @0048                               trapnz v5, heap_oob
 ;; @0048                               v6 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0048                               v7 = iadd v6, v2
-;; @0048                               v8 = uload8.i32 little region0 v7
+;; @0048                               v8 = uload8.i32 little region1 v7
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -19,9 +19,10 @@
     i32.load8_u offset=0x1000))
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -36,7 +37,7 @@
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 4096
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 4096
-;; @0040                               istore8 little region0 v3, v9
+;; @0040                               istore8 little region1 v3, v9
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -44,9 +45,10 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -61,7 +63,7 @@
 ;; @0049                               v7 = iadd v6, v2
 ;; @0049                               v8 = iconst.i64 4096
 ;; @0049                               v9 = iadd v7, v8  ; v8 = 4096
-;; @0049                               v10 = uload8.i32 little region0 v9
+;; @0049                               v10 = uload8.i32 little region1 v9
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -19,9 +19,10 @@
     i32.load8_u offset=0xffff0000))
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -36,7 +37,7 @@
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 0xffff_0000
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
-;; @0040                               istore8 little region0 v3, v9
+;; @0040                               istore8 little region1 v3, v9
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -44,9 +45,10 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -61,7 +63,7 @@
 ;; @004c                               v7 = iadd v6, v2
 ;; @004c                               v8 = iconst.i64 0xffff_0000
 ;; @004c                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
-;; @004c                               v10 = uload8.i32 little region0 v9
+;; @004c                               v10 = uload8.i32 little region1 v9
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
@@ -19,9 +19,10 @@
     i32.load offset=0))
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -35,7 +36,7 @@
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 0
 ;; @0040                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0
-;; @0040                               store little region0 v3, v9
+;; @0040                               store little region1 v3, v9
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -43,9 +44,10 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -59,7 +61,7 @@
 ;; @0048                               v7 = iadd v6, v2
 ;; @0048                               v8 = iconst.i64 0
 ;; @0048                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0
-;; @0048                               v10 = load.i32 little region0 v9
+;; @0048                               v10 = load.i32 little region1 v9
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -19,9 +19,10 @@
     i32.load offset=0x1000))
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -37,7 +38,7 @@
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 4096
 ;; @0040                               v10 = iconst.i64 0
 ;; @0040                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
-;; @0040                               store little region0 v3, v11
+;; @0040                               store little region1 v3, v11
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -45,9 +46,10 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -63,7 +65,7 @@
 ;; @0049                               v9 = iadd v7, v8  ; v8 = 4096
 ;; @0049                               v10 = iconst.i64 0
 ;; @0049                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
-;; @0049                               v12 = load.i32 little region0 v11
+;; @0049                               v12 = load.i32 little region1 v11
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -19,9 +19,10 @@
     i32.load offset=0xffff0000))
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -37,7 +38,7 @@
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
 ;; @0040                               v10 = iconst.i64 0
 ;; @0040                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
-;; @0040                               store little region0 v3, v11
+;; @0040                               store little region1 v3, v11
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -45,9 +46,10 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -63,7 +65,7 @@
 ;; @004c                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
 ;; @004c                               v10 = iconst.i64 0
 ;; @004c                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
-;; @004c                               v12 = load.i32 little region0 v11
+;; @004c                               v12 = load.i32 little region1 v11
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
@@ -19,9 +19,10 @@
     i32.load8_u offset=0))
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -35,7 +36,7 @@
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 0
 ;; @0040                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0
-;; @0040                               istore8 little region0 v3, v9
+;; @0040                               istore8 little region1 v3, v9
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -43,9 +44,10 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -59,7 +61,7 @@
 ;; @0048                               v7 = iadd v6, v2
 ;; @0048                               v8 = iconst.i64 0
 ;; @0048                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0
-;; @0048                               v10 = uload8.i32 little region0 v9
+;; @0048                               v10 = uload8.i32 little region1 v9
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -19,9 +19,10 @@
     i32.load8_u offset=0x1000))
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -37,7 +38,7 @@
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 4096
 ;; @0040                               v10 = iconst.i64 0
 ;; @0040                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
-;; @0040                               istore8 little region0 v3, v11
+;; @0040                               istore8 little region1 v3, v11
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -45,9 +46,10 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -63,7 +65,7 @@
 ;; @0049                               v9 = iadd v7, v8  ; v8 = 4096
 ;; @0049                               v10 = iconst.i64 0
 ;; @0049                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
-;; @0049                               v12 = uload8.i32 little region0 v11
+;; @0049                               v12 = uload8.i32 little region1 v11
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -19,9 +19,10 @@
     i32.load8_u offset=0xffff0000))
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -37,7 +38,7 @@
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
 ;; @0040                               v10 = iconst.i64 0
 ;; @0040                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
-;; @0040                               istore8 little region0 v3, v11
+;; @0040                               istore8 little region1 v3, v11
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -45,9 +46,10 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -63,7 +65,7 @@
 ;; @004c                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
 ;; @004c                               v10 = iconst.i64 0
 ;; @004c                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
-;; @004c                               v12 = uload8.i32 little region0 v11
+;; @004c                               v12 = uload8.i32 little region1 v11
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/memory-copy-epochs.wat
+++ b/tests/disas/memory-copy-epochs.wat
@@ -9,8 +9,10 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32, i32) tail {
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 24 "VMContext+0x18"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -22,9 +24,9 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
-;; @001e                               v5 = load.i64 notrap aligned v0+24
+;; @001e                               v5 = load.i64 notrap aligned region1 v0+24
 ;; @001e                               v6 = load.i64 notrap aligned v5
-;; @001e                               v7 = load.i64 notrap aligned readonly can_move v0+8
+;; @001e                               v7 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @001e                               v8 = load.i64 notrap aligned v7+8
 ;; @001e                               v9 = icmp uge v6, v8
 ;; @001e                               brif v9, block3, block2(v8)

--- a/tests/disas/memory-copy-fuel.wat
+++ b/tests/disas/memory-copy-fuel.wat
@@ -9,8 +9,9 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32, i32) tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -22,7 +23,7 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
-;; @001e                               v5 = load.i64 notrap aligned readonly can_move v0+8
+;; @001e                               v5 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @001e                               v6 = load.i64 notrap aligned v5
 ;; @001e                               v7 = iconst.i64 1
 ;; @001e                               v8 = iadd v6, v7  ; v7 = 1

--- a/tests/disas/memory-copy-inline.wat
+++ b/tests/disas/memory-copy-inline.wat
@@ -12,8 +12,9 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64

--- a/tests/disas/memory-min-max-same.wat
+++ b/tests/disas/memory-min-max-same.wat
@@ -34,9 +34,12 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 96 "VMContext+0x60"
+;;     region2 = 80 "VMContext+0x50"
+;;     region3 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -46,8 +49,8 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0028                               v3 = iconst.i32 0
-;; @0030                               v7 = load.i64 notrap aligned readonly can_move v0+80
-;; @0030                               v6 = load.i64 notrap aligned readonly can_move v0+96
+;; @0030                               v7 = load.i64 notrap aligned readonly can_move region2 v0+80
+;; @0030                               v6 = load.i64 notrap aligned readonly can_move region1 v0+96
 ;; @0039                               v13 = iconst.i64 0x0001_0000
 ;; @0039                               v17 = iconst.i64 0
 ;; @0039                               v15 = load.i64 notrap aligned readonly can_move v0+56
@@ -64,7 +67,7 @@
 ;; @0039                               v16 = iadd.i64 v15, v12
 ;;                                     v25 = iconst.i64 0
 ;;                                     v26 = select_spectre_guard v24, v25, v16  ; v25 = 0
-;; @0039                               store little region0 v22, v26  ; v22 = 0
+;; @0039                               store little region3 v22, v26  ; v22 = 0
 ;;                                     v27 = iconst.i32 1
 ;;                                     v28 = iadd v9, v27  ; v27 = 1
 ;; @0043                               jump block2(v28)

--- a/tests/disas/memory.wat
+++ b/tests/disas/memory.wat
@@ -13,9 +13,10 @@
 )
 
 ;; function u0:0(i64 vmctx, i64) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -29,12 +30,12 @@
 ;; @0025                               v5 = uextend.i64 v3  ; v3 = 0
 ;; @0025                               v6 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0025                               v7 = iadd v6, v5
-;; @0025                               store little region0 v4, v7  ; v4 = 0
+;; @0025                               store little region1 v4, v7  ; v4 = 0
 ;; @0028                               v8 = iconst.i32 0
 ;; @002a                               v9 = uextend.i64 v8  ; v8 = 0
 ;; @002a                               v10 = load.i64 notrap aligned readonly can_move v0+56
 ;; @002a                               v11 = iadd v10, v9
-;; @002a                               v12 = load.i32 little region0 v11
+;; @002a                               v12 = load.i32 little region1 v11
 ;; @002d                               brif v12, block2, block4
 ;;
 ;;                                 block2:
@@ -43,7 +44,7 @@
 ;; @0033                               v15 = uextend.i64 v13  ; v13 = 0
 ;; @0033                               v16 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0033                               v17 = iadd v16, v15
-;; @0033                               store little region0 v14, v17  ; v14 = 10
+;; @0033                               store little region1 v14, v17  ; v14 = 10
 ;; @0036                               jump block3
 ;;
 ;;                                 block4:
@@ -52,7 +53,7 @@
 ;; @003b                               v20 = uextend.i64 v18  ; v18 = 0
 ;; @003b                               v21 = load.i64 notrap aligned readonly can_move v0+56
 ;; @003b                               v22 = iadd v21, v20
-;; @003b                               store little region0 v19, v22  ; v19 = 11
+;; @003b                               store little region1 v19, v22  ; v19 = 11
 ;; @003e                               jump block3
 ;;
 ;;                                 block3:

--- a/tests/disas/memory_copy_host64.wat
+++ b/tests/disas/memory_copy_host64.wat
@@ -50,8 +50,9 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32, i32) tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+88
@@ -82,8 +83,9 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32, i32, i32) tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+88
@@ -118,8 +120,9 @@
 ;; }
 ;;
 ;; function u0:2(i64 vmctx, i64, i64, i32, i32) tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+88
@@ -153,8 +156,9 @@
 ;; }
 ;;
 ;; function u0:3(i64 vmctx, i64, i64, i64, i64) tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+120
@@ -182,8 +186,9 @@
 ;; }
 ;;
 ;; function u0:4(i64 vmctx, i64, i64, i64, i64) tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+120
@@ -215,8 +220,9 @@
 ;; }
 ;;
 ;; function u0:5(i64 vmctx, i64, i32, i64, i32) tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+120

--- a/tests/disas/memory_fill_host64.wat
+++ b/tests/disas/memory_fill_host64.wat
@@ -44,8 +44,9 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
@@ -72,8 +73,9 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i64, i64) tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+112
@@ -98,8 +100,9 @@
 ;; }
 ;;
 ;; function u0:2(i64 vmctx, i64, i32, i32) tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+128
@@ -126,8 +129,9 @@
 ;; }
 ;;
 ;; function u0:3(i64 vmctx, i64, i64, i64) tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+144
@@ -152,8 +156,9 @@
 ;; }
 ;;
 ;; function u0:4(i64 vmctx, i64, i32, i32) tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+160

--- a/tests/disas/multi-0.wat
+++ b/tests/disas/multi-0.wat
@@ -5,8 +5,9 @@
     (local.get 0) (local.get 0)))
 
 ;; function u0:0(i64 vmctx, i64, i64) -> i64, i64 tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     stack_limit = gv2
 ;;

--- a/tests/disas/multi-1.wat
+++ b/tests/disas/multi-1.wat
@@ -8,8 +8,9 @@
       (f64.const 1234.5))))
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) -> i32, i64, f64 tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     stack_limit = gv2
 ;;

--- a/tests/disas/multi-10.wat
+++ b/tests/disas/multi-10.wat
@@ -12,8 +12,9 @@
         (i64.const -2)))))
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) -> i64, i64 tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     stack_limit = gv2
 ;;

--- a/tests/disas/multi-11.wat
+++ b/tests/disas/multi-11.wat
@@ -9,8 +9,9 @@
       return)))
 
 ;; function u0:0(i64 vmctx, i64, i64) -> i64, i64 tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     stack_limit = gv2
 ;;

--- a/tests/disas/multi-12.wat
+++ b/tests/disas/multi-12.wat
@@ -11,8 +11,9 @@
       return)))
 
 ;; function u0:0(i64 vmctx, i64, i64, i64, i64) -> i64, i64 tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     stack_limit = gv2
 ;;

--- a/tests/disas/multi-13.wat
+++ b/tests/disas/multi-13.wat
@@ -12,8 +12,9 @@
 )
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) -> i32 tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     stack_limit = gv2
 ;;

--- a/tests/disas/multi-14.wat
+++ b/tests/disas/multi-14.wat
@@ -12,8 +12,9 @@
 )
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) -> i32 tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     stack_limit = gv2
 ;;

--- a/tests/disas/multi-15.wat
+++ b/tests/disas/multi-15.wat
@@ -24,8 +24,9 @@
 )
 
 ;; function u0:0(i64 vmctx, i64, i32, i64, f32, f32, i32, f64, f32, i32, i32, i32, f32, f64, f64, f64, i32, i32, f32) -> f64, f32, i32, i32, i32, i64, f32, i32, i32, f32, f64, f64, i32, f32, i32, f64 tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     stack_limit = gv2
 ;;

--- a/tests/disas/multi-16.wat
+++ b/tests/disas/multi-16.wat
@@ -11,8 +11,9 @@
 )
 
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     stack_limit = gv2
 ;;

--- a/tests/disas/multi-17.wat
+++ b/tests/disas/multi-17.wat
@@ -28,8 +28,9 @@
   (export "main" (func $main)))
 
 ;; function u0:0(i64 vmctx, i64, i32, i32, i32) -> i32 tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     sig0 = (i64 vmctx, i64, i32, i32, i32) -> i32 tail
 ;;     fn0 = colocated u0:0 sig0

--- a/tests/disas/multi-2.wat
+++ b/tests/disas/multi-2.wat
@@ -8,8 +8,9 @@
        return)))
 
 ;; function u0:0(i64 vmctx, i64, i64, i64) -> i64, i64 tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     stack_limit = gv2
 ;;

--- a/tests/disas/multi-3.wat
+++ b/tests/disas/multi-3.wat
@@ -15,8 +15,9 @@
         (i64.const 0)))))
 
 ;; function u0:0(i64 vmctx, i64, i32, i64, i64) -> i64, i64 tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     stack_limit = gv2
 ;;

--- a/tests/disas/multi-4.wat
+++ b/tests/disas/multi-4.wat
@@ -15,8 +15,9 @@
         i64.const 2))))
 
 ;; function u0:0(i64 vmctx, i64, i32, i64, i64) -> i64, i64 tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     stack_limit = gv2
 ;;

--- a/tests/disas/multi-5.wat
+++ b/tests/disas/multi-5.wat
@@ -13,8 +13,9 @@
 )
 
 ;; function u0:0(i64 vmctx, i64) tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     stack_limit = gv2
 ;;

--- a/tests/disas/multi-6.wat
+++ b/tests/disas/multi-6.wat
@@ -13,8 +13,9 @@
 )
 
 ;; function u0:0(i64 vmctx, i64) tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     stack_limit = gv2
 ;;

--- a/tests/disas/multi-7.wat
+++ b/tests/disas/multi-7.wat
@@ -11,8 +11,9 @@
         (i64.const -1)))))
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) -> i64 tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     stack_limit = gv2
 ;;

--- a/tests/disas/multi-8.wat
+++ b/tests/disas/multi-8.wat
@@ -14,8 +14,9 @@
         (i64.const -2)))))
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) -> i64 tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     stack_limit = gv2
 ;;

--- a/tests/disas/multi-9.wat
+++ b/tests/disas/multi-9.wat
@@ -17,8 +17,9 @@
         (i64.const -2)))))
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) -> i64 tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     stack_limit = gv2
 ;;

--- a/tests/disas/non-fixed-size-memory.wat
+++ b/tests/disas/non-fixed-size-memory.wat
@@ -21,9 +21,10 @@
     i32.load8_u offset=0))
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -37,7 +38,7 @@
 ;; @0041                               trapnz v6, heap_oob
 ;; @0041                               v7 = load.i64 notrap aligned can_move v0+56
 ;; @0041                               v8 = iadd v7, v4
-;; @0041                               istore8 little region0 v3, v8
+;; @0041                               istore8 little region1 v3, v8
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -45,9 +46,10 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -61,7 +63,7 @@
 ;; @0049                               trapnz v6, heap_oob
 ;; @0049                               v7 = load.i64 notrap aligned can_move v0+56
 ;; @0049                               v8 = iadd v7, v4
-;; @0049                               v9 = uload8.i32 little region0 v8
+;; @0049                               v9 = uload8.i32 little region1 v8
 ;; @004c                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/nullref.wat
+++ b/tests/disas/nullref.wat
@@ -13,8 +13,9 @@
 )
 
 ;; function u0:0(i64 vmctx, i64) -> i32 tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     stack_limit = gv2
 ;;
@@ -27,8 +28,9 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64) -> i32 tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     stack_limit = gv2
 ;;

--- a/tests/disas/passive-data.wat
+++ b/tests/disas/passive-data.wat
@@ -14,8 +14,9 @@
     data.drop $passive))
 
 ;; function u0:0(i64 vmctx, i64, i32, i32, i32) tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -59,8 +60,9 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64) tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     stack_limit = gv2
 ;;

--- a/tests/disas/pic.wat
+++ b/tests/disas/pic.wat
@@ -48,9 +48,10 @@
   )
 )
 ;; function u0:0(i64 vmctx, i64) -> i32 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -61,7 +62,7 @@
 ;; @005e                               v7 = load.i64 notrap aligned readonly can_move v0+56
 ;;                                     v16 = iconst.i64 0x0010_0000
 ;; @005e                               v8 = iadd v7, v16  ; v16 = 0x0010_0000
-;; @005e                               v9 = load.i32 little region0 v8
+;; @005e                               v9 = load.i32 little region1 v8
 ;; @0061                               jump block1
 ;;
 ;;                                 block1:
@@ -69,10 +70,13 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 1879048192 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(0))"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 1879048192 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(0))"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region3 = 96 "VMContext+0x60"
+;;     region4 = 80 "VMContext+0x50"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -81,28 +85,28 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0066                               v6 = load.i32 notrap aligned region0 v0+128
+;; @0066                               v6 = load.i32 notrap aligned region1 v0+128
 ;; @0068                               v7 = iconst.i32 16
 ;; @006a                               v8 = isub v6, v7  ; v7 = 16
-;; @006d                               store notrap aligned region0 v8, v0+128
+;; @006d                               store notrap aligned region1 v8, v0+128
 ;; @0073                               v11 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0073                               v10 = uextend.i64 v2
 ;; @0073                               v12 = iadd v11, v10
-;; @0073                               v13 = load.i32 little region1 v12
+;; @0073                               v13 = load.i32 little region2 v12
 ;; @0078                               v14 = uextend.i64 v8
 ;; @0078                               v16 = iadd v11, v14
 ;; @0078                               v17 = iconst.i64 12
 ;; @0078                               v18 = iadd v16, v17  ; v17 = 12
-;; @0078                               store little region1 v13, v18
-;; @0084                               v24 = load.i64 notrap aligned readonly can_move v0+80
-;; @0084                               v23 = load.i64 notrap aligned readonly can_move v0+96
+;; @0078                               store little region2 v13, v18
+;; @0084                               v24 = load.i64 notrap aligned readonly can_move region4 v0+80
+;; @0084                               v23 = load.i64 notrap aligned readonly can_move region3 v0+96
 ;;                                     v36 = iconst.i32 -4
 ;;                                     v37 = iadd v6, v36  ; v36 = -4
 ;; @0084                               call_indirect sig0, v24(v23, v0, v37)
 ;;                                     v44 = iconst.i64 0x0010_0000
 ;; @0090                               v29 = iadd v11, v44  ; v44 = 0x0010_0000
-;; @0090                               store little region1 v13, v29
-;; @0098                               store notrap aligned region0 v6, v0+128
+;; @0090                               store little region2 v13, v29
+;; @0098                               store notrap aligned region1 v6, v0+128
 ;; @009c                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/pr2303.wat
+++ b/tests/disas/pr2303.wat
@@ -17,9 +17,10 @@
 )
 
 ;; function u0:0(i64 vmctx, i64, i32) tail {
-;;     region0 = 536870912 "PublicMemory"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 536870912 "PublicMemory"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -32,12 +33,12 @@
 ;; @003a                               v5 = uextend.i64 v4  ; v4 = 0
 ;; @003a                               v6 = load.i64 notrap aligned readonly can_move v0+56
 ;; @003a                               v7 = iadd v6, v5
-;; @003a                               v8 = load.i8x16 little region0 v7
+;; @003a                               v8 = load.i8x16 little region1 v7
 ;; @003e                               v9 = iconst.i32 16
 ;; @0040                               v10 = uextend.i64 v9  ; v9 = 16
 ;; @0040                               v11 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0040                               v12 = iadd v11, v10
-;; @0040                               v13 = load.i8x16 little region0 v12
+;; @0040                               v13 = load.i8x16 little region1 v12
 ;; @0046                               brif v2, block2, block4
 ;;
 ;;                                 block2:
@@ -48,7 +49,7 @@
 ;; @004d                               v20 = uextend.i64 v19  ; v19 = 32
 ;; @004d                               v21 = load.i64 notrap aligned readonly can_move v0+56
 ;; @004d                               v22 = iadd v21, v20
-;; @004d                               v23 = load.i8x16 little region0 v22
+;; @004d                               v23 = load.i8x16 little region1 v22
 ;; @0051                               v26 = bitcast.i8x16 little v18
 ;; @0051                               jump block3(v26, v23)
 ;;
@@ -60,7 +61,7 @@
 ;; @0057                               v31 = uextend.i64 v30  ; v30 = 0
 ;; @0057                               v32 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0057                               v33 = iadd v32, v31
-;; @0057                               v34 = load.i8x16 little region0 v33
+;; @0057                               v34 = load.i8x16 little region1 v33
 ;; @005b                               v35 = bitcast.i8x16 little v29
 ;; @005b                               jump block3(v35, v34)
 ;;
@@ -71,7 +72,7 @@
 ;; @005f                               v39 = uextend.i64 v3  ; v3 = 48
 ;; @005f                               v40 = load.i64 notrap aligned readonly can_move v0+56
 ;; @005f                               v41 = iadd v40, v39
-;; @005f                               store little region0 v38, v41
+;; @005f                               store little region1 v38, v41
 ;; @0063                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/pr2559.wat
+++ b/tests/disas/pr2559.wat
@@ -53,8 +53,9 @@
 )
 
 ;; function u0:0(i64 vmctx, i64) -> i8x16, i8x16, i8x16 tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     sig0 = (i64 vmctx, i64) -> i8x16, i8x16, i8x16 tail
 ;;     fn0 = colocated u0:0 sig0
@@ -93,8 +94,9 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64) -> i8x16, i8x16, i8x16 tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     sig0 = (i64 vmctx, i64) -> i8x16, i8x16, i8x16 tail
 ;;     fn0 = colocated u0:1 sig0

--- a/tests/disas/readonly-funcrefs.wat
+++ b/tests/disas/readonly-funcrefs.wat
@@ -19,8 +19,9 @@
 )
 
 ;; function u0:0(i64 vmctx, i64) tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     stack_limit = gv2
 ;;
@@ -32,9 +33,11 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) tail {
-;;     region0 = 1342177280 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 1342177280 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
+;;     region2 = 40 "VMContext+0x28"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned readonly can_move gv3+48
@@ -53,7 +56,7 @@
 ;; @0031                               v8 = ishl v5, v7  ; v7 = 3
 ;; @0031                               v9 = iadd v6, v8
 ;; @0031                               v11 = select_spectre_guard v4, v10, v9  ; v10 = 0
-;; @0031                               v12 = load.i64 user6 aligned region0 v11
+;; @0031                               v12 = load.i64 user6 aligned region1 v11
 ;; @0031                               v13 = iconst.i64 -2
 ;; @0031                               v14 = band v12, v13  ; v13 = -2
 ;; @0031                               brif v12, block3(v14), block2
@@ -65,7 +68,7 @@
 ;;
 ;;                                 block3(v15: i64):
 ;; @0031                               v21 = load.i32 user7 aligned readonly v15+16
-;; @0031                               v19 = load.i64 notrap aligned readonly can_move v0+40
+;; @0031                               v19 = load.i64 notrap aligned readonly can_move region2 v0+40
 ;; @0031                               v20 = load.i32 notrap aligned readonly can_move v19
 ;; @0031                               v22 = icmp eq v21, v20
 ;; @0031                               trapz v22, user8

--- a/tests/disas/readonly-heap-base-pointer1.wat
+++ b/tests/disas/readonly-heap-base-pointer1.wat
@@ -8,9 +8,10 @@
     (i32.load (local.get 0)))
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -25,7 +26,7 @@
 ;; @0020                               v7 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0020                               v8 = iadd v7, v4
 ;; @0020                               v10 = select_spectre_guard v6, v9, v8  ; v9 = 0
-;; @0020                               v11 = load.i32 little region0 v10
+;; @0020                               v11 = load.i32 little region1 v10
 ;; @0023                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/readonly-heap-base-pointer2.wat
+++ b/tests/disas/readonly-heap-base-pointer2.wat
@@ -8,12 +8,14 @@
     (i32.load (local.get 0)))
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 48 "VMContext+0x30"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+48
+;;     gv4 = load.i64 notrap aligned readonly can_move region1 gv3+48
 ;;     gv5 = load.i64 notrap aligned gv4+8
 ;;     gv6 = load.i64 notrap aligned readonly can_move gv4
 ;;     stack_limit = gv2
@@ -23,11 +25,11 @@
 ;; @0022                               v5 = iconst.i64 0x0001_fffc
 ;; @0022                               v6 = icmp ugt v4, v5  ; v5 = 0x0001_fffc
 ;; @0022                               v9 = iconst.i64 0
-;; @0022                               v12 = load.i64 notrap aligned readonly can_move v0+48
+;; @0022                               v12 = load.i64 notrap aligned readonly can_move region1 v0+48
 ;; @0022                               v7 = load.i64 notrap aligned readonly can_move v12
 ;; @0022                               v8 = iadd v7, v4
 ;; @0022                               v10 = select_spectre_guard v6, v9, v8  ; v9 = 0
-;; @0022                               v11 = load.i32 little region0 v10
+;; @0022                               v11 = load.i32 little region2 v10
 ;; @0025                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/readonly-heap-base-pointer3.wat
+++ b/tests/disas/readonly-heap-base-pointer3.wat
@@ -8,9 +8,10 @@
     (i32.load (local.get 0)))
 )
 ;; function u0:0(i64 vmctx, i64, i64) -> i32 tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -24,7 +25,7 @@
 ;; @0020                               v6 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0020                               v7 = iadd v6, v2
 ;; @0020                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0
-;; @0020                               v10 = load.i32 little region0 v9
+;; @0020                               v10 = load.i32 little region1 v9
 ;; @0023                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/ref-func-0.wat
+++ b/tests/disas/ref-func-0.wat
@@ -14,9 +14,10 @@
   (global (export "funcref-local") funcref (ref.func $local)))
 
 ;; function u0:0(i64 vmctx, i64) -> i32, i32, i64, i64 tail {
-;;     region0 = 1610612736 "PublicGlobal"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 1610612736 "PublicGlobal"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     stack_limit = gv2
@@ -28,8 +29,8 @@
 ;; @0091                               v11 = iconst.i64 96
 ;; @0091                               v12 = iadd v0, v11  ; v11 = 96
 ;; @0091                               v13 = load.i32 notrap aligned v12
-;; @0093                               v15 = load.i64 notrap aligned region0 v0+112
-;; @0095                               v17 = load.i64 notrap aligned region0 v0+128
+;; @0093                               v15 = load.i64 notrap aligned region1 v0+112
+;; @0095                               v17 = load.i64 notrap aligned region1 v0+128
 ;; @0097                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/riscv64-component-builtins.wat
+++ b/tests/disas/riscv64-component-builtins.wat
@@ -12,6 +12,7 @@
 
 ;; function u0:0(i64 vmctx, i64, i32) tail {
 ;;     region0 = 2 "vmctx"
+;;     region1 = 16 "VMContext+0x10"
 ;;     sig0 = (i64 sext, i32 sext, i32 sext, i32 sext) -> i64 sext system_v
 ;;     sig1 = (i64 sext vmctx) system_v
 ;;
@@ -34,7 +35,7 @@
 ;;     brif v15, block2, block1
 ;;
 ;; block1 cold:
-;;     v16 = load.i64 notrap aligned readonly v1+16
+;;     v16 = load.i64 notrap aligned readonly region1 v1+16
 ;;     v17 = load.i64 notrap aligned readonly v16+328
 ;;     call_indirect sig1, v17(v1)
 ;;     trap user1

--- a/tests/disas/select.wat
+++ b/tests/disas/select.wat
@@ -21,8 +21,9 @@
 )
 
 ;; function u0:0(i64 vmctx, i64) -> i32 tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     stack_limit = gv2
 ;;
@@ -38,8 +39,9 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64) -> i32 tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     stack_limit = gv2
 ;;
@@ -55,8 +57,9 @@
 ;; }
 ;;
 ;; function u0:2(i64 vmctx, i64, i32) -> i32 tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     stack_limit = gv2
 ;;

--- a/tests/disas/simd-store.wat
+++ b/tests/disas/simd-store.wat
@@ -85,9 +85,10 @@
 )
 
 ;; function u0:0(i64 vmctx, i64, i8x16) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -100,7 +101,7 @@
 ;; @0047                               v5 = uextend.i64 v3  ; v3 = 0
 ;; @0047                               v6 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0047                               v7 = iadd v6, v5
-;; @0047                               store little region0 v4, v7
+;; @0047                               store little region1 v4, v7
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:
@@ -108,9 +109,10 @@
 ;; }
 ;;
 ;; function u0:10(i64 vmctx, i64, i8x16) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -125,7 +127,7 @@
 ;; @00df                               v7 = uextend.i64 v3  ; v3 = 0
 ;; @00df                               v8 = load.i64 notrap aligned readonly can_move v0+56
 ;; @00df                               v9 = iadd v8, v7
-;; @00df                               store little region0 v6, v9
+;; @00df                               store little region1 v6, v9
 ;; @00e3                               jump block1
 ;;
 ;;                                 block1:
@@ -133,9 +135,10 @@
 ;; }
 ;;
 ;; function u0:11(i64 vmctx, i64, i8x16) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -150,7 +153,7 @@
 ;; @00ef                               v7 = uextend.i64 v3  ; v3 = 0
 ;; @00ef                               v8 = load.i64 notrap aligned readonly can_move v0+56
 ;; @00ef                               v9 = iadd v8, v7
-;; @00ef                               store little region0 v6, v9
+;; @00ef                               store little region1 v6, v9
 ;; @00f3                               jump block1
 ;;
 ;;                                 block1:
@@ -158,9 +161,10 @@
 ;; }
 ;;
 ;; function u0:12(i64 vmctx, i64, i8x16) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -173,7 +177,7 @@
 ;; @00fe                               v5 = uextend.i64 v3  ; v3 = 0
 ;; @00fe                               v6 = load.i64 notrap aligned readonly can_move v0+56
 ;; @00fe                               v7 = iadd v6, v5
-;; @00fe                               store little region0 v4, v7
+;; @00fe                               store little region1 v4, v7
 ;; @0102                               jump block1
 ;;
 ;;                                 block1:
@@ -181,9 +185,10 @@
 ;; }
 ;;
 ;; function u0:13(i64 vmctx, i64, i8x16) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -198,7 +203,7 @@
 ;; @010d                               v7 = uextend.i64 v3  ; v3 = 0
 ;; @010d                               v8 = load.i64 notrap aligned readonly can_move v0+56
 ;; @010d                               v9 = iadd v8, v7
-;; @010d                               store little region0 v6, v9
+;; @010d                               store little region1 v6, v9
 ;; @0111                               jump block1
 ;;
 ;;                                 block1:
@@ -206,9 +211,10 @@
 ;; }
 ;;
 ;; function u0:14(i64 vmctx, i64, i8x16) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -223,7 +229,7 @@
 ;; @011c                               v7 = uextend.i64 v3  ; v3 = 0
 ;; @011c                               v8 = load.i64 notrap aligned readonly can_move v0+56
 ;; @011c                               v9 = iadd v8, v7
-;; @011c                               store little region0 v6, v9
+;; @011c                               store little region1 v6, v9
 ;; @0120                               jump block1
 ;;
 ;;                                 block1:
@@ -231,9 +237,10 @@
 ;; }
 ;;
 ;; function u0:15(i64 vmctx, i64, i8x16) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -246,7 +253,7 @@
 ;; @012b                               v5 = uextend.i64 v3  ; v3 = 0
 ;; @012b                               v6 = load.i64 notrap aligned readonly can_move v0+56
 ;; @012b                               v7 = iadd v6, v5
-;; @012b                               store little region0 v4, v7
+;; @012b                               store little region1 v4, v7
 ;; @012f                               jump block1
 ;;
 ;;                                 block1:
@@ -254,9 +261,10 @@
 ;; }
 ;;
 ;; function u0:16(i64 vmctx, i64, i8x16) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -271,7 +279,7 @@
 ;; @013a                               v7 = uextend.i64 v3  ; v3 = 0
 ;; @013a                               v8 = load.i64 notrap aligned readonly can_move v0+56
 ;; @013a                               v9 = iadd v8, v7
-;; @013a                               store little region0 v6, v9
+;; @013a                               store little region1 v6, v9
 ;; @013e                               jump block1
 ;;
 ;;                                 block1:
@@ -279,9 +287,10 @@
 ;; }
 ;;
 ;; function u0:17(i64 vmctx, i64, i8x16) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -296,7 +305,7 @@
 ;; @0149                               v7 = uextend.i64 v3  ; v3 = 0
 ;; @0149                               v8 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0149                               v9 = iadd v8, v7
-;; @0149                               store little region0 v6, v9
+;; @0149                               store little region1 v6, v9
 ;; @014d                               jump block1
 ;;
 ;;                                 block1:
@@ -304,9 +313,10 @@
 ;; }
 ;;
 ;; function u0:18(i64 vmctx, i64, i8x16) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -321,7 +331,7 @@
 ;; @0159                               v7 = uextend.i64 v3  ; v3 = 0
 ;; @0159                               v8 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0159                               v9 = iadd v8, v7
-;; @0159                               store little region0 v6, v9
+;; @0159                               store little region1 v6, v9
 ;; @015d                               jump block1
 ;;
 ;;                                 block1:
@@ -329,9 +339,10 @@
 ;; }
 ;;
 ;; function u0:19(i64 vmctx, i64, i8x16) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -344,7 +355,7 @@
 ;; @0168                               v5 = uextend.i64 v3  ; v3 = 0
 ;; @0168                               v6 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0168                               v7 = iadd v6, v5
-;; @0168                               store little region0 v4, v7
+;; @0168                               store little region1 v4, v7
 ;; @016c                               jump block1
 ;;
 ;;                                 block1:
@@ -352,9 +363,10 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i8x16) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -369,7 +381,7 @@
 ;; @0056                               v7 = uextend.i64 v3  ; v3 = 0
 ;; @0056                               v8 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0056                               v9 = iadd v8, v7
-;; @0056                               store little region0 v6, v9
+;; @0056                               store little region1 v6, v9
 ;; @005a                               jump block1
 ;;
 ;;                                 block1:
@@ -377,9 +389,10 @@
 ;; }
 ;;
 ;; function u0:20(i64 vmctx, i64, i8x16) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -394,7 +407,7 @@
 ;; @0177                               v7 = uextend.i64 v3  ; v3 = 0
 ;; @0177                               v8 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0177                               v9 = iadd v8, v7
-;; @0177                               store little region0 v6, v9
+;; @0177                               store little region1 v6, v9
 ;; @017b                               jump block1
 ;;
 ;;                                 block1:
@@ -402,9 +415,10 @@
 ;; }
 ;;
 ;; function u0:21(i64 vmctx, i64, i8x16) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -419,7 +433,7 @@
 ;; @0186                               v7 = uextend.i64 v3  ; v3 = 0
 ;; @0186                               v8 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0186                               v9 = iadd v8, v7
-;; @0186                               store little region0 v6, v9
+;; @0186                               store little region1 v6, v9
 ;; @018a                               jump block1
 ;;
 ;;                                 block1:
@@ -427,9 +441,10 @@
 ;; }
 ;;
 ;; function u0:22(i64 vmctx, i64, i8x16) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -444,7 +459,7 @@
 ;; @0195                               v7 = uextend.i64 v3  ; v3 = 0
 ;; @0195                               v8 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0195                               v9 = iadd v8, v7
-;; @0195                               store little region0 v6, v9
+;; @0195                               store little region1 v6, v9
 ;; @0199                               jump block1
 ;;
 ;;                                 block1:
@@ -452,9 +467,10 @@
 ;; }
 ;;
 ;; function u0:23(i64 vmctx, i64, i8x16) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -469,7 +485,7 @@
 ;; @01a4                               v7 = uextend.i64 v3  ; v3 = 0
 ;; @01a4                               v8 = load.i64 notrap aligned readonly can_move v0+56
 ;; @01a4                               v9 = iadd v8, v7
-;; @01a4                               store little region0 v6, v9
+;; @01a4                               store little region1 v6, v9
 ;; @01a8                               jump block1
 ;;
 ;;                                 block1:
@@ -477,9 +493,10 @@
 ;; }
 ;;
 ;; function u0:24(i64 vmctx, i64, i8x16) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -494,7 +511,7 @@
 ;; @01b3                               v7 = uextend.i64 v3  ; v3 = 0
 ;; @01b3                               v8 = load.i64 notrap aligned readonly can_move v0+56
 ;; @01b3                               v9 = iadd v8, v7
-;; @01b3                               store little region0 v6, v9
+;; @01b3                               store little region1 v6, v9
 ;; @01b7                               jump block1
 ;;
 ;;                                 block1:
@@ -502,9 +519,10 @@
 ;; }
 ;;
 ;; function u0:25(i64 vmctx, i64, i8x16) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -519,7 +537,7 @@
 ;; @01c2                               v7 = uextend.i64 v3  ; v3 = 0
 ;; @01c2                               v8 = load.i64 notrap aligned readonly can_move v0+56
 ;; @01c2                               v9 = iadd v8, v7
-;; @01c2                               store little region0 v6, v9
+;; @01c2                               store little region1 v6, v9
 ;; @01c6                               jump block1
 ;;
 ;;                                 block1:
@@ -527,9 +545,10 @@
 ;; }
 ;;
 ;; function u0:26(i64 vmctx, i64, i8x16) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -544,7 +563,7 @@
 ;; @01d1                               v7 = uextend.i64 v3  ; v3 = 0
 ;; @01d1                               v8 = load.i64 notrap aligned readonly can_move v0+56
 ;; @01d1                               v9 = iadd v8, v7
-;; @01d1                               store little region0 v6, v9
+;; @01d1                               store little region1 v6, v9
 ;; @01d5                               jump block1
 ;;
 ;;                                 block1:
@@ -552,9 +571,10 @@
 ;; }
 ;;
 ;; function u0:27(i64 vmctx, i64, i8x16) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -569,7 +589,7 @@
 ;; @01e0                               v7 = uextend.i64 v3  ; v3 = 0
 ;; @01e0                               v8 = load.i64 notrap aligned readonly can_move v0+56
 ;; @01e0                               v9 = iadd v8, v7
-;; @01e0                               store little region0 v6, v9
+;; @01e0                               store little region1 v6, v9
 ;; @01e4                               jump block1
 ;;
 ;;                                 block1:
@@ -577,9 +597,10 @@
 ;; }
 ;;
 ;; function u0:28(i64 vmctx, i64, i8x16) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -594,7 +615,7 @@
 ;; @01ef                               v7 = uextend.i64 v3  ; v3 = 0
 ;; @01ef                               v8 = load.i64 notrap aligned readonly can_move v0+56
 ;; @01ef                               v9 = iadd v8, v7
-;; @01ef                               store little region0 v6, v9
+;; @01ef                               store little region1 v6, v9
 ;; @01f3                               jump block1
 ;;
 ;;                                 block1:
@@ -602,9 +623,10 @@
 ;; }
 ;;
 ;; function u0:29(i64 vmctx, i64, i8x16) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -619,7 +641,7 @@
 ;; @01fe                               v7 = uextend.i64 v3  ; v3 = 0
 ;; @01fe                               v8 = load.i64 notrap aligned readonly can_move v0+56
 ;; @01fe                               v9 = iadd v8, v7
-;; @01fe                               store little region0 v6, v9
+;; @01fe                               store little region1 v6, v9
 ;; @0202                               jump block1
 ;;
 ;;                                 block1:
@@ -627,9 +649,10 @@
 ;; }
 ;;
 ;; function u0:2(i64 vmctx, i64, i8x16) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -644,7 +667,7 @@
 ;; @0065                               v7 = uextend.i64 v3  ; v3 = 0
 ;; @0065                               v8 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0065                               v9 = iadd v8, v7
-;; @0065                               store little region0 v6, v9
+;; @0065                               store little region1 v6, v9
 ;; @0069                               jump block1
 ;;
 ;;                                 block1:
@@ -652,9 +675,10 @@
 ;; }
 ;;
 ;; function u0:30(i64 vmctx, i64, i8x16) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -669,7 +693,7 @@
 ;; @020d                               v7 = uextend.i64 v3  ; v3 = 0
 ;; @020d                               v8 = load.i64 notrap aligned readonly can_move v0+56
 ;; @020d                               v9 = iadd v8, v7
-;; @020d                               store little region0 v6, v9
+;; @020d                               store little region1 v6, v9
 ;; @0211                               jump block1
 ;;
 ;;                                 block1:
@@ -677,9 +701,10 @@
 ;; }
 ;;
 ;; function u0:31(i64 vmctx, i64, i8x16) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -694,7 +719,7 @@
 ;; @021c                               v7 = uextend.i64 v3  ; v3 = 0
 ;; @021c                               v8 = load.i64 notrap aligned readonly can_move v0+56
 ;; @021c                               v9 = iadd v8, v7
-;; @021c                               store little region0 v6, v9
+;; @021c                               store little region1 v6, v9
 ;; @0220                               jump block1
 ;;
 ;;                                 block1:
@@ -702,9 +727,10 @@
 ;; }
 ;;
 ;; function u0:32(i64 vmctx, i64, i8x16) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -719,7 +745,7 @@
 ;; @022b                               v7 = uextend.i64 v3  ; v3 = 0
 ;; @022b                               v8 = load.i64 notrap aligned readonly can_move v0+56
 ;; @022b                               v9 = iadd v8, v7
-;; @022b                               store little region0 v6, v9
+;; @022b                               store little region1 v6, v9
 ;; @022f                               jump block1
 ;;
 ;;                                 block1:
@@ -727,9 +753,10 @@
 ;; }
 ;;
 ;; function u0:33(i64 vmctx, i64, i8x16) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -744,7 +771,7 @@
 ;; @023a                               v7 = uextend.i64 v3  ; v3 = 0
 ;; @023a                               v8 = load.i64 notrap aligned readonly can_move v0+56
 ;; @023a                               v9 = iadd v8, v7
-;; @023a                               store little region0 v6, v9
+;; @023a                               store little region1 v6, v9
 ;; @023e                               jump block1
 ;;
 ;;                                 block1:
@@ -752,9 +779,10 @@
 ;; }
 ;;
 ;; function u0:3(i64 vmctx, i64, i8x16) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -769,7 +797,7 @@
 ;; @0075                               v7 = uextend.i64 v3  ; v3 = 0
 ;; @0075                               v8 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0075                               v9 = iadd v8, v7
-;; @0075                               store little region0 v6, v9
+;; @0075                               store little region1 v6, v9
 ;; @0079                               jump block1
 ;;
 ;;                                 block1:
@@ -777,9 +805,10 @@
 ;; }
 ;;
 ;; function u0:4(i64 vmctx, i64, i8x16) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -792,7 +821,7 @@
 ;; @0084                               v5 = uextend.i64 v3  ; v3 = 0
 ;; @0084                               v6 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0084                               v7 = iadd v6, v5
-;; @0084                               store little region0 v4, v7
+;; @0084                               store little region1 v4, v7
 ;; @0088                               jump block1
 ;;
 ;;                                 block1:
@@ -800,9 +829,10 @@
 ;; }
 ;;
 ;; function u0:5(i64 vmctx, i64, i8x16) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -817,7 +847,7 @@
 ;; @0093                               v7 = uextend.i64 v3  ; v3 = 0
 ;; @0093                               v8 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0093                               v9 = iadd v8, v7
-;; @0093                               store little region0 v6, v9
+;; @0093                               store little region1 v6, v9
 ;; @0097                               jump block1
 ;;
 ;;                                 block1:
@@ -825,9 +855,10 @@
 ;; }
 ;;
 ;; function u0:6(i64 vmctx, i64, i8x16) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -842,7 +873,7 @@
 ;; @00a2                               v7 = uextend.i64 v3  ; v3 = 0
 ;; @00a2                               v8 = load.i64 notrap aligned readonly can_move v0+56
 ;; @00a2                               v9 = iadd v8, v7
-;; @00a2                               store little region0 v6, v9
+;; @00a2                               store little region1 v6, v9
 ;; @00a6                               jump block1
 ;;
 ;;                                 block1:
@@ -850,9 +881,10 @@
 ;; }
 ;;
 ;; function u0:7(i64 vmctx, i64, i8x16) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -867,7 +899,7 @@
 ;; @00b2                               v7 = uextend.i64 v3  ; v3 = 0
 ;; @00b2                               v8 = load.i64 notrap aligned readonly can_move v0+56
 ;; @00b2                               v9 = iadd v8, v7
-;; @00b2                               store little region0 v6, v9
+;; @00b2                               store little region1 v6, v9
 ;; @00b6                               jump block1
 ;;
 ;;                                 block1:
@@ -875,9 +907,10 @@
 ;; }
 ;;
 ;; function u0:8(i64 vmctx, i64, i8x16) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -890,7 +923,7 @@
 ;; @00c1                               v5 = uextend.i64 v3  ; v3 = 0
 ;; @00c1                               v6 = load.i64 notrap aligned readonly can_move v0+56
 ;; @00c1                               v7 = iadd v6, v5
-;; @00c1                               store little region0 v4, v7
+;; @00c1                               store little region1 v4, v7
 ;; @00c5                               jump block1
 ;;
 ;;                                 block1:
@@ -898,9 +931,10 @@
 ;; }
 ;;
 ;; function u0:9(i64 vmctx, i64, i8x16) tail {
-;;     region0 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+64
@@ -915,7 +949,7 @@
 ;; @00d0                               v7 = uextend.i64 v3  ; v3 = 0
 ;; @00d0                               v8 = load.i64 notrap aligned readonly can_move v0+56
 ;; @00d0                               v9 = iadd v8, v7
-;; @00d0                               store little region0 v6, v9
+;; @00d0                               store little region1 v6, v9
 ;; @00d4                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/simd.wat
+++ b/tests/disas/simd.wat
@@ -31,8 +31,9 @@
 )
 
 ;; function u0:0(i64 vmctx, i64) -> i32 tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     stack_limit = gv2
 ;;
@@ -47,8 +48,9 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64) -> i32 tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     const0 = 0x00000000000000000000000000000000
 ;;     stack_limit = gv2
@@ -66,8 +68,9 @@
 ;; }
 ;;
 ;; function u0:2(i64 vmctx, i64) -> i32 tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     const0 = 0x00000004000000030000000200000001
 ;;     stack_limit = gv2
@@ -83,8 +86,9 @@
 ;; }
 ;;
 ;; function u0:3(i64 vmctx, i64) tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     const0 = 0x00000000000000000000000000000000
 ;;     stack_limit = gv2

--- a/tests/disas/simple.wat
+++ b/tests/disas/simple.wat
@@ -19,8 +19,9 @@
     )
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     stack_limit = gv2
 ;;
@@ -34,8 +35,9 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     stack_limit = gv2
 ;;
@@ -46,8 +48,9 @@
 ;; }
 ;;
 ;; function u0:2(i64 vmctx, i64) -> i32 tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     stack_limit = gv2
 ;;

--- a/tests/disas/stack-switching/resume-suspend-data-passing.wat
+++ b/tests/disas/stack-switching/resume-suspend-data-passing.wat
@@ -39,8 +39,9 @@
 
 ;; function u0:0(i64 vmctx, i64) tail {
 ;;     ss0 = explicit_slot 16, align = 65536
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     stack_limit = gv2
 ;;
@@ -56,7 +57,7 @@
 ;; @0040                               jump block2(v3)  ; v3 = 10
 ;;
 ;;                                 block2(v4: i32):
-;; @0044                               v7 = load.i64 notrap aligned v0+8
+;; @0044                               v7 = load.i64 notrap aligned region0 v0+8
 ;; @0044                               v8 = load.i64 notrap aligned v7+88
 ;; @0044                               v9 = load.i64 notrap aligned v7+96
 ;; @0044                               v12 = iconst.i64 1
@@ -145,8 +146,9 @@
 ;;
 ;; function u0:1(i64 vmctx, i64) tail {
 ;;     ss0 = explicit_slot 8, align = 256
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     sig0 = (i64 vmctx, i32) -> i64 tail
 ;;     sig1 = (i64 vmctx, i64, i32, i32) -> i64 tail
@@ -197,14 +199,14 @@
 ;;                                     v127 = iadd v22, v126  ; v126 = 1
 ;; @0062                               store notrap aligned v127, v17+72
 ;; @0062                               v26 = load.i64 notrap aligned v17+64
-;; @0062                               v27 = load.i64 notrap aligned v0+8
+;; @0062                               v27 = load.i64 notrap aligned region0 v0+8
 ;; @0062                               v28 = load.i64 notrap aligned v27+88
 ;; @0062                               v29 = load.i64 notrap aligned v27+96
 ;; @0062                               store notrap aligned v28, v26+48
 ;; @0062                               store notrap aligned v29, v26+56
 ;;                                     v128 = iconst.i64 0
 ;; @0062                               store notrap aligned v128, v17+64  ; v128 = 0
-;; @0062                               v32 = load.i64 notrap aligned v0+8
+;; @0062                               v32 = load.i64 notrap aligned region0 v0+8
 ;;                                     v129 = iconst.i64 2
 ;; @0062                               store notrap aligned v129, v32+88  ; v129 = 2
 ;; @0062                               store notrap aligned v17, v32+96
@@ -215,7 +217,7 @@
 ;;                                     v133 = iconst.i32 2
 ;;                                     v134 = iadd v29, v131  ; v131 = 16
 ;; @0062                               store notrap aligned v133, v134  ; v133 = 2
-;; @0062                               v41 = load.i64 notrap aligned readonly v0+8
+;; @0062                               v41 = load.i64 notrap aligned readonly region0 v0+8
 ;; @0062                               v44 = load.i64 notrap aligned v41+72
 ;; @0062                               store notrap aligned v44, v29+8
 ;; @0062                               v45 = load.i64 notrap aligned v41+24
@@ -239,7 +241,7 @@
 ;;                                     v141 = iadd v64, v140  ; v140 = -24
 ;;                                     v142 = iconst.i64 0x0001_0000_0000
 ;; @0062                               v67 = stack_switch v141, v141, v142  ; v142 = 0x0001_0000_0000
-;; @0062                               v68 = load.i64 notrap aligned v0+8
+;; @0062                               v68 = load.i64 notrap aligned region0 v0+8
 ;; @0062                               v69 = load.i64 notrap aligned v68+88
 ;; @0062                               v70 = load.i64 notrap aligned v68+96
 ;; @0062                               store notrap aligned v28, v68+88

--- a/tests/disas/stack-switching/resume-suspend.wat
+++ b/tests/disas/stack-switching/resume-suspend.wat
@@ -23,13 +23,14 @@
 )
 
 ;; function u0:0(i64 vmctx, i64) tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @003b                               v4 = load.i64 notrap aligned v0+8
+;; @003b                               v4 = load.i64 notrap aligned region0 v0+8
 ;; @003b                               v5 = load.i64 notrap aligned v4+88
 ;; @003b                               v6 = load.i64 notrap aligned v4+96
 ;; @003b                               v9 = iconst.i64 1
@@ -106,8 +107,9 @@
 ;;
 ;; function u0:1(i64 vmctx, i64) tail {
 ;;     ss0 = explicit_slot 8, align = 256
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     sig0 = (i64 vmctx, i32) -> i64 tail
 ;;     sig1 = (i64 vmctx, i64, i32, i32) -> i64 tail
@@ -141,14 +143,14 @@
 ;; @004e                               v30 = iadd v27, v29  ; v29 = 1
 ;; @004e                               store notrap aligned v30, v134+72
 ;; @004e                               v31 = load.i64 notrap aligned v134+64
-;; @004e                               v32 = load.i64 notrap aligned v0+8
+;; @004e                               v32 = load.i64 notrap aligned region0 v0+8
 ;; @004e                               v33 = load.i64 notrap aligned v32+88
 ;; @004e                               v34 = load.i64 notrap aligned v32+96
 ;; @004e                               store notrap aligned v33, v31+48
 ;; @004e                               store notrap aligned v34, v31+56
 ;; @0040                               v2 = iconst.i64 0
 ;; @004e                               store notrap aligned v2, v134+64  ; v2 = 0
-;; @004e                               v37 = load.i64 notrap aligned v0+8
+;; @004e                               v37 = load.i64 notrap aligned region0 v0+8
 ;; @004e                               v36 = iconst.i64 2
 ;; @004e                               store notrap aligned v36, v37+88  ; v36 = 2
 ;; @004e                               store notrap aligned v134, v37+96
@@ -159,7 +161,7 @@
 ;; @004e                               v43 = iconst.i32 2
 ;; @004e                               v45 = iadd v34, v41  ; v41 = 16
 ;; @004e                               store notrap aligned v43, v45  ; v43 = 2
-;; @004e                               v46 = load.i64 notrap aligned readonly v0+8
+;; @004e                               v46 = load.i64 notrap aligned readonly region0 v0+8
 ;; @004e                               v49 = load.i64 notrap aligned v46+72
 ;; @004e                               store notrap aligned v49, v34+8
 ;; @004e                               v50 = load.i64 notrap aligned v46+24
@@ -185,7 +187,7 @@
 ;; @004e                               v71 = iadd v69, v70  ; v70 = -24
 ;;                                     v138 = iconst.i64 0x0001_0000_0000
 ;; @004e                               v72 = stack_switch v71, v71, v138  ; v138 = 0x0001_0000_0000
-;; @004e                               v73 = load.i64 notrap aligned v0+8
+;; @004e                               v73 = load.i64 notrap aligned region0 v0+8
 ;; @004e                               v74 = load.i64 notrap aligned v73+88
 ;; @004e                               v75 = load.i64 notrap aligned v73+96
 ;; @004e                               store notrap aligned v33, v73+88

--- a/tests/disas/stack-switching/symmetric-switch.wat
+++ b/tests/disas/stack-switching/symmetric-switch.wat
@@ -27,8 +27,9 @@
 
 ;; function u0:0(i64 vmctx, i64) tail {
 ;;     ss0 = explicit_slot 24, align = 256
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     sig0 = (i64 vmctx, i32) -> i64 tail
 ;;     sig1 = (i64 vmctx, i64, i32, i32) -> i64 tail
@@ -64,7 +65,7 @@
 ;; @003e                               store notrap aligned v22, v14+72
 ;; @003e                               v23 = iconst.i64 48
 ;; @003e                               v24 = iadd v0, v23  ; v23 = 48
-;; @003e                               v25 = load.i64 notrap aligned v0+8
+;; @003e                               v25 = load.i64 notrap aligned region0 v0+8
 ;; @003e                               v26 = load.i64 notrap aligned v25+88
 ;; @003e                               v27 = load.i64 notrap aligned v25+96
 ;; @003e                               jump block2(v26, v27)
@@ -114,7 +115,7 @@
 ;; @003e                               v57 = iconst.i64 0
 ;; @003e                               store notrap aligned v56, v29+48  ; v56 = 0
 ;; @003e                               store notrap aligned v57, v29+56  ; v57 = 0
-;; @003e                               v58 = load.i64 notrap aligned readonly v0+8
+;; @003e                               v58 = load.i64 notrap aligned readonly region0 v0+8
 ;; @003e                               v59 = iconst.i64 0
 ;; @003e                               v60 = iadd v52, v59  ; v59 = 0
 ;; @003e                               v61 = load.i64 notrap aligned v58+72
@@ -175,7 +176,7 @@
 ;; @003e                               store.i64 notrap aligned v32, v102+48
 ;; @003e                               store.i64 notrap aligned v33, v102+56
 ;; @003e                               v103 = iconst.i64 2
-;; @003e                               v104 = load.i64 notrap aligned v0+8
+;; @003e                               v104 = load.i64 notrap aligned region0 v0+8
 ;; @003e                               store notrap aligned v103, v104+88  ; v103 = 2
 ;; @003e                               store.i64 notrap aligned v14, v104+96
 ;; @003e                               v105 = iconst.i64 0
@@ -227,8 +228,9 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i128) tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     stack_limit = gv2
 ;;
@@ -241,8 +243,9 @@
 ;;
 ;; function u0:2(i64 vmctx, i64) tail {
 ;;     ss0 = explicit_slot 8, align = 256
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     sig0 = (i64 vmctx, i32) -> i64 tail
 ;;     sig1 = (i64 vmctx, i64, i32, i32) -> i64 tail
@@ -280,7 +283,7 @@
 ;; @004b                               v22 = iadd v19, v21  ; v21 = 1
 ;; @004b                               store notrap aligned v22, v14+72
 ;; @004b                               v23 = load.i64 notrap aligned v14+64
-;; @004b                               v24 = load.i64 notrap aligned v0+8
+;; @004b                               v24 = load.i64 notrap aligned region0 v0+8
 ;; @004b                               v25 = load.i64 notrap aligned v24+88
 ;; @004b                               v26 = load.i64 notrap aligned v24+96
 ;; @004b                               store notrap aligned v25, v23+48
@@ -288,7 +291,7 @@
 ;; @004b                               v27 = iconst.i64 0
 ;; @004b                               store notrap aligned v27, v14+64  ; v27 = 0
 ;; @004b                               v28 = iconst.i64 2
-;; @004b                               v29 = load.i64 notrap aligned v0+8
+;; @004b                               v29 = load.i64 notrap aligned region0 v0+8
 ;; @004b                               store notrap aligned v28, v29+88  ; v28 = 2
 ;; @004b                               store notrap aligned v14, v29+96
 ;; @004b                               v30 = iconst.i64 0
@@ -301,7 +304,7 @@
 ;; @004b                               v36 = iconst.i64 16
 ;; @004b                               v37 = iadd v26, v36  ; v36 = 16
 ;; @004b                               store notrap aligned v35, v37  ; v35 = 2
-;; @004b                               v38 = load.i64 notrap aligned readonly v0+8
+;; @004b                               v38 = load.i64 notrap aligned readonly region0 v0+8
 ;; @004b                               v39 = iconst.i64 0
 ;; @004b                               v40 = iadd v26, v39  ; v39 = 0
 ;; @004b                               v41 = load.i64 notrap aligned v38+72
@@ -337,10 +340,10 @@
 ;; @004b                               v62 = iconst.i64 -24
 ;; @004b                               v63 = iadd v61, v62  ; v62 = -24
 ;; @004b                               v64 = stack_switch v63, v63, v58
-;; @004b                               v65 = load.i64 notrap aligned v0+8
+;; @004b                               v65 = load.i64 notrap aligned region0 v0+8
 ;; @004b                               v66 = load.i64 notrap aligned v65+88
 ;; @004b                               v67 = load.i64 notrap aligned v65+96
-;; @004b                               v68 = load.i64 notrap aligned v0+8
+;; @004b                               v68 = load.i64 notrap aligned region0 v0+8
 ;; @004b                               store notrap aligned v25, v68+88
 ;; @004b                               store notrap aligned v26, v68+96
 ;; @004b                               v69 = iconst.i32 1

--- a/tests/disas/startup-data-active.wat
+++ b/tests/disas/startup-data-active.wat
@@ -9,6 +9,7 @@
   (data (i32.const 1) "hi")
 )
 ;; function u2415919104:1(i64 vmctx, i64, i64, i64) -> i8 system_v {
+;;     region0 = 8 "VMContext+0x8"
 ;;     sig0 = (i64 vmctx, i64) tail
 ;;     fn0 = colocated u2415919104:0 sig0
 ;;
@@ -16,7 +17,7 @@
 ;;     jump block1
 ;;
 ;; block1:
-;;     v4 = load.i64 notrap aligned v0+8
+;;     v4 = load.i64 notrap aligned region0 v0+8
 ;;     v5 = get_frame_pointer.i64 
 ;;     store notrap aligned v5, v4+72
 ;;     v6 = get_stack_pointer.i64 

--- a/tests/disas/startup-elem-active.wat
+++ b/tests/disas/startup-elem-active.wat
@@ -13,6 +13,7 @@
   )
 )
 ;; function u2415919104:1(i64 vmctx, i64, i64, i64) -> i8 system_v {
+;;     region0 = 8 "VMContext+0x8"
 ;;     sig0 = (i64 vmctx, i64) tail
 ;;     fn0 = colocated u2415919104:0 sig0
 ;;
@@ -20,7 +21,7 @@
 ;;     jump block1
 ;;
 ;; block1:
-;;     v4 = load.i64 notrap aligned v0+8
+;;     v4 = load.i64 notrap aligned region0 v0+8
 ;;     v5 = get_frame_pointer.i64 
 ;;     store notrap aligned v5, v4+72
 ;;     v6 = get_stack_pointer.i64 

--- a/tests/disas/startup-global.wat
+++ b/tests/disas/startup-global.wat
@@ -6,6 +6,7 @@
   (global i64 i64.const 0 i64.const 0 i64.add)
 )
 ;; function u2415919104:1(i64 vmctx, i64, i64, i64) -> i8 system_v {
+;;     region0 = 8 "VMContext+0x8"
 ;;     sig0 = (i64 vmctx, i64) tail
 ;;     fn0 = colocated u2415919104:0 sig0
 ;;
@@ -13,7 +14,7 @@
 ;;     jump block1
 ;;
 ;; block1:
-;;     v4 = load.i64 notrap aligned v0+8
+;;     v4 = load.i64 notrap aligned region0 v0+8
 ;;     v5 = get_frame_pointer.i64 
 ;;     store notrap aligned v5, v4+72
 ;;     v6 = get_stack_pointer.i64 

--- a/tests/disas/startup-passive-segment.wat
+++ b/tests/disas/startup-passive-segment.wat
@@ -7,6 +7,7 @@
   (elem (ref i31) (item (ref.i31 (i32.const 0))) (item (ref.i31 (i32.const 1))))
 )
 ;; function u2415919104:1(i64 vmctx, i64, i64, i64) -> i8 system_v {
+;;     region0 = 8 "VMContext+0x8"
 ;;     sig0 = (i64 vmctx, i64) tail
 ;;     fn0 = colocated u2415919104:0 sig0
 ;;
@@ -14,7 +15,7 @@
 ;;     jump block1
 ;;
 ;; block1:
-;;     v4 = load.i64 notrap aligned v0+8
+;;     v4 = load.i64 notrap aligned region0 v0+8
 ;;     v5 = get_frame_pointer.i64 
 ;;     store notrap aligned v5, v4+72
 ;;     v6 = get_stack_pointer.i64 

--- a/tests/disas/startup-start.wat
+++ b/tests/disas/startup-start.wat
@@ -7,6 +7,7 @@
   (start $f)
 )
 ;; function u2415919104:1(i64 vmctx, i64, i64, i64) -> i8 system_v {
+;;     region0 = 8 "VMContext+0x8"
 ;;     sig0 = (i64 vmctx, i64) tail
 ;;     fn0 = colocated u2415919104:0 sig0
 ;;
@@ -14,7 +15,7 @@
 ;;     jump block1
 ;;
 ;; block1:
-;;     v4 = load.i64 notrap aligned v0+8
+;;     v4 = load.i64 notrap aligned region0 v0+8
 ;;     v5 = get_frame_pointer.i64 
 ;;     store notrap aligned v5, v4+72
 ;;     v6 = get_stack_pointer.i64 

--- a/tests/disas/startup-table-initial-value.wat
+++ b/tests/disas/startup-table-initial-value.wat
@@ -7,6 +7,7 @@
   (table 10 (ref i31) (ref.i31 (i32.const 0)))
 )
 ;; function u2415919104:1(i64 vmctx, i64, i64, i64) -> i8 system_v {
+;;     region0 = 8 "VMContext+0x8"
 ;;     sig0 = (i64 vmctx, i64) tail
 ;;     fn0 = colocated u2415919104:0 sig0
 ;;
@@ -14,7 +15,7 @@
 ;;     jump block1
 ;;
 ;; block1:
-;;     v4 = load.i64 notrap aligned v0+8
+;;     v4 = load.i64 notrap aligned region0 v0+8
 ;;     v5 = get_frame_pointer.i64 
 ;;     store notrap aligned v5, v4+72
 ;;     v6 = get_stack_pointer.i64 

--- a/tests/disas/sub-global.wat
+++ b/tests/disas/sub-global.wat
@@ -13,18 +13,19 @@
 )
 
 ;; function u0:0(i64 vmctx, i64) tail {
-;;     region0 = 1879048192 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 1879048192 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @0020                               v3 = load.i32 notrap aligned region0 v0+48
+;; @0020                               v3 = load.i32 notrap aligned region1 v0+48
 ;; @0022                               v4 = iconst.i32 16
 ;; @0024                               v5 = isub v3, v4  ; v4 = 16
-;; @0025                               store notrap aligned region0 v5, v0+48
+;; @0025                               store notrap aligned region1 v5, v0+48
 ;; @0027                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/table-copy.wat
+++ b/tests/disas/table-copy.wat
@@ -24,8 +24,9 @@
     table.copy $u $t))
 
 ;; function u0:0(i64 vmctx, i64, i32, i32, i32, i32, i32, i32) -> i32 tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     stack_limit = gv2
 ;;
@@ -37,8 +38,9 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32, i32, i32, i32, i32, i32) -> i32 tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     stack_limit = gv2
 ;;
@@ -50,8 +52,9 @@
 ;; }
 ;;
 ;; function u0:2(i64 vmctx, i64, i32, i32, i32, i32, i32, i32) -> i32 tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     stack_limit = gv2
 ;;
@@ -63,12 +66,14 @@
 ;; }
 ;;
 ;; function u0:3(i64 vmctx, i64, i32, i32, i32, i32) -> i32 tail {
-;;     region0 = 1073741824 "PublicTable"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 48 "VMContext+0x30"
+;;     region2 = 1073741824 "PublicTable"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+48
+;;     gv4 = load.i64 notrap aligned readonly can_move region1 gv3+48
 ;;     gv5 = load.i64 notrap aligned gv4
 ;;     gv6 = load.i64 notrap aligned gv4+8
 ;;     gv7 = load.i64 notrap aligned readonly can_move gv3+72
@@ -77,7 +82,7 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):
-;; @0090                               v109 = load.i64 notrap aligned readonly can_move v0+48
+;; @0090                               v109 = load.i64 notrap aligned readonly can_move region1 v0+48
 ;; @0090                               v7 = load.i64 notrap aligned v109+8
 ;; @0090                               v8 = ireduce.i32 v7
 ;; @0090                               v9 = uextend.i64 v8
@@ -88,7 +93,7 @@
 ;; @0090                               v14 = iadd v10, v13
 ;; @0090                               v15 = icmp ugt v14, v9
 ;; @0090                               trapnz v15, user6
-;; @0090                               v107 = load.i64 notrap aligned readonly can_move v0+48
+;; @0090                               v107 = load.i64 notrap aligned readonly can_move region1 v0+48
 ;; @0090                               v16 = load.i64 notrap aligned v107
 ;; @0090                               v17 = uextend.i64 v3
 ;; @0090                               v18 = iconst.i64 8
@@ -137,7 +142,7 @@
 ;; @0090                               v57 = iadd v54, v56
 ;; @0090                               v58 = iconst.i64 0
 ;; @0090                               v59 = select_spectre_guard v52, v58, v57  ; v58 = 0
-;; @0090                               v60 = load.i64 user6 aligned region0 v59
+;; @0090                               v60 = load.i64 user6 aligned region2 v59
 ;; @0090                               v61 = iconst.i64 -2
 ;; @0090                               v62 = band v60, v61  ; v61 = -2
 ;; @0090                               brif v60, block7(v62), block6
@@ -158,7 +163,7 @@
 ;; @0090                               v91 = iadd v88, v90
 ;; @0090                               v92 = iconst.i64 0
 ;; @0090                               v93 = select_spectre_guard v86, v92, v91  ; v92 = 0
-;; @0090                               v94 = load.i64 user6 aligned region0 v93
+;; @0090                               v94 = load.i64 user6 aligned region2 v93
 ;; @0090                               v95 = iconst.i64 -2
 ;; @0090                               v96 = band v94, v95  ; v95 = -2
 ;; @0090                               brif v94, block9(v96), block8
@@ -203,13 +208,15 @@
 ;; }
 ;;
 ;; function u0:4(i64 vmctx, i64, i32, i32, i32, i32) -> i32 tail {
-;;     region0 = 1073741824 "PublicTable"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 48 "VMContext+0x30"
+;;     region2 = 1073741824 "PublicTable"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned readonly can_move gv3+72
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+48
+;;     gv5 = load.i64 notrap aligned readonly can_move region1 gv3+48
 ;;     gv6 = load.i64 notrap aligned gv5
 ;;     gv7 = load.i64 notrap aligned gv5+8
 ;;     sig0 = (i64 vmctx, i32, i64) -> i64 tail
@@ -231,7 +238,7 @@
 ;; @009f                               v17 = iconst.i64 8
 ;; @009f                               v18 = imul v16, v17  ; v17 = 8
 ;; @009f                               v19 = iadd v15, v18
-;; @009f                               v116 = load.i64 notrap aligned readonly can_move v0+48
+;; @009f                               v116 = load.i64 notrap aligned readonly can_move region1 v0+48
 ;; @009f                               v20 = load.i64 notrap aligned v116+8
 ;; @009f                               v21 = ireduce.i32 v20
 ;; @009f                               v22 = uextend.i64 v21
@@ -242,7 +249,7 @@
 ;; @009f                               v27 = iadd v23, v26
 ;; @009f                               v28 = icmp ugt v27, v22
 ;; @009f                               trapnz v28, user6
-;; @009f                               v114 = load.i64 notrap aligned readonly can_move v0+48
+;; @009f                               v114 = load.i64 notrap aligned readonly can_move region1 v0+48
 ;; @009f                               v29 = load.i64 notrap aligned v114
 ;; @009f                               v30 = uextend.i64 v4
 ;; @009f                               v31 = iconst.i64 8
@@ -268,19 +275,19 @@
 ;; @009f                               brif v39, block3(v19, v33, v4), block4(v44, v45, v47)
 ;;
 ;;                                 block3(v48: i64, v49: i64, v50: i32):
-;; @009f                               v112 = load.i64 notrap aligned readonly can_move v0+48
+;; @009f                               v112 = load.i64 notrap aligned readonly can_move region1 v0+48
 ;; @009f                               v51 = load.i64 notrap aligned v112+8
 ;; @009f                               v52 = ireduce.i32 v51
 ;; @009f                               v53 = icmp uge v50, v52
 ;; @009f                               v54 = uextend.i64 v50
-;; @009f                               v110 = load.i64 notrap aligned readonly can_move v0+48
+;; @009f                               v110 = load.i64 notrap aligned readonly can_move region1 v0+48
 ;; @009f                               v55 = load.i64 notrap aligned v110
 ;; @009f                               v56 = iconst.i64 3
 ;; @009f                               v57 = ishl v54, v56  ; v56 = 3
 ;; @009f                               v58 = iadd v55, v57
 ;; @009f                               v59 = iconst.i64 0
 ;; @009f                               v60 = select_spectre_guard v53, v59, v58  ; v59 = 0
-;; @009f                               v61 = load.i64 user6 aligned region0 v60
+;; @009f                               v61 = load.i64 user6 aligned region2 v60
 ;; @009f                               v62 = iconst.i64 -2
 ;; @009f                               v63 = band v61, v62  ; v62 = -2
 ;; @009f                               brif v61, block7(v63), block6
@@ -292,19 +299,19 @@
 ;; @009f                               v83 = isub v78, v82  ; v82 = 8
 ;; @009f                               v84 = iconst.i32 1
 ;; @009f                               v85 = isub v79, v84  ; v84 = 1
-;; @009f                               v108 = load.i64 notrap aligned readonly can_move v0+48
+;; @009f                               v108 = load.i64 notrap aligned readonly can_move region1 v0+48
 ;; @009f                               v86 = load.i64 notrap aligned v108+8
 ;; @009f                               v87 = ireduce.i32 v86
 ;; @009f                               v88 = icmp uge v85, v87
 ;; @009f                               v89 = uextend.i64 v85
-;; @009f                               v106 = load.i64 notrap aligned readonly can_move v0+48
+;; @009f                               v106 = load.i64 notrap aligned readonly can_move region1 v0+48
 ;; @009f                               v90 = load.i64 notrap aligned v106
 ;; @009f                               v91 = iconst.i64 3
 ;; @009f                               v92 = ishl v89, v91  ; v91 = 3
 ;; @009f                               v93 = iadd v90, v92
 ;; @009f                               v94 = iconst.i64 0
 ;; @009f                               v95 = select_spectre_guard v88, v94, v93  ; v94 = 0
-;; @009f                               v96 = load.i64 user6 aligned region0 v95
+;; @009f                               v96 = load.i64 user6 aligned region2 v95
 ;; @009f                               v97 = iconst.i64 -2
 ;; @009f                               v98 = band v96, v97  ; v97 = -2
 ;; @009f                               brif v96, block9(v98), block8

--- a/tests/disas/table-get-fixed-size.wat
+++ b/tests/disas/table-get-fixed-size.wat
@@ -16,9 +16,10 @@
     table.get 0))
 
 ;; function u0:0(i64 vmctx, i64) -> i32 tail {
-;;     region0 = 1073741824 "PublicTable"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 1073741824 "PublicTable"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned readonly can_move gv3+48
@@ -35,7 +36,7 @@
 ;; @0054                               v10 = iadd v7, v9
 ;; @0054                               v11 = iconst.i64 0
 ;; @0054                               v12 = select_spectre_guard v5, v11, v10  ; v11 = 0
-;; @0054                               v13 = load.i32 user6 aligned region0 v12
+;; @0054                               v13 = load.i32 user6 aligned region1 v12
 ;; @0056                               jump block1
 ;;
 ;;                                 block1:
@@ -43,9 +44,10 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 1073741824 "PublicTable"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 1073741824 "PublicTable"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned readonly can_move gv3+48
@@ -61,7 +63,7 @@
 ;; @005b                               v10 = iadd v7, v9
 ;; @005b                               v11 = iconst.i64 0
 ;; @005b                               v12 = select_spectre_guard v5, v11, v10  ; v11 = 0
-;; @005b                               v13 = load.i32 user6 aligned region0 v12
+;; @005b                               v13 = load.i32 user6 aligned region1 v12
 ;; @005d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/table-get.wat
+++ b/tests/disas/table-get.wat
@@ -15,9 +15,10 @@
     table.get 0))
 
 ;; function u0:0(i64 vmctx, i64) -> i32 tail {
-;;     region0 = 1073741824 "PublicTable"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 1073741824 "PublicTable"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+48
@@ -36,7 +37,7 @@
 ;; @0053                               v11 = iadd v8, v10
 ;; @0053                               v12 = iconst.i64 0
 ;; @0053                               v13 = select_spectre_guard v6, v12, v11  ; v12 = 0
-;; @0053                               v14 = load.i32 user6 aligned region0 v13
+;; @0053                               v14 = load.i32 user6 aligned region1 v13
 ;; @0055                               jump block1
 ;;
 ;;                                 block1:
@@ -44,9 +45,10 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
-;;     region0 = 1073741824 "PublicTable"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 1073741824 "PublicTable"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+48
@@ -64,7 +66,7 @@
 ;; @005a                               v11 = iadd v8, v10
 ;; @005a                               v12 = iconst.i64 0
 ;; @005a                               v13 = select_spectre_guard v6, v12, v11  ; v12 = 0
-;; @005a                               v14 = load.i32 user6 aligned region0 v13
+;; @005a                               v14 = load.i32 user6 aligned region1 v13
 ;; @005c                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/table-set-fixed-size.wat
+++ b/tests/disas/table-set-fixed-size.wat
@@ -17,9 +17,10 @@
     local.get 1
     table.set 0))
 ;; function u0:0(i64 vmctx, i64, i32) tail {
-;;     region0 = 1073741824 "PublicTable"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 1073741824 "PublicTable"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned readonly can_move gv3+48
@@ -36,7 +37,7 @@
 ;; @0056                               v10 = iadd v7, v9
 ;; @0056                               v11 = iconst.i64 0
 ;; @0056                               v12 = select_spectre_guard v5, v11, v10  ; v11 = 0
-;; @0056                               store user6 aligned region0 v2, v12
+;; @0056                               store user6 aligned region1 v2, v12
 ;; @0058                               jump block1
 ;;
 ;;                                 block1:
@@ -44,9 +45,10 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32, i32) tail {
-;;     region0 = 1073741824 "PublicTable"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 1073741824 "PublicTable"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned readonly can_move gv3+48
@@ -62,7 +64,7 @@
 ;; @005f                               v10 = iadd v7, v9
 ;; @005f                               v11 = iconst.i64 0
 ;; @005f                               v12 = select_spectre_guard v5, v11, v10  ; v11 = 0
-;; @005f                               store user6 aligned region0 v3, v12
+;; @005f                               store user6 aligned region1 v3, v12
 ;; @0061                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/table-set.wat
+++ b/tests/disas/table-set.wat
@@ -17,9 +17,10 @@
     table.set 0))
 
 ;; function u0:0(i64 vmctx, i64, i32) tail {
-;;     region0 = 1073741824 "PublicTable"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 1073741824 "PublicTable"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+48
@@ -38,7 +39,7 @@
 ;; @0055                               v11 = iadd v8, v10
 ;; @0055                               v12 = iconst.i64 0
 ;; @0055                               v13 = select_spectre_guard v6, v12, v11  ; v12 = 0
-;; @0055                               store user6 aligned region0 v2, v13
+;; @0055                               store user6 aligned region1 v2, v13
 ;; @0057                               jump block1
 ;;
 ;;                                 block1:
@@ -46,9 +47,10 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32, i32) tail {
-;;     region0 = 1073741824 "PublicTable"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 1073741824 "PublicTable"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+48
@@ -66,7 +68,7 @@
 ;; @005e                               v11 = iadd v8, v10
 ;; @005e                               v12 = iconst.i64 0
 ;; @005e                               v13 = select_spectre_guard v6, v12, v11  ; v12 = 0
-;; @005e                               store user6 aligned region0 v3, v13
+;; @005e                               store user6 aligned region1 v3, v13
 ;; @0060                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/typed-funcrefs-eager-init.wat
+++ b/tests/disas/typed-funcrefs-eager-init.wat
@@ -114,8 +114,9 @@
 )
 
 ;; function u0:0(i64 vmctx, i64, i32, i32, i32, i32) -> i32 tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     stack_limit = gv2
 ;;
@@ -127,9 +128,10 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32, i32, i32, i32) -> i32 tail {
-;;     region0 = 1342177280 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 1342177280 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned readonly can_move gv3+48
@@ -140,13 +142,13 @@
 ;; @0048                               v12 = load.i64 notrap aligned readonly can_move v0+48
 ;;                                     v47 = iconst.i64 8
 ;; @0048                               v15 = iadd v12, v47  ; v47 = 8
-;; @0048                               v18 = load.i64 user6 aligned region0 v15
+;; @0048                               v18 = load.i64 user6 aligned region1 v15
 ;; @004a                               v19 = load.i64 user16 aligned readonly v18+8
 ;; @004a                               v20 = load.i64 notrap aligned readonly v18+24
 ;; @004a                               v21 = call_indirect sig0, v19(v20, v0, v2, v3, v4, v5)
 ;;                                     v54 = iconst.i64 16
 ;; @005b                               v30 = iadd v12, v54  ; v54 = 16
-;; @005b                               v33 = load.i64 user6 aligned region0 v30
+;; @005b                               v33 = load.i64 user6 aligned region1 v30
 ;; @005d                               v34 = load.i64 user16 aligned readonly v33+8
 ;; @005d                               v35 = load.i64 notrap aligned readonly v33+24
 ;; @005d                               v36 = call_indirect sig0, v34(v35, v0, v2, v3, v4, v5)
@@ -158,9 +160,10 @@
 ;; }
 ;;
 ;; function u0:2(i64 vmctx, i64, i32, i32, i32, i32) -> i32 tail {
-;;     region0 = 1342177280 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 1342177280 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned readonly can_move gv3+48
@@ -171,13 +174,13 @@
 ;; @0075                               v12 = load.i64 notrap aligned readonly can_move v0+48
 ;;                                     v47 = iconst.i64 8
 ;; @0075                               v15 = iadd v12, v47  ; v47 = 8
-;; @0075                               v18 = load.i64 user6 aligned region0 v15
+;; @0075                               v18 = load.i64 user6 aligned region1 v15
 ;; @0075                               v19 = load.i64 user7 aligned readonly v18+8
 ;; @0075                               v20 = load.i64 notrap aligned readonly v18+24
 ;; @0075                               v21 = call_indirect sig0, v19(v20, v0, v2, v3, v4, v5)
 ;;                                     v54 = iconst.i64 16
 ;; @0087                               v30 = iadd v12, v54  ; v54 = 16
-;; @0087                               v33 = load.i64 user6 aligned region0 v30
+;; @0087                               v33 = load.i64 user6 aligned region1 v30
 ;; @0087                               v34 = load.i64 user7 aligned readonly v33+8
 ;; @0087                               v35 = load.i64 notrap aligned readonly v33+24
 ;; @0087                               v36 = call_indirect sig0, v34(v35, v0, v2, v3, v4, v5)
@@ -189,21 +192,22 @@
 ;; }
 ;;
 ;; function u0:3(i64 vmctx, i64, i32, i32, i32, i32) -> i32 tail {
-;;     region0 = 1879048192 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(0))"
-;;     region1 = 1879048193 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(1))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 1879048192 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(0))"
+;;     region2 = 1879048193 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(1))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, i64, i32, i32, i32, i32) -> i32 tail
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):
-;; @009e                               v9 = load.i64 notrap aligned region0 v0+64
+;; @009e                               v9 = load.i64 notrap aligned region1 v0+64
 ;; @00a0                               v10 = load.i64 user16 aligned readonly v9+8
 ;; @00a0                               v11 = load.i64 notrap aligned readonly v9+24
 ;; @00a0                               v12 = call_indirect sig0, v10(v11, v0, v2, v3, v4, v5)
-;; @00af                               v15 = load.i64 notrap aligned region1 v0+80
+;; @00af                               v15 = load.i64 notrap aligned region2 v0+80
 ;; @00b1                               v16 = load.i64 user16 aligned readonly v15+8
 ;; @00b1                               v17 = load.i64 notrap aligned readonly v15+24
 ;; @00b1                               v18 = call_indirect sig0, v16(v17, v0, v2, v3, v4, v5)

--- a/tests/disas/typed-funcrefs.wat
+++ b/tests/disas/typed-funcrefs.wat
@@ -114,8 +114,9 @@
 )
 
 ;; function u0:0(i64 vmctx, i64, i32, i32, i32, i32) -> i32 tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     stack_limit = gv2
 ;;
@@ -127,9 +128,10 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32, i32, i32, i32) -> i32 tail {
-;;     region0 = 1342177280 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 1342177280 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned readonly can_move gv3+48
@@ -142,7 +144,7 @@
 ;; @0048                               v12 = load.i64 notrap aligned readonly can_move v0+48
 ;;                                     v65 = iconst.i64 8
 ;; @0048                               v15 = iadd v12, v65  ; v65 = 8
-;; @0048                               v18 = load.i64 user6 aligned region0 v15
+;; @0048                               v18 = load.i64 user6 aligned region1 v15
 ;; @0048                               v19 = iconst.i64 -2
 ;; @0048                               v20 = band v18, v19  ; v19 = -2
 ;; @0048                               brif v18, block3(v20), block2
@@ -159,7 +161,7 @@
 ;; @004a                               v27 = call_indirect sig1, v25(v26, v0, v2, v3, v4, v5)
 ;;                                     v72 = iconst.i64 16
 ;; @005b                               v41 = iadd.i64 v12, v72  ; v72 = 16
-;; @005b                               v44 = load.i64 user6 aligned region0 v41
+;; @005b                               v44 = load.i64 user6 aligned region1 v41
 ;;                                     v73 = iconst.i64 -2
 ;;                                     v74 = band v44, v73  ; v73 = -2
 ;; @005b                               brif v44, block5(v74), block4
@@ -182,9 +184,10 @@
 ;; }
 ;;
 ;; function u0:2(i64 vmctx, i64, i32, i32, i32, i32) -> i32 tail {
-;;     region0 = 1342177280 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 1342177280 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned readonly can_move gv3+48
@@ -197,7 +200,7 @@
 ;; @0075                               v12 = load.i64 notrap aligned readonly can_move v0+48
 ;;                                     v65 = iconst.i64 8
 ;; @0075                               v15 = iadd v12, v65  ; v65 = 8
-;; @0075                               v18 = load.i64 user6 aligned region0 v15
+;; @0075                               v18 = load.i64 user6 aligned region1 v15
 ;; @0075                               v19 = iconst.i64 -2
 ;; @0075                               v20 = band v18, v19  ; v19 = -2
 ;; @0075                               brif v18, block3(v20), block2
@@ -214,7 +217,7 @@
 ;; @0075                               v27 = call_indirect sig0, v25(v26, v0, v2, v3, v4, v5)
 ;;                                     v72 = iconst.i64 16
 ;; @0087                               v41 = iadd.i64 v12, v72  ; v72 = 16
-;; @0087                               v44 = load.i64 user6 aligned region0 v41
+;; @0087                               v44 = load.i64 user6 aligned region1 v41
 ;;                                     v73 = iconst.i64 -2
 ;;                                     v74 = band v44, v73  ; v73 = -2
 ;; @0087                               brif v44, block5(v74), block4
@@ -237,21 +240,22 @@
 ;; }
 ;;
 ;; function u0:3(i64 vmctx, i64, i32, i32, i32, i32) -> i32 tail {
-;;     region0 = 1879048192 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(0))"
-;;     region1 = 1879048193 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(1))"
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 1879048192 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(0))"
+;;     region2 = 1879048193 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(1))"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, i64, i32, i32, i32, i32) -> i32 tail
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):
-;; @009e                               v9 = load.i64 notrap aligned region0 v0+64
+;; @009e                               v9 = load.i64 notrap aligned region1 v0+64
 ;; @00a0                               v10 = load.i64 user16 aligned readonly v9+8
 ;; @00a0                               v11 = load.i64 notrap aligned readonly v9+24
 ;; @00a0                               v12 = call_indirect sig0, v10(v11, v0, v2, v3, v4, v5)
-;; @00af                               v15 = load.i64 notrap aligned region1 v0+80
+;; @00af                               v15 = load.i64 notrap aligned region2 v0+80
 ;; @00b1                               v16 = load.i64 user16 aligned readonly v15+8
 ;; @00b1                               v17 = load.i64 notrap aligned readonly v15+24
 ;; @00b1                               v18 = call_indirect sig0, v16(v17, v0, v2, v3, v4, v5)

--- a/tests/disas/unreachable_code.wat
+++ b/tests/disas/unreachable_code.wat
@@ -79,8 +79,9 @@
 )
 
 ;; function u0:0(i64 vmctx, i64) -> i32 tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     stack_limit = gv2
 ;;
@@ -89,8 +90,9 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64) -> i32 tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     stack_limit = gv2
 ;;
@@ -102,8 +104,9 @@
 ;; }
 ;;
 ;; function u0:2(i64 vmctx, i64) -> i32 tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     stack_limit = gv2
 ;;
@@ -134,8 +137,9 @@
 ;; }
 ;;
 ;; function u0:3(i64 vmctx, i64) tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     stack_limit = gv2
 ;;

--- a/tests/disas/x64-simd-round-without-sse41.wat
+++ b/tests/disas/x64-simd-round-without-sse41.wat
@@ -12,8 +12,9 @@
   (func $i32x4.trunc_sat_f64x2_u_zero (param v128) (result v128) (i32x4.trunc_sat_f64x2_u_zero (local.get 0)))
 )
 ;; function u0:0(i64 vmctx, i64, i8x16) -> i8x16 tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     sig0 = (i64 vmctx, f32) -> f32 tail
 ;;     fn0 = colocated u805306368:28 sig0
@@ -43,8 +44,9 @@
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i8x16) -> i8x16 tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     sig0 = (i64 vmctx, f32) -> f32 tail
 ;;     fn0 = colocated u805306368:30 sig0
@@ -74,8 +76,9 @@
 ;; }
 ;;
 ;; function u0:2(i64 vmctx, i64, i8x16) -> i8x16 tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     sig0 = (i64 vmctx, f32) -> f32 tail
 ;;     fn0 = colocated u805306368:32 sig0
@@ -105,8 +108,9 @@
 ;; }
 ;;
 ;; function u0:3(i64 vmctx, i64, i8x16) -> i8x16 tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     sig0 = (i64 vmctx, f32) -> f32 tail
 ;;     fn0 = colocated u805306368:34 sig0
@@ -136,8 +140,9 @@
 ;; }
 ;;
 ;; function u0:4(i64 vmctx, i64, i8x16) -> i8x16 tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     sig0 = (i64 vmctx, f64) -> f64 tail
 ;;     fn0 = colocated u805306368:29 sig0
@@ -161,8 +166,9 @@
 ;; }
 ;;
 ;; function u0:5(i64 vmctx, i64, i8x16) -> i8x16 tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     sig0 = (i64 vmctx, f64) -> f64 tail
 ;;     fn0 = colocated u805306368:31 sig0
@@ -186,8 +192,9 @@
 ;; }
 ;;
 ;; function u0:6(i64 vmctx, i64, i8x16) -> i8x16 tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     sig0 = (i64 vmctx, f64) -> f64 tail
 ;;     fn0 = colocated u805306368:33 sig0
@@ -211,8 +218,9 @@
 ;; }
 ;;
 ;; function u0:7(i64 vmctx, i64, i8x16) -> i8x16 tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     sig0 = (i64 vmctx, f64) -> f64 tail
 ;;     fn0 = colocated u805306368:35 sig0
@@ -236,8 +244,9 @@
 ;; }
 ;;
 ;; function u0:8(i64 vmctx, i64, i8x16) -> i8x16 tail {
+;;     region0 = 8 "VMContext+0x8"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     const0 = 0x00000000000000000000000000000000
 ;;     stack_limit = gv2


### PR DESCRIPTION
Additionally slightly refactors `AliasRegionKey` to have a `Vm { ty: VmType, ... }` variant instead of `AliasRegionKey::VMContext` and `AliasRegionKey::VMStoreContext` variants (and `VMMemoryDefinition`, `VMTableDefinition`, etc... in commits to follow this one).

Big diff is just the disas tests being updated.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
