### PR TITLE
Turn down tests count in `gc_acess_oracle_passes`

### DIFF
--- a/crates/fuzzing/src/oracles/gc_access.rs
+++ b/crates/fuzzing/src/oracles/gc_access.rs
@@ -68,7 +68,7 @@ mod tests {
 
     #[test]
     fn gc_access_oracle_passes() {
-        crate::test::test_n_times(1024, |config: generators::Config, u| {
+        crate::test::test_n_times(128, |config: generators::Config, u| {
             let input: GcAccess = u.arbitrary()?;
             gc_access(config, input);
             Ok(())


### PR DESCRIPTION
This takes ~2 minutes to complete in debug mode locally, so turn down the count to complete in a few seconds instead.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
