### PR TITLE
Tag all `VMContext` field accesses with alias regions

### DIFF
--- a/crates/cranelift/src/compiler.rs
+++ b/crates/cranelift/src/compiler.rs
@@ -1395,9 +1395,12 @@ impl Compiler {
         if !self.emit_debug_checks {
             return;
         }
+        let magic_region = vmctx_alias_region(builder.func, 0);
         let magic = builder.ins().load(
             ir::types::I32,
-            MemFlagsData::trusted().with_endianness(self.isa.endianness()),
+            MemFlagsData::trusted()
+                .with_endianness(self.isa.endianness())
+                .with_alias_region(Some(magic_region)),
             vmctx,
             0,
         );

--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -4276,11 +4276,13 @@ impl FuncEnvironment<'_> {
         // the value 0 to the `VMContext`'s slot for this passive data segment.
         let vmctx = self.vmctx_val(&mut pos);
         let new_length = pos.ins().iconst(I32, 0);
+        let length_offset = self.offsets.vmctx_runtime_data_length(runtime_index);
+        let region = self.vmctx_alias_region(pos.func, length_offset);
         pos.ins().store(
-            ir::MemFlagsData::trusted(),
+            ir::MemFlagsData::trusted().with_alias_region(Some(region)),
             new_length,
             vmctx,
-            i32::try_from(self.offsets.vmctx_runtime_data_length(runtime_index)).unwrap(),
+            i32::try_from(length_offset).unwrap(),
         );
 
         Ok(())
@@ -4561,9 +4563,12 @@ impl FuncEnvironment<'_> {
         runtime_index: RuntimeDataIndex,
     ) -> ir::Value {
         let vmctx = self.vmctx_val(&mut builder.cursor());
-        let offset = i32::try_from(self.offsets.vmctx_runtime_data_length(runtime_index)).unwrap();
-        let flags = ir::MemFlagsData::trusted();
-        builder.ins().load(I32, flags, vmctx, offset)
+        let length_offset = self.offsets.vmctx_runtime_data_length(runtime_index);
+        let region = self.vmctx_alias_region(builder.func, length_offset);
+        let flags = ir::MemFlagsData::trusted().with_alias_region(Some(region));
+        builder
+            .ins()
+            .load(I32, flags, vmctx, i32::try_from(length_offset).unwrap())
     }
 
     fn load_runtime_data_length_as_pointer(
@@ -4581,12 +4586,13 @@ impl FuncEnvironment<'_> {
         runtime_index: RuntimeDataIndex,
     ) -> ir::Value {
         let vmctx = self.vmctx_val(&mut builder.cursor());
-        let offset = i32::try_from(self.offsets.vmctx_runtime_data_base(runtime_index)).unwrap();
+        let base_offset = self.offsets.vmctx_runtime_data_base(runtime_index);
+        let region = self.vmctx_alias_region(builder.func, base_offset);
         builder.ins().load(
             self.pointer_type(),
-            ir::MemFlagsData::trusted(),
+            ir::MemFlagsData::trusted().with_alias_region(Some(region)),
             vmctx,
-            offset,
+            i32::try_from(base_offset).unwrap(),
         )
     }
 

--- a/crates/cranelift/src/func_environ/gc/copying.rs
+++ b/crates/cranelift/src/func_environ/gc/copying.rs
@@ -33,12 +33,18 @@ impl CopyingCompiler {
         builder: &mut FunctionBuilder,
     ) -> ir::Value {
         let pointer_type = func_env.pointer_type();
+        let gc_heap_data_offset = func_env.offsets.ptr.vmctx_gc_heap_data();
+        let vmctx_region =
+            func_env.vmctx_alias_region(&mut builder.func, u32::from(gc_heap_data_offset));
         let vmctx = func_env.vmctx_val(&mut builder.cursor());
         builder.ins().load(
             pointer_type,
-            ir::MemFlagsData::trusted().with_readonly().with_can_move(),
+            ir::MemFlagsData::trusted()
+                .with_readonly()
+                .with_can_move()
+                .with_alias_region(Some(vmctx_region)),
             vmctx,
-            i32::from(func_env.offsets.ptr.vmctx_gc_heap_data()),
+            i32::from(gc_heap_data_offset),
         )
     }
 

