### PR TITLE
Use `MaybeUninit.write` instead of `initialize<T>`

### DIFF
--- a/crates/c-api/src/anyref.rs
+++ b/crates/c-api/src/anyref.rs
@@ -126,7 +126,7 @@ macro_rules! ref_wrapper {
                 let mut scope = wasmtime::RootScope::new(cx);
                 let anyref = $wasmtime::from_raw(&mut scope, raw)
                     .map(|a| a.to_owned_rooted(&mut scope).expect("in scope"));
-                crate::initialize(val, anyref.into());
+                val.write(anyref.into());
             }
         )?
     };
@@ -151,7 +151,7 @@ pub extern "C" fn wasmtime_anyref_from_i31(
     let mut scope = RootScope::new(cx);
     let anyref = AnyRef::from_i31(&mut scope, I31::wrapping_u32(val));
     let anyref = anyref.to_owned_rooted(&mut scope).expect("in scope");
-    crate::initialize(out, Some(anyref).into())
+    out.write(Some(anyref).into());
 }
 
 #[unsafe(no_mangle)]
@@ -177,7 +177,7 @@ pub unsafe extern "C" fn wasmtime_anyref_i31_get_u(
                 .unwrap_i31(&cx)
                 .expect("OwnedRooted always in scope")
                 .get_u32();
-            crate::initialize(dst, val);
+            dst.write(val);
             true
         }
         _ => false,
@@ -196,7 +196,7 @@ pub unsafe extern "C" fn wasmtime_anyref_i31_get_s(
                 .unwrap_i31(&cx)
                 .expect("OwnedRooted always in scope")
                 .get_i32();
-            crate::initialize(dst, val);
+            dst.write(val);
             true
         }
         _ => false,
@@ -225,11 +225,11 @@ pub unsafe extern "C" fn wasmtime_anyref_as_eqref(
         let rooted = anyref.to_rooted(&mut scope);
         if let Ok(Some(eqref)) = rooted.as_eqref(&mut scope) {
             let owned = eqref.to_owned_rooted(&mut scope).expect("in scope");
-            crate::initialize(out, Some(owned).into());
+            out.write(Some(owned).into());
             return true;
         }
     }
-    crate::initialize(out, None::<OwnedRooted<EqRef>>.into());
+    out.write(None::<OwnedRooted<EqRef>>.into());
     false
 }
 
@@ -255,11 +255,11 @@ pub unsafe extern "C" fn wasmtime_anyref_as_struct(
         let rooted = anyref.to_rooted(&mut scope);
         if let Ok(Some(structref)) = rooted.as_struct(&scope) {
             let owned = structref.to_owned_rooted(&mut scope).expect("in scope");
-            crate::initialize(out, Some(owned).into());
+            out.write(Some(owned).into());
             return true;
         }
     }
-    crate::initialize(out, None::<OwnedRooted<StructRef>>.into());
+    out.write(None::<OwnedRooted<StructRef>>.into());
     false
 }
 
@@ -285,11 +285,11 @@ pub unsafe extern "C" fn wasmtime_anyref_as_array(
         let rooted = anyref.to_rooted(&mut scope);
         if let Ok(Some(arrayref)) = rooted.as_array(&scope) {
             let owned = arrayref.to_owned_rooted(&mut scope).expect("in scope");
-            crate::initialize(out, Some(owned).into());
+            out.write(Some(owned).into());
             return true;
         }
     }
-    crate::initialize(out, None::<OwnedRooted<ArrayRef>>.into());
+    out.write(None::<OwnedRooted<ArrayRef>>.into());
     false
 }
 

--- a/crates/c-api/src/arrayref.rs
+++ b/crates/c-api/src/arrayref.rs
@@ -38,11 +38,11 @@ pub unsafe extern "C" fn wasmtime_arrayref_new(
             let owned = arrayref
                 .to_owned_rooted(&mut scope)
                 .expect("just allocated");
-            crate::initialize(out, Some(owned).into());
+            out.write(Some(owned).into());
             None
         }
         Err(e) => {
-            crate::initialize(out, None::<OwnedRooted<ArrayRef>>.into());
+            out.write(None::<OwnedRooted<ArrayRef>>.into());
             Some(Box::new(e.into()))
         }
     }
@@ -56,7 +56,7 @@ pub unsafe extern "C" fn wasmtime_arrayref_to_anyref(
     let anyref = arrayref
         .and_then(|a| a.as_wasmtime())
         .map(|a| a.to_anyref());
-    crate::initialize(out, anyref.into());
+    out.write(anyref.into());
 }
 
 #[unsafe(no_mangle)]
