### PR TITLE
Flag all wasi-testsuite tests as expected to pass

### DIFF
--- a/tests/wasi.rs
+++ b/tests/wasi.rs
@@ -19,99 +19,10 @@ use wasmtime::{Result, ToWasmtimeResult as _, format_err};
 use wit_component::ComponentEncoder;
 
 const KNOWN_FAILURES: &[&str] = &[
-    // FIXME(#11524)
-    "remove_directory_trailing_slashes",
-    // FIXME(#12568)
-    "sockets-udp-send",
-    #[cfg(target_vendor = "apple")]
-    "filesystem-advise",
-    // FIXME(WebAssembly/wasi-testsuite#128)
-    #[cfg(windows)]
-    "fd_fdstat_set_rights",
-    #[cfg(windows)]
-    "filesystem-flags-and-type",
-    #[cfg(windows)]
-    "path_link",
-    #[cfg(windows)]
-    "dangling_fd",
-    #[cfg(windows)]
-    "dangling_symlink",
-    #[cfg(windows)]
-    "file_allocate",
-    #[cfg(windows)]
-    "file_pread_pwrite",
-    #[cfg(windows)]
-    "file_seek_tell",
-    #[cfg(windows)]
-    "file_truncation",
-    #[cfg(windows)]
-    "file_unbuffered_write",
-    #[cfg(windows)]
-    "interesting_paths",
-    #[cfg(windows)]
-    "isatty",
-    #[cfg(windows)]
-    "fd_readdir",
-    #[cfg(windows)]
-    "nofollow_errors",
-    #[cfg(windows)]
-    "overwrite_preopen",
-    #[cfg(windows)]
-    "path_exists",
-    #[cfg(windows)]
-    "path_filestat",
-    #[cfg(windows)]
-    "path_open_create_existing",
-    #[cfg(windows)]
-    "path_open_dirfd_not_dir",
-    #[cfg(windows)]
-    "path_open_missing",
-    #[cfg(windows)]
-    "path_open_read_write",
-    #[cfg(windows)]
-    "path_rename",
-    #[cfg(windows)]
-    "path_rename_dir_trailing_slashes",
-    #[cfg(windows)]
-    "path_symlink_trailing_slashes",
-    #[cfg(windows)]
-    "readlink",
-    #[cfg(windows)]
-    "remove_nonempty_directory",
     #[cfg(windows)]
     "renumber",
     #[cfg(windows)]
-    "symlink_create",
-    #[cfg(windows)]
     "stdio",
-    #[cfg(windows)]
-    "symlink_filestat",
-    #[cfg(windows)]
-    "truncation_rights",
-    #[cfg(windows)]
-    "symlink_loop",
-    #[cfg(windows)]
-    "unlink_file_trailing_slashes",
-    #[cfg(windows)]
-    "filesystem-unlink-errors",
-    #[cfg(windows)]
-    "filesystem-stat",
-    #[cfg(windows)]
-    "filesystem-set-size",
-    #[cfg(windows)]
-    "filesystem-rename",
-    #[cfg(windows)]
-    "filesystem-read-directory",
-    #[cfg(windows)]
-    "filesystem-open-errors",
-    #[cfg(windows)]
-    "filesystem-mkdir-rmdir",
-    #[cfg(windows)]
-    "filesystem-metadata-hash",
-    #[cfg(windows)]
-    "filesystem-hard-links",
-    #[cfg(windows)]
-    "filesystem-io",
 ];
 
 fn main() -> Result<()> {


### PR DESCRIPTION
Upstream refactorings mean that we should be able to ratchet this for all tests now to keep them passing on all platforms.

prtest:full

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
