### PR TITLE
feat: allow custom fiber API impls on unsupported arches

### DIFF
--- a/crates/fiber/Cargo.toml
+++ b/crates/fiber/Cargo.toml
@@ -39,3 +39,7 @@ backtrace = "0.3.68"
 # Assume presence of the standard library. Allows propagating
 # panic-unwinds across fiber invocations.
 std = []
+
+# Use embedder-provided stack-switching routines on unsupported architectures.
+# See `src/stackswitch/custom.rs` for the C ABI the embedder must implement.
+custom = []

--- a/crates/fiber/src/lib.rs
+++ b/crates/fiber/src/lib.rs
@@ -34,7 +34,9 @@ cfg_if::cfg_if! {
         use unix as imp;
         mod stackswitch;
     } else {
-        compile_error!("fibers are not supported on this platform");
+        mod nostd;
+        use nostd as imp;
+        mod stackswitch;
     }
 }
 

--- a/crates/fiber/src/stackswitch.rs
+++ b/crates/fiber/src/stackswitch.rs
@@ -33,6 +33,10 @@ cfg_if::cfg_if! {
         mod riscv32imac;
         pub(crate) use supported::*;
         pub(crate) use riscv32imac::*;
+    } else if #[cfg(feature = "custom")] {
+        mod custom;
+        pub(crate) use supported::*;
+        pub(crate) use custom::*;
     } else {
         // No support for this platform. Don't fail compilation though and
         // instead defer the error to happen at runtime when a fiber is created.

--- a/crates/fiber/src/stackswitch/custom.rs
+++ b/crates/fiber/src/stackswitch/custom.rs
@@ -1,0 +1,18 @@
+//! Embedder-provided stack-switching routines.
+//!
+//! This module is used when the `custom` feature is enabled and the target
+//! architecture has no built-in inline-assembly implementation. It is the
+//! stack-switching analogue of Wasmtime's `custom-virtual-memory` feature:
+//! rather than relying on inline assembly for a known architecture, the
+//! routines below are declared as `extern "C"` imports which the embedder is
+//! expected to supply.
+
+unsafe extern "C" {
+    pub(crate) fn wasmtime_fiber_init(
+        top_of_stack: *mut u8,
+        entry: extern "C" fn(*mut u8, *mut u8) -> *mut u8,
+        entry_arg0: *mut u8,
+    );
+
+    pub(crate) fn wasmtime_fiber_switch(top_of_stack: *mut u8);
+}

--- a/crates/fiber/src/stackswitch/custom.rs
+++ b/crates/fiber/src/stackswitch/custom.rs
@@ -6,6 +6,10 @@
 //! rather than relying on inline assembly for a known architecture, the
 //! routines below are declared as `extern "C"` imports which the embedder is
 //! expected to supply.
+//!
+//! These declarations are duplicated in
+//! `crates/wasmtime/src/runtime/vm/sys/custom/capi.rs`,
+//! keep the two copies in-sync.
 
 unsafe extern "C" {
     pub(crate) fn wasmtime_fiber_init(

--- a/crates/wasmtime/Cargo.toml
+++ b/crates/wasmtime/Cargo.toml
@@ -385,6 +385,9 @@ custom-native-signals = []
 # Same as `custom-virtual-memory` above, but for custom sync primitive APIs.
 custom-sync-primitives = []
 
+# Same as `custom-virtual-memory` above, but for custom fiber APIs.
+custom-fiber = ["wasmtime-fiber?/custom"]
+
 # Off-by-default support to profile the Pulley interpreter. This has a
 # performance hit, even when not profiling, so it's disabled by default at
 # compile time.

--- a/crates/wasmtime/build.rs
+++ b/crates/wasmtime/build.rs
@@ -15,10 +15,24 @@ fn main() {
     // feature to also be active so check that too.
     let supported_os = (unix || windows) && cfg!(feature = "std");
 
+    let target_arch = std::env::var("CARGO_CFG_TARGET_ARCH").unwrap();
+
     // Determine if the current host architecture is supported by Cranelift
     // meaning that we might be executing native code.
-    let has_host_compiler_backend = match std::env::var("CARGO_CFG_TARGET_ARCH").unwrap().as_str() {
+    let has_host_compiler_backend = match target_arch.as_str() {
         "x86_64" | "riscv64" | "s390x" | "aarch64" => true,
+        _ => false,
+    };
+
+    // Determine if builtin stack-switching routines are provided for the
+    // current host architecture by `wasmtime-internal-fiber`.
+    let has_builtin_stackswitch = match target_arch.as_str() {
+        "aarch64" | "x86_64" | "x86" | "arm" | "s390x" | "riscv64" => true,
+        "riscv32" => std::env::var("CARGO_CFG_TARGET_FEATURE")
+            .unwrap()
+            .split(',')
+            .find(|&feat| matches!(feat, "f" | "v"))
+            .is_none(),
         _ => false,
     };
 
@@ -30,9 +44,11 @@ fn main() {
     let has_custom_sync = !cfg!(feature = "std")
         && cfg!(feature = "custom-sync-primitives")
         && cfg!(feature = "runtime");
+    let has_custom_fiber = !has_builtin_stackswitch && cfg!(feature = "custom-fiber");
 
     custom_cfg("has_native_signals", has_native_signals);
     custom_cfg("has_virtual_memory", has_virtual_memory);
+    custom_cfg("has_custom_fiber", has_custom_fiber);
     custom_cfg("has_custom_sync", has_custom_sync);
     custom_cfg("has_host_compiler_backend", has_host_compiler_backend);
     custom_cfg("gc_zeal", cfg("fuzzing"));

--- a/crates/wasmtime/src/runtime/vm/sys/custom/capi.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/custom/capi.rs
@@ -236,4 +236,29 @@ unsafe extern "C" {
     /// The implementor must handle this case gracefully.
     #[cfg(has_custom_sync)]
     pub fn wasmtime_sync_rwlock_free(lock: *mut usize);
+
+    // The `wasmtime_fiber_*` declarations below are duplicated in
+    // `crates/fiber/src/stackswitch/custom.rs`, which is where Wasmtime
+    // actually imports them from (the `wasmtime-internal-fiber` crate cannot
+    // depend on this crate). Keep the two copies in-sync.
+
+    /// Initializes a fiber stack so that switching to it will begin executing `entry`.
+    #[cfg(has_custom_fiber)]
+    #[expect(
+        dead_code,
+        reason = "imported and called from the `wasmtime-internal-fiber`"
+    )]
+    pub fn wasmtime_fiber_init(
+        top_of_stack: *mut u8,
+        entry: extern "C" fn(*mut u8, *mut u8) -> *mut u8,
+        entry_arg0: *mut u8,
+    );
+
+    /// Switches execution to the fiber stack whose top is `top_of_stack`.
+    #[cfg(has_custom_fiber)]
+    #[expect(
+        dead_code,
+        reason = "imported and called from `wasmtime-internal-fiber`"
+    )]
+    pub fn wasmtime_fiber_switch(top_of_stack: *mut u8);
 }

--- a/examples/min-platform/embedding/cbindgen.toml
+++ b/examples/min-platform/embedding/cbindgen.toml
@@ -22,6 +22,7 @@ header = """
 //
 // * `WASMTIME_SIGNALS_BASED_TRAPS` - corresponds to `signals-based-traps`
 // * `WASMTIME_CUSTOM_SYNC` - corresponds to `custom-sync-primitives`
+// * `WASMTIME_CUSTOM_FIBER` - corresponds to `custom-fiber`
 //
 // Some more information about this header can additionally be found at
 // <https://docs.wasmtime.dev/stability-platform-support.html>.
@@ -31,3 +32,4 @@ header = """
 has_virtual_memory = 'WASMTIME_VIRTUAL_MEMORY'
 has_native_signals = 'WASMTIME_NATIVE_SIGNALS'
 has_custom_sync = 'WASMTIME_CUSTOM_SYNC'
+has_custom_fiber = 'WASMTIME_CUSTOM_FIBER'

--- a/examples/min-platform/embedding/wasmtime-platform.h
+++ b/examples/min-platform/embedding/wasmtime-platform.h
@@ -16,6 +16,7 @@
 //
 // * `WASMTIME_SIGNALS_BASED_TRAPS` - corresponds to `signals-based-traps`
 // * `WASMTIME_CUSTOM_SYNC` - corresponds to `custom-sync-primitives`
+// * `WASMTIME_CUSTOM_FIBER` - corresponds to `custom-fiber`
 //
 // Some more information about this header can additionally be found at
 // <https://docs.wasmtime.dev/stability-platform-support.html>.
@@ -330,6 +331,22 @@ extern void wasmtime_sync_rwlock_write_release(uintptr_t *lock);
  * The implementor must handle this case gracefully.
  */
 extern void wasmtime_sync_rwlock_free(uintptr_t *lock);
+#endif
+
+#if defined(WASMTIME_CUSTOM_FIBER)
+/**
+ * Initializes a fiber stack so that switching to it will begin executing `entry`.
+ */
+extern void wasmtime_fiber_init(uint8_t *top_of_stack,
+                                uint8_t *(*entry)(uint8_t*, uint8_t*),
+                                uint8_t *entry_arg0);
+#endif
+
+#if defined(WASMTIME_CUSTOM_FIBER)
+/**
+ * Switches execution to the fiber stack whose top is `top_of_stack`.
+ */
+extern void wasmtime_fiber_switch(uint8_t *top_of_stack);
 #endif
 
 #ifdef __cplusplus


### PR DESCRIPTION
Add support for custom embedder-supplied fiber implementations, similar to e.g. `custom-virtual-memory` feature and others that already exist.

I'm not sure whether `custom-fiber` or `custom-stack-switch` is more appropriate, went for the one matching the crate name.

For my concrete use case, this is sufficient to allow running Wasmtime with cranelift in interpreter mode using Pulley with `async`/`component-model-async` features enabled, compiled to wasm32-unknown-unknown with a bit of JS glue based on JSPI in the browser or node.js