### PR TITLE
wasi-sockets: restore UDP send address validation

### DIFF
--- a/crates/test-programs/src/bin/p3_sockets_udp_send.rs
+++ b/crates/test-programs/src/bin/p3_sockets_udp_send.rs
@@ -1,6 +1,5 @@
 use test_programs::p3::wasi::sockets::types::{
-    ErrorCode, IpAddress, IpAddressFamily, IpSocketAddress, Ipv4SocketAddress, Ipv6SocketAddress,
-    UdpSocket,
+    ErrorCode, IpAddress, IpAddressFamily, IpSocketAddress, UdpSocket,
 };
 
 struct Component;
@@ -25,6 +24,14 @@ async fn test_udp_send_without_bind_or_connect(family: IpAddressFamily) {
     assert!(matches!(sock.get_remote_address(), Err(_)));
 }
 
+async fn test_unspecified_remote_addr(family: IpAddressFamily) {
+    let sock = UdpSocket::create(family).unwrap();
+    let unspec = IpSocketAddress::new(IpAddress::new_unspecified(family), 1234);
+    let result = sock.send(vec![0; 1], Some(unspec)).await;
+
+    assert!(matches!(result, Err(ErrorCode::InvalidArgument)));
+}
+
 impl test_programs::p3::exports::wasi::cli::run::Guest for Component {
     async fn run() -> Result<(), ()> {
         test_udp_send_without_bind_or_connect(IpAddressFamily::Ipv4).await;
@@ -33,34 +40,23 @@ impl test_programs::p3::exports::wasi::cli::run::Guest for Component {
         test_wrong_address_family(IpAddressFamily::Ipv4).await;
         test_wrong_address_family(IpAddressFamily::Ipv6).await;
 
+        test_unspecified_remote_addr(IpAddressFamily::Ipv4).await;
+        test_unspecified_remote_addr(IpAddressFamily::Ipv6).await;
+
         Ok(())
     }
 }
 async fn test_wrong_address_family(family: IpAddressFamily) {
-    let sock = UdpSocket::create(family).unwrap();
-
-    let addr = match family {
-        IpAddressFamily::Ipv4 => IpSocketAddress::Ipv6(Ipv6SocketAddress {
-            port: 0,
-            address: (0, 0, 0, 0, 0, 0, 0, 1),
-            flow_info: 0,
-            scope_id: 0,
-        }),
-        IpAddressFamily::Ipv6 => IpSocketAddress::Ipv4(Ipv4SocketAddress {
-            port: 0,
-            address: (127, 0, 0, 1),
-        }),
+    let wrong_family = match family {
+        IpAddressFamily::Ipv4 => IpAddressFamily::Ipv6,
+        IpAddressFamily::Ipv6 => IpAddressFamily::Ipv4,
     };
+    let addr = IpSocketAddress::new(IpAddress::new_loopback(wrong_family), 1234);
 
+    let sock = UdpSocket::create(family).unwrap();
     let result = sock.send(vec![0; 1], Some(addr)).await;
     assert!(
-        matches!(
-            result,
-            Err(ErrorCode::NotSupported
-                | ErrorCode::InvalidArgument
-                | ErrorCode::RemoteUnreachable
-                | ErrorCode::Other(_))
-        ),
+        matches!(result, Err(ErrorCode::InvalidArgument)),
         "bad error {result:?}"
     );
 }

--- a/crates/wasi/src/sockets/udp.rs
+++ b/crates/wasi/src/sockets/udp.rs
@@ -181,7 +181,12 @@ impl UdpSocket {
             (UdpState::BindStarted, _) => Err(ErrorCode::InvalidState),
             (UdpState::Default | UdpState::Bound, None) => Err(ErrorCode::InvalidArgument),
             (UdpState::Default | UdpState::Bound, Some(addr)) => {
-                Ok(Mode::SendTo(Arc::clone(&self.socket), addr))
+                if is_valid_remote_address(addr) && is_valid_address_family(addr.ip(), self.family)
+                {
+                    Ok(Mode::SendTo(Arc::clone(&self.socket), addr))
+                } else {
+                    Err(ErrorCode::InvalidArgument)
+                }
             }
             (UdpState::Connected(..), None) => Ok(Mode::Send(Arc::clone(&self.socket))),
             (UdpState::Connected(caddr), Some(addr)) => {


### PR DESCRIPTION
Make the P3 implementation of UDP `send` perform the same validation as in P2

Fixes #12568 
Relates to #12475 