### PR TITLE
Wasmtime: enable exception-handling by default.

### DIFF
--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -2437,7 +2437,6 @@ impl Config {
         features |= WasmFeatures::MEMORY64;
         features |= WasmFeatures::FUNCTION_REFERENCES;
         features |= WasmFeatures::GC;
-        features |= WasmFeatures::EXCEPTIONS;
         // NB: if you add a feature above this line please double-check
         // https://docs.wasmtime.dev/stability-wasm-proposals.html
         // to ensure all requirements are met and/or update the documentation
@@ -2446,6 +2445,9 @@ impl Config {
         // Set some features to their conditionally-enabled defaults depending
         // on crate compile-time features.
         features.set(WasmFeatures::GC_TYPES, cfg!(feature = "gc"));
+        // Exception handling requires the `gc` build-time feature for runtime
+        // support.
+        features.set(WasmFeatures::EXCEPTIONS, cfg!(feature = "gc"));
         features.set(WasmFeatures::THREADS, cfg!(feature = "threads"));
         features.set(
             WasmFeatures::COMPONENT_MODEL,

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -1336,6 +1336,8 @@ impl Config {
 
     /// Configures whether the [Exception-handling proposal][proposal] is enabled or not.
     ///
+    /// This is `true` by default.
+    ///
     /// [proposal]: https://github.com/WebAssembly/exception-handling
     #[cfg(feature = "gc")]
     pub fn wasm_exceptions(&mut self, enable: bool) -> &mut Self {
@@ -2435,6 +2437,7 @@ impl Config {
         features |= WasmFeatures::MEMORY64;
         features |= WasmFeatures::FUNCTION_REFERENCES;
         features |= WasmFeatures::GC;
+        features |= WasmFeatures::EXCEPTIONS;
         // NB: if you add a feature above this line please double-check
         // https://docs.wasmtime.dev/stability-wasm-proposals.html
         // to ensure all requirements are met and/or update the documentation

--- a/docs/stability-tiers.md
+++ b/docs/stability-tiers.md
@@ -42,6 +42,7 @@ For explanations of what each tier means see below.
 | WebAssembly Proposal | [`memory64`]                               |
 | WebAssembly Proposal | [`function-references`]                    |
 | WebAssembly Proposal | [`gc`]                                     |
+| WebAssembly Proposal | [`exception-handling`]                     |
 | WASI Proposal        | [`wasi-io`]                                |
 | WASI Proposal        | [`wasi-clocks`]                            |
 | WASI Proposal        | [`wasi-filesystem`]                        |
@@ -71,6 +72,7 @@ For explanations of what each tier means see below.
 [`wasi-sockets`]: https://github.com/WebAssembly/wasi-sockets
 [`wasi-http`]: https://github.com/WebAssembly/wasi-http
 [`tail-call`]: https://github.com/WebAssembly/tail-call/blob/main/proposals/tail-call/Overview.md
+[`exception-handling`]: https://github.com/WebAssembly/exception-handling
 
 [^support]: Compiler support is further broken down [below](#compiler-support)
   into finer-grained target/wasm proposal combinations. Compilers are not
@@ -86,7 +88,6 @@ For explanations of what each tier means see below.
 | Target               | `x86_64-pc-windows-gnu`    | Clear owner of the target   |
 | Target               | Support for `#![no_std]`   | Support beyond CI checks    |
 | WebAssembly Proposal | [`custom-page-sizes`]      | Unstable wasm proposal      |
-| WebAssembly Proposal | [`exception-handling`]     | fuzzing, dependence on GC   |
 | WebAssembly Proposal | [`threads`]                | fuzzing, API quality        |
 | WebAssembly Proposal | [`wide-arithmetic`]        | Unstable wasm proposal      |
 | Execution Backend    | Pulley                     | More time fuzzing/baking    |
@@ -98,7 +99,6 @@ For explanations of what each tier means see below.
 [`component-model`]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/Explainer.md
 [`relaxed-simd`]: https://github.com/WebAssembly/relaxed-simd/blob/main/proposals/relaxed-simd/Overview.md
 [`wide-arithmetic`]: https://github.com/WebAssembly/wide-arithmetic/blob/main/proposals/wide-arithmetic/Overview.md
-[`exception-handling`]: https://github.com/WebAssembly/exception-handling
 [`stack-switching`]: https://github.com/WebAssembly/stack-switching
 
 #### Tier 3

--- a/docs/stability-wasm-proposals.md
+++ b/docs/stability-wasm-proposals.md
@@ -34,6 +34,7 @@ The emoji legend is:
 | [`memory64`]             | ✅      | ✅    | ✅       | ✅     | ✅  | ✅    |
 | [`function-references`]  | ✅      | ✅    | ✅       | ✅     | ✅  | ✅    |
 | [`gc`]                   | ✅      | ✅    | ✅       | ✅     | ✅  | ✅    |
+| [`exception-handling`]   | ✅      | ✅    | ✅       | ✅     | ✅  | ✅    |
 
 [^1]: The `component-model` proposal is not at phase 4 in the standardization
     process but it is still enabled-by-default in Wasmtime.
@@ -49,7 +50,6 @@ The emoji legend is:
 |  Proposal                | Phase 4 | Tests | Finished | Fuzzed | API | C API  |
 |--------------------------|---------|-------|----------|--------|-----|--------|
 | [`custom-page-sizes`]    | ❌      | ✅    | ✅       | ✅     | ✅  | ✅     |
-| [`exception-handling`]   | ✅      | ✅    | ✅       | ✅     | ✅  | ✅     |
 | [`threads`]              | ✅      | ✅    | 🚧[^8]   | ❌[^4] | ✅  | ✅     |
 | [`wide-arithmetic`]      | ❌      | ✅    | ✅       | ✅     | ✅  | ✅     |
 


### PR DESCRIPTION
Following [discussion in the most recent Wasmtime
meeting](https://github.com/bytecodealliance/meetings/blob/main/wasmtime/2026/wasmtime-06-04.md), and following the enablement by default of garbage collection (#13594), we are now ready to ship [Wasm exception
handling](https://github.com/WebAssembly/exception-handling) as well. It has been fuzzed for a while now, has good test coverage, has not had a reported bug for quite a while, and in general meets our requirements for tier-1 features. This PR thus promotes it to tier 1 (on all platforms, with the Cranelift compiler backend) and enables it by default.

May exceptions be the norm!

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