@@ -65,7 +65,7 @@ pub unsafe extern "C" fn wasmtime_arrayref_to_eqref(
     out: &mut MaybeUninit<wasmtime_eqref_t>,
 ) {
     let eqref = arrayref.and_then(|a| a.as_wasmtime()).map(|a| a.to_eqref());
-    crate::initialize(out, eqref.into());
+    out.write(eqref.into());
 }
 
 #[unsafe(no_mangle)]
@@ -79,7 +79,7 @@ pub unsafe extern "C" fn wasmtime_arrayref_len(
         .expect("non-null arrayref required");
     match arrayref.len(&cx) {
         Ok(len) => {
-            crate::initialize(out, len);
+            out.write(len);
             None
         }
         Err(e) => Some(Box::new(e.into())),
@@ -101,7 +101,7 @@ pub unsafe extern "C" fn wasmtime_arrayref_get(
     match rooted.get(&mut scope, index) {
         Ok(val) => {
             let c_val = crate::wasmtime_val_t::from_val(&mut scope, val);
-            crate::initialize(out, c_val);
+            out.write(c_val);
             None
         }
         Err(e) => Some(Box::new(e.into())),

--- a/crates/c-api/src/async.rs
+++ b/crates/c-api/src/async.rs
@@ -236,7 +236,7 @@ async fn do_func_call_async(
     match result {
         Ok(()) => {
             for (slot, val) in results.iter_mut().zip(wt_results.iter()) {
-                crate::initialize(slot, wasmtime_val_t::from_val(&mut store, *val));
+                slot.write(wasmtime_val_t::from_val(&mut store, *val));
             }
             params.truncate(0);
             store.as_context_mut().data_mut().wasm_val_storage = params;

--- a/crates/c-api/src/eqref.rs
+++ b/crates/c-api/src/eqref.rs
@@ -18,7 +18,7 @@ pub unsafe extern "C" fn wasmtime_eqref_to_anyref(
     out: &mut MaybeUninit<wasmtime_anyref_t>,
 ) {
     let anyref = eqref.and_then(|e| e.as_wasmtime()).map(|e| e.to_anyref());
-    crate::initialize(out, anyref.into());
+    out.write(anyref.into());
 }
 
 #[unsafe(no_mangle)]
@@ -30,7 +30,7 @@ pub extern "C" fn wasmtime_eqref_from_i31(
     let mut scope = RootScope::new(cx);
     let eqref = EqRef::from_i31(&mut scope, I31::wrapping_u32(val));
     let eqref = eqref.to_owned_rooted(&mut scope).expect("in scope");
-    crate::initialize(out, Some(eqref).into())
+    out.write(Some(eqref).into());
 }
 
 #[unsafe(no_mangle)]
@@ -53,7 +53,7 @@ pub unsafe extern "C" fn wasmtime_eqref_i31_get_u(
     let mut scope = RootScope::new(cx);
     if let Some(eqref) = eqref.and_then(|e| e.as_wasmtime()) {
         if let Some(val) = eqref.as_i31(&mut scope).expect("in scope") {
-            crate::initialize(dst, val.get_u32());
+            dst.write(val.get_u32());
             return true;
         }
     }
@@ -69,7 +69,7 @@ pub unsafe extern "C" fn wasmtime_eqref_i31_get_s(
     let mut scope = RootScope::new(cx);
     if let Some(eqref) = eqref.and_then(|e| e.as_wasmtime()) {
         if let Some(val) = eqref.as_i31(&mut scope).expect("in scope") {
-            crate::initialize(dst, val.get_i32());
+            dst.write(val.get_i32());
             return true;
         }
     }
@@ -98,11 +98,11 @@ pub unsafe extern "C" fn wasmtime_eqref_as_struct(
         let rooted = eqref.to_rooted(&mut scope);
         if let Ok(Some(structref)) = rooted.as_struct(&scope) {
             let owned = structref.to_owned_rooted(&mut scope).expect("in scope");
-            crate::initialize(out, Some(owned).into());
+            out.write(Some(owned).into());
             return true;
         }
     }
-    crate::initialize(out, None::<OwnedRooted<StructRef>>.into());
+    out.write(None::<OwnedRooted<StructRef>>.into());
     false
 }
 
@@ -128,11 +128,11 @@ pub unsafe extern "C" fn wasmtime_eqref_as_array(
         let rooted = eqref.to_rooted(&mut scope);
         if let Ok(Some(arrayref)) = rooted.as_array(&scope) {
             let owned = arrayref.to_owned_rooted(&mut scope).expect("just created");
-            crate::initialize(out, Some(owned).into());
+            out.write(Some(owned).into());
             return true;
         }
     }
-    crate::initialize(out, None::<OwnedRooted<ArrayRef>>.into());
+    out.write(None::<OwnedRooted<ArrayRef>>.into());
     false
 }
 

--- a/crates/c-api/src/exnref.rs
+++ b/crates/c-api/src/exnref.rs
@@ -77,7 +77,7 @@ pub unsafe extern "C" fn wasmtime_exnref_field(
     let mut scope = RootScope::new(&mut store);
     let rooted = exn.as_wasmtime()?.to_rooted(&mut scope);
     handle_result(rooted.field(&mut scope, index), |val| {
-        crate::initialize(val_ret, wasmtime_val_t::from_val(&mut scope, val));
+        val_ret.write(wasmtime_val_t::from_val(&mut scope, val));
     })
 }
 

--- a/crates/c-api/src/externref.rs
+++ b/crates/c-api/src/externref.rs
@@ -25,7 +25,7 @@ pub extern "C" fn wasmtime_externref_new(
         Err(_) => return false,
     };
     let e = e.to_owned_rooted(&mut scope).expect("in scope");
-    crate::initialize(out, Some(e).into());
+    out.write(Some(e).into());
     true
 }
 

--- a/crates/c-api/src/func.rs
+++ b/crates/c-api/src/func.rs
@@ -155,7 +155,7 @@ pub unsafe extern "C" fn wasm_func_call(
     match result {
         Ok(Ok(())) => {
             for (slot, val) in results.iter_mut().zip(wt_results.iter().cloned()) {
-                crate::initialize(slot, wasm_val_t::from_val(val));
+                slot.write(wasm_val_t::from_val(val));
             }
             ptr::null_mut()
         }
@@ -376,7 +376,7 @@ pub unsafe extern "C" fn wasmtime_func_call(
         Ok(Ok(())) => {
             let results = crate::slice_from_raw_parts_mut(results, nresults);
             for (slot, val) in results.iter_mut().zip(wt_results.iter()) {
-                crate::initialize(slot, wasmtime_val_t::from_val(&mut store, *val));
+                slot.write(wasmtime_val_t::from_val(&mut store, *val));
             }
             params.truncate(0);
             store.as_context_mut().data_mut().wasm_val_storage = params;
@@ -455,7 +455,7 @@ pub unsafe extern "C" fn wasmtime_caller_export_get(
         Some(item) => item,
         None => return false,
     };
-    crate::initialize(item, which.into());
+    item.write(which.into());
     true
 }
 

--- a/crates/c-api/src/global.rs
+++ b/crates/c-api/src/global.rs
@@ -67,10 +67,7 @@ pub unsafe extern "C" fn wasm_global_type(g: &wasm_global_t) -> Box<wasm_globalt
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn wasm_global_get(g: &mut wasm_global_t, out: &mut MaybeUninit<wasm_val_t>) {
     let global = g.global();
-    crate::initialize(
-        out,
-        wasm_val_t::from_val(global.get(g.ext.store.context_mut())),
-    );
+    out.write(wasm_val_t::from_val(global.get(g.ext.store.context_mut())));
 }
 
 #[unsafe(no_mangle)]
@@ -116,7 +113,7 @@ pub extern "C" fn wasmtime_global_get(
     let mut store = RootScope::new(&mut store);
 
     let gval = global.get(&mut store);
-    crate::initialize(val, wasmtime_val_t::from_val(&mut store, gval))
+    val.write(wasmtime_val_t::from_val(&mut store, gval));
 }
 
 #[unsafe(no_mangle)]

--- a/crates/c-api/src/instance.rs
+++ b/crates/c-api/src/instance.rs
@@ -127,7 +127,7 @@ pub unsafe extern "C" fn wasmtime_instance_export_get(
     };
     match instance.get_export(store, name) {
         Some(e) => {
-            crate::initialize(item, e.into());
+            item.write(e.into());
             true
         }
         None => false,
@@ -147,7 +147,7 @@ pub unsafe extern "C" fn wasmtime_instance_export_nth(
         Some(e) => {
             *name_ptr = e.name().as_ptr();
             *name_len = e.name().len();
-            crate::initialize(item, e.into_extern().into());
+            item.write(e.into_extern().into());
             true
         }
         None => false,

--- a/crates/c-api/src/lib.rs
+++ b/crates/c-api/src/lib.rs
@@ -106,17 +106,6 @@ mod component;
 #[cfg(feature = "component-model")]
 pub use crate::component::*;
 
-/// Initialize a `MaybeUninit<T>`
-///
-/// TODO: Replace calls to this function with
-/// https://doc.rust-lang.org/nightly/std/mem/union.MaybeUninit.html#method.write
-/// once it is stable.
-pub(crate) fn initialize<T>(dst: &mut std::mem::MaybeUninit<T>, val: T) {
-    unsafe {
-        std::ptr::write(dst.as_mut_ptr(), val);
-    }
-}
-
 /// Helper for running a C-defined finalizer over some data when the Rust
 /// structure is dropped.
 pub struct ForeignData {

--- a/crates/c-api/src/linker.rs
+++ b/crates/c-api/src/linker.rs
@@ -205,7 +205,7 @@ pub unsafe extern "C" fn wasmtime_linker_get(
     };
     match linker.get(store, module, name) {
         Ok(which) => {
-            crate::initialize(item_ptr, which.into());
+            item_ptr.write(which.into());
             true
         }
         Err(_) => false,

--- a/crates/c-api/src/structref.rs
+++ b/crates/c-api/src/structref.rs
@@ -39,11 +39,11 @@ pub unsafe extern "C" fn wasmtime_structref_new(
             let owned = structref
                 .to_owned_rooted(&mut scope)
                 .expect("just allocated");
-            crate::initialize(out, Some(owned).into());
+            out.write(Some(owned).into());
             None
         }
         Err(e) => {
-            crate::initialize(out, None::<OwnedRooted<StructRef>>.into());
+            out.write(None::<OwnedRooted<StructRef>>.into());
             Some(Box::new(e.into()))
         }
     }
@@ -57,7 +57,7 @@ pub unsafe extern "C" fn wasmtime_structref_to_anyref(
     let anyref = structref
         .and_then(|s| s.as_wasmtime())
         .map(|s| s.to_anyref());
-    crate::initialize(out, anyref.into());
+    out.write(anyref.into());
 }
 
 #[unsafe(no_mangle)]
@@ -68,7 +68,7 @@ pub unsafe extern "C" fn wasmtime_structref_to_eqref(
     let eqref = structref
         .and_then(|s| s.as_wasmtime())
         .map(|s| s.to_eqref());
-    crate::initialize(out, eqref.into());
+    out.write(eqref.into());
 }
 
 #[unsafe(no_mangle)]
@@ -86,7 +86,7 @@ pub unsafe extern "C" fn wasmtime_structref_field(
     match rooted.field(&mut scope, index) {
         Ok(val) => {
             let c_val = crate::wasmtime_val_t::from_val(&mut scope, val);
-            crate::initialize(out, c_val);
+            out.write(c_val);
             None
         }
         Err(e) => Some(Box::new(e.into())),

--- a/crates/c-api/src/table.rs
+++ b/crates/c-api/src/table.rs
@@ -163,7 +163,7 @@ pub extern "C" fn wasmtime_table_get(
 
     match table.get(&mut store, index) {
         Some(r) => {
-            crate::initialize(ret, wasmtime_val_t::from_val(&mut store, r.into()));
+            ret.write(wasmtime_val_t::from_val(&mut store, r.into()));
             true
         }
         None => false,

--- a/crates/c-api/src/val.rs
+++ b/crates/c-api/src/val.rs
@@ -140,7 +140,7 @@ impl wasm_val_t {
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn wasm_val_copy(out: &mut MaybeUninit<wasm_val_t>, source: &wasm_val_t) {
-    crate::initialize(out, source.clone());
+    out.write(source.clone());
 }
 
 #[unsafe(no_mangle)]


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->

```
/// TODO: Replace calls to this function with
/// https://doc.rust-lang.org/nightly/std/mem/union.MaybeUninit.html#method.write
/// once it is stable.
pub(crate) fn initialize<T>(dst: &mut std::mem::MaybeUninit<T>, val: T) {
```
Solve a TODO: 
Since `std::mem::MaybeUninit<T>.write()` has been stable, use it instead of the wrapper `initialize()`.