### PR TITLE
cranelift-jit: re-export JITMemoryKind

### DIFF
--- a/cranelift/jit/src/lib.rs
+++ b/cranelift/jit/src/lib.rs
@@ -12,7 +12,7 @@ mod memory;
 
 pub use crate::backend::{JITBuilder, JITModule};
 pub use crate::memory::{
-    ArenaMemoryProvider, BranchProtection, JITMemoryProvider, SystemMemoryProvider,
+    ArenaMemoryProvider, BranchProtection, JITMemoryKind, JITMemoryProvider, SystemMemoryProvider,
 };
 
 /// Version number of this crate.

--- a/cranelift/jit/src/memory/mod.rs
+++ b/cranelift/jit/src/memory/mod.rs
@@ -16,6 +16,7 @@ pub enum BranchProtection {
     BTI,
 }
 
+/// The kind of memory allocation requested by a [`JITMemoryProvider`].
 pub enum JITMemoryKind {
     /// Allocate memory that will be executable once finalized.
     Executable,


### PR DESCRIPTION
Fixes #13200.

`JITMemoryProvider::allocate` takes a `JITMemoryKind`, but downstream crates
could not name that type because it was only available through the private
`memory` module.

This re-exports `JITMemoryKind` from the `cranelift_jit` crate root alongside
`JITMemoryProvider` and adds rustdoc for the public enum.

Tested with `cargo check -p cranelift-jit`, `cargo test -p cranelift-jit`, and
`cargo doc -p cranelift-jit --no-deps`.