### PR TITLE
fix(cranelift): pulley clobber slot collision

### DIFF
--- a/cranelift/codegen/src/isa/pulley_shared/abi.rs
+++ b/cranelift/codegen/src/isa/pulley_shared/abi.rs
@@ -713,29 +713,47 @@ impl FrameLayout {
         &'a self,
         style: &'a FrameStyle,
     ) -> impl Iterator<Item = (i32, Type, Reg)> + 'a {
-        let mut offset = self.stack_size();
+        // `push_frame_save` always saves the pulley-managed registers at the
+        // *top* of the allocated frame (the highest addresses, `amt - 8`
+        // downward). Therefore the manually-managed clobbers must be placed
+        // *below* that pulley-saved region. The pulley-saved registers are not
+        // necessarily first in `clobbered_callee_saves` (it is sorted by
+        // register, and the manually-managed integer registers x0..x15 sort
+        // before the pulley-managed x16..x31), so we cannot simply walk the
+        // list from the top assigning slots in order -- doing so would place a
+        // manually-managed register on top of a pulley-saved one and the two
+        // stores would collide.
+        //
+        // Instead reserve the top `num_saved_by_pulley` 8-byte slots for the
+        // pulley-managed registers (matching `push_frame_save`) and hand out
+        // the remaining, lower slots to the manually-managed registers.
+        let num_saved_by_pulley = match style {
+            FrameStyle::PulleySetupAndSaveClobbers {
+                saved_by_pulley, ..
+            } => u32::from(saved_by_pulley.len()),
+            _ => 0,
+        };
+        let mut offset = self.stack_size() - num_saved_by_pulley * 8;
         self.clobbered_callee_saves.iter().filter_map(move |reg| {
-            // Allocate space for this clobber no matter what. If pulley is
-            // managing this then we're just accounting for the pulley-saved
-            // registers as well. Note that all pulley-managed registers come
-            // first in the list here.
-            offset -= 8;
             let r_reg = reg.to_reg();
-            let ty = match r_reg.class() {
-                RegClass::Int => {
-                    // If this register is saved by pulley, skip this clobber.
-                    if let FrameStyle::PulleySetupAndSaveClobbers {
-                        saved_by_pulley, ..
-                    } = style
-                    {
-                        if let Some(reg) = r_reg.hw_enc().checked_sub(16) {
-                            if saved_by_pulley.contains(reg) {
-                                return None;
-                            }
+            // If this register is saved by pulley, skip it: its slot is one of
+            // the reserved top slots accounted for above.
+            if let FrameStyle::PulleySetupAndSaveClobbers {
+                saved_by_pulley, ..
+            } = style
+            {
+                if r_reg.class() == RegClass::Int {
+                    if let Some(reg) = r_reg.hw_enc().checked_sub(16) {
+                        if saved_by_pulley.contains(reg) {
+                            return None;
                         }
                     }
-                    I64
                 }
+            }
+            // Allocate space for this manually-managed clobber.
+            offset -= 8;
+            let ty = match r_reg.class() {
+                RegClass::Int => I64,
                 RegClass::Float => F64,
                 RegClass::Vector => I8X16,
             };

--- a/cranelift/filetests/filetests/isa/pulley32/preserve-all.clif
+++ b/cranelift/filetests/filetests/isa/pulley32/preserve-all.clif
@@ -419,3 +419,350 @@ block0(v0: i64):
 ; pop_frame
 ; ret
 
+function %clobber_save_no_slot_collision(i64, i64) preserve_all {
+    fn0 = %host(i64) system_v
+block0(v0: i64, v1: i64):
+    call fn0(v0)
+    call fn0(v1)
+    return
+}
+
+; VCode:
+;   push_frame_save 912, {x16}
+;   xstore64 sp+896, x0 // flags =  notrap aligned
+;   xstore64 sp+888, x1 // flags =  notrap aligned
+;   xstore64 sp+880, x2 // flags =  notrap aligned
+;   xstore64 sp+872, x3 // flags =  notrap aligned
+;   xstore64 sp+864, x4 // flags =  notrap aligned
+;   xstore64 sp+856, x5 // flags =  notrap aligned
+;   xstore64 sp+848, x6 // flags =  notrap aligned
+;   xstore64 sp+840, x7 // flags =  notrap aligned
+;   xstore64 sp+832, x8 // flags =  notrap aligned
+;   xstore64 sp+824, x9 // flags =  notrap aligned
+;   xstore64 sp+816, x10 // flags =  notrap aligned
+;   xstore64 sp+808, x11 // flags =  notrap aligned
+;   xstore64 sp+800, x12 // flags =  notrap aligned
+;   xstore64 sp+792, x13 // flags =  notrap aligned
+;   xstore64 sp+784, x14 // flags =  notrap aligned
+;   xstore64 sp+776, x15 // flags =  notrap aligned
+;   fstore64 sp+768, f0 // flags =  notrap aligned
+;   fstore64 sp+760, f1 // flags =  notrap aligned
+;   fstore64 sp+752, f2 // flags =  notrap aligned
+;   fstore64 sp+744, f3 // flags =  notrap aligned
+;   fstore64 sp+736, f4 // flags =  notrap aligned
+;   fstore64 sp+728, f5 // flags =  notrap aligned
+;   fstore64 sp+720, f6 // flags =  notrap aligned
+;   fstore64 sp+712, f7 // flags =  notrap aligned
+;   fstore64 sp+704, f8 // flags =  notrap aligned
+;   fstore64 sp+696, f9 // flags =  notrap aligned
+;   fstore64 sp+688, f10 // flags =  notrap aligned
+;   fstore64 sp+680, f11 // flags =  notrap aligned
+;   fstore64 sp+672, f12 // flags =  notrap aligned
+;   fstore64 sp+664, f13 // flags =  notrap aligned
+;   fstore64 sp+656, f14 // flags =  notrap aligned
+;   fstore64 sp+648, f15 // flags =  notrap aligned
+;   fstore64 sp+640, f16 // flags =  notrap aligned
+;   fstore64 sp+632, f17 // flags =  notrap aligned
+;   fstore64 sp+624, f18 // flags =  notrap aligned
+;   fstore64 sp+616, f19 // flags =  notrap aligned
+;   fstore64 sp+608, f20 // flags =  notrap aligned
+;   fstore64 sp+600, f21 // flags =  notrap aligned
+;   fstore64 sp+592, f22 // flags =  notrap aligned
+;   fstore64 sp+584, f23 // flags =  notrap aligned
+;   fstore64 sp+576, f24 // flags =  notrap aligned
+;   fstore64 sp+568, f25 // flags =  notrap aligned
+;   fstore64 sp+560, f26 // flags =  notrap aligned
+;   fstore64 sp+552, f27 // flags =  notrap aligned
+;   fstore64 sp+544, f28 // flags =  notrap aligned
+;   fstore64 sp+536, f29 // flags =  notrap aligned
+;   fstore64 sp+528, f30 // flags =  notrap aligned
+;   fstore64 sp+520, f31 // flags =  notrap aligned
+;   vstore128 sp+512, v0 // flags =  notrap aligned little
+;   vstore128 sp+504, v1 // flags =  notrap aligned little
+;   vstore128 sp+496, v2 // flags =  notrap aligned little
+;   vstore128 sp+488, v3 // flags =  notrap aligned little
+;   vstore128 sp+480, v4 // flags =  notrap aligned little
+;   vstore128 sp+472, v5 // flags =  notrap aligned little
+;   vstore128 sp+464, v6 // flags =  notrap aligned little
+;   vstore128 sp+456, v7 // flags =  notrap aligned little
+;   vstore128 sp+448, v8 // flags =  notrap aligned little
+;   vstore128 sp+440, v9 // flags =  notrap aligned little
+;   vstore128 sp+432, v10 // flags =  notrap aligned little
+;   vstore128 sp+424, v11 // flags =  notrap aligned little
+;   vstore128 sp+416, v12 // flags =  notrap aligned little
+;   vstore128 sp+408, v13 // flags =  notrap aligned little
+;   vstore128 sp+400, v14 // flags =  notrap aligned little
+;   vstore128 sp+392, v15 // flags =  notrap aligned little
+;   vstore128 sp+384, v16 // flags =  notrap aligned little
+;   vstore128 sp+376, v17 // flags =  notrap aligned little
+;   vstore128 sp+368, v18 // flags =  notrap aligned little
+;   vstore128 sp+360, v19 // flags =  notrap aligned little
+;   vstore128 sp+352, v20 // flags =  notrap aligned little
+;   vstore128 sp+344, v21 // flags =  notrap aligned little
+;   vstore128 sp+336, v22 // flags =  notrap aligned little
+;   vstore128 sp+328, v23 // flags =  notrap aligned little
+;   vstore128 sp+320, v24 // flags =  notrap aligned little
+;   vstore128 sp+312, v25 // flags =  notrap aligned little
+;   vstore128 sp+304, v26 // flags =  notrap aligned little
+;   vstore128 sp+296, v27 // flags =  notrap aligned little
+;   vstore128 sp+288, v28 // flags =  notrap aligned little
+;   vstore128 sp+280, v29 // flags =  notrap aligned little
+;   vstore128 sp+272, v30 // flags =  notrap aligned little
+;   vstore128 sp+264, v31 // flags =  notrap aligned little
+; block0:
+;   xmov x16, x1
+;   indirect_call_host CallInfo { dest: TestCase(%host), uses: [CallArgPair { vreg: p0i, preg: p0i }], defs: [], clobbers: PRegSet { bits: [65535, 4294967295, 4294967295, 0] }, callee_conv: SystemV, caller_conv: PreserveAll, callee_pop_size: 0, try_call_info: None, patchable: false }
+;   xmov x0, x16
+;   indirect_call_host CallInfo { dest: TestCase(%host), uses: [CallArgPair { vreg: p0i, preg: p0i }], defs: [], clobbers: PRegSet { bits: [65535, 4294967295, 4294967295, 0] }, callee_conv: SystemV, caller_conv: PreserveAll, callee_pop_size: 0, try_call_info: None, patchable: false }
+;   x0 = xload64 sp+896 // flags = notrap aligned
+;   x1 = xload64 sp+888 // flags = notrap aligned
+;   x2 = xload64 sp+880 // flags = notrap aligned
+;   x3 = xload64 sp+872 // flags = notrap aligned
+;   x4 = xload64 sp+864 // flags = notrap aligned
+;   x5 = xload64 sp+856 // flags = notrap aligned
+;   x6 = xload64 sp+848 // flags = notrap aligned
+;   x7 = xload64 sp+840 // flags = notrap aligned
+;   x8 = xload64 sp+832 // flags = notrap aligned
+;   x9 = xload64 sp+824 // flags = notrap aligned
+;   x10 = xload64 sp+816 // flags = notrap aligned
+;   x11 = xload64 sp+808 // flags = notrap aligned
+;   x12 = xload64 sp+800 // flags = notrap aligned
+;   x13 = xload64 sp+792 // flags = notrap aligned
+;   x14 = xload64 sp+784 // flags = notrap aligned
+;   x15 = xload64 sp+776 // flags = notrap aligned
+;   f0 = fload64 sp+768 // flags = notrap aligned
+;   f1 = fload64 sp+760 // flags = notrap aligned
+;   f2 = fload64 sp+752 // flags = notrap aligned
+;   f3 = fload64 sp+744 // flags = notrap aligned
+;   f4 = fload64 sp+736 // flags = notrap aligned
+;   f5 = fload64 sp+728 // flags = notrap aligned
+;   f6 = fload64 sp+720 // flags = notrap aligned
+;   f7 = fload64 sp+712 // flags = notrap aligned
+;   f8 = fload64 sp+704 // flags = notrap aligned
+;   f9 = fload64 sp+696 // flags = notrap aligned
+;   f10 = fload64 sp+688 // flags = notrap aligned
+;   f11 = fload64 sp+680 // flags = notrap aligned
+;   f12 = fload64 sp+672 // flags = notrap aligned
+;   f13 = fload64 sp+664 // flags = notrap aligned
+;   f14 = fload64 sp+656 // flags = notrap aligned
+;   f15 = fload64 sp+648 // flags = notrap aligned
+;   f16 = fload64 sp+640 // flags = notrap aligned
+;   f17 = fload64 sp+632 // flags = notrap aligned
+;   f18 = fload64 sp+624 // flags = notrap aligned
+;   f19 = fload64 sp+616 // flags = notrap aligned
+;   f20 = fload64 sp+608 // flags = notrap aligned
+;   f21 = fload64 sp+600 // flags = notrap aligned
+;   f22 = fload64 sp+592 // flags = notrap aligned
+;   f23 = fload64 sp+584 // flags = notrap aligned
+;   f24 = fload64 sp+576 // flags = notrap aligned
+;   f25 = fload64 sp+568 // flags = notrap aligned
+;   f26 = fload64 sp+560 // flags = notrap aligned
+;   f27 = fload64 sp+552 // flags = notrap aligned
+;   f28 = fload64 sp+544 // flags = notrap aligned
+;   f29 = fload64 sp+536 // flags = notrap aligned
+;   f30 = fload64 sp+528 // flags = notrap aligned
+;   f31 = fload64 sp+520 // flags = notrap aligned
+;   v0 = vload128 sp+512 // flags = notrap aligned little
+;   v1 = vload128 sp+504 // flags = notrap aligned little
+;   v2 = vload128 sp+496 // flags = notrap aligned little
+;   v3 = vload128 sp+488 // flags = notrap aligned little
+;   v4 = vload128 sp+480 // flags = notrap aligned little
+;   v5 = vload128 sp+472 // flags = notrap aligned little
+;   v6 = vload128 sp+464 // flags = notrap aligned little
+;   v7 = vload128 sp+456 // flags = notrap aligned little
+;   v8 = vload128 sp+448 // flags = notrap aligned little
+;   v9 = vload128 sp+440 // flags = notrap aligned little
+;   v10 = vload128 sp+432 // flags = notrap aligned little
+;   v11 = vload128 sp+424 // flags = notrap aligned little
+;   v12 = vload128 sp+416 // flags = notrap aligned little
+;   v13 = vload128 sp+408 // flags = notrap aligned little
+;   v14 = vload128 sp+400 // flags = notrap aligned little
+;   v15 = vload128 sp+392 // flags = notrap aligned little
+;   v16 = vload128 sp+384 // flags = notrap aligned little
+;   v17 = vload128 sp+376 // flags = notrap aligned little
+;   v18 = vload128 sp+368 // flags = notrap aligned little
+;   v19 = vload128 sp+360 // flags = notrap aligned little
+;   v20 = vload128 sp+352 // flags = notrap aligned little
+;   v21 = vload128 sp+344 // flags = notrap aligned little
+;   v22 = vload128 sp+336 // flags = notrap aligned little
+;   v23 = vload128 sp+328 // flags = notrap aligned little
+;   v24 = vload128 sp+320 // flags = notrap aligned little
+;   v25 = vload128 sp+312 // flags = notrap aligned little
+;   v26 = vload128 sp+304 // flags = notrap aligned little
+;   v27 = vload128 sp+296 // flags = notrap aligned little
+;   v28 = vload128 sp+288 // flags = notrap aligned little
+;   v29 = vload128 sp+280 // flags = notrap aligned little
+;   v30 = vload128 sp+272 // flags = notrap aligned little
+;   v31 = vload128 sp+264 // flags = notrap aligned little
+;   pop_frame_restore 912, {x16}
+;   ret
+;
+; Disassembled:
+; push_frame_save 912, x16
+; xstore64le_o32 sp, 896, x0
+; xstore64le_o32 sp, 888, x1
+; xstore64le_o32 sp, 880, x2
+; xstore64le_o32 sp, 872, x3
+; xstore64le_o32 sp, 864, x4
+; xstore64le_o32 sp, 856, x5
+; xstore64le_o32 sp, 848, x6
+; xstore64le_o32 sp, 840, x7
+; xstore64le_o32 sp, 832, x8
+; xstore64le_o32 sp, 824, x9
+; xstore64le_o32 sp, 816, x10
+; xstore64le_o32 sp, 808, x11
+; xstore64le_o32 sp, 800, x12
+; xstore64le_o32 sp, 792, x13
+; xstore64le_o32 sp, 784, x14
+; xstore64le_o32 sp, 776, x15
+; fstore64le_o32 sp, 768, f0
+; fstore64le_o32 sp, 760, f1
+; fstore64le_o32 sp, 752, f2
+; fstore64le_o32 sp, 744, f3
+; fstore64le_o32 sp, 736, f4
+; fstore64le_o32 sp, 728, f5
+; fstore64le_o32 sp, 720, f6
+; fstore64le_o32 sp, 712, f7
+; fstore64le_o32 sp, 704, f8
+; fstore64le_o32 sp, 696, f9
+; fstore64le_o32 sp, 688, f10
+; fstore64le_o32 sp, 680, f11
+; fstore64le_o32 sp, 672, f12
+; fstore64le_o32 sp, 664, f13
+; fstore64le_o32 sp, 656, f14
+; fstore64le_o32 sp, 648, f15
+; fstore64le_o32 sp, 640, f16
+; fstore64le_o32 sp, 632, f17
+; fstore64le_o32 sp, 624, f18
+; fstore64le_o32 sp, 616, f19
+; fstore64le_o32 sp, 608, f20
+; fstore64le_o32 sp, 600, f21
+; fstore64le_o32 sp, 592, f22
+; fstore64le_o32 sp, 584, f23
+; fstore64le_o32 sp, 576, f24
+; fstore64le_o32 sp, 568, f25
+; fstore64le_o32 sp, 560, f26
+; fstore64le_o32 sp, 552, f27
+; fstore64le_o32 sp, 544, f28
+; fstore64le_o32 sp, 536, f29
+; fstore64le_o32 sp, 528, f30
+; fstore64le_o32 sp, 520, f31
+; vstore128le_o32 sp, 512, v0
+; vstore128le_o32 sp, 504, v1
+; vstore128le_o32 sp, 496, v2
+; vstore128le_o32 sp, 488, v3
+; vstore128le_o32 sp, 480, v4
+; vstore128le_o32 sp, 472, v5
+; vstore128le_o32 sp, 464, v6
+; vstore128le_o32 sp, 456, v7
+; vstore128le_o32 sp, 448, v8
+; vstore128le_o32 sp, 440, v9
+; vstore128le_o32 sp, 432, v10
+; vstore128le_o32 sp, 424, v11
+; vstore128le_o32 sp, 416, v12
+; vstore128le_o32 sp, 408, v13
+; vstore128le_o32 sp, 400, v14
+; vstore128le_o32 sp, 392, v15
+; vstore128le_o32 sp, 384, v16
+; vstore128le_o32 sp, 376, v17
+; vstore128le_o32 sp, 368, v18
+; vstore128le_o32 sp, 360, v19
+; vstore128le_o32 sp, 352, v20
+; vstore128le_o32 sp, 344, v21
+; vstore128le_o32 sp, 336, v22
+; vstore128le_o32 sp, 328, v23
+; vstore128le_o32 sp, 320, v24
+; vstore128le_o32 sp, 312, v25
+; vstore128le_o32 sp, 304, v26
+; vstore128le_o32 sp, 296, v27
+; vstore128le_o32 sp, 288, v28
+; vstore128le_o32 sp, 280, v29
+; vstore128le_o32 sp, 272, v30
+; vstore128le_o32 sp, 264, v31
+; xmov x16, x1
+; call_indirect_host 0
+; xmov x0, x16
+; call_indirect_host 0
+; xload64le_o32 x0, sp, 896
+; xload64le_o32 x1, sp, 888
+; xload64le_o32 x2, sp, 880
+; xload64le_o32 x3, sp, 872
+; xload64le_o32 x4, sp, 864
+; xload64le_o32 x5, sp, 856
+; xload64le_o32 x6, sp, 848
+; xload64le_o32 x7, sp, 840
+; xload64le_o32 x8, sp, 832
+; xload64le_o32 x9, sp, 824
+; xload64le_o32 x10, sp, 816
+; xload64le_o32 x11, sp, 808
+; xload64le_o32 x12, sp, 800
+; xload64le_o32 x13, sp, 792
+; xload64le_o32 x14, sp, 784
+; xload64le_o32 x15, sp, 776
+; fload64le_o32 f0, sp, 768
+; fload64le_o32 f1, sp, 760
+; fload64le_o32 f2, sp, 752
+; fload64le_o32 f3, sp, 744
+; fload64le_o32 f4, sp, 736
+; fload64le_o32 f5, sp, 728
+; fload64le_o32 f6, sp, 720
+; fload64le_o32 f7, sp, 712
+; fload64le_o32 f8, sp, 704
+; fload64le_o32 f9, sp, 696
+; fload64le_o32 f10, sp, 688
+; fload64le_o32 f11, sp, 680
+; fload64le_o32 f12, sp, 672
+; fload64le_o32 f13, sp, 664
+; fload64le_o32 f14, sp, 656
+; fload64le_o32 f15, sp, 648
+; fload64le_o32 f16, sp, 640
+; fload64le_o32 f17, sp, 632
+; fload64le_o32 f18, sp, 624
+; fload64le_o32 f19, sp, 616
+; fload64le_o32 f20, sp, 608
+; fload64le_o32 f21, sp, 600
+; fload64le_o32 f22, sp, 592
+; fload64le_o32 f23, sp, 584
+; fload64le_o32 f24, sp, 576
+; fload64le_o32 f25, sp, 568
+; fload64le_o32 f26, sp, 560
+; fload64le_o32 f27, sp, 552
+; fload64le_o32 f28, sp, 544
+; fload64le_o32 f29, sp, 536
+; fload64le_o32 f30, sp, 528
+; fload64le_o32 f31, sp, 520
+; vload128le_o32 v0, sp, 512
+; vload128le_o32 v1, sp, 504
+; vload128le_o32 v2, sp, 496
+; vload128le_o32 v3, sp, 488
+; vload128le_o32 v4, sp, 480
+; vload128le_o32 v5, sp, 472
+; vload128le_o32 v6, sp, 464
+; vload128le_o32 v7, sp, 456
+; vload128le_o32 v8, sp, 448
+; vload128le_o32 v9, sp, 440
+; vload128le_o32 v10, sp, 432
+; vload128le_o32 v11, sp, 424
+; vload128le_o32 v12, sp, 416
+; vload128le_o32 v13, sp, 408
+; vload128le_o32 v14, sp, 400
+; vload128le_o32 v15, sp, 392
+; vload128le_o32 v16, sp, 384
+; vload128le_o32 v17, sp, 376
+; vload128le_o32 v18, sp, 368
+; vload128le_o32 v19, sp, 360
+; vload128le_o32 v20, sp, 352
+; vload128le_o32 v21, sp, 344
+; vload128le_o32 v22, sp, 336
+; vload128le_o32 v23, sp, 328
+; vload128le_o32 v24, sp, 320
+; vload128le_o32 v25, sp, 312
+; vload128le_o32 v26, sp, 304
+; vload128le_o32 v27, sp, 296
+; vload128le_o32 v28, sp, 288
+; vload128le_o32 v29, sp, 280
+; vload128le_o32 v30, sp, 272
+; vload128le_o32 v31, sp, 264
+; pop_frame_restore 912, x16
+; ret
+

--- a/cranelift/filetests/filetests/isa/pulley64/preserve-all.clif
+++ b/cranelift/filetests/filetests/isa/pulley64/preserve-all.clif
@@ -390,3 +390,350 @@ block0(v0: i64):
 ; pop_frame
 ; ret
 
+function %clobber_save_no_slot_collision(i64, i64) preserve_all {
+    fn0 = %host(i64) system_v
+block0(v0: i64, v1: i64):
+    call fn0(v0)
+    call fn0(v1)
+    return
+}
+
+; VCode:
+;   push_frame_save 912, {x16}
+;   xstore64 sp+896, x0 // flags =  notrap aligned
+;   xstore64 sp+888, x1 // flags =  notrap aligned
+;   xstore64 sp+880, x2 // flags =  notrap aligned
+;   xstore64 sp+872, x3 // flags =  notrap aligned
+;   xstore64 sp+864, x4 // flags =  notrap aligned
+;   xstore64 sp+856, x5 // flags =  notrap aligned
+;   xstore64 sp+848, x6 // flags =  notrap aligned
+;   xstore64 sp+840, x7 // flags =  notrap aligned
+;   xstore64 sp+832, x8 // flags =  notrap aligned
+;   xstore64 sp+824, x9 // flags =  notrap aligned
+;   xstore64 sp+816, x10 // flags =  notrap aligned
+;   xstore64 sp+808, x11 // flags =  notrap aligned
+;   xstore64 sp+800, x12 // flags =  notrap aligned
+;   xstore64 sp+792, x13 // flags =  notrap aligned
+;   xstore64 sp+784, x14 // flags =  notrap aligned
+;   xstore64 sp+776, x15 // flags =  notrap aligned
+;   fstore64 sp+768, f0 // flags =  notrap aligned
+;   fstore64 sp+760, f1 // flags =  notrap aligned
+;   fstore64 sp+752, f2 // flags =  notrap aligned
+;   fstore64 sp+744, f3 // flags =  notrap aligned
+;   fstore64 sp+736, f4 // flags =  notrap aligned
+;   fstore64 sp+728, f5 // flags =  notrap aligned
+;   fstore64 sp+720, f6 // flags =  notrap aligned
+;   fstore64 sp+712, f7 // flags =  notrap aligned
+;   fstore64 sp+704, f8 // flags =  notrap aligned
+;   fstore64 sp+696, f9 // flags =  notrap aligned
+;   fstore64 sp+688, f10 // flags =  notrap aligned
+;   fstore64 sp+680, f11 // flags =  notrap aligned
+;   fstore64 sp+672, f12 // flags =  notrap aligned
+;   fstore64 sp+664, f13 // flags =  notrap aligned
+;   fstore64 sp+656, f14 // flags =  notrap aligned
+;   fstore64 sp+648, f15 // flags =  notrap aligned
+;   fstore64 sp+640, f16 // flags =  notrap aligned
+;   fstore64 sp+632, f17 // flags =  notrap aligned
+;   fstore64 sp+624, f18 // flags =  notrap aligned
+;   fstore64 sp+616, f19 // flags =  notrap aligned
+;   fstore64 sp+608, f20 // flags =  notrap aligned
+;   fstore64 sp+600, f21 // flags =  notrap aligned
+;   fstore64 sp+592, f22 // flags =  notrap aligned
+;   fstore64 sp+584, f23 // flags =  notrap aligned
+;   fstore64 sp+576, f24 // flags =  notrap aligned
+;   fstore64 sp+568, f25 // flags =  notrap aligned
+;   fstore64 sp+560, f26 // flags =  notrap aligned
+;   fstore64 sp+552, f27 // flags =  notrap aligned
+;   fstore64 sp+544, f28 // flags =  notrap aligned
+;   fstore64 sp+536, f29 // flags =  notrap aligned
+;   fstore64 sp+528, f30 // flags =  notrap aligned
+;   fstore64 sp+520, f31 // flags =  notrap aligned
+;   vstore128 sp+512, v0 // flags =  notrap aligned little
+;   vstore128 sp+504, v1 // flags =  notrap aligned little
+;   vstore128 sp+496, v2 // flags =  notrap aligned little
+;   vstore128 sp+488, v3 // flags =  notrap aligned little
+;   vstore128 sp+480, v4 // flags =  notrap aligned little
+;   vstore128 sp+472, v5 // flags =  notrap aligned little
+;   vstore128 sp+464, v6 // flags =  notrap aligned little
+;   vstore128 sp+456, v7 // flags =  notrap aligned little
+;   vstore128 sp+448, v8 // flags =  notrap aligned little
+;   vstore128 sp+440, v9 // flags =  notrap aligned little
+;   vstore128 sp+432, v10 // flags =  notrap aligned little
+;   vstore128 sp+424, v11 // flags =  notrap aligned little
+;   vstore128 sp+416, v12 // flags =  notrap aligned little
+;   vstore128 sp+408, v13 // flags =  notrap aligned little
+;   vstore128 sp+400, v14 // flags =  notrap aligned little
+;   vstore128 sp+392, v15 // flags =  notrap aligned little
+;   vstore128 sp+384, v16 // flags =  notrap aligned little
+;   vstore128 sp+376, v17 // flags =  notrap aligned little
+;   vstore128 sp+368, v18 // flags =  notrap aligned little
+;   vstore128 sp+360, v19 // flags =  notrap aligned little
+;   vstore128 sp+352, v20 // flags =  notrap aligned little
+;   vstore128 sp+344, v21 // flags =  notrap aligned little
+;   vstore128 sp+336, v22 // flags =  notrap aligned little
+;   vstore128 sp+328, v23 // flags =  notrap aligned little
+;   vstore128 sp+320, v24 // flags =  notrap aligned little
+;   vstore128 sp+312, v25 // flags =  notrap aligned little
+;   vstore128 sp+304, v26 // flags =  notrap aligned little
+;   vstore128 sp+296, v27 // flags =  notrap aligned little
+;   vstore128 sp+288, v28 // flags =  notrap aligned little
+;   vstore128 sp+280, v29 // flags =  notrap aligned little
+;   vstore128 sp+272, v30 // flags =  notrap aligned little
+;   vstore128 sp+264, v31 // flags =  notrap aligned little
+; block0:
+;   xmov x16, x1
+;   indirect_call_host CallInfo { dest: TestCase(%host), uses: [CallArgPair { vreg: p0i, preg: p0i }], defs: [], clobbers: PRegSet { bits: [65535, 4294967295, 4294967295, 0] }, callee_conv: SystemV, caller_conv: PreserveAll, callee_pop_size: 0, try_call_info: None, patchable: false }
+;   xmov x0, x16
+;   indirect_call_host CallInfo { dest: TestCase(%host), uses: [CallArgPair { vreg: p0i, preg: p0i }], defs: [], clobbers: PRegSet { bits: [65535, 4294967295, 4294967295, 0] }, callee_conv: SystemV, caller_conv: PreserveAll, callee_pop_size: 0, try_call_info: None, patchable: false }
+;   x0 = xload64 sp+896 // flags = notrap aligned
+;   x1 = xload64 sp+888 // flags = notrap aligned
+;   x2 = xload64 sp+880 // flags = notrap aligned
+;   x3 = xload64 sp+872 // flags = notrap aligned
+;   x4 = xload64 sp+864 // flags = notrap aligned
+;   x5 = xload64 sp+856 // flags = notrap aligned
+;   x6 = xload64 sp+848 // flags = notrap aligned
+;   x7 = xload64 sp+840 // flags = notrap aligned
+;   x8 = xload64 sp+832 // flags = notrap aligned
+;   x9 = xload64 sp+824 // flags = notrap aligned
+;   x10 = xload64 sp+816 // flags = notrap aligned
+;   x11 = xload64 sp+808 // flags = notrap aligned
+;   x12 = xload64 sp+800 // flags = notrap aligned
+;   x13 = xload64 sp+792 // flags = notrap aligned
+;   x14 = xload64 sp+784 // flags = notrap aligned
+;   x15 = xload64 sp+776 // flags = notrap aligned
+;   f0 = fload64 sp+768 // flags = notrap aligned
+;   f1 = fload64 sp+760 // flags = notrap aligned
+;   f2 = fload64 sp+752 // flags = notrap aligned
+;   f3 = fload64 sp+744 // flags = notrap aligned
+;   f4 = fload64 sp+736 // flags = notrap aligned
+;   f5 = fload64 sp+728 // flags = notrap aligned
+;   f6 = fload64 sp+720 // flags = notrap aligned
+;   f7 = fload64 sp+712 // flags = notrap aligned
+;   f8 = fload64 sp+704 // flags = notrap aligned
+;   f9 = fload64 sp+696 // flags = notrap aligned
+;   f10 = fload64 sp+688 // flags = notrap aligned
+;   f11 = fload64 sp+680 // flags = notrap aligned
+;   f12 = fload64 sp+672 // flags = notrap aligned
+;   f13 = fload64 sp+664 // flags = notrap aligned
+;   f14 = fload64 sp+656 // flags = notrap aligned
+;   f15 = fload64 sp+648 // flags = notrap aligned
+;   f16 = fload64 sp+640 // flags = notrap aligned
+;   f17 = fload64 sp+632 // flags = notrap aligned
+;   f18 = fload64 sp+624 // flags = notrap aligned
+;   f19 = fload64 sp+616 // flags = notrap aligned
+;   f20 = fload64 sp+608 // flags = notrap aligned
+;   f21 = fload64 sp+600 // flags = notrap aligned
+;   f22 = fload64 sp+592 // flags = notrap aligned
+;   f23 = fload64 sp+584 // flags = notrap aligned
+;   f24 = fload64 sp+576 // flags = notrap aligned
+;   f25 = fload64 sp+568 // flags = notrap aligned
+;   f26 = fload64 sp+560 // flags = notrap aligned
+;   f27 = fload64 sp+552 // flags = notrap aligned
+;   f28 = fload64 sp+544 // flags = notrap aligned
+;   f29 = fload64 sp+536 // flags = notrap aligned
+;   f30 = fload64 sp+528 // flags = notrap aligned
+;   f31 = fload64 sp+520 // flags = notrap aligned
+;   v0 = vload128 sp+512 // flags = notrap aligned little
+;   v1 = vload128 sp+504 // flags = notrap aligned little
+;   v2 = vload128 sp+496 // flags = notrap aligned little
+;   v3 = vload128 sp+488 // flags = notrap aligned little
+;   v4 = vload128 sp+480 // flags = notrap aligned little
+;   v5 = vload128 sp+472 // flags = notrap aligned little
+;   v6 = vload128 sp+464 // flags = notrap aligned little
+;   v7 = vload128 sp+456 // flags = notrap aligned little
+;   v8 = vload128 sp+448 // flags = notrap aligned little
+;   v9 = vload128 sp+440 // flags = notrap aligned little
+;   v10 = vload128 sp+432 // flags = notrap aligned little
+;   v11 = vload128 sp+424 // flags = notrap aligned little
+;   v12 = vload128 sp+416 // flags = notrap aligned little
+;   v13 = vload128 sp+408 // flags = notrap aligned little
+;   v14 = vload128 sp+400 // flags = notrap aligned little
+;   v15 = vload128 sp+392 // flags = notrap aligned little
+;   v16 = vload128 sp+384 // flags = notrap aligned little
+;   v17 = vload128 sp+376 // flags = notrap aligned little
+;   v18 = vload128 sp+368 // flags = notrap aligned little
+;   v19 = vload128 sp+360 // flags = notrap aligned little
+;   v20 = vload128 sp+352 // flags = notrap aligned little
+;   v21 = vload128 sp+344 // flags = notrap aligned little
+;   v22 = vload128 sp+336 // flags = notrap aligned little
+;   v23 = vload128 sp+328 // flags = notrap aligned little
+;   v24 = vload128 sp+320 // flags = notrap aligned little
+;   v25 = vload128 sp+312 // flags = notrap aligned little
+;   v26 = vload128 sp+304 // flags = notrap aligned little
+;   v27 = vload128 sp+296 // flags = notrap aligned little
+;   v28 = vload128 sp+288 // flags = notrap aligned little
+;   v29 = vload128 sp+280 // flags = notrap aligned little
+;   v30 = vload128 sp+272 // flags = notrap aligned little
+;   v31 = vload128 sp+264 // flags = notrap aligned little
+;   pop_frame_restore 912, {x16}
+;   ret
+;
+; Disassembled:
+; push_frame_save 912, x16
+; xstore64le_o32 sp, 896, x0
+; xstore64le_o32 sp, 888, x1
+; xstore64le_o32 sp, 880, x2
+; xstore64le_o32 sp, 872, x3
+; xstore64le_o32 sp, 864, x4
+; xstore64le_o32 sp, 856, x5
+; xstore64le_o32 sp, 848, x6
+; xstore64le_o32 sp, 840, x7
+; xstore64le_o32 sp, 832, x8
+; xstore64le_o32 sp, 824, x9
+; xstore64le_o32 sp, 816, x10
+; xstore64le_o32 sp, 808, x11
+; xstore64le_o32 sp, 800, x12
+; xstore64le_o32 sp, 792, x13
+; xstore64le_o32 sp, 784, x14
+; xstore64le_o32 sp, 776, x15
+; fstore64le_o32 sp, 768, f0
+; fstore64le_o32 sp, 760, f1
+; fstore64le_o32 sp, 752, f2
+; fstore64le_o32 sp, 744, f3
+; fstore64le_o32 sp, 736, f4
+; fstore64le_o32 sp, 728, f5
+; fstore64le_o32 sp, 720, f6
+; fstore64le_o32 sp, 712, f7
+; fstore64le_o32 sp, 704, f8
+; fstore64le_o32 sp, 696, f9
+; fstore64le_o32 sp, 688, f10
+; fstore64le_o32 sp, 680, f11
+; fstore64le_o32 sp, 672, f12
+; fstore64le_o32 sp, 664, f13
+; fstore64le_o32 sp, 656, f14
+; fstore64le_o32 sp, 648, f15
+; fstore64le_o32 sp, 640, f16
+; fstore64le_o32 sp, 632, f17
+; fstore64le_o32 sp, 624, f18
+; fstore64le_o32 sp, 616, f19
+; fstore64le_o32 sp, 608, f20
+; fstore64le_o32 sp, 600, f21
+; fstore64le_o32 sp, 592, f22
+; fstore64le_o32 sp, 584, f23
+; fstore64le_o32 sp, 576, f24
+; fstore64le_o32 sp, 568, f25
+; fstore64le_o32 sp, 560, f26
+; fstore64le_o32 sp, 552, f27
+; fstore64le_o32 sp, 544, f28
+; fstore64le_o32 sp, 536, f29
+; fstore64le_o32 sp, 528, f30
+; fstore64le_o32 sp, 520, f31
+; vstore128le_o32 sp, 512, v0
+; vstore128le_o32 sp, 504, v1
+; vstore128le_o32 sp, 496, v2
+; vstore128le_o32 sp, 488, v3
+; vstore128le_o32 sp, 480, v4
+; vstore128le_o32 sp, 472, v5
+; vstore128le_o32 sp, 464, v6
+; vstore128le_o32 sp, 456, v7
+; vstore128le_o32 sp, 448, v8
+; vstore128le_o32 sp, 440, v9
+; vstore128le_o32 sp, 432, v10
+; vstore128le_o32 sp, 424, v11
+; vstore128le_o32 sp, 416, v12
+; vstore128le_o32 sp, 408, v13
+; vstore128le_o32 sp, 400, v14
+; vstore128le_o32 sp, 392, v15
+; vstore128le_o32 sp, 384, v16
+; vstore128le_o32 sp, 376, v17
+; vstore128le_o32 sp, 368, v18
+; vstore128le_o32 sp, 360, v19
+; vstore128le_o32 sp, 352, v20
+; vstore128le_o32 sp, 344, v21
+; vstore128le_o32 sp, 336, v22
+; vstore128le_o32 sp, 328, v23
+; vstore128le_o32 sp, 320, v24
+; vstore128le_o32 sp, 312, v25
+; vstore128le_o32 sp, 304, v26
+; vstore128le_o32 sp, 296, v27
+; vstore128le_o32 sp, 288, v28
+; vstore128le_o32 sp, 280, v29
+; vstore128le_o32 sp, 272, v30
+; vstore128le_o32 sp, 264, v31
+; xmov x16, x1
+; call_indirect_host 0
+; xmov x0, x16
+; call_indirect_host 0
+; xload64le_o32 x0, sp, 896
+; xload64le_o32 x1, sp, 888
+; xload64le_o32 x2, sp, 880
+; xload64le_o32 x3, sp, 872
+; xload64le_o32 x4, sp, 864
+; xload64le_o32 x5, sp, 856
+; xload64le_o32 x6, sp, 848
+; xload64le_o32 x7, sp, 840
+; xload64le_o32 x8, sp, 832
+; xload64le_o32 x9, sp, 824
+; xload64le_o32 x10, sp, 816
+; xload64le_o32 x11, sp, 808
+; xload64le_o32 x12, sp, 800
+; xload64le_o32 x13, sp, 792
+; xload64le_o32 x14, sp, 784
+; xload64le_o32 x15, sp, 776
+; fload64le_o32 f0, sp, 768
+; fload64le_o32 f1, sp, 760
+; fload64le_o32 f2, sp, 752
+; fload64le_o32 f3, sp, 744
+; fload64le_o32 f4, sp, 736
+; fload64le_o32 f5, sp, 728
+; fload64le_o32 f6, sp, 720
+; fload64le_o32 f7, sp, 712
+; fload64le_o32 f8, sp, 704
+; fload64le_o32 f9, sp, 696
+; fload64le_o32 f10, sp, 688
+; fload64le_o32 f11, sp, 680
+; fload64le_o32 f12, sp, 672
+; fload64le_o32 f13, sp, 664
+; fload64le_o32 f14, sp, 656
+; fload64le_o32 f15, sp, 648
+; fload64le_o32 f16, sp, 640
+; fload64le_o32 f17, sp, 632
+; fload64le_o32 f18, sp, 624
+; fload64le_o32 f19, sp, 616
+; fload64le_o32 f20, sp, 608
+; fload64le_o32 f21, sp, 600
+; fload64le_o32 f22, sp, 592
+; fload64le_o32 f23, sp, 584
+; fload64le_o32 f24, sp, 576
+; fload64le_o32 f25, sp, 568
+; fload64le_o32 f26, sp, 560
+; fload64le_o32 f27, sp, 552
+; fload64le_o32 f28, sp, 544
+; fload64le_o32 f29, sp, 536
+; fload64le_o32 f30, sp, 528
+; fload64le_o32 f31, sp, 520
+; vload128le_o32 v0, sp, 512
+; vload128le_o32 v1, sp, 504
+; vload128le_o32 v2, sp, 496
+; vload128le_o32 v3, sp, 488
+; vload128le_o32 v4, sp, 480
+; vload128le_o32 v5, sp, 472
+; vload128le_o32 v6, sp, 464
+; vload128le_o32 v7, sp, 456
+; vload128le_o32 v8, sp, 448
+; vload128le_o32 v9, sp, 440
+; vload128le_o32 v10, sp, 432
+; vload128le_o32 v11, sp, 424
+; vload128le_o32 v12, sp, 416
+; vload128le_o32 v13, sp, 408
+; vload128le_o32 v14, sp, 400
+; vload128le_o32 v15, sp, 392
+; vload128le_o32 v16, sp, 384
+; vload128le_o32 v17, sp, 376
+; vload128le_o32 v18, sp, 368
+; vload128le_o32 v19, sp, 360
+; vload128le_o32 v20, sp, 352
+; vload128le_o32 v21, sp, 344
+; vload128le_o32 v22, sp, 336
+; vload128le_o32 v23, sp, 328
+; vload128le_o32 v24, sp, 320
+; vload128le_o32 v25, sp, 312
+; vload128le_o32 v26, sp, 304
+; vload128le_o32 v27, sp, 296
+; vload128le_o32 v28, sp, 288
+; vload128le_o32 v29, sp, 280
+; vload128le_o32 v30, sp, 272
+; vload128le_o32 v31, sp, 264
+; pop_frame_restore 912, x16
+; ret
+


### PR DESCRIPTION
I've encountered an odd runtime failure in a component using `pulley32` target and having `guest_debug` feature enabled with debugger in single-step mode - I had an LLM debug the issue, provide a reproducer and a potential fix.

The reasoning and fix seem to make sense to me, however, this is not exactly my area of expertise, and I cannot confidently review this change in-depth, therefore I'm filing this as a draft PR. Please feel free to treat this as a bug report.

I am in no way attached to this solution, however it does unblock a critical feature for a Wasmtime embedding I am currently working on.
Happy to discard any or all of this and work with someone on a proper fix in case this contribution is not on par.
Similarly, please feel free to take over this effort.
Otherwise, if this seems sensible - let me know, I'll address any feedback and undraft this PR.