### PR TITLE
Relax version requirement on `cc`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -377,7 +377,7 @@ arbitrary = "1.4.2"
 backtrace = "0.3.76"
 bumpalo = "3.20.2"
 mutatis = { version = "0.5.2", features = ["alloc", "derive", "check"] }
-cc = "1.2.41"
+cc = "1.2.0" # intentionally smaller-than-latest to accommodate rust-lang/rust
 object = { version = "0.39.0", default-features = false, features = ['read_core', 'elf'] }
 gimli = { version = "0.33.0", default-features = false, features = ['read'] }
 addr2line = { version = "0.26.0", default-features = false }


### PR DESCRIPTION
Integration upstream into rust-lang/rust will be a bit easier with this relaxed bound, so widen the version requirement here a bit.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
