### PR TITLE
validate content-length is decimal digits in wasi-http

### DIFF
--- a/crates/wasi-http/src/lib.rs
+++ b/crates/wasi-http/src/lib.rs
@@ -33,8 +33,42 @@ fn get_content_length(headers: &http::HeaderMap) -> wasmtime::Result<Option<u64>
         return Ok(None);
     };
     let v = v.to_str()?;
+    // RFC 9110 defines `Content-Length` as `1*DIGIT`. `u64`'s `FromStr` is more
+    // lenient and also accepts a leading `+`, so reject anything that isn't a
+    // non-empty run of decimal digits before parsing.
+    if v.is_empty() || !v.bytes().all(|b| b.is_ascii_digit()) {
+        wasmtime::bail!("invalid `content-length` header value: {v:?}");
+    }
     let v = v.parse()?;
     Ok(Some(v))
+}
+
+#[cfg(all(test, any(feature = "p2", feature = "p3")))]
+mod content_length_tests {
+    use super::get_content_length;
+    use http::{HeaderMap, HeaderValue, header};
+
+    fn headers(value: &str) -> HeaderMap {
+        let mut map = HeaderMap::new();
+        map.insert(
+            header::CONTENT_LENGTH,
+            HeaderValue::from_str(value).unwrap(),
+        );
+        map
+    }
+
+    #[test]
+    fn content_length_must_be_decimal_digits() {
+        assert_eq!(get_content_length(&HeaderMap::new()).unwrap(), None);
+        assert_eq!(get_content_length(&headers("0")).unwrap(), Some(0));
+        assert_eq!(get_content_length(&headers("1234")).unwrap(), Some(1234));
+
+        // `u64::from_str` accepts these but they are not `1*DIGIT` per RFC 9110.
+        assert!(get_content_length(&headers("+5")).is_err());
+        assert!(get_content_length(&headers("-5")).is_err());
+        assert!(get_content_length(&headers(" 5")).is_err());
+        assert!(get_content_length(&headers("")).is_err());
+    }
 }
 
 /// Set of [http::header::HeaderName], that are forbidden by default

--- a/crates/wasi-http/src/p3/host/types.rs
+++ b/crates/wasi-http/src/p3/host/types.rs
@@ -129,6 +129,12 @@ fn parse_header_value(
 ) -> Result<http::HeaderValue, HeaderError> {
     if name == CONTENT_LENGTH {
         let s = str::from_utf8(value.as_ref()).or(Err(HeaderError::InvalidSyntax))?;
+        // RFC 9110 defines `Content-Length` as `1*DIGIT`. `u64`'s `FromStr` is
+        // more lenient and also accepts a leading `+`, so reject anything that
+        // isn't a non-empty run of decimal digits.
+        if s.is_empty() || !s.bytes().all(|b| b.is_ascii_digit()) {
+            return Err(HeaderError::InvalidSyntax);
+        }
         let v: u64 = s.parse().or(Err(HeaderError::InvalidSyntax))?;
         Ok(v.into())
     } else {
@@ -703,5 +709,26 @@ impl Host for WasiHttpCtxView<'_> {
         error: crate::p3::RequestOptionsError,
     ) -> wasmtime::Result<RequestOptionsError> {
         error.downcast()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_header_value;
+    use http::header::{CONTENT_LENGTH, CONTENT_TYPE};
+
+    #[test]
+    fn content_length_rejects_non_digits() {
+        assert!(parse_header_value(&CONTENT_LENGTH, "0").is_ok());
+        assert!(parse_header_value(&CONTENT_LENGTH, "1234").is_ok());
+
+        // `u64::from_str` accepts these but they are not `1*DIGIT` per RFC 9110.
+        assert!(parse_header_value(&CONTENT_LENGTH, "+5").is_err());
+        assert!(parse_header_value(&CONTENT_LENGTH, "-5").is_err());
+        assert!(parse_header_value(&CONTENT_LENGTH, " 5").is_err());
+        assert!(parse_header_value(&CONTENT_LENGTH, "").is_err());
+
+        // other header names are unaffected
+        assert!(parse_header_value(&CONTENT_TYPE, "text/plain").is_ok());
     }
 }


### PR DESCRIPTION
1. `get_content_length` and the p3 `parse_header_value` read `Content-Length` with `u64`'s `FromStr`, which also accepts a leading `+`, so a value like `+5` is parsed as `5`.
2. RFC 9110 defines the field value as `1*DIGIT`, so a value like that is accepted here while a strict parser (a proxy or the peer) would reject it. The parsed value drives the p2 and p3 request/response body framing, and `parse_header_value` runs when a guest builds a field map.

Reject any `content-length` value that is not a non-empty run of ASCII decimal digits before parsing, at both sites. Added unit tests covering `+5`, `-5`, a leading space, and the empty value.