### PR TITLE
Release Wasmtime 24.0.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -216,7 +216,7 @@ checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
 
 [[package]]
 name = "byte-array-literals"
-version = "24.0.9"
+version = "24.0.10"
 
 [[package]]
 name = "byteorder"
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift"
-version = "0.111.9"
+version = "0.111.10"
 dependencies = [
  "cranelift-codegen",
  "cranelift-frontend",
@@ -569,14 +569,14 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.111.9"
+version = "0.111.10"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.111.9"
+version = "0.111.10"
 dependencies = [
  "serde",
  "serde_derive",
@@ -584,7 +584,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.111.9"
+version = "0.111.10"
 dependencies = [
  "anyhow",
  "bumpalo",
@@ -615,25 +615,25 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.111.9"
+version = "0.111.10"
 dependencies = [
  "cranelift-codegen-shared",
 ]
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.111.9"
+version = "0.111.10"
 
 [[package]]
 name = "cranelift-control"
-version = "0.111.9"
+version = "0.111.10"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.111.9"
+version = "0.111.10"
 dependencies = [
  "cranelift-bitset",
  "serde",
@@ -671,7 +671,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.111.9"
+version = "0.111.10"
 dependencies = [
  "cranelift-codegen",
  "env_logger",
@@ -696,7 +696,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-interpreter"
-version = "0.111.9"
+version = "0.111.10"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -710,7 +710,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.111.9"
+version = "0.111.10"
 dependencies = [
  "codespan-reporting",
  "log",
@@ -719,7 +719,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-jit"
-version = "0.111.9"
+version = "0.111.10"
 dependencies = [
  "anyhow",
  "cranelift",
@@ -740,7 +740,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-module"
-version = "0.111.9"
+version = "0.111.10"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -752,7 +752,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-native"
-version = "0.111.9"
+version = "0.111.10"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -761,7 +761,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-object"
-version = "0.111.9"
+version = "0.111.10"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-reader"
-version = "0.111.9"
+version = "0.111.10"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -786,7 +786,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-serde"
-version = "0.111.9"
+version = "0.111.10"
 dependencies = [
  "clap",
  "cranelift-codegen",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-wasm"
-version = "0.111.9"
+version = "0.111.10"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -1045,7 +1045,7 @@ checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
 
 [[package]]
 name = "embedding"
-version = "24.0.9"
+version = "24.0.10"
 dependencies = [
  "anyhow",
  "dlmalloc",
@@ -1846,7 +1846,7 @@ dependencies = [
 
 [[package]]
 name = "min-platform-host"
-version = "24.0.9"
+version = "24.0.10"
 dependencies = [
  "anyhow",
  "libloading",
@@ -3088,7 +3088,7 @@ checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "verify-component-adapter"
-version = "24.0.9"
+version = "24.0.10"
 dependencies = [
  "anyhow",
  "wasmparser",
@@ -3138,7 +3138,7 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasi-common"
-version = "24.0.9"
+version = "24.0.10"
 dependencies = [
  "anyhow",
  "bitflags 2.4.1",
@@ -3178,7 +3178,7 @@ dependencies = [
 
 [[package]]
 name = "wasi-preview1-component-adapter"
-version = "24.0.9"
+version = "24.0.10"
 dependencies = [
  "bitflags 2.4.1",
  "byte-array-literals",
@@ -3372,7 +3372,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime"
-version = "24.0.9"
+version = "24.0.10"
 dependencies = [
  "addr2line",
  "anyhow",
@@ -3432,14 +3432,14 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-asm-macros"
-version = "24.0.9"
+version = "24.0.10"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "wasmtime-bench-api"
-version = "24.0.9"
+version = "24.0.10"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -3455,14 +3455,14 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-c-api"
-version = "24.0.9"
+version = "24.0.10"
 dependencies = [
  "wasmtime-c-api-impl",
 ]
 
 [[package]]
 name = "wasmtime-c-api-impl"
-version = "24.0.9"
+version = "24.0.10"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -3480,7 +3480,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-c-api-macros"
-version = "24.0.9"
+version = "24.0.10"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3488,7 +3488,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cache"
-version = "24.0.9"
+version = "24.0.10"
 dependencies = [
  "anyhow",
  "base64",
@@ -3510,7 +3510,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cli"
-version = "24.0.9"
+version = "24.0.10"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3578,7 +3578,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cli-flags"
-version = "24.0.9"
+version = "24.0.10"
 dependencies = [
  "anyhow",
  "clap",
@@ -3591,7 +3591,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-component-macro"
-version = "24.0.9"
+version = "24.0.10"
 dependencies = [
  "anyhow",
  "component-macro-test-helpers",
@@ -3611,11 +3611,11 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-component-util"
-version = "24.0.9"
+version = "24.0.10"
 
 [[package]]
 name = "wasmtime-cranelift"
-version = "24.0.9"
+version = "24.0.10"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -3637,7 +3637,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "24.0.9"
+version = "24.0.10"
 dependencies = [
  "anyhow",
  "clap",
@@ -3679,7 +3679,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-explorer"
-version = "24.0.9"
+version = "24.0.10"
 dependencies = [
  "anyhow",
  "capstone",
@@ -3694,7 +3694,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-fiber"
-version = "24.0.9"
+version = "24.0.10"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -3766,7 +3766,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-debug"
-version = "24.0.9"
+version = "24.0.10"
 dependencies = [
  "object",
  "once_cell",
@@ -3776,7 +3776,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-icache-coherence"
-version = "24.0.9"
+version = "24.0.10"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -3786,7 +3786,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-slab"
-version = "24.0.9"
+version = "24.0.10"
 
 [[package]]
 name = "wasmtime-test-macros"
@@ -3800,7 +3800,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-types"
-version = "24.0.9"
+version = "24.0.10"
 dependencies = [
  "anyhow",
  "cranelift-entity",
@@ -3812,7 +3812,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-versioned-export-macros"
-version = "24.0.9"
+version = "24.0.10"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3821,7 +3821,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi"
-version = "24.0.9"
+version = "24.0.10"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3854,7 +3854,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-http"
-version = "24.0.9"
+version = "24.0.10"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3880,7 +3880,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-keyvalue"
-version = "24.0.9"
+version = "24.0.10"
 dependencies = [
  "anyhow",
  "test-programs-artifacts",
@@ -3891,7 +3891,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-nn"
-version = "24.0.9"
+version = "24.0.10"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -3911,7 +3911,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-runtime-config"
-version = "24.0.9"
+version = "24.0.10"
 dependencies = [
  "anyhow",
  "test-programs-artifacts",
@@ -3922,7 +3922,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-threads"
-version = "24.0.9"
+version = "24.0.10"
 dependencies = [
  "anyhow",
  "log",
@@ -3933,7 +3933,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wast"
-version = "24.0.9"
+version = "24.0.10"
 dependencies = [
  "anyhow",
  "log",
@@ -3943,7 +3943,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-winch"
-version = "24.0.9"
+version = "24.0.10"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -3958,7 +3958,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wit-bindgen"
-version = "24.0.9"
+version = "24.0.10"
 dependencies = [
  "anyhow",
  "heck 0.4.0",
@@ -3968,7 +3968,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wmemcheck"
-version = "24.0.9"
+version = "24.0.10"
 
 [[package]]
 name = "wast"
@@ -4035,7 +4035,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle"
-version = "24.0.9"
+version = "24.0.10"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4052,7 +4052,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle-generate"
-version = "24.0.9"
+version = "24.0.10"
 dependencies = [
  "anyhow",
  "heck 0.4.0",
@@ -4065,7 +4065,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle-macro"
-version = "24.0.9"
+version = "24.0.10"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4120,7 +4120,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winch-codegen"
-version = "0.22.9"
+version = "0.22.10"
 dependencies = [
  "anyhow",
  "cranelift-codegen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -156,7 +156,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "24.0.9"
+version = "24.0.10"
 authors = ["The Wasmtime Project Developers"]
 edition = "2021"
 # Wasmtime's current policy is that this number can be no larger than the
@@ -183,60 +183,60 @@ manual_strip = 'warn'
 
 [workspace.dependencies]
 arbitrary = { version = "1.3.1" }
-wasmtime-wmemcheck = { path = "crates/wmemcheck", version = "=24.0.9" }
-wasmtime = { path = "crates/wasmtime", version = "24.0.9", default-features = false }
-wasmtime-c-api-macros = { path = "crates/c-api-macros", version = "=24.0.9" }
-wasmtime-cache = { path = "crates/cache", version = "=24.0.9" }
-wasmtime-cli-flags = { path = "crates/cli-flags", version = "=24.0.9" }
-wasmtime-cranelift = { path = "crates/cranelift", version = "=24.0.9" }
-wasmtime-winch = { path = "crates/winch", version = "=24.0.9" }
-wasmtime-environ = { path = "crates/environ", version = "=24.0.9" }
-wasmtime-explorer = { path = "crates/explorer", version = "=24.0.9" }
-wasmtime-fiber = { path = "crates/fiber", version = "=24.0.9" }
-wasmtime-types = { path = "crates/types", version = "24.0.9" }
-wasmtime-jit-debug = { path = "crates/jit-debug", version = "=24.0.9" }
-wasmtime-wast = { path = "crates/wast", version = "=24.0.9" }
-wasmtime-wasi = { path = "crates/wasi", version = "24.0.9", default-features = false }
-wasmtime-wasi-http = { path = "crates/wasi-http", version = "=24.0.9", default-features = false }
-wasmtime-wasi-nn = { path = "crates/wasi-nn", version = "24.0.9" }
-wasmtime-wasi-runtime-config = { path = "crates/wasi-runtime-config", version = "24.0.9" }
-wasmtime-wasi-keyvalue = { path = "crates/wasi-keyvalue", version = "24.0.9" }
-wasmtime-wasi-threads = { path = "crates/wasi-threads", version = "24.0.9" }
-wasmtime-component-util = { path = "crates/component-util", version = "=24.0.9" }
-wasmtime-component-macro = { path = "crates/component-macro", version = "=24.0.9" }
-wasmtime-asm-macros = { path = "crates/asm-macros", version = "=24.0.9" }
-wasmtime-versioned-export-macros = { path = "crates/versioned-export-macros", version = "=24.0.9" }
-wasmtime-slab = { path = "crates/slab", version = "=24.0.9" }
+wasmtime-wmemcheck = { path = "crates/wmemcheck", version = "=24.0.10" }
+wasmtime = { path = "crates/wasmtime", version = "24.0.10", default-features = false }
+wasmtime-c-api-macros = { path = "crates/c-api-macros", version = "=24.0.10" }
+wasmtime-cache = { path = "crates/cache", version = "=24.0.10" }
+wasmtime-cli-flags = { path = "crates/cli-flags", version = "=24.0.10" }
+wasmtime-cranelift = { path = "crates/cranelift", version = "=24.0.10" }
+wasmtime-winch = { path = "crates/winch", version = "=24.0.10" }
+wasmtime-environ = { path = "crates/environ", version = "=24.0.10" }
+wasmtime-explorer = { path = "crates/explorer", version = "=24.0.10" }
+wasmtime-fiber = { path = "crates/fiber", version = "=24.0.10" }
+wasmtime-types = { path = "crates/types", version = "24.0.10" }
+wasmtime-jit-debug = { path = "crates/jit-debug", version = "=24.0.10" }
+wasmtime-wast = { path = "crates/wast", version = "=24.0.10" }
+wasmtime-wasi = { path = "crates/wasi", version = "24.0.10", default-features = false }
+wasmtime-wasi-http = { path = "crates/wasi-http", version = "=24.0.10", default-features = false }
+wasmtime-wasi-nn = { path = "crates/wasi-nn", version = "24.0.10" }
+wasmtime-wasi-runtime-config = { path = "crates/wasi-runtime-config", version = "24.0.10" }
+wasmtime-wasi-keyvalue = { path = "crates/wasi-keyvalue", version = "24.0.10" }
+wasmtime-wasi-threads = { path = "crates/wasi-threads", version = "24.0.10" }
+wasmtime-component-util = { path = "crates/component-util", version = "=24.0.10" }
+wasmtime-component-macro = { path = "crates/component-macro", version = "=24.0.10" }
+wasmtime-asm-macros = { path = "crates/asm-macros", version = "=24.0.10" }
+wasmtime-versioned-export-macros = { path = "crates/versioned-export-macros", version = "=24.0.10" }
+wasmtime-slab = { path = "crates/slab", version = "=24.0.10" }
 component-test-util = { path = "crates/misc/component-test-util" }
 component-fuzz-util = { path = "crates/misc/component-fuzz-util" }
-wiggle = { path = "crates/wiggle", version = "=24.0.9", default-features = false }
-wiggle-macro = { path = "crates/wiggle/macro", version = "=24.0.9" }
-wiggle-generate = { path = "crates/wiggle/generate", version = "=24.0.9" }
-wasi-common = { path = "crates/wasi-common", version = "=24.0.9", default-features = false }
+wiggle = { path = "crates/wiggle", version = "=24.0.10", default-features = false }
+wiggle-macro = { path = "crates/wiggle/macro", version = "=24.0.10" }
+wiggle-generate = { path = "crates/wiggle/generate", version = "=24.0.10" }
+wasi-common = { path = "crates/wasi-common", version = "=24.0.10", default-features = false }
 wasmtime-fuzzing = { path = "crates/fuzzing" }
-wasmtime-jit-icache-coherence = { path = "crates/jit-icache-coherence", version = "=24.0.9" }
-wasmtime-wit-bindgen = { path = "crates/wit-bindgen", version = "=24.0.9" }
+wasmtime-jit-icache-coherence = { path = "crates/jit-icache-coherence", version = "=24.0.10" }
+wasmtime-wit-bindgen = { path = "crates/wit-bindgen", version = "=24.0.10" }
 test-programs-artifacts = { path = 'crates/test-programs/artifacts' }
 pulley-interpreter-fuzz = { path = 'pulley/fuzz' }
 
-cranelift-wasm = { path = "cranelift/wasm", version = "0.111.9" }
-cranelift-codegen = { path = "cranelift/codegen", version = "0.111.9", default-features = false, features = ["std", "unwind", "trace-log"] }
-cranelift-frontend = { path = "cranelift/frontend", version = "0.111.9" }
-cranelift-entity = { path = "cranelift/entity", version = "0.111.9" }
-cranelift-native = { path = "cranelift/native", version = "0.111.9" }
-cranelift-module = { path = "cranelift/module", version = "0.111.9" }
-cranelift-interpreter = { path = "cranelift/interpreter", version = "0.111.9" }
-cranelift-reader = { path = "cranelift/reader", version = "0.111.9" }
+cranelift-wasm = { path = "cranelift/wasm", version = "0.111.10" }
+cranelift-codegen = { path = "cranelift/codegen", version = "0.111.10", default-features = false, features = ["std", "unwind", "trace-log"] }
+cranelift-frontend = { path = "cranelift/frontend", version = "0.111.10" }
+cranelift-entity = { path = "cranelift/entity", version = "0.111.10" }
+cranelift-native = { path = "cranelift/native", version = "0.111.10" }
+cranelift-module = { path = "cranelift/module", version = "0.111.10" }
+cranelift-interpreter = { path = "cranelift/interpreter", version = "0.111.10" }
+cranelift-reader = { path = "cranelift/reader", version = "0.111.10" }
 cranelift-filetests = { path = "cranelift/filetests" }
-cranelift-object = { path = "cranelift/object", version = "0.111.9" }
-cranelift-jit = { path = "cranelift/jit", version = "0.111.9" }
+cranelift-object = { path = "cranelift/object", version = "0.111.10" }
+cranelift-jit = { path = "cranelift/jit", version = "0.111.10" }
 cranelift-fuzzgen = { path = "cranelift/fuzzgen" }
-cranelift-bforest = { path = "cranelift/bforest", version = "0.111.9" }
-cranelift-bitset = { path = "cranelift/bitset", version = "0.111.9" }
-cranelift-control = { path = "cranelift/control", version = "0.111.9" }
-cranelift = { path = "cranelift/umbrella", version = "0.111.9" }
+cranelift-bforest = { path = "cranelift/bforest", version = "0.111.10" }
+cranelift-bitset = { path = "cranelift/bitset", version = "0.111.10" }
+cranelift-control = { path = "cranelift/control", version = "0.111.10" }
+cranelift = { path = "cranelift/umbrella", version = "0.111.10" }
 
-winch-codegen = { path = "winch/codegen", version = "=0.22.9" }
+winch-codegen = { path = "winch/codegen", version = "=0.22.10" }
 
 wasi-preview1-component-adapter = { path = "crates/wasi-preview1-component-adapter" }
 byte-array-literals = { path = "crates/wasi-preview1-component-adapter/byte-array-literals" }

--- a/cranelift/bforest/Cargo.toml
+++ b/cranelift/bforest/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-bforest"
-version = "0.111.9"
+version = "0.111.10"
 description = "A forest of B+-trees"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-bforest"

--- a/cranelift/bitset/Cargo.toml
+++ b/cranelift/bitset/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-bitset"
-version = "0.111.9"
+version = "0.111.10"
 description = "Various bitset stuff for use inside Cranelift"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-bitset"

--- a/cranelift/codegen/Cargo.toml
+++ b/cranelift/codegen/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-codegen"
-version = "0.111.9"
+version = "0.111.10"
 description = "Low-level code generator library"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-codegen"
@@ -19,7 +19,7 @@ workspace = true
 anyhow = { workspace = true, optional = true, features = ['std'] }
 bumpalo = "3"
 capstone = { workspace = true, optional = true }
-cranelift-codegen-shared = { path = "./shared", version = "0.111.9" }
+cranelift-codegen-shared = { path = "./shared", version = "0.111.10" }
 cranelift-entity = { workspace = true }
 cranelift-bforest = { workspace = true }
 cranelift-bitset = { workspace = true }
@@ -47,8 +47,8 @@ similar = "2.1.0"
 env_logger = { workspace = true }
 
 [build-dependencies]
-cranelift-codegen-meta = { path = "meta", version = "0.111.9" }
-cranelift-isle = { path = "../isle/isle", version = "=0.111.9" }
+cranelift-codegen-meta = { path = "meta", version = "0.111.10" }
+cranelift-isle = { path = "../isle/isle", version = "=0.111.10" }
 
 [features]
 default = ["std", "unwind", "host-arch", "timing"]

--- a/cranelift/codegen/meta/Cargo.toml
+++ b/cranelift/codegen/meta/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cranelift-codegen-meta"
 authors = ["The Cranelift Project Developers"]
-version = "0.111.9"
+version = "0.111.10"
 description = "Metaprogram for cranelift-codegen code generator library"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"
@@ -15,4 +15,4 @@ workspace = true
 rustdoc-args = [ "--document-private-items" ]
 
 [dependencies]
-cranelift-codegen-shared = { path = "../shared", version = "0.111.9" }
+cranelift-codegen-shared = { path = "../shared", version = "0.111.10" }

--- a/cranelift/codegen/shared/Cargo.toml
+++ b/cranelift/codegen/shared/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-codegen-shared"
-version = "0.111.9"
+version = "0.111.10"
 description = "For code shared between cranelift-codegen-meta and cranelift-codegen"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/control/Cargo.toml
+++ b/cranelift/control/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-control"
-version = "0.111.9"
+version = "0.111.10"
 description = "White-box fuzz testing framework"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/entity/Cargo.toml
+++ b/cranelift/entity/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-entity"
-version = "0.111.9"
+version = "0.111.10"
 description = "Data structures using entity references as mapping keys"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-entity"

--- a/cranelift/frontend/Cargo.toml
+++ b/cranelift/frontend/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-frontend"
-version = "0.111.9"
+version = "0.111.10"
 description = "Cranelift IR builder helper"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-frontend"

--- a/cranelift/interpreter/Cargo.toml
+++ b/cranelift/interpreter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-interpreter"
-version = "0.111.9"
+version = "0.111.10"
 authors = ["The Cranelift Project Developers"]
 description = "Interpret Cranelift IR"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/isle/isle/Cargo.toml
+++ b/cranelift/isle/isle/Cargo.toml
@@ -6,7 +6,7 @@ license = "Apache-2.0 WITH LLVM-exception"
 name = "cranelift-isle"
 readme = "../README.md"
 repository = "https://github.com/bytecodealliance/wasmtime/tree/main/cranelift/isle"
-version = "0.111.9"
+version = "0.111.10"
 
 [lints]
 workspace = true

--- a/cranelift/jit/Cargo.toml
+++ b/cranelift/jit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-jit"
-version = "0.111.9"
+version = "0.111.10"
 authors = ["The Cranelift Project Developers"]
 description = "A JIT library backed by Cranelift"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/module/Cargo.toml
+++ b/cranelift/module/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-module"
-version = "0.111.9"
+version = "0.111.10"
 authors = ["The Cranelift Project Developers"]
 description = "Support for linking functions and data with Cranelift"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/native/Cargo.toml
+++ b/cranelift/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-native"
-version = "0.111.9"
+version = "0.111.10"
 authors = ["The Cranelift Project Developers"]
 description = "Support for targeting the host with Cranelift"
 documentation = "https://docs.rs/cranelift-native"

--- a/cranelift/object/Cargo.toml
+++ b/cranelift/object/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-object"
-version = "0.111.9"
+version = "0.111.10"
 authors = ["The Cranelift Project Developers"]
 description = "Emit Cranelift output to native object files with `object`"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/reader/Cargo.toml
+++ b/cranelift/reader/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-reader"
-version = "0.111.9"
+version = "0.111.10"
 description = "Cranelift textual IR reader"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-reader"

--- a/cranelift/serde/Cargo.toml
+++ b/cranelift/serde/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-serde"
-version = "0.111.9"
+version = "0.111.10"
 authors = ["The Cranelift Project Developers"]
 description = "Serializer/Deserializer for Cranelift IR"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/umbrella/Cargo.toml
+++ b/cranelift/umbrella/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift"
-version = "0.111.9"
+version = "0.111.10"
 description = "Umbrella for commonly-used cranelift crates"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift"

--- a/cranelift/wasm/Cargo.toml
+++ b/cranelift/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-wasm"
-version = "0.111.9"
+version = "0.111.10"
 authors = ["The Cranelift Project Developers"]
 description = "Translator from WebAssembly to Cranelift IR"
 documentation = "https://docs.rs/cranelift-wasm"

--- a/crates/c-api/include/wasmtime.h
+++ b/crates/c-api/include/wasmtime.h
@@ -206,7 +206,7 @@
 /**
  * \brief Wasmtime version string.
  */
-#define WASMTIME_VERSION "24.0.9"
+#define WASMTIME_VERSION "24.0.10"
 /**
  * \brief Wasmtime major version number.
  */
@@ -218,7 +218,7 @@
 /**
  * \brief Wasmtime patch version number.
  */
-#define WASMTIME_VERSION_PATCH 9
+#define WASMTIME_VERSION_PATCH 10
 
 #ifdef __cplusplus
 extern "C" {

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -41,6 +41,10 @@ audited_as = "0.111.7"
 version = "0.111.9"
 audited_as = "0.111.8"
 
+[[unpublished.cranelift]]
+version = "0.111.10"
+audited_as = "0.111.9"
+
 [[unpublished.cranelift-bforest]]
 version = "0.111.0"
 audited_as = "0.110.1"
@@ -80,6 +84,10 @@ audited_as = "0.111.7"
 [[unpublished.cranelift-bforest]]
 version = "0.111.9"
 audited_as = "0.111.8"
+
+[[unpublished.cranelift-bforest]]
+version = "0.111.10"
+audited_as = "0.111.9"
 
 [[unpublished.cranelift-bitset]]
 version = "0.111.0"
@@ -121,6 +129,10 @@ audited_as = "0.111.7"
 version = "0.111.9"
 audited_as = "0.111.8"
 
+[[unpublished.cranelift-bitset]]
+version = "0.111.10"
+audited_as = "0.111.9"
+
 [[unpublished.cranelift-codegen]]
 version = "0.111.0"
 audited_as = "0.110.1"
@@ -160,6 +172,10 @@ audited_as = "0.111.7"
 [[unpublished.cranelift-codegen]]
 version = "0.111.9"
 audited_as = "0.111.8"
+
+[[unpublished.cranelift-codegen]]
+version = "0.111.10"
+audited_as = "0.111.9"
 
 [[unpublished.cranelift-codegen-meta]]
 version = "0.111.0"
@@ -201,6 +217,10 @@ audited_as = "0.111.7"
 version = "0.111.9"
 audited_as = "0.111.8"
 
+[[unpublished.cranelift-codegen-meta]]
+version = "0.111.10"
+audited_as = "0.111.9"
+
 [[unpublished.cranelift-codegen-shared]]
 version = "0.111.0"
 audited_as = "0.110.1"
@@ -240,6 +260,10 @@ audited_as = "0.111.7"
 [[unpublished.cranelift-codegen-shared]]
 version = "0.111.9"
 audited_as = "0.111.8"
+
+[[unpublished.cranelift-codegen-shared]]
+version = "0.111.10"
+audited_as = "0.111.9"
 
 [[unpublished.cranelift-control]]
 version = "0.111.0"
@@ -281,6 +305,10 @@ audited_as = "0.111.7"
 version = "0.111.9"
 audited_as = "0.111.8"
 
+[[unpublished.cranelift-control]]
+version = "0.111.10"
+audited_as = "0.111.9"
+
 [[unpublished.cranelift-entity]]
 version = "0.111.0"
 audited_as = "0.110.1"
@@ -320,6 +348,10 @@ audited_as = "0.111.7"
 [[unpublished.cranelift-entity]]
 version = "0.111.9"
 audited_as = "0.111.8"
+
+[[unpublished.cranelift-entity]]
+version = "0.111.10"
+audited_as = "0.111.9"
 
 [[unpublished.cranelift-frontend]]
 version = "0.111.0"
@@ -361,6 +393,10 @@ audited_as = "0.111.7"
 version = "0.111.9"
 audited_as = "0.111.8"
 
+[[unpublished.cranelift-frontend]]
+version = "0.111.10"
+audited_as = "0.111.9"
+
 [[unpublished.cranelift-interpreter]]
 version = "0.111.0"
 audited_as = "0.110.1"
@@ -401,6 +437,10 @@ audited_as = "0.111.7"
 version = "0.111.9"
 audited_as = "0.111.8"
 
+[[unpublished.cranelift-interpreter]]
+version = "0.111.10"
+audited_as = "0.111.9"
+
 [[unpublished.cranelift-isle]]
 version = "0.111.0"
 audited_as = "0.110.1"
@@ -441,6 +481,10 @@ audited_as = "0.111.7"
 version = "0.111.9"
 audited_as = "0.111.8"
 
+[[unpublished.cranelift-isle]]
+version = "0.111.10"
+audited_as = "0.111.9"
+
 [[unpublished.cranelift-jit]]
 version = "0.111.0"
 audited_as = "0.110.1"
@@ -481,6 +525,10 @@ audited_as = "0.111.7"
 version = "0.111.9"
 audited_as = "0.111.8"
 
+[[unpublished.cranelift-jit]]
+version = "0.111.10"
+audited_as = "0.111.9"
+
 [[unpublished.cranelift-module]]
 version = "0.111.0"
 audited_as = "0.110.1"
@@ -521,6 +569,10 @@ audited_as = "0.111.7"
 version = "0.111.9"
 audited_as = "0.111.8"
 
+[[unpublished.cranelift-module]]
+version = "0.111.10"
+audited_as = "0.111.9"
+
 [[unpublished.cranelift-native]]
 version = "0.111.0"
 audited_as = "0.110.1"
@@ -561,6 +613,10 @@ audited_as = "0.111.7"
 version = "0.111.9"
 audited_as = "0.111.8"
 
+[[unpublished.cranelift-native]]
+version = "0.111.10"
+audited_as = "0.111.9"
+
 [[unpublished.cranelift-object]]
 version = "0.111.0"
 audited_as = "0.110.1"
@@ -601,6 +657,10 @@ audited_as = "0.111.7"
 version = "0.111.9"
 audited_as = "0.111.8"
 
+[[unpublished.cranelift-object]]
+version = "0.111.10"
+audited_as = "0.111.9"
+
 [[unpublished.cranelift-reader]]
 version = "0.111.0"
 audited_as = "0.110.1"
@@ -641,6 +701,10 @@ audited_as = "0.111.7"
 version = "0.111.9"
 audited_as = "0.111.8"
 
+[[unpublished.cranelift-reader]]
+version = "0.111.10"
+audited_as = "0.111.9"
+
 [[unpublished.cranelift-serde]]
 version = "0.111.0"
 audited_as = "0.110.1"
@@ -681,6 +745,10 @@ audited_as = "0.111.7"
 version = "0.111.9"
 audited_as = "0.111.8"
 
+[[unpublished.cranelift-serde]]
+version = "0.111.10"
+audited_as = "0.111.9"
+
 [[unpublished.cranelift-wasm]]
 version = "0.111.0"
 audited_as = "0.110.1"
@@ -721,6 +789,10 @@ audited_as = "0.111.7"
 version = "0.111.9"
 audited_as = "0.111.8"
 
+[[unpublished.cranelift-wasm]]
+version = "0.111.10"
+audited_as = "0.111.9"
+
 [[unpublished.wasi-common]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -760,6 +832,10 @@ audited_as = "24.0.7"
 [[unpublished.wasi-common]]
 version = "24.0.9"
 audited_as = "24.0.8"
+
+[[unpublished.wasi-common]]
+version = "24.0.10"
+audited_as = "24.0.9"
 
 [[unpublished.wasmtime]]
 version = "24.0.0"
@@ -801,6 +877,10 @@ audited_as = "24.0.7"
 version = "24.0.9"
 audited_as = "24.0.8"
 
+[[unpublished.wasmtime]]
+version = "24.0.10"
+audited_as = "24.0.9"
+
 [[unpublished.wasmtime-asm-macros]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -840,6 +920,10 @@ audited_as = "24.0.7"
 [[unpublished.wasmtime-asm-macros]]
 version = "24.0.9"
 audited_as = "24.0.8"
+
+[[unpublished.wasmtime-asm-macros]]
+version = "24.0.10"
+audited_as = "24.0.9"
 
 [[unpublished.wasmtime-cache]]
 version = "24.0.0"
@@ -881,6 +965,10 @@ audited_as = "24.0.7"
 version = "24.0.9"
 audited_as = "24.0.8"
 
+[[unpublished.wasmtime-cache]]
+version = "24.0.10"
+audited_as = "24.0.9"
+
 [[unpublished.wasmtime-cli]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -920,6 +1008,10 @@ audited_as = "24.0.7"
 [[unpublished.wasmtime-cli]]
 version = "24.0.9"
 audited_as = "24.0.8"
+
+[[unpublished.wasmtime-cli]]
+version = "24.0.10"
+audited_as = "24.0.9"
 
 [[unpublished.wasmtime-cli-flags]]
 version = "24.0.0"
@@ -961,6 +1053,10 @@ audited_as = "24.0.7"
 version = "24.0.9"
 audited_as = "24.0.8"
 
+[[unpublished.wasmtime-cli-flags]]
+version = "24.0.10"
+audited_as = "24.0.9"
+
 [[unpublished.wasmtime-component-macro]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -1000,6 +1096,10 @@ audited_as = "24.0.7"
 [[unpublished.wasmtime-component-macro]]
 version = "24.0.9"
 audited_as = "24.0.8"
+
+[[unpublished.wasmtime-component-macro]]
+version = "24.0.10"
+audited_as = "24.0.9"
 
 [[unpublished.wasmtime-component-util]]
 version = "24.0.0"
@@ -1041,6 +1141,10 @@ audited_as = "24.0.7"
 version = "24.0.9"
 audited_as = "24.0.8"
 
+[[unpublished.wasmtime-component-util]]
+version = "24.0.10"
+audited_as = "24.0.9"
+
 [[unpublished.wasmtime-cranelift]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -1080,6 +1184,10 @@ audited_as = "24.0.7"
 [[unpublished.wasmtime-cranelift]]
 version = "24.0.9"
 audited_as = "24.0.8"
+
+[[unpublished.wasmtime-cranelift]]
+version = "24.0.10"
+audited_as = "24.0.9"
 
 [[unpublished.wasmtime-environ]]
 version = "24.0.0"
@@ -1121,6 +1229,10 @@ audited_as = "24.0.7"
 version = "24.0.9"
 audited_as = "24.0.8"
 
+[[unpublished.wasmtime-environ]]
+version = "24.0.10"
+audited_as = "24.0.9"
+
 [[unpublished.wasmtime-explorer]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -1161,6 +1273,10 @@ audited_as = "24.0.7"
 version = "24.0.9"
 audited_as = "24.0.8"
 
+[[unpublished.wasmtime-explorer]]
+version = "24.0.10"
+audited_as = "24.0.9"
+
 [[unpublished.wasmtime-fiber]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -1201,6 +1317,10 @@ audited_as = "24.0.7"
 version = "24.0.9"
 audited_as = "24.0.8"
 
+[[unpublished.wasmtime-fiber]]
+version = "24.0.10"
+audited_as = "24.0.9"
+
 [[unpublished.wasmtime-jit-debug]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -1241,6 +1361,10 @@ audited_as = "24.0.7"
 version = "24.0.9"
 audited_as = "24.0.8"
 
+[[unpublished.wasmtime-jit-debug]]
+version = "24.0.10"
+audited_as = "24.0.9"
+
 [[unpublished.wasmtime-jit-icache-coherence]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -1281,6 +1405,10 @@ audited_as = "24.0.7"
 version = "24.0.9"
 audited_as = "24.0.8"
 
+[[unpublished.wasmtime-jit-icache-coherence]]
+version = "24.0.10"
+audited_as = "24.0.9"
+
 [[unpublished.wasmtime-slab]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -1321,6 +1449,10 @@ audited_as = "24.0.7"
 version = "24.0.9"
 audited_as = "24.0.8"
 
+[[unpublished.wasmtime-slab]]
+version = "24.0.10"
+audited_as = "24.0.9"
+
 [[unpublished.wasmtime-types]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -1361,6 +1493,10 @@ audited_as = "24.0.7"
 version = "24.0.9"
 audited_as = "24.0.8"
 
+[[unpublished.wasmtime-types]]
+version = "24.0.10"
+audited_as = "24.0.9"
+
 [[unpublished.wasmtime-wasi]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -1401,6 +1537,10 @@ audited_as = "24.0.7"
 version = "24.0.9"
 audited_as = "24.0.8"
 
+[[unpublished.wasmtime-wasi]]
+version = "24.0.10"
+audited_as = "24.0.9"
+
 [[unpublished.wasmtime-wasi-http]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -1440,6 +1580,10 @@ audited_as = "24.0.7"
 [[unpublished.wasmtime-wasi-http]]
 version = "24.0.9"
 audited_as = "24.0.8"
+
+[[unpublished.wasmtime-wasi-http]]
+version = "24.0.10"
+audited_as = "24.0.9"
 
 [[unpublished.wasmtime-wasi-keyvalue]]
 version = "24.0.1"
@@ -1477,6 +1621,10 @@ audited_as = "24.0.7"
 version = "24.0.9"
 audited_as = "24.0.8"
 
+[[unpublished.wasmtime-wasi-keyvalue]]
+version = "24.0.10"
+audited_as = "24.0.9"
+
 [[unpublished.wasmtime-wasi-nn]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -1517,6 +1665,10 @@ audited_as = "24.0.7"
 version = "24.0.9"
 audited_as = "24.0.8"
 
+[[unpublished.wasmtime-wasi-nn]]
+version = "24.0.10"
+audited_as = "24.0.9"
+
 [[unpublished.wasmtime-wasi-runtime-config]]
 version = "24.0.1"
 audited_as = "24.0.0"
@@ -1552,6 +1704,10 @@ audited_as = "24.0.7"
 [[unpublished.wasmtime-wasi-runtime-config]]
 version = "24.0.9"
 audited_as = "24.0.8"
+
+[[unpublished.wasmtime-wasi-runtime-config]]
+version = "24.0.10"
+audited_as = "24.0.9"
 
 [[unpublished.wasmtime-wasi-threads]]
 version = "24.0.0"
@@ -1593,6 +1749,10 @@ audited_as = "24.0.7"
 version = "24.0.9"
 audited_as = "24.0.8"
 
+[[unpublished.wasmtime-wasi-threads]]
+version = "24.0.10"
+audited_as = "24.0.9"
+
 [[unpublished.wasmtime-wast]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -1633,6 +1793,10 @@ audited_as = "24.0.7"
 version = "24.0.9"
 audited_as = "24.0.8"
 
+[[unpublished.wasmtime-wast]]
+version = "24.0.10"
+audited_as = "24.0.9"
+
 [[unpublished.wasmtime-winch]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -1673,6 +1837,10 @@ audited_as = "24.0.7"
 version = "24.0.9"
 audited_as = "24.0.8"
 
+[[unpublished.wasmtime-winch]]
+version = "24.0.10"
+audited_as = "24.0.9"
+
 [[unpublished.wasmtime-wit-bindgen]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -1713,6 +1881,10 @@ audited_as = "24.0.7"
 version = "24.0.9"
 audited_as = "24.0.8"
 
+[[unpublished.wasmtime-wit-bindgen]]
+version = "24.0.10"
+audited_as = "24.0.9"
+
 [[unpublished.wasmtime-wmemcheck]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -1753,6 +1925,10 @@ audited_as = "24.0.7"
 version = "24.0.9"
 audited_as = "24.0.8"
 
+[[unpublished.wasmtime-wmemcheck]]
+version = "24.0.10"
+audited_as = "24.0.9"
+
 [[unpublished.wiggle]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -1793,6 +1969,10 @@ audited_as = "24.0.7"
 version = "24.0.9"
 audited_as = "24.0.8"
 
+[[unpublished.wiggle]]
+version = "24.0.10"
+audited_as = "24.0.9"
+
 [[unpublished.wiggle-generate]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -1833,6 +2013,10 @@ audited_as = "24.0.7"
 version = "24.0.9"
 audited_as = "24.0.8"
 
+[[unpublished.wiggle-generate]]
+version = "24.0.10"
+audited_as = "24.0.9"
+
 [[unpublished.wiggle-macro]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -1872,6 +2056,10 @@ audited_as = "24.0.7"
 [[unpublished.wiggle-macro]]
 version = "24.0.9"
 audited_as = "24.0.8"
+
+[[unpublished.wiggle-macro]]
+version = "24.0.10"
+audited_as = "24.0.9"
 
 [[unpublished.wiggle-test]]
 version = "0.0.0"
@@ -1916,6 +2104,10 @@ audited_as = "0.22.7"
 [[unpublished.winch-codegen]]
 version = "0.22.9"
 audited_as = "0.22.8"
+
+[[unpublished.winch-codegen]]
+version = "0.22.10"
+audited_as = "0.22.9"
 
 [[publisher.aho-corasick]]
 version = "1.0.2"

--- a/winch/codegen/Cargo.toml
+++ b/winch/codegen/Cargo.toml
@@ -4,7 +4,7 @@ name = "winch-codegen"
 description = "Winch code generation library"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"
-version = "0.22.9"
+version = "0.22.10"
 edition.workspace = true
 
 [lints]


### PR DESCRIPTION
This is an [automated pull request][process] from CI to create a patch release for Wasmtime 24.0.10, requested by @alexcrichton.

It's recommended that maintainers double-check that [RELEASES.md] is up-to-date and that there are no known issues before merging this PR. When this PR is merged a release tag will automatically be created, crates will be published, and CI artifacts will be produced.

[RELEASES.md]: https://github.com/bytecodealliance/wasmtime/blob/release-24.0.10/RELEASES.md
[process]: https://docs.wasmtime.dev/contributing-release-process.html
