### PR TITLE
fix(tests): loosen p3 outbound content length error conditions

### DIFF
--- a/crates/test-programs/src/bin/p3_http_outbound_request_content_length.rs
+++ b/crates/test-programs/src/bin/p3_http_outbound_request_content_length.rs
@@ -63,7 +63,7 @@ impl test_programs::p3::exports::wasi::cli::run::Guest for Component {
         println!("writing too little");
         {
             let (request, mut contents_tx, trailers_tx, transmit) = make_request();
-            let (handle, transmit, ()) = join!(
+            let (_handle, transmit, ()) = join!(
                 async { client::send(request).await },
                 async { transmit.await },
                 async {
@@ -73,18 +73,26 @@ impl test_programs::p3::exports::wasi::cli::run::Guest for Component {
                     drop(contents_tx);
                 },
             );
-            // The request body will be polled before `handle` returns.
+
+            // Note: The request body will be polled before `handle` returns.
             // Due to the way implementation is structured, by the time it happens
             // the error will be already available in most cases and `handle` will fail,
             // but it is a race condition, since `handle` may also succeed if
             // polling body returns `Poll::Pending`
-            assert!(
-                matches!(handle, Ok(..) | Err(ErrorCode::HttpProtocolError)),
-                "unexpected handle result: {handle:#?}"
-            );
+            //
+            // In those cases, the `ErrorCode::HttpProtocolError` would be observable
+            // as the handle.
+            //
+            // Rather than checking for this condition, which may race, we check the
+            // transmit directly below
             let err = transmit.expect_err("request transmission should have failed");
             assert!(
-                matches!(err, ErrorCode::HttpRequestBodySize(Some(3))),
+                matches!(
+                    err,
+                    // Depending on timing, other non-wasmtime hosts may already
+                    // have reported the request body size error
+                    ErrorCode::HttpRequestBodySize(Some(3))
+                ),
                 "unexpected error: {err:#?}"
             );
         }


### PR DESCRIPTION
This commit updates the test to allow for timings that match non-wasmtime implementations (i.e. Jco), which may not report the intermediate error (`ErrorCode::HttpProtocolError`) ahead of the "real" expected error (`ErrorCode::HttpRequestBodySize`)

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
