### PR TITLE
Remove `ExceptionTable::lookup_pc_tag`

### DIFF
--- a/cranelift/filetests/src/function_runner.rs
+++ b/cranelift/filetests/src/function_runner.rs
@@ -652,14 +652,15 @@ extern "C-unwind" fn __cranelift_throw(
         )
         .expect("module larger than 4GiB");
 
-        table
-            .lookup_pc_tag(relative_pc, tag)
-            .map(|(frame_offset, handler)| {
+        let (frame_offset, mut handlers) = table.lookup_pc(relative_pc);
+        handlers
+            .find(|handler| handler.tag == Some(tag) || handler.tag.is_none())
+            .map(|handler| {
                 let handler_sp = frame
                     .fp()
-                    .wrapping_sub(usize::try_from(frame_offset).unwrap());
+                    .wrapping_sub(usize::try_from(frame_offset.unwrap_or(0)).unwrap());
                 let handler_pc = base
-                    .checked_add(usize::try_from(handler).unwrap())
+                    .checked_add(usize::try_from(handler.handler_offset).unwrap())
                     .expect("Handler address computation overflowed");
                 (handler_pc, handler_sp)
             })

--- a/crates/unwinder/src/exception_table.rs
+++ b/crates/unwinder/src/exception_table.rs
@@ -322,39 +322,6 @@ impl<'a> ExceptionTable<'a> {
         )
     }
 
-    /// Look up the frame offset and handler destination if any, for a
-    /// given return address (as an offset into the code section) and
-    /// exception tag.
-    ///
-    /// Note: we use raw `u32` types for code offsets and tags here to
-    /// avoid dependencies on `cranelift-codegen` when this crate is
-    /// built without compiler backend support (runtime-only config).
-    pub fn lookup_pc_tag(&self, pc: u32, tag: u32) -> Option<(u32, u32)> {
-        // First, look up the callsite in the sorted callsites list.
-        let callsite_idx = self
-            .callsites
-            .binary_search_by_key(&pc, |callsite| callsite.get(LittleEndian))
-            .ok()?;
-        let frame_offset =
-            option_from_u32(self.frame_offsets[callsite_idx].get(LittleEndian)).unwrap_or(0);
-
-        let (tags, _, handlers) = self.tags_contexts_handlers_for_callsite(callsite_idx);
-
-        // Is there any handler with an exact tag match?
-        if let Ok(handler_idx) = tags.binary_search_by_key(&tag, |tag| tag.get(LittleEndian)) {
-            return Some((frame_offset, handlers[handler_idx].get(LittleEndian)));
-        }
-
-        // If not, is there a fallback handler? Note that we serialize
-        // it with the tag `u32::MAX`, so it is always last in sorted
-        // order.
-        if tags.last().map(|v| v.get(LittleEndian)) == Some(u32::MAX) {
-            return Some((frame_offset, handlers.last().unwrap().get(LittleEndian)));
-        }
-
-        None
-    }
-
     fn tags_contexts_handlers_for_callsite(
         &self,
         idx: usize,


### PR DESCRIPTION
This helps keep wasm/clif-util using the same exact code and additionally removes the implicit assumption that tags are sorted which isn't always the case for wasm. The replacement isn't a perfect fit but it's workable enough for clif-util.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
