### PR TITLE
Fix a multiplication overflow on 32-bit platforms

### DIFF
--- a/crates/wasmtime/src/runtime/component/concurrent/futures_and_streams.rs
+++ b/crates/wasmtime/src/runtime/component/concurrent/futures_and_streams.rs
@@ -3502,7 +3502,7 @@ impl Instance {
         if count > 0 && size > 0 {
             self.options_memory(store, options)
                 .get(address..)
-                .and_then(|b| b.get(..(size * count)))
+                .and_then(|b| b.get(..size.checked_mul(count)?))
                 .map(drop)
                 .ok_or_else(|| crate::format_err!("read pointer out of bounds of memory"))
         } else {

--- a/tests/misc_testsuite/component-model/async/stream-big-read-and-writes.wast
+++ b/tests/misc_testsuite/component-model/async/stream-big-read-and-writes.wast
@@ -41,3 +41,47 @@
 )
 (assert_return (invoke "run" (u32.const 0x0fffffff)) (u32.const 42))
 (assert_trap (invoke "run" (u32.const 0x10000000)) "stream read/write count too large")
+
+;; Perform a write that overflows the 32-bit index space and ensure that a trap
+;; of some kind is generated.
+(component
+  (type $elem (tuple u64 u64 u8)) ;; 24-byte structure
+  (type $s (stream $elem))
+
+  (core module $libc (memory (export "memory") 1))
+  (core instance $libc (instantiate $libc))
+
+  (core module $m
+    (import "libc" "memory" (memory 1))
+    (import "" "stream.new" (func $stream.new (result i64)))
+    (import "" "stream.write" (func $stream.write (param i32 i32 i32) (result i32)))
+
+    (func (export "run") (result i32)
+      (local $s i64)
+      (local $w i32)
+      (local.set $s (call $stream.new))
+      (local.set $w (i32.wrap_i64 (i64.shr_u (local.get $s) (i64.const 32))))
+      (call $stream.write
+        (local.get $w)
+        (i32.const 0)
+        (i32.const 200000000)) ;; count: < 2^28, but 24*count > 2^32
+      unreachable)
+
+    (func (export "cb") (param i32 i32 i32) (result i32) unreachable)
+  )
+
+  (core func $stream.new (canon stream.new $s))
+  (core func $stream.write (canon stream.write $s async (memory $libc "memory")))
+
+  (core instance $m (instantiate $m
+    (with "libc" (instance $libc))
+    (with "" (instance
+      (export "stream.new" (func $stream.new))
+      (export "stream.write" (func $stream.write))
+    ))
+  ))
+
+  (func (export "run") async
+    (canon lift (core func $m "run") async (callback (func $m "cb"))))
+)
+(assert_trap (invoke "run") "out of bounds")


### PR DESCRIPTION
This commit updates the bounds checks for async stream reads/writes to do a checked multiplication of the size-by-count instead of unchecked multiplication. This couldn't ever overflow on a 64-bit platform, but it can overflow on 32-bit platforms. The added test here fails on 32-bit platforms before this commit, for example.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
