### PR TITLE
Fix leaking fiber stacks on OOM

### DIFF
--- a/crates/fiber/src/lib.rs
+++ b/crates/fiber/src/lib.rs
@@ -41,6 +41,12 @@ cfg_if::cfg_if! {
 /// Represents an execution stack to use for a fiber.
 pub struct FiberStack(imp::FiberStack);
 
+impl core::fmt::Debug for FiberStack {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("FiberStack").finish_non_exhaustive()
+    }
+}
+
 fn _assert_send_sync() {
     fn _assert_send<T: Send>() {}
     fn _assert_sync<T: Sync>() {}
@@ -171,11 +177,17 @@ impl<'a, Resume, Yield, Return> Fiber<'a, Resume, Yield, Return> {
     /// This function returns a `Fiber` which, when resumed, will execute `func`
     /// to completion. When desired the `func` can suspend itself via
     /// `Fiber::suspend`.
+    /// On error the provided `stack` is handed back to the caller (paired with
+    /// the error) so that it can be deallocated rather than leaked; the stack is
+    /// only consumed by this `Fiber` on success.
     pub fn new(
         stack: FiberStack,
         func: impl FnOnce(Resume, &mut Suspend<Resume, Yield, Return>) -> Return + 'a,
-    ) -> Result<Self> {
-        let inner = imp::Fiber::new(&stack.0, func)?;
+    ) -> Result<Self, (Error, FiberStack)> {
+        let inner = match imp::Fiber::new(&stack.0, func) {
+            Ok(inner) => inner,
+            Err(e) => return Err((e, stack)),
+        };
 
         Ok(Self {
             stack: Some(stack),

--- a/crates/fiber/src/miri.rs
+++ b/crates/fiber/src/miri.rs
@@ -24,7 +24,7 @@ use std::ops::Range;
 use std::sync::{Arc, Condvar, Mutex};
 use std::thread::{self, JoinHandle};
 
-pub type Error = io::Error;
+pub use wasmtime_environ::error::Error;
 
 pub struct FiberStack(usize);
 
@@ -34,7 +34,7 @@ impl FiberStack {
     }
 
     pub unsafe fn from_raw_parts(_base: *mut u8, _guard_size: usize, _len: usize) -> Result<Self> {
-        Err(io::ErrorKind::Unsupported.into())
+        Err(io::Error::from(io::ErrorKind::Unsupported).into())
     }
 
     pub fn is_from_raw_parts(&self) -> bool {
@@ -42,7 +42,7 @@ impl FiberStack {
     }
 
     pub fn from_custom(_custom: Box<dyn RuntimeFiberStack>) -> Result<Self> {
-        Err(io::ErrorKind::Unsupported.into())
+        Err(io::Error::from(io::ErrorKind::Unsupported).into())
     }
 
     pub fn top(&self) -> Option<*mut u8> {

--- a/crates/fiber/src/windows.rs
+++ b/crates/fiber/src/windows.rs
@@ -6,6 +6,7 @@ use std::io;
 use std::mem::needs_drop;
 use std::ops::Range;
 use std::ptr;
+use wasmtime_environ::prelude::*;
 use windows_sys::Win32::Foundation::*;
 use windows_sys::Win32::System::Threading::*;
 
@@ -102,13 +103,13 @@ where
 }
 
 impl Fiber {
-    pub fn new<F, A, B, C>(stack: &FiberStack, func: F) -> io::Result<Self>
+    pub fn new<F, A, B, C>(stack: &FiberStack, func: F) -> Result<Self>
     where
         F: FnOnce(A, &mut super::Suspend<A, B, C>) -> C,
     {
         unsafe {
             let state = Box::new(StartState {
-                initial_closure: Cell::new(Box::into_raw(Box::new(func)).cast()),
+                initial_closure: Cell::new(Box::into_raw(try_new(func)?).cast()),
                 parent: Cell::new(ptr::null_mut()),
                 result_location: Cell::new(ptr::null()),
             });
@@ -123,7 +124,7 @@ impl Fiber {
 
             if fiber.is_null() {
                 drop(Box::from_raw(state.initial_closure.get().cast::<F>()));
-                return Err(io::Error::last_os_error());
+                return Err(io::Error::last_os_error().into());
             }
 
             Ok(Self { fiber, state })

--- a/crates/fuzzing/tests/oom/fiber_stack.rs
+++ b/crates/fuzzing/tests/oom/fiber_stack.rs
@@ -1,0 +1,35 @@
+#![cfg(arc_try_new)]
+
+use wasmtime::{
+    Config, Engine, InstanceAllocationStrategy, Linker, Module, PoolingAllocationConfig, Result,
+    Store,
+};
+use wasmtime_fuzzing::oom::OomTest;
+
+#[tokio::test]
+async fn pooling_allocator_fiber_stack_slot_leak_on_oom() -> Result<()> {
+    let mut pool = PoolingAllocationConfig::default();
+    pool.total_stacks(1);
+    pool.total_memories(10);
+    pool.total_tables(10);
+    pool.total_core_instances(10);
+
+    let mut config = Config::new();
+    config.concurrency_support(false);
+    config.allocation_strategy(InstanceAllocationStrategy::Pooling(pool));
+    let engine = Engine::new(&config)?;
+    let module = Module::new(&engine, r#"(module (func (export "f")))"#)?;
+    let linker = Linker::<()>::new(&engine);
+    let instance_pre = linker.instantiate_pre(&module)?;
+
+    OomTest::new()
+        .allow_alloc_after_oom(true)
+        .test_async(|| async {
+            let mut store = Store::try_new(&engine, ())?;
+            let instance = instance_pre.instantiate_async(&mut store).await?;
+            let f = instance.get_typed_func::<(), ()>(&mut store, "f")?;
+            f.call_async(&mut store, ()).await?;
+            Ok(())
+        })
+        .await
+}

--- a/crates/fuzzing/tests/oom/main.rs
+++ b/crates/fuzzing/tests/oom/main.rs
@@ -14,6 +14,7 @@ mod config;
 mod engine;
 mod entity_set;
 mod error;
+mod fiber_stack;
 mod func;
 mod func_type;
 mod fuzz;

--- a/crates/wasmtime/src/runtime/fiber.rs
+++ b/crates/wasmtime/src/runtime/fiber.rs
@@ -836,7 +836,16 @@ where
         let reset = ResetCurrentPointersToNull(store_ref);
 
         fun(reset.0)
-    })?;
+    });
+    let fiber = match fiber {
+        Ok(fiber) => fiber,
+        Err((e, stack)) => {
+            unsafe {
+                engine.allocator().deallocate_fiber_stack(stack);
+            }
+            return Err(e);
+        }
+    };
     Ok(StoreFiber {
         state: Some(
             FiberResumeState {


### PR DESCRIPTION
This commit fixes an issue where a fiber stack could be allocated, but then allocating a fiber itself could fail, which would leak the fiber stack within the pooling allocator.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
