### PR TITLE
Run `cargo fetch` in a retry loop on CI

### DIFF
--- a/.github/actions/install-rust/action.yml
+++ b/.github/actions/install-rust/action.yml
@@ -80,3 +80,12 @@ runs:
     - name: Install the WASI target
       shell: bash
       run: rustup target add wasm32-wasip2 wasm32-wasip1 wasm32-unknown-unknown
+
+    - name: Fetch all Cargo dependencies
+      shell: bash
+      run: |
+        for attempt in 1 2 3 4 5; do
+          [ "$attempt" = "5" ] && exit 1
+          cargo fetch --locked && break
+          sleep 5
+        done

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -710,8 +710,6 @@ jobs:
     - uses: ./.github/actions/apt-get-install
       with:
         packages: ocaml-nox ocamlbuild ocaml-findlib libzarith-ocaml-dev
-    - run: cargo fetch
-      working-directory: ./fuzz
     - run: cargo fuzz check --dev
     - run: cargo fuzz check --dev --fuzz-dir ./cranelift/isle/fuzz
     - run: cargo fuzz check --dev --fuzz-dir ./crates/environ/fuzz --features component-model
@@ -842,8 +840,6 @@ jobs:
     - shell: pwsh
       run: echo "C:\msys64\mingw64\bin" >> $Env:GITHUB_PATH
       if: matrix.target == 'x86_64-pc-windows-gnu'
-
-    - run: cargo fetch --locked
 
     - uses: ./.github/actions/apt-get-install
       name: Install cross-compilation tools


### PR DESCRIPTION
The number of failures right now is... high. Bake a `cargo fetch` directly into all Rust installations on CI and put a loop around it.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