--- a/tests/disas/gc/array-init-data.wat
+++ b/tests/disas/gc/array-init-data.wat
@@ -16,6 +16,8 @@
 ;; function u0:0(i64 vmctx, i64, i32, i32, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 2147483648 "GcHeap"
+;;     region2 = 56 "VMContext+0x38"
+;;     region3 = 48 "VMContext+0x30"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -42,13 +44,13 @@
 ;; @002a                               v12 = uextend.i64 v11
 ;; @002a                               v18 = icmp ugt v17, v12
 ;; @002a                               trapnz v18, user17
-;; @002a                               v29 = load.i32 notrap aligned v0+56
+;; @002a                               v29 = load.i32 notrap aligned region2 v0+56
 ;; @002a                               v31 = uextend.i64 v4
 ;; @002a                               v35 = iadd v31, v14
 ;; @002a                               v30 = uextend.i64 v29
 ;; @002a                               v36 = icmp ugt v35, v30
 ;; @002a                               trapnz v36, heap_oob
-;; @002a                               v37 = load.i64 notrap aligned v0+48
+;; @002a                               v37 = load.i64 notrap aligned region3 v0+48
 ;; @002a                               v48 = load.i64 notrap aligned v52+40
 ;; @002a                               v23 = iconst.i64 20
 ;; @002a                               v24 = iadd v8, v23  ; v23 = 20

--- a/tests/disas/gc/array-new-data.wat
+++ b/tests/disas/gc/array-new-data.wat
@@ -78,9 +78,11 @@
 ;; function u0:0(i64 vmctx, i64, i32, i32) -> i32 tail {
 ;;     ss0 = explicit_slot 4, align = 4
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 40 "VMContext+0x28"
-;;     region2 = 32 "VMContext+0x20"
-;;     region3 = 2147483648 "GcHeap"
+;;     region1 = 56 "VMContext+0x38"
+;;     region2 = 48 "VMContext+0x30"
+;;     region3 = 32 "VMContext+0x20"
+;;     region4 = 40 "VMContext+0x28"
+;;     region5 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -95,20 +97,20 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
-;; @0025                               v5 = load.i32 notrap aligned v0+56
+;; @0025                               v5 = load.i32 notrap aligned region1 v0+56
 ;; @0025                               v7 = uextend.i64 v2
 ;; @0025                               v8 = uextend.i64 v3
 ;; @0025                               v11 = iadd v7, v8
 ;; @0025                               v6 = uextend.i64 v5
 ;; @0025                               v12 = icmp ugt v11, v6
 ;; @0025                               trapnz v12, heap_oob
-;; @0025                               v13 = load.i64 notrap aligned v0+48
+;; @0025                               v13 = load.i64 notrap aligned region2 v0+48
 ;; @0025                               v20 = iconst.i64 32
 ;; @0025                               v21 = ushr v8, v20  ; v20 = 32
 ;; @0025                               trapnz v21, user18
 ;; @0025                               v16 = iconst.i32 20
 ;; @0025                               v23 = uadd_overflow_trap v16, v3, user18  ; v16 = 20
-;; @0025                               v24 = load.i64 notrap aligned readonly can_move v0+32
+;; @0025                               v24 = load.i64 notrap aligned readonly can_move region3 v0+32
 ;; @0025                               v25 = load.i32 notrap aligned v24
 ;; @0025                               v26 = load.i32 notrap aligned v24+4
 ;; @0025                               v32 = uextend.i64 v25
@@ -128,13 +130,13 @@
 ;;                                     v126 = iconst.i32 -16
 ;;                                     v127 = band v123, v126  ; v126 = -16
 ;;                                     v129 = iadd.i32 v25, v127
-;; @0025                               store notrap aligned region2 v129, v24
+;; @0025                               store notrap aligned region3 v129, v24
 ;;                                     v143 = iconst.i32 -1476395002
 ;;                                     v144 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;;                                     v145 = load.i64 notrap aligned readonly can_move v144+32
 ;; @0025                               v49 = iadd v145, v32
 ;; @0025                               store notrap aligned v143, v49  ; v143 = -1476395002
-;;                                     v146 = load.i64 notrap aligned readonly can_move region1 v0+40
+;;                                     v146 = load.i64 notrap aligned readonly can_move region4 v0+40
 ;;                                     v147 = load.i32 notrap aligned readonly can_move v146
 ;; @0025                               store notrap aligned v147, v49+4
 ;;                                     v148 = band.i64 v30, v29  ; v29 = -16
@@ -143,7 +145,7 @@
 ;;
 ;;                                 block3 cold:
 ;; @0025                               v36 = iconst.i32 -1476395002
-;; @0025                               v37 = load.i64 notrap aligned readonly can_move region1 v0+40
+;; @0025                               v37 = load.i64 notrap aligned readonly can_move region4 v0+40
 ;; @0025                               v38 = load.i32 notrap aligned readonly can_move v37
 ;; @0025                               v39 = iconst.i32 16
 ;; @0025                               v40 = call fn0(v0, v36, v38, v23, v39)  ; v36 = -1476395002, v39 = 16
@@ -158,22 +160,22 @@
 ;;                                     store notrap v53, v112
 ;; @0025                               v55 = iconst.i64 16
 ;; @0025                               v56 = iadd v54, v55  ; v55 = 16
-;; @0025                               store.i32 user2 region3 v3, v56
+;; @0025                               store.i32 user2 region5 v3, v56
 ;; @0025                               trapz v53, user16
 ;;                                     v149 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;;                                     v150 = load.i64 notrap aligned readonly can_move v149+32
 ;; @0025                               v58 = uextend.i64 v53
 ;; @0025                               v60 = iadd v150, v58
 ;; @0025                               v62 = iadd v60, v55  ; v55 = 16
-;; @0025                               v63 = load.i32 user2 readonly region3 v62
+;; @0025                               v63 = load.i32 user2 readonly region5 v62
 ;; @0025                               v64 = uextend.i64 v63
 ;; @0025                               v70 = icmp.i64 ugt v8, v64
 ;; @0025                               trapnz v70, user17
-;; @0025                               v81 = load.i32 notrap aligned v0+56
+;; @0025                               v81 = load.i32 notrap aligned region1 v0+56
 ;; @0025                               v82 = uextend.i64 v81
 ;; @0025                               v88 = icmp.i64 ugt v11, v82
 ;; @0025                               trapnz v88, heap_oob
-;; @0025                               v89 = load.i64 notrap aligned v0+48
+;; @0025                               v89 = load.i64 notrap aligned region2 v0+48
 ;; @0025                               v100 = load.i64 notrap aligned v149+40
 ;; @0025                               v75 = iconst.i64 20
 ;; @0025                               v76 = iadd v60, v75  ; v75 = 20

--- a/tests/disas/gc/array-new-default-anyref.wat
+++ b/tests/disas/gc/array-new-default-anyref.wat
@@ -11,8 +11,8 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 40 "VMContext+0x28"
-;;     region2 = 32 "VMContext+0x20"
+;;     region1 = 32 "VMContext+0x20"
+;;     region2 = 40 "VMContext+0x28"
 ;;     region3 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
@@ -36,7 +36,7 @@
 ;;                                     v96 = iconst.i32 2
 ;;                                     v97 = ishl v2, v96  ; v96 = 2
 ;; @001f                               v11 = uadd_overflow_trap v4, v97, user18  ; v4 = 20
-;; @001f                               v12 = load.i64 notrap aligned readonly can_move v0+32
+;; @001f                               v12 = load.i64 notrap aligned readonly can_move region1 v0+32
 ;; @001f                               v13 = load.i32 notrap aligned v12
 ;; @001f                               v14 = load.i32 notrap aligned v12+4
 ;; @001f                               v20 = uextend.i64 v13
@@ -56,13 +56,13 @@
 ;;                                     v109 = iconst.i32 -16
 ;;                                     v110 = band v106, v109  ; v109 = -16
 ;;                                     v112 = iadd.i32 v13, v110
-;; @001f                               store notrap aligned region2 v112, v12
+;; @001f                               store notrap aligned region1 v112, v12
 ;;                                     v128 = iconst.i32 -1476394994
 ;;                                     v129 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;;                                     v130 = load.i64 notrap aligned readonly can_move v129+32
 ;; @001f                               v37 = iadd v130, v20
 ;; @001f                               store notrap aligned v128, v37  ; v128 = -1476394994
-;;                                     v131 = load.i64 notrap aligned readonly can_move region1 v0+40
+;;                                     v131 = load.i64 notrap aligned readonly can_move region2 v0+40
 ;;                                     v132 = load.i32 notrap aligned readonly can_move v131
 ;; @001f                               store notrap aligned v132, v37+4
 ;;                                     v133 = band.i64 v18, v17  ; v17 = -16
@@ -71,7 +71,7 @@
 ;;
 ;;                                 block3 cold:
 ;; @001f                               v24 = iconst.i32 -1476394994
-;; @001f                               v25 = load.i64 notrap aligned readonly can_move region1 v0+40
+;; @001f                               v25 = load.i64 notrap aligned readonly can_move region2 v0+40
 ;; @001f                               v26 = load.i32 notrap aligned readonly can_move v25
 ;; @001f                               v27 = iconst.i32 16
 ;; @001f                               v28 = call fn0(v0, v24, v26, v11, v27)  ; v24 = -1476394994, v27 = 16

--- a/tests/disas/gc/array-new-default-exnref.wat
+++ b/tests/disas/gc/array-new-default-exnref.wat
@@ -11,8 +11,8 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 40 "VMContext+0x28"
-;;     region2 = 32 "VMContext+0x20"
+;;     region1 = 32 "VMContext+0x20"
+;;     region2 = 40 "VMContext+0x28"
 ;;     region3 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
@@ -36,7 +36,7 @@
 ;;                                     v96 = iconst.i32 2
 ;;                                     v97 = ishl v2, v96  ; v96 = 2
 ;; @001f                               v11 = uadd_overflow_trap v4, v97, user18  ; v4 = 20
-;; @001f                               v12 = load.i64 notrap aligned readonly can_move v0+32
+;; @001f                               v12 = load.i64 notrap aligned readonly can_move region1 v0+32
 ;; @001f                               v13 = load.i32 notrap aligned v12
 ;; @001f                               v14 = load.i32 notrap aligned v12+4
 ;; @001f                               v20 = uextend.i64 v13
@@ -56,13 +56,13 @@
 ;;                                     v109 = iconst.i32 -16
 ;;                                     v110 = band v106, v109  ; v109 = -16
 ;;                                     v112 = iadd.i32 v13, v110
-;; @001f                               store notrap aligned region2 v112, v12
+;; @001f                               store notrap aligned region1 v112, v12
 ;;                                     v128 = iconst.i32 -1476394994
 ;;                                     v129 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;;                                     v130 = load.i64 notrap aligned readonly can_move v129+32
 ;; @001f                               v37 = iadd v130, v20
 ;; @001f                               store notrap aligned v128, v37  ; v128 = -1476394994
-;;                                     v131 = load.i64 notrap aligned readonly can_move region1 v0+40
+;;                                     v131 = load.i64 notrap aligned readonly can_move region2 v0+40
 ;;                                     v132 = load.i32 notrap aligned readonly can_move v131
 ;; @001f                               store notrap aligned v132, v37+4
 ;;                                     v133 = band.i64 v18, v17  ; v17 = -16
@@ -71,7 +71,7 @@
 ;;
 ;;                                 block3 cold:
 ;; @001f                               v24 = iconst.i32 -1476394994
-;; @001f                               v25 = load.i64 notrap aligned readonly can_move region1 v0+40
+;; @001f                               v25 = load.i64 notrap aligned readonly can_move region2 v0+40
 ;; @001f                               v26 = load.i32 notrap aligned readonly can_move v25
 ;; @001f                               v27 = iconst.i32 16
 ;; @001f                               v28 = call fn0(v0, v24, v26, v11, v27)  ; v24 = -1476394994, v27 = 16

--- a/tests/disas/gc/array-new-default-externref.wat
+++ b/tests/disas/gc/array-new-default-externref.wat
@@ -11,8 +11,8 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 40 "VMContext+0x28"
-;;     region2 = 32 "VMContext+0x20"
+;;     region1 = 32 "VMContext+0x20"
+;;     region2 = 40 "VMContext+0x28"
 ;;     region3 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
@@ -36,7 +36,7 @@
 ;;                                     v96 = iconst.i32 2
 ;;                                     v97 = ishl v2, v96  ; v96 = 2
 ;; @001f                               v11 = uadd_overflow_trap v4, v97, user18  ; v4 = 20
-;; @001f                               v12 = load.i64 notrap aligned readonly can_move v0+32
+;; @001f                               v12 = load.i64 notrap aligned readonly can_move region1 v0+32
 ;; @001f                               v13 = load.i32 notrap aligned v12
 ;; @001f                               v14 = load.i32 notrap aligned v12+4
 ;; @001f                               v20 = uextend.i64 v13
@@ -56,13 +56,13 @@
 ;;                                     v109 = iconst.i32 -16
 ;;                                     v110 = band v106, v109  ; v109 = -16
 ;;                                     v112 = iadd.i32 v13, v110
-;; @001f                               store notrap aligned region2 v112, v12
+;; @001f                               store notrap aligned region1 v112, v12
 ;;                                     v128 = iconst.i32 -1476394994
 ;;                                     v129 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;;                                     v130 = load.i64 notrap aligned readonly can_move v129+32
 ;; @001f                               v37 = iadd v130, v20
 ;; @001f                               store notrap aligned v128, v37  ; v128 = -1476394994
-;;                                     v131 = load.i64 notrap aligned readonly can_move region1 v0+40
+;;                                     v131 = load.i64 notrap aligned readonly can_move region2 v0+40
 ;;                                     v132 = load.i32 notrap aligned readonly can_move v131
 ;; @001f                               store notrap aligned v132, v37+4
 ;;                                     v133 = band.i64 v18, v17  ; v17 = -16
@@ -71,7 +71,7 @@
 ;;
 ;;                                 block3 cold:
 ;; @001f                               v24 = iconst.i32 -1476394994
-;; @001f                               v25 = load.i64 notrap aligned readonly can_move region1 v0+40
+;; @001f                               v25 = load.i64 notrap aligned readonly can_move region2 v0+40
 ;; @001f                               v26 = load.i32 notrap aligned readonly can_move v25
 ;; @001f                               v27 = iconst.i32 16
 ;; @001f                               v28 = call fn0(v0, v24, v26, v11, v27)  ; v24 = -1476394994, v27 = 16

--- a/tests/disas/gc/array-new-default-f32.wat
+++ b/tests/disas/gc/array-new-default-f32.wat
@@ -12,8 +12,8 @@
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     ss0 = explicit_slot 4, align = 4
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 40 "VMContext+0x28"
-;;     region2 = 32 "VMContext+0x20"
+;;     region1 = 32 "VMContext+0x20"
+;;     region2 = 40 "VMContext+0x28"
 ;;     region3 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
@@ -39,7 +39,7 @@
 ;;                                     v99 = iconst.i32 2
 ;;                                     v100 = ishl v2, v99  ; v99 = 2
 ;; @001f                               v11 = uadd_overflow_trap v4, v100, user18  ; v4 = 20
-;; @001f                               v12 = load.i64 notrap aligned readonly can_move v0+32
+;; @001f                               v12 = load.i64 notrap aligned readonly can_move region1 v0+32
 ;; @001f                               v13 = load.i32 notrap aligned v12
 ;; @001f                               v14 = load.i32 notrap aligned v12+4
 ;; @001f                               v20 = uextend.i64 v13
@@ -59,13 +59,13 @@
 ;;                                     v112 = iconst.i32 -16
 ;;                                     v113 = band v109, v112  ; v112 = -16
 ;;                                     v115 = iadd.i32 v13, v113
-;; @001f                               store notrap aligned region2 v115, v12
+;; @001f                               store notrap aligned region1 v115, v12
 ;;                                     v131 = iconst.i32 -1476395002
 ;;                                     v132 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;;                                     v133 = load.i64 notrap aligned readonly can_move v132+32
 ;; @001f                               v37 = iadd v133, v20
 ;; @001f                               store notrap aligned v131, v37  ; v131 = -1476395002
-;;                                     v134 = load.i64 notrap aligned readonly can_move region1 v0+40
+;;                                     v134 = load.i64 notrap aligned readonly can_move region2 v0+40
 ;;                                     v135 = load.i32 notrap aligned readonly can_move v134
 ;; @001f                               store notrap aligned v135, v37+4
 ;;                                     v136 = band.i64 v18, v17  ; v17 = -16
@@ -74,7 +74,7 @@
 ;;
 ;;                                 block3 cold:
 ;; @001f                               v24 = iconst.i32 -1476395002
-;; @001f                               v25 = load.i64 notrap aligned readonly can_move region1 v0+40
+;; @001f                               v25 = load.i64 notrap aligned readonly can_move region2 v0+40
 ;; @001f                               v26 = load.i32 notrap aligned readonly can_move v25
 ;; @001f                               v27 = iconst.i32 16
 ;; @001f                               v28 = call fn0(v0, v24, v26, v11, v27)  ; v24 = -1476395002, v27 = 16

--- a/tests/disas/gc/array-new-default-f64.wat
+++ b/tests/disas/gc/array-new-default-f64.wat
@@ -12,8 +12,8 @@
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     ss0 = explicit_slot 4, align = 4
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 40 "VMContext+0x28"
-;;     region2 = 32 "VMContext+0x20"
+;;     region1 = 32 "VMContext+0x20"
+;;     region2 = 40 "VMContext+0x28"
 ;;     region3 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
@@ -39,7 +39,7 @@
 ;;                                     v99 = iconst.i32 3
 ;;                                     v100 = ishl v2, v99  ; v99 = 3
 ;; @001f                               v11 = uadd_overflow_trap v4, v100, user18  ; v4 = 24
-;; @001f                               v12 = load.i64 notrap aligned readonly can_move v0+32
+;; @001f                               v12 = load.i64 notrap aligned readonly can_move region1 v0+32
 ;; @001f                               v13 = load.i32 notrap aligned v12
 ;; @001f                               v14 = load.i32 notrap aligned v12+4
 ;; @001f                               v20 = uextend.i64 v13
@@ -59,13 +59,13 @@
 ;;                                     v112 = iconst.i32 -16
 ;;                                     v113 = band v109, v112  ; v112 = -16
 ;;                                     v115 = iadd.i32 v13, v113
-;; @001f                               store notrap aligned region2 v115, v12
+;; @001f                               store notrap aligned region1 v115, v12
 ;;                                     v131 = iconst.i32 -1476395002
 ;;                                     v132 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;;                                     v133 = load.i64 notrap aligned readonly can_move v132+32
 ;; @001f                               v37 = iadd v133, v20
 ;; @001f                               store notrap aligned v131, v37  ; v131 = -1476395002
-;;                                     v134 = load.i64 notrap aligned readonly can_move region1 v0+40
+;;                                     v134 = load.i64 notrap aligned readonly can_move region2 v0+40
 ;;                                     v135 = load.i32 notrap aligned readonly can_move v134
 ;; @001f                               store notrap aligned v135, v37+4
 ;;                                     v136 = band.i64 v18, v17  ; v17 = -16
@@ -74,7 +74,7 @@
 ;;
 ;;                                 block3 cold:
 ;; @001f                               v24 = iconst.i32 -1476395002
-;; @001f                               v25 = load.i64 notrap aligned readonly can_move region1 v0+40
+;; @001f                               v25 = load.i64 notrap aligned readonly can_move region2 v0+40
 ;; @001f                               v26 = load.i32 notrap aligned readonly can_move v25
 ;; @001f                               v27 = iconst.i32 16
 ;; @001f                               v28 = call fn0(v0, v24, v26, v11, v27)  ; v24 = -1476395002, v27 = 16

--- a/tests/disas/gc/array-new-default-funcref.wat
+++ b/tests/disas/gc/array-new-default-funcref.wat
@@ -12,8 +12,8 @@
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     ss0 = explicit_slot 4, align = 4
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 40 "VMContext+0x28"
-;;     region2 = 32 "VMContext+0x20"
+;;     region1 = 32 "VMContext+0x20"
+;;     region2 = 40 "VMContext+0x28"
 ;;     region3 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
@@ -39,7 +39,7 @@
 ;;                                     v107 = iconst.i32 2
 ;;                                     v108 = ishl v2, v107  ; v107 = 2
 ;; @001f                               v11 = uadd_overflow_trap v4, v108, user18  ; v4 = 20
-;; @001f                               v12 = load.i64 notrap aligned readonly can_move v0+32
+;; @001f                               v12 = load.i64 notrap aligned readonly can_move region1 v0+32
 ;; @001f                               v13 = load.i32 notrap aligned v12
 ;; @001f                               v14 = load.i32 notrap aligned v12+4
 ;; @001f                               v20 = uextend.i64 v13
@@ -59,13 +59,13 @@
 ;;                                     v120 = iconst.i32 -16
 ;;                                     v121 = band v117, v120  ; v120 = -16
 ;;                                     v123 = iadd.i32 v13, v121
-;; @001f                               store notrap aligned region2 v123, v12
+;; @001f                               store notrap aligned region1 v123, v12
 ;;                                     v138 = iconst.i32 -1476395002
 ;;                                     v139 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;;                                     v140 = load.i64 notrap aligned readonly can_move v139+32
 ;; @001f                               v37 = iadd v140, v20
 ;; @001f                               store notrap aligned v138, v37  ; v138 = -1476395002
-;;                                     v141 = load.i64 notrap aligned readonly can_move region1 v0+40
+;;                                     v141 = load.i64 notrap aligned readonly can_move region2 v0+40
 ;;                                     v142 = load.i32 notrap aligned readonly can_move v141
 ;; @001f                               store notrap aligned v142, v37+4
 ;;                                     v143 = band.i64 v18, v17  ; v17 = -16
@@ -74,7 +74,7 @@
 ;;
 ;;                                 block3 cold:
 ;; @001f                               v24 = iconst.i32 -1476395002
-;; @001f                               v25 = load.i64 notrap aligned readonly can_move region1 v0+40
+;; @001f                               v25 = load.i64 notrap aligned readonly can_move region2 v0+40
 ;; @001f                               v26 = load.i32 notrap aligned readonly can_move v25
 ;; @001f                               v27 = iconst.i32 16
 ;; @001f                               v28 = call fn0(v0, v24, v26, v11, v27)  ; v24 = -1476395002, v27 = 16

--- a/tests/disas/gc/array-new-default-i16.wat
+++ b/tests/disas/gc/array-new-default-i16.wat
@@ -12,8 +12,8 @@
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     ss0 = explicit_slot 4, align = 4
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 40 "VMContext+0x28"
-;;     region2 = 32 "VMContext+0x20"
+;;     region1 = 32 "VMContext+0x20"
+;;     region2 = 40 "VMContext+0x28"
 ;;     region3 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
@@ -38,7 +38,7 @@
 ;; @001f                               v4 = iconst.i32 20
 ;;                                     v98 = iadd v2, v2
 ;; @001f                               v11 = uadd_overflow_trap v4, v98, user18  ; v4 = 20
-;; @001f                               v12 = load.i64 notrap aligned readonly can_move v0+32
+;; @001f                               v12 = load.i64 notrap aligned readonly can_move region1 v0+32
 ;; @001f                               v13 = load.i32 notrap aligned v12
 ;; @001f                               v14 = load.i32 notrap aligned v12+4
 ;; @001f                               v20 = uextend.i64 v13
@@ -58,13 +58,13 @@
 ;;                                     v117 = iconst.i32 -16
 ;;                                     v118 = band v114, v117  ; v117 = -16
 ;;                                     v120 = iadd.i32 v13, v118
-;; @001f                               store notrap aligned region2 v120, v12
+;; @001f                               store notrap aligned region1 v120, v12
 ;;                                     v141 = iconst.i32 -1476395002
 ;;                                     v142 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;;                                     v143 = load.i64 notrap aligned readonly can_move v142+32
 ;; @001f                               v37 = iadd v143, v20
 ;; @001f                               store notrap aligned v141, v37  ; v141 = -1476395002
-;;                                     v144 = load.i64 notrap aligned readonly can_move region1 v0+40
+;;                                     v144 = load.i64 notrap aligned readonly can_move region2 v0+40
 ;;                                     v145 = load.i32 notrap aligned readonly can_move v144
 ;; @001f                               store notrap aligned v145, v37+4
 ;;                                     v146 = band.i64 v18, v17  ; v17 = -16
@@ -73,7 +73,7 @@
 ;;
 ;;                                 block3 cold:
 ;; @001f                               v24 = iconst.i32 -1476395002
-;; @001f                               v25 = load.i64 notrap aligned readonly can_move region1 v0+40
+;; @001f                               v25 = load.i64 notrap aligned readonly can_move region2 v0+40
 ;; @001f                               v26 = load.i32 notrap aligned readonly can_move v25
 ;; @001f                               v27 = iconst.i32 16
 ;; @001f                               v28 = call fn0(v0, v24, v26, v11, v27)  ; v24 = -1476395002, v27 = 16

--- a/tests/disas/gc/array-new-default-i32.wat
+++ b/tests/disas/gc/array-new-default-i32.wat
@@ -12,8 +12,8 @@
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     ss0 = explicit_slot 4, align = 4
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 40 "VMContext+0x28"
-;;     region2 = 32 "VMContext+0x20"
+;;     region1 = 32 "VMContext+0x20"
+;;     region2 = 40 "VMContext+0x28"
 ;;     region3 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
@@ -39,7 +39,7 @@
 ;;                                     v99 = iconst.i32 2
 ;;                                     v100 = ishl v2, v99  ; v99 = 2
 ;; @001f                               v11 = uadd_overflow_trap v4, v100, user18  ; v4 = 20
-;; @001f                               v12 = load.i64 notrap aligned readonly can_move v0+32
+;; @001f                               v12 = load.i64 notrap aligned readonly can_move region1 v0+32
 ;; @001f                               v13 = load.i32 notrap aligned v12
 ;; @001f                               v14 = load.i32 notrap aligned v12+4
 ;; @001f                               v20 = uextend.i64 v13
@@ -59,13 +59,13 @@
 ;;                                     v112 = iconst.i32 -16
 ;;                                     v113 = band v109, v112  ; v112 = -16
 ;;                                     v115 = iadd.i32 v13, v113
-;; @001f                               store notrap aligned region2 v115, v12
+;; @001f                               store notrap aligned region1 v115, v12
 ;;                                     v131 = iconst.i32 -1476395002
 ;;                                     v132 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;;                                     v133 = load.i64 notrap aligned readonly can_move v132+32
 ;; @001f                               v37 = iadd v133, v20
 ;; @001f                               store notrap aligned v131, v37  ; v131 = -1476395002
-;;                                     v134 = load.i64 notrap aligned readonly can_move region1 v0+40
+;;                                     v134 = load.i64 notrap aligned readonly can_move region2 v0+40
 ;;                                     v135 = load.i32 notrap aligned readonly can_move v134
 ;; @001f                               store notrap aligned v135, v37+4
 ;;                                     v136 = band.i64 v18, v17  ; v17 = -16
@@ -74,7 +74,7 @@
 ;;
 ;;                                 block3 cold:
 ;; @001f                               v24 = iconst.i32 -1476395002
-;; @001f                               v25 = load.i64 notrap aligned readonly can_move region1 v0+40
+;; @001f                               v25 = load.i64 notrap aligned readonly can_move region2 v0+40
 ;; @001f                               v26 = load.i32 notrap aligned readonly can_move v25
 ;; @001f                               v27 = iconst.i32 16
 ;; @001f                               v28 = call fn0(v0, v24, v26, v11, v27)  ; v24 = -1476395002, v27 = 16

--- a/tests/disas/gc/array-new-default-i64.wat
+++ b/tests/disas/gc/array-new-default-i64.wat
@@ -12,8 +12,8 @@
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     ss0 = explicit_slot 4, align = 4
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 40 "VMContext+0x28"
-;;     region2 = 32 "VMContext+0x20"
+;;     region1 = 32 "VMContext+0x20"
+;;     region2 = 40 "VMContext+0x28"
 ;;     region3 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
@@ -39,7 +39,7 @@
 ;;                                     v99 = iconst.i32 3
 ;;                                     v100 = ishl v2, v99  ; v99 = 3
 ;; @001f                               v11 = uadd_overflow_trap v4, v100, user18  ; v4 = 24
-;; @001f                               v12 = load.i64 notrap aligned readonly can_move v0+32
+;; @001f                               v12 = load.i64 notrap aligned readonly can_move region1 v0+32
 ;; @001f                               v13 = load.i32 notrap aligned v12
 ;; @001f                               v14 = load.i32 notrap aligned v12+4
 ;; @001f                               v20 = uextend.i64 v13
@@ -59,13 +59,13 @@
 ;;                                     v112 = iconst.i32 -16
 ;;                                     v113 = band v109, v112  ; v112 = -16
 ;;                                     v115 = iadd.i32 v13, v113
-;; @001f                               store notrap aligned region2 v115, v12
+;; @001f                               store notrap aligned region1 v115, v12
 ;;                                     v130 = iconst.i32 -1476395002
 ;;                                     v131 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;;                                     v132 = load.i64 notrap aligned readonly can_move v131+32
 ;; @001f                               v37 = iadd v132, v20
 ;; @001f                               store notrap aligned v130, v37  ; v130 = -1476395002
-;;                                     v133 = load.i64 notrap aligned readonly can_move region1 v0+40
+;;                                     v133 = load.i64 notrap aligned readonly can_move region2 v0+40
 ;;                                     v134 = load.i32 notrap aligned readonly can_move v133
 ;; @001f                               store notrap aligned v134, v37+4
 ;;                                     v135 = band.i64 v18, v17  ; v17 = -16
@@ -74,7 +74,7 @@
 ;;
 ;;                                 block3 cold:
 ;; @001f                               v24 = iconst.i32 -1476395002
-;; @001f                               v25 = load.i64 notrap aligned readonly can_move region1 v0+40
+;; @001f                               v25 = load.i64 notrap aligned readonly can_move region2 v0+40
 ;; @001f                               v26 = load.i32 notrap aligned readonly can_move v25
 ;; @001f                               v27 = iconst.i32 16
 ;; @001f                               v28 = call fn0(v0, v24, v26, v11, v27)  ; v24 = -1476395002, v27 = 16

--- a/tests/disas/gc/array-new-default-i8.wat
+++ b/tests/disas/gc/array-new-default-i8.wat
@@ -12,8 +12,8 @@
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     ss0 = explicit_slot 4, align = 4
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 40 "VMContext+0x28"
-;;     region2 = 32 "VMContext+0x20"
+;;     region1 = 32 "VMContext+0x20"
+;;     region2 = 40 "VMContext+0x28"
 ;;     region3 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
@@ -35,7 +35,7 @@
 ;; @001f                               trapnz v9, user18
 ;; @001f                               v4 = iconst.i32 20
 ;; @001f                               v11 = uadd_overflow_trap v4, v2, user18  ; v4 = 20
-;; @001f                               v12 = load.i64 notrap aligned readonly can_move v0+32
+;; @001f                               v12 = load.i64 notrap aligned readonly can_move region1 v0+32
 ;; @001f                               v13 = load.i32 notrap aligned v12
 ;; @001f                               v14 = load.i32 notrap aligned v12+4
 ;; @001f                               v20 = uextend.i64 v13
@@ -55,13 +55,13 @@
 ;;                                     v102 = iconst.i32 -16
 ;;                                     v103 = band v99, v102  ; v102 = -16
 ;;                                     v105 = iadd.i32 v13, v103
-;; @001f                               store notrap aligned region2 v105, v12
+;; @001f                               store notrap aligned region1 v105, v12
 ;;                                     v119 = iconst.i32 -1476395002
 ;;                                     v120 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;;                                     v121 = load.i64 notrap aligned readonly can_move v120+32
 ;; @001f                               v37 = iadd v121, v20
 ;; @001f                               store notrap aligned v119, v37  ; v119 = -1476395002
-;;                                     v122 = load.i64 notrap aligned readonly can_move region1 v0+40
+;;                                     v122 = load.i64 notrap aligned readonly can_move region2 v0+40
 ;;                                     v123 = load.i32 notrap aligned readonly can_move v122
 ;; @001f                               store notrap aligned v123, v37+4
 ;;                                     v124 = band.i64 v18, v17  ; v17 = -16
@@ -70,7 +70,7 @@
 ;;
 ;;                                 block3 cold:
 ;; @001f                               v24 = iconst.i32 -1476395002
-;; @001f                               v25 = load.i64 notrap aligned readonly can_move region1 v0+40
+;; @001f                               v25 = load.i64 notrap aligned readonly can_move region2 v0+40
 ;; @001f                               v26 = load.i32 notrap aligned readonly can_move v25
 ;; @001f                               v27 = iconst.i32 16
 ;; @001f                               v28 = call fn0(v0, v24, v26, v11, v27)  ; v24 = -1476395002, v27 = 16

--- a/tests/disas/gc/copying/array-new-fixed-of-gc-refs.wat
+++ b/tests/disas/gc/copying/array-new-fixed-of-gc-refs.wat
@@ -13,8 +13,8 @@
 ;;     ss1 = explicit_slot 4, align = 4
 ;;     ss2 = explicit_slot 4, align = 4
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 40 "VMContext+0x28"
-;;     region2 = 32 "VMContext+0x20"
+;;     region1 = 32 "VMContext+0x20"
+;;     region2 = 40 "VMContext+0x28"
 ;;     region3 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
@@ -34,7 +34,7 @@
 ;;                                     store notrap v3, v133
 ;;                                     v134 = stack_addr.i64 ss0
 ;;                                     store notrap v4, v134
-;; @0025                               v15 = load.i64 notrap aligned readonly can_move v0+32
+;; @0025                               v15 = load.i64 notrap aligned readonly can_move region1 v0+32
 ;; @0025                               v16 = load.i32 notrap aligned v15
 ;; @0025                               v17 = load.i32 notrap aligned v15+4
 ;; @0025                               v23 = uextend.i64 v16
@@ -47,13 +47,13 @@
 ;;                                 block2:
 ;;                                     v266 = iconst.i32 32
 ;;                                     v172 = iadd.i32 v16, v266  ; v266 = 32
-;; @0025                               store notrap aligned region2 v172, v15
+;; @0025                               store notrap aligned region1 v172, v15
 ;;                                     v267 = iconst.i32 -1476394994
 ;;                                     v268 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;;                                     v269 = load.i64 notrap aligned readonly can_move v268+32
 ;; @0025                               v40 = iadd v269, v23
 ;; @0025                               store notrap aligned v267, v40  ; v267 = -1476394994
-;;                                     v270 = load.i64 notrap aligned readonly can_move region1 v0+40
+;;                                     v270 = load.i64 notrap aligned readonly can_move region2 v0+40
 ;;                                     v271 = load.i32 notrap aligned readonly can_move v270
 ;; @0025                               store notrap aligned v271, v40+4
 ;;                                     v272 = iconst.i64 32
@@ -62,7 +62,7 @@
 ;;
 ;;                                 block3 cold:
 ;; @0025                               v27 = iconst.i32 -1476394994
-;; @0025                               v28 = load.i64 notrap aligned readonly can_move region1 v0+40
+;; @0025                               v28 = load.i64 notrap aligned readonly can_move region2 v0+40
 ;; @0025                               v29 = load.i32 notrap aligned readonly can_move v28
 ;;                                     v158 = iconst.i32 32
 ;; @0025                               v30 = iconst.i32 16

--- a/tests/disas/gc/copying/array-new-fixed.wat
+++ b/tests/disas/gc/copying/array-new-fixed.wat
@@ -10,8 +10,8 @@
 )
 ;; function u0:0(i64 vmctx, i64, i64, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 40 "VMContext+0x28"
-;;     region2 = 32 "VMContext+0x20"
+;;     region1 = 32 "VMContext+0x20"
+;;     region2 = 40 "VMContext+0x28"
 ;;     region3 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
@@ -25,7 +25,7 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i64, v4: i64):
-;; @0025                               v15 = load.i64 notrap aligned readonly can_move v0+32
+;; @0025                               v15 = load.i64 notrap aligned readonly can_move region1 v0+32
 ;; @0025                               v16 = load.i32 notrap aligned v15
 ;; @0025                               v17 = load.i32 notrap aligned v15+4
 ;; @0025                               v23 = uextend.i64 v16
@@ -38,13 +38,13 @@
 ;;                                 block2:
 ;;                                     v254 = iconst.i32 48
 ;;                                     v162 = iadd.i32 v16, v254  ; v254 = 48
-;; @0025                               store notrap aligned region2 v162, v15
+;; @0025                               store notrap aligned region1 v162, v15
 ;;                                     v255 = iconst.i32 -1476395002
 ;;                                     v256 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;;                                     v257 = load.i64 notrap aligned readonly can_move v256+32
 ;; @0025                               v40 = iadd v257, v23
 ;; @0025                               store notrap aligned v255, v40  ; v255 = -1476395002
-;;                                     v258 = load.i64 notrap aligned readonly can_move region1 v0+40
+;;                                     v258 = load.i64 notrap aligned readonly can_move region2 v0+40
 ;;                                     v259 = load.i32 notrap aligned readonly can_move v258
 ;; @0025                               store notrap aligned v259, v40+4
 ;;                                     v260 = iconst.i64 48
@@ -53,7 +53,7 @@
 ;;
 ;;                                 block3 cold:
 ;; @0025                               v27 = iconst.i32 -1476395002
-;; @0025                               v28 = load.i64 notrap aligned readonly can_move region1 v0+40
+;; @0025                               v28 = load.i64 notrap aligned readonly can_move region2 v0+40
 ;; @0025                               v29 = load.i32 notrap aligned readonly can_move v28
 ;;                                     v147 = iconst.i32 48
 ;; @0025                               v30 = iconst.i32 16

--- a/tests/disas/gc/copying/array-new.wat
+++ b/tests/disas/gc/copying/array-new.wat
@@ -10,8 +10,8 @@
 )
 ;; function u0:0(i64 vmctx, i64, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 40 "VMContext+0x28"
-;;     region2 = 32 "VMContext+0x20"
+;;     region1 = 32 "VMContext+0x20"
+;;     region2 = 40 "VMContext+0x28"
 ;;     region3 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
@@ -35,7 +35,7 @@
 ;;                                     v96 = iconst.i32 3
 ;;                                     v97 = ishl v3, v96  ; v96 = 3
 ;; @0022                               v12 = uadd_overflow_trap v5, v97, user18  ; v5 = 24
-;; @0022                               v13 = load.i64 notrap aligned readonly can_move v0+32
+;; @0022                               v13 = load.i64 notrap aligned readonly can_move region1 v0+32
 ;; @0022                               v14 = load.i32 notrap aligned v13
 ;; @0022                               v15 = load.i32 notrap aligned v13+4
 ;; @0022                               v21 = uextend.i64 v14
@@ -55,13 +55,13 @@
 ;;                                     v109 = iconst.i32 -16
 ;;                                     v110 = band v106, v109  ; v109 = -16
 ;;                                     v112 = iadd.i32 v14, v110
-;; @0022                               store notrap aligned region2 v112, v13
+;; @0022                               store notrap aligned region1 v112, v13
 ;;                                     v128 = iconst.i32 -1476395002
 ;;                                     v129 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;;                                     v130 = load.i64 notrap aligned readonly can_move v129+32
 ;; @0022                               v38 = iadd v130, v21
 ;; @0022                               store notrap aligned v128, v38  ; v128 = -1476395002
-;;                                     v131 = load.i64 notrap aligned readonly can_move region1 v0+40
+;;                                     v131 = load.i64 notrap aligned readonly can_move region2 v0+40
 ;;                                     v132 = load.i32 notrap aligned readonly can_move v131
 ;; @0022                               store notrap aligned v132, v38+4
 ;;                                     v133 = band.i64 v19, v18  ; v18 = -16
@@ -70,7 +70,7 @@
 ;;
 ;;                                 block3 cold:
 ;; @0022                               v25 = iconst.i32 -1476395002
-;; @0022                               v26 = load.i64 notrap aligned readonly can_move region1 v0+40
+;; @0022                               v26 = load.i64 notrap aligned readonly can_move region2 v0+40
 ;; @0022                               v27 = load.i32 notrap aligned readonly can_move v26
 ;; @0022                               v28 = iconst.i32 16
 ;; @0022                               v29 = call fn0(v0, v25, v27, v12, v28)  ; v25 = -1476395002, v28 = 16

--- a/tests/disas/gc/copying/funcref-in-gc-heap-new.wat
+++ b/tests/disas/gc/copying/funcref-in-gc-heap-new.wat
@@ -11,8 +11,8 @@
 ;; function u0:0(i64 vmctx, i64, i64) -> i32 tail {
 ;;     ss0 = explicit_slot 4, align = 4
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 40 "VMContext+0x28"
-;;     region2 = 32 "VMContext+0x20"
+;;     region1 = 32 "VMContext+0x20"
+;;     region2 = 40 "VMContext+0x28"
 ;;     region3 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
@@ -24,7 +24,7 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0020                               v5 = load.i64 notrap aligned readonly can_move v0+32
+;; @0020                               v5 = load.i64 notrap aligned readonly can_move region1 v0+32
 ;; @0020                               v6 = load.i32 notrap aligned v5
 ;; @0020                               v7 = load.i32 notrap aligned v5+4
 ;; @0020                               v13 = uextend.i64 v6
@@ -37,13 +37,13 @@
 ;;                                 block2:
 ;;                                     v59 = iconst.i32 32
 ;;                                     v57 = iadd.i32 v6, v59  ; v59 = 32
-;; @0020                               store notrap aligned region2 v57, v5
+;; @0020                               store notrap aligned region1 v57, v5
 ;;                                     v60 = iconst.i32 -1342177278
 ;;                                     v61 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;;                                     v62 = load.i64 notrap aligned readonly can_move v61+32
 ;; @0020                               v30 = iadd v62, v13
 ;; @0020                               store notrap aligned v60, v30  ; v60 = -1342177278
-;;                                     v63 = load.i64 notrap aligned readonly can_move region1 v0+40
+;;                                     v63 = load.i64 notrap aligned readonly can_move region2 v0+40
 ;;                                     v64 = load.i32 notrap aligned readonly can_move v63
 ;; @0020                               store notrap aligned v64, v30+4
 ;;                                     v65 = iconst.i64 32
@@ -52,7 +52,7 @@
 ;;
 ;;                                 block3 cold:
 ;; @0020                               v17 = iconst.i32 -1342177278
-;; @0020                               v18 = load.i64 notrap aligned readonly can_move region1 v0+40
+;; @0020                               v18 = load.i64 notrap aligned readonly can_move region2 v0+40
 ;; @0020                               v19 = load.i32 notrap aligned readonly can_move v18
 ;; @0020                               v4 = iconst.i32 32
 ;; @0020                               v20 = iconst.i32 16

--- a/tests/disas/gc/copying/struct-new-default.wat
+++ b/tests/disas/gc/copying/struct-new-default.wat
@@ -12,8 +12,8 @@
 )
 ;; function u0:0(i64 vmctx, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 40 "VMContext+0x28"
-;;     region2 = 32 "VMContext+0x20"
+;;     region1 = 32 "VMContext+0x20"
+;;     region2 = 40 "VMContext+0x28"
 ;;     region3 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
@@ -23,7 +23,7 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @0021                               v7 = load.i64 notrap aligned readonly can_move v0+32
+;; @0021                               v7 = load.i64 notrap aligned readonly can_move region1 v0+32
 ;; @0021                               v8 = load.i32 notrap aligned v7
 ;; @0021                               v9 = load.i32 notrap aligned v7+4
 ;; @0021                               v15 = uextend.i64 v8
@@ -36,13 +36,13 @@
 ;;                                 block2:
 ;;                                     v60 = iconst.i32 32
 ;;                                     v58 = iadd.i32 v8, v60  ; v60 = 32
-;; @0021                               store notrap aligned region2 v58, v7
+;; @0021                               store notrap aligned region1 v58, v7
 ;;                                     v61 = iconst.i32 -1342177246
 ;;                                     v62 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;;                                     v63 = load.i64 notrap aligned readonly can_move v62+32
 ;; @0021                               v32 = iadd v63, v15
 ;; @0021                               store notrap aligned v61, v32  ; v61 = -1342177246
-;;                                     v64 = load.i64 notrap aligned readonly can_move region1 v0+40
+;;                                     v64 = load.i64 notrap aligned readonly can_move region2 v0+40
 ;;                                     v65 = load.i32 notrap aligned readonly can_move v64
 ;; @0021                               store notrap aligned v65, v32+4
 ;;                                     v66 = iconst.i64 32
@@ -51,7 +51,7 @@
 ;;
 ;;                                 block3 cold:
 ;; @0021                               v19 = iconst.i32 -1342177246
-;; @0021                               v20 = load.i64 notrap aligned readonly can_move region1 v0+40
+;; @0021                               v20 = load.i64 notrap aligned readonly can_move region2 v0+40
 ;; @0021                               v21 = load.i32 notrap aligned readonly can_move v20
 ;; @0021                               v6 = iconst.i32 32
 ;; @0021                               v22 = iconst.i32 16

--- a/tests/disas/gc/copying/struct-new.wat
+++ b/tests/disas/gc/copying/struct-new.wat
@@ -13,8 +13,8 @@
 ;; function u0:0(i64 vmctx, i64, f32, i32, i32) -> i32 tail {
 ;;     ss0 = explicit_slot 4, align = 4
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 40 "VMContext+0x28"
-;;     region2 = 32 "VMContext+0x20"
+;;     region1 = 32 "VMContext+0x20"
+;;     region2 = 40 "VMContext+0x28"
 ;;     region3 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
@@ -26,7 +26,7 @@
 ;;                                 block0(v0: i64, v1: i64, v2: f32, v3: i32, v4: i32):
 ;;                                     v46 = stack_addr.i64 ss0
 ;;                                     store notrap v4, v46
-;; @002a                               v7 = load.i64 notrap aligned readonly can_move v0+32
+;; @002a                               v7 = load.i64 notrap aligned readonly can_move region1 v0+32
 ;; @002a                               v8 = load.i32 notrap aligned v7
 ;; @002a                               v9 = load.i32 notrap aligned v7+4
 ;; @002a                               v15 = uextend.i64 v8
@@ -39,13 +39,13 @@
 ;;                                 block2:
 ;;                                     v63 = iconst.i32 32
 ;;                                     v61 = iadd.i32 v8, v63  ; v63 = 32
-;; @002a                               store notrap aligned region2 v61, v7
+;; @002a                               store notrap aligned region1 v61, v7
 ;;                                     v64 = iconst.i32 -1342177246
 ;;                                     v65 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;;                                     v66 = load.i64 notrap aligned readonly can_move v65+32
 ;; @002a                               v32 = iadd v66, v15
 ;; @002a                               store notrap aligned v64, v32  ; v64 = -1342177246
-;;                                     v67 = load.i64 notrap aligned readonly can_move region1 v0+40
+;;                                     v67 = load.i64 notrap aligned readonly can_move region2 v0+40
 ;;                                     v68 = load.i32 notrap aligned readonly can_move v67
 ;; @002a                               store notrap aligned v68, v32+4
 ;;                                     v69 = iconst.i64 32
@@ -54,7 +54,7 @@
 ;;
 ;;                                 block3 cold:
 ;; @002a                               v19 = iconst.i32 -1342177246
-;; @002a                               v20 = load.i64 notrap aligned readonly can_move region1 v0+40
+;; @002a                               v20 = load.i64 notrap aligned readonly can_move region2 v0+40
 ;; @002a                               v21 = load.i32 notrap aligned readonly can_move v20
 ;; @002a                               v6 = iconst.i32 32
 ;; @002a                               v22 = iconst.i32 16

--- a/tests/disas/gc/struct-new-default.wat
+++ b/tests/disas/gc/struct-new-default.wat
@@ -14,8 +14,8 @@
 )
 ;; function u0:0(i64 vmctx, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 40 "VMContext+0x28"
-;;     region2 = 32 "VMContext+0x20"
+;;     region1 = 32 "VMContext+0x20"
+;;     region2 = 40 "VMContext+0x28"
 ;;     region3 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
@@ -26,7 +26,7 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @0023                               v8 = load.i64 notrap aligned readonly can_move v0+32
+;; @0023                               v8 = load.i64 notrap aligned readonly can_move region1 v0+32
 ;; @0023                               v9 = load.i32 notrap aligned v8
 ;; @0023                               v10 = load.i32 notrap aligned v8+4
 ;; @0023                               v16 = uextend.i64 v9
@@ -39,13 +39,13 @@
 ;;                                 block2:
 ;;                                     v63 = iconst.i32 48
 ;;                                     v61 = iadd.i32 v9, v63  ; v63 = 48
-;; @0023                               store notrap aligned region2 v61, v8
+;; @0023                               store notrap aligned region1 v61, v8
 ;;                                     v64 = iconst.i32 -1342177246
 ;;                                     v65 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;;                                     v66 = load.i64 notrap aligned readonly can_move v65+32
 ;; @0023                               v33 = iadd v66, v16
 ;; @0023                               store notrap aligned v64, v33  ; v64 = -1342177246
-;;                                     v67 = load.i64 notrap aligned readonly can_move region1 v0+40
+;;                                     v67 = load.i64 notrap aligned readonly can_move region2 v0+40
 ;;                                     v68 = load.i32 notrap aligned readonly can_move v67
 ;; @0023                               store notrap aligned v68, v33+4
 ;;                                     v69 = iconst.i64 48
@@ -54,7 +54,7 @@
 ;;
 ;;                                 block3 cold:
 ;; @0023                               v20 = iconst.i32 -1342177246
-;; @0023                               v21 = load.i64 notrap aligned readonly can_move region1 v0+40
+;; @0023                               v21 = load.i64 notrap aligned readonly can_move region2 v0+40
 ;; @0023                               v22 = load.i32 notrap aligned readonly can_move v21
 ;; @0023                               v7 = iconst.i32 48
 ;; @0023                               v23 = iconst.i32 16

--- a/tests/disas/gc/struct-new.wat
+++ b/tests/disas/gc/struct-new.wat
@@ -14,8 +14,8 @@
 ;; function u0:0(i64 vmctx, i64, f32, i32, i32) -> i32 tail {
 ;;     ss0 = explicit_slot 4, align = 4
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 40 "VMContext+0x28"
-;;     region2 = 32 "VMContext+0x20"
+;;     region1 = 32 "VMContext+0x20"
+;;     region2 = 40 "VMContext+0x28"
 ;;     region3 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
@@ -27,7 +27,7 @@
 ;;                                 block0(v0: i64, v1: i64, v2: f32, v3: i32, v4: i32):
 ;;                                     v46 = stack_addr.i64 ss0
 ;;                                     store notrap v4, v46
-;; @002a                               v7 = load.i64 notrap aligned readonly can_move v0+32
+;; @002a                               v7 = load.i64 notrap aligned readonly can_move region1 v0+32
 ;; @002a                               v8 = load.i32 notrap aligned v7
 ;; @002a                               v9 = load.i32 notrap aligned v7+4
 ;; @002a                               v15 = uextend.i64 v8
@@ -40,13 +40,13 @@
 ;;                                 block2:
 ;;                                     v63 = iconst.i32 32
 ;;                                     v61 = iadd.i32 v8, v63  ; v63 = 32
-;; @002a                               store notrap aligned region2 v61, v7
+;; @002a                               store notrap aligned region1 v61, v7
 ;;                                     v64 = iconst.i32 -1342177246
 ;;                                     v65 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;;                                     v66 = load.i64 notrap aligned readonly can_move v65+32
 ;; @002a                               v32 = iadd v66, v15
 ;; @002a                               store notrap aligned v64, v32  ; v64 = -1342177246
-;;                                     v67 = load.i64 notrap aligned readonly can_move region1 v0+40
+;;                                     v67 = load.i64 notrap aligned readonly can_move region2 v0+40
 ;;                                     v68 = load.i32 notrap aligned readonly can_move v67
 ;; @002a                               store notrap aligned v68, v32+4
 ;;                                     v69 = iconst.i64 32
@@ -55,7 +55,7 @@
 ;;
 ;;                                 block3 cold:
 ;; @002a                               v19 = iconst.i32 -1342177246
-;; @002a                               v20 = load.i64 notrap aligned readonly can_move region1 v0+40
+;; @002a                               v20 = load.i64 notrap aligned readonly can_move region2 v0+40
 ;; @002a                               v21 = load.i32 notrap aligned readonly can_move v20
 ;; @002a                               v6 = iconst.i32 32
 ;; @002a                               v22 = iconst.i32 16

--- a/tests/disas/passive-data.wat
+++ b/tests/disas/passive-data.wat
@@ -15,6 +15,8 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 152 "VMContext+0x98"
+;;     region2 = 144 "VMContext+0x90"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -39,7 +41,7 @@
 ;; @003d                               v15 = iconst.i64 1
 ;; @003d                               v16 = imul v14, v15  ; v15 = 1
 ;; @003d                               v17 = iadd v13, v16
-;; @003d                               v18 = load.i32 notrap aligned v0+152
+;; @003d                               v18 = load.i32 notrap aligned region1 v0+152
 ;; @003d                               v19 = uextend.i64 v18
 ;; @003d                               v20 = uextend.i64 v3
 ;; @003d                               v21 = uextend.i64 v4
@@ -48,7 +50,7 @@
 ;; @003d                               v24 = iadd v20, v23
 ;; @003d                               v25 = icmp ugt v24, v19
 ;; @003d                               trapnz v25, heap_oob
-;; @003d                               v26 = load.i64 notrap aligned v0+144
+;; @003d                               v26 = load.i64 notrap aligned region2 v0+144
 ;; @003d                               v27 = uextend.i64 v3
 ;; @003d                               v28 = iadd v26, v27
 ;; @003d                               v29 = uextend.i64 v4
@@ -61,6 +63,7 @@
 ;;
 ;; function u0:1(i64 vmctx, i64) tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 152 "VMContext+0x98"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -68,7 +71,7 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64):
 ;; @0044                               v2 = iconst.i32 0
-;; @0044                               store notrap aligned v2, v0+152  ; v2 = 0
+;; @0044                               store notrap aligned region1 v2, v0+152  ; v2 = 0
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/startup-data-active.wat
+++ b/tests/disas/startup-data-active.wat
@@ -36,6 +36,8 @@
 ;; }
 ;;
 ;; function u2415919104:0(i64 vmctx, i64) tail {
+;;     region0 = 112 "VMContext+0x70"
+;;     region1 = 120 "VMContext+0x78"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned gv0+64
 ;;     gv2 = load.i64 notrap aligned readonly can_move gv0+56
@@ -43,13 +45,13 @@
 ;;     fn0 = colocated u805306368:1 sig0
 ;;
 ;; block0(v0: i64, v1: i64):
-;;     v2 = load.i64 notrap aligned v0+112
+;;     v2 = load.i64 notrap aligned region0 v0+112
 ;;     v3 = iconst.i64 0
 ;;     v4 = icmp eq v2, v3  ; v3 = 0
 ;;     brif v4, block2, block1
 ;;
 ;; block1:
-;;     v6 = load.i32 notrap aligned v0+120
+;;     v6 = load.i32 notrap aligned region1 v0+120
 ;;     v9 = load.i64 notrap aligned v0+64
 ;;     v11 = uextend.i64 v6
 ;;     v15 = icmp ugt v11, v9


### PR DESCRIPTION
Annotates the passive runtime-data length/base array loads/stores and the copying collector's gc-heap-data pointer load with the `VMContext` alias region, which were the only `VMContext` fields left that didn't use alias regions.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
