### PR TITLE
Tag all `VMStoreContext` field loads/stores with alias regions

### DIFF
--- a/crates/cranelift/src/alias_region.rs
+++ b/crates/cranelift/src/alias_region.rs
@@ -853,4 +853,322 @@ where
             new_version,
         )
     }
+
+    /// Get the alias region for the `VMStoreContext` field at `offset`, for use
+    /// in an `ir::GlobalValue`'s memory flags.
+    ///
+    /// XXX: This is ONLY for use with `ir::GlobalValue`s; all other uses should
+    /// instead use a helper method that actually emits the full load/store
+    /// instruction.
+    pub fn vmstore_context_region_for_use_in_ir_global(
+        &mut self,
+        func: &mut ir::Function,
+        offset: u32,
+    ) -> ir::AliasRegion {
+        self.vmstore_context_region(func, offset)
+    }
+
+    /// Load the `VMStoreContext::fuel_consumed` field.
+    pub fn vmstore_context_fuel_consumed(
+        &mut self,
+        cursor: &mut FuncCursor<'_>,
+        vmstore_ctx: ir::Value,
+    ) -> ir::Value {
+        self.vmstore_context_load(
+            cursor,
+            ir::types::I64,
+            ir::MemFlagsData::trusted(),
+            vmstore_ctx,
+            self.offsets
+                .get_ptr_size()
+                .vmstore_context_fuel_consumed()
+                .into(),
+        )
+    }
+
+    /// Store the `VMStoreContext::fuel_consumed` field.
+    pub fn store_vmstore_context_fuel_consumed(
+        &mut self,
+        cursor: &mut FuncCursor<'_>,
+        vmstore_ctx: ir::Value,
+        fuel_consumed: ir::Value,
+    ) {
+        self.vmstore_context_store(
+            cursor,
+            ir::MemFlagsData::trusted(),
+            vmstore_ctx,
+            self.offsets
+                .get_ptr_size()
+                .vmstore_context_fuel_consumed()
+                .into(),
+            fuel_consumed,
+        )
+    }
+
+    /// Load the `VMStoreContext::epoch_deadline` field.
+    pub fn vmstore_context_epoch_deadline(
+        &mut self,
+        cursor: &mut FuncCursor<'_>,
+        vmstore_ctx: ir::Value,
+    ) -> ir::Value {
+        self.vmstore_context_load(
+            cursor,
+            ir::types::I64,
+            ir::MemFlagsData::trusted(),
+            vmstore_ctx,
+            self.offsets
+                .get_ptr_size()
+                .vmstore_context_epoch_deadline()
+                .into(),
+        )
+    }
+
+    /// Load the `VMStoreContext::stack_limit` field.
+    pub fn vmstore_context_stack_limit(
+        &mut self,
+        cursor: &mut FuncCursor<'_>,
+        vmstore_ctx: ir::Value,
+    ) -> ir::Value {
+        self.vmstore_context_load(
+            cursor,
+            self.pointer_type,
+            ir::MemFlagsData::trusted(),
+            vmstore_ctx,
+            self.offsets
+                .get_ptr_size()
+                .vmstore_context_stack_limit()
+                .into(),
+        )
+    }
+
+    /// Store the `VMStoreContext::stack_limit` field.
+    pub fn store_vmstore_context_stack_limit(
+        &mut self,
+        cursor: &mut FuncCursor<'_>,
+        vmstore_ctx: ir::Value,
+        stack_limit: ir::Value,
+    ) {
+        self.vmstore_context_store(
+            cursor,
+            ir::MemFlagsData::trusted(),
+            vmstore_ctx,
+            self.offsets
+                .get_ptr_size()
+                .vmstore_context_stack_limit()
+                .into(),
+            stack_limit,
+        )
+    }
+
+    /// Load the GC heap base pointer (`VMStoreContext::gc_heap.base`).
+    ///
+    /// The caller supplies the base flags because whether the base pointer is
+    /// `readonly`/`can_move` depends on the GC heap's tunables.
+    pub fn vmstore_context_gc_heap_base(
+        &mut self,
+        cursor: &mut FuncCursor<'_>,
+        base_flags: ir::MemFlagsData,
+        vmstore_ctx: ir::Value,
+    ) -> ir::Value {
+        self.vmstore_context_load(
+            cursor,
+            self.pointer_type,
+            base_flags,
+            vmstore_ctx,
+            self.offsets
+                .get_ptr_size()
+                .vmstore_context_gc_heap_base()
+                .into(),
+        )
+    }
+
+    /// Load the GC heap bound (`VMStoreContext::gc_heap.current_length`).
+    pub fn vmstore_context_gc_heap_current_length(
+        &mut self,
+        cursor: &mut FuncCursor<'_>,
+        vmstore_ctx: ir::Value,
+    ) -> ir::Value {
+        self.vmstore_context_load(
+            cursor,
+            self.pointer_type,
+            ir::MemFlagsData::trusted(),
+            vmstore_ctx,
+            self.offsets
+                .get_ptr_size()
+                .vmstore_context_gc_heap_current_length()
+                .into(),
+        )
+    }
+
+    /// Load the `VMStoreContext::last_wasm_entry_fp` field.
+    pub fn vmstore_context_last_wasm_entry_fp(
+        &mut self,
+        cursor: &mut FuncCursor<'_>,
+        vmstore_ctx: ir::Value,
+    ) -> ir::Value {
+        self.vmstore_context_load(
+            cursor,
+            self.pointer_type,
+            ir::MemFlagsData::trusted(),
+            vmstore_ctx,
+            self.offsets
+                .get_ptr_size()
+                .vmstore_context_last_wasm_entry_fp()
+                .into(),
+        )
+    }
+
+    /// Store the `VMStoreContext::last_wasm_entry_fp` field.
+    pub fn store_vmstore_context_last_wasm_entry_fp(
+        &mut self,
+        cursor: &mut FuncCursor<'_>,
+        vmstore_ctx: ir::Value,
+        fp: ir::Value,
+    ) {
+        self.vmstore_context_store(
+            cursor,
+            ir::MemFlagsData::trusted(),
+            vmstore_ctx,
+            self.offsets
+                .get_ptr_size()
+                .vmstore_context_last_wasm_entry_fp()
+                .into(),
+            fp,
+        )
+    }
+
+    /// Store the `VMStoreContext::last_wasm_entry_sp` field.
+    pub fn store_vmstore_context_last_wasm_entry_sp(
+        &mut self,
+        cursor: &mut FuncCursor<'_>,
+        vmstore_ctx: ir::Value,
+        sp: ir::Value,
+    ) {
+        self.vmstore_context_store(
+            cursor,
+            ir::MemFlagsData::trusted(),
+            vmstore_ctx,
+            self.offsets
+                .get_ptr_size()
+                .vmstore_context_last_wasm_entry_sp()
+                .into(),
+            sp,
+        )
+    }
+
+    /// Store the `VMStoreContext::last_wasm_entry_trap_handler` field.
+    pub fn store_vmstore_context_last_wasm_entry_trap_handler(
+        &mut self,
+        cursor: &mut FuncCursor<'_>,
+        vmstore_ctx: ir::Value,
+        trap_handler: ir::Value,
+    ) {
+        self.vmstore_context_store(
+            cursor,
+            ir::MemFlagsData::trusted(),
+            vmstore_ctx,
+            self.offsets
+                .get_ptr_size()
+                .vmstore_context_last_wasm_entry_trap_handler()
+                .into(),
+            trap_handler,
+        )
+    }
+
+    /// Store the `VMStoreContext::last_wasm_exit_trampoline_fp` field.
+    pub fn store_vmstore_context_last_wasm_exit_trampoline_fp(
+        &mut self,
+        cursor: &mut FuncCursor<'_>,
+        vmstore_ctx: ir::Value,
+        fp: ir::Value,
+    ) {
+        self.vmstore_context_store(
+            cursor,
+            ir::MemFlagsData::trusted(),
+            vmstore_ctx,
+            self.offsets
+                .get_ptr_size()
+                .vmstore_context_last_wasm_exit_trampoline_fp()
+                .into(),
+            fp,
+        )
+    }
+
+    /// Store the `VMStoreContext::last_wasm_exit_pc` field.
+    pub fn store_vmstore_context_last_wasm_exit_pc(
+        &mut self,
+        cursor: &mut FuncCursor<'_>,
+        vmstore_ctx: ir::Value,
+        pc: ir::Value,
+    ) {
+        self.vmstore_context_store(
+            cursor,
+            ir::MemFlagsData::trusted(),
+            vmstore_ctx,
+            self.offsets
+                .get_ptr_size()
+                .vmstore_context_last_wasm_exit_pc()
+                .into(),
+            pc,
+        )
+    }
+
+    /// Get the alias region for the `VMStoreContext::stack_chain` field.
+    ///
+    /// The `VMStackChain` is two pointers wide and is emitted by the stack
+    /// switching `VMStackChain` load/store helpers, which take a region
+    /// argument; this provides that region.
+    pub fn vmstore_context_stack_chain_region(
+        &mut self,
+        func: &mut ir::Function,
+    ) -> ir::AliasRegion {
+        let offset = self.offsets.get_ptr_size().vmstore_context_stack_chain();
+        self.vmstore_context_region(func, offset.into())
+    }
+
+    /// Load a `VMStoreContext` component-context slot.
+    ///
+    /// The slot is indexed by a compile-time constant, so the alias region is
+    /// keyed on the precise per-slot offset.
+    pub fn vmstore_context_component_context_slot(
+        &mut self,
+        cursor: &mut FuncCursor<'_>,
+        ty: ir::Type,
+        vmstore_ctx: ir::Value,
+        slot: u8,
+    ) -> ir::Value {
+        self.vmstore_context_load(
+            cursor,
+            ty,
+            ir::MemFlagsData::trusted(),
+            vmstore_ctx,
+            self.offsets
+                .get_ptr_size()
+                .vmstore_context_component_context_slot(slot)
+                .into(),
+        )
+    }
+
+    /// Store a `VMStoreContext` component-context slot.
+    ///
+    /// The slot is indexed by a compile-time constant, so the alias region is
+    /// keyed on the precise per-slot offset.
+    pub fn store_vmstore_context_component_context_slot(
+        &mut self,
+        cursor: &mut FuncCursor<'_>,
+        vmstore_ctx: ir::Value,
+        slot: u8,
+        val: ir::Value,
+    ) {
+        self.vmstore_context_store(
+            cursor,
+            ir::MemFlagsData::trusted(),
+            vmstore_ctx,
+            self.offsets
+                .get_ptr_size()
+                .vmstore_context_component_context_slot(slot)
+                .into(),
+            val,
+        )
+    }
 }

--- a/crates/cranelift/src/compiler.rs
+++ b/crates/cranelift/src/compiler.rs
@@ -230,10 +230,14 @@ impl Compiler {
             caller_vmctx,
             wasmtime_environ::VMCONTEXT_MAGIC,
         );
-        let ptr = isa.pointer_bytes();
         let vm_store_context =
             alias_regions.vmctx_store_context(&mut builder.cursor(), caller_vmctx);
-        save_last_wasm_exit_fp_and_pc(&mut builder, pointer_type, &ptr, vm_store_context);
+        save_last_wasm_exit_fp_and_pc(
+            &mut builder,
+            pointer_type,
+            &mut alias_regions,
+            vm_store_context,
+        );
 
         // Spill all wasm arguments to the stack in `ValRaw` slots.
         let (args_base, args_len) =
@@ -333,7 +337,12 @@ impl Compiler {
             wasmtime_environ::VMCONTEXT_MAGIC,
         );
         let vm_store_context = alias_regions.vmctx_store_context(&mut builder.cursor(), vmctx);
-        save_last_wasm_exit_fp_and_pc(&mut builder, pointer_type, &ptr_size, vm_store_context);
+        save_last_wasm_exit_fp_and_pc(
+            &mut builder,
+            pointer_type,
+            &mut alias_regions,
+            vm_store_context,
+        );
 
         // Now it's time to delegate to the actual builtin. Forward all our own
         // arguments to the libcall itself.
@@ -558,11 +567,17 @@ impl wasmtime_environ::Compiler for Compiler {
                 flags,
             });
 
+            let stack_limit_region = func_env
+                .alias_regions
+                .vmstore_context_region_for_use_in_ir_global(
+                    &mut context.func,
+                    func_env.offsets.ptr.vmstore_context_stack_limit().into(),
+                );
             let flags = context
                 .func
                 .dfg
                 .mem_flags
-                .insert(MemFlagsData::trusted())
+                .insert(MemFlagsData::trusted().with_alias_region(Some(stack_limit_region)))
                 .unwrap();
 
             let stack_limit = context.func.create_global_value(ir::GlobalValueData::Load {
@@ -1481,7 +1496,7 @@ impl Compiler {
         save_last_wasm_entry_context(
             &mut builder,
             pointer_type,
-            &self.isa.pointer_bytes(),
+            &mut alias_regions,
             vm_store_ctx,
             try_call_block,
         );
@@ -1805,27 +1820,27 @@ fn clif_to_env_breakpoints(
     Ok(())
 }
 
-fn save_last_wasm_entry_context(
+fn save_last_wasm_entry_context<O>(
     builder: &mut FunctionBuilder,
     pointer_type: ir::Type,
-    ptr_size: &dyn PtrSize,
+    alias_regions: &mut AliasRegions<O>,
     vm_store_context: ir::Value,
     block: ir::Block,
-) {
+) where
+    O: GetPtrSize,
+{
     // Save the current fp/sp of the entry trampoline into the `VMStoreContext`.
     let fp = builder.ins().get_frame_pointer(pointer_type);
-    builder.ins().store(
-        MemFlagsData::trusted(),
-        fp,
+    alias_regions.store_vmstore_context_last_wasm_entry_fp(
+        &mut builder.cursor(),
         vm_store_context,
-        ptr_size.vmstore_context_last_wasm_entry_fp(),
+        fp,
     );
     let sp = builder.ins().get_stack_pointer(pointer_type);
-    builder.ins().store(
-        MemFlagsData::trusted(),
-        sp,
+    alias_regions.store_vmstore_context_last_wasm_entry_sp(
+        &mut builder.cursor(),
         vm_store_context,
-        ptr_size.vmstore_context_last_wasm_entry_sp(),
+        sp,
     );
 
     // Also save the address of this function's exception handler. This is used
@@ -1833,39 +1848,34 @@ fn save_last_wasm_entry_context(
     let trap_handler = builder
         .ins()
         .get_exception_handler_address(pointer_type, block, 0);
-    builder.ins().store(
-        MemFlagsData::trusted(),
-        trap_handler,
+    alias_regions.store_vmstore_context_last_wasm_entry_trap_handler(
+        &mut builder.cursor(),
         vm_store_context,
-        ptr_size.vmstore_context_last_wasm_entry_trap_handler(),
+        trap_handler,
     );
 }
 
-fn save_last_wasm_exit_fp_and_pc(
+fn save_last_wasm_exit_fp_and_pc<O>(
     builder: &mut FunctionBuilder,
     pointer_type: ir::Type,
-    ptr: &impl PtrSize,
+    alias_regions: &mut AliasRegions<O>,
     limits: Value,
-) {
+) where
+    O: GetPtrSize,
+{
     // Save the trampoline FP to the limits. Exception unwind needs
     // this so that it can know the SP (bottom of frame) for the very
     // last Wasm frame.
     let trampoline_fp = builder.ins().get_frame_pointer(pointer_type);
-    builder.ins().store(
-        MemFlagsData::trusted(),
-        trampoline_fp,
+    alias_regions.store_vmstore_context_last_wasm_exit_trampoline_fp(
+        &mut builder.cursor(),
         limits,
-        ptr.vmstore_context_last_wasm_exit_trampoline_fp(),
+        trampoline_fp,
     );
 
     // Finally save the Wasm return address to the limits.
     let wasm_pc = builder.ins().get_return_address(pointer_type);
-    builder.ins().store(
-        MemFlagsData::trusted(),
-        wasm_pc,
-        limits,
-        ptr.vmstore_context_last_wasm_exit_pc(),
-    );
+    alias_regions.store_vmstore_context_last_wasm_exit_pc(&mut builder.cursor(), limits, wasm_pc);
 }
 
 fn key_to_name(key: FuncKey) -> ir::UserFuncName {

--- a/crates/cranelift/src/compiler/component.rs
+++ b/crates/cranelift/src/compiler/component.rs
@@ -1742,7 +1742,7 @@ impl ComponentCompiler for Compiler {
         super::save_last_wasm_exit_fp_and_pc(
             &mut c.builder,
             pointer_type,
-            &c.offsets.ptr,
+            &mut c.alias_regions,
             vm_store_context,
         );
 
@@ -1823,12 +1823,10 @@ impl ComponentCompiler for Compiler {
         // value (if any) it produces.
         let params = c.abi_load_params();
         let isa = c.isa;
-        let ptr = c.offsets.ptr;
         let (mut traps, builder) = c.traps();
         let mut intrinsic_compiler = UnsafeIntrinsicCompiler {
             isa,
             builder,
-            ptr,
             traps: &mut traps,
             phantom: PhantomData,
         };
@@ -2081,7 +2079,6 @@ where
 {
     pub isa: &'a (dyn TargetIsa + 'static),
     pub builder: &'a mut FunctionBuilder<'b>,
-    pub ptr: u8,
     pub traps: &'a mut T,
     pub phantom: PhantomData<O>,
 }
@@ -2377,26 +2374,30 @@ where
             UnsafeIntrinsic::ContextGetI32_1 | UnsafeIntrinsic::ContextSetI32_1 => 1,
             _ => unreachable!(),
         };
-        let offset = self.ptr.vmstore_context_component_context_slot(slot);
         let vmstore_context = self.load_vm_store_context(params);
         match intrinsic {
             UnsafeIntrinsic::ContextGetI32_0 | UnsafeIntrinsic::ContextGetI32_1 => {
-                let context = self.builder.ins().load(
-                    ty,
-                    MemFlagsData::trusted(),
-                    vmstore_context,
-                    i32::from(offset),
-                );
+                let context = self
+                    .traps
+                    .alias_regions()
+                    .vmstore_context_component_context_slot(
+                        &mut self.builder.cursor(),
+                        ty,
+                        vmstore_context,
+                        slot,
+                    );
                 Some(context)
             }
             UnsafeIntrinsic::ContextSetI32_0 | UnsafeIntrinsic::ContextSetI32_1 => {
                 let new_context = params[2];
-                self.builder.ins().store(
-                    MemFlagsData::trusted(),
-                    new_context,
-                    vmstore_context,
-                    i32::from(offset),
-                );
+                self.traps
+                    .alias_regions()
+                    .store_vmstore_context_component_context_slot(
+                        &mut self.builder.cursor(),
+                        vmstore_context,
+                        slot,
+                        new_context,
+                    );
                 None
             }
             _ => unreachable!(),

--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -584,34 +584,23 @@ impl<'module_environment> FuncEnvironment<'module_environment> {
 
     /// Loads the fuel consumption value from `VMStoreContext` into `self.fuel_var`
     fn fuel_load_into_var(&mut self, builder: &mut FunctionBuilder<'_>) {
-        let (addr, offset) = self.fuel_addr_offset(builder);
-        let fuel = builder
-            .ins()
-            .load(ir::types::I64, ir::MemFlagsData::trusted(), addr, offset);
+        let vmstore_ctx = self.get_vmstore_context_ptr(builder);
+        let fuel = self
+            .alias_regions
+            .vmstore_context_fuel_consumed(&mut builder.cursor(), vmstore_ctx);
         builder.def_var(self.fuel_var, fuel);
     }
 
     /// Stores the fuel consumption value from `self.fuel_var` into
     /// `VMStoreContext`.
     fn fuel_save_from_var(&mut self, builder: &mut FunctionBuilder<'_>) {
-        let (addr, offset) = self.fuel_addr_offset(builder);
-        let fuel_consumed = builder.use_var(self.fuel_var);
-        builder
-            .ins()
-            .store(ir::MemFlagsData::trusted(), fuel_consumed, addr, offset);
-    }
-
-    /// Returns the `(address, offset)` of the fuel consumption within
-    /// `VMStoreContext`, used to perform loads/stores later.
-    fn fuel_addr_offset(
-        &mut self,
-        builder: &mut FunctionBuilder<'_>,
-    ) -> (ir::Value, ir::immediates::Offset32) {
         let vmstore_ctx = self.get_vmstore_context_ptr(builder);
-        (
+        let fuel_consumed = builder.use_var(self.fuel_var);
+        self.alias_regions.store_vmstore_context_fuel_consumed(
+            &mut builder.cursor(),
             vmstore_ctx,
-            i32::from(self.offsets.ptr.vmstore_context_fuel_consumed()).into(),
-        )
+            fuel_consumed,
+        );
     }
 
     /// Checks the amount of remaining, and if we've run out of fuel we call
@@ -805,12 +794,9 @@ impl<'module_environment> FuncEnvironment<'module_environment> {
         // in the common case (between epoch ticks) but we want to do a
         // precise check here by reloading the cache first.
         let vmstore_ctx = self.get_vmstore_context_ptr(builder);
-        let deadline = builder.ins().load(
-            ir::types::I64,
-            ir::MemFlagsData::trusted(),
-            vmstore_ctx,
-            ir::immediates::Offset32::new(self.offsets.ptr.vmstore_context_epoch_deadline() as i32),
-        );
+        let deadline = self
+            .alias_regions
+            .vmstore_context_epoch_deadline(&mut builder.cursor(), vmstore_ctx);
         builder.def_var(self.epoch_deadline_var, deadline);
         self.epoch_check_cached(builder, cur_epoch_value, continuation_block);
 
@@ -1901,12 +1887,10 @@ impl<'a, 'func, 'module_env> Call<'a, 'func, 'module_env> {
                     .get_or_create_imported_func_ref(self.builder.func, callee_index);
                 if self.can_directly_inline_unsafe_intrinsic(*abi) {
                     let isa = self.env.compiler.isa();
-                    let ptr = self.env.offsets.ptr;
                     let mut intrinsic_compiler =
                         super::compiler::component::UnsafeIntrinsicCompiler {
                             builder: self.builder,
                             isa,
-                            ptr,
                             traps: self.env,
                             phantom: PhantomData,
                         };

--- a/crates/cranelift/src/func_environ/gc.rs
+++ b/crates/cranelift/src/func_environ/gc.rs
@@ -1441,9 +1441,6 @@ impl FuncEnvironment<'_> {
         &mut self,
         builder: &mut FunctionBuilder,
     ) -> WasmResult<ir::Value> {
-        let pointer_type = self.pointer_type();
-        let offset = i32::from(self.offsets.ptr.vmstore_context_gc_heap_base());
-
         let mut flags = ir::MemFlagsData::trusted();
         let memory_tunables =
             wasmtime_environ::MemoryTunables::new(self.tunables, MemoryKind::GcHeap);
@@ -1461,9 +1458,11 @@ impl FuncEnvironment<'_> {
         }
 
         let store_context_ptr = self.get_vmstore_context_ptr(builder);
-        Ok(builder
-            .ins()
-            .load(pointer_type, flags, store_context_ptr, offset))
+        Ok(self.alias_regions.vmstore_context_gc_heap_base(
+            &mut builder.cursor(),
+            flags,
+            store_context_ptr,
+        ))
     }
 
     /// Get the GC heap's bound.
@@ -1471,15 +1470,10 @@ impl FuncEnvironment<'_> {
         &mut self,
         builder: &mut FunctionBuilder,
     ) -> WasmResult<ir::Value> {
-        let pointer_type = self.pointer_type();
-        let offset = i32::from(self.offsets.ptr.vmstore_context_gc_heap_current_length());
         let store_context_ptr = self.get_vmstore_context_ptr(builder);
-        Ok(builder.ins().load(
-            pointer_type,
-            ir::MemFlagsData::trusted(),
-            store_context_ptr,
-            offset,
-        ))
+        Ok(self
+            .alias_regions
+            .vmstore_context_gc_heap_current_length(&mut builder.cursor(), store_context_ptr))
     }
 
     /// Get or create the `Heap` for our GC heap.
@@ -1490,11 +1484,23 @@ impl FuncEnvironment<'_> {
 
         let store_ctx = self.alias_regions.vmctx_store_context_load(func);
 
+        // The GC heap base/bound live in the `VMStoreContext`, so the second
+        // load in each chain (off the `*mut VMStoreContext`) is tagged with the
+        // `VMStoreContext` region for that field.
+        let base_offset = u32::from(self.offsets.ptr.vmstore_context_gc_heap_base());
+        let bound_offset = u32::from(self.offsets.ptr.vmstore_context_gc_heap_current_length());
+        let base_region = self
+            .alias_regions
+            .vmstore_context_region_for_use_in_ir_global(func, base_offset);
+        let bound_region = self
+            .alias_regions
+            .vmstore_context_region_for_use_in_ir_global(func, bound_offset);
+
         // The base pointer's load is `can_move` and `readonly` when the GC
         // heap's base can never move.
         let memory_tunables =
             wasmtime_environ::MemoryTunables::new(self.tunables, MemoryKind::GcHeap);
-        let mut flags = ir::MemFlagsData::trusted();
+        let mut flags = ir::MemFlagsData::trusted().with_alias_region(Some(base_region));
         if !self
             .tunables
             .gc_heap_memory_type()
@@ -1509,7 +1515,7 @@ impl FuncEnvironment<'_> {
             base: VmctxLoadChain::new(smallvec![
                 store_ctx,
                 Load {
-                    offset: u32::from(self.offsets.ptr.vmstore_context_gc_heap_base()),
+                    offset: base_offset,
                     flags,
                     ty: self.pointer_type(),
                 }
@@ -1517,8 +1523,8 @@ impl FuncEnvironment<'_> {
             bound: VmctxLoadChain::new(smallvec![
                 store_ctx,
                 Load {
-                    offset: u32::from(self.offsets.ptr.vmstore_context_gc_heap_current_length()),
-                    flags: ir::MemFlagsData::trusted(),
+                    offset: bound_offset,
+                    flags: ir::MemFlagsData::trusted().with_alias_region(Some(bound_region)),
                     ty: self.pointer_type(),
                 }
             ]),

--- a/crates/cranelift/src/func_environ/stack_switching/instructions.rs
+++ b/crates/cranelift/src/func_environ/stack_switching/instructions.rs
@@ -772,8 +772,9 @@ pub(crate) mod stack_switching_helpers {
         }
 
         /// Overwrites the `last_wasm_entry_fp` field of the `VMStackLimits`
-        /// object in the `VMStackLimits` of this object by loading the corresponding
-        /// field from the `VMRuntimeLimits`.
+        /// object in the `VMStackLimits` of this object by loading the
+        /// corresponding field from the `VMStoreContext`.
+        ///
         /// If `load_stack_limit` is true, we do the same for the `stack_limit`
         /// field.
         pub fn load_limits_from_vmcontext<'a>(
@@ -785,28 +786,28 @@ pub(crate) mod stack_switching_helpers {
         ) {
             let stack_limits_ptr = self.get_stack_limits_ptr(env, builder);
 
-            // The load side reads the `VMStoreContext`; the store side writes
-            // this continuation's inline `VMStackLimits`.
-            let our_memflags = ir::MemFlagsData::trusted();
-            let last_wasm_entry_fp_offset = env.offsets.ptr.vmstack_limits_last_wasm_entry_fp();
-
+            // The load side reads the `VMStoreContext`...
             let last_wasm_entry_fp = env
                 .alias_regions
                 .vmstore_context_last_wasm_entry_fp(&mut builder.cursor(), vmruntime_limits_ptr);
+            // ...and store to this continuation's inline `VMStackLimits`.
+            let last_wasm_entry_fp_offset = env.offsets.ptr.vmstack_limits_last_wasm_entry_fp();
             builder.ins().store(
-                our_memflags,
+                ir::MemFlagsData::trusted(),
                 last_wasm_entry_fp,
                 stack_limits_ptr,
                 i32::from(last_wasm_entry_fp_offset),
             );
 
             if load_stack_limit {
-                let stack_limit_offset = env.offsets.ptr.vmstack_limits_stack_limit();
+                // Load from the `VMStoreContext`...
                 let stack_limit = env
                     .alias_regions
                     .vmstore_context_stack_limit(&mut builder.cursor(), vmruntime_limits_ptr);
+                // ...and store to this continuation's inline `VMStackLimits`.
+                let stack_limit_offset = env.offsets.ptr.vmstack_limits_stack_limit();
                 builder.ins().store(
-                    our_memflags,
+                    ir::MemFlagsData::trusted(),
                     stack_limit,
                     stack_limits_ptr,
                     i32::from(stack_limit_offset),

--- a/crates/cranelift/src/func_environ/stack_switching/instructions.rs
+++ b/crates/cranelift/src/func_environ/stack_switching/instructions.rs
@@ -137,7 +137,8 @@ pub(crate) mod stack_switching_helpers {
             new_stack_chain: &VMStackChain,
         ) {
             let offset = env.offsets.ptr.vmcontref_parent_chain().into();
-            new_stack_chain.store(env, builder, self.address, offset)
+            // TODO: tag with the `VMContRef` alias region.
+            new_stack_chain.store(env, builder, self.address, offset, None)
         }
 
         /// Loads the parent of this continuation, which may either be another
@@ -149,7 +150,8 @@ pub(crate) mod stack_switching_helpers {
             builder: &mut FunctionBuilder,
         ) -> VMStackChain {
             let offset = env.offsets.ptr.vmcontref_parent_chain().into();
-            VMStackChain::load(env, builder, self.address, offset, env.pointer_type())
+            // TODO: tag with the `VMContRef` alias region.
+            VMStackChain::load(env, builder, self.address, offset, env.pointer_type(), None)
         }
 
         pub fn set_last_ancestor<'a>(
@@ -510,14 +512,19 @@ pub(crate) mod stack_switching_helpers {
         }
 
         /// Load a `VMStackChain` object from the given address.
+        ///
+        /// The `region` is the alias region for the two-pointer field being
+        /// loaded (e.g. the `VMStoreContext::stack_chain` region, or the
+        /// `VMContRef` region for a continuation's parent chain).
         pub fn load<'a>(
             _env: &mut crate::func_environ::FuncEnvironment<'a>,
             builder: &mut FunctionBuilder,
             pointer: ir::Value,
             initial_offset: i32,
             pointer_type: ir::Type,
+            region: Option<ir::AliasRegion>,
         ) -> VMStackChain {
-            let memflags = ir::MemFlagsData::trusted();
+            let memflags = ir::MemFlagsData::trusted().with_alias_region(region);
             let mut offset = initial_offset;
             let mut data = vec![];
             for _ in 0..2 {
@@ -529,14 +536,19 @@ pub(crate) mod stack_switching_helpers {
         }
 
         /// Store this `VMStackChain` object at the given address.
+        ///
+        /// The `region` is the alias region for the two-pointer field being
+        /// stored (e.g. the `VMStoreContext::stack_chain` region, or the
+        /// `VMContRef` region for a continuation's parent chain).
         pub fn store<'a>(
             &self,
             env: &mut crate::func_environ::FuncEnvironment<'a>,
             builder: &mut FunctionBuilder,
             target_pointer: ir::Value,
             initial_offset: i32,
+            region: Option<ir::AliasRegion>,
         ) {
-            let memflags = ir::MemFlagsData::trusted();
+            let memflags = ir::MemFlagsData::trusted().with_alias_region(region);
             let mut offset = initial_offset;
             let data = self.to_raw_parts();
 
@@ -726,33 +738,36 @@ pub(crate) mod stack_switching_helpers {
         ) {
             let stack_limits_ptr = self.get_stack_limits_ptr(env, builder);
 
-            let memflags = ir::MemFlagsData::trusted();
-
-            let mut copy_to_vm_runtime_limits = |our_offset, their_offset| {
-                let our_value = builder.ins().load(
-                    env.pointer_type(),
-                    memflags,
-                    stack_limits_ptr,
-                    i32::from(our_offset),
-                );
-                builder.ins().store(
-                    memflags,
-                    our_value,
-                    vmruntime_limits_ptr,
-                    i32::from(their_offset),
-                );
-            };
-
-            let pointer_size = u8::try_from(env.pointer_type().bytes()).unwrap();
+            let pointer_type = env.pointer_type();
             let stack_limit_offset = env.offsets.ptr.vmstack_limits_stack_limit();
             let last_wasm_entry_fp_offset = env.offsets.ptr.vmstack_limits_last_wasm_entry_fp();
-            copy_to_vm_runtime_limits(
-                stack_limit_offset,
-                pointer_size.vmstore_context_stack_limit(),
+
+            // The load side reads this continuation's inline `VMStackLimits`;
+            // the store side targets the `VMStoreContext`.
+            let our_memflags = ir::MemFlagsData::trusted();
+
+            let stack_limit = builder.ins().load(
+                pointer_type,
+                our_memflags,
+                stack_limits_ptr,
+                i32::from(stack_limit_offset),
             );
-            copy_to_vm_runtime_limits(
-                last_wasm_entry_fp_offset,
-                pointer_size.vmstore_context_last_wasm_entry_fp(),
+            env.alias_regions.store_vmstore_context_stack_limit(
+                &mut builder.cursor(),
+                vmruntime_limits_ptr,
+                stack_limit,
+            );
+
+            let last_wasm_entry_fp = builder.ins().load(
+                pointer_type,
+                our_memflags,
+                stack_limits_ptr,
+                i32::from(last_wasm_entry_fp_offset),
+            );
+            env.alias_regions.store_vmstore_context_last_wasm_entry_fp(
+                &mut builder.cursor(),
+                vmruntime_limits_ptr,
+                last_wasm_entry_fp,
             );
         }
 
@@ -770,35 +785,31 @@ pub(crate) mod stack_switching_helpers {
         ) {
             let stack_limits_ptr = self.get_stack_limits_ptr(env, builder);
 
-            let memflags = ir::MemFlagsData::trusted();
-            let pointer_size = u8::try_from(env.pointer_type().bytes()).unwrap();
-
-            let mut copy = |runtime_limits_offset, stack_limits_offset| {
-                let from_vm_runtime_limits = builder.ins().load(
-                    env.pointer_type(),
-                    memflags,
-                    vmruntime_limits_ptr,
-                    runtime_limits_offset,
-                );
-                builder.ins().store(
-                    memflags,
-                    from_vm_runtime_limits,
-                    stack_limits_ptr,
-                    stack_limits_offset,
-                );
-            };
-
+            // The load side reads the `VMStoreContext`; the store side writes
+            // this continuation's inline `VMStackLimits`.
+            let our_memflags = ir::MemFlagsData::trusted();
             let last_wasm_entry_fp_offset = env.offsets.ptr.vmstack_limits_last_wasm_entry_fp();
-            copy(
-                pointer_size.vmstore_context_last_wasm_entry_fp(),
-                last_wasm_entry_fp_offset,
+
+            let last_wasm_entry_fp = env
+                .alias_regions
+                .vmstore_context_last_wasm_entry_fp(&mut builder.cursor(), vmruntime_limits_ptr);
+            builder.ins().store(
+                our_memflags,
+                last_wasm_entry_fp,
+                stack_limits_ptr,
+                i32::from(last_wasm_entry_fp_offset),
             );
 
             if load_stack_limit {
                 let stack_limit_offset = env.offsets.ptr.vmstack_limits_stack_limit();
-                copy(
-                    pointer_size.vmstore_context_stack_limit(),
-                    stack_limit_offset,
+                let stack_limit = env
+                    .alias_regions
+                    .vmstore_context_stack_limit(&mut builder.cursor(), vmruntime_limits_ptr);
+                builder.ins().store(
+                    our_memflags,
+                    stack_limit,
+                    stack_limits_ptr,
+                    i32::from(stack_limit_offset),
                 );
             }
         }
@@ -938,12 +949,16 @@ pub fn vmctx_load_stack_chain<'a>(
         .alias_regions
         .vmctx_store_context(&mut builder.cursor(), vmctx);
 
+    let stack_chain_region = env
+        .alias_regions
+        .vmstore_context_stack_chain_region(builder.func);
     VMStackChain::load(
         env,
         builder,
         vm_store_context,
         stack_chain_offset,
         env.pointer_type(),
+        Some(stack_chain_region),
     )
 }
 
@@ -962,7 +977,16 @@ pub fn vmctx_store_stack_chain<'a>(
         .alias_regions
         .vmctx_store_context(&mut builder.cursor(), vmctx);
 
-    stack_chain.store(env, builder, vm_store_context, stack_chain_offset)
+    let stack_chain_region = env
+        .alias_regions
+        .vmstore_context_stack_chain_region(builder.func);
+    stack_chain.store(
+        env,
+        builder,
+        vm_store_context,
+        stack_chain_offset,
+        Some(stack_chain_region),
+    )
 }
 
 /// Similar to `vmctx_store_stack_chain`, but instead of storing an arbitrary

--- a/tests/disas/alias-region-globals.wat
+++ b/tests/disas/alias-region-globals.wat
@@ -16,18 +16,19 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 48 "VMContext+0x30"
-;;     region2 = 1610612736 "PublicGlobal"
-;;     region3 = 1879048192 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 48 "VMContext+0x30"
+;;     region3 = 1610612736 "PublicGlobal"
+;;     region4 = 1879048192 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0039                               v4 = load.i64 notrap aligned readonly can_move region1 v0+48
-;; @0039                               store notrap aligned region2 v2, v4
-;; @003d                               store notrap aligned region3 v2, v0+80
+;; @0039                               v4 = load.i64 notrap aligned readonly can_move region2 v0+48
+;; @0039                               store notrap aligned region3 v2, v4
+;; @003d                               store notrap aligned region4 v2, v0+80
 ;; @0041                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/alias-region-memories.wat
+++ b/tests/disas/alias-region-memories.wat
@@ -16,23 +16,24 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 48 "VMContext+0x30"
-;;     region2 = 536870912 "PublicMemory"
-;;     region3 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 48 "VMContext+0x30"
+;;     region3 = 536870912 "PublicMemory"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
-;; @003b                               v6 = load.i64 notrap aligned readonly can_move region1 v0+48
+;; @003b                               v6 = load.i64 notrap aligned readonly can_move region2 v0+48
 ;; @003b                               v7 = load.i64 notrap aligned readonly can_move v6
 ;; @003b                               v5 = uextend.i64 v2
 ;; @003b                               v8 = iadd v7, v5
-;; @003b                               store little region2 v3, v8
+;; @003b                               store little region3 v3, v8
 ;; @0042                               v10 = load.i64 notrap aligned readonly can_move v0+80
 ;; @0042                               v11 = iadd v10, v5
-;; @0042                               store little region3 v3, v11
+;; @0042                               store little region4 v3, v11
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/alias-region-tables.wat
+++ b/tests/disas/alias-region-tables.wat
@@ -17,20 +17,21 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 48 "VMContext+0x30"
-;;     region2 = 1073741824 "PublicTable"
-;;     region3 = 1342177280 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
-;;     region4 = 40 "VMContext+0x28"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 48 "VMContext+0x30"
+;;     region3 = 1073741824 "PublicTable"
+;;     region4 = 1342177280 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
+;;     region5 = 40 "VMContext+0x28"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, i64) -> i32 tail
 ;;     sig1 = (i64 vmctx, i32, i64) -> i64 tail
 ;;     fn0 = colocated u805306368:7 sig1
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i64):
-;; @0043                               v5 = load.i64 notrap aligned readonly can_move region1 v0+48
+;; @0043                               v5 = load.i64 notrap aligned readonly can_move region2 v0+48
 ;; @0043                               v6 = load.i64 notrap aligned v5+8
 ;; @0043                               v11 = load.i64 notrap aligned v5
 ;; @0043                               v17 = iconst.i64 1
@@ -43,14 +44,14 @@
 ;; @0043                               v13 = ishl v9, v12  ; v12 = 3
 ;; @0043                               v14 = iadd v11, v13
 ;; @0043                               v16 = select_spectre_guard v8, v15, v14  ; v15 = 0
-;; @0043                               store user6 aligned region2 v18, v16
+;; @0043                               store user6 aligned region3 v18, v16
 ;; @0049                               v19 = load.i64 notrap aligned v0+80
 ;; @0049                               v23 = load.i64 notrap aligned v0+72
 ;; @0049                               v20 = ireduce.i32 v19
 ;; @0049                               v21 = icmp uge v2, v20
 ;; @0049                               v26 = iadd v23, v13
 ;; @0049                               v28 = select_spectre_guard v21, v15, v26  ; v15 = 0
-;; @0049                               store user6 aligned region3 v18, v28
+;; @0049                               store user6 aligned region4 v18, v28
 ;; @004d                               v44 = iconst.i64 -2
 ;; @004d                               v45 = band v18, v44  ; v44 = -2
 ;; @004d                               brif v18, block3(v45), block2
@@ -62,7 +63,7 @@
 ;;
 ;;                                 block3(v46: i64):
 ;; @004d                               v52 = load.i32 user7 aligned readonly v46+16
-;; @004d                               v50 = load.i64 notrap aligned readonly can_move region4 v0+40
+;; @004d                               v50 = load.i64 notrap aligned readonly can_move region5 v0+40
 ;; @004d                               v51 = load.i32 notrap aligned readonly can_move v50
 ;; @004d                               v53 = icmp eq v52, v51
 ;; @004d                               trapz v53, user8

--- a/tests/disas/arith.wat
+++ b/tests/disas/arith.wat
@@ -16,9 +16,10 @@
 
 ;; function u0:0(i64 vmctx, i64) tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):

--- a/tests/disas/array-copy-anyref.wat
+++ b/tests/disas/array-copy-anyref.wat
@@ -11,21 +11,24 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32, i32, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 268435488 "VMStoreContext+0x20"
+;;     region3 = 268435496 "VMStoreContext+0x28"
+;;     region4 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32, v6: i32):
 ;; @002b                               trapz v2, user16
 ;; @002b                               v8 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @002b                               v9 = load.i64 notrap aligned readonly can_move v8+32
+;; @002b                               v9 = load.i64 notrap aligned readonly can_move region2 v8+32
 ;; @002b                               v7 = uextend.i64 v2
 ;; @002b                               v10 = iadd v9, v7
 ;; @002b                               v11 = iconst.i64 16
 ;; @002b                               v12 = iadd v10, v11  ; v11 = 16
-;; @002b                               v13 = load.i32 user2 readonly region1 v12
+;; @002b                               v13 = load.i32 user2 readonly region4 v12
 ;; @002b                               v15 = uextend.i64 v3
 ;; @002b                               v16 = uextend.i64 v6
 ;; @002b                               v19 = iadd v15, v16
@@ -36,13 +39,13 @@
 ;; @002b                               v31 = uextend.i64 v4
 ;; @002b                               v34 = iadd v9, v31
 ;; @002b                               v36 = iadd v34, v11  ; v11 = 16
-;; @002b                               v37 = load.i32 user2 readonly region1 v36
+;; @002b                               v37 = load.i32 user2 readonly region4 v36
 ;; @002b                               v39 = uextend.i64 v5
 ;; @002b                               v43 = iadd v39, v16
 ;; @002b                               v38 = uextend.i64 v37
 ;; @002b                               v44 = icmp ugt v43, v38
 ;; @002b                               trapnz v44, user17
-;; @002b                               v63 = load.i64 notrap aligned v8+40
+;; @002b                               v63 = load.i64 notrap aligned region3 v8+40
 ;; @002b                               v25 = iconst.i64 20
 ;; @002b                               v26 = iadd v10, v25  ; v25 = 20
 ;;                                     v111 = iconst.i64 2
@@ -71,8 +74,8 @@
 ;; @002b                               brif v74, block3(v30, v54, v5), block4(v79, v80, v82)
 ;;
 ;;                                 block3(v83: i64, v84: i64, v85: i32):
-;; @002b                               v88 = load.i32 user2 little region1 v84
-;; @002b                               store user2 little region1 v88, v83
+;; @002b                               v88 = load.i32 user2 little region4 v84
+;; @002b                               store user2 little region4 v88, v83
 ;;                                     v123 = iconst.i64 4
 ;;                                     v124 = iadd v84, v123  ; v123 = 4
 ;; @002b                               v95 = icmp eq v124, v80
@@ -84,9 +87,9 @@
 ;;                                 block4(v96: i64, v97: i64, v98: i32):
 ;;                                     v118 = iconst.i64 4
 ;;                                     v119 = isub v97, v118  ; v118 = 4
-;; @002b                               v107 = load.i32 user2 little region1 v119
+;; @002b                               v107 = load.i32 user2 little region4 v119
 ;;                                     v120 = isub v96, v118  ; v118 = 4
-;; @002b                               store user2 little region1 v107, v120
+;; @002b                               store user2 little region4 v107, v120
 ;; @002b                               v108 = icmp eq v119, v54
 ;;                                     v121 = iconst.i32 1
 ;;                                     v122 = isub v98, v121  ; v121 = 1

--- a/tests/disas/array-copy-i64.wat
+++ b/tests/disas/array-copy-i64.wat
@@ -11,10 +11,13 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32, i32, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 268435488 "VMStoreContext+0x20"
+;;     region3 = 268435496 "VMStoreContext+0x28"
+;;     region4 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, i64, i64, i64) tail
 ;;     fn0 = colocated u805306368:1 sig0
 ;;     stack_limit = gv2
@@ -22,12 +25,12 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32, v6: i32):
 ;; @002b                               trapz v2, user16
 ;; @002b                               v8 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @002b                               v9 = load.i64 notrap aligned readonly can_move v8+32
+;; @002b                               v9 = load.i64 notrap aligned readonly can_move region2 v8+32
 ;; @002b                               v7 = uextend.i64 v2
 ;; @002b                               v10 = iadd v9, v7
 ;; @002b                               v11 = iconst.i64 16
 ;; @002b                               v12 = iadd v10, v11  ; v11 = 16
-;; @002b                               v13 = load.i32 user2 readonly region1 v12
+;; @002b                               v13 = load.i32 user2 readonly region4 v12
 ;; @002b                               v15 = uextend.i64 v3
 ;; @002b                               v16 = uextend.i64 v6
 ;; @002b                               v19 = iadd v15, v16
@@ -38,13 +41,13 @@
 ;; @002b                               v31 = uextend.i64 v4
 ;; @002b                               v34 = iadd v9, v31
 ;; @002b                               v36 = iadd v34, v11  ; v11 = 16
-;; @002b                               v37 = load.i32 user2 readonly region1 v36
+;; @002b                               v37 = load.i32 user2 readonly region4 v36
 ;; @002b                               v39 = uextend.i64 v5
 ;; @002b                               v43 = iadd v39, v16
 ;; @002b                               v38 = uextend.i64 v37
 ;; @002b                               v44 = icmp ugt v43, v38
 ;; @002b                               trapnz v44, user17
-;; @002b                               v63 = load.i64 notrap aligned v8+40
+;; @002b                               v63 = load.i64 notrap aligned region3 v8+40
 ;; @002b                               v25 = iconst.i64 24
 ;; @002b                               v26 = iadd v10, v25  ; v25 = 24
 ;;                                     v76 = iconst.i64 3

--- a/tests/disas/array-copy-i8.wat
+++ b/tests/disas/array-copy-i8.wat
@@ -11,10 +11,13 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32, i32, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 268435488 "VMStoreContext+0x20"
+;;     region3 = 268435496 "VMStoreContext+0x28"
+;;     region4 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, i64, i64, i64) tail
 ;;     fn0 = colocated u805306368:1 sig0
 ;;     stack_limit = gv2
@@ -22,12 +25,12 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32, v6: i32):
 ;; @002b                               trapz v2, user16
 ;; @002b                               v8 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @002b                               v9 = load.i64 notrap aligned readonly can_move v8+32
+;; @002b                               v9 = load.i64 notrap aligned readonly can_move region2 v8+32
 ;; @002b                               v7 = uextend.i64 v2
 ;; @002b                               v10 = iadd v9, v7
 ;; @002b                               v11 = iconst.i64 16
 ;; @002b                               v12 = iadd v10, v11  ; v11 = 16
-;; @002b                               v13 = load.i32 user2 readonly region1 v12
+;; @002b                               v13 = load.i32 user2 readonly region4 v12
 ;; @002b                               v15 = uextend.i64 v3
 ;; @002b                               v16 = uextend.i64 v6
 ;; @002b                               v19 = iadd v15, v16
@@ -38,13 +41,13 @@
 ;; @002b                               v31 = uextend.i64 v4
 ;; @002b                               v34 = iadd v9, v31
 ;; @002b                               v36 = iadd v34, v11  ; v11 = 16
-;; @002b                               v37 = load.i32 user2 readonly region1 v36
+;; @002b                               v37 = load.i32 user2 readonly region4 v36
 ;; @002b                               v39 = uextend.i64 v5
 ;; @002b                               v43 = iadd v39, v16
 ;; @002b                               v38 = uextend.i64 v37
 ;; @002b                               v44 = icmp ugt v43, v38
 ;; @002b                               trapnz v44, user17
-;; @002b                               v63 = load.i64 notrap aligned v8+40
+;; @002b                               v63 = load.i64 notrap aligned region3 v8+40
 ;; @002b                               v25 = iconst.i64 20
 ;; @002b                               v26 = iadd v10, v25  ; v25 = 20
 ;; @002b                               v30 = iadd v26, v15

--- a/tests/disas/array-copy-inline.wat
+++ b/tests/disas/array-copy-inline.wat
@@ -17,21 +17,24 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 268435488 "VMStoreContext+0x20"
+;;     region3 = 268435496 "VMStoreContext+0x28"
+;;     region4 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):
 ;; @002a                               trapz v2, user16
 ;; @002a                               v8 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @002a                               v9 = load.i64 notrap aligned readonly can_move v8+32
+;; @002a                               v9 = load.i64 notrap aligned readonly can_move region2 v8+32
 ;; @002a                               v7 = uextend.i64 v2
 ;; @002a                               v10 = iadd v9, v7
 ;; @002a                               v11 = iconst.i64 16
 ;; @002a                               v12 = iadd v10, v11  ; v11 = 16
-;; @002a                               v13 = load.i32 user2 readonly region1 v12
+;; @002a                               v13 = load.i32 user2 readonly region4 v12
 ;; @002a                               v15 = uextend.i64 v3
 ;;                                     v77 = iconst.i64 7
 ;; @002a                               v19 = iadd v15, v77  ; v77 = 7
@@ -42,13 +45,13 @@
 ;; @002a                               v31 = uextend.i64 v4
 ;; @002a                               v34 = iadd v9, v31
 ;; @002a                               v36 = iadd v34, v11  ; v11 = 16
-;; @002a                               v37 = load.i32 user2 readonly region1 v36
+;; @002a                               v37 = load.i32 user2 readonly region4 v36
 ;; @002a                               v39 = uextend.i64 v5
 ;; @002a                               v43 = iadd v39, v77  ; v77 = 7
 ;; @002a                               v38 = uextend.i64 v37
 ;; @002a                               v44 = icmp ugt v43, v38
 ;; @002a                               trapnz v44, user17
-;; @002a                               v63 = load.i64 notrap aligned v8+40
+;; @002a                               v63 = load.i64 notrap aligned region3 v8+40
 ;; @002a                               v25 = iconst.i64 20
 ;; @002a                               v26 = iadd v10, v25  ; v25 = 20
 ;;                                     v85 = iconst.i64 2
@@ -65,12 +68,12 @@
 ;; @002a                               v72 = uadd_overflow_trap v54, v90, user2  ; v90 = 28
 ;; @002a                               v73 = icmp ugt v72, v64
 ;; @002a                               trapnz v73, user2
-;; @002a                               v74 = load.i8x16 notrap aligned little region1 v54
-;; @002a                               v75 = load.i64 notrap aligned little region1 v54+16
-;; @002a                               v76 = load.i32 notrap aligned little region1 v54+24
-;; @002a                               store notrap aligned little region1 v74, v30
-;; @002a                               store notrap aligned little region1 v75, v30+16
-;; @002a                               store notrap aligned little region1 v76, v30+24
+;; @002a                               v74 = load.i8x16 notrap aligned little region4 v54
+;; @002a                               v75 = load.i64 notrap aligned little region4 v54+16
+;; @002a                               v76 = load.i32 notrap aligned little region4 v54+24
+;; @002a                               store notrap aligned little region4 v74, v30
+;; @002a                               store notrap aligned little region4 v75, v30+16
+;; @002a                               store notrap aligned little region4 v76, v30+24
 ;; @002e                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/array-fill-anyref.wat
+++ b/tests/disas/array-fill-anyref.wat
@@ -19,28 +19,31 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 268435488 "VMStoreContext+0x20"
+;;     region3 = 268435496 "VMStoreContext+0x28"
+;;     region4 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):
 ;; @0030                               trapz v2, user16
 ;; @0030                               v7 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0030                               v8 = load.i64 notrap aligned readonly can_move v7+32
+;; @0030                               v8 = load.i64 notrap aligned readonly can_move region2 v7+32
 ;; @0030                               v6 = uextend.i64 v2
 ;; @0030                               v9 = iadd v8, v6
 ;; @0030                               v10 = iconst.i64 16
 ;; @0030                               v11 = iadd v9, v10  ; v10 = 16
-;; @0030                               v12 = load.i32 user2 readonly region1 v11
+;; @0030                               v12 = load.i32 user2 readonly region4 v11
 ;; @0030                               v14 = uextend.i64 v3
 ;; @0030                               v15 = uextend.i64 v5
 ;; @0030                               v18 = iadd v14, v15
 ;; @0030                               v13 = uextend.i64 v12
 ;; @0030                               v19 = icmp ugt v18, v13
 ;; @0030                               trapnz v19, user17
-;; @0030                               v36 = load.i64 notrap aligned v7+40
+;; @0030                               v36 = load.i64 notrap aligned region3 v7+40
 ;; @0030                               v24 = iconst.i64 20
 ;; @0030                               v25 = iadd v9, v24  ; v24 = 20
 ;;                                     v49 = iconst.i64 2
@@ -58,7 +61,7 @@
 ;; @0030                               brif v42, block3, block2(v29)
 ;;
 ;;                                 block2(v43: i64):
-;; @0030                               store.i32 user2 little region1 v4, v43
+;; @0030                               store.i32 user2 little region4 v4, v43
 ;;                                     v54 = iconst.i64 4
 ;;                                     v55 = iadd v43, v54  ; v54 = 4
 ;; @0030                               v46 = icmp eq v55, v40
@@ -73,28 +76,31 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 268435488 "VMStoreContext+0x20"
+;;     region3 = 268435496 "VMStoreContext+0x28"
+;;     region4 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
 ;; @003e                               trapz v2, user16
 ;; @003e                               v7 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @003e                               v8 = load.i64 notrap aligned readonly can_move v7+32
+;; @003e                               v8 = load.i64 notrap aligned readonly can_move region2 v7+32
 ;; @003e                               v6 = uextend.i64 v2
 ;; @003e                               v9 = iadd v8, v6
 ;; @003e                               v10 = iconst.i64 16
 ;; @003e                               v11 = iadd v9, v10  ; v10 = 16
-;; @003e                               v12 = load.i32 user2 readonly region1 v11
+;; @003e                               v12 = load.i32 user2 readonly region4 v11
 ;; @003e                               v14 = uextend.i64 v3
 ;; @003e                               v15 = uextend.i64 v4
 ;; @003e                               v18 = iadd v14, v15
 ;; @003e                               v13 = uextend.i64 v12
 ;; @003e                               v19 = icmp ugt v18, v13
 ;; @003e                               trapnz v19, user17
-;; @003e                               v36 = load.i64 notrap aligned v7+40
+;; @003e                               v36 = load.i64 notrap aligned region3 v7+40
 ;; @003e                               v24 = iconst.i64 20
 ;; @003e                               v25 = iadd v9, v24  ; v24 = 20
 ;;                                     v49 = iconst.i64 2
@@ -114,7 +120,7 @@
 ;;
 ;;                                 block2(v43: i64):
 ;;                                     v54 = iconst.i32 0
-;; @003e                               store user2 little region1 v54, v43  ; v54 = 0
+;; @003e                               store user2 little region4 v54, v43  ; v54 = 0
 ;;                                     v55 = iconst.i64 4
 ;;                                     v56 = iadd v43, v55  ; v55 = 4
 ;; @003e                               v46 = icmp eq v56, v40
@@ -129,28 +135,31 @@
 ;;
 ;; function u0:2(i64 vmctx, i64, i32, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 268435488 "VMStoreContext+0x20"
+;;     region3 = 268435496 "VMStoreContext+0x28"
+;;     region4 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
 ;; @004e                               trapz v2, user16
 ;; @004e                               v11 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @004e                               v12 = load.i64 notrap aligned readonly can_move v11+32
+;; @004e                               v12 = load.i64 notrap aligned readonly can_move region2 v11+32
 ;; @004e                               v10 = uextend.i64 v2
 ;; @004e                               v13 = iadd v12, v10
 ;; @004e                               v14 = iconst.i64 16
 ;; @004e                               v15 = iadd v13, v14  ; v14 = 16
-;; @004e                               v16 = load.i32 user2 readonly region1 v15
+;; @004e                               v16 = load.i32 user2 readonly region4 v15
 ;; @004e                               v18 = uextend.i64 v3
 ;; @004e                               v19 = uextend.i64 v4
 ;; @004e                               v22 = iadd v18, v19
 ;; @004e                               v17 = uextend.i64 v16
 ;; @004e                               v23 = icmp ugt v22, v17
 ;; @004e                               trapnz v23, user17
-;; @004e                               v40 = load.i64 notrap aligned v11+40
+;; @004e                               v40 = load.i64 notrap aligned region3 v11+40
 ;; @004e                               v28 = iconst.i64 20
 ;; @004e                               v29 = iadd v13, v28  ; v28 = 20
 ;;                                     v59 = iconst.i64 2
@@ -170,7 +179,7 @@
 ;;
 ;;                                 block2(v47: i64):
 ;;                                     v64 = iconst.i32 -1
-;; @004e                               store user2 little region1 v64, v47  ; v64 = -1
+;; @004e                               store user2 little region4 v64, v47  ; v64 = -1
 ;;                                     v65 = iconst.i64 4
 ;;                                     v66 = iadd v47, v65  ; v65 = 4
 ;; @004e                               v50 = icmp eq v66, v44

--- a/tests/disas/array-fill-externref.wat
+++ b/tests/disas/array-fill-externref.wat
@@ -15,28 +15,31 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 268435488 "VMStoreContext+0x20"
+;;     region3 = 268435496 "VMStoreContext+0x28"
+;;     region4 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):
 ;; @002f                               trapz v2, user16
 ;; @002f                               v7 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @002f                               v8 = load.i64 notrap aligned readonly can_move v7+32
+;; @002f                               v8 = load.i64 notrap aligned readonly can_move region2 v7+32
 ;; @002f                               v6 = uextend.i64 v2
 ;; @002f                               v9 = iadd v8, v6
 ;; @002f                               v10 = iconst.i64 16
 ;; @002f                               v11 = iadd v9, v10  ; v10 = 16
-;; @002f                               v12 = load.i32 user2 readonly region1 v11
+;; @002f                               v12 = load.i32 user2 readonly region4 v11
 ;; @002f                               v14 = uextend.i64 v3
 ;; @002f                               v15 = uextend.i64 v5
 ;; @002f                               v18 = iadd v14, v15
 ;; @002f                               v13 = uextend.i64 v12
 ;; @002f                               v19 = icmp ugt v18, v13
 ;; @002f                               trapnz v19, user17
-;; @002f                               v36 = load.i64 notrap aligned v7+40
+;; @002f                               v36 = load.i64 notrap aligned region3 v7+40
 ;; @002f                               v24 = iconst.i64 20
 ;; @002f                               v25 = iadd v9, v24  ; v24 = 20
 ;;                                     v49 = iconst.i64 2
@@ -54,7 +57,7 @@
 ;; @002f                               brif v42, block3, block2(v29)
 ;;
 ;;                                 block2(v43: i64):
-;; @002f                               store.i32 user2 little region1 v4, v43
+;; @002f                               store.i32 user2 little region4 v4, v43
 ;;                                     v54 = iconst.i64 4
 ;;                                     v55 = iadd v43, v54  ; v54 = 4
 ;; @002f                               v46 = icmp eq v55, v40
@@ -69,28 +72,31 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 268435488 "VMStoreContext+0x20"
+;;     region3 = 268435496 "VMStoreContext+0x28"
+;;     region4 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
 ;; @003d                               trapz v2, user16
 ;; @003d                               v7 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @003d                               v8 = load.i64 notrap aligned readonly can_move v7+32
+;; @003d                               v8 = load.i64 notrap aligned readonly can_move region2 v7+32
 ;; @003d                               v6 = uextend.i64 v2
 ;; @003d                               v9 = iadd v8, v6
 ;; @003d                               v10 = iconst.i64 16
 ;; @003d                               v11 = iadd v9, v10  ; v10 = 16
-;; @003d                               v12 = load.i32 user2 readonly region1 v11
+;; @003d                               v12 = load.i32 user2 readonly region4 v11
 ;; @003d                               v14 = uextend.i64 v3
 ;; @003d                               v15 = uextend.i64 v4
 ;; @003d                               v18 = iadd v14, v15
 ;; @003d                               v13 = uextend.i64 v12
 ;; @003d                               v19 = icmp ugt v18, v13
 ;; @003d                               trapnz v19, user17
-;; @003d                               v36 = load.i64 notrap aligned v7+40
+;; @003d                               v36 = load.i64 notrap aligned region3 v7+40
 ;; @003d                               v24 = iconst.i64 20
 ;; @003d                               v25 = iadd v9, v24  ; v24 = 20
 ;;                                     v49 = iconst.i64 2
@@ -110,7 +116,7 @@
 ;;
 ;;                                 block2(v43: i64):
 ;;                                     v54 = iconst.i32 0
-;; @003d                               store user2 little region1 v54, v43  ; v54 = 0
+;; @003d                               store user2 little region4 v54, v43  ; v54 = 0
 ;;                                     v55 = iconst.i64 4
 ;;                                     v56 = iadd v43, v55  ; v55 = 4
 ;; @003d                               v46 = icmp eq v56, v40

--- a/tests/disas/array-fill-f32.wat
+++ b/tests/disas/array-fill-f32.wat
@@ -19,28 +19,31 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32, f32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 268435488 "VMStoreContext+0x20"
+;;     region3 = 268435496 "VMStoreContext+0x28"
+;;     region4 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: f32, v5: i32):
 ;; @0030                               trapz v2, user16
 ;; @0030                               v7 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0030                               v8 = load.i64 notrap aligned readonly can_move v7+32
+;; @0030                               v8 = load.i64 notrap aligned readonly can_move region2 v7+32
 ;; @0030                               v6 = uextend.i64 v2
 ;; @0030                               v9 = iadd v8, v6
 ;; @0030                               v10 = iconst.i64 16
 ;; @0030                               v11 = iadd v9, v10  ; v10 = 16
-;; @0030                               v12 = load.i32 user2 readonly region1 v11
+;; @0030                               v12 = load.i32 user2 readonly region4 v11
 ;; @0030                               v14 = uextend.i64 v3
 ;; @0030                               v15 = uextend.i64 v5
 ;; @0030                               v18 = iadd v14, v15
 ;; @0030                               v13 = uextend.i64 v12
 ;; @0030                               v19 = icmp ugt v18, v13
 ;; @0030                               trapnz v19, user17
-;; @0030                               v36 = load.i64 notrap aligned v7+40
+;; @0030                               v36 = load.i64 notrap aligned region3 v7+40
 ;; @0030                               v24 = iconst.i64 20
 ;; @0030                               v25 = iadd v9, v24  ; v24 = 20
 ;;                                     v49 = iconst.i64 2
@@ -58,7 +61,7 @@
 ;; @0030                               brif v42, block3, block2(v29)
 ;;
 ;;                                 block2(v43: i64):
-;; @0030                               store.f32 user2 little region1 v4, v43
+;; @0030                               store.f32 user2 little region4 v4, v43
 ;;                                     v54 = iconst.i64 4
 ;;                                     v55 = iadd v43, v54  ; v54 = 4
 ;; @0030                               v46 = icmp eq v55, v40
@@ -73,10 +76,13 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 268435488 "VMStoreContext+0x20"
+;;     region3 = 268435496 "VMStoreContext+0x28"
+;;     region4 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, i64, i32, i64) tail
 ;;     fn0 = colocated u805306368:2 sig0
 ;;     stack_limit = gv2
@@ -84,19 +90,19 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
 ;; @0041                               trapz v2, user16
 ;; @0041                               v7 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0041                               v8 = load.i64 notrap aligned readonly can_move v7+32
+;; @0041                               v8 = load.i64 notrap aligned readonly can_move region2 v7+32
 ;; @0041                               v6 = uextend.i64 v2
 ;; @0041                               v9 = iadd v8, v6
 ;; @0041                               v10 = iconst.i64 16
 ;; @0041                               v11 = iadd v9, v10  ; v10 = 16
-;; @0041                               v12 = load.i32 user2 readonly region1 v11
+;; @0041                               v12 = load.i32 user2 readonly region4 v11
 ;; @0041                               v14 = uextend.i64 v3
 ;; @0041                               v15 = uextend.i64 v4
 ;; @0041                               v18 = iadd v14, v15
 ;; @0041                               v13 = uextend.i64 v12
 ;; @0041                               v19 = icmp ugt v18, v13
 ;; @0041                               trapnz v19, user17
-;; @0041                               v36 = load.i64 notrap aligned v7+40
+;; @0041                               v36 = load.i64 notrap aligned region3 v7+40
 ;; @0041                               v24 = iconst.i64 20
 ;; @0041                               v25 = iadd v9, v24  ; v24 = 20
 ;;                                     v43 = iconst.i64 2
@@ -117,28 +123,31 @@
 ;;
 ;; function u0:2(i64 vmctx, i64, i32, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 268435488 "VMStoreContext+0x20"
+;;     region3 = 268435496 "VMStoreContext+0x28"
+;;     region4 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
 ;; @0052                               trapz v2, user16
 ;; @0052                               v7 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0052                               v8 = load.i64 notrap aligned readonly can_move v7+32
+;; @0052                               v8 = load.i64 notrap aligned readonly can_move region2 v7+32
 ;; @0052                               v6 = uextend.i64 v2
 ;; @0052                               v9 = iadd v8, v6
 ;; @0052                               v10 = iconst.i64 16
 ;; @0052                               v11 = iadd v9, v10  ; v10 = 16
-;; @0052                               v12 = load.i32 user2 readonly region1 v11
+;; @0052                               v12 = load.i32 user2 readonly region4 v11
 ;; @0052                               v14 = uextend.i64 v3
 ;; @0052                               v15 = uextend.i64 v4
 ;; @0052                               v18 = iadd v14, v15
 ;; @0052                               v13 = uextend.i64 v12
 ;; @0052                               v19 = icmp ugt v18, v13
 ;; @0052                               trapnz v19, user17
-;; @0052                               v36 = load.i64 notrap aligned v7+40
+;; @0052                               v36 = load.i64 notrap aligned region3 v7+40
 ;; @0052                               v24 = iconst.i64 20
 ;; @0052                               v25 = iadd v9, v24  ; v24 = 20
 ;;                                     v49 = iconst.i64 2
@@ -158,7 +167,7 @@
 ;;
 ;;                                 block2(v43: i64):
 ;;                                     v54 = f32const 0x1.000000p0
-;; @0052                               store user2 little region1 v54, v43  ; v54 = 0x1.000000p0
+;; @0052                               store user2 little region4 v54, v43  ; v54 = 0x1.000000p0
 ;;                                     v55 = iconst.i64 4
 ;;                                     v56 = iadd v43, v55  ; v55 = 4
 ;; @0052                               v46 = icmp eq v56, v40

--- a/tests/disas/array-fill-f64.wat
+++ b/tests/disas/array-fill-f64.wat
@@ -19,28 +19,31 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32, f64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 268435488 "VMStoreContext+0x20"
+;;     region3 = 268435496 "VMStoreContext+0x28"
+;;     region4 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: f64, v5: i32):
 ;; @0030                               trapz v2, user16
 ;; @0030                               v7 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0030                               v8 = load.i64 notrap aligned readonly can_move v7+32
+;; @0030                               v8 = load.i64 notrap aligned readonly can_move region2 v7+32
 ;; @0030                               v6 = uextend.i64 v2
 ;; @0030                               v9 = iadd v8, v6
 ;; @0030                               v10 = iconst.i64 16
 ;; @0030                               v11 = iadd v9, v10  ; v10 = 16
-;; @0030                               v12 = load.i32 user2 readonly region1 v11
+;; @0030                               v12 = load.i32 user2 readonly region4 v11
 ;; @0030                               v14 = uextend.i64 v3
 ;; @0030                               v15 = uextend.i64 v5
 ;; @0030                               v18 = iadd v14, v15
 ;; @0030                               v13 = uextend.i64 v12
 ;; @0030                               v19 = icmp ugt v18, v13
 ;; @0030                               trapnz v19, user17
-;; @0030                               v36 = load.i64 notrap aligned v7+40
+;; @0030                               v36 = load.i64 notrap aligned region3 v7+40
 ;; @0030                               v24 = iconst.i64 24
 ;; @0030                               v25 = iadd v9, v24  ; v24 = 24
 ;;                                     v49 = iconst.i64 3
@@ -58,7 +61,7 @@
 ;; @0030                               brif v42, block3, block2(v29)
 ;;
 ;;                                 block2(v43: i64):
-;; @0030                               store.f64 user2 little region1 v4, v43
+;; @0030                               store.f64 user2 little region4 v4, v43
 ;;                                     v54 = iconst.i64 8
 ;;                                     v55 = iadd v43, v54  ; v54 = 8
 ;; @0030                               v46 = icmp eq v55, v40
@@ -73,10 +76,13 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 268435488 "VMStoreContext+0x20"
+;;     region3 = 268435496 "VMStoreContext+0x28"
+;;     region4 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, i64, i32, i64) tail
 ;;     fn0 = colocated u805306368:2 sig0
 ;;     stack_limit = gv2
@@ -84,19 +90,19 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
 ;; @0045                               trapz v2, user16
 ;; @0045                               v7 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0045                               v8 = load.i64 notrap aligned readonly can_move v7+32
+;; @0045                               v8 = load.i64 notrap aligned readonly can_move region2 v7+32
 ;; @0045                               v6 = uextend.i64 v2
 ;; @0045                               v9 = iadd v8, v6
 ;; @0045                               v10 = iconst.i64 16
 ;; @0045                               v11 = iadd v9, v10  ; v10 = 16
-;; @0045                               v12 = load.i32 user2 readonly region1 v11
+;; @0045                               v12 = load.i32 user2 readonly region4 v11
 ;; @0045                               v14 = uextend.i64 v3
 ;; @0045                               v15 = uextend.i64 v4
 ;; @0045                               v18 = iadd v14, v15
 ;; @0045                               v13 = uextend.i64 v12
 ;; @0045                               v19 = icmp ugt v18, v13
 ;; @0045                               trapnz v19, user17
-;; @0045                               v36 = load.i64 notrap aligned v7+40
+;; @0045                               v36 = load.i64 notrap aligned region3 v7+40
 ;; @0045                               v24 = iconst.i64 24
 ;; @0045                               v25 = iadd v9, v24  ; v24 = 24
 ;;                                     v43 = iconst.i64 3
@@ -117,28 +123,31 @@
 ;;
 ;; function u0:2(i64 vmctx, i64, i32, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 268435488 "VMStoreContext+0x20"
+;;     region3 = 268435496 "VMStoreContext+0x28"
+;;     region4 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
 ;; @005a                               trapz v2, user16
 ;; @005a                               v7 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @005a                               v8 = load.i64 notrap aligned readonly can_move v7+32
+;; @005a                               v8 = load.i64 notrap aligned readonly can_move region2 v7+32
 ;; @005a                               v6 = uextend.i64 v2
 ;; @005a                               v9 = iadd v8, v6
 ;; @005a                               v10 = iconst.i64 16
 ;; @005a                               v11 = iadd v9, v10  ; v10 = 16
-;; @005a                               v12 = load.i32 user2 readonly region1 v11
+;; @005a                               v12 = load.i32 user2 readonly region4 v11
 ;; @005a                               v14 = uextend.i64 v3
 ;; @005a                               v15 = uextend.i64 v4
 ;; @005a                               v18 = iadd v14, v15
 ;; @005a                               v13 = uextend.i64 v12
 ;; @005a                               v19 = icmp ugt v18, v13
 ;; @005a                               trapnz v19, user17
-;; @005a                               v36 = load.i64 notrap aligned v7+40
+;; @005a                               v36 = load.i64 notrap aligned region3 v7+40
 ;; @005a                               v24 = iconst.i64 24
 ;; @005a                               v25 = iadd v9, v24  ; v24 = 24
 ;;                                     v49 = iconst.i64 3
@@ -158,7 +167,7 @@
 ;;
 ;;                                 block2(v43: i64):
 ;;                                     v54 = f64const 0x1.0000000000000p0
-;; @005a                               store user2 little region1 v54, v43  ; v54 = 0x1.0000000000000p0
+;; @005a                               store user2 little region4 v54, v43  ; v54 = 0x1.0000000000000p0
 ;;                                     v55 = iconst.i64 8
 ;;                                     v56 = iadd v43, v55  ; v55 = 8
 ;; @005a                               v46 = icmp eq v56, v40

--- a/tests/disas/array-fill-funcref.wat
+++ b/tests/disas/array-fill-funcref.wat
@@ -22,10 +22,13 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 268435488 "VMStoreContext+0x20"
+;;     region3 = 268435496 "VMStoreContext+0x28"
+;;     region4 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, i64) -> i64 tail
 ;;     fn0 = colocated u805306368:25 sig0
 ;;     stack_limit = gv2
@@ -33,19 +36,19 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i64, v5: i32):
 ;; @003b                               trapz v2, user16
 ;; @003b                               v7 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @003b                               v8 = load.i64 notrap aligned readonly can_move v7+32
+;; @003b                               v8 = load.i64 notrap aligned readonly can_move region2 v7+32
 ;; @003b                               v6 = uextend.i64 v2
 ;; @003b                               v9 = iadd v8, v6
 ;; @003b                               v10 = iconst.i64 16
 ;; @003b                               v11 = iadd v9, v10  ; v10 = 16
-;; @003b                               v12 = load.i32 user2 readonly region1 v11
+;; @003b                               v12 = load.i32 user2 readonly region4 v11
 ;; @003b                               v14 = uextend.i64 v3
 ;; @003b                               v15 = uextend.i64 v5
 ;; @003b                               v18 = iadd v14, v15
 ;; @003b                               v13 = uextend.i64 v12
 ;; @003b                               v19 = icmp ugt v18, v13
 ;; @003b                               trapnz v19, user17
-;; @003b                               v36 = load.i64 notrap aligned v7+40
+;; @003b                               v36 = load.i64 notrap aligned region3 v7+40
 ;; @003b                               v24 = iconst.i64 20
 ;; @003b                               v25 = iadd v9, v24  ; v24 = 20
 ;;                                     v51 = iconst.i64 2
@@ -80,10 +83,13 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 268435488 "VMStoreContext+0x20"
+;;     region3 = 268435496 "VMStoreContext+0x28"
+;;     region4 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, i64) -> i64 tail
 ;;     fn0 = colocated u805306368:25 sig0
 ;;     stack_limit = gv2
@@ -91,19 +97,19 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
 ;; @0049                               trapz v2, user16
 ;; @0049                               v7 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0049                               v8 = load.i64 notrap aligned readonly can_move v7+32
+;; @0049                               v8 = load.i64 notrap aligned readonly can_move region2 v7+32
 ;; @0049                               v6 = uextend.i64 v2
 ;; @0049                               v9 = iadd v8, v6
 ;; @0049                               v10 = iconst.i64 16
 ;; @0049                               v11 = iadd v9, v10  ; v10 = 16
-;; @0049                               v12 = load.i32 user2 readonly region1 v11
+;; @0049                               v12 = load.i32 user2 readonly region4 v11
 ;; @0049                               v14 = uextend.i64 v3
 ;; @0049                               v15 = uextend.i64 v4
 ;; @0049                               v18 = iadd v14, v15
 ;; @0049                               v13 = uextend.i64 v12
 ;; @0049                               v19 = icmp ugt v18, v13
 ;; @0049                               trapnz v19, user17
-;; @0049                               v36 = load.i64 notrap aligned v7+40
+;; @0049                               v36 = load.i64 notrap aligned region3 v7+40
 ;; @0049                               v24 = iconst.i64 20
 ;; @0049                               v25 = iadd v9, v24  ; v24 = 20
 ;;                                     v50 = iconst.i64 2
@@ -139,10 +145,13 @@
 ;; function u0:2(i64 vmctx, i64, i32, i32, i32) tail {
 ;;     ss0 = explicit_slot 4, align = 4
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 268435488 "VMStoreContext+0x20"
+;;     region3 = 268435496 "VMStoreContext+0x28"
+;;     region4 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, i32) -> i64 tail
 ;;     sig1 = (i64 vmctx, i64) -> i64 tail
 ;;     fn0 = colocated u805306368:6 sig0
@@ -157,19 +166,19 @@
 ;;                                     v55 = load.i32 notrap v56
 ;; @0057                               trapz v55, user16
 ;; @0057                               v8 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0057                               v9 = load.i64 notrap aligned readonly can_move v8+32
+;; @0057                               v9 = load.i64 notrap aligned readonly can_move region2 v8+32
 ;; @0057                               v7 = uextend.i64 v55
 ;; @0057                               v10 = iadd v9, v7
 ;; @0057                               v11 = iconst.i64 16
 ;; @0057                               v12 = iadd v10, v11  ; v11 = 16
-;; @0057                               v13 = load.i32 user2 readonly region1 v12
+;; @0057                               v13 = load.i32 user2 readonly region4 v12
 ;; @0057                               v15 = uextend.i64 v3
 ;; @0057                               v16 = uextend.i64 v4
 ;; @0057                               v19 = iadd v15, v16
 ;; @0057                               v14 = uextend.i64 v13
 ;; @0057                               v20 = icmp ugt v19, v14
 ;; @0057                               trapnz v20, user17
-;; @0057                               v37 = load.i64 notrap aligned v8+40
+;; @0057                               v37 = load.i64 notrap aligned region3 v8+40
 ;; @0057                               v25 = iconst.i64 20
 ;; @0057                               v26 = iadd v10, v25  ; v25 = 20
 ;;                                     v59 = iconst.i64 2
@@ -204,9 +213,10 @@
 ;;
 ;; function u0:3(i64 vmctx, i64) tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):

--- a/tests/disas/array-fill-i16.wat
+++ b/tests/disas/array-fill-i16.wat
@@ -23,28 +23,31 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 268435488 "VMStoreContext+0x20"
+;;     region3 = 268435496 "VMStoreContext+0x28"
+;;     region4 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):
 ;; @0031                               trapz v2, user16
 ;; @0031                               v7 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0031                               v8 = load.i64 notrap aligned readonly can_move v7+32
+;; @0031                               v8 = load.i64 notrap aligned readonly can_move region2 v7+32
 ;; @0031                               v6 = uextend.i64 v2
 ;; @0031                               v9 = iadd v8, v6
 ;; @0031                               v10 = iconst.i64 16
 ;; @0031                               v11 = iadd v9, v10  ; v10 = 16
-;; @0031                               v12 = load.i32 user2 readonly region1 v11
+;; @0031                               v12 = load.i32 user2 readonly region4 v11
 ;; @0031                               v14 = uextend.i64 v3
 ;; @0031                               v15 = uextend.i64 v5
 ;; @0031                               v18 = iadd v14, v15
 ;; @0031                               v13 = uextend.i64 v12
 ;; @0031                               v19 = icmp ugt v18, v13
 ;; @0031                               trapnz v19, user17
-;; @0031                               v36 = load.i64 notrap aligned v7+40
+;; @0031                               v36 = load.i64 notrap aligned region3 v7+40
 ;; @0031                               v24 = iconst.i64 20
 ;; @0031                               v25 = iadd v9, v24  ; v24 = 20
 ;; @0031                               v16 = iconst.i64 1
@@ -62,7 +65,7 @@
 ;; @0031                               brif v42, block3, block2(v29)
 ;;
 ;;                                 block2(v43: i64):
-;; @0031                               istore16.i32 user2 little region1 v4, v43
+;; @0031                               istore16.i32 user2 little region4 v4, v43
 ;;                                     v57 = iconst.i64 2
 ;;                                     v58 = iadd v43, v57  ; v57 = 2
 ;; @0031                               v46 = icmp eq v58, v40
@@ -77,10 +80,13 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 268435488 "VMStoreContext+0x20"
+;;     region3 = 268435496 "VMStoreContext+0x28"
+;;     region4 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, i64, i32, i64) tail
 ;;     fn0 = colocated u805306368:2 sig0
 ;;     stack_limit = gv2
@@ -88,19 +94,19 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
 ;; @003f                               trapz v2, user16
 ;; @003f                               v7 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @003f                               v8 = load.i64 notrap aligned readonly can_move v7+32
+;; @003f                               v8 = load.i64 notrap aligned readonly can_move region2 v7+32
 ;; @003f                               v6 = uextend.i64 v2
 ;; @003f                               v9 = iadd v8, v6
 ;; @003f                               v10 = iconst.i64 16
 ;; @003f                               v11 = iadd v9, v10  ; v10 = 16
-;; @003f                               v12 = load.i32 user2 readonly region1 v11
+;; @003f                               v12 = load.i32 user2 readonly region4 v11
 ;; @003f                               v14 = uextend.i64 v3
 ;; @003f                               v15 = uextend.i64 v4
 ;; @003f                               v18 = iadd v14, v15
 ;; @003f                               v13 = uextend.i64 v12
 ;; @003f                               v19 = icmp ugt v18, v13
 ;; @003f                               trapnz v19, user17
-;; @003f                               v36 = load.i64 notrap aligned v7+40
+;; @003f                               v36 = load.i64 notrap aligned region3 v7+40
 ;; @003f                               v24 = iconst.i64 20
 ;; @003f                               v25 = iadd v9, v24  ; v24 = 20
 ;; @003f                               v16 = iconst.i64 1
@@ -121,10 +127,13 @@
 ;;
 ;; function u0:2(i64 vmctx, i64, i32, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 268435488 "VMStoreContext+0x20"
+;;     region3 = 268435496 "VMStoreContext+0x28"
+;;     region4 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, i64, i32, i64) tail
 ;;     fn0 = colocated u805306368:2 sig0
 ;;     stack_limit = gv2
@@ -132,19 +141,19 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
 ;; @004d                               trapz v2, user16
 ;; @004d                               v7 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @004d                               v8 = load.i64 notrap aligned readonly can_move v7+32
+;; @004d                               v8 = load.i64 notrap aligned readonly can_move region2 v7+32
 ;; @004d                               v6 = uextend.i64 v2
 ;; @004d                               v9 = iadd v8, v6
 ;; @004d                               v10 = iconst.i64 16
 ;; @004d                               v11 = iadd v9, v10  ; v10 = 16
-;; @004d                               v12 = load.i32 user2 readonly region1 v11
+;; @004d                               v12 = load.i32 user2 readonly region4 v11
 ;; @004d                               v14 = uextend.i64 v3
 ;; @004d                               v15 = uextend.i64 v4
 ;; @004d                               v18 = iadd v14, v15
 ;; @004d                               v13 = uextend.i64 v12
 ;; @004d                               v19 = icmp ugt v18, v13
 ;; @004d                               trapnz v19, user17
-;; @004d                               v36 = load.i64 notrap aligned v7+40
+;; @004d                               v36 = load.i64 notrap aligned region3 v7+40
 ;; @004d                               v24 = iconst.i64 20
 ;; @004d                               v25 = iadd v9, v24  ; v24 = 20
 ;; @004d                               v16 = iconst.i64 1
@@ -165,28 +174,31 @@
 ;;
 ;; function u0:3(i64 vmctx, i64, i32, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 268435488 "VMStoreContext+0x20"
+;;     region3 = 268435496 "VMStoreContext+0x28"
+;;     region4 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
 ;; @005d                               trapz v2, user16
 ;; @005d                               v7 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @005d                               v8 = load.i64 notrap aligned readonly can_move v7+32
+;; @005d                               v8 = load.i64 notrap aligned readonly can_move region2 v7+32
 ;; @005d                               v6 = uextend.i64 v2
 ;; @005d                               v9 = iadd v8, v6
 ;; @005d                               v10 = iconst.i64 16
 ;; @005d                               v11 = iadd v9, v10  ; v10 = 16
-;; @005d                               v12 = load.i32 user2 readonly region1 v11
+;; @005d                               v12 = load.i32 user2 readonly region4 v11
 ;; @005d                               v14 = uextend.i64 v3
 ;; @005d                               v15 = uextend.i64 v4
 ;; @005d                               v18 = iadd v14, v15
 ;; @005d                               v13 = uextend.i64 v12
 ;; @005d                               v19 = icmp ugt v18, v13
 ;; @005d                               trapnz v19, user17
-;; @005d                               v36 = load.i64 notrap aligned v7+40
+;; @005d                               v36 = load.i64 notrap aligned region3 v7+40
 ;; @005d                               v24 = iconst.i64 20
 ;; @005d                               v25 = iadd v9, v24  ; v24 = 20
 ;; @005d                               v16 = iconst.i64 1
@@ -206,7 +218,7 @@
 ;;
 ;;                                 block2(v43: i64):
 ;;                                     v57 = iconst.i32 0xdead
-;; @005d                               istore16 user2 little region1 v57, v43  ; v57 = 0xdead
+;; @005d                               istore16 user2 little region4 v57, v43  ; v57 = 0xdead
 ;;                                     v58 = iconst.i64 2
 ;;                                     v59 = iadd v43, v58  ; v58 = 2
 ;; @005d                               v46 = icmp eq v59, v40

--- a/tests/disas/array-fill-i31ref.wat
+++ b/tests/disas/array-fill-i31ref.wat
@@ -19,28 +19,31 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 268435488 "VMStoreContext+0x20"
+;;     region3 = 268435496 "VMStoreContext+0x28"
+;;     region4 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):
 ;; @0030                               trapz v2, user16
 ;; @0030                               v7 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0030                               v8 = load.i64 notrap aligned readonly can_move v7+32
+;; @0030                               v8 = load.i64 notrap aligned readonly can_move region2 v7+32
 ;; @0030                               v6 = uextend.i64 v2
 ;; @0030                               v9 = iadd v8, v6
 ;; @0030                               v10 = iconst.i64 16
 ;; @0030                               v11 = iadd v9, v10  ; v10 = 16
-;; @0030                               v12 = load.i32 user2 readonly region1 v11
+;; @0030                               v12 = load.i32 user2 readonly region4 v11
 ;; @0030                               v14 = uextend.i64 v3
 ;; @0030                               v15 = uextend.i64 v5
 ;; @0030                               v18 = iadd v14, v15
 ;; @0030                               v13 = uextend.i64 v12
 ;; @0030                               v19 = icmp ugt v18, v13
 ;; @0030                               trapnz v19, user17
-;; @0030                               v36 = load.i64 notrap aligned v7+40
+;; @0030                               v36 = load.i64 notrap aligned region3 v7+40
 ;; @0030                               v24 = iconst.i64 20
 ;; @0030                               v25 = iadd v9, v24  ; v24 = 20
 ;;                                     v49 = iconst.i64 2
@@ -58,7 +61,7 @@
 ;; @0030                               brif v42, block3, block2(v29)
 ;;
 ;;                                 block2(v43: i64):
-;; @0030                               store.i32 user2 little region1 v4, v43
+;; @0030                               store.i32 user2 little region4 v4, v43
 ;;                                     v54 = iconst.i64 4
 ;;                                     v55 = iadd v43, v54  ; v54 = 4
 ;; @0030                               v46 = icmp eq v55, v40
@@ -73,28 +76,31 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 268435488 "VMStoreContext+0x20"
+;;     region3 = 268435496 "VMStoreContext+0x28"
+;;     region4 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
 ;; @003e                               trapz v2, user16
 ;; @003e                               v7 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @003e                               v8 = load.i64 notrap aligned readonly can_move v7+32
+;; @003e                               v8 = load.i64 notrap aligned readonly can_move region2 v7+32
 ;; @003e                               v6 = uextend.i64 v2
 ;; @003e                               v9 = iadd v8, v6
 ;; @003e                               v10 = iconst.i64 16
 ;; @003e                               v11 = iadd v9, v10  ; v10 = 16
-;; @003e                               v12 = load.i32 user2 readonly region1 v11
+;; @003e                               v12 = load.i32 user2 readonly region4 v11
 ;; @003e                               v14 = uextend.i64 v3
 ;; @003e                               v15 = uextend.i64 v4
 ;; @003e                               v18 = iadd v14, v15
 ;; @003e                               v13 = uextend.i64 v12
 ;; @003e                               v19 = icmp ugt v18, v13
 ;; @003e                               trapnz v19, user17
-;; @003e                               v36 = load.i64 notrap aligned v7+40
+;; @003e                               v36 = load.i64 notrap aligned region3 v7+40
 ;; @003e                               v24 = iconst.i64 20
 ;; @003e                               v25 = iadd v9, v24  ; v24 = 20
 ;;                                     v49 = iconst.i64 2
@@ -114,7 +120,7 @@
 ;;
 ;;                                 block2(v43: i64):
 ;;                                     v54 = iconst.i32 0
-;; @003e                               store user2 little region1 v54, v43  ; v54 = 0
+;; @003e                               store user2 little region4 v54, v43  ; v54 = 0
 ;;                                     v55 = iconst.i64 4
 ;;                                     v56 = iadd v43, v55  ; v55 = 4
 ;; @003e                               v46 = icmp eq v56, v40
@@ -129,28 +135,31 @@
 ;;
 ;; function u0:2(i64 vmctx, i64, i32, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 268435488 "VMStoreContext+0x20"
+;;     region3 = 268435496 "VMStoreContext+0x28"
+;;     region4 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
 ;; @004e                               trapz v2, user16
 ;; @004e                               v11 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @004e                               v12 = load.i64 notrap aligned readonly can_move v11+32
+;; @004e                               v12 = load.i64 notrap aligned readonly can_move region2 v11+32
 ;; @004e                               v10 = uextend.i64 v2
 ;; @004e                               v13 = iadd v12, v10
 ;; @004e                               v14 = iconst.i64 16
 ;; @004e                               v15 = iadd v13, v14  ; v14 = 16
-;; @004e                               v16 = load.i32 user2 readonly region1 v15
+;; @004e                               v16 = load.i32 user2 readonly region4 v15
 ;; @004e                               v18 = uextend.i64 v3
 ;; @004e                               v19 = uextend.i64 v4
 ;; @004e                               v22 = iadd v18, v19
 ;; @004e                               v17 = uextend.i64 v16
 ;; @004e                               v23 = icmp ugt v22, v17
 ;; @004e                               trapnz v23, user17
-;; @004e                               v40 = load.i64 notrap aligned v11+40
+;; @004e                               v40 = load.i64 notrap aligned region3 v11+40
 ;; @004e                               v28 = iconst.i64 20
 ;; @004e                               v29 = iadd v13, v28  ; v28 = 20
 ;;                                     v59 = iconst.i64 2
@@ -170,7 +179,7 @@
 ;;
 ;;                                 block2(v47: i64):
 ;;                                     v64 = iconst.i32 -1
-;; @004e                               store user2 little region1 v64, v47  ; v64 = -1
+;; @004e                               store user2 little region4 v64, v47  ; v64 = -1
 ;;                                     v65 = iconst.i64 4
 ;;                                     v66 = iadd v47, v65  ; v65 = 4
 ;; @004e                               v50 = icmp eq v66, v44

--- a/tests/disas/array-fill-i32.wat
+++ b/tests/disas/array-fill-i32.wat
@@ -23,28 +23,31 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 268435488 "VMStoreContext+0x20"
+;;     region3 = 268435496 "VMStoreContext+0x28"
+;;     region4 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):
 ;; @0031                               trapz v2, user16
 ;; @0031                               v7 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0031                               v8 = load.i64 notrap aligned readonly can_move v7+32
+;; @0031                               v8 = load.i64 notrap aligned readonly can_move region2 v7+32
 ;; @0031                               v6 = uextend.i64 v2
 ;; @0031                               v9 = iadd v8, v6
 ;; @0031                               v10 = iconst.i64 16
 ;; @0031                               v11 = iadd v9, v10  ; v10 = 16
-;; @0031                               v12 = load.i32 user2 readonly region1 v11
+;; @0031                               v12 = load.i32 user2 readonly region4 v11
 ;; @0031                               v14 = uextend.i64 v3
 ;; @0031                               v15 = uextend.i64 v5
 ;; @0031                               v18 = iadd v14, v15
 ;; @0031                               v13 = uextend.i64 v12
 ;; @0031                               v19 = icmp ugt v18, v13
 ;; @0031                               trapnz v19, user17
-;; @0031                               v36 = load.i64 notrap aligned v7+40
+;; @0031                               v36 = load.i64 notrap aligned region3 v7+40
 ;; @0031                               v24 = iconst.i64 20
 ;; @0031                               v25 = iadd v9, v24  ; v24 = 20
 ;;                                     v49 = iconst.i64 2
@@ -62,7 +65,7 @@
 ;; @0031                               brif v42, block3, block2(v29)
 ;;
 ;;                                 block2(v43: i64):
-;; @0031                               store.i32 user2 little region1 v4, v43
+;; @0031                               store.i32 user2 little region4 v4, v43
 ;;                                     v54 = iconst.i64 4
 ;;                                     v55 = iadd v43, v54  ; v54 = 4
 ;; @0031                               v46 = icmp eq v55, v40
@@ -77,10 +80,13 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 268435488 "VMStoreContext+0x20"
+;;     region3 = 268435496 "VMStoreContext+0x28"
+;;     region4 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, i64, i32, i64) tail
 ;;     fn0 = colocated u805306368:2 sig0
 ;;     stack_limit = gv2
@@ -88,19 +94,19 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
 ;; @003f                               trapz v2, user16
 ;; @003f                               v7 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @003f                               v8 = load.i64 notrap aligned readonly can_move v7+32
+;; @003f                               v8 = load.i64 notrap aligned readonly can_move region2 v7+32
 ;; @003f                               v6 = uextend.i64 v2
 ;; @003f                               v9 = iadd v8, v6
 ;; @003f                               v10 = iconst.i64 16
 ;; @003f                               v11 = iadd v9, v10  ; v10 = 16
-;; @003f                               v12 = load.i32 user2 readonly region1 v11
+;; @003f                               v12 = load.i32 user2 readonly region4 v11
 ;; @003f                               v14 = uextend.i64 v3
 ;; @003f                               v15 = uextend.i64 v4
 ;; @003f                               v18 = iadd v14, v15
 ;; @003f                               v13 = uextend.i64 v12
 ;; @003f                               v19 = icmp ugt v18, v13
 ;; @003f                               trapnz v19, user17
-;; @003f                               v36 = load.i64 notrap aligned v7+40
+;; @003f                               v36 = load.i64 notrap aligned region3 v7+40
 ;; @003f                               v24 = iconst.i64 20
 ;; @003f                               v25 = iadd v9, v24  ; v24 = 20
 ;;                                     v43 = iconst.i64 2
@@ -121,10 +127,13 @@
 ;;
 ;; function u0:2(i64 vmctx, i64, i32, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 268435488 "VMStoreContext+0x20"
+;;     region3 = 268435496 "VMStoreContext+0x28"
+;;     region4 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, i64, i32, i64) tail
 ;;     fn0 = colocated u805306368:2 sig0
 ;;     stack_limit = gv2
@@ -132,19 +141,19 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
 ;; @004d                               trapz v2, user16
 ;; @004d                               v7 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @004d                               v8 = load.i64 notrap aligned readonly can_move v7+32
+;; @004d                               v8 = load.i64 notrap aligned readonly can_move region2 v7+32
 ;; @004d                               v6 = uextend.i64 v2
 ;; @004d                               v9 = iadd v8, v6
 ;; @004d                               v10 = iconst.i64 16
 ;; @004d                               v11 = iadd v9, v10  ; v10 = 16
-;; @004d                               v12 = load.i32 user2 readonly region1 v11
+;; @004d                               v12 = load.i32 user2 readonly region4 v11
 ;; @004d                               v14 = uextend.i64 v3
 ;; @004d                               v15 = uextend.i64 v4
 ;; @004d                               v18 = iadd v14, v15
 ;; @004d                               v13 = uextend.i64 v12
 ;; @004d                               v19 = icmp ugt v18, v13
 ;; @004d                               trapnz v19, user17
-;; @004d                               v36 = load.i64 notrap aligned v7+40
+;; @004d                               v36 = load.i64 notrap aligned region3 v7+40
 ;; @004d                               v24 = iconst.i64 20
 ;; @004d                               v25 = iadd v9, v24  ; v24 = 20
 ;;                                     v43 = iconst.i64 2
@@ -165,28 +174,31 @@
 ;;
 ;; function u0:3(i64 vmctx, i64, i32, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 268435488 "VMStoreContext+0x20"
+;;     region3 = 268435496 "VMStoreContext+0x28"
+;;     region4 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
 ;; @005d                               trapz v2, user16
 ;; @005d                               v7 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @005d                               v8 = load.i64 notrap aligned readonly can_move v7+32
+;; @005d                               v8 = load.i64 notrap aligned readonly can_move region2 v7+32
 ;; @005d                               v6 = uextend.i64 v2
 ;; @005d                               v9 = iadd v8, v6
 ;; @005d                               v10 = iconst.i64 16
 ;; @005d                               v11 = iadd v9, v10  ; v10 = 16
-;; @005d                               v12 = load.i32 user2 readonly region1 v11
+;; @005d                               v12 = load.i32 user2 readonly region4 v11
 ;; @005d                               v14 = uextend.i64 v3
 ;; @005d                               v15 = uextend.i64 v4
 ;; @005d                               v18 = iadd v14, v15
 ;; @005d                               v13 = uextend.i64 v12
 ;; @005d                               v19 = icmp ugt v18, v13
 ;; @005d                               trapnz v19, user17
-;; @005d                               v36 = load.i64 notrap aligned v7+40
+;; @005d                               v36 = load.i64 notrap aligned region3 v7+40
 ;; @005d                               v24 = iconst.i64 20
 ;; @005d                               v25 = iadd v9, v24  ; v24 = 20
 ;;                                     v49 = iconst.i64 2
@@ -206,7 +218,7 @@
 ;;
 ;;                                 block2(v43: i64):
 ;;                                     v54 = iconst.i32 0xdead
-;; @005d                               store user2 little region1 v54, v43  ; v54 = 0xdead
+;; @005d                               store user2 little region4 v54, v43  ; v54 = 0xdead
 ;;                                     v55 = iconst.i64 4
 ;;                                     v56 = iadd v43, v55  ; v55 = 4
 ;; @005d                               v46 = icmp eq v56, v40

--- a/tests/disas/array-fill-i64.wat
+++ b/tests/disas/array-fill-i64.wat
@@ -23,28 +23,31 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 268435488 "VMStoreContext+0x20"
+;;     region3 = 268435496 "VMStoreContext+0x28"
+;;     region4 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i64, v5: i32):
 ;; @0031                               trapz v2, user16
 ;; @0031                               v7 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0031                               v8 = load.i64 notrap aligned readonly can_move v7+32
+;; @0031                               v8 = load.i64 notrap aligned readonly can_move region2 v7+32
 ;; @0031                               v6 = uextend.i64 v2
 ;; @0031                               v9 = iadd v8, v6
 ;; @0031                               v10 = iconst.i64 16
 ;; @0031                               v11 = iadd v9, v10  ; v10 = 16
-;; @0031                               v12 = load.i32 user2 readonly region1 v11
+;; @0031                               v12 = load.i32 user2 readonly region4 v11
 ;; @0031                               v14 = uextend.i64 v3
 ;; @0031                               v15 = uextend.i64 v5
 ;; @0031                               v18 = iadd v14, v15
 ;; @0031                               v13 = uextend.i64 v12
 ;; @0031                               v19 = icmp ugt v18, v13
 ;; @0031                               trapnz v19, user17
-;; @0031                               v36 = load.i64 notrap aligned v7+40
+;; @0031                               v36 = load.i64 notrap aligned region3 v7+40
 ;; @0031                               v24 = iconst.i64 24
 ;; @0031                               v25 = iadd v9, v24  ; v24 = 24
 ;;                                     v49 = iconst.i64 3
@@ -62,7 +65,7 @@
 ;; @0031                               brif v42, block3, block2(v29)
 ;;
 ;;                                 block2(v43: i64):
-;; @0031                               store.i64 user2 little region1 v4, v43
+;; @0031                               store.i64 user2 little region4 v4, v43
 ;;                                     v54 = iconst.i64 8
 ;;                                     v55 = iadd v43, v54  ; v54 = 8
 ;; @0031                               v46 = icmp eq v55, v40
@@ -77,10 +80,13 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 268435488 "VMStoreContext+0x20"
+;;     region3 = 268435496 "VMStoreContext+0x28"
+;;     region4 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, i64, i32, i64) tail
 ;;     fn0 = colocated u805306368:2 sig0
 ;;     stack_limit = gv2
@@ -88,19 +94,19 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
 ;; @003f                               trapz v2, user16
 ;; @003f                               v7 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @003f                               v8 = load.i64 notrap aligned readonly can_move v7+32
+;; @003f                               v8 = load.i64 notrap aligned readonly can_move region2 v7+32
 ;; @003f                               v6 = uextend.i64 v2
 ;; @003f                               v9 = iadd v8, v6
 ;; @003f                               v10 = iconst.i64 16
 ;; @003f                               v11 = iadd v9, v10  ; v10 = 16
-;; @003f                               v12 = load.i32 user2 readonly region1 v11
+;; @003f                               v12 = load.i32 user2 readonly region4 v11
 ;; @003f                               v14 = uextend.i64 v3
 ;; @003f                               v15 = uextend.i64 v4
 ;; @003f                               v18 = iadd v14, v15
 ;; @003f                               v13 = uextend.i64 v12
 ;; @003f                               v19 = icmp ugt v18, v13
 ;; @003f                               trapnz v19, user17
-;; @003f                               v36 = load.i64 notrap aligned v7+40
+;; @003f                               v36 = load.i64 notrap aligned region3 v7+40
 ;; @003f                               v24 = iconst.i64 24
 ;; @003f                               v25 = iadd v9, v24  ; v24 = 24
 ;;                                     v42 = iconst.i64 3
@@ -121,10 +127,13 @@
 ;;
 ;; function u0:2(i64 vmctx, i64, i32, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 268435488 "VMStoreContext+0x20"
+;;     region3 = 268435496 "VMStoreContext+0x28"
+;;     region4 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, i64, i32, i64) tail
 ;;     fn0 = colocated u805306368:2 sig0
 ;;     stack_limit = gv2
@@ -132,19 +141,19 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
 ;; @004d                               trapz v2, user16
 ;; @004d                               v7 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @004d                               v8 = load.i64 notrap aligned readonly can_move v7+32
+;; @004d                               v8 = load.i64 notrap aligned readonly can_move region2 v7+32
 ;; @004d                               v6 = uextend.i64 v2
 ;; @004d                               v9 = iadd v8, v6
 ;; @004d                               v10 = iconst.i64 16
 ;; @004d                               v11 = iadd v9, v10  ; v10 = 16
-;; @004d                               v12 = load.i32 user2 readonly region1 v11
+;; @004d                               v12 = load.i32 user2 readonly region4 v11
 ;; @004d                               v14 = uextend.i64 v3
 ;; @004d                               v15 = uextend.i64 v4
 ;; @004d                               v18 = iadd v14, v15
 ;; @004d                               v13 = uextend.i64 v12
 ;; @004d                               v19 = icmp ugt v18, v13
 ;; @004d                               trapnz v19, user17
-;; @004d                               v36 = load.i64 notrap aligned v7+40
+;; @004d                               v36 = load.i64 notrap aligned region3 v7+40
 ;; @004d                               v24 = iconst.i64 24
 ;; @004d                               v25 = iadd v9, v24  ; v24 = 24
 ;;                                     v43 = iconst.i64 3
@@ -165,28 +174,31 @@
 ;;
 ;; function u0:3(i64 vmctx, i64, i32, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 268435488 "VMStoreContext+0x20"
+;;     region3 = 268435496 "VMStoreContext+0x28"
+;;     region4 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
 ;; @005b                               trapz v2, user16
 ;; @005b                               v7 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @005b                               v8 = load.i64 notrap aligned readonly can_move v7+32
+;; @005b                               v8 = load.i64 notrap aligned readonly can_move region2 v7+32
 ;; @005b                               v6 = uextend.i64 v2
 ;; @005b                               v9 = iadd v8, v6
 ;; @005b                               v10 = iconst.i64 16
 ;; @005b                               v11 = iadd v9, v10  ; v10 = 16
-;; @005b                               v12 = load.i32 user2 readonly region1 v11
+;; @005b                               v12 = load.i32 user2 readonly region4 v11
 ;; @005b                               v14 = uextend.i64 v3
 ;; @005b                               v15 = uextend.i64 v4
 ;; @005b                               v18 = iadd v14, v15
 ;; @005b                               v13 = uextend.i64 v12
 ;; @005b                               v19 = icmp ugt v18, v13
 ;; @005b                               trapnz v19, user17
-;; @005b                               v36 = load.i64 notrap aligned v7+40
+;; @005b                               v36 = load.i64 notrap aligned region3 v7+40
 ;; @005b                               v24 = iconst.i64 24
 ;; @005b                               v25 = iadd v9, v24  ; v24 = 24
 ;;                                     v49 = iconst.i64 3
@@ -206,7 +218,7 @@
 ;;
 ;;                                 block2(v43: i64):
 ;;                                     v54 = iconst.i64 1
-;; @005b                               store user2 little region1 v54, v43  ; v54 = 1
+;; @005b                               store user2 little region4 v54, v43  ; v54 = 1
 ;;                                     v55 = iconst.i64 8
 ;;                                     v56 = iadd v43, v55  ; v55 = 8
 ;; @005b                               v46 = icmp eq v56, v40

--- a/tests/disas/basic-wat-test.wat
+++ b/tests/disas/basic-wat-test.wat
@@ -11,21 +11,22 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0021                               v5 = uextend.i64 v2
 ;; @0021                               v6 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0021                               v7 = iadd v6, v5
-;; @0021                               v8 = load.i32 little region1 v7
+;; @0021                               v8 = load.i32 little region2 v7
 ;; @0026                               v9 = uextend.i64 v3
 ;; @0026                               v10 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0026                               v11 = iadd v10, v9
-;; @0026                               v12 = load.i32 little region1 v11
+;; @0026                               v12 = load.i32 little region2 v11
 ;; @0029                               v13 = iadd v8, v12
 ;; @002a                               jump block1
 ;;

--- a/tests/disas/bounds-check.wat
+++ b/tests/disas/bounds-check.wat
@@ -26,10 +26,11 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -37,17 +38,17 @@
 ;; @002c                               v5 = load.i64 notrap aligned readonly can_move v0+56
 ;; @002c                               v4 = uextend.i64 v2
 ;; @002c                               v6 = iadd v5, v4
-;; @002c                               istore8 little region1 v3, v6  ; v3 = 0
+;; @002c                               istore8 little region2 v3, v6  ; v3 = 0
 ;; @0033                               v11 = iconst.i64 0x07ff_ffff
 ;; @0033                               v12 = iadd v6, v11  ; v11 = 0x07ff_ffff
-;; @0033                               istore8 little region1 v3, v12  ; v3 = 0
+;; @0033                               istore8 little region2 v3, v12  ; v3 = 0
 ;; @003d                               v15 = load.i64 notrap aligned v0+64
 ;; @003d                               v16 = icmp ugt v4, v15
 ;; @003d                               v21 = iconst.i64 0
 ;; @003d                               v19 = iconst.i64 0xffff_ffff
 ;; @003d                               v20 = iadd v6, v19  ; v19 = 0xffff_ffff
 ;; @003d                               v22 = select_spectre_guard v16, v21, v20  ; v21 = 0
-;; @003d                               istore8 little region1 v3, v22  ; v3 = 0
+;; @003d                               istore8 little region2 v3, v22  ; v3 = 0
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/br_table.wat
+++ b/tests/disas/br_table.wat
@@ -33,9 +33,10 @@
 
 ;; function u0:0(i64 vmctx, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
@@ -70,9 +71,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
@@ -107,9 +109,10 @@
 ;;
 ;; function u0:2(i64 vmctx, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
@@ -132,9 +135,10 @@
 ;;
 ;; function u0:3(i64 vmctx, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):

--- a/tests/disas/branch-hinting-disabled.wat
+++ b/tests/disas/branch-hinting-disabled.wat
@@ -29,9 +29,10 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -54,9 +55,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/branch-hinting.wat
+++ b/tests/disas/branch-hinting.wat
@@ -74,9 +74,10 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -96,9 +97,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -118,9 +120,10 @@
 ;;
 ;; function u0:2(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -143,9 +146,10 @@
 ;;
 ;; function u0:3(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -168,10 +172,11 @@
 ;;
 ;; function u0:4(i64 vmctx, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 1879048192 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 1879048192 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -179,12 +184,12 @@
 ;;
 ;;                                 block2:
 ;; @009b                               v3 = iconst.i32 1
-;; @009d                               store notrap aligned region1 v3, v0+48  ; v3 = 1
+;; @009d                               store notrap aligned region2 v3, v0+48  ; v3 = 1
 ;; @009f                               jump block3
 ;;
 ;;                                 block4 cold:
 ;; @00a0                               v4 = iconst.i32 2
-;; @00a2                               store notrap aligned region1 v4, v0+48  ; v4 = 2
+;; @00a2                               store notrap aligned region2 v4, v0+48  ; v4 = 2
 ;; @00a4                               jump block3
 ;;
 ;;                                 block3:

--- a/tests/disas/byteswap.wat
+++ b/tests/disas/byteswap.wat
@@ -73,9 +73,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -88,9 +89,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i64 tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):

--- a/tests/disas/call-indirect-with-gc.wat
+++ b/tests/disas/call-indirect-with-gc.wat
@@ -11,11 +11,12 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 1073741824 "PublicTable"
-;;     region2 = 40 "VMContext+0x28"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 1073741824 "PublicTable"
+;;     region3 = 40 "VMContext+0x28"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, i64, i32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i32, i64) -> i64 tail
 ;;     fn0 = colocated u805306368:7 sig1
@@ -32,7 +33,7 @@
 ;; @0035                               v11 = ishl v8, v10  ; v10 = 3
 ;; @0035                               v12 = iadd v9, v11
 ;; @0035                               v14 = select_spectre_guard v7, v13, v12  ; v13 = 0
-;; @0035                               v15 = load.i64 user6 aligned region1 v14
+;; @0035                               v15 = load.i64 user6 aligned region2 v14
 ;; @0035                               v16 = iconst.i64 -2
 ;; @0035                               v17 = band v15, v16  ; v16 = -2
 ;; @0035                               brif v15, block3(v17), block2
@@ -44,7 +45,7 @@
 ;;
 ;;                                 block3(v18: i64):
 ;; @0035                               v24 = load.i32 user7 aligned readonly v18+16
-;; @0035                               v22 = load.i64 notrap aligned readonly can_move region2 v0+40
+;; @0035                               v22 = load.i64 notrap aligned readonly can_move region3 v0+40
 ;; @0035                               v23 = load.i32 notrap aligned readonly can_move v22+4
 ;; @0035                               v25 = icmp eq v24, v23
 ;; @0035                               trapz v25, user8

--- a/tests/disas/call-indirect-without-gc.wat
+++ b/tests/disas/call-indirect-without-gc.wat
@@ -11,11 +11,12 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 1073741824 "PublicTable"
-;;     region2 = 40 "VMContext+0x28"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 1073741824 "PublicTable"
+;;     region3 = 40 "VMContext+0x28"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, i64, i32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i32, i64) -> i64 tail
 ;;     fn0 = colocated u805306368:7 sig1
@@ -32,7 +33,7 @@
 ;; @0035                               v11 = ishl v8, v10  ; v10 = 3
 ;; @0035                               v12 = iadd v9, v11
 ;; @0035                               v14 = select_spectre_guard v7, v13, v12  ; v13 = 0
-;; @0035                               v15 = load.i64 user6 aligned region1 v14
+;; @0035                               v15 = load.i64 user6 aligned region2 v14
 ;; @0035                               v16 = iconst.i64 -2
 ;; @0035                               v17 = band v15, v16  ; v16 = -2
 ;; @0035                               brif v15, block3(v17), block2
@@ -44,7 +45,7 @@
 ;;
 ;;                                 block3(v18: i64):
 ;; @0035                               v24 = load.i32 user7 aligned readonly v18+16
-;; @0035                               v22 = load.i64 notrap aligned readonly can_move region2 v0+40
+;; @0035                               v22 = load.i64 notrap aligned readonly can_move region3 v0+40
 ;; @0035                               v23 = load.i32 notrap aligned readonly can_move v22+4
 ;; @0035                               v25 = icmp eq v24, v23
 ;; @0035                               trapz v25, user8

--- a/tests/disas/call-indirect.wat
+++ b/tests/disas/call-indirect.wat
@@ -9,11 +9,12 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 1073741824 "PublicTable"
-;;     region2 = 40 "VMContext+0x28"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 1073741824 "PublicTable"
+;;     region3 = 40 "VMContext+0x28"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, i64, i32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i32, i64) -> i64 tail
 ;;     fn0 = colocated u805306368:7 sig1
@@ -30,7 +31,7 @@
 ;; @0035                               v12 = iadd v9, v11
 ;; @0035                               v13 = iconst.i64 0
 ;; @0035                               v14 = select_spectre_guard v7, v13, v12  ; v13 = 0
-;; @0035                               v15 = load.i64 user6 aligned region1 v14
+;; @0035                               v15 = load.i64 user6 aligned region2 v14
 ;; @0035                               v16 = iconst.i64 -2
 ;; @0035                               v17 = band v15, v16  ; v16 = -2
 ;; @0035                               brif v15, block3(v17), block2
@@ -42,7 +43,7 @@
 ;; @0035                               jump block3(v21)
 ;;
 ;;                                 block3(v18: i64):
-;; @0035                               v22 = load.i64 notrap aligned readonly can_move region2 v0+40
+;; @0035                               v22 = load.i64 notrap aligned readonly can_move region3 v0+40
 ;; @0035                               v23 = load.i32 notrap aligned readonly can_move v22+4
 ;; @0035                               v24 = load.i32 user7 aligned readonly v18+16
 ;; @0035                               v25 = icmp eq v24, v23

--- a/tests/disas/call-simd.wat
+++ b/tests/disas/call-simd.wat
@@ -17,9 +17,10 @@
 
 ;; function u0:0(i64 vmctx, i64) tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, i64, i8x16, i8x16) -> i8x16 tail
 ;;     fn0 = colocated u0:1 sig0
 ;;     const0 = 0x00000004000000030000000200000001
@@ -37,9 +38,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i8x16, i8x16) -> i8x16 tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16, v3: i8x16):

--- a/tests/disas/call.wat
+++ b/tests/disas/call.wat
@@ -13,9 +13,10 @@
 
 ;; function u0:0(i64 vmctx, i64) tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, i64) -> i32 tail
 ;;     fn0 = colocated u0:1 sig0
 ;;     stack_limit = gv2
@@ -32,9 +33,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):

--- a/tests/disas/component-model/checked-intrinsics-inlined-no-spectre.wat
+++ b/tests/disas/component-model/checked-intrinsics-inlined-no-spectre.wat
@@ -49,13 +49,14 @@
 )
 ;; function u0:0(i64 vmctx, i64, i64, i64) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 72 "VMContext+0x48"
-;;     region2 = 268435560 "VMStoreContext+0x68"
-;;     region3 = 104 "VMContext+0x68"
-;;     region4 = 136 "VMContext+0x88"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 72 "VMContext+0x48"
+;;     region3 = 268435560 "VMStoreContext+0x68"
+;;     region4 = 104 "VMContext+0x68"
+;;     region5 = 136 "VMContext+0x88"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, i64) -> i64 tail
 ;;     sig1 = (i64 vmctx, i64, i64, i64, i64) -> i32 tail
 ;;     sig2 = (i64 vmctx, i64, i64, i64, i64, i32) tail
@@ -71,7 +72,7 @@
 ;; @01b0                               v13 = bor v11, v12
 ;; @01b0                               trapnz v13, heap_oob
 ;; @01aa                               v6 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @01aa                               v7 = load.i64 notrap aligned readonly can_move region2 v6+104
+;; @01aa                               v7 = load.i64 notrap aligned readonly can_move region3 v6+104
 ;; @01b0                               v14 = iadd v7, v2
 ;; @01b0                               v15 = load.i32 notrap aligned v14
 ;; @01bf                               v23, v24 = uadd_overflow v2, v9  ; v9 = 4

--- a/tests/disas/component-model/checked-intrinsics-inlined.wat
+++ b/tests/disas/component-model/checked-intrinsics-inlined.wat
@@ -50,13 +50,14 @@
 )
 ;; function u0:0(i64 vmctx, i64, i64, i64) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 72 "VMContext+0x48"
-;;     region2 = 268435560 "VMStoreContext+0x68"
-;;     region3 = 104 "VMContext+0x68"
-;;     region4 = 136 "VMContext+0x88"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 72 "VMContext+0x48"
+;;     region3 = 268435560 "VMStoreContext+0x68"
+;;     region4 = 104 "VMContext+0x68"
+;;     region5 = 136 "VMContext+0x88"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, i64) -> i64 tail
 ;;     sig1 = (i64 vmctx, i64, i64, i64, i64) -> i32 tail
 ;;     sig2 = (i64 vmctx, i64, i64, i64, i64, i32) tail
@@ -72,7 +73,7 @@
 ;; @01b0                               v13 = bor v11, v12
 ;; @01b0                               v15 = iconst.i64 0
 ;; @01aa                               v6 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @01aa                               v7 = load.i64 notrap aligned readonly can_move region2 v6+104
+;; @01aa                               v7 = load.i64 notrap aligned readonly can_move region3 v6+104
 ;; @01b0                               v14 = iadd v7, v2
 ;; @01b0                               v16 = select_spectre_guard v13, v15, v14  ; v15 = 0
 ;; @01b0                               trapz v16, heap_oob

--- a/tests/disas/component-model/direct-adapter-calls-inlining.wat
+++ b/tests/disas/component-model/direct-adapter-calls-inlining.wat
@@ -56,21 +56,22 @@
 
 ;; function u1:0(i64 vmctx, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 72 "VMContext+0x48"
-;;     region2 = 136 "VMContext+0x88"
-;;     region3 = 1610612736 "PublicGlobal"
-;;     region4 = 104 "VMContext+0x68"
-;;     region5 = 88 "VMContext+0x58"
-;;     region6 = 112 "VMContext+0x70"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 72 "VMContext+0x48"
+;;     region3 = 136 "VMContext+0x88"
+;;     region4 = 1610612736 "PublicGlobal"
+;;     region5 = 104 "VMContext+0x68"
+;;     region6 = 88 "VMContext+0x58"
+;;     region7 = 112 "VMContext+0x70"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned gv4+24
+;;     gv5 = load.i64 notrap aligned region1 gv4+24
 ;;     gv6 = vmctx
 ;;     gv7 = load.i64 notrap aligned readonly can_move region0 gv6+8
-;;     gv8 = load.i64 notrap aligned gv7+24
+;;     gv8 = load.i64 notrap aligned region1 gv7+24
 ;;     sig0 = (i64 vmctx, i64, i32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i64, i32) tail
 ;;     sig2 = (i64 vmctx, i64, i32) -> i32 tail
@@ -88,9 +89,9 @@
 ;;                                     jump block5
 ;;
 ;;                                 block6:
-;; @00ee                               v4 = load.i64 notrap aligned readonly can_move region1 v0+72
-;;                                     v14 = load.i64 notrap aligned readonly can_move region2 v4+136
-;;                                     v15 = load.i32 notrap aligned region3 v14
+;; @00ee                               v4 = load.i64 notrap aligned readonly can_move region2 v0+72
+;;                                     v14 = load.i64 notrap aligned readonly can_move region3 v4+136
+;;                                     v15 = load.i32 notrap aligned region4 v14
 ;;                                     v16 = iconst.i32 1
 ;;                                     v17 = band v15, v16  ; v16 = 1
 ;;                                     v13 = iconst.i32 0
@@ -98,8 +99,8 @@
 ;;                                     brif v19, block9, block10
 ;;
 ;;                                 block9:
-;;                                     v23 = load.i64 notrap aligned readonly can_move region5 v4+88
-;;                                     v22 = load.i64 notrap aligned readonly can_move region4 v4+104
+;;                                     v23 = load.i64 notrap aligned readonly can_move region6 v4+88
+;;                                     v22 = load.i64 notrap aligned readonly can_move region5 v4+104
 ;;                                     v21 = iconst.i32 23
 ;;                                     try_call_indirect v23(v22, v4, v21), sig1, block11, [ context v4, default: block8(exn0) ]  ; v21 = 23
 ;;
@@ -107,14 +108,14 @@
 ;;                                     trap user12
 ;;
 ;;                                 block10:
-;;                                     v28 = load.i64 notrap aligned readonly can_move region6 v4+112
-;;                                     v29 = load.i32 notrap aligned region3 v28
+;;                                     v28 = load.i64 notrap aligned readonly can_move region7 v4+112
+;;                                     v29 = load.i32 notrap aligned region4 v28
 ;;                                     v30 = iconst.i32 -2
 ;;                                     v31 = band v29, v30  ; v30 = -2
-;;                                     store notrap aligned region3 v31, v28
+;;                                     store notrap aligned region4 v31, v28
 ;;                                     v61 = iconst.i32 1
 ;;                                     v62 = bor v29, v61  ; v61 = 1
-;;                                     store notrap aligned region3 v62, v28
+;;                                     store notrap aligned region4 v62, v28
 ;;                                     jump block13
 ;;
 ;;                                 block13:
@@ -124,13 +125,13 @@
 ;;                                     jump block12
 ;;
 ;;                                 block12:
-;;                                     v42 = load.i32 notrap aligned region3 v14
+;;                                     v42 = load.i32 notrap aligned region4 v14
 ;;                                     v63 = iconst.i32 -2
 ;;                                     v64 = band v42, v63  ; v63 = -2
-;;                                     store notrap aligned region3 v64, v14
+;;                                     store notrap aligned region4 v64, v14
 ;;                                     v65 = iconst.i32 1
 ;;                                     v66 = bor v42, v65  ; v65 = 1
-;;                                     store notrap aligned region3 v66, v14
+;;                                     store notrap aligned region4 v66, v14
 ;;                                     jump block7
 ;;
 ;;                                 block7:

--- a/tests/disas/component-model/direct-adapter-calls.wat
+++ b/tests/disas/component-model/direct-adapter-calls.wat
@@ -59,9 +59,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -75,16 +76,17 @@
 ;;
 ;; function u1:0(i64 vmctx, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 72 "VMContext+0x48"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 72 "VMContext+0x48"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, i64, i32) -> i32 tail
 ;;     fn0 = colocated u2:0 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @00ee                               v4 = load.i64 notrap aligned readonly can_move region1 v0+72
+;; @00ee                               v4 = load.i64 notrap aligned readonly can_move region2 v0+72
 ;; @00eb                               v3 = iconst.i32 1234
 ;; @00ee                               v5 = call fn0(v4, v0, v3)  ; v3 = 1234
 ;; @00f0                               jump block1
@@ -95,15 +97,16 @@
 ;;
 ;; function u2:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 136 "VMContext+0x88"
-;;     region2 = 1610612736 "PublicGlobal"
-;;     region3 = 104 "VMContext+0x68"
-;;     region4 = 88 "VMContext+0x58"
-;;     region5 = 112 "VMContext+0x70"
-;;     region6 = 72 "VMContext+0x48"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 136 "VMContext+0x88"
+;;     region3 = 1610612736 "PublicGlobal"
+;;     region4 = 104 "VMContext+0x68"
+;;     region5 = 88 "VMContext+0x58"
+;;     region6 = 112 "VMContext+0x70"
+;;     region7 = 72 "VMContext+0x48"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, i64, i32) tail
 ;;     sig1 = (i64 vmctx, i64, i32) -> i32 tail
 ;;     fn0 = colocated u0:0 sig1
@@ -116,8 +119,8 @@
 ;; @007b                               jump block3
 ;;
 ;;                                 block4:
-;; @0080                               v9 = load.i64 notrap aligned readonly can_move region1 v0+136
-;; @0080                               v10 = load.i32 notrap aligned region2 v9
+;; @0080                               v9 = load.i64 notrap aligned readonly can_move region2 v0+136
+;; @0080                               v10 = load.i32 notrap aligned region3 v9
 ;; @0082                               v11 = iconst.i32 1
 ;; @0084                               v12 = band v10, v11  ; v11 = 1
 ;; @0075                               v4 = iconst.i32 0
@@ -125,8 +128,8 @@
 ;; @0086                               brif v14, block7, block8
 ;;
 ;;                                 block7:
-;; @008a                               v18 = load.i64 notrap aligned readonly can_move region4 v0+88
-;; @008a                               v17 = load.i64 notrap aligned readonly can_move region3 v0+104
+;; @008a                               v18 = load.i64 notrap aligned readonly can_move region5 v0+88
+;; @008a                               v17 = load.i64 notrap aligned readonly can_move region4 v0+104
 ;; @0088                               v16 = iconst.i32 23
 ;; @008a                               try_call_indirect v18(v17, v0, v16), sig0, block9, [ context v0, default: block6(exn0) ]  ; v16 = 23
 ;;
@@ -134,33 +137,33 @@
 ;; @008c                               trap user12
 ;;
 ;;                                 block8:
-;; @008e                               v19 = load.i64 notrap aligned readonly can_move region5 v0+112
-;; @008e                               v20 = load.i32 notrap aligned region2 v19
+;; @008e                               v19 = load.i64 notrap aligned readonly can_move region6 v0+112
+;; @008e                               v20 = load.i32 notrap aligned region3 v19
 ;; @0090                               v21 = iconst.i32 -2
 ;; @0092                               v22 = band v20, v21  ; v21 = -2
-;; @0093                               store notrap aligned region2 v22, v19
+;; @0093                               store notrap aligned region3 v22, v19
 ;;                                     v48 = iconst.i32 1
 ;;                                     v49 = bor v20, v48  ; v48 = 1
-;; @009c                               store notrap aligned region2 v49, v19
-;; @009e                               v29 = load.i64 notrap aligned readonly can_move region6 v0+72
+;; @009c                               store notrap aligned region3 v49, v19
+;; @009e                               v29 = load.i64 notrap aligned readonly can_move region7 v0+72
 ;; @009e                               try_call fn0(v29, v0, v2), sig1, block10(ret0), [ context v0, default: block6(exn0) ]
 ;;
 ;;                                 block10(v30: i32):
-;; @00a2                               v32 = load.i32 notrap aligned region2 v9
+;; @00a2                               v32 = load.i32 notrap aligned region3 v9
 ;;                                     v50 = iconst.i32 -2
 ;;                                     v51 = band v32, v50  ; v50 = -2
-;; @00a7                               store notrap aligned region2 v51, v9
+;; @00a7                               store notrap aligned region3 v51, v9
 ;;                                     v52 = iconst.i32 1
 ;;                                     v53 = bor v32, v52  ; v52 = 1
-;; @00b0                               store notrap aligned region2 v53, v9
+;; @00b0                               store notrap aligned region3 v53, v9
 ;; @00b2                               jump block5(v30)
 ;;
 ;;                                 block5(v6: i32):
 ;; @00b3                               jump block2(v6)
 ;;
 ;;                                 block3:
-;;                                     v54 = load.i64 notrap aligned readonly can_move region4 v0+88
-;;                                     v55 = load.i64 notrap aligned readonly can_move region3 v0+104
+;;                                     v54 = load.i64 notrap aligned readonly can_move region5 v0+88
+;;                                     v55 = load.i64 notrap aligned readonly can_move region4 v0+104
 ;; @00b6                               v41 = iconst.i32 49
 ;; @00b8                               call_indirect sig0, v54(v55, v0, v41)  ; v41 = 49
 ;; @00ba                               trap user12

--- a/tests/disas/component-model/exported-module-makes-adapters-indirect.wat
+++ b/tests/disas/component-model/exported-module-makes-adapters-indirect.wat
@@ -60,17 +60,18 @@
 
 ;; function u1:0(i64 vmctx, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 72 "VMContext+0x48"
-;;     region2 = 56 "VMContext+0x38"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 72 "VMContext+0x48"
+;;     region3 = 56 "VMContext+0x38"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, i64, i32) -> i32 tail
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @00ee                               v5 = load.i64 notrap aligned readonly can_move region2 v0+56
-;; @00ee                               v4 = load.i64 notrap aligned readonly can_move region1 v0+72
+;; @00ee                               v5 = load.i64 notrap aligned readonly can_move region3 v0+56
+;; @00ee                               v4 = load.i64 notrap aligned readonly can_move region2 v0+72
 ;; @00eb                               v3 = iconst.i32 1234
 ;; @00ee                               v6 = call_indirect sig0, v5(v4, v0, v3)  ; v3 = 1234
 ;; @00f0                               jump block1

--- a/tests/disas/component-model/inlining-and-unsafe-intrinsics.wat
+++ b/tests/disas/component-model/inlining-and-unsafe-intrinsics.wat
@@ -44,13 +44,14 @@
 
 ;; function u0:0(i64 vmctx, i64) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 72 "VMContext+0x48"
-;;     region2 = 268435560 "VMStoreContext+0x68"
-;;     region3 = 104 "VMContext+0x68"
-;;     region4 = 136 "VMContext+0x88"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 72 "VMContext+0x48"
+;;     region3 = 268435560 "VMStoreContext+0x68"
+;;     region4 = 104 "VMContext+0x68"
+;;     region5 = 136 "VMContext+0x88"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, i64) -> i64 tail
 ;;     sig1 = (i64 vmctx, i64, i64) -> i32 tail
 ;;     sig2 = (i64 vmctx, i64, i64, i32) tail
@@ -61,7 +62,7 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64):
 ;; @0153                               v4 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0153                               v5 = load.i64 notrap aligned readonly can_move region2 v4+104
+;; @0153                               v5 = load.i64 notrap aligned readonly can_move region3 v4+104
 ;; @0155                               v7 = load.i8 notrap aligned v5
 ;;                                     v18 = iconst.i8 1
 ;;                                     v19 = iadd v7, v18  ; v18 = 1

--- a/tests/disas/component-model/inlining-bug.wat
+++ b/tests/disas/component-model/inlining-bug.wat
@@ -36,17 +36,18 @@
 
 ;; function u2:0(i64 vmctx, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 72 "VMContext+0x48"
-;;     region2 = 104 "VMContext+0x68"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 72 "VMContext+0x48"
+;;     region3 = 104 "VMContext+0x68"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned gv4+24
+;;     gv5 = load.i64 notrap aligned region1 gv4+24
 ;;     gv6 = vmctx
 ;;     gv7 = load.i64 notrap aligned readonly can_move region0 gv6+8
-;;     gv8 = load.i64 notrap aligned gv7+24
+;;     gv8 = load.i64 notrap aligned region1 gv7+24
 ;;     sig0 = (i64 vmctx, i64) -> i32 tail
 ;;     sig1 = (i64 vmctx, i64) -> i32 tail
 ;;     sig2 = (i64 vmctx, i64) tail
@@ -62,8 +63,8 @@
 ;;                                     jump block4
 ;;
 ;;                                 block4:
-;; @00d4                               v3 = load.i64 notrap aligned readonly can_move region1 v0+72
-;;                                     v9 = load.i64 notrap aligned readonly can_move region2 v3+104
+;; @00d4                               v3 = load.i64 notrap aligned readonly can_move region2 v0+72
+;;                                     v9 = load.i64 notrap aligned readonly can_move region3 v3+104
 ;;                                     call fn2(v9, v9)
 ;;                                     jump block5
 ;;

--- a/tests/disas/component-model/inlining-fuzz-bug.wat
+++ b/tests/disas/component-model/inlining-fuzz-bug.wat
@@ -39,20 +39,21 @@
 
 ;; function u2:0(i64 vmctx, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 72 "VMContext+0x48"
-;;     region2 = 104 "VMContext+0x68"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 72 "VMContext+0x48"
+;;     region3 = 104 "VMContext+0x68"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned gv4+24
+;;     gv5 = load.i64 notrap aligned region1 gv4+24
 ;;     gv6 = vmctx
 ;;     gv7 = load.i64 notrap aligned readonly can_move region0 gv6+8
-;;     gv8 = load.i64 notrap aligned gv7+24
+;;     gv8 = load.i64 notrap aligned region1 gv7+24
 ;;     gv9 = vmctx
 ;;     gv10 = load.i64 notrap aligned readonly can_move region0 gv9+8
-;;     gv11 = load.i64 notrap aligned gv10+24
+;;     gv11 = load.i64 notrap aligned region1 gv10+24
 ;;     sig0 = (i64 vmctx, i64) -> i32 tail
 ;;     sig1 = (i64 vmctx, i64) -> i32 tail
 ;;     fn0 = colocated u1:0 sig0

--- a/tests/disas/component-model/issue-11458.wat
+++ b/tests/disas/component-model/issue-11458.wat
@@ -21,13 +21,14 @@
 
 ;; function u1:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 72 "VMContext+0x48"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 72 "VMContext+0x48"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned gv4+24
+;;     gv5 = load.i64 notrap aligned region1 gv4+24
 ;;     sig0 = (i64 vmctx, i64, i32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i64, i32) -> i32 tail
 ;;     fn0 = colocated u0:0 sig0
@@ -38,7 +39,7 @@
 ;; @006f                               jump block2
 ;;
 ;;                                 block2:
-;; @006f                               v5 = load.i64 notrap aligned readonly can_move region1 v0+72
+;; @006f                               v5 = load.i64 notrap aligned readonly can_move region2 v0+72
 ;;                                     v9 = iconst.i32 1
 ;;                                     v11 = call fn1(v5, v5, v9)  ; v9 = 1
 ;;                                     jump block4

--- a/tests/disas/component-model/multiple-instantiations-makes-adapters-indirect.wat
+++ b/tests/disas/component-model/multiple-instantiations-makes-adapters-indirect.wat
@@ -66,17 +66,18 @@
 
 ;; function u1:0(i64 vmctx, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 72 "VMContext+0x48"
-;;     region2 = 56 "VMContext+0x38"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 72 "VMContext+0x48"
+;;     region3 = 56 "VMContext+0x38"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, i64, i32) -> i32 tail
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @00ee                               v5 = load.i64 notrap aligned readonly can_move region2 v0+56
-;; @00ee                               v4 = load.i64 notrap aligned readonly can_move region1 v0+72
+;; @00ee                               v5 = load.i64 notrap aligned readonly can_move region3 v0+56
+;; @00ee                               v4 = load.i64 notrap aligned readonly can_move region2 v0+72
 ;; @00eb                               v3 = iconst.i32 1234
 ;; @00ee                               v6 = call_indirect sig0, v5(v4, v0, v3)  ; v3 = 1234
 ;; @00f0                               jump block1

--- a/tests/disas/conditional-traps.wat
+++ b/tests/disas/conditional-traps.wat
@@ -23,9 +23,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -41,9 +42,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/dead-code.wat
+++ b/tests/disas/dead-code.wat
@@ -23,9 +23,10 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -49,9 +50,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -63,9 +65,10 @@
 ;;
 ;; function u0:2(i64 vmctx, i64) tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
@@ -77,9 +80,10 @@
 ;;
 ;; function u0:3(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/duplicate-function-types.wat
+++ b/tests/disas/duplicate-function-types.wat
@@ -18,31 +18,32 @@
 
 ;; function u0:0(i64 vmctx, i64, i32) -> i32, i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 48 "VMContext+0x30"
-;;     region2 = 1073741824 "PublicTable"
-;;     region3 = 40 "VMContext+0x28"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 48 "VMContext+0x30"
+;;     region3 = 1073741824 "PublicTable"
+;;     region4 = 40 "VMContext+0x28"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, i64) -> i32 tail
 ;;     sig1 = (i64 vmctx, i32, i64) -> i64 tail
 ;;     fn0 = colocated u805306368:7 sig1
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @002d                               v5 = load.i64 notrap aligned readonly can_move region1 v0+48
+;; @002d                               v5 = load.i64 notrap aligned readonly can_move region2 v0+48
 ;; @002d                               v6 = load.i64 notrap aligned v5+8
 ;; @002d                               v7 = ireduce.i32 v6
 ;; @002d                               v8 = icmp uge v2, v7
 ;; @002d                               v9 = uextend.i64 v2
-;; @002d                               v10 = load.i64 notrap aligned readonly can_move region1 v0+48
+;; @002d                               v10 = load.i64 notrap aligned readonly can_move region2 v0+48
 ;; @002d                               v11 = load.i64 notrap aligned v10
 ;; @002d                               v12 = iconst.i64 3
 ;; @002d                               v13 = ishl v9, v12  ; v12 = 3
 ;; @002d                               v14 = iadd v11, v13
 ;; @002d                               v15 = iconst.i64 0
 ;; @002d                               v16 = select_spectre_guard v8, v15, v14  ; v15 = 0
-;; @002d                               v17 = load.i64 user6 aligned region2 v16
+;; @002d                               v17 = load.i64 user6 aligned region3 v16
 ;; @002d                               v18 = iconst.i64 -2
 ;; @002d                               v19 = band v17, v18  ; v18 = -2
 ;; @002d                               brif v17, block3(v19), block2
@@ -54,7 +55,7 @@
 ;; @002d                               jump block3(v23)
 ;;
 ;;                                 block3(v20: i64):
-;; @002d                               v24 = load.i64 notrap aligned readonly can_move region3 v0+40
+;; @002d                               v24 = load.i64 notrap aligned readonly can_move region4 v0+40
 ;; @002d                               v25 = load.i32 notrap aligned readonly can_move v24
 ;; @002d                               v26 = load.i32 user7 aligned readonly v20+16
 ;; @002d                               v27 = icmp eq v26, v25
@@ -63,19 +64,19 @@
 ;; @002d                               v29 = load.i64 notrap aligned readonly v20+8
 ;; @002d                               v30 = load.i64 notrap aligned readonly v20+24
 ;; @002d                               v31 = call_indirect sig0, v29(v30, v0)
-;; @0032                               v33 = load.i64 notrap aligned readonly can_move region1 v0+48
+;; @0032                               v33 = load.i64 notrap aligned readonly can_move region2 v0+48
 ;; @0032                               v34 = load.i64 notrap aligned v33+8
 ;; @0032                               v35 = ireduce.i32 v34
 ;; @0032                               v36 = icmp.i32 uge v2, v35
 ;; @0032                               v37 = uextend.i64 v2
-;; @0032                               v38 = load.i64 notrap aligned readonly can_move region1 v0+48
+;; @0032                               v38 = load.i64 notrap aligned readonly can_move region2 v0+48
 ;; @0032                               v39 = load.i64 notrap aligned v38
 ;; @0032                               v40 = iconst.i64 3
 ;; @0032                               v41 = ishl v37, v40  ; v40 = 3
 ;; @0032                               v42 = iadd v39, v41
 ;; @0032                               v43 = iconst.i64 0
 ;; @0032                               v44 = select_spectre_guard v36, v43, v42  ; v43 = 0
-;; @0032                               v45 = load.i64 user6 aligned region2 v44
+;; @0032                               v45 = load.i64 user6 aligned region3 v44
 ;; @0032                               v46 = iconst.i64 -2
 ;; @0032                               v47 = band v45, v46  ; v46 = -2
 ;; @0032                               brif v45, block5(v47), block4
@@ -87,7 +88,7 @@
 ;; @0032                               jump block5(v51)
 ;;
 ;;                                 block5(v48: i64):
-;; @0032                               v52 = load.i64 notrap aligned readonly can_move region3 v0+40
+;; @0032                               v52 = load.i64 notrap aligned readonly can_move region4 v0+40
 ;; @0032                               v53 = load.i32 notrap aligned readonly can_move v52
 ;; @0032                               v54 = load.i32 user7 aligned readonly v48+16
 ;; @0032                               v55 = icmp eq v54, v53

--- a/tests/disas/duplicate-loads-dynamic-memory.wat
+++ b/tests/disas/duplicate-loads-dynamic-memory.wat
@@ -24,10 +24,11 @@
 
 ;; function u0:0(i64 vmctx, i64, i32) -> i32, i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 536870912 "PublicMemory"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 536870912 "PublicMemory"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -38,7 +39,7 @@
 ;; @0057                               v10 = iconst.i64 0
 ;; @0057                               v9 = iadd v8, v5
 ;; @0057                               v11 = select_spectre_guard v7, v10, v9  ; v10 = 0
-;; @0057                               v12 = load.i32 little region1 v11
+;; @0057                               v12 = load.i32 little region2 v11
 ;; @005f                               jump block1
 ;;
 ;;                                 block1:
@@ -47,10 +48,11 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32, i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 536870912 "PublicMemory"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 536870912 "PublicMemory"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -63,7 +65,7 @@
 ;; @0064                               v10 = iconst.i64 1234
 ;; @0064                               v11 = iadd v9, v10  ; v10 = 1234
 ;; @0064                               v13 = select_spectre_guard v7, v12, v11  ; v12 = 0
-;; @0064                               v14 = load.i32 little region1 v13
+;; @0064                               v14 = load.i32 little region2 v13
 ;; @006e                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/duplicate-loads-static-memory.wat
+++ b/tests/disas/duplicate-loads-static-memory.wat
@@ -19,17 +19,18 @@
 
 ;; function u0:0(i64 vmctx, i64, i32) -> i32, i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 536870912 "PublicMemory"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 536870912 "PublicMemory"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0057                               v6 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0057                               v5 = uextend.i64 v2
 ;; @0057                               v7 = iadd v6, v5
-;; @0057                               v8 = load.i32 little region1 v7
+;; @0057                               v8 = load.i32 little region2 v7
 ;; @005f                               jump block1
 ;;
 ;;                                 block1:
@@ -38,10 +39,11 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32, i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 536870912 "PublicMemory"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 536870912 "PublicMemory"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -50,7 +52,7 @@
 ;; @0064                               v7 = iadd v6, v5
 ;; @0064                               v8 = iconst.i64 1234
 ;; @0064                               v9 = iadd v7, v8  ; v8 = 1234
-;; @0064                               v10 = load.i32 little region1 v9
+;; @0064                               v10 = load.i32 little region2 v9
 ;; @006e                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/dynamic-memory-no-spectre-access-same-index-different-offsets.wat
+++ b/tests/disas/dynamic-memory-no-spectre-access-same-index-different-offsets.wat
@@ -37,10 +37,11 @@
 
 ;; function u0:0(i64 vmctx, i64, i32) -> i32, i32, i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 536870912 "PublicMemory"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 536870912 "PublicMemory"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -50,17 +51,17 @@
 ;; @0047                               trapnz v8, heap_oob
 ;; @0047                               v9 = load.i64 notrap aligned can_move v0+56
 ;; @0047                               v10 = iadd v9, v6
-;; @0047                               v11 = load.i32 little region1 v10
+;; @0047                               v11 = load.i32 little region2 v10
 ;; @004c                               v17 = iconst.i64 4
 ;; @004c                               v18 = iadd v10, v17  ; v17 = 4
-;; @004c                               v19 = load.i32 little region1 v18
+;; @004c                               v19 = load.i32 little region2 v18
 ;; @0051                               v21 = iconst.i64 0x0010_0003
 ;; @0051                               v22 = uadd_overflow_trap v6, v21, heap_oob  ; v21 = 0x0010_0003
 ;; @0051                               v24 = icmp ugt v22, v7
 ;; @0051                               trapnz v24, heap_oob
 ;; @0051                               v27 = iconst.i64 0x000f_ffff
 ;; @0051                               v28 = iadd v10, v27  ; v27 = 0x000f_ffff
-;; @0051                               v29 = load.i32 little region1 v28
+;; @0051                               v29 = load.i32 little region2 v28
 ;; @0056                               jump block1
 ;;
 ;;                                 block1:
@@ -69,10 +70,11 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32, i32, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 536870912 "PublicMemory"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 536870912 "PublicMemory"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):
@@ -82,17 +84,17 @@
 ;; @005d                               trapnz v8, heap_oob
 ;; @005d                               v9 = load.i64 notrap aligned can_move v0+56
 ;; @005d                               v10 = iadd v9, v6
-;; @005d                               store little region1 v3, v10
+;; @005d                               store little region2 v3, v10
 ;; @0064                               v16 = iconst.i64 4
 ;; @0064                               v17 = iadd v10, v16  ; v16 = 4
-;; @0064                               store little region1 v4, v17
+;; @0064                               store little region2 v4, v17
 ;; @006b                               v19 = iconst.i64 0x0010_0003
 ;; @006b                               v20 = uadd_overflow_trap v6, v19, heap_oob  ; v19 = 0x0010_0003
 ;; @006b                               v22 = icmp ugt v20, v7
 ;; @006b                               trapnz v22, heap_oob
 ;; @006b                               v25 = iconst.i64 0x000f_ffff
 ;; @006b                               v26 = iadd v10, v25  ; v25 = 0x000f_ffff
-;; @006b                               store little region1 v5, v26
+;; @006b                               store little region2 v5, v26
 ;; @0070                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/dynamic-memory-yes-spectre-access-same-index-different-offsets.wat
+++ b/tests/disas/dynamic-memory-yes-spectre-access-same-index-different-offsets.wat
@@ -33,10 +33,11 @@
 
 ;; function u0:0(i64 vmctx, i64, i32) -> i32, i32, i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 536870912 "PublicMemory"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 536870912 "PublicMemory"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -47,18 +48,18 @@
 ;; @0047                               v11 = iconst.i64 0
 ;; @0047                               v10 = iadd v9, v6
 ;; @0047                               v12 = select_spectre_guard v8, v11, v10  ; v11 = 0
-;; @0047                               v13 = load.i32 little region1 v12
+;; @0047                               v13 = load.i32 little region2 v12
 ;; @004c                               v19 = iconst.i64 4
 ;; @004c                               v20 = iadd v10, v19  ; v19 = 4
 ;; @004c                               v22 = select_spectre_guard v8, v11, v20  ; v11 = 0
-;; @004c                               v23 = load.i32 little region1 v22
+;; @004c                               v23 = load.i32 little region2 v22
 ;; @0051                               v25 = iconst.i64 0x0010_0003
 ;; @0051                               v26 = uadd_overflow_trap v6, v25, heap_oob  ; v25 = 0x0010_0003
 ;; @0051                               v28 = icmp ugt v26, v7
 ;; @0051                               v31 = iconst.i64 0x000f_ffff
 ;; @0051                               v32 = iadd v10, v31  ; v31 = 0x000f_ffff
 ;; @0051                               v34 = select_spectre_guard v28, v11, v32  ; v11 = 0
-;; @0051                               v35 = load.i32 little region1 v34
+;; @0051                               v35 = load.i32 little region2 v34
 ;; @0056                               jump block1
 ;;
 ;;                                 block1:
@@ -67,10 +68,11 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32, i32, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 536870912 "PublicMemory"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 536870912 "PublicMemory"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):
@@ -81,18 +83,18 @@
 ;; @005d                               v11 = iconst.i64 0
 ;; @005d                               v10 = iadd v9, v6
 ;; @005d                               v12 = select_spectre_guard v8, v11, v10  ; v11 = 0
-;; @005d                               store little region1 v3, v12
+;; @005d                               store little region2 v3, v12
 ;; @0064                               v18 = iconst.i64 4
 ;; @0064                               v19 = iadd v10, v18  ; v18 = 4
 ;; @0064                               v21 = select_spectre_guard v8, v11, v19  ; v11 = 0
-;; @0064                               store little region1 v4, v21
+;; @0064                               store little region2 v4, v21
 ;; @006b                               v23 = iconst.i64 0x0010_0003
 ;; @006b                               v24 = uadd_overflow_trap v6, v23, heap_oob  ; v23 = 0x0010_0003
 ;; @006b                               v26 = icmp ugt v24, v7
 ;; @006b                               v29 = iconst.i64 0x000f_ffff
 ;; @006b                               v30 = iadd v10, v29  ; v29 = 0x000f_ffff
 ;; @006b                               v32 = select_spectre_guard v26, v11, v30  ; v11 = 0
-;; @006b                               store little region1 v5, v32
+;; @006b                               store little region2 v5, v32
 ;; @0070                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/epoch-interruption.wat
+++ b/tests/disas/epoch-interruption.wat
@@ -6,19 +6,21 @@
 
 ;; function u0:0(i64 vmctx, i64) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 24 "VMContext+0x18"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 24 "VMContext+0x18"
+;;     region3 = 268435464 "VMStoreContext+0x8"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx) -> i64 tail
 ;;     fn0 = colocated u805306368:13 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @0016                               v2 = load.i64 notrap aligned region1 v0+24
+;; @0016                               v2 = load.i64 notrap aligned region2 v0+24
 ;; @0016                               v3 = load.i64 notrap aligned v2
 ;; @0016                               v4 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0016                               v5 = load.i64 notrap aligned v4+8
+;; @0016                               v5 = load.i64 notrap aligned region3 v4+8
 ;; @0016                               v6 = icmp uge v3, v5
 ;; @0016                               brif v6, block3, block2(v5)
 ;;
@@ -35,7 +37,7 @@
 ;; @0017                               brif v11, block7, block6(v10)
 ;;
 ;;                                 block7 cold:
-;; @0017                               v13 = load.i64 notrap aligned v4+8
+;; @0017                               v13 = load.i64 notrap aligned region3 v4+8
 ;; @0017                               v14 = icmp.i64 uge v9, v13
 ;; @0017                               brif v14, block8, block6(v13)
 ;;

--- a/tests/disas/f32-load.wat
+++ b/tests/disas/f32-load.wat
@@ -8,17 +8,18 @@
 
 ;; function u0:0(i64 vmctx, i64, i32) -> f32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @002e                               v4 = uextend.i64 v2
 ;; @002e                               v5 = load.i64 notrap aligned readonly can_move v0+56
 ;; @002e                               v6 = iadd v5, v4
-;; @002e                               v7 = load.f32 little region1 v6
+;; @002e                               v7 = load.f32 little region2 v6
 ;; @0031                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/f32-store.wat
+++ b/tests/disas/f32-store.wat
@@ -11,17 +11,18 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, f32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: f32):
 ;; @0031                               v4 = uextend.i64 v2
 ;; @0031                               v5 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0031                               v6 = iadd v5, v4
-;; @0031                               store little region1 v3, v6
+;; @0031                               store little region2 v3, v6
 ;; @0034                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/f64-load.wat
+++ b/tests/disas/f64-load.wat
@@ -10,17 +10,18 @@
 
 ;; function u0:0(i64 vmctx, i64, i32) -> f64 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @002e                               v4 = uextend.i64 v2
 ;; @002e                               v5 = load.i64 notrap aligned readonly can_move v0+56
 ;; @002e                               v6 = iadd v5, v4
-;; @002e                               v7 = load.f64 little region1 v6
+;; @002e                               v7 = load.f64 little region2 v6
 ;; @0031                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/f64-store.wat
+++ b/tests/disas/f64-store.wat
@@ -11,17 +11,18 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, f64) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: f64):
 ;; @0031                               v4 = uextend.i64 v2
 ;; @0031                               v5 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0031                               v6 = iadd v5, v4
-;; @0031                               store little region1 v3, v6
+;; @0031                               store little region2 v3, v6
 ;; @0034                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/fac-multi-value.wat
+++ b/tests/disas/fac-multi-value.wat
@@ -22,9 +22,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i64) -> i64, i64 tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
@@ -36,9 +37,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i64, i64) -> i64, i64, i64 tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i64):
@@ -50,9 +52,10 @@
 ;;
 ;; function u0:2(i64 vmctx, i64, i64) -> i64 tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, i64, i64, i64) -> i64, i64, i64 tail
 ;;     sig1 = (i64 vmctx, i64, i64) -> i64, i64 tail
 ;;     fn0 = colocated u0:1 sig0

--- a/tests/disas/fibonacci.wat
+++ b/tests/disas/fibonacci.wat
@@ -25,10 +25,11 @@
 
 ;; function u0:0(i64 vmctx, i64) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
@@ -56,7 +57,7 @@
 ;; @005a                               v17 = uextend.i64 v16  ; v16 = 0
 ;; @005a                               v18 = load.i64 notrap aligned readonly can_move v0+56
 ;; @005a                               v19 = iadd v18, v17
-;; @005a                               store.i32 little region1 v11, v19
+;; @005a                               store.i32 little region2 v11, v19
 ;; @005d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/fixed-size-memory.wat
+++ b/tests/disas/fixed-size-memory.wat
@@ -22,10 +22,11 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -35,7 +36,7 @@
 ;; @0041                               trapnz v6, heap_oob
 ;; @0041                               v7 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0041                               v8 = iadd v7, v4
-;; @0041                               istore8 little region1 v3, v8
+;; @0041                               istore8 little region2 v3, v8
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -44,10 +45,11 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -57,7 +59,7 @@
 ;; @0049                               trapnz v6, heap_oob
 ;; @0049                               v7 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0049                               v8 = iadd v7, v4
-;; @0049                               v9 = uload8.i32 little region1 v8
+;; @0049                               v9 = uload8.i32 little region2 v8
 ;; @004c                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/foo.wat
+++ b/tests/disas/foo.wat
@@ -16,13 +16,14 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32) -> i32, i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
-;;     region2 = 72 "VMContext+0x48"
-;;     region3 = 1073741824 "PublicTable"
-;;     region4 = 40 "VMContext+0x28"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region3 = 72 "VMContext+0x48"
+;;     region4 = 1073741824 "PublicTable"
+;;     region5 = 40 "VMContext+0x28"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, i64, i32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i32, i64) -> i64 tail
 ;;     fn0 = colocated u805306368:7 sig1
@@ -32,8 +33,8 @@
 ;; @0040                               v7 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0040                               v6 = uextend.i64 v3
 ;; @0040                               v8 = iadd v7, v6
-;; @0040                               v9 = load.i32 little region1 v8
-;; @0043                               v10 = load.i64 notrap aligned readonly can_move region2 v0+72
+;; @0040                               v9 = load.i32 little region2 v8
+;; @0043                               v10 = load.i64 notrap aligned readonly can_move region3 v0+72
 ;; @0043                               v11 = load.i64 notrap aligned v10+8
 ;; @0043                               v16 = load.i64 notrap aligned v10
 ;; @0043                               v12 = ireduce.i32 v11
@@ -44,7 +45,7 @@
 ;; @0043                               v18 = ishl v14, v17  ; v17 = 3
 ;; @0043                               v19 = iadd v16, v18
 ;; @0043                               v21 = select_spectre_guard v13, v20, v19  ; v20 = 0
-;; @0043                               v22 = load.i64 user6 aligned region3 v21
+;; @0043                               v22 = load.i64 user6 aligned region4 v21
 ;; @0043                               v23 = iconst.i64 -2
 ;; @0043                               v24 = band v22, v23  ; v23 = -2
 ;; @0043                               brif v22, block3(v24), block2
@@ -56,14 +57,14 @@
 ;;
 ;;                                 block3(v25: i64):
 ;; @0043                               v31 = load.i32 user7 aligned readonly v25+16
-;; @0043                               v29 = load.i64 notrap aligned readonly can_move region4 v0+40
+;; @0043                               v29 = load.i64 notrap aligned readonly can_move region5 v0+40
 ;; @0043                               v30 = load.i32 notrap aligned readonly can_move v29+4
 ;; @0043                               v32 = icmp eq v31, v30
 ;; @0043                               trapz v32, user8
 ;; @0043                               v34 = load.i64 notrap aligned readonly v25+8
 ;; @0043                               v35 = load.i64 notrap aligned readonly v25+24
 ;; @0043                               v36 = call_indirect sig0, v34(v35, v0, v2)
-;; @004a                               v42 = load.i32 little region1 v8
+;; @004a                               v42 = load.i32 little region2 v8
 ;; @004d                               v44 = load.i64 notrap aligned v10+8
 ;; @004d                               v49 = load.i64 notrap aligned v10
 ;; @004d                               v45 = ireduce.i32 v44
@@ -74,7 +75,7 @@
 ;; @004d                               v52 = iadd v49, v71
 ;;                                     v72 = iconst.i64 0
 ;;                                     v73 = select_spectre_guard v46, v72, v52  ; v72 = 0
-;; @004d                               v55 = load.i64 user6 aligned region3 v73
+;; @004d                               v55 = load.i64 user6 aligned region4 v73
 ;;                                     v74 = iconst.i64 -2
 ;;                                     v75 = band v55, v74  ; v74 = -2
 ;; @004d                               brif v55, block5(v75), block4

--- a/tests/disas/gc/array-copy-with-fuel.wat
+++ b/tests/disas/gc/array-copy-with-fuel.wat
@@ -13,10 +13,14 @@
 ;;     ss0 = explicit_slot 4, align = 4
 ;;     ss1 = explicit_slot 4, align = 4
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 268435456 "VMStoreContext+0x0"
+;;     region3 = 268435488 "VMStoreContext+0x20"
+;;     region4 = 268435496 "VMStoreContext+0x28"
+;;     region5 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx) -> i8 tail
 ;;     fn0 = colocated u805306368:12 sig0
 ;;     stack_limit = gv2
@@ -27,7 +31,7 @@
 ;;                                     v182 = stack_addr.i64 ss1
 ;;                                     store notrap v4, v182
 ;; @0020                               v7 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0020                               v8 = load.i64 notrap aligned v7
+;; @0020                               v8 = load.i64 notrap aligned region2 v7
 ;; @0020                               v9 = iconst.i64 1
 ;; @0020                               v10 = iadd v8, v9  ; v9 = 1
 ;; @0020                               v11 = iconst.i64 0
@@ -36,20 +40,20 @@
 ;;
 ;;                                 block2:
 ;;                                     v191 = iadd.i64 v8, v9  ; v9 = 1
-;; @0020                               store notrap aligned v191, v7
+;; @0020                               store notrap aligned region2 v191, v7
 ;; @0020                               v14 = call fn0(v0), stack_map=[i32 @ ss0+0, i32 @ ss1+0]
-;; @0020                               v16 = load.i64 notrap aligned v7
+;; @0020                               v16 = load.i64 notrap aligned region2 v7
 ;; @0020                               jump block3(v16)
 ;;
 ;;                                 block3(v89: i64):
 ;;                                     v180 = load.i32 notrap v181
 ;; @002b                               trapz v180, user16
-;; @002b                               v24 = load.i64 notrap aligned readonly can_move v7+32
+;; @002b                               v24 = load.i64 notrap aligned readonly can_move region3 v7+32
 ;; @002b                               v22 = uextend.i64 v180
 ;; @002b                               v25 = iadd v24, v22
 ;; @002b                               v26 = iconst.i64 16
 ;; @002b                               v27 = iadd v25, v26  ; v26 = 16
-;; @002b                               v28 = load.i32 user2 readonly region1 v27
+;; @002b                               v28 = load.i32 user2 readonly region5 v27
 ;; @002b                               v30 = uextend.i64 v3
 ;; @002b                               v31 = uextend.i64 v6
 ;; @002b                               v34 = iadd v30, v31
@@ -61,13 +65,13 @@
 ;; @002b                               v46 = uextend.i64 v174
 ;; @002b                               v49 = iadd v24, v46
 ;; @002b                               v51 = iadd v49, v26  ; v26 = 16
-;; @002b                               v52 = load.i32 user2 readonly region1 v51
+;; @002b                               v52 = load.i32 user2 readonly region5 v51
 ;; @002b                               v54 = uextend.i64 v5
 ;; @002b                               v58 = iadd v54, v31
 ;; @002b                               v53 = uextend.i64 v52
 ;; @002b                               v59 = icmp ugt v58, v53
 ;; @002b                               trapnz v59, user17
-;; @002b                               v78 = load.i64 notrap aligned v7+40
+;; @002b                               v78 = load.i64 notrap aligned region4 v7+40
 ;; @002b                               v40 = iconst.i64 20
 ;; @002b                               v41 = iadd v25, v40  ; v40 = 20
 ;;                                     v184 = iconst.i64 2
@@ -122,14 +126,14 @@
 ;; @002f                               jump block1
 ;;
 ;;                                 block8:
-;; @002b                               store.i64 notrap aligned v203, v7
+;; @002b                               store.i64 notrap aligned region2 v203, v7
 ;; @002b                               v112 = call fn0(v0), stack_map=[i32 @ ss0+0, i32 @ ss1+0]
-;; @002b                               v114 = load.i64 notrap aligned v7
+;; @002b                               v114 = load.i64 notrap aligned region2 v7
 ;; @002b                               jump block9(v114)
 ;;
 ;;                                 block9(v145: i64):
-;; @002b                               v115 = load.i32 user2 little region1 v102
-;; @002b                               store user2 little region1 v115, v101
+;; @002b                               v115 = load.i32 user2 little region5 v102
+;; @002b                               store user2 little region5 v115, v101
 ;;                                     v150 = load.i32 notrap v181
 ;;                                     v152 = load.i32 notrap v182
 ;;                                     v206 = iconst.i64 4
@@ -141,17 +145,17 @@
 ;; @002b                               brif v122, block7(v145), block5(v208, v207, v210, v150, v152, v145)
 ;;
 ;;                                 block10:
-;; @002b                               store.i64 notrap aligned v194, v7
+;; @002b                               store.i64 notrap aligned region2 v194, v7
 ;; @002b                               v134 = call fn0(v0), stack_map=[i32 @ ss1+0, i32 @ ss0+0]
-;; @002b                               v136 = load.i64 notrap aligned v7
+;; @002b                               v136 = load.i64 notrap aligned region2 v7
 ;; @002b                               jump block11(v136)
 ;;
 ;;                                 block11(v146: i64):
 ;;                                     v197 = iconst.i64 4
 ;;                                     v198 = isub.i64 v124, v197  ; v197 = 4
-;; @002b                               v143 = load.i32 user2 little region1 v198
+;; @002b                               v143 = load.i32 user2 little region5 v198
 ;;                                     v199 = isub.i64 v123, v197  ; v197 = 4
-;; @002b                               store user2 little region1 v143, v199
+;; @002b                               store user2 little region5 v143, v199
 ;;                                     v156 = load.i32 notrap v182
 ;;                                     v158 = load.i32 notrap v181
 ;; @002b                               v144 = icmp eq v198, v69
@@ -160,6 +164,6 @@
 ;; @002b                               brif v144, block7(v146), block6(v199, v198, v201, v156, v158, v146)
 ;;
 ;;                                 block1:
-;; @002f                               store.i64 notrap aligned v148, v7
+;; @002f                               store.i64 notrap aligned region2 v148, v7
 ;; @002f                               return
 ;; }

--- a/tests/disas/gc/array-fill-i8.wat
+++ b/tests/disas/gc/array-fill-i8.wat
@@ -11,10 +11,13 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 268435488 "VMStoreContext+0x20"
+;;     region3 = 268435496 "VMStoreContext+0x28"
+;;     region4 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, i64, i32, i64) tail
 ;;     fn0 = colocated u805306368:2 sig0
 ;;     stack_limit = gv2
@@ -22,19 +25,19 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):
 ;; @0027                               trapz v2, user16
 ;; @0027                               v7 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0027                               v8 = load.i64 notrap aligned readonly can_move v7+32
+;; @0027                               v8 = load.i64 notrap aligned readonly can_move region2 v7+32
 ;; @0027                               v6 = uextend.i64 v2
 ;; @0027                               v9 = iadd v8, v6
 ;; @0027                               v10 = iconst.i64 16
 ;; @0027                               v11 = iadd v9, v10  ; v10 = 16
-;; @0027                               v12 = load.i32 user2 readonly region1 v11
+;; @0027                               v12 = load.i32 user2 readonly region4 v11
 ;; @0027                               v14 = uextend.i64 v3
 ;; @0027                               v15 = uextend.i64 v5
 ;; @0027                               v18 = iadd v14, v15
 ;; @0027                               v13 = uextend.i64 v12
 ;; @0027                               v19 = icmp ugt v18, v13
 ;; @0027                               trapnz v19, user17
-;; @0027                               v36 = load.i64 notrap aligned v7+40
+;; @0027                               v36 = load.i64 notrap aligned region3 v7+40
 ;; @0027                               v24 = iconst.i64 20
 ;; @0027                               v25 = iadd v9, v24  ; v24 = 20
 ;; @0027                               v29 = iadd v25, v14

--- a/tests/disas/gc/array-init-data.wat
+++ b/tests/disas/gc/array-init-data.wat
@@ -15,12 +15,15 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 2147483648 "GcHeap"
-;;     region2 = 56 "VMContext+0x38"
-;;     region3 = 48 "VMContext+0x30"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 268435488 "VMStoreContext+0x20"
+;;     region3 = 268435496 "VMStoreContext+0x28"
+;;     region4 = 2147483648 "GcHeap"
+;;     region5 = 56 "VMContext+0x38"
+;;     region6 = 48 "VMContext+0x30"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, i64, i64, i64) tail
 ;;     fn0 = colocated u805306368:1 sig0
 ;;     stack_limit = gv2
@@ -28,26 +31,26 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):
 ;; @002a                               trapz v2, user16
 ;; @002a                               v7 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @002a                               v8 = load.i64 notrap aligned readonly can_move v7+32
+;; @002a                               v8 = load.i64 notrap aligned readonly can_move region2 v7+32
 ;; @002a                               v6 = uextend.i64 v2
 ;; @002a                               v9 = iadd v8, v6
 ;; @002a                               v10 = iconst.i64 16
 ;; @002a                               v11 = iadd v9, v10  ; v10 = 16
-;; @002a                               v12 = load.i32 user2 readonly region1 v11
+;; @002a                               v12 = load.i32 user2 readonly region4 v11
 ;; @002a                               v14 = uextend.i64 v3
 ;; @002a                               v15 = uextend.i64 v5
 ;; @002a                               v18 = iadd v14, v15
 ;; @002a                               v13 = uextend.i64 v12
 ;; @002a                               v19 = icmp ugt v18, v13
 ;; @002a                               trapnz v19, user17
-;; @002a                               v30 = load.i32 notrap aligned region2 v0+56
+;; @002a                               v30 = load.i32 notrap aligned region5 v0+56
 ;; @002a                               v32 = uextend.i64 v4
 ;; @002a                               v36 = iadd v32, v15
 ;; @002a                               v31 = uextend.i64 v30
 ;; @002a                               v37 = icmp ugt v36, v31
 ;; @002a                               trapnz v37, heap_oob
-;; @002a                               v38 = load.i64 notrap aligned region3 v0+48
-;; @002a                               v49 = load.i64 notrap aligned v7+40
+;; @002a                               v38 = load.i64 notrap aligned region6 v0+48
+;; @002a                               v49 = load.i64 notrap aligned region3 v7+40
 ;; @002a                               v24 = iconst.i64 20
 ;; @002a                               v25 = iadd v9, v24  ; v24 = 20
 ;; @002a                               v29 = iadd v25, v14

--- a/tests/disas/gc/array-new-data.wat
+++ b/tests/disas/gc/array-new-data.wat
@@ -78,14 +78,17 @@
 ;; function u0:0(i64 vmctx, i64, i32, i32) -> i32 tail {
 ;;     ss0 = explicit_slot 4, align = 4
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 56 "VMContext+0x38"
-;;     region2 = 48 "VMContext+0x30"
-;;     region3 = 32 "VMContext+0x20"
-;;     region4 = 40 "VMContext+0x28"
-;;     region5 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 56 "VMContext+0x38"
+;;     region3 = 48 "VMContext+0x30"
+;;     region4 = 32 "VMContext+0x20"
+;;     region5 = 40 "VMContext+0x28"
+;;     region6 = 268435488 "VMStoreContext+0x20"
+;;     region7 = 2147483648 "GcHeap"
+;;     region8 = 268435496 "VMStoreContext+0x28"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i64, i64, i64) tail
 ;;     fn0 = colocated u805306368:24 sig0
@@ -93,20 +96,20 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
-;; @0025                               v5 = load.i32 notrap aligned region1 v0+56
+;; @0025                               v5 = load.i32 notrap aligned region2 v0+56
 ;; @0025                               v7 = uextend.i64 v2
 ;; @0025                               v8 = uextend.i64 v3
 ;; @0025                               v11 = iadd v7, v8
 ;; @0025                               v6 = uextend.i64 v5
 ;; @0025                               v12 = icmp ugt v11, v6
 ;; @0025                               trapnz v12, heap_oob
-;; @0025                               v13 = load.i64 notrap aligned region2 v0+48
+;; @0025                               v13 = load.i64 notrap aligned region3 v0+48
 ;; @0025                               v20 = iconst.i64 32
 ;; @0025                               v21 = ushr v8, v20  ; v20 = 32
 ;; @0025                               trapnz v21, user18
 ;; @0025                               v16 = iconst.i32 20
 ;; @0025                               v23 = uadd_overflow_trap v16, v3, user18  ; v16 = 20
-;; @0025                               v24 = load.i64 notrap aligned readonly can_move region3 v0+32
+;; @0025                               v24 = load.i64 notrap aligned readonly can_move region4 v0+32
 ;; @0025                               v25 = load.i32 notrap aligned v24
 ;; @0025                               v26 = load.i32 notrap aligned v24+4
 ;; @0025                               v32 = uextend.i64 v25
@@ -129,10 +132,10 @@
 ;; @0025                               store notrap aligned v128, v24
 ;;                                     v142 = iconst.i32 -1476395002
 ;;                                     v143 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v144 = load.i64 notrap aligned readonly can_move v143+32
+;;                                     v144 = load.i64 notrap aligned readonly can_move region6 v143+32
 ;; @0025                               v49 = iadd v144, v32
 ;; @0025                               store notrap aligned v142, v49  ; v142 = -1476395002
-;;                                     v145 = load.i64 notrap aligned readonly can_move region4 v0+40
+;;                                     v145 = load.i64 notrap aligned readonly can_move region5 v0+40
 ;;                                     v146 = load.i32 notrap aligned readonly can_move v145
 ;; @0025                               store notrap aligned v146, v49+4
 ;;                                     v147 = band.i64 v30, v29  ; v29 = -16
@@ -141,12 +144,12 @@
 ;;
 ;;                                 block3 cold:
 ;; @0025                               v36 = iconst.i32 -1476395002
-;; @0025                               v37 = load.i64 notrap aligned readonly can_move region4 v0+40
+;; @0025                               v37 = load.i64 notrap aligned readonly can_move region5 v0+40
 ;; @0025                               v38 = load.i32 notrap aligned readonly can_move v37
 ;; @0025                               v39 = iconst.i32 16
 ;; @0025                               v40 = call fn0(v0, v36, v38, v23, v39)  ; v36 = -1476395002, v39 = 16
 ;; @0025                               v41 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0025                               v42 = load.i64 notrap aligned readonly can_move v41+32
+;; @0025                               v42 = load.i64 notrap aligned readonly can_move region6 v41+32
 ;; @0025                               v43 = uextend.i64 v40
 ;; @0025                               v44 = iadd v42, v43
 ;; @0025                               jump block4(v40, v44)
@@ -156,23 +159,23 @@
 ;;                                     store notrap v53, v113
 ;; @0025                               v55 = iconst.i64 16
 ;; @0025                               v56 = iadd v54, v55  ; v55 = 16
-;; @0025                               store.i32 user2 region5 v3, v56
+;; @0025                               store.i32 user2 region7 v3, v56
 ;; @0025                               trapz v53, user16
 ;;                                     v148 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v149 = load.i64 notrap aligned readonly can_move v148+32
+;;                                     v149 = load.i64 notrap aligned readonly can_move region6 v148+32
 ;; @0025                               v58 = uextend.i64 v53
 ;; @0025                               v61 = iadd v149, v58
 ;; @0025                               v63 = iadd v61, v55  ; v55 = 16
-;; @0025                               v64 = load.i32 user2 readonly region5 v63
+;; @0025                               v64 = load.i32 user2 readonly region7 v63
 ;; @0025                               v65 = uextend.i64 v64
 ;; @0025                               v71 = icmp.i64 ugt v8, v65
 ;; @0025                               trapnz v71, user17
-;; @0025                               v82 = load.i32 notrap aligned region1 v0+56
+;; @0025                               v82 = load.i32 notrap aligned region2 v0+56
 ;; @0025                               v83 = uextend.i64 v82
 ;; @0025                               v89 = icmp.i64 ugt v11, v83
 ;; @0025                               trapnz v89, heap_oob
-;; @0025                               v90 = load.i64 notrap aligned region2 v0+48
-;; @0025                               v101 = load.i64 notrap aligned v148+40
+;; @0025                               v90 = load.i64 notrap aligned region3 v0+48
+;; @0025                               v101 = load.i64 notrap aligned region8 v148+40
 ;; @0025                               v76 = iconst.i64 20
 ;; @0025                               v77 = iadd v61, v76  ; v76 = 20
 ;; @0025                               v103 = uadd_overflow_trap v77, v8, user2

--- a/tests/disas/gc/array-new-default-anyref.wat
+++ b/tests/disas/gc/array-new-default-anyref.wat
@@ -11,12 +11,15 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 32 "VMContext+0x20"
-;;     region2 = 40 "VMContext+0x28"
-;;     region3 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 32 "VMContext+0x20"
+;;     region3 = 40 "VMContext+0x28"
+;;     region4 = 268435488 "VMStoreContext+0x20"
+;;     region5 = 2147483648 "GcHeap"
+;;     region6 = 268435496 "VMStoreContext+0x28"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
 ;;     fn0 = colocated u805306368:24 sig0
 ;;     stack_limit = gv2
@@ -32,7 +35,7 @@
 ;;                                     v95 = iconst.i32 2
 ;;                                     v96 = ishl v2, v95  ; v95 = 2
 ;; @001f                               v11 = uadd_overflow_trap v4, v96, user18  ; v4 = 20
-;; @001f                               v12 = load.i64 notrap aligned readonly can_move region1 v0+32
+;; @001f                               v12 = load.i64 notrap aligned readonly can_move region2 v0+32
 ;; @001f                               v13 = load.i32 notrap aligned v12
 ;; @001f                               v14 = load.i32 notrap aligned v12+4
 ;; @001f                               v20 = uextend.i64 v13
@@ -55,10 +58,10 @@
 ;; @001f                               store notrap aligned v111, v12
 ;;                                     v127 = iconst.i32 -1476394994
 ;;                                     v128 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v129 = load.i64 notrap aligned readonly can_move v128+32
+;;                                     v129 = load.i64 notrap aligned readonly can_move region4 v128+32
 ;; @001f                               v37 = iadd v129, v20
 ;; @001f                               store notrap aligned v127, v37  ; v127 = -1476394994
-;;                                     v130 = load.i64 notrap aligned readonly can_move region2 v0+40
+;;                                     v130 = load.i64 notrap aligned readonly can_move region3 v0+40
 ;;                                     v131 = load.i32 notrap aligned readonly can_move v130
 ;; @001f                               store notrap aligned v131, v37+4
 ;;                                     v132 = band.i64 v18, v17  ; v17 = -16
@@ -67,12 +70,12 @@
 ;;
 ;;                                 block3 cold:
 ;; @001f                               v24 = iconst.i32 -1476394994
-;; @001f                               v25 = load.i64 notrap aligned readonly can_move region2 v0+40
+;; @001f                               v25 = load.i64 notrap aligned readonly can_move region3 v0+40
 ;; @001f                               v26 = load.i32 notrap aligned readonly can_move v25
 ;; @001f                               v27 = iconst.i32 16
 ;; @001f                               v28 = call fn0(v0, v24, v26, v11, v27)  ; v24 = -1476394994, v27 = 16
 ;; @001f                               v29 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @001f                               v30 = load.i64 notrap aligned readonly can_move v29+32
+;; @001f                               v30 = load.i64 notrap aligned readonly can_move region4 v29+32
 ;; @001f                               v31 = uextend.i64 v28
 ;; @001f                               v32 = iadd v30, v31
 ;; @001f                               jump block4(v28, v32)
@@ -80,18 +83,18 @@
 ;;                                 block4(v41: i32, v42: i64):
 ;; @001f                               v43 = iconst.i64 16
 ;; @001f                               v44 = iadd v42, v43  ; v43 = 16
-;; @001f                               store.i32 user2 region3 v2, v44
+;; @001f                               store.i32 user2 region5 v2, v44
 ;; @001f                               trapz v41, user16
 ;;                                     v133 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v134 = load.i64 notrap aligned readonly can_move v133+32
+;;                                     v134 = load.i64 notrap aligned readonly can_move region4 v133+32
 ;; @001f                               v47 = uextend.i64 v41
 ;; @001f                               v50 = iadd v134, v47
 ;; @001f                               v52 = iadd v50, v43  ; v43 = 16
-;; @001f                               v53 = load.i32 user2 readonly region3 v52
+;; @001f                               v53 = load.i32 user2 readonly region5 v52
 ;; @001f                               v54 = uextend.i64 v53
 ;; @001f                               v60 = icmp.i64 ugt v5, v54
 ;; @001f                               trapnz v60, user17
-;; @001f                               v77 = load.i64 notrap aligned v133+40
+;; @001f                               v77 = load.i64 notrap aligned region6 v133+40
 ;; @001f                               v65 = iconst.i64 20
 ;; @001f                               v66 = iadd v50, v65  ; v65 = 20
 ;; @001f                               v79 = uadd_overflow_trap v66, v89, user2
@@ -107,7 +110,7 @@
 ;;
 ;;                                 block5(v84: i64):
 ;;                                     v135 = iconst.i32 0
-;; @001f                               store user2 little region3 v135, v84  ; v135 = 0
+;; @001f                               store user2 little region5 v135, v84  ; v135 = 0
 ;;                                     v136 = iconst.i64 4
 ;;                                     v137 = iadd v84, v136  ; v136 = 4
 ;; @001f                               v87 = icmp eq v137, v81

--- a/tests/disas/gc/array-new-default-exnref.wat
+++ b/tests/disas/gc/array-new-default-exnref.wat
@@ -11,12 +11,15 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 32 "VMContext+0x20"
-;;     region2 = 40 "VMContext+0x28"
-;;     region3 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 32 "VMContext+0x20"
+;;     region3 = 40 "VMContext+0x28"
+;;     region4 = 268435488 "VMStoreContext+0x20"
+;;     region5 = 2147483648 "GcHeap"
+;;     region6 = 268435496 "VMStoreContext+0x28"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
 ;;     fn0 = colocated u805306368:24 sig0
 ;;     stack_limit = gv2
@@ -32,7 +35,7 @@
 ;;                                     v95 = iconst.i32 2
 ;;                                     v96 = ishl v2, v95  ; v95 = 2
 ;; @001f                               v11 = uadd_overflow_trap v4, v96, user18  ; v4 = 20
-;; @001f                               v12 = load.i64 notrap aligned readonly can_move region1 v0+32
+;; @001f                               v12 = load.i64 notrap aligned readonly can_move region2 v0+32
 ;; @001f                               v13 = load.i32 notrap aligned v12
 ;; @001f                               v14 = load.i32 notrap aligned v12+4
 ;; @001f                               v20 = uextend.i64 v13
@@ -55,10 +58,10 @@
 ;; @001f                               store notrap aligned v111, v12
 ;;                                     v127 = iconst.i32 -1476394994
 ;;                                     v128 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v129 = load.i64 notrap aligned readonly can_move v128+32
+;;                                     v129 = load.i64 notrap aligned readonly can_move region4 v128+32
 ;; @001f                               v37 = iadd v129, v20
 ;; @001f                               store notrap aligned v127, v37  ; v127 = -1476394994
-;;                                     v130 = load.i64 notrap aligned readonly can_move region2 v0+40
+;;                                     v130 = load.i64 notrap aligned readonly can_move region3 v0+40
 ;;                                     v131 = load.i32 notrap aligned readonly can_move v130
 ;; @001f                               store notrap aligned v131, v37+4
 ;;                                     v132 = band.i64 v18, v17  ; v17 = -16
@@ -67,12 +70,12 @@
 ;;
 ;;                                 block3 cold:
 ;; @001f                               v24 = iconst.i32 -1476394994
-;; @001f                               v25 = load.i64 notrap aligned readonly can_move region2 v0+40
+;; @001f                               v25 = load.i64 notrap aligned readonly can_move region3 v0+40
 ;; @001f                               v26 = load.i32 notrap aligned readonly can_move v25
 ;; @001f                               v27 = iconst.i32 16
 ;; @001f                               v28 = call fn0(v0, v24, v26, v11, v27)  ; v24 = -1476394994, v27 = 16
 ;; @001f                               v29 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @001f                               v30 = load.i64 notrap aligned readonly can_move v29+32
+;; @001f                               v30 = load.i64 notrap aligned readonly can_move region4 v29+32
 ;; @001f                               v31 = uextend.i64 v28
 ;; @001f                               v32 = iadd v30, v31
 ;; @001f                               jump block4(v28, v32)
@@ -80,18 +83,18 @@
 ;;                                 block4(v41: i32, v42: i64):
 ;; @001f                               v43 = iconst.i64 16
 ;; @001f                               v44 = iadd v42, v43  ; v43 = 16
-;; @001f                               store.i32 user2 region3 v2, v44
+;; @001f                               store.i32 user2 region5 v2, v44
 ;; @001f                               trapz v41, user16
 ;;                                     v133 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v134 = load.i64 notrap aligned readonly can_move v133+32
+;;                                     v134 = load.i64 notrap aligned readonly can_move region4 v133+32
 ;; @001f                               v47 = uextend.i64 v41
 ;; @001f                               v50 = iadd v134, v47
 ;; @001f                               v52 = iadd v50, v43  ; v43 = 16
-;; @001f                               v53 = load.i32 user2 readonly region3 v52
+;; @001f                               v53 = load.i32 user2 readonly region5 v52
 ;; @001f                               v54 = uextend.i64 v53
 ;; @001f                               v60 = icmp.i64 ugt v5, v54
 ;; @001f                               trapnz v60, user17
-;; @001f                               v77 = load.i64 notrap aligned v133+40
+;; @001f                               v77 = load.i64 notrap aligned region6 v133+40
 ;; @001f                               v65 = iconst.i64 20
 ;; @001f                               v66 = iadd v50, v65  ; v65 = 20
 ;; @001f                               v79 = uadd_overflow_trap v66, v89, user2
@@ -107,7 +110,7 @@
 ;;
 ;;                                 block5(v84: i64):
 ;;                                     v135 = iconst.i32 0
-;; @001f                               store user2 little region3 v135, v84  ; v135 = 0
+;; @001f                               store user2 little region5 v135, v84  ; v135 = 0
 ;;                                     v136 = iconst.i64 4
 ;;                                     v137 = iadd v84, v136  ; v136 = 4
 ;; @001f                               v87 = icmp eq v137, v81

--- a/tests/disas/gc/array-new-default-externref.wat
+++ b/tests/disas/gc/array-new-default-externref.wat
@@ -11,12 +11,15 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 32 "VMContext+0x20"
-;;     region2 = 40 "VMContext+0x28"
-;;     region3 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 32 "VMContext+0x20"
+;;     region3 = 40 "VMContext+0x28"
+;;     region4 = 268435488 "VMStoreContext+0x20"
+;;     region5 = 2147483648 "GcHeap"
+;;     region6 = 268435496 "VMStoreContext+0x28"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
 ;;     fn0 = colocated u805306368:24 sig0
 ;;     stack_limit = gv2
@@ -32,7 +35,7 @@
 ;;                                     v95 = iconst.i32 2
 ;;                                     v96 = ishl v2, v95  ; v95 = 2
 ;; @001f                               v11 = uadd_overflow_trap v4, v96, user18  ; v4 = 20
-;; @001f                               v12 = load.i64 notrap aligned readonly can_move region1 v0+32
+;; @001f                               v12 = load.i64 notrap aligned readonly can_move region2 v0+32
 ;; @001f                               v13 = load.i32 notrap aligned v12
 ;; @001f                               v14 = load.i32 notrap aligned v12+4
 ;; @001f                               v20 = uextend.i64 v13
@@ -55,10 +58,10 @@
 ;; @001f                               store notrap aligned v111, v12
 ;;                                     v127 = iconst.i32 -1476394994
 ;;                                     v128 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v129 = load.i64 notrap aligned readonly can_move v128+32
+;;                                     v129 = load.i64 notrap aligned readonly can_move region4 v128+32
 ;; @001f                               v37 = iadd v129, v20
 ;; @001f                               store notrap aligned v127, v37  ; v127 = -1476394994
-;;                                     v130 = load.i64 notrap aligned readonly can_move region2 v0+40
+;;                                     v130 = load.i64 notrap aligned readonly can_move region3 v0+40
 ;;                                     v131 = load.i32 notrap aligned readonly can_move v130
 ;; @001f                               store notrap aligned v131, v37+4
 ;;                                     v132 = band.i64 v18, v17  ; v17 = -16
@@ -67,12 +70,12 @@
 ;;
 ;;                                 block3 cold:
 ;; @001f                               v24 = iconst.i32 -1476394994
-;; @001f                               v25 = load.i64 notrap aligned readonly can_move region2 v0+40
+;; @001f                               v25 = load.i64 notrap aligned readonly can_move region3 v0+40
 ;; @001f                               v26 = load.i32 notrap aligned readonly can_move v25
 ;; @001f                               v27 = iconst.i32 16
 ;; @001f                               v28 = call fn0(v0, v24, v26, v11, v27)  ; v24 = -1476394994, v27 = 16
 ;; @001f                               v29 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @001f                               v30 = load.i64 notrap aligned readonly can_move v29+32
+;; @001f                               v30 = load.i64 notrap aligned readonly can_move region4 v29+32
 ;; @001f                               v31 = uextend.i64 v28
 ;; @001f                               v32 = iadd v30, v31
 ;; @001f                               jump block4(v28, v32)
@@ -80,18 +83,18 @@
 ;;                                 block4(v41: i32, v42: i64):
 ;; @001f                               v43 = iconst.i64 16
 ;; @001f                               v44 = iadd v42, v43  ; v43 = 16
-;; @001f                               store.i32 user2 region3 v2, v44
+;; @001f                               store.i32 user2 region5 v2, v44
 ;; @001f                               trapz v41, user16
 ;;                                     v133 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v134 = load.i64 notrap aligned readonly can_move v133+32
+;;                                     v134 = load.i64 notrap aligned readonly can_move region4 v133+32
 ;; @001f                               v47 = uextend.i64 v41
 ;; @001f                               v50 = iadd v134, v47
 ;; @001f                               v52 = iadd v50, v43  ; v43 = 16
-;; @001f                               v53 = load.i32 user2 readonly region3 v52
+;; @001f                               v53 = load.i32 user2 readonly region5 v52
 ;; @001f                               v54 = uextend.i64 v53
 ;; @001f                               v60 = icmp.i64 ugt v5, v54
 ;; @001f                               trapnz v60, user17
-;; @001f                               v77 = load.i64 notrap aligned v133+40
+;; @001f                               v77 = load.i64 notrap aligned region6 v133+40
 ;; @001f                               v65 = iconst.i64 20
 ;; @001f                               v66 = iadd v50, v65  ; v65 = 20
 ;; @001f                               v79 = uadd_overflow_trap v66, v89, user2
@@ -107,7 +110,7 @@
 ;;
 ;;                                 block5(v84: i64):
 ;;                                     v135 = iconst.i32 0
-;; @001f                               store user2 little region3 v135, v84  ; v135 = 0
+;; @001f                               store user2 little region5 v135, v84  ; v135 = 0
 ;;                                     v136 = iconst.i64 4
 ;;                                     v137 = iadd v84, v136  ; v136 = 4
 ;; @001f                               v87 = icmp eq v137, v81

--- a/tests/disas/gc/array-new-default-f32.wat
+++ b/tests/disas/gc/array-new-default-f32.wat
@@ -12,12 +12,15 @@
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     ss0 = explicit_slot 4, align = 4
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 32 "VMContext+0x20"
-;;     region2 = 40 "VMContext+0x28"
-;;     region3 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 32 "VMContext+0x20"
+;;     region3 = 40 "VMContext+0x28"
+;;     region4 = 268435488 "VMStoreContext+0x20"
+;;     region5 = 2147483648 "GcHeap"
+;;     region6 = 268435496 "VMStoreContext+0x28"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i64, i32, i64) tail
 ;;     fn0 = colocated u805306368:24 sig0
@@ -35,7 +38,7 @@
 ;;                                     v98 = iconst.i32 2
 ;;                                     v99 = ishl v2, v98  ; v98 = 2
 ;; @001f                               v11 = uadd_overflow_trap v4, v99, user18  ; v4 = 20
-;; @001f                               v12 = load.i64 notrap aligned readonly can_move region1 v0+32
+;; @001f                               v12 = load.i64 notrap aligned readonly can_move region2 v0+32
 ;; @001f                               v13 = load.i32 notrap aligned v12
 ;; @001f                               v14 = load.i32 notrap aligned v12+4
 ;; @001f                               v20 = uextend.i64 v13
@@ -58,10 +61,10 @@
 ;; @001f                               store notrap aligned v114, v12
 ;;                                     v130 = iconst.i32 -1476395002
 ;;                                     v131 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v132 = load.i64 notrap aligned readonly can_move v131+32
+;;                                     v132 = load.i64 notrap aligned readonly can_move region4 v131+32
 ;; @001f                               v37 = iadd v132, v20
 ;; @001f                               store notrap aligned v130, v37  ; v130 = -1476395002
-;;                                     v133 = load.i64 notrap aligned readonly can_move region2 v0+40
+;;                                     v133 = load.i64 notrap aligned readonly can_move region3 v0+40
 ;;                                     v134 = load.i32 notrap aligned readonly can_move v133
 ;; @001f                               store notrap aligned v134, v37+4
 ;;                                     v135 = band.i64 v18, v17  ; v17 = -16
@@ -70,12 +73,12 @@
 ;;
 ;;                                 block3 cold:
 ;; @001f                               v24 = iconst.i32 -1476395002
-;; @001f                               v25 = load.i64 notrap aligned readonly can_move region2 v0+40
+;; @001f                               v25 = load.i64 notrap aligned readonly can_move region3 v0+40
 ;; @001f                               v26 = load.i32 notrap aligned readonly can_move v25
 ;; @001f                               v27 = iconst.i32 16
 ;; @001f                               v28 = call fn0(v0, v24, v26, v11, v27)  ; v24 = -1476395002, v27 = 16
 ;; @001f                               v29 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @001f                               v30 = load.i64 notrap aligned readonly can_move v29+32
+;; @001f                               v30 = load.i64 notrap aligned readonly can_move region4 v29+32
 ;; @001f                               v31 = uextend.i64 v28
 ;; @001f                               v32 = iadd v30, v31
 ;; @001f                               jump block4(v28, v32)
@@ -85,18 +88,18 @@
 ;;                                     store notrap v41, v90
 ;; @001f                               v43 = iconst.i64 16
 ;; @001f                               v44 = iadd v42, v43  ; v43 = 16
-;; @001f                               store.i32 user2 region3 v2, v44
+;; @001f                               store.i32 user2 region5 v2, v44
 ;; @001f                               trapz v41, user16
 ;;                                     v136 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v137 = load.i64 notrap aligned readonly can_move v136+32
+;;                                     v137 = load.i64 notrap aligned readonly can_move region4 v136+32
 ;; @001f                               v47 = uextend.i64 v41
 ;; @001f                               v50 = iadd v137, v47
 ;; @001f                               v52 = iadd v50, v43  ; v43 = 16
-;; @001f                               v53 = load.i32 user2 readonly region3 v52
+;; @001f                               v53 = load.i32 user2 readonly region5 v52
 ;; @001f                               v54 = uextend.i64 v53
 ;; @001f                               v60 = icmp.i64 ugt v5, v54
 ;; @001f                               trapnz v60, user17
-;; @001f                               v77 = load.i64 notrap aligned v136+40
+;; @001f                               v77 = load.i64 notrap aligned region6 v136+40
 ;; @001f                               v65 = iconst.i64 20
 ;; @001f                               v66 = iadd v50, v65  ; v65 = 20
 ;; @001f                               v79 = uadd_overflow_trap v66, v92, user2

--- a/tests/disas/gc/array-new-default-f64.wat
+++ b/tests/disas/gc/array-new-default-f64.wat
@@ -12,12 +12,15 @@
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     ss0 = explicit_slot 4, align = 4
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 32 "VMContext+0x20"
-;;     region2 = 40 "VMContext+0x28"
-;;     region3 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 32 "VMContext+0x20"
+;;     region3 = 40 "VMContext+0x28"
+;;     region4 = 268435488 "VMStoreContext+0x20"
+;;     region5 = 2147483648 "GcHeap"
+;;     region6 = 268435496 "VMStoreContext+0x28"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i64, i32, i64) tail
 ;;     fn0 = colocated u805306368:24 sig0
@@ -35,7 +38,7 @@
 ;;                                     v98 = iconst.i32 3
 ;;                                     v99 = ishl v2, v98  ; v98 = 3
 ;; @001f                               v11 = uadd_overflow_trap v4, v99, user18  ; v4 = 24
-;; @001f                               v12 = load.i64 notrap aligned readonly can_move region1 v0+32
+;; @001f                               v12 = load.i64 notrap aligned readonly can_move region2 v0+32
 ;; @001f                               v13 = load.i32 notrap aligned v12
 ;; @001f                               v14 = load.i32 notrap aligned v12+4
 ;; @001f                               v20 = uextend.i64 v13
@@ -58,10 +61,10 @@
 ;; @001f                               store notrap aligned v114, v12
 ;;                                     v130 = iconst.i32 -1476395002
 ;;                                     v131 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v132 = load.i64 notrap aligned readonly can_move v131+32
+;;                                     v132 = load.i64 notrap aligned readonly can_move region4 v131+32
 ;; @001f                               v37 = iadd v132, v20
 ;; @001f                               store notrap aligned v130, v37  ; v130 = -1476395002
-;;                                     v133 = load.i64 notrap aligned readonly can_move region2 v0+40
+;;                                     v133 = load.i64 notrap aligned readonly can_move region3 v0+40
 ;;                                     v134 = load.i32 notrap aligned readonly can_move v133
 ;; @001f                               store notrap aligned v134, v37+4
 ;;                                     v135 = band.i64 v18, v17  ; v17 = -16
@@ -70,12 +73,12 @@
 ;;
 ;;                                 block3 cold:
 ;; @001f                               v24 = iconst.i32 -1476395002
-;; @001f                               v25 = load.i64 notrap aligned readonly can_move region2 v0+40
+;; @001f                               v25 = load.i64 notrap aligned readonly can_move region3 v0+40
 ;; @001f                               v26 = load.i32 notrap aligned readonly can_move v25
 ;; @001f                               v27 = iconst.i32 16
 ;; @001f                               v28 = call fn0(v0, v24, v26, v11, v27)  ; v24 = -1476395002, v27 = 16
 ;; @001f                               v29 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @001f                               v30 = load.i64 notrap aligned readonly can_move v29+32
+;; @001f                               v30 = load.i64 notrap aligned readonly can_move region4 v29+32
 ;; @001f                               v31 = uextend.i64 v28
 ;; @001f                               v32 = iadd v30, v31
 ;; @001f                               jump block4(v28, v32)
@@ -85,18 +88,18 @@
 ;;                                     store notrap v41, v90
 ;; @001f                               v43 = iconst.i64 16
 ;; @001f                               v44 = iadd v42, v43  ; v43 = 16
-;; @001f                               store.i32 user2 region3 v2, v44
+;; @001f                               store.i32 user2 region5 v2, v44
 ;; @001f                               trapz v41, user16
 ;;                                     v136 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v137 = load.i64 notrap aligned readonly can_move v136+32
+;;                                     v137 = load.i64 notrap aligned readonly can_move region4 v136+32
 ;; @001f                               v47 = uextend.i64 v41
 ;; @001f                               v50 = iadd v137, v47
 ;; @001f                               v52 = iadd v50, v43  ; v43 = 16
-;; @001f                               v53 = load.i32 user2 readonly region3 v52
+;; @001f                               v53 = load.i32 user2 readonly region5 v52
 ;; @001f                               v54 = uextend.i64 v53
 ;; @001f                               v60 = icmp.i64 ugt v5, v54
 ;; @001f                               trapnz v60, user17
-;; @001f                               v77 = load.i64 notrap aligned v136+40
+;; @001f                               v77 = load.i64 notrap aligned region6 v136+40
 ;; @001f                               v65 = iconst.i64 24
 ;; @001f                               v66 = iadd v50, v65  ; v65 = 24
 ;; @001f                               v79 = uadd_overflow_trap v66, v92, user2

--- a/tests/disas/gc/array-new-default-funcref.wat
+++ b/tests/disas/gc/array-new-default-funcref.wat
@@ -12,12 +12,15 @@
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     ss0 = explicit_slot 4, align = 4
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 32 "VMContext+0x20"
-;;     region2 = 40 "VMContext+0x28"
-;;     region3 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 32 "VMContext+0x20"
+;;     region3 = 40 "VMContext+0x28"
+;;     region4 = 268435488 "VMStoreContext+0x20"
+;;     region5 = 2147483648 "GcHeap"
+;;     region6 = 268435496 "VMStoreContext+0x28"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i64) -> i64 tail
 ;;     fn0 = colocated u805306368:24 sig0
@@ -35,7 +38,7 @@
 ;;                                     v106 = iconst.i32 2
 ;;                                     v107 = ishl v2, v106  ; v106 = 2
 ;; @001f                               v11 = uadd_overflow_trap v4, v107, user18  ; v4 = 20
-;; @001f                               v12 = load.i64 notrap aligned readonly can_move region1 v0+32
+;; @001f                               v12 = load.i64 notrap aligned readonly can_move region2 v0+32
 ;; @001f                               v13 = load.i32 notrap aligned v12
 ;; @001f                               v14 = load.i32 notrap aligned v12+4
 ;; @001f                               v20 = uextend.i64 v13
@@ -58,10 +61,10 @@
 ;; @001f                               store notrap aligned v122, v12
 ;;                                     v137 = iconst.i32 -1476395002
 ;;                                     v138 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v139 = load.i64 notrap aligned readonly can_move v138+32
+;;                                     v139 = load.i64 notrap aligned readonly can_move region4 v138+32
 ;; @001f                               v37 = iadd v139, v20
 ;; @001f                               store notrap aligned v137, v37  ; v137 = -1476395002
-;;                                     v140 = load.i64 notrap aligned readonly can_move region2 v0+40
+;;                                     v140 = load.i64 notrap aligned readonly can_move region3 v0+40
 ;;                                     v141 = load.i32 notrap aligned readonly can_move v140
 ;; @001f                               store notrap aligned v141, v37+4
 ;;                                     v142 = band.i64 v18, v17  ; v17 = -16
@@ -70,12 +73,12 @@
 ;;
 ;;                                 block3 cold:
 ;; @001f                               v24 = iconst.i32 -1476395002
-;; @001f                               v25 = load.i64 notrap aligned readonly can_move region2 v0+40
+;; @001f                               v25 = load.i64 notrap aligned readonly can_move region3 v0+40
 ;; @001f                               v26 = load.i32 notrap aligned readonly can_move v25
 ;; @001f                               v27 = iconst.i32 16
 ;; @001f                               v28 = call fn0(v0, v24, v26, v11, v27)  ; v24 = -1476395002, v27 = 16
 ;; @001f                               v29 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @001f                               v30 = load.i64 notrap aligned readonly can_move v29+32
+;; @001f                               v30 = load.i64 notrap aligned readonly can_move region4 v29+32
 ;; @001f                               v31 = uextend.i64 v28
 ;; @001f                               v32 = iadd v30, v31
 ;; @001f                               jump block4(v28, v32)
@@ -85,18 +88,18 @@
 ;;                                     store notrap v41, v98
 ;; @001f                               v43 = iconst.i64 16
 ;; @001f                               v44 = iadd v42, v43  ; v43 = 16
-;; @001f                               store.i32 user2 region3 v2, v44
+;; @001f                               store.i32 user2 region5 v2, v44
 ;; @001f                               trapz v41, user16
 ;;                                     v143 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v144 = load.i64 notrap aligned readonly can_move v143+32
+;;                                     v144 = load.i64 notrap aligned readonly can_move region4 v143+32
 ;; @001f                               v47 = uextend.i64 v41
 ;; @001f                               v50 = iadd v144, v47
 ;; @001f                               v52 = iadd v50, v43  ; v43 = 16
-;; @001f                               v53 = load.i32 user2 readonly region3 v52
+;; @001f                               v53 = load.i32 user2 readonly region5 v52
 ;; @001f                               v54 = uextend.i64 v53
 ;; @001f                               v60 = icmp.i64 ugt v5, v54
 ;; @001f                               trapnz v60, user17
-;; @001f                               v77 = load.i64 notrap aligned v143+40
+;; @001f                               v77 = load.i64 notrap aligned region6 v143+40
 ;; @001f                               v65 = iconst.i64 20
 ;; @001f                               v66 = iadd v50, v65  ; v65 = 20
 ;; @001f                               v79 = uadd_overflow_trap v66, v100, user2

--- a/tests/disas/gc/array-new-default-i16.wat
+++ b/tests/disas/gc/array-new-default-i16.wat
@@ -12,12 +12,15 @@
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     ss0 = explicit_slot 4, align = 4
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 32 "VMContext+0x20"
-;;     region2 = 40 "VMContext+0x28"
-;;     region3 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 32 "VMContext+0x20"
+;;     region3 = 40 "VMContext+0x28"
+;;     region4 = 268435488 "VMStoreContext+0x20"
+;;     region5 = 2147483648 "GcHeap"
+;;     region6 = 268435496 "VMStoreContext+0x28"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i64, i32, i64) tail
 ;;     fn0 = colocated u805306368:24 sig0
@@ -34,7 +37,7 @@
 ;; @001f                               v4 = iconst.i32 20
 ;;                                     v97 = iadd v2, v2
 ;; @001f                               v11 = uadd_overflow_trap v4, v97, user18  ; v4 = 20
-;; @001f                               v12 = load.i64 notrap aligned readonly can_move region1 v0+32
+;; @001f                               v12 = load.i64 notrap aligned readonly can_move region2 v0+32
 ;; @001f                               v13 = load.i32 notrap aligned v12
 ;; @001f                               v14 = load.i32 notrap aligned v12+4
 ;; @001f                               v20 = uextend.i64 v13
@@ -57,10 +60,10 @@
 ;; @001f                               store notrap aligned v119, v12
 ;;                                     v140 = iconst.i32 -1476395002
 ;;                                     v141 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v142 = load.i64 notrap aligned readonly can_move v141+32
+;;                                     v142 = load.i64 notrap aligned readonly can_move region4 v141+32
 ;; @001f                               v37 = iadd v142, v20
 ;; @001f                               store notrap aligned v140, v37  ; v140 = -1476395002
-;;                                     v143 = load.i64 notrap aligned readonly can_move region2 v0+40
+;;                                     v143 = load.i64 notrap aligned readonly can_move region3 v0+40
 ;;                                     v144 = load.i32 notrap aligned readonly can_move v143
 ;; @001f                               store notrap aligned v144, v37+4
 ;;                                     v145 = band.i64 v18, v17  ; v17 = -16
@@ -69,12 +72,12 @@
 ;;
 ;;                                 block3 cold:
 ;; @001f                               v24 = iconst.i32 -1476395002
-;; @001f                               v25 = load.i64 notrap aligned readonly can_move region2 v0+40
+;; @001f                               v25 = load.i64 notrap aligned readonly can_move region3 v0+40
 ;; @001f                               v26 = load.i32 notrap aligned readonly can_move v25
 ;; @001f                               v27 = iconst.i32 16
 ;; @001f                               v28 = call fn0(v0, v24, v26, v11, v27)  ; v24 = -1476395002, v27 = 16
 ;; @001f                               v29 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @001f                               v30 = load.i64 notrap aligned readonly can_move v29+32
+;; @001f                               v30 = load.i64 notrap aligned readonly can_move region4 v29+32
 ;; @001f                               v31 = uextend.i64 v28
 ;; @001f                               v32 = iadd v30, v31
 ;; @001f                               jump block4(v28, v32)
@@ -84,18 +87,18 @@
 ;;                                     store notrap v41, v90
 ;; @001f                               v43 = iconst.i64 16
 ;; @001f                               v44 = iadd v42, v43  ; v43 = 16
-;; @001f                               store.i32 user2 region3 v2, v44
+;; @001f                               store.i32 user2 region5 v2, v44
 ;; @001f                               trapz v41, user16
 ;;                                     v146 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v147 = load.i64 notrap aligned readonly can_move v146+32
+;;                                     v147 = load.i64 notrap aligned readonly can_move region4 v146+32
 ;; @001f                               v47 = uextend.i64 v41
 ;; @001f                               v50 = iadd v147, v47
 ;; @001f                               v52 = iadd v50, v43  ; v43 = 16
-;; @001f                               v53 = load.i32 user2 readonly region3 v52
+;; @001f                               v53 = load.i32 user2 readonly region5 v52
 ;; @001f                               v54 = uextend.i64 v53
 ;; @001f                               v60 = icmp.i64 ugt v5, v54
 ;; @001f                               trapnz v60, user17
-;; @001f                               v77 = load.i64 notrap aligned v146+40
+;; @001f                               v77 = load.i64 notrap aligned region6 v146+40
 ;; @001f                               v65 = iconst.i64 20
 ;; @001f                               v66 = iadd v50, v65  ; v65 = 20
 ;; @001f                               v79 = uadd_overflow_trap v66, v93, user2

--- a/tests/disas/gc/array-new-default-i32.wat
+++ b/tests/disas/gc/array-new-default-i32.wat
@@ -12,12 +12,15 @@
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     ss0 = explicit_slot 4, align = 4
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 32 "VMContext+0x20"
-;;     region2 = 40 "VMContext+0x28"
-;;     region3 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 32 "VMContext+0x20"
+;;     region3 = 40 "VMContext+0x28"
+;;     region4 = 268435488 "VMStoreContext+0x20"
+;;     region5 = 2147483648 "GcHeap"
+;;     region6 = 268435496 "VMStoreContext+0x28"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i64, i32, i64) tail
 ;;     fn0 = colocated u805306368:24 sig0
@@ -35,7 +38,7 @@
 ;;                                     v98 = iconst.i32 2
 ;;                                     v99 = ishl v2, v98  ; v98 = 2
 ;; @001f                               v11 = uadd_overflow_trap v4, v99, user18  ; v4 = 20
-;; @001f                               v12 = load.i64 notrap aligned readonly can_move region1 v0+32
+;; @001f                               v12 = load.i64 notrap aligned readonly can_move region2 v0+32
 ;; @001f                               v13 = load.i32 notrap aligned v12
 ;; @001f                               v14 = load.i32 notrap aligned v12+4
 ;; @001f                               v20 = uextend.i64 v13
@@ -58,10 +61,10 @@
 ;; @001f                               store notrap aligned v114, v12
 ;;                                     v130 = iconst.i32 -1476395002
 ;;                                     v131 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v132 = load.i64 notrap aligned readonly can_move v131+32
+;;                                     v132 = load.i64 notrap aligned readonly can_move region4 v131+32
 ;; @001f                               v37 = iadd v132, v20
 ;; @001f                               store notrap aligned v130, v37  ; v130 = -1476395002
-;;                                     v133 = load.i64 notrap aligned readonly can_move region2 v0+40
+;;                                     v133 = load.i64 notrap aligned readonly can_move region3 v0+40
 ;;                                     v134 = load.i32 notrap aligned readonly can_move v133
 ;; @001f                               store notrap aligned v134, v37+4
 ;;                                     v135 = band.i64 v18, v17  ; v17 = -16
@@ -70,12 +73,12 @@
 ;;
 ;;                                 block3 cold:
 ;; @001f                               v24 = iconst.i32 -1476395002
-;; @001f                               v25 = load.i64 notrap aligned readonly can_move region2 v0+40
+;; @001f                               v25 = load.i64 notrap aligned readonly can_move region3 v0+40
 ;; @001f                               v26 = load.i32 notrap aligned readonly can_move v25
 ;; @001f                               v27 = iconst.i32 16
 ;; @001f                               v28 = call fn0(v0, v24, v26, v11, v27)  ; v24 = -1476395002, v27 = 16
 ;; @001f                               v29 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @001f                               v30 = load.i64 notrap aligned readonly can_move v29+32
+;; @001f                               v30 = load.i64 notrap aligned readonly can_move region4 v29+32
 ;; @001f                               v31 = uextend.i64 v28
 ;; @001f                               v32 = iadd v30, v31
 ;; @001f                               jump block4(v28, v32)
@@ -85,18 +88,18 @@
 ;;                                     store notrap v41, v90
 ;; @001f                               v43 = iconst.i64 16
 ;; @001f                               v44 = iadd v42, v43  ; v43 = 16
-;; @001f                               store.i32 user2 region3 v2, v44
+;; @001f                               store.i32 user2 region5 v2, v44
 ;; @001f                               trapz v41, user16
 ;;                                     v136 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v137 = load.i64 notrap aligned readonly can_move v136+32
+;;                                     v137 = load.i64 notrap aligned readonly can_move region4 v136+32
 ;; @001f                               v47 = uextend.i64 v41
 ;; @001f                               v50 = iadd v137, v47
 ;; @001f                               v52 = iadd v50, v43  ; v43 = 16
-;; @001f                               v53 = load.i32 user2 readonly region3 v52
+;; @001f                               v53 = load.i32 user2 readonly region5 v52
 ;; @001f                               v54 = uextend.i64 v53
 ;; @001f                               v60 = icmp.i64 ugt v5, v54
 ;; @001f                               trapnz v60, user17
-;; @001f                               v77 = load.i64 notrap aligned v136+40
+;; @001f                               v77 = load.i64 notrap aligned region6 v136+40
 ;; @001f                               v65 = iconst.i64 20
 ;; @001f                               v66 = iadd v50, v65  ; v65 = 20
 ;; @001f                               v79 = uadd_overflow_trap v66, v92, user2

--- a/tests/disas/gc/array-new-default-i64.wat
+++ b/tests/disas/gc/array-new-default-i64.wat
@@ -12,12 +12,15 @@
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     ss0 = explicit_slot 4, align = 4
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 32 "VMContext+0x20"
-;;     region2 = 40 "VMContext+0x28"
-;;     region3 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 32 "VMContext+0x20"
+;;     region3 = 40 "VMContext+0x28"
+;;     region4 = 268435488 "VMStoreContext+0x20"
+;;     region5 = 2147483648 "GcHeap"
+;;     region6 = 268435496 "VMStoreContext+0x28"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i64, i32, i64) tail
 ;;     fn0 = colocated u805306368:24 sig0
@@ -35,7 +38,7 @@
 ;;                                     v98 = iconst.i32 3
 ;;                                     v99 = ishl v2, v98  ; v98 = 3
 ;; @001f                               v11 = uadd_overflow_trap v4, v99, user18  ; v4 = 24
-;; @001f                               v12 = load.i64 notrap aligned readonly can_move region1 v0+32
+;; @001f                               v12 = load.i64 notrap aligned readonly can_move region2 v0+32
 ;; @001f                               v13 = load.i32 notrap aligned v12
 ;; @001f                               v14 = load.i32 notrap aligned v12+4
 ;; @001f                               v20 = uextend.i64 v13
@@ -58,10 +61,10 @@
 ;; @001f                               store notrap aligned v114, v12
 ;;                                     v129 = iconst.i32 -1476395002
 ;;                                     v130 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v131 = load.i64 notrap aligned readonly can_move v130+32
+;;                                     v131 = load.i64 notrap aligned readonly can_move region4 v130+32
 ;; @001f                               v37 = iadd v131, v20
 ;; @001f                               store notrap aligned v129, v37  ; v129 = -1476395002
-;;                                     v132 = load.i64 notrap aligned readonly can_move region2 v0+40
+;;                                     v132 = load.i64 notrap aligned readonly can_move region3 v0+40
 ;;                                     v133 = load.i32 notrap aligned readonly can_move v132
 ;; @001f                               store notrap aligned v133, v37+4
 ;;                                     v134 = band.i64 v18, v17  ; v17 = -16
@@ -70,12 +73,12 @@
 ;;
 ;;                                 block3 cold:
 ;; @001f                               v24 = iconst.i32 -1476395002
-;; @001f                               v25 = load.i64 notrap aligned readonly can_move region2 v0+40
+;; @001f                               v25 = load.i64 notrap aligned readonly can_move region3 v0+40
 ;; @001f                               v26 = load.i32 notrap aligned readonly can_move v25
 ;; @001f                               v27 = iconst.i32 16
 ;; @001f                               v28 = call fn0(v0, v24, v26, v11, v27)  ; v24 = -1476395002, v27 = 16
 ;; @001f                               v29 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @001f                               v30 = load.i64 notrap aligned readonly can_move v29+32
+;; @001f                               v30 = load.i64 notrap aligned readonly can_move region4 v29+32
 ;; @001f                               v31 = uextend.i64 v28
 ;; @001f                               v32 = iadd v30, v31
 ;; @001f                               jump block4(v28, v32)
@@ -85,18 +88,18 @@
 ;;                                     store notrap v41, v90
 ;; @001f                               v43 = iconst.i64 16
 ;; @001f                               v44 = iadd v42, v43  ; v43 = 16
-;; @001f                               store.i32 user2 region3 v2, v44
+;; @001f                               store.i32 user2 region5 v2, v44
 ;; @001f                               trapz v41, user16
 ;;                                     v135 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v136 = load.i64 notrap aligned readonly can_move v135+32
+;;                                     v136 = load.i64 notrap aligned readonly can_move region4 v135+32
 ;; @001f                               v47 = uextend.i64 v41
 ;; @001f                               v50 = iadd v136, v47
 ;; @001f                               v52 = iadd v50, v43  ; v43 = 16
-;; @001f                               v53 = load.i32 user2 readonly region3 v52
+;; @001f                               v53 = load.i32 user2 readonly region5 v52
 ;; @001f                               v54 = uextend.i64 v53
 ;; @001f                               v60 = icmp.i64 ugt v5, v54
 ;; @001f                               trapnz v60, user17
-;; @001f                               v77 = load.i64 notrap aligned v135+40
+;; @001f                               v77 = load.i64 notrap aligned region6 v135+40
 ;; @001f                               v65 = iconst.i64 24
 ;; @001f                               v66 = iadd v50, v65  ; v65 = 24
 ;; @001f                               v79 = uadd_overflow_trap v66, v92, user2

--- a/tests/disas/gc/array-new-default-i8.wat
+++ b/tests/disas/gc/array-new-default-i8.wat
@@ -12,12 +12,15 @@
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     ss0 = explicit_slot 4, align = 4
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 32 "VMContext+0x20"
-;;     region2 = 40 "VMContext+0x28"
-;;     region3 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 32 "VMContext+0x20"
+;;     region3 = 40 "VMContext+0x28"
+;;     region4 = 268435488 "VMStoreContext+0x20"
+;;     region5 = 2147483648 "GcHeap"
+;;     region6 = 268435496 "VMStoreContext+0x28"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i64, i32, i64) tail
 ;;     fn0 = colocated u805306368:24 sig0
@@ -31,7 +34,7 @@
 ;; @001f                               trapnz v9, user18
 ;; @001f                               v4 = iconst.i32 20
 ;; @001f                               v11 = uadd_overflow_trap v4, v2, user18  ; v4 = 20
-;; @001f                               v12 = load.i64 notrap aligned readonly can_move region1 v0+32
+;; @001f                               v12 = load.i64 notrap aligned readonly can_move region2 v0+32
 ;; @001f                               v13 = load.i32 notrap aligned v12
 ;; @001f                               v14 = load.i32 notrap aligned v12+4
 ;; @001f                               v20 = uextend.i64 v13
@@ -54,10 +57,10 @@
 ;; @001f                               store notrap aligned v104, v12
 ;;                                     v118 = iconst.i32 -1476395002
 ;;                                     v119 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v120 = load.i64 notrap aligned readonly can_move v119+32
+;;                                     v120 = load.i64 notrap aligned readonly can_move region4 v119+32
 ;; @001f                               v37 = iadd v120, v20
 ;; @001f                               store notrap aligned v118, v37  ; v118 = -1476395002
-;;                                     v121 = load.i64 notrap aligned readonly can_move region2 v0+40
+;;                                     v121 = load.i64 notrap aligned readonly can_move region3 v0+40
 ;;                                     v122 = load.i32 notrap aligned readonly can_move v121
 ;; @001f                               store notrap aligned v122, v37+4
 ;;                                     v123 = band.i64 v18, v17  ; v17 = -16
@@ -66,12 +69,12 @@
 ;;
 ;;                                 block3 cold:
 ;; @001f                               v24 = iconst.i32 -1476395002
-;; @001f                               v25 = load.i64 notrap aligned readonly can_move region2 v0+40
+;; @001f                               v25 = load.i64 notrap aligned readonly can_move region3 v0+40
 ;; @001f                               v26 = load.i32 notrap aligned readonly can_move v25
 ;; @001f                               v27 = iconst.i32 16
 ;; @001f                               v28 = call fn0(v0, v24, v26, v11, v27)  ; v24 = -1476395002, v27 = 16
 ;; @001f                               v29 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @001f                               v30 = load.i64 notrap aligned readonly can_move v29+32
+;; @001f                               v30 = load.i64 notrap aligned readonly can_move region4 v29+32
 ;; @001f                               v31 = uextend.i64 v28
 ;; @001f                               v32 = iadd v30, v31
 ;; @001f                               jump block4(v28, v32)
@@ -81,18 +84,18 @@
 ;;                                     store notrap v41, v89
 ;; @001f                               v43 = iconst.i64 16
 ;; @001f                               v44 = iadd v42, v43  ; v43 = 16
-;; @001f                               store.i32 user2 region3 v2, v44
+;; @001f                               store.i32 user2 region5 v2, v44
 ;; @001f                               trapz v41, user16
 ;;                                     v124 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v125 = load.i64 notrap aligned readonly can_move v124+32
+;;                                     v125 = load.i64 notrap aligned readonly can_move region4 v124+32
 ;; @001f                               v47 = uextend.i64 v41
 ;; @001f                               v50 = iadd v125, v47
 ;; @001f                               v52 = iadd v50, v43  ; v43 = 16
-;; @001f                               v53 = load.i32 user2 readonly region3 v52
+;; @001f                               v53 = load.i32 user2 readonly region5 v52
 ;; @001f                               v54 = uextend.i64 v53
 ;; @001f                               v60 = icmp.i64 ugt v5, v54
 ;; @001f                               trapnz v60, user17
-;; @001f                               v77 = load.i64 notrap aligned v124+40
+;; @001f                               v77 = load.i64 notrap aligned region6 v124+40
 ;; @001f                               v65 = iconst.i64 20
 ;; @001f                               v66 = iadd v50, v65  ; v65 = 20
 ;; @001f                               v79 = uadd_overflow_trap v66, v5, user2

--- a/tests/disas/gc/call-indirect-final-type.wat
+++ b/tests/disas/gc/call-indirect-final-type.wat
@@ -17,11 +17,12 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 1342177280 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
-;;     region2 = 40 "VMContext+0x28"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 1342177280 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
+;;     region3 = 40 "VMContext+0x28"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, i64, i32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i32, i64) -> i64 tail
 ;;     fn0 = colocated u805306368:7 sig1
@@ -38,7 +39,7 @@
 ;; @002b                               v11 = ishl v8, v10  ; v10 = 3
 ;; @002b                               v12 = iadd v9, v11
 ;; @002b                               v14 = select_spectre_guard v7, v13, v12  ; v13 = 0
-;; @002b                               v15 = load.i64 user6 aligned region1 v14
+;; @002b                               v15 = load.i64 user6 aligned region2 v14
 ;; @002b                               v16 = iconst.i64 -2
 ;; @002b                               v17 = band v15, v16  ; v16 = -2
 ;; @002b                               brif v15, block3(v17), block2
@@ -50,7 +51,7 @@
 ;;
 ;;                                 block3(v18: i64):
 ;; @002b                               v24 = load.i32 user7 aligned readonly v18+16
-;; @002b                               v22 = load.i64 notrap aligned readonly can_move region2 v0+40
+;; @002b                               v22 = load.i64 notrap aligned readonly can_move region3 v0+40
 ;; @002b                               v23 = load.i32 notrap aligned readonly can_move v22
 ;; @002b                               v25 = icmp eq v24, v23
 ;; @002b                               trapz v25, user8
@@ -65,11 +66,12 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 1342177280 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
-;;     region2 = 40 "VMContext+0x28"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 1342177280 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
+;;     region3 = 40 "VMContext+0x28"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, i64, i32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i32, i64) -> i64 tail
 ;;     fn0 = colocated u805306368:7 sig1
@@ -86,7 +88,7 @@
 ;; @0035                               v11 = ishl v8, v10  ; v10 = 3
 ;; @0035                               v12 = iadd v9, v11
 ;; @0035                               v14 = select_spectre_guard v7, v13, v12  ; v13 = 0
-;; @0035                               v15 = load.i64 user6 aligned region1 v14
+;; @0035                               v15 = load.i64 user6 aligned region2 v14
 ;; @0035                               v16 = iconst.i64 -2
 ;; @0035                               v17 = band v15, v16  ; v16 = -2
 ;; @0035                               brif v15, block3(v17), block2
@@ -98,7 +100,7 @@
 ;;
 ;;                                 block3(v18: i64):
 ;; @0035                               v24 = load.i32 user7 aligned readonly v18+16
-;; @0035                               v22 = load.i64 notrap aligned readonly can_move region2 v0+40
+;; @0035                               v22 = load.i64 notrap aligned readonly can_move region3 v0+40
 ;; @0035                               v23 = load.i32 notrap aligned readonly can_move v22
 ;; @0035                               v25 = icmp eq v24, v23
 ;; @0035                               trapz v25, user8

--- a/tests/disas/gc/copying/array-fill.wat
+++ b/tests/disas/gc/copying/array-fill.wat
@@ -10,28 +10,31 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 268435488 "VMStoreContext+0x20"
+;;     region3 = 268435496 "VMStoreContext+0x28"
+;;     region4 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i64, v5: i32):
 ;; @0027                               trapz v2, user16
 ;; @0027                               v7 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0027                               v8 = load.i64 notrap aligned readonly can_move v7+32
+;; @0027                               v8 = load.i64 notrap aligned readonly can_move region2 v7+32
 ;; @0027                               v6 = uextend.i64 v2
 ;; @0027                               v9 = iadd v8, v6
 ;; @0027                               v10 = iconst.i64 16
 ;; @0027                               v11 = iadd v9, v10  ; v10 = 16
-;; @0027                               v12 = load.i32 user2 readonly region1 v11
+;; @0027                               v12 = load.i32 user2 readonly region4 v11
 ;; @0027                               v14 = uextend.i64 v3
 ;; @0027                               v15 = uextend.i64 v5
 ;; @0027                               v18 = iadd v14, v15
 ;; @0027                               v13 = uextend.i64 v12
 ;; @0027                               v19 = icmp ugt v18, v13
 ;; @0027                               trapnz v19, user17
-;; @0027                               v36 = load.i64 notrap aligned v7+40
+;; @0027                               v36 = load.i64 notrap aligned region3 v7+40
 ;; @0027                               v24 = iconst.i64 24
 ;; @0027                               v25 = iadd v9, v24  ; v24 = 24
 ;;                                     v49 = iconst.i64 3
@@ -49,7 +52,7 @@
 ;; @0027                               brif v42, block3, block2(v29)
 ;;
 ;;                                 block2(v43: i64):
-;; @0027                               store.i64 user2 little region1 v4, v43
+;; @0027                               store.i64 user2 little region4 v4, v43
 ;;                                     v54 = iconst.i64 8
 ;;                                     v55 = iadd v43, v54  ; v54 = 8
 ;; @0027                               v46 = icmp eq v55, v40

--- a/tests/disas/gc/copying/array-get-s.wat
+++ b/tests/disas/gc/copying/array-get-s.wat
@@ -10,21 +10,24 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 268435488 "VMStoreContext+0x20"
+;;     region3 = 268435496 "VMStoreContext+0x28"
+;;     region4 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0022                               trapz v2, user16
 ;; @0022                               v6 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0022                               v7 = load.i64 notrap aligned readonly can_move v6+32
+;; @0022                               v7 = load.i64 notrap aligned readonly can_move region2 v6+32
 ;; @0022                               v5 = uextend.i64 v2
 ;; @0022                               v8 = iadd v7, v5
 ;; @0022                               v9 = iconst.i64 16
 ;; @0022                               v10 = iadd v8, v9  ; v9 = 16
-;; @0022                               v11 = load.i32 user2 readonly region1 v10
+;; @0022                               v11 = load.i32 user2 readonly region4 v10
 ;; @0022                               v12 = icmp ult v3, v11
 ;; @0022                               trapz v12, user17
 ;; @0022                               v14 = uextend.i64 v11
@@ -40,7 +43,7 @@
 ;; @0022                               v29 = isub v20, v23
 ;; @0022                               v30 = uextend.i64 v29
 ;; @0022                               v31 = isub v28, v30
-;; @0022                               v32 = load.i8 user2 little region1 v31
+;; @0022                               v32 = load.i8 user2 little region4 v31
 ;; @0025                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/copying/array-get-u.wat
+++ b/tests/disas/gc/copying/array-get-u.wat
@@ -10,21 +10,24 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 268435488 "VMStoreContext+0x20"
+;;     region3 = 268435496 "VMStoreContext+0x28"
+;;     region4 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0022                               trapz v2, user16
 ;; @0022                               v6 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0022                               v7 = load.i64 notrap aligned readonly can_move v6+32
+;; @0022                               v7 = load.i64 notrap aligned readonly can_move region2 v6+32
 ;; @0022                               v5 = uextend.i64 v2
 ;; @0022                               v8 = iadd v7, v5
 ;; @0022                               v9 = iconst.i64 16
 ;; @0022                               v10 = iadd v8, v9  ; v9 = 16
-;; @0022                               v11 = load.i32 user2 readonly region1 v10
+;; @0022                               v11 = load.i32 user2 readonly region4 v10
 ;; @0022                               v12 = icmp ult v3, v11
 ;; @0022                               trapz v12, user17
 ;; @0022                               v14 = uextend.i64 v11
@@ -40,7 +43,7 @@
 ;; @0022                               v29 = isub v20, v23
 ;; @0022                               v30 = uextend.i64 v29
 ;; @0022                               v31 = isub v28, v30
-;; @0022                               v32 = load.i8 user2 little region1 v31
+;; @0022                               v32 = load.i8 user2 little region4 v31
 ;; @0025                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/copying/array-get.wat
+++ b/tests/disas/gc/copying/array-get.wat
@@ -10,21 +10,24 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32) -> i64 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 268435488 "VMStoreContext+0x20"
+;;     region3 = 268435496 "VMStoreContext+0x28"
+;;     region4 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0022                               trapz v2, user16
 ;; @0022                               v6 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0022                               v7 = load.i64 notrap aligned readonly can_move v6+32
+;; @0022                               v7 = load.i64 notrap aligned readonly can_move region2 v6+32
 ;; @0022                               v5 = uextend.i64 v2
 ;; @0022                               v8 = iadd v7, v5
 ;; @0022                               v9 = iconst.i64 16
 ;; @0022                               v10 = iadd v8, v9  ; v9 = 16
-;; @0022                               v11 = load.i32 user2 readonly region1 v10
+;; @0022                               v11 = load.i32 user2 readonly region4 v10
 ;; @0022                               v12 = icmp ult v3, v11
 ;; @0022                               trapz v12, user17
 ;; @0022                               v14 = uextend.i64 v11
@@ -45,7 +48,7 @@
 ;; @0022                               v29 = isub v20, v23
 ;; @0022                               v30 = uextend.i64 v29
 ;; @0022                               v31 = isub v28, v30
-;; @0022                               v32 = load.i64 user2 little region1 v31
+;; @0022                               v32 = load.i64 user2 little region4 v31
 ;; @0025                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/copying/array-len.wat
+++ b/tests/disas/gc/copying/array-len.wat
@@ -10,21 +10,24 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 268435488 "VMStoreContext+0x20"
+;;     region3 = 268435496 "VMStoreContext+0x28"
+;;     region4 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @001f                               trapz v2, user16
 ;; @001f                               v5 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @001f                               v6 = load.i64 notrap aligned readonly can_move v5+32
+;; @001f                               v6 = load.i64 notrap aligned readonly can_move region2 v5+32
 ;; @001f                               v4 = uextend.i64 v2
 ;; @001f                               v7 = iadd v6, v4
 ;; @001f                               v8 = iconst.i64 16
 ;; @001f                               v9 = iadd v7, v8  ; v8 = 16
-;; @001f                               v10 = load.i32 user2 readonly region1 v9
+;; @001f                               v10 = load.i32 user2 readonly region4 v9
 ;; @0021                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/copying/array-new-fixed-of-gc-refs.wat
+++ b/tests/disas/gc/copying/array-new-fixed-of-gc-refs.wat
@@ -13,12 +13,15 @@
 ;;     ss1 = explicit_slot 4, align = 4
 ;;     ss2 = explicit_slot 4, align = 4
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 32 "VMContext+0x20"
-;;     region2 = 40 "VMContext+0x28"
-;;     region3 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 32 "VMContext+0x20"
+;;     region3 = 40 "VMContext+0x28"
+;;     region4 = 268435488 "VMStoreContext+0x20"
+;;     region5 = 2147483648 "GcHeap"
+;;     region6 = 268435496 "VMStoreContext+0x28"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
 ;;     fn0 = colocated u805306368:24 sig0
 ;;     stack_limit = gv2
@@ -30,7 +33,7 @@
 ;;                                     store notrap v3, v139
 ;;                                     v140 = stack_addr.i64 ss0
 ;;                                     store notrap v4, v140
-;; @0025                               v15 = load.i64 notrap aligned readonly can_move region1 v0+32
+;; @0025                               v15 = load.i64 notrap aligned readonly can_move region2 v0+32
 ;; @0025                               v16 = load.i32 notrap aligned v15
 ;; @0025                               v17 = load.i32 notrap aligned v15+4
 ;; @0025                               v23 = uextend.i64 v16
@@ -46,10 +49,10 @@
 ;; @0025                               store notrap aligned v166, v15
 ;;                                     v261 = iconst.i32 -1476394994
 ;;                                     v262 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v263 = load.i64 notrap aligned readonly can_move v262+32
+;;                                     v263 = load.i64 notrap aligned readonly can_move region4 v262+32
 ;; @0025                               v40 = iadd v263, v23
 ;; @0025                               store notrap aligned v261, v40  ; v261 = -1476394994
-;;                                     v264 = load.i64 notrap aligned readonly can_move region2 v0+40
+;;                                     v264 = load.i64 notrap aligned readonly can_move region3 v0+40
 ;;                                     v265 = load.i32 notrap aligned readonly can_move v264
 ;; @0025                               store notrap aligned v265, v40+4
 ;;                                     v266 = iconst.i64 32
@@ -58,13 +61,13 @@
 ;;
 ;;                                 block3 cold:
 ;; @0025                               v27 = iconst.i32 -1476394994
-;; @0025                               v28 = load.i64 notrap aligned readonly can_move region2 v0+40
+;; @0025                               v28 = load.i64 notrap aligned readonly can_move region3 v0+40
 ;; @0025                               v29 = load.i32 notrap aligned readonly can_move v28
 ;;                                     v152 = iconst.i32 32
 ;; @0025                               v30 = iconst.i32 16
 ;; @0025                               v31 = call fn0(v0, v27, v29, v152, v30), stack_map=[i32 @ ss2+0, i32 @ ss1+0, i32 @ ss0+0]  ; v27 = -1476394994, v152 = 32, v30 = 16
 ;; @0025                               v32 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0025                               v33 = load.i64 notrap aligned readonly can_move v32+32
+;; @0025                               v33 = load.i64 notrap aligned readonly can_move region4 v32+32
 ;; @0025                               v34 = uextend.i64 v31
 ;; @0025                               v35 = iadd v33, v34
 ;; @0025                               jump block4(v31, v35)
@@ -73,14 +76,14 @@
 ;; @0025                               v6 = iconst.i32 3
 ;; @0025                               v46 = iconst.i64 16
 ;; @0025                               v47 = iadd v45, v46  ; v46 = 16
-;; @0025                               store user2 region3 v6, v47  ; v6 = 3
+;; @0025                               store user2 region5 v6, v47  ; v6 = 3
 ;; @0025                               trapz v44, user16
 ;;                                     v267 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v268 = load.i64 notrap aligned readonly can_move v267+32
+;;                                     v268 = load.i64 notrap aligned readonly can_move region4 v267+32
 ;; @0025                               v49 = uextend.i64 v44
 ;; @0025                               v52 = iadd v268, v49
 ;; @0025                               v54 = iadd v52, v46  ; v46 = 16
-;; @0025                               v55 = load.i32 user2 readonly region3 v54
+;; @0025                               v55 = load.i32 user2 readonly region5 v54
 ;; @0025                               trapz v55, user17
 ;; @0025                               v58 = uextend.i64 v55
 ;;                                     v143 = iconst.i64 2
@@ -99,8 +102,8 @@
 ;; @0025                               v73 = isub v64, v7  ; v7 = 20
 ;; @0025                               v74 = uextend.i64 v73
 ;; @0025                               v75 = isub v72, v74
-;; @0025                               store user2 little region3 v137, v75
-;; @0025                               v83 = load.i32 user2 readonly region3 v54
+;; @0025                               store user2 little region5 v137, v75
+;; @0025                               v83 = load.i32 user2 readonly region5 v54
 ;; @0025                               v76 = iconst.i32 1
 ;;                                     v199 = icmp ugt v83, v76  ; v76 = 1
 ;; @0025                               trapz v199, user17
@@ -118,8 +121,8 @@
 ;; @0025                               v101 = isub v92, v221  ; v221 = 24
 ;; @0025                               v102 = uextend.i64 v101
 ;; @0025                               v103 = isub v100, v102
-;; @0025                               store user2 little region3 v135, v103
-;; @0025                               v111 = load.i32 user2 readonly region3 v54
+;; @0025                               store user2 little region5 v135, v103
+;; @0025                               v111 = load.i32 user2 readonly region5 v54
 ;;                                     v227 = icmp ugt v111, v181  ; v181 = 2
 ;; @0025                               trapz v227, user17
 ;; @0025                               v114 = uextend.i64 v111
@@ -136,7 +139,7 @@
 ;; @0025                               v129 = isub v120, v254  ; v254 = 28
 ;; @0025                               v130 = uextend.i64 v129
 ;; @0025                               v131 = isub v128, v130
-;; @0025                               store user2 little region3 v133, v131
+;; @0025                               store user2 little region5 v133, v131
 ;; @0029                               jump block1(v44)
 ;;
 ;;                                 block1(v5: i32):

--- a/tests/disas/gc/copying/array-new-fixed.wat
+++ b/tests/disas/gc/copying/array-new-fixed.wat
@@ -10,18 +10,21 @@
 )
 ;; function u0:0(i64 vmctx, i64, i64, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 32 "VMContext+0x20"
-;;     region2 = 40 "VMContext+0x28"
-;;     region3 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 32 "VMContext+0x20"
+;;     region3 = 40 "VMContext+0x28"
+;;     region4 = 268435488 "VMStoreContext+0x20"
+;;     region5 = 2147483648 "GcHeap"
+;;     region6 = 268435496 "VMStoreContext+0x28"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
 ;;     fn0 = colocated u805306368:24 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i64, v4: i64):
-;; @0025                               v15 = load.i64 notrap aligned readonly can_move region1 v0+32
+;; @0025                               v15 = load.i64 notrap aligned readonly can_move region2 v0+32
 ;; @0025                               v16 = load.i32 notrap aligned v15
 ;; @0025                               v17 = load.i32 notrap aligned v15+4
 ;; @0025                               v23 = uextend.i64 v16
@@ -37,10 +40,10 @@
 ;; @0025                               store notrap aligned v156, v15
 ;;                                     v249 = iconst.i32 -1476395002
 ;;                                     v250 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v251 = load.i64 notrap aligned readonly can_move v250+32
+;;                                     v251 = load.i64 notrap aligned readonly can_move region4 v250+32
 ;; @0025                               v40 = iadd v251, v23
 ;; @0025                               store notrap aligned v249, v40  ; v249 = -1476395002
-;;                                     v252 = load.i64 notrap aligned readonly can_move region2 v0+40
+;;                                     v252 = load.i64 notrap aligned readonly can_move region3 v0+40
 ;;                                     v253 = load.i32 notrap aligned readonly can_move v252
 ;; @0025                               store notrap aligned v253, v40+4
 ;;                                     v254 = iconst.i64 48
@@ -49,13 +52,13 @@
 ;;
 ;;                                 block3 cold:
 ;; @0025                               v27 = iconst.i32 -1476395002
-;; @0025                               v28 = load.i64 notrap aligned readonly can_move region2 v0+40
+;; @0025                               v28 = load.i64 notrap aligned readonly can_move region3 v0+40
 ;; @0025                               v29 = load.i32 notrap aligned readonly can_move v28
 ;;                                     v141 = iconst.i32 48
 ;; @0025                               v30 = iconst.i32 16
 ;; @0025                               v31 = call fn0(v0, v27, v29, v141, v30)  ; v27 = -1476395002, v141 = 48, v30 = 16
 ;; @0025                               v32 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0025                               v33 = load.i64 notrap aligned readonly can_move v32+32
+;; @0025                               v33 = load.i64 notrap aligned readonly can_move region4 v32+32
 ;; @0025                               v34 = uextend.i64 v31
 ;; @0025                               v35 = iadd v33, v34
 ;; @0025                               jump block4(v31, v35)
@@ -64,14 +67,14 @@
 ;; @0025                               v6 = iconst.i32 3
 ;; @0025                               v46 = iconst.i64 16
 ;; @0025                               v47 = iadd v45, v46  ; v46 = 16
-;; @0025                               store user2 region3 v6, v47  ; v6 = 3
+;; @0025                               store user2 region5 v6, v47  ; v6 = 3
 ;; @0025                               trapz v44, user16
 ;;                                     v255 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v256 = load.i64 notrap aligned readonly can_move v255+32
+;;                                     v256 = load.i64 notrap aligned readonly can_move region4 v255+32
 ;; @0025                               v49 = uextend.i64 v44
 ;; @0025                               v52 = iadd v256, v49
 ;; @0025                               v54 = iadd v52, v46  ; v46 = 16
-;; @0025                               v55 = load.i32 user2 readonly region3 v54
+;; @0025                               v55 = load.i32 user2 readonly region5 v54
 ;; @0025                               trapz v55, user17
 ;; @0025                               v58 = uextend.i64 v55
 ;;                                     v132 = iconst.i64 3
@@ -88,8 +91,8 @@
 ;; @0025                               v73 = isub v64, v7  ; v7 = 24
 ;; @0025                               v74 = uextend.i64 v73
 ;; @0025                               v75 = isub v72, v74
-;; @0025                               store.i64 user2 little region3 v2, v75
-;; @0025                               v83 = load.i32 user2 readonly region3 v54
+;; @0025                               store.i64 user2 little region5 v2, v75
+;; @0025                               v83 = load.i32 user2 readonly region5 v54
 ;; @0025                               v76 = iconst.i32 1
 ;;                                     v188 = icmp ugt v83, v76  ; v76 = 1
 ;; @0025                               trapz v188, user17
@@ -106,8 +109,8 @@
 ;; @0025                               v101 = isub v92, v210  ; v210 = 32
 ;; @0025                               v102 = uextend.i64 v101
 ;; @0025                               v103 = isub v100, v102
-;; @0025                               store.i64 user2 little region3 v3, v103
-;; @0025                               v111 = load.i32 user2 readonly region3 v54
+;; @0025                               store.i64 user2 little region5 v3, v103
+;; @0025                               v111 = load.i32 user2 readonly region5 v54
 ;; @0025                               v104 = iconst.i32 2
 ;;                                     v216 = icmp ugt v111, v104  ; v104 = 2
 ;; @0025                               trapz v216, user17
@@ -124,7 +127,7 @@
 ;; @0025                               v129 = isub v120, v242  ; v242 = 40
 ;; @0025                               v130 = uextend.i64 v129
 ;; @0025                               v131 = isub v128, v130
-;; @0025                               store.i64 user2 little region3 v4, v131
+;; @0025                               store.i64 user2 little region5 v4, v131
 ;; @0029                               jump block1(v44)
 ;;
 ;;                                 block1(v5: i32):

--- a/tests/disas/gc/copying/array-new.wat
+++ b/tests/disas/gc/copying/array-new.wat
@@ -10,12 +10,15 @@
 )
 ;; function u0:0(i64 vmctx, i64, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 32 "VMContext+0x20"
-;;     region2 = 40 "VMContext+0x28"
-;;     region3 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 32 "VMContext+0x20"
+;;     region3 = 40 "VMContext+0x28"
+;;     region4 = 268435488 "VMStoreContext+0x20"
+;;     region5 = 2147483648 "GcHeap"
+;;     region6 = 268435496 "VMStoreContext+0x28"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
 ;;     fn0 = colocated u805306368:24 sig0
 ;;     stack_limit = gv2
@@ -31,7 +34,7 @@
 ;;                                     v95 = iconst.i32 3
 ;;                                     v96 = ishl v3, v95  ; v95 = 3
 ;; @0022                               v12 = uadd_overflow_trap v5, v96, user18  ; v5 = 24
-;; @0022                               v13 = load.i64 notrap aligned readonly can_move region1 v0+32
+;; @0022                               v13 = load.i64 notrap aligned readonly can_move region2 v0+32
 ;; @0022                               v14 = load.i32 notrap aligned v13
 ;; @0022                               v15 = load.i32 notrap aligned v13+4
 ;; @0022                               v21 = uextend.i64 v14
@@ -54,10 +57,10 @@
 ;; @0022                               store notrap aligned v111, v13
 ;;                                     v127 = iconst.i32 -1476395002
 ;;                                     v128 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v129 = load.i64 notrap aligned readonly can_move v128+32
+;;                                     v129 = load.i64 notrap aligned readonly can_move region4 v128+32
 ;; @0022                               v38 = iadd v129, v21
 ;; @0022                               store notrap aligned v127, v38  ; v127 = -1476395002
-;;                                     v130 = load.i64 notrap aligned readonly can_move region2 v0+40
+;;                                     v130 = load.i64 notrap aligned readonly can_move region3 v0+40
 ;;                                     v131 = load.i32 notrap aligned readonly can_move v130
 ;; @0022                               store notrap aligned v131, v38+4
 ;;                                     v132 = band.i64 v19, v18  ; v18 = -16
@@ -66,12 +69,12 @@
 ;;
 ;;                                 block3 cold:
 ;; @0022                               v25 = iconst.i32 -1476395002
-;; @0022                               v26 = load.i64 notrap aligned readonly can_move region2 v0+40
+;; @0022                               v26 = load.i64 notrap aligned readonly can_move region3 v0+40
 ;; @0022                               v27 = load.i32 notrap aligned readonly can_move v26
 ;; @0022                               v28 = iconst.i32 16
 ;; @0022                               v29 = call fn0(v0, v25, v27, v12, v28)  ; v25 = -1476395002, v28 = 16
 ;; @0022                               v30 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0022                               v31 = load.i64 notrap aligned readonly can_move v30+32
+;; @0022                               v31 = load.i64 notrap aligned readonly can_move region4 v30+32
 ;; @0022                               v32 = uextend.i64 v29
 ;; @0022                               v33 = iadd v31, v32
 ;; @0022                               jump block4(v29, v33)
@@ -79,18 +82,18 @@
 ;;                                 block4(v42: i32, v43: i64):
 ;; @0022                               v44 = iconst.i64 16
 ;; @0022                               v45 = iadd v43, v44  ; v44 = 16
-;; @0022                               store.i32 user2 region3 v3, v45
+;; @0022                               store.i32 user2 region5 v3, v45
 ;; @0022                               trapz v42, user16
 ;;                                     v133 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v134 = load.i64 notrap aligned readonly can_move v133+32
+;;                                     v134 = load.i64 notrap aligned readonly can_move region4 v133+32
 ;; @0022                               v47 = uextend.i64 v42
 ;; @0022                               v50 = iadd v134, v47
 ;; @0022                               v52 = iadd v50, v44  ; v44 = 16
-;; @0022                               v53 = load.i32 user2 readonly region3 v52
+;; @0022                               v53 = load.i32 user2 readonly region5 v52
 ;; @0022                               v54 = uextend.i64 v53
 ;; @0022                               v60 = icmp.i64 ugt v6, v54
 ;; @0022                               trapnz v60, user17
-;; @0022                               v77 = load.i64 notrap aligned v133+40
+;; @0022                               v77 = load.i64 notrap aligned region6 v133+40
 ;; @0022                               v65 = iconst.i64 24
 ;; @0022                               v66 = iadd v50, v65  ; v65 = 24
 ;; @0022                               v79 = uadd_overflow_trap v66, v89, user2
@@ -104,7 +107,7 @@
 ;; @0022                               brif v83, block6, block5(v66)
 ;;
 ;;                                 block5(v84: i64):
-;; @0022                               store.i64 user2 little region3 v2, v84
+;; @0022                               store.i64 user2 little region5 v2, v84
 ;;                                     v135 = iconst.i64 8
 ;;                                     v136 = iadd v84, v135  ; v135 = 8
 ;; @0022                               v87 = icmp eq v136, v81

--- a/tests/disas/gc/copying/array-set.wat
+++ b/tests/disas/gc/copying/array-set.wat
@@ -10,21 +10,24 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32, i64) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 268435488 "VMStoreContext+0x20"
+;;     region3 = 268435496 "VMStoreContext+0x28"
+;;     region4 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i64):
 ;; @0024                               trapz v2, user16
 ;; @0024                               v6 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0024                               v7 = load.i64 notrap aligned readonly can_move v6+32
+;; @0024                               v7 = load.i64 notrap aligned readonly can_move region2 v6+32
 ;; @0024                               v5 = uextend.i64 v2
 ;; @0024                               v8 = iadd v7, v5
 ;; @0024                               v9 = iconst.i64 16
 ;; @0024                               v10 = iadd v8, v9  ; v9 = 16
-;; @0024                               v11 = load.i32 user2 readonly region1 v10
+;; @0024                               v11 = load.i32 user2 readonly region4 v10
 ;; @0024                               v12 = icmp ult v3, v11
 ;; @0024                               trapz v12, user17
 ;; @0024                               v14 = uextend.i64 v11
@@ -45,7 +48,7 @@
 ;; @0024                               v29 = isub v20, v23
 ;; @0024                               v30 = uextend.i64 v29
 ;; @0024                               v31 = isub v28, v30
-;; @0024                               store user2 little region1 v4, v31
+;; @0024                               store user2 little region4 v4, v31
 ;; @0027                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/copying/br-on-cast-fail.wat
+++ b/tests/disas/gc/copying/br-on-cast-fail.wat
@@ -17,15 +17,18 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 40 "VMContext+0x28"
-;;     region2 = 2147483648 "GcHeap"
-;;     region3 = 72 "VMContext+0x48"
-;;     region4 = 56 "VMContext+0x38"
-;;     region5 = 104 "VMContext+0x68"
-;;     region6 = 88 "VMContext+0x58"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 40 "VMContext+0x28"
+;;     region3 = 268435488 "VMStoreContext+0x20"
+;;     region4 = 268435496 "VMStoreContext+0x28"
+;;     region5 = 2147483648 "GcHeap"
+;;     region6 = 72 "VMContext+0x48"
+;;     region7 = 56 "VMContext+0x38"
+;;     region8 = 104 "VMContext+0x68"
+;;     region9 = 88 "VMContext+0x58"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, i64) tail
 ;;     stack_limit = gv2
 ;;
@@ -42,13 +45,13 @@
 ;;
 ;;                                 block4:
 ;; @002e                               v14 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @002e                               v15 = load.i64 notrap aligned readonly can_move v14+32
+;; @002e                               v15 = load.i64 notrap aligned readonly can_move region3 v14+32
 ;; @002e                               v13 = uextend.i64 v2
 ;; @002e                               v16 = iadd v15, v13
 ;; @002e                               v17 = iconst.i64 4
 ;; @002e                               v18 = iadd v16, v17  ; v17 = 4
-;; @002e                               v19 = load.i32 user2 readonly region2 v18
-;; @002e                               v11 = load.i64 notrap aligned readonly can_move region1 v0+40
+;; @002e                               v19 = load.i32 user2 readonly region5 v18
+;; @002e                               v11 = load.i64 notrap aligned readonly can_move region2 v0+40
 ;; @002e                               v12 = load.i32 notrap aligned readonly can_move v11
 ;; @002e                               v20 = icmp eq v19, v12
 ;; @002e                               v21 = uextend.i32 v20
@@ -58,14 +61,14 @@
 ;; @002e                               brif v22, block6, block2
 ;;
 ;;                                 block6:
-;; @0034                               v24 = load.i64 notrap aligned readonly can_move region4 v0+56
-;; @0034                               v23 = load.i64 notrap aligned readonly can_move region3 v0+72
+;; @0034                               v24 = load.i64 notrap aligned readonly can_move region7 v0+56
+;; @0034                               v23 = load.i64 notrap aligned readonly can_move region6 v0+72
 ;; @0034                               call_indirect sig0, v24(v23, v0)
 ;; @0036                               return
 ;;
 ;;                                 block2:
-;; @0038                               v26 = load.i64 notrap aligned readonly can_move region6 v0+88
-;; @0038                               v25 = load.i64 notrap aligned readonly can_move region5 v0+104
+;; @0038                               v26 = load.i64 notrap aligned readonly can_move region9 v0+88
+;; @0038                               v25 = load.i64 notrap aligned readonly can_move region8 v0+104
 ;; @0038                               call_indirect sig0, v26(v25, v0)
 ;; @003a                               return
 ;; }

--- a/tests/disas/gc/copying/br-on-cast.wat
+++ b/tests/disas/gc/copying/br-on-cast.wat
@@ -17,15 +17,18 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 40 "VMContext+0x28"
-;;     region2 = 2147483648 "GcHeap"
-;;     region3 = 72 "VMContext+0x48"
-;;     region4 = 56 "VMContext+0x38"
-;;     region5 = 104 "VMContext+0x68"
-;;     region6 = 88 "VMContext+0x58"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 40 "VMContext+0x28"
+;;     region3 = 268435488 "VMStoreContext+0x20"
+;;     region4 = 268435496 "VMStoreContext+0x28"
+;;     region5 = 2147483648 "GcHeap"
+;;     region6 = 72 "VMContext+0x48"
+;;     region7 = 56 "VMContext+0x38"
+;;     region8 = 104 "VMContext+0x68"
+;;     region9 = 88 "VMContext+0x58"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, i64) tail
 ;;     stack_limit = gv2
 ;;
@@ -42,13 +45,13 @@
 ;;
 ;;                                 block4:
 ;; @002f                               v14 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @002f                               v15 = load.i64 notrap aligned readonly can_move v14+32
+;; @002f                               v15 = load.i64 notrap aligned readonly can_move region3 v14+32
 ;; @002f                               v13 = uextend.i64 v2
 ;; @002f                               v16 = iadd v15, v13
 ;; @002f                               v17 = iconst.i64 4
 ;; @002f                               v18 = iadd v16, v17  ; v17 = 4
-;; @002f                               v19 = load.i32 user2 readonly region2 v18
-;; @002f                               v11 = load.i64 notrap aligned readonly can_move region1 v0+40
+;; @002f                               v19 = load.i32 user2 readonly region5 v18
+;; @002f                               v11 = load.i64 notrap aligned readonly can_move region2 v0+40
 ;; @002f                               v12 = load.i32 notrap aligned readonly can_move v11
 ;; @002f                               v20 = icmp eq v19, v12
 ;; @002f                               v21 = uextend.i32 v20
@@ -58,14 +61,14 @@
 ;; @002f                               brif v22, block2, block6
 ;;
 ;;                                 block6:
-;; @0035                               v24 = load.i64 notrap aligned readonly can_move region4 v0+56
-;; @0035                               v23 = load.i64 notrap aligned readonly can_move region3 v0+72
+;; @0035                               v24 = load.i64 notrap aligned readonly can_move region7 v0+56
+;; @0035                               v23 = load.i64 notrap aligned readonly can_move region6 v0+72
 ;; @0035                               call_indirect sig0, v24(v23, v0)
 ;; @0037                               return
 ;;
 ;;                                 block2:
-;; @0039                               v26 = load.i64 notrap aligned readonly can_move region6 v0+88
-;; @0039                               v25 = load.i64 notrap aligned readonly can_move region5 v0+104
+;; @0039                               v26 = load.i64 notrap aligned readonly can_move region9 v0+88
+;; @0039                               v25 = load.i64 notrap aligned readonly can_move region8 v0+104
 ;; @0039                               call_indirect sig0, v26(v25, v0)
 ;; @003b                               return
 ;; }

--- a/tests/disas/gc/copying/call-indirect-and-subtyping.wat
+++ b/tests/disas/gc/copying/call-indirect-and-subtyping.wat
@@ -17,11 +17,12 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 1342177280 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
-;;     region2 = 40 "VMContext+0x28"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 1342177280 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
+;;     region3 = 40 "VMContext+0x28"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, i64) tail
 ;;     sig1 = (i64 vmctx, i32, i64) -> i64 tail
 ;;     sig2 = (i64 vmctx, i32, i32) -> i32 tail
@@ -39,7 +40,7 @@
 ;; @005c                               v8 = ishl v5, v7  ; v7 = 3
 ;; @005c                               v9 = iadd v6, v8
 ;; @005c                               v11 = select_spectre_guard v4, v10, v9  ; v10 = 0
-;; @005c                               v12 = load.i64 user6 aligned region1 v11
+;; @005c                               v12 = load.i64 user6 aligned region2 v11
 ;; @005c                               v13 = iconst.i64 -2
 ;; @005c                               v14 = band v12, v13  ; v13 = -2
 ;; @005c                               brif v12, block3(v14), block2
@@ -51,7 +52,7 @@
 ;;
 ;;                                 block3(v15: i64):
 ;; @005c                               v21 = load.i32 user7 aligned readonly v15+16
-;; @005c                               v19 = load.i64 notrap aligned readonly can_move region2 v0+40
+;; @005c                               v19 = load.i64 notrap aligned readonly can_move region3 v0+40
 ;; @005c                               v20 = load.i32 notrap aligned readonly can_move v19
 ;; @005c                               v22 = icmp eq v21, v20
 ;; @005c                               v23 = uextend.i32 v22

--- a/tests/disas/gc/copying/externref-globals.wat
+++ b/tests/disas/gc/copying/externref-globals.wat
@@ -12,9 +12,10 @@
 )
 ;; function u0:0(i64 vmctx, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
@@ -29,9 +30,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/gc/copying/funcref-in-gc-heap-get.wat
+++ b/tests/disas/gc/copying/funcref-in-gc-heap-get.wat
@@ -10,10 +10,13 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i64 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 268435488 "VMStoreContext+0x20"
+;;     region3 = 268435496 "VMStoreContext+0x28"
+;;     region4 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, i32, i32) -> i64 tail
 ;;     fn0 = colocated u805306368:26 sig0
 ;;     stack_limit = gv2
@@ -21,12 +24,12 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0020                               trapz v2, user16
 ;; @0020                               v5 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0020                               v6 = load.i64 notrap aligned readonly can_move v5+32
+;; @0020                               v6 = load.i64 notrap aligned readonly can_move region2 v5+32
 ;; @0020                               v4 = uextend.i64 v2
 ;; @0020                               v7 = iadd v6, v4
 ;; @0020                               v8 = iconst.i64 16
 ;; @0020                               v9 = iadd v7, v8  ; v8 = 16
-;; @0020                               v11 = load.i32 user2 little region1 v9
+;; @0020                               v11 = load.i32 user2 little region4 v9
 ;; @0020                               v10 = iconst.i32 -1
 ;; @0020                               v12 = call fn0(v0, v11, v10)  ; v10 = -1
 ;; @0024                               jump block1

--- a/tests/disas/gc/copying/funcref-in-gc-heap-new.wat
+++ b/tests/disas/gc/copying/funcref-in-gc-heap-new.wat
@@ -11,12 +11,14 @@
 ;; function u0:0(i64 vmctx, i64, i64) -> i32 tail {
 ;;     ss0 = explicit_slot 4, align = 4
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 32 "VMContext+0x20"
-;;     region2 = 40 "VMContext+0x28"
-;;     region3 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 32 "VMContext+0x20"
+;;     region3 = 40 "VMContext+0x28"
+;;     region4 = 268435488 "VMStoreContext+0x20"
+;;     region5 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i64) -> i64 tail
 ;;     fn0 = colocated u805306368:24 sig0
@@ -24,7 +26,7 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0020                               v5 = load.i64 notrap aligned readonly can_move region1 v0+32
+;; @0020                               v5 = load.i64 notrap aligned readonly can_move region2 v0+32
 ;; @0020                               v6 = load.i32 notrap aligned v5
 ;; @0020                               v7 = load.i32 notrap aligned v5+4
 ;; @0020                               v13 = uextend.i64 v6
@@ -40,10 +42,10 @@
 ;; @0020                               store notrap aligned v57, v5
 ;;                                     v60 = iconst.i32 -1342177278
 ;;                                     v61 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v62 = load.i64 notrap aligned readonly can_move v61+32
+;;                                     v62 = load.i64 notrap aligned readonly can_move region4 v61+32
 ;; @0020                               v30 = iadd v62, v13
 ;; @0020                               store notrap aligned v60, v30  ; v60 = -1342177278
-;;                                     v63 = load.i64 notrap aligned readonly can_move region2 v0+40
+;;                                     v63 = load.i64 notrap aligned readonly can_move region3 v0+40
 ;;                                     v64 = load.i32 notrap aligned readonly can_move v63
 ;; @0020                               store notrap aligned v64, v30+4
 ;;                                     v65 = iconst.i64 32
@@ -52,13 +54,13 @@
 ;;
 ;;                                 block3 cold:
 ;; @0020                               v17 = iconst.i32 -1342177278
-;; @0020                               v18 = load.i64 notrap aligned readonly can_move region2 v0+40
+;; @0020                               v18 = load.i64 notrap aligned readonly can_move region3 v0+40
 ;; @0020                               v19 = load.i32 notrap aligned readonly can_move v18
 ;; @0020                               v4 = iconst.i32 32
 ;; @0020                               v20 = iconst.i32 16
 ;; @0020                               v21 = call fn0(v0, v17, v19, v4, v20)  ; v17 = -1342177278, v4 = 32, v20 = 16
 ;; @0020                               v22 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0020                               v23 = load.i64 notrap aligned readonly can_move v22+32
+;; @0020                               v23 = load.i64 notrap aligned readonly can_move region4 v22+32
 ;; @0020                               v24 = uextend.i64 v21
 ;; @0020                               v25 = iadd v23, v24
 ;; @0020                               jump block4(v21, v25)
@@ -70,7 +72,7 @@
 ;; @0020                               v39 = ireduce.i32 v38
 ;; @0020                               v36 = iconst.i64 16
 ;; @0020                               v37 = iadd v35, v36  ; v36 = 16
-;; @0020                               store user2 little region3 v39, v37
+;; @0020                               store user2 little region5 v39, v37
 ;;                                     v41 = load.i32 notrap v42
 ;; @0023                               jump block1
 ;;

--- a/tests/disas/gc/copying/funcref-in-gc-heap-set.wat
+++ b/tests/disas/gc/copying/funcref-in-gc-heap-set.wat
@@ -10,10 +10,13 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32, i64) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 268435488 "VMStoreContext+0x20"
+;;     region3 = 268435496 "VMStoreContext+0x28"
+;;     region4 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, i64) -> i64 tail
 ;;     fn0 = colocated u805306368:25 sig0
 ;;     stack_limit = gv2
@@ -23,12 +26,12 @@
 ;; @0022                               v10 = call fn0(v0, v3)
 ;; @0022                               v11 = ireduce.i32 v10
 ;; @0022                               v5 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0022                               v6 = load.i64 notrap aligned readonly can_move v5+32
+;; @0022                               v6 = load.i64 notrap aligned readonly can_move region2 v5+32
 ;; @0022                               v4 = uextend.i64 v2
 ;; @0022                               v7 = iadd v6, v4
 ;; @0022                               v8 = iconst.i64 16
 ;; @0022                               v9 = iadd v7, v8  ; v8 = 16
-;; @0022                               store user2 little region1 v11, v9
+;; @0022                               store user2 little region4 v11, v9
 ;; @0026                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/copying/i31ref-globals.wat
+++ b/tests/disas/gc/copying/i31ref-globals.wat
@@ -12,9 +12,10 @@
 )
 ;; function u0:0(i64 vmctx, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
@@ -29,9 +30,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/gc/copying/multiple-array-get.wat
+++ b/tests/disas/gc/copying/multiple-array-get.wat
@@ -11,21 +11,24 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32, i32) -> i64, i64 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 268435488 "VMStoreContext+0x20"
+;;     region3 = 268435496 "VMStoreContext+0x28"
+;;     region4 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
 ;; @0024                               trapz v2, user16
 ;; @0024                               v8 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0024                               v9 = load.i64 notrap aligned readonly can_move v8+32
+;; @0024                               v9 = load.i64 notrap aligned readonly can_move region2 v8+32
 ;; @0024                               v7 = uextend.i64 v2
 ;; @0024                               v10 = iadd v9, v7
 ;; @0024                               v11 = iconst.i64 16
 ;; @0024                               v12 = iadd v10, v11  ; v11 = 16
-;; @0024                               v13 = load.i32 user2 readonly region1 v12
+;; @0024                               v13 = load.i32 user2 readonly region4 v12
 ;; @0024                               v14 = icmp ult v3, v13
 ;; @0024                               trapz v14, user17
 ;; @0024                               v16 = uextend.i64 v13
@@ -46,7 +49,7 @@
 ;; @0024                               v31 = isub v22, v25
 ;; @0024                               v32 = uextend.i64 v31
 ;; @0024                               v33 = isub v30, v32
-;; @0024                               v34 = load.i64 user2 little region1 v33
+;; @0024                               v34 = load.i64 user2 little region4 v33
 ;; @002b                               v42 = icmp ult v4, v13
 ;; @002b                               trapz v42, user17
 ;;                                     v82 = ishl v4, v73  ; v73 = 3
@@ -54,7 +57,7 @@
 ;; @002b                               v59 = isub v22, v53
 ;; @002b                               v60 = uextend.i64 v59
 ;; @002b                               v61 = isub v30, v60
-;; @002b                               v62 = load.i64 user2 little region1 v61
+;; @002b                               v62 = load.i64 user2 little region4 v61
 ;; @002e                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/copying/multiple-struct-get.wat
+++ b/tests/disas/gc/copying/multiple-struct-get.wat
@@ -12,24 +12,27 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> f32, i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 268435488 "VMStoreContext+0x20"
+;;     region3 = 268435496 "VMStoreContext+0x28"
+;;     region4 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0023                               trapz v2, user16
 ;; @0023                               v6 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0023                               v7 = load.i64 notrap aligned readonly can_move v6+32
+;; @0023                               v7 = load.i64 notrap aligned readonly can_move region2 v6+32
 ;; @0023                               v5 = uextend.i64 v2
 ;; @0023                               v8 = iadd v7, v5
 ;; @0023                               v9 = iconst.i64 16
 ;; @0023                               v10 = iadd v8, v9  ; v9 = 16
-;; @0023                               v11 = load.f32 user2 little region1 v10
+;; @0023                               v11 = load.f32 user2 little region4 v10
 ;; @0029                               v16 = iconst.i64 20
 ;; @0029                               v17 = iadd v8, v16  ; v16 = 20
-;; @0029                               v18 = load.i8 user2 little region1 v17
+;; @0029                               v18 = load.i8 user2 little region4 v17
 ;; @002d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/copying/ref-cast.wat
+++ b/tests/disas/gc/copying/ref-cast.wat
@@ -9,11 +9,14 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 40 "VMContext+0x28"
-;;     region2 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 40 "VMContext+0x28"
+;;     region3 = 268435488 "VMStoreContext+0x20"
+;;     region4 = 268435496 "VMStoreContext+0x28"
+;;     region5 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -29,13 +32,13 @@
 ;;
 ;;                                 block3:
 ;; @001e                               v14 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @001e                               v15 = load.i64 notrap aligned readonly can_move v14+32
+;; @001e                               v15 = load.i64 notrap aligned readonly can_move region3 v14+32
 ;; @001e                               v13 = uextend.i64 v2
 ;; @001e                               v16 = iadd v15, v13
 ;; @001e                               v17 = iconst.i64 4
 ;; @001e                               v18 = iadd v16, v17  ; v17 = 4
-;; @001e                               v19 = load.i32 user2 readonly region2 v18
-;; @001e                               v11 = load.i64 notrap aligned readonly can_move region1 v0+40
+;; @001e                               v19 = load.i32 user2 readonly region5 v18
+;; @001e                               v11 = load.i64 notrap aligned readonly can_move region2 v0+40
 ;; @001e                               v12 = load.i32 notrap aligned readonly can_move v11
 ;; @001e                               v20 = icmp eq v19, v12
 ;; @001e                               v21 = uextend.i32 v20

--- a/tests/disas/gc/copying/ref-is-null.wat
+++ b/tests/disas/gc/copying/ref-is-null.wat
@@ -11,9 +11,10 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -28,9 +29,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/gc/copying/ref-test-any.wat
+++ b/tests/disas/gc/copying/ref-test-any.wat
@@ -11,9 +11,10 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -28,9 +29,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/gc/copying/ref-test-array.wat
+++ b/tests/disas/gc/copying/ref-test-array.wat
@@ -8,10 +8,13 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 268435488 "VMStoreContext+0x20"
+;;     region3 = 268435496 "VMStoreContext+0x28"
+;;     region4 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -27,10 +30,10 @@
 ;;
 ;;                                 block3:
 ;; @001b                               v12 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @001b                               v13 = load.i64 notrap aligned readonly can_move v12+32
+;; @001b                               v13 = load.i64 notrap aligned readonly can_move region2 v12+32
 ;; @001b                               v11 = uextend.i64 v2
 ;; @001b                               v14 = iadd v13, v11
-;; @001b                               v17 = load.i32 user2 readonly region1 v14
+;; @001b                               v17 = load.i32 user2 readonly region4 v14
 ;; @001b                               v18 = iconst.i32 -1476395008
 ;; @001b                               v19 = band v17, v18  ; v18 = -1476395008
 ;; @001b                               v20 = icmp eq v19, v18  ; v18 = -1476395008

--- a/tests/disas/gc/copying/ref-test-concrete-func-type.wat
+++ b/tests/disas/gc/copying/ref-test-concrete-func-type.wat
@@ -9,11 +9,12 @@
 )
 ;; function u0:0(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 40 "VMContext+0x28"
-;;     region2 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 40 "VMContext+0x28"
+;;     region3 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
@@ -26,8 +27,8 @@
 ;; @0020                               jump block3
 ;;
 ;;                                 block3:
-;; @0020                               v10 = load.i32 user2 readonly region2 v2+16
-;; @0020                               v8 = load.i64 notrap aligned readonly can_move region1 v0+40
+;; @0020                               v10 = load.i32 user2 readonly region3 v2+16
+;; @0020                               v8 = load.i64 notrap aligned readonly can_move region2 v0+40
 ;; @0020                               v9 = load.i32 notrap aligned readonly can_move v8
 ;; @0020                               v11 = icmp eq v10, v9
 ;; @0020                               v12 = uextend.i32 v11

--- a/tests/disas/gc/copying/ref-test-concrete-type.wat
+++ b/tests/disas/gc/copying/ref-test-concrete-type.wat
@@ -9,11 +9,14 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 40 "VMContext+0x28"
-;;     region2 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 40 "VMContext+0x28"
+;;     region3 = 268435488 "VMStoreContext+0x20"
+;;     region4 = 268435496 "VMStoreContext+0x28"
+;;     region5 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -29,13 +32,13 @@
 ;;
 ;;                                 block3:
 ;; @001d                               v14 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @001d                               v15 = load.i64 notrap aligned readonly can_move v14+32
+;; @001d                               v15 = load.i64 notrap aligned readonly can_move region3 v14+32
 ;; @001d                               v13 = uextend.i64 v2
 ;; @001d                               v16 = iadd v15, v13
 ;; @001d                               v17 = iconst.i64 4
 ;; @001d                               v18 = iadd v16, v17  ; v17 = 4
-;; @001d                               v19 = load.i32 user2 readonly region2 v18
-;; @001d                               v11 = load.i64 notrap aligned readonly can_move region1 v0+40
+;; @001d                               v19 = load.i32 user2 readonly region5 v18
+;; @001d                               v11 = load.i64 notrap aligned readonly can_move region2 v0+40
 ;; @001d                               v12 = load.i32 notrap aligned readonly can_move v11
 ;; @001d                               v20 = icmp eq v19, v12
 ;; @001d                               v21 = uextend.i32 v20

--- a/tests/disas/gc/copying/ref-test-eq.wat
+++ b/tests/disas/gc/copying/ref-test-eq.wat
@@ -8,10 +8,13 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 268435488 "VMStoreContext+0x20"
+;;     region3 = 268435496 "VMStoreContext+0x28"
+;;     region4 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -26,10 +29,10 @@
 ;;
 ;;                                 block3:
 ;; @001b                               v12 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @001b                               v13 = load.i64 notrap aligned readonly can_move v12+32
+;; @001b                               v13 = load.i64 notrap aligned readonly can_move region2 v12+32
 ;; @001b                               v11 = uextend.i64 v2
 ;; @001b                               v14 = iadd v13, v11
-;; @001b                               v17 = load.i32 user2 readonly region1 v14
+;; @001b                               v17 = load.i32 user2 readonly region4 v14
 ;; @001b                               v18 = iconst.i32 -1610612736
 ;; @001b                               v19 = band v17, v18  ; v18 = -1610612736
 ;; @001b                               v20 = icmp eq v19, v18  ; v18 = -1610612736

--- a/tests/disas/gc/copying/ref-test-i31.wat
+++ b/tests/disas/gc/copying/ref-test-i31.wat
@@ -8,9 +8,10 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/gc/copying/ref-test-none.wat
+++ b/tests/disas/gc/copying/ref-test-none.wat
@@ -11,9 +11,10 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -26,9 +27,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/gc/copying/ref-test-struct.wat
+++ b/tests/disas/gc/copying/ref-test-struct.wat
@@ -8,10 +8,13 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 268435488 "VMStoreContext+0x20"
+;;     region3 = 268435496 "VMStoreContext+0x28"
+;;     region4 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -27,10 +30,10 @@
 ;;
 ;;                                 block3:
 ;; @001b                               v12 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @001b                               v13 = load.i64 notrap aligned readonly can_move v12+32
+;; @001b                               v13 = load.i64 notrap aligned readonly can_move region2 v12+32
 ;; @001b                               v11 = uextend.i64 v2
 ;; @001b                               v14 = iadd v13, v11
-;; @001b                               v17 = load.i32 user2 readonly region1 v14
+;; @001b                               v17 = load.i32 user2 readonly region4 v14
 ;; @001b                               v18 = iconst.i32 -1342177280
 ;; @001b                               v19 = band v17, v18  ; v18 = -1342177280
 ;; @001b                               v20 = icmp eq v19, v18  ; v18 = -1342177280

--- a/tests/disas/gc/copying/struct-get.wat
+++ b/tests/disas/gc/copying/struct-get.wat
@@ -24,21 +24,24 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> f32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 268435488 "VMStoreContext+0x20"
+;;     region3 = 268435496 "VMStoreContext+0x28"
+;;     region4 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0033                               trapz v2, user16
 ;; @0033                               v5 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0033                               v6 = load.i64 notrap aligned readonly can_move v5+32
+;; @0033                               v6 = load.i64 notrap aligned readonly can_move region2 v5+32
 ;; @0033                               v4 = uextend.i64 v2
 ;; @0033                               v7 = iadd v6, v4
 ;; @0033                               v8 = iconst.i64 16
 ;; @0033                               v9 = iadd v7, v8  ; v8 = 16
-;; @0033                               v10 = load.f32 user2 little region1 v9
+;; @0033                               v10 = load.f32 user2 little region4 v9
 ;; @0037                               jump block1
 ;;
 ;;                                 block1:
@@ -47,21 +50,24 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 268435488 "VMStoreContext+0x20"
+;;     region3 = 268435496 "VMStoreContext+0x28"
+;;     region4 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @003c                               trapz v2, user16
 ;; @003c                               v5 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @003c                               v6 = load.i64 notrap aligned readonly can_move v5+32
+;; @003c                               v6 = load.i64 notrap aligned readonly can_move region2 v5+32
 ;; @003c                               v4 = uextend.i64 v2
 ;; @003c                               v7 = iadd v6, v4
 ;; @003c                               v8 = iconst.i64 20
 ;; @003c                               v9 = iadd v7, v8  ; v8 = 20
-;; @003c                               v10 = load.i8 user2 little region1 v9
+;; @003c                               v10 = load.i8 user2 little region4 v9
 ;; @0040                               jump block1
 ;;
 ;;                                 block1:
@@ -71,21 +77,24 @@
 ;;
 ;; function u0:2(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 268435488 "VMStoreContext+0x20"
+;;     region3 = 268435496 "VMStoreContext+0x28"
+;;     region4 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0045                               trapz v2, user16
 ;; @0045                               v5 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0045                               v6 = load.i64 notrap aligned readonly can_move v5+32
+;; @0045                               v6 = load.i64 notrap aligned readonly can_move region2 v5+32
 ;; @0045                               v4 = uextend.i64 v2
 ;; @0045                               v7 = iadd v6, v4
 ;; @0045                               v8 = iconst.i64 20
 ;; @0045                               v9 = iadd v7, v8  ; v8 = 20
-;; @0045                               v10 = load.i8 user2 little region1 v9
+;; @0045                               v10 = load.i8 user2 little region4 v9
 ;; @0049                               jump block1
 ;;
 ;;                                 block1:
@@ -95,21 +104,24 @@
 ;;
 ;; function u0:3(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 268435488 "VMStoreContext+0x20"
+;;     region3 = 268435496 "VMStoreContext+0x28"
+;;     region4 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @004e                               trapz v2, user16
 ;; @004e                               v5 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @004e                               v6 = load.i64 notrap aligned readonly can_move v5+32
+;; @004e                               v6 = load.i64 notrap aligned readonly can_move region2 v5+32
 ;; @004e                               v4 = uextend.i64 v2
 ;; @004e                               v7 = iadd v6, v4
 ;; @004e                               v8 = iconst.i64 24
 ;; @004e                               v9 = iadd v7, v8  ; v8 = 24
-;; @004e                               v10 = load.i32 user2 little region1 v9
+;; @004e                               v10 = load.i32 user2 little region4 v9
 ;; @0052                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/copying/struct-new-default.wat
+++ b/tests/disas/gc/copying/struct-new-default.wat
@@ -12,18 +12,20 @@
 )
 ;; function u0:0(i64 vmctx, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 32 "VMContext+0x20"
-;;     region2 = 40 "VMContext+0x28"
-;;     region3 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 32 "VMContext+0x20"
+;;     region3 = 40 "VMContext+0x28"
+;;     region4 = 268435488 "VMStoreContext+0x20"
+;;     region5 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
 ;;     fn0 = colocated u805306368:24 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @0021                               v7 = load.i64 notrap aligned readonly can_move region1 v0+32
+;; @0021                               v7 = load.i64 notrap aligned readonly can_move region2 v0+32
 ;; @0021                               v8 = load.i32 notrap aligned v7
 ;; @0021                               v9 = load.i32 notrap aligned v7+4
 ;; @0021                               v15 = uextend.i64 v8
@@ -39,10 +41,10 @@
 ;; @0021                               store notrap aligned v58, v7
 ;;                                     v61 = iconst.i32 -1342177246
 ;;                                     v62 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v63 = load.i64 notrap aligned readonly can_move v62+32
+;;                                     v63 = load.i64 notrap aligned readonly can_move region4 v62+32
 ;; @0021                               v32 = iadd v63, v15
 ;; @0021                               store notrap aligned v61, v32  ; v61 = -1342177246
-;;                                     v64 = load.i64 notrap aligned readonly can_move region2 v0+40
+;;                                     v64 = load.i64 notrap aligned readonly can_move region3 v0+40
 ;;                                     v65 = load.i32 notrap aligned readonly can_move v64
 ;; @0021                               store notrap aligned v65, v32+4
 ;;                                     v66 = iconst.i64 32
@@ -51,13 +53,13 @@
 ;;
 ;;                                 block3 cold:
 ;; @0021                               v19 = iconst.i32 -1342177246
-;; @0021                               v20 = load.i64 notrap aligned readonly can_move region2 v0+40
+;; @0021                               v20 = load.i64 notrap aligned readonly can_move region3 v0+40
 ;; @0021                               v21 = load.i32 notrap aligned readonly can_move v20
 ;; @0021                               v6 = iconst.i32 32
 ;; @0021                               v22 = iconst.i32 16
 ;; @0021                               v23 = call fn0(v0, v19, v21, v6, v22)  ; v19 = -1342177246, v6 = 32, v22 = 16
 ;; @0021                               v24 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0021                               v25 = load.i64 notrap aligned readonly can_move v24+32
+;; @0021                               v25 = load.i64 notrap aligned readonly can_move region4 v24+32
 ;; @0021                               v26 = uextend.i64 v23
 ;; @0021                               v27 = iadd v25, v26
 ;; @0021                               jump block4(v23, v27)
@@ -66,14 +68,14 @@
 ;; @0021                               v3 = f32const 0.0
 ;; @0021                               v38 = iconst.i64 16
 ;; @0021                               v39 = iadd v37, v38  ; v38 = 16
-;; @0021                               store user2 little region3 v3, v39  ; v3 = 0.0
+;; @0021                               store user2 little region5 v3, v39  ; v3 = 0.0
 ;; @0021                               v4 = iconst.i32 0
 ;; @0021                               v40 = iconst.i64 20
 ;; @0021                               v41 = iadd v37, v40  ; v40 = 20
-;; @0021                               istore8 user2 little region3 v4, v41  ; v4 = 0
+;; @0021                               istore8 user2 little region5 v4, v41  ; v4 = 0
 ;; @0021                               v42 = iconst.i64 24
 ;; @0021                               v43 = iadd v37, v42  ; v42 = 24
-;; @0021                               store user2 little region3 v4, v43  ; v4 = 0
+;; @0021                               store user2 little region5 v4, v43  ; v4 = 0
 ;; @0024                               jump block1(v36)
 ;;
 ;;                                 block1(v2: i32):

--- a/tests/disas/gc/copying/struct-new.wat
+++ b/tests/disas/gc/copying/struct-new.wat
@@ -13,12 +13,14 @@
 ;; function u0:0(i64 vmctx, i64, f32, i32, i32) -> i32 tail {
 ;;     ss0 = explicit_slot 4, align = 4
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 32 "VMContext+0x20"
-;;     region2 = 40 "VMContext+0x28"
-;;     region3 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 32 "VMContext+0x20"
+;;     region3 = 40 "VMContext+0x28"
+;;     region4 = 268435488 "VMStoreContext+0x20"
+;;     region5 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
 ;;     fn0 = colocated u805306368:24 sig0
 ;;     stack_limit = gv2
@@ -26,7 +28,7 @@
 ;;                                 block0(v0: i64, v1: i64, v2: f32, v3: i32, v4: i32):
 ;;                                     v46 = stack_addr.i64 ss0
 ;;                                     store notrap v4, v46
-;; @002a                               v7 = load.i64 notrap aligned readonly can_move region1 v0+32
+;; @002a                               v7 = load.i64 notrap aligned readonly can_move region2 v0+32
 ;; @002a                               v8 = load.i32 notrap aligned v7
 ;; @002a                               v9 = load.i32 notrap aligned v7+4
 ;; @002a                               v15 = uextend.i64 v8
@@ -42,10 +44,10 @@
 ;; @002a                               store notrap aligned v61, v7
 ;;                                     v64 = iconst.i32 -1342177246
 ;;                                     v65 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v66 = load.i64 notrap aligned readonly can_move v65+32
+;;                                     v66 = load.i64 notrap aligned readonly can_move region4 v65+32
 ;; @002a                               v32 = iadd v66, v15
 ;; @002a                               store notrap aligned v64, v32  ; v64 = -1342177246
-;;                                     v67 = load.i64 notrap aligned readonly can_move region2 v0+40
+;;                                     v67 = load.i64 notrap aligned readonly can_move region3 v0+40
 ;;                                     v68 = load.i32 notrap aligned readonly can_move v67
 ;; @002a                               store notrap aligned v68, v32+4
 ;;                                     v69 = iconst.i64 32
@@ -54,13 +56,13 @@
 ;;
 ;;                                 block3 cold:
 ;; @002a                               v19 = iconst.i32 -1342177246
-;; @002a                               v20 = load.i64 notrap aligned readonly can_move region2 v0+40
+;; @002a                               v20 = load.i64 notrap aligned readonly can_move region3 v0+40
 ;; @002a                               v21 = load.i32 notrap aligned readonly can_move v20
 ;; @002a                               v6 = iconst.i32 32
 ;; @002a                               v22 = iconst.i32 16
 ;; @002a                               v23 = call fn0(v0, v19, v21, v6, v22), stack_map=[i32 @ ss0+0]  ; v19 = -1342177246, v6 = 32, v22 = 16
 ;; @002a                               v24 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @002a                               v25 = load.i64 notrap aligned readonly can_move v24+32
+;; @002a                               v25 = load.i64 notrap aligned readonly can_move region4 v24+32
 ;; @002a                               v26 = uextend.i64 v23
 ;; @002a                               v27 = iadd v25, v26
 ;; @002a                               jump block4(v23, v27)
@@ -68,14 +70,14 @@
 ;;                                 block4(v36: i32, v37: i64):
 ;; @002a                               v38 = iconst.i64 16
 ;; @002a                               v39 = iadd v37, v38  ; v38 = 16
-;; @002a                               store.f32 user2 little region3 v2, v39
+;; @002a                               store.f32 user2 little region5 v2, v39
 ;; @002a                               v40 = iconst.i64 20
 ;; @002a                               v41 = iadd v37, v40  ; v40 = 20
-;; @002a                               istore8.i32 user2 little region3 v3, v41
+;; @002a                               istore8.i32 user2 little region5 v3, v41
 ;;                                     v45 = load.i32 notrap v46
 ;; @002a                               v42 = iconst.i64 24
 ;; @002a                               v43 = iadd v37, v42  ; v42 = 24
-;; @002a                               store user2 little region3 v45, v43
+;; @002a                               store user2 little region5 v45, v43
 ;; @002d                               jump block1(v36)
 ;;
 ;;                                 block1(v5: i32):

--- a/tests/disas/gc/copying/struct-set.wat
+++ b/tests/disas/gc/copying/struct-set.wat
@@ -20,21 +20,24 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32, f32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 268435488 "VMStoreContext+0x20"
+;;     region3 = 268435496 "VMStoreContext+0x28"
+;;     region4 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: f32):
 ;; @0034                               trapz v2, user16
 ;; @0034                               v5 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0034                               v6 = load.i64 notrap aligned readonly can_move v5+32
+;; @0034                               v6 = load.i64 notrap aligned readonly can_move region2 v5+32
 ;; @0034                               v4 = uextend.i64 v2
 ;; @0034                               v7 = iadd v6, v4
 ;; @0034                               v8 = iconst.i64 16
 ;; @0034                               v9 = iadd v7, v8  ; v8 = 16
-;; @0034                               store user2 little region1 v3, v9
+;; @0034                               store user2 little region4 v3, v9
 ;; @0038                               jump block1
 ;;
 ;;                                 block1:
@@ -43,21 +46,24 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 268435488 "VMStoreContext+0x20"
+;;     region3 = 268435496 "VMStoreContext+0x28"
+;;     region4 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @003f                               trapz v2, user16
 ;; @003f                               v5 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @003f                               v6 = load.i64 notrap aligned readonly can_move v5+32
+;; @003f                               v6 = load.i64 notrap aligned readonly can_move region2 v5+32
 ;; @003f                               v4 = uextend.i64 v2
 ;; @003f                               v7 = iadd v6, v4
 ;; @003f                               v8 = iconst.i64 20
 ;; @003f                               v9 = iadd v7, v8  ; v8 = 20
-;; @003f                               istore8 user2 little region1 v3, v9
+;; @003f                               istore8 user2 little region4 v3, v9
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -66,21 +72,24 @@
 ;;
 ;; function u0:2(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 268435488 "VMStoreContext+0x20"
+;;     region3 = 268435496 "VMStoreContext+0x28"
+;;     region4 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @004a                               trapz v2, user16
 ;; @004a                               v5 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @004a                               v6 = load.i64 notrap aligned readonly can_move v5+32
+;; @004a                               v6 = load.i64 notrap aligned readonly can_move region2 v5+32
 ;; @004a                               v4 = uextend.i64 v2
 ;; @004a                               v7 = iadd v6, v4
 ;; @004a                               v8 = iconst.i64 24
 ;; @004a                               v9 = iadd v7, v8  ; v8 = 24
-;; @004a                               store user2 little region1 v3, v9
+;; @004a                               store user2 little region4 v3, v9
 ;; @004e                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/copying/v128-fields.wat
+++ b/tests/disas/gc/copying/v128-fields.wat
@@ -12,21 +12,24 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i8x16 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 268435488 "VMStoreContext+0x20"
+;;     region3 = 268435496 "VMStoreContext+0x28"
+;;     region4 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0022                               trapz v2, user16
 ;; @0022                               v5 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0022                               v6 = load.i64 notrap aligned readonly can_move v5+32
+;; @0022                               v6 = load.i64 notrap aligned readonly can_move region2 v5+32
 ;; @0022                               v4 = uextend.i64 v2
 ;; @0022                               v7 = iadd v6, v4
 ;; @0022                               v8 = iconst.i64 16
 ;; @0022                               v9 = iadd v7, v8  ; v8 = 16
-;; @0022                               v10 = load.i8x16 user2 little region1 v9
+;; @0022                               v10 = load.i8x16 user2 little region4 v9
 ;; @002e                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/drc/array-fill.wat
+++ b/tests/disas/gc/drc/array-fill.wat
@@ -11,28 +11,31 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 268435488 "VMStoreContext+0x20"
+;;     region3 = 268435496 "VMStoreContext+0x28"
+;;     region4 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i64, v5: i32):
 ;; @0027                               trapz v2, user16
 ;; @0027                               v7 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0027                               v8 = load.i64 notrap aligned readonly can_move v7+32
+;; @0027                               v8 = load.i64 notrap aligned readonly can_move region2 v7+32
 ;; @0027                               v6 = uextend.i64 v2
 ;; @0027                               v9 = iadd v8, v6
 ;; @0027                               v10 = iconst.i64 24
 ;; @0027                               v11 = iadd v9, v10  ; v10 = 24
-;; @0027                               v12 = load.i32 user2 readonly region1 v11
+;; @0027                               v12 = load.i32 user2 readonly region4 v11
 ;; @0027                               v14 = uextend.i64 v3
 ;; @0027                               v15 = uextend.i64 v5
 ;; @0027                               v18 = iadd v14, v15
 ;; @0027                               v13 = uextend.i64 v12
 ;; @0027                               v19 = icmp ugt v18, v13
 ;; @0027                               trapnz v19, user17
-;; @0027                               v36 = load.i64 notrap aligned v7+40
+;; @0027                               v36 = load.i64 notrap aligned region3 v7+40
 ;; @0027                               v24 = iconst.i64 32
 ;; @0027                               v25 = iadd v9, v24  ; v24 = 32
 ;;                                     v49 = iconst.i64 3
@@ -50,7 +53,7 @@
 ;; @0027                               brif v42, block3, block2(v29)
 ;;
 ;;                                 block2(v43: i64):
-;; @0027                               store.i64 user2 little region1 v4, v43
+;; @0027                               store.i64 user2 little region4 v4, v43
 ;;                                     v54 = iconst.i64 8
 ;;                                     v55 = iadd v43, v54  ; v54 = 8
 ;; @0027                               v46 = icmp eq v55, v40

--- a/tests/disas/gc/drc/array-get-s.wat
+++ b/tests/disas/gc/drc/array-get-s.wat
@@ -11,21 +11,24 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 268435488 "VMStoreContext+0x20"
+;;     region3 = 268435496 "VMStoreContext+0x28"
+;;     region4 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0022                               trapz v2, user16
 ;; @0022                               v6 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0022                               v7 = load.i64 notrap aligned readonly can_move v6+32
+;; @0022                               v7 = load.i64 notrap aligned readonly can_move region2 v6+32
 ;; @0022                               v5 = uextend.i64 v2
 ;; @0022                               v8 = iadd v7, v5
 ;; @0022                               v9 = iconst.i64 24
 ;; @0022                               v10 = iadd v8, v9  ; v9 = 24
-;; @0022                               v11 = load.i32 user2 readonly region1 v10
+;; @0022                               v11 = load.i32 user2 readonly region4 v10
 ;; @0022                               v12 = icmp ult v3, v11
 ;; @0022                               trapz v12, user17
 ;; @0022                               v14 = uextend.i64 v11
@@ -41,7 +44,7 @@
 ;; @0022                               v29 = isub v20, v23
 ;; @0022                               v30 = uextend.i64 v29
 ;; @0022                               v31 = isub v28, v30
-;; @0022                               v32 = load.i8 user2 little region1 v31
+;; @0022                               v32 = load.i8 user2 little region4 v31
 ;; @0025                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/drc/array-get-u.wat
+++ b/tests/disas/gc/drc/array-get-u.wat
@@ -11,21 +11,24 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 268435488 "VMStoreContext+0x20"
+;;     region3 = 268435496 "VMStoreContext+0x28"
+;;     region4 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0022                               trapz v2, user16
 ;; @0022                               v6 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0022                               v7 = load.i64 notrap aligned readonly can_move v6+32
+;; @0022                               v7 = load.i64 notrap aligned readonly can_move region2 v6+32
 ;; @0022                               v5 = uextend.i64 v2
 ;; @0022                               v8 = iadd v7, v5
 ;; @0022                               v9 = iconst.i64 24
 ;; @0022                               v10 = iadd v8, v9  ; v9 = 24
-;; @0022                               v11 = load.i32 user2 readonly region1 v10
+;; @0022                               v11 = load.i32 user2 readonly region4 v10
 ;; @0022                               v12 = icmp ult v3, v11
 ;; @0022                               trapz v12, user17
 ;; @0022                               v14 = uextend.i64 v11
@@ -41,7 +44,7 @@
 ;; @0022                               v29 = isub v20, v23
 ;; @0022                               v30 = uextend.i64 v29
 ;; @0022                               v31 = isub v28, v30
-;; @0022                               v32 = load.i8 user2 little region1 v31
+;; @0022                               v32 = load.i8 user2 little region4 v31
 ;; @0025                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/drc/array-get.wat
+++ b/tests/disas/gc/drc/array-get.wat
@@ -11,21 +11,24 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32) -> i64 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 268435488 "VMStoreContext+0x20"
+;;     region3 = 268435496 "VMStoreContext+0x28"
+;;     region4 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0022                               trapz v2, user16
 ;; @0022                               v6 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0022                               v7 = load.i64 notrap aligned readonly can_move v6+32
+;; @0022                               v7 = load.i64 notrap aligned readonly can_move region2 v6+32
 ;; @0022                               v5 = uextend.i64 v2
 ;; @0022                               v8 = iadd v7, v5
 ;; @0022                               v9 = iconst.i64 24
 ;; @0022                               v10 = iadd v8, v9  ; v9 = 24
-;; @0022                               v11 = load.i32 user2 readonly region1 v10
+;; @0022                               v11 = load.i32 user2 readonly region4 v10
 ;; @0022                               v12 = icmp ult v3, v11
 ;; @0022                               trapz v12, user17
 ;; @0022                               v14 = uextend.i64 v11
@@ -46,7 +49,7 @@
 ;; @0022                               v29 = isub v20, v23
 ;; @0022                               v30 = uextend.i64 v29
 ;; @0022                               v31 = isub v28, v30
-;; @0022                               v32 = load.i64 user2 little region1 v31
+;; @0022                               v32 = load.i64 user2 little region4 v31
 ;; @0025                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/drc/array-len.wat
+++ b/tests/disas/gc/drc/array-len.wat
@@ -11,21 +11,24 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 268435488 "VMStoreContext+0x20"
+;;     region3 = 268435496 "VMStoreContext+0x28"
+;;     region4 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @001f                               trapz v2, user16
 ;; @001f                               v5 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @001f                               v6 = load.i64 notrap aligned readonly can_move v5+32
+;; @001f                               v6 = load.i64 notrap aligned readonly can_move region2 v5+32
 ;; @001f                               v4 = uextend.i64 v2
 ;; @001f                               v7 = iadd v6, v4
 ;; @001f                               v8 = iconst.i64 24
 ;; @001f                               v9 = iadd v7, v8  ; v8 = 24
-;; @001f                               v10 = load.i32 user2 readonly region1 v9
+;; @001f                               v10 = load.i32 user2 readonly region4 v9
 ;; @0021                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/drc/array-new-fixed-of-gc-refs.wat
+++ b/tests/disas/gc/drc/array-new-fixed-of-gc-refs.wat
@@ -14,11 +14,14 @@
 ;;     ss1 = explicit_slot 4, align = 4
 ;;     ss2 = explicit_slot 4, align = 4
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 40 "VMContext+0x28"
-;;     region2 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 40 "VMContext+0x28"
+;;     region3 = 268435488 "VMStoreContext+0x20"
+;;     region4 = 2147483648 "GcHeap"
+;;     region5 = 268435496 "VMStoreContext+0x28"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
 ;;     fn0 = colocated u805306368:24 sig0
 ;;     stack_limit = gv2
@@ -31,19 +34,19 @@
 ;;                                     v205 = stack_addr.i64 ss0
 ;;                                     store notrap v4, v205
 ;; @0025                               v15 = iconst.i32 -1476395008
-;; @0025                               v16 = load.i64 notrap aligned readonly can_move region1 v0+40
+;; @0025                               v16 = load.i64 notrap aligned readonly can_move region2 v0+40
 ;; @0025                               v17 = load.i32 notrap aligned readonly can_move v16
 ;;                                     v217 = iconst.i32 40
 ;; @0025                               v18 = iconst.i32 8
 ;; @0025                               v19 = call fn0(v0, v15, v17, v217, v18), stack_map=[i32 @ ss2+0, i32 @ ss1+0, i32 @ ss0+0]  ; v15 = -1476395008, v217 = 40, v18 = 8
 ;; @0025                               v6 = iconst.i32 3
 ;; @0025                               v20 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0025                               v21 = load.i64 notrap aligned readonly can_move v20+32
+;; @0025                               v21 = load.i64 notrap aligned readonly can_move region3 v20+32
 ;; @0025                               v22 = uextend.i64 v19
 ;; @0025                               v23 = iadd v21, v22
 ;; @0025                               v24 = iconst.i64 24
 ;; @0025                               v25 = iadd v23, v24  ; v24 = 24
-;; @0025                               store user2 region2 v6, v25  ; v6 = 3
+;; @0025                               store user2 region4 v6, v25  ; v6 = 3
 ;; @0025                               trapz v19, user16
 ;; @0025                               v46 = uadd_overflow_trap v19, v217, user2  ; v217 = 40
 ;;                                     v202 = load.i32 notrap v203
@@ -61,10 +64,10 @@
 ;; @0025                               v63 = iadd.i64 v21, v60
 ;; @0025                               v64 = iconst.i64 8
 ;; @0025                               v65 = iadd v63, v64  ; v64 = 8
-;; @0025                               v66 = load.i64 user2 region2 v65
+;; @0025                               v66 = load.i64 user2 region4 v65
 ;; @0025                               v67 = iconst.i64 1
 ;; @0025                               v68 = iadd v66, v67  ; v67 = 1
-;; @0025                               store user2 region2 v68, v65
+;; @0025                               store user2 region4 v68, v65
 ;; @0025                               jump block3
 ;;
 ;;                                 block3:
@@ -73,9 +76,9 @@
 ;; @0025                               v50 = iadd.i64 v21, v47
 ;;                                     v207 = iconst.i64 12
 ;; @0025                               v53 = isub v50, v207  ; v207 = 12
-;; @0025                               store user2 little region2 v194, v53
+;; @0025                               store user2 little region4 v194, v53
 ;;                                     v310 = iadd.i64 v23, v24  ; v24 = 24
-;; @0025                               v82 = load.i32 user2 readonly region2 v310
+;; @0025                               v82 = load.i32 user2 readonly region4 v310
 ;;                                     v311 = iconst.i32 1
 ;;                                     v312 = icmp ugt v82, v311  ; v311 = 1
 ;; @0025                               trapz v312, user17
@@ -104,10 +107,10 @@
 ;; @0025                               v112 = iadd.i64 v21, v109
 ;;                                     v316 = iconst.i64 8
 ;; @0025                               v114 = iadd v112, v316  ; v316 = 8
-;; @0025                               v115 = load.i64 user2 region2 v114
+;; @0025                               v115 = load.i64 user2 region4 v114
 ;;                                     v317 = iconst.i64 1
 ;; @0025                               v117 = iadd v115, v317  ; v317 = 1
-;; @0025                               store user2 region2 v117, v114
+;; @0025                               store user2 region4 v117, v114
 ;; @0025                               jump block5
 ;;
 ;;                                 block5:
@@ -118,9 +121,9 @@
 ;; @0025                               v100 = isub.i32 v91, v272  ; v272 = 32
 ;; @0025                               v101 = uextend.i64 v100
 ;; @0025                               v102 = isub v99, v101
-;; @0025                               store user2 little region2 v184, v102
+;; @0025                               store user2 little region4 v184, v102
 ;;                                     v318 = iadd.i64 v23, v24  ; v24 = 24
-;; @0025                               v131 = load.i32 user2 readonly region2 v318
+;; @0025                               v131 = load.i32 user2 readonly region4 v318
 ;;                                     v319 = iconst.i32 2
 ;;                                     v320 = icmp ugt v131, v319  ; v319 = 2
 ;; @0025                               trapz v320, user17
@@ -149,10 +152,10 @@
 ;; @0025                               v161 = iadd.i64 v21, v158
 ;;                                     v331 = iconst.i64 8
 ;; @0025                               v163 = iadd v161, v331  ; v331 = 8
-;; @0025                               v164 = load.i64 user2 region2 v163
+;; @0025                               v164 = load.i64 user2 region4 v163
 ;;                                     v332 = iconst.i64 1
 ;; @0025                               v166 = iadd v164, v332  ; v332 = 1
-;; @0025                               store user2 region2 v166, v163
+;; @0025                               store user2 region4 v166, v163
 ;; @0025                               jump block7
 ;;
 ;;                                 block7:
@@ -163,7 +166,7 @@
 ;; @0025                               v149 = isub.i32 v140, v304  ; v304 = 36
 ;; @0025                               v150 = uextend.i64 v149
 ;; @0025                               v151 = isub v148, v150
-;; @0025                               store user2 little region2 v174, v151
+;; @0025                               store user2 little region4 v174, v151
 ;; @0029                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/drc/array-new-fixed.wat
+++ b/tests/disas/gc/drc/array-new-fixed.wat
@@ -11,37 +11,40 @@
 )
 ;; function u0:0(i64 vmctx, i64, i64, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 40 "VMContext+0x28"
-;;     region2 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 40 "VMContext+0x28"
+;;     region3 = 268435488 "VMStoreContext+0x20"
+;;     region4 = 2147483648 "GcHeap"
+;;     region5 = 268435496 "VMStoreContext+0x28"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
 ;;     fn0 = colocated u805306368:24 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i64, v4: i64):
 ;; @0025                               v15 = iconst.i32 -1476395008
-;; @0025                               v16 = load.i64 notrap aligned readonly can_move region1 v0+40
+;; @0025                               v16 = load.i64 notrap aligned readonly can_move region2 v0+40
 ;; @0025                               v17 = load.i32 notrap aligned readonly can_move v16
 ;;                                     v120 = iconst.i32 56
 ;; @0025                               v18 = iconst.i32 8
 ;; @0025                               v19 = call fn0(v0, v15, v17, v120, v18)  ; v15 = -1476395008, v120 = 56, v18 = 8
 ;; @0025                               v6 = iconst.i32 3
 ;; @0025                               v20 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0025                               v21 = load.i64 notrap aligned readonly can_move v20+32
+;; @0025                               v21 = load.i64 notrap aligned readonly can_move region3 v20+32
 ;; @0025                               v22 = uextend.i64 v19
 ;; @0025                               v23 = iadd v21, v22
 ;;                                     v111 = iconst.i64 24
 ;; @0025                               v25 = iadd v23, v111  ; v111 = 24
-;; @0025                               store user2 region2 v6, v25  ; v6 = 3
+;; @0025                               store user2 region4 v6, v25  ; v6 = 3
 ;; @0025                               trapz v19, user16
 ;; @0025                               v46 = uadd_overflow_trap v19, v120, user2  ; v120 = 56
 ;; @0025                               v47 = uextend.i64 v46
 ;; @0025                               v50 = iadd v21, v47
 ;; @0025                               v53 = isub v50, v111  ; v111 = 24
-;; @0025                               store user2 little region2 v2, v53
-;; @0025                               v61 = load.i32 user2 readonly region2 v25
+;; @0025                               store user2 little region4 v2, v53
+;; @0025                               v61 = load.i32 user2 readonly region4 v25
 ;; @0025                               v54 = iconst.i32 1
 ;;                                     v151 = icmp ugt v61, v54  ; v54 = 1
 ;; @0025                               trapz v151, user17
@@ -61,8 +64,8 @@
 ;; @0025                               v79 = isub v70, v173  ; v173 = 40
 ;; @0025                               v80 = uextend.i64 v79
 ;; @0025                               v81 = isub v78, v80
-;; @0025                               store user2 little region2 v3, v81
-;; @0025                               v89 = load.i32 user2 readonly region2 v25
+;; @0025                               store user2 little region4 v3, v81
+;; @0025                               v89 = load.i32 user2 readonly region4 v25
 ;; @0025                               v82 = iconst.i32 2
 ;;                                     v179 = icmp ugt v89, v82  ; v82 = 2
 ;; @0025                               trapz v179, user17
@@ -79,7 +82,7 @@
 ;; @0025                               v107 = isub v98, v206  ; v206 = 48
 ;; @0025                               v108 = uextend.i64 v107
 ;; @0025                               v109 = isub v106, v108
-;; @0025                               store user2 little region2 v4, v109
+;; @0025                               store user2 little region4 v4, v109
 ;; @0029                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/drc/array-new.wat
+++ b/tests/disas/gc/drc/array-new.wat
@@ -11,11 +11,14 @@
 )
 ;; function u0:0(i64 vmctx, i64, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 40 "VMContext+0x28"
-;;     region2 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 40 "VMContext+0x28"
+;;     region3 = 268435488 "VMStoreContext+0x20"
+;;     region4 = 2147483648 "GcHeap"
+;;     region5 = 268435496 "VMStoreContext+0x28"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
 ;;     fn0 = colocated u805306368:24 sig0
 ;;     stack_limit = gv2
@@ -32,19 +35,19 @@
 ;;                                     v74 = ishl v3, v73  ; v73 = 3
 ;; @0022                               v12 = uadd_overflow_trap v5, v74, user18  ; v5 = 32
 ;; @0022                               v13 = iconst.i32 -1476395008
-;; @0022                               v14 = load.i64 notrap aligned readonly can_move region1 v0+40
+;; @0022                               v14 = load.i64 notrap aligned readonly can_move region2 v0+40
 ;; @0022                               v15 = load.i32 notrap aligned readonly can_move v14
 ;;                                     v71 = iconst.i32 8
 ;; @0022                               v17 = call fn0(v0, v13, v15, v12, v71)  ; v13 = -1476395008, v71 = 8
 ;; @0022                               v18 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0022                               v19 = load.i64 notrap aligned readonly can_move v18+32
+;; @0022                               v19 = load.i64 notrap aligned readonly can_move region3 v18+32
 ;; @0022                               v20 = uextend.i64 v17
 ;; @0022                               v21 = iadd v19, v20
 ;; @0022                               v22 = iconst.i64 24
 ;; @0022                               v23 = iadd v21, v22  ; v22 = 24
-;; @0022                               store user2 region2 v3, v23
+;; @0022                               store user2 region4 v3, v23
 ;; @0022                               trapz v17, user16
-;; @0022                               v55 = load.i64 notrap aligned v18+40
+;; @0022                               v55 = load.i64 notrap aligned region5 v18+40
 ;; @0022                               v44 = iadd v21, v9  ; v9 = 32
 ;; @0022                               v57 = uadd_overflow_trap v44, v67, user2
 ;; @0022                               v56 = iadd v19, v55
@@ -57,7 +60,7 @@
 ;; @0022                               brif v61, block3, block2(v44)
 ;;
 ;;                                 block2(v62: i64):
-;; @0022                               store.i64 user2 little region2 v2, v62
+;; @0022                               store.i64 user2 little region4 v2, v62
 ;;                                     v92 = iconst.i64 8
 ;;                                     v93 = iadd v62, v92  ; v92 = 8
 ;; @0022                               v65 = icmp eq v93, v59

--- a/tests/disas/gc/drc/array-set.wat
+++ b/tests/disas/gc/drc/array-set.wat
@@ -11,21 +11,24 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32, i64) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 268435488 "VMStoreContext+0x20"
+;;     region3 = 268435496 "VMStoreContext+0x28"
+;;     region4 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i64):
 ;; @0024                               trapz v2, user16
 ;; @0024                               v6 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0024                               v7 = load.i64 notrap aligned readonly can_move v6+32
+;; @0024                               v7 = load.i64 notrap aligned readonly can_move region2 v6+32
 ;; @0024                               v5 = uextend.i64 v2
 ;; @0024                               v8 = iadd v7, v5
 ;; @0024                               v9 = iconst.i64 24
 ;; @0024                               v10 = iadd v8, v9  ; v9 = 24
-;; @0024                               v11 = load.i32 user2 readonly region1 v10
+;; @0024                               v11 = load.i32 user2 readonly region4 v10
 ;; @0024                               v12 = icmp ult v3, v11
 ;; @0024                               trapz v12, user17
 ;; @0024                               v14 = uextend.i64 v11
@@ -46,7 +49,7 @@
 ;; @0024                               v29 = isub v20, v23
 ;; @0024                               v30 = uextend.i64 v29
 ;; @0024                               v31 = isub v28, v30
-;; @0024                               store user2 little region1 v4, v31
+;; @0024                               store user2 little region4 v4, v31
 ;; @0027                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/drc/br-on-cast-fail.wat
+++ b/tests/disas/gc/drc/br-on-cast-fail.wat
@@ -18,15 +18,18 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 40 "VMContext+0x28"
-;;     region2 = 2147483648 "GcHeap"
-;;     region3 = 72 "VMContext+0x48"
-;;     region4 = 56 "VMContext+0x38"
-;;     region5 = 104 "VMContext+0x68"
-;;     region6 = 88 "VMContext+0x58"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 40 "VMContext+0x28"
+;;     region3 = 268435488 "VMStoreContext+0x20"
+;;     region4 = 268435496 "VMStoreContext+0x28"
+;;     region5 = 2147483648 "GcHeap"
+;;     region6 = 72 "VMContext+0x48"
+;;     region7 = 56 "VMContext+0x38"
+;;     region8 = 104 "VMContext+0x68"
+;;     region9 = 88 "VMContext+0x58"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, i64) tail
 ;;     stack_limit = gv2
 ;;
@@ -43,13 +46,13 @@
 ;;
 ;;                                 block4:
 ;; @002e                               v14 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @002e                               v15 = load.i64 notrap aligned readonly can_move v14+32
+;; @002e                               v15 = load.i64 notrap aligned readonly can_move region3 v14+32
 ;; @002e                               v13 = uextend.i64 v2
 ;; @002e                               v16 = iadd v15, v13
 ;; @002e                               v17 = iconst.i64 4
 ;; @002e                               v18 = iadd v16, v17  ; v17 = 4
-;; @002e                               v19 = load.i32 user2 readonly region2 v18
-;; @002e                               v11 = load.i64 notrap aligned readonly can_move region1 v0+40
+;; @002e                               v19 = load.i32 user2 readonly region5 v18
+;; @002e                               v11 = load.i64 notrap aligned readonly can_move region2 v0+40
 ;; @002e                               v12 = load.i32 notrap aligned readonly can_move v11
 ;; @002e                               v20 = icmp eq v19, v12
 ;; @002e                               v21 = uextend.i32 v20
@@ -59,14 +62,14 @@
 ;; @002e                               brif v22, block6, block2
 ;;
 ;;                                 block6:
-;; @0034                               v24 = load.i64 notrap aligned readonly can_move region4 v0+56
-;; @0034                               v23 = load.i64 notrap aligned readonly can_move region3 v0+72
+;; @0034                               v24 = load.i64 notrap aligned readonly can_move region7 v0+56
+;; @0034                               v23 = load.i64 notrap aligned readonly can_move region6 v0+72
 ;; @0034                               call_indirect sig0, v24(v23, v0)
 ;; @0036                               return
 ;;
 ;;                                 block2:
-;; @0038                               v26 = load.i64 notrap aligned readonly can_move region6 v0+88
-;; @0038                               v25 = load.i64 notrap aligned readonly can_move region5 v0+104
+;; @0038                               v26 = load.i64 notrap aligned readonly can_move region9 v0+88
+;; @0038                               v25 = load.i64 notrap aligned readonly can_move region8 v0+104
 ;; @0038                               call_indirect sig0, v26(v25, v0)
 ;; @003a                               return
 ;; }

--- a/tests/disas/gc/drc/br-on-cast.wat
+++ b/tests/disas/gc/drc/br-on-cast.wat
@@ -18,15 +18,18 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 40 "VMContext+0x28"
-;;     region2 = 2147483648 "GcHeap"
-;;     region3 = 72 "VMContext+0x48"
-;;     region4 = 56 "VMContext+0x38"
-;;     region5 = 104 "VMContext+0x68"
-;;     region6 = 88 "VMContext+0x58"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 40 "VMContext+0x28"
+;;     region3 = 268435488 "VMStoreContext+0x20"
+;;     region4 = 268435496 "VMStoreContext+0x28"
+;;     region5 = 2147483648 "GcHeap"
+;;     region6 = 72 "VMContext+0x48"
+;;     region7 = 56 "VMContext+0x38"
+;;     region8 = 104 "VMContext+0x68"
+;;     region9 = 88 "VMContext+0x58"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, i64) tail
 ;;     stack_limit = gv2
 ;;
@@ -43,13 +46,13 @@
 ;;
 ;;                                 block4:
 ;; @002f                               v14 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @002f                               v15 = load.i64 notrap aligned readonly can_move v14+32
+;; @002f                               v15 = load.i64 notrap aligned readonly can_move region3 v14+32
 ;; @002f                               v13 = uextend.i64 v2
 ;; @002f                               v16 = iadd v15, v13
 ;; @002f                               v17 = iconst.i64 4
 ;; @002f                               v18 = iadd v16, v17  ; v17 = 4
-;; @002f                               v19 = load.i32 user2 readonly region2 v18
-;; @002f                               v11 = load.i64 notrap aligned readonly can_move region1 v0+40
+;; @002f                               v19 = load.i32 user2 readonly region5 v18
+;; @002f                               v11 = load.i64 notrap aligned readonly can_move region2 v0+40
 ;; @002f                               v12 = load.i32 notrap aligned readonly can_move v11
 ;; @002f                               v20 = icmp eq v19, v12
 ;; @002f                               v21 = uextend.i32 v20
@@ -59,14 +62,14 @@
 ;; @002f                               brif v22, block2, block6
 ;;
 ;;                                 block6:
-;; @0035                               v24 = load.i64 notrap aligned readonly can_move region4 v0+56
-;; @0035                               v23 = load.i64 notrap aligned readonly can_move region3 v0+72
+;; @0035                               v24 = load.i64 notrap aligned readonly can_move region7 v0+56
+;; @0035                               v23 = load.i64 notrap aligned readonly can_move region6 v0+72
 ;; @0035                               call_indirect sig0, v24(v23, v0)
 ;; @0037                               return
 ;;
 ;;                                 block2:
-;; @0039                               v26 = load.i64 notrap aligned readonly can_move region6 v0+88
-;; @0039                               v25 = load.i64 notrap aligned readonly can_move region5 v0+104
+;; @0039                               v26 = load.i64 notrap aligned readonly can_move region9 v0+88
+;; @0039                               v25 = load.i64 notrap aligned readonly can_move region8 v0+104
 ;; @0039                               call_indirect sig0, v26(v25, v0)
 ;; @003b                               return
 ;; }

--- a/tests/disas/gc/drc/call-indirect-and-subtyping.wat
+++ b/tests/disas/gc/drc/call-indirect-and-subtyping.wat
@@ -18,11 +18,12 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 1342177280 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
-;;     region2 = 40 "VMContext+0x28"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 1342177280 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
+;;     region3 = 40 "VMContext+0x28"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, i64) tail
 ;;     sig1 = (i64 vmctx, i32, i64) -> i64 tail
 ;;     sig2 = (i64 vmctx, i32, i32) -> i32 tail
@@ -40,7 +41,7 @@
 ;; @005c                               v8 = ishl v5, v7  ; v7 = 3
 ;; @005c                               v9 = iadd v6, v8
 ;; @005c                               v11 = select_spectre_guard v4, v10, v9  ; v10 = 0
-;; @005c                               v12 = load.i64 user6 aligned region1 v11
+;; @005c                               v12 = load.i64 user6 aligned region2 v11
 ;; @005c                               v13 = iconst.i64 -2
 ;; @005c                               v14 = band v12, v13  ; v13 = -2
 ;; @005c                               brif v12, block3(v14), block2
@@ -52,7 +53,7 @@
 ;;
 ;;                                 block3(v15: i64):
 ;; @005c                               v21 = load.i32 user7 aligned readonly v15+16
-;; @005c                               v19 = load.i64 notrap aligned readonly can_move region2 v0+40
+;; @005c                               v19 = load.i64 notrap aligned readonly can_move region3 v0+40
 ;; @005c                               v20 = load.i32 notrap aligned readonly can_move v19
 ;; @005c                               v22 = icmp eq v21, v20
 ;; @005c                               v23 = uextend.i32 v22

--- a/tests/disas/gc/drc/externref-globals.wat
+++ b/tests/disas/gc/drc/externref-globals.wat
@@ -15,11 +15,14 @@
 ;; function u0:0(i64 vmctx, i64) -> i32 tail {
 ;;     ss0 = explicit_slot 4, align = 4
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 2147483648 "GcHeap"
-;;     region2 = 32 "VMContext+0x20"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 268435488 "VMStoreContext+0x20"
+;;     region3 = 268435496 "VMStoreContext+0x28"
+;;     region4 = 2147483648 "GcHeap"
+;;     region5 = 32 "VMContext+0x20"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx) -> i8 tail
 ;;     fn0 = colocated u805306368:45 sig0
 ;;     stack_limit = gv2
@@ -40,30 +43,30 @@
 ;;
 ;;                                 block2:
 ;; @0034                               v13 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0034                               v14 = load.i64 notrap aligned readonly can_move v13+32
+;; @0034                               v14 = load.i64 notrap aligned readonly can_move region2 v13+32
 ;; @0034                               v12 = uextend.i64 v5
 ;; @0034                               v15 = iadd v14, v12
-;; @0034                               v16 = load.i32 user2 region1 v15
+;; @0034                               v16 = load.i32 user2 region4 v15
 ;; @0034                               v17 = iconst.i32 2
 ;; @0034                               v18 = band v16, v17  ; v17 = 2
 ;; @0034                               brif v18, block4, block3
 ;;
 ;;                                 block3:
-;; @0034                               v19 = load.i64 notrap aligned readonly can_move region2 v0+32
-;; @0034                               v20 = load.i32 user2 region1 v19
+;; @0034                               v19 = load.i64 notrap aligned readonly can_move region5 v0+32
+;; @0034                               v20 = load.i32 user2 region4 v19
 ;; @0034                               v25 = iconst.i64 16
 ;; @0034                               v26 = iadd.i64 v15, v25  ; v25 = 16
-;; @0034                               store user2 region1 v20, v26
+;; @0034                               store user2 region4 v20, v26
 ;;                                     v81 = iconst.i32 2
 ;;                                     v82 = bor.i32 v16, v81  ; v81 = 2
-;; @0034                               store user2 region1 v82, v15
+;; @0034                               store user2 region4 v82, v15
 ;; @0034                               v37 = iconst.i64 8
 ;; @0034                               v38 = iadd.i64 v15, v37  ; v37 = 8
-;; @0034                               v39 = load.i64 user2 region1 v38
+;; @0034                               v39 = load.i64 user2 region4 v38
 ;; @0034                               v40 = iconst.i64 1
 ;; @0034                               v41 = iadd v39, v40  ; v40 = 1
-;; @0034                               store user2 region1 v41, v38
-;; @0034                               store.i32 user2 region1 v5, v19
+;; @0034                               store user2 region4 v41, v38
+;; @0034                               store.i32 user2 region4 v5, v19
 ;; @0034                               v49 = load.i32 notrap aligned v19+4
 ;;                                     v83 = iconst.i32 1
 ;;                                     v84 = iadd v49, v83  ; v83 = 1
@@ -92,10 +95,13 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 268435488 "VMStoreContext+0x20"
+;;     region3 = 268435496 "VMStoreContext+0x28"
+;;     region4 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, i32) tail
 ;;     fn0 = colocated u805306368:22 sig0
 ;;     stack_limit = gv2
@@ -114,15 +120,15 @@
 ;;
 ;;                                 block2:
 ;; @003b                               v13 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @003b                               v14 = load.i64 notrap aligned readonly can_move v13+32
+;; @003b                               v14 = load.i64 notrap aligned readonly can_move region2 v13+32
 ;; @003b                               v12 = uextend.i64 v2
 ;; @003b                               v15 = iadd v14, v12
 ;; @003b                               v16 = iconst.i64 8
 ;; @003b                               v17 = iadd v15, v16  ; v16 = 8
-;; @003b                               v18 = load.i64 user2 region1 v17
+;; @003b                               v18 = load.i64 user2 region4 v17
 ;; @003b                               v19 = iconst.i64 1
 ;; @003b                               v20 = iadd v18, v19  ; v19 = 1
-;; @003b                               store user2 region1 v20, v17
+;; @003b                               store user2 region4 v20, v17
 ;; @003b                               jump block3
 ;;
 ;;                                 block3:
@@ -138,12 +144,12 @@
 ;;
 ;;                                 block4:
 ;;                                     v67 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v68 = load.i64 notrap aligned readonly can_move v67+32
+;;                                     v68 = load.i64 notrap aligned readonly can_move region2 v67+32
 ;; @003b                               v33 = uextend.i64 v5
 ;; @003b                               v36 = iadd v68, v33
 ;;                                     v69 = iconst.i64 8
 ;; @003b                               v38 = iadd v36, v69  ; v69 = 8
-;; @003b                               v39 = load.i64 user2 region1 v38
+;; @003b                               v39 = load.i64 user2 region4 v38
 ;;                                     v70 = iconst.i64 1
 ;;                                     v60 = icmp eq v39, v70  ; v70 = 1
 ;; @003b                               brif v60, block5, block6
@@ -156,7 +162,7 @@
 ;; @003b                               v40 = iconst.i64 -1
 ;; @003b                               v41 = iadd.i64 v39, v40  ; v40 = -1
 ;;                                     v71 = iadd.i64 v36, v69  ; v69 = 8
-;; @003b                               store user2 region1 v41, v71
+;; @003b                               store user2 region4 v41, v71
 ;; @003b                               jump block7
 ;;
 ;;                                 block7:

--- a/tests/disas/gc/drc/funcref-in-gc-heap-get.wat
+++ b/tests/disas/gc/drc/funcref-in-gc-heap-get.wat
@@ -11,10 +11,13 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i64 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 268435488 "VMStoreContext+0x20"
+;;     region3 = 268435496 "VMStoreContext+0x28"
+;;     region4 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, i32, i32) -> i64 tail
 ;;     fn0 = colocated u805306368:26 sig0
 ;;     stack_limit = gv2
@@ -22,12 +25,12 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0020                               trapz v2, user16
 ;; @0020                               v5 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0020                               v6 = load.i64 notrap aligned readonly can_move v5+32
+;; @0020                               v6 = load.i64 notrap aligned readonly can_move region2 v5+32
 ;; @0020                               v4 = uextend.i64 v2
 ;; @0020                               v7 = iadd v6, v4
 ;; @0020                               v8 = iconst.i64 24
 ;; @0020                               v9 = iadd v7, v8  ; v8 = 24
-;; @0020                               v11 = load.i32 user2 little region1 v9
+;; @0020                               v11 = load.i32 user2 little region4 v9
 ;; @0020                               v10 = iconst.i32 -1
 ;; @0020                               v12 = call fn0(v0, v11, v10)  ; v10 = -1
 ;; @0024                               jump block1

--- a/tests/disas/gc/drc/funcref-in-gc-heap-new.wat
+++ b/tests/disas/gc/drc/funcref-in-gc-heap-new.wat
@@ -12,11 +12,13 @@
 ;; function u0:0(i64 vmctx, i64, i64) -> i32 tail {
 ;;     ss0 = explicit_slot 4, align = 4
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 40 "VMContext+0x28"
-;;     region2 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 40 "VMContext+0x28"
+;;     region3 = 268435488 "VMStoreContext+0x20"
+;;     region4 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i64) -> i64 tail
 ;;     fn0 = colocated u805306368:24 sig0
@@ -25,7 +27,7 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @0020                               v5 = iconst.i32 -1342177280
-;; @0020                               v6 = load.i64 notrap aligned readonly can_move region1 v0+40
+;; @0020                               v6 = load.i64 notrap aligned readonly can_move region2 v0+40
 ;; @0020                               v7 = load.i32 notrap aligned readonly can_move v6
 ;; @0020                               v4 = iconst.i32 32
 ;; @0020                               v8 = iconst.i32 8
@@ -35,12 +37,12 @@
 ;; @0020                               v16 = call fn1(v0, v2), stack_map=[i32 @ ss0+0]
 ;; @0020                               v17 = ireduce.i32 v16
 ;; @0020                               v10 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0020                               v11 = load.i64 notrap aligned readonly can_move v10+32
+;; @0020                               v11 = load.i64 notrap aligned readonly can_move region3 v10+32
 ;; @0020                               v12 = uextend.i64 v9
 ;; @0020                               v13 = iadd v11, v12
 ;; @0020                               v14 = iconst.i64 24
 ;; @0020                               v15 = iadd v13, v14  ; v14 = 24
-;; @0020                               store user2 little region2 v17, v15
+;; @0020                               store user2 little region4 v17, v15
 ;;                                     v19 = load.i32 notrap v22
 ;; @0023                               jump block1
 ;;

--- a/tests/disas/gc/drc/funcref-in-gc-heap-set.wat
+++ b/tests/disas/gc/drc/funcref-in-gc-heap-set.wat
@@ -11,10 +11,13 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32, i64) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 268435488 "VMStoreContext+0x20"
+;;     region3 = 268435496 "VMStoreContext+0x28"
+;;     region4 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, i64) -> i64 tail
 ;;     fn0 = colocated u805306368:25 sig0
 ;;     stack_limit = gv2
@@ -24,12 +27,12 @@
 ;; @0022                               v10 = call fn0(v0, v3)
 ;; @0022                               v11 = ireduce.i32 v10
 ;; @0022                               v5 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0022                               v6 = load.i64 notrap aligned readonly can_move v5+32
+;; @0022                               v6 = load.i64 notrap aligned readonly can_move region2 v5+32
 ;; @0022                               v4 = uextend.i64 v2
 ;; @0022                               v7 = iadd v6, v4
 ;; @0022                               v8 = iconst.i64 24
 ;; @0022                               v9 = iadd v7, v8  ; v8 = 24
-;; @0022                               store user2 little region1 v11, v9
+;; @0022                               store user2 little region4 v11, v9
 ;; @0026                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/drc/i31ref-globals.wat
+++ b/tests/disas/gc/drc/i31ref-globals.wat
@@ -14,9 +14,10 @@
 
 ;; function u0:0(i64 vmctx, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
@@ -31,9 +32,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/gc/drc/multiple-array-get.wat
+++ b/tests/disas/gc/drc/multiple-array-get.wat
@@ -12,21 +12,24 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32, i32) -> i64, i64 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 268435488 "VMStoreContext+0x20"
+;;     region3 = 268435496 "VMStoreContext+0x28"
+;;     region4 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
 ;; @0024                               trapz v2, user16
 ;; @0024                               v8 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0024                               v9 = load.i64 notrap aligned readonly can_move v8+32
+;; @0024                               v9 = load.i64 notrap aligned readonly can_move region2 v8+32
 ;; @0024                               v7 = uextend.i64 v2
 ;; @0024                               v10 = iadd v9, v7
 ;; @0024                               v11 = iconst.i64 24
 ;; @0024                               v12 = iadd v10, v11  ; v11 = 24
-;; @0024                               v13 = load.i32 user2 readonly region1 v12
+;; @0024                               v13 = load.i32 user2 readonly region4 v12
 ;; @0024                               v14 = icmp ult v3, v13
 ;; @0024                               trapz v14, user17
 ;; @0024                               v16 = uextend.i64 v13
@@ -47,7 +50,7 @@
 ;; @0024                               v31 = isub v22, v25
 ;; @0024                               v32 = uextend.i64 v31
 ;; @0024                               v33 = isub v30, v32
-;; @0024                               v34 = load.i64 user2 little region1 v33
+;; @0024                               v34 = load.i64 user2 little region4 v33
 ;; @002b                               v42 = icmp ult v4, v13
 ;; @002b                               trapz v42, user17
 ;;                                     v82 = ishl v4, v73  ; v73 = 3
@@ -55,7 +58,7 @@
 ;; @002b                               v59 = isub v22, v53
 ;; @002b                               v60 = uextend.i64 v59
 ;; @002b                               v61 = isub v30, v60
-;; @002b                               v62 = load.i64 user2 little region1 v61
+;; @002b                               v62 = load.i64 user2 little region4 v61
 ;; @002e                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/drc/multiple-struct-get.wat
+++ b/tests/disas/gc/drc/multiple-struct-get.wat
@@ -13,24 +13,27 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> f32, i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 268435488 "VMStoreContext+0x20"
+;;     region3 = 268435496 "VMStoreContext+0x28"
+;;     region4 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0023                               trapz v2, user16
 ;; @0023                               v6 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0023                               v7 = load.i64 notrap aligned readonly can_move v6+32
+;; @0023                               v7 = load.i64 notrap aligned readonly can_move region2 v6+32
 ;; @0023                               v5 = uextend.i64 v2
 ;; @0023                               v8 = iadd v7, v5
 ;; @0023                               v9 = iconst.i64 24
 ;; @0023                               v10 = iadd v8, v9  ; v9 = 24
-;; @0023                               v11 = load.f32 user2 little region1 v10
+;; @0023                               v11 = load.f32 user2 little region4 v10
 ;; @0029                               v16 = iconst.i64 28
 ;; @0029                               v17 = iadd v8, v16  ; v16 = 28
-;; @0029                               v18 = load.i8 user2 little region1 v17
+;; @0029                               v18 = load.i8 user2 little region4 v17
 ;; @002d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/drc/ref-cast.wat
+++ b/tests/disas/gc/drc/ref-cast.wat
@@ -10,11 +10,14 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 40 "VMContext+0x28"
-;;     region2 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 40 "VMContext+0x28"
+;;     region3 = 268435488 "VMStoreContext+0x20"
+;;     region4 = 268435496 "VMStoreContext+0x28"
+;;     region5 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -30,13 +33,13 @@
 ;;
 ;;                                 block3:
 ;; @001e                               v14 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @001e                               v15 = load.i64 notrap aligned readonly can_move v14+32
+;; @001e                               v15 = load.i64 notrap aligned readonly can_move region3 v14+32
 ;; @001e                               v13 = uextend.i64 v2
 ;; @001e                               v16 = iadd v15, v13
 ;; @001e                               v17 = iconst.i64 4
 ;; @001e                               v18 = iadd v16, v17  ; v17 = 4
-;; @001e                               v19 = load.i32 user2 readonly region2 v18
-;; @001e                               v11 = load.i64 notrap aligned readonly can_move region1 v0+40
+;; @001e                               v19 = load.i32 user2 readonly region5 v18
+;; @001e                               v11 = load.i64 notrap aligned readonly can_move region2 v0+40
 ;; @001e                               v12 = load.i32 notrap aligned readonly can_move v11
 ;; @001e                               v20 = icmp eq v19, v12
 ;; @001e                               v21 = uextend.i32 v20

--- a/tests/disas/gc/drc/ref-is-null.wat
+++ b/tests/disas/gc/drc/ref-is-null.wat
@@ -12,9 +12,10 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -29,9 +30,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/gc/drc/ref-test-any.wat
+++ b/tests/disas/gc/drc/ref-test-any.wat
@@ -12,9 +12,10 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -29,9 +30,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/gc/drc/ref-test-array.wat
+++ b/tests/disas/gc/drc/ref-test-array.wat
@@ -9,10 +9,13 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 268435488 "VMStoreContext+0x20"
+;;     region3 = 268435496 "VMStoreContext+0x28"
+;;     region4 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -28,10 +31,10 @@
 ;;
 ;;                                 block3:
 ;; @001b                               v12 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @001b                               v13 = load.i64 notrap aligned readonly can_move v12+32
+;; @001b                               v13 = load.i64 notrap aligned readonly can_move region2 v12+32
 ;; @001b                               v11 = uextend.i64 v2
 ;; @001b                               v14 = iadd v13, v11
-;; @001b                               v17 = load.i32 user2 readonly region1 v14
+;; @001b                               v17 = load.i32 user2 readonly region4 v14
 ;; @001b                               v18 = iconst.i32 -1476395008
 ;; @001b                               v19 = band v17, v18  ; v18 = -1476395008
 ;; @001b                               v20 = icmp eq v19, v18  ; v18 = -1476395008

--- a/tests/disas/gc/drc/ref-test-concrete-func-type.wat
+++ b/tests/disas/gc/drc/ref-test-concrete-func-type.wat
@@ -10,11 +10,12 @@
 )
 ;; function u0:0(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 40 "VMContext+0x28"
-;;     region2 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 40 "VMContext+0x28"
+;;     region3 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
@@ -27,8 +28,8 @@
 ;; @0020                               jump block3
 ;;
 ;;                                 block3:
-;; @0020                               v10 = load.i32 user2 readonly region2 v2+16
-;; @0020                               v8 = load.i64 notrap aligned readonly can_move region1 v0+40
+;; @0020                               v10 = load.i32 user2 readonly region3 v2+16
+;; @0020                               v8 = load.i64 notrap aligned readonly can_move region2 v0+40
 ;; @0020                               v9 = load.i32 notrap aligned readonly can_move v8
 ;; @0020                               v11 = icmp eq v10, v9
 ;; @0020                               v12 = uextend.i32 v11

--- a/tests/disas/gc/drc/ref-test-concrete-type.wat
+++ b/tests/disas/gc/drc/ref-test-concrete-type.wat
@@ -10,11 +10,14 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 40 "VMContext+0x28"
-;;     region2 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 40 "VMContext+0x28"
+;;     region3 = 268435488 "VMStoreContext+0x20"
+;;     region4 = 268435496 "VMStoreContext+0x28"
+;;     region5 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -30,13 +33,13 @@
 ;;
 ;;                                 block3:
 ;; @001d                               v14 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @001d                               v15 = load.i64 notrap aligned readonly can_move v14+32
+;; @001d                               v15 = load.i64 notrap aligned readonly can_move region3 v14+32
 ;; @001d                               v13 = uextend.i64 v2
 ;; @001d                               v16 = iadd v15, v13
 ;; @001d                               v17 = iconst.i64 4
 ;; @001d                               v18 = iadd v16, v17  ; v17 = 4
-;; @001d                               v19 = load.i32 user2 readonly region2 v18
-;; @001d                               v11 = load.i64 notrap aligned readonly can_move region1 v0+40
+;; @001d                               v19 = load.i32 user2 readonly region5 v18
+;; @001d                               v11 = load.i64 notrap aligned readonly can_move region2 v0+40
 ;; @001d                               v12 = load.i32 notrap aligned readonly can_move v11
 ;; @001d                               v20 = icmp eq v19, v12
 ;; @001d                               v21 = uextend.i32 v20

--- a/tests/disas/gc/drc/ref-test-eq.wat
+++ b/tests/disas/gc/drc/ref-test-eq.wat
@@ -9,10 +9,13 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 268435488 "VMStoreContext+0x20"
+;;     region3 = 268435496 "VMStoreContext+0x28"
+;;     region4 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -27,10 +30,10 @@
 ;;
 ;;                                 block3:
 ;; @001b                               v12 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @001b                               v13 = load.i64 notrap aligned readonly can_move v12+32
+;; @001b                               v13 = load.i64 notrap aligned readonly can_move region2 v12+32
 ;; @001b                               v11 = uextend.i64 v2
 ;; @001b                               v14 = iadd v13, v11
-;; @001b                               v17 = load.i32 user2 readonly region1 v14
+;; @001b                               v17 = load.i32 user2 readonly region4 v14
 ;; @001b                               v18 = iconst.i32 -1610612736
 ;; @001b                               v19 = band v17, v18  ; v18 = -1610612736
 ;; @001b                               v20 = icmp eq v19, v18  ; v18 = -1610612736

--- a/tests/disas/gc/drc/ref-test-i31.wat
+++ b/tests/disas/gc/drc/ref-test-i31.wat
@@ -9,9 +9,10 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/gc/drc/ref-test-none.wat
+++ b/tests/disas/gc/drc/ref-test-none.wat
@@ -12,9 +12,10 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -27,9 +28,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/gc/drc/ref-test-struct.wat
+++ b/tests/disas/gc/drc/ref-test-struct.wat
@@ -9,10 +9,13 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 268435488 "VMStoreContext+0x20"
+;;     region3 = 268435496 "VMStoreContext+0x28"
+;;     region4 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -28,10 +31,10 @@
 ;;
 ;;                                 block3:
 ;; @001b                               v12 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @001b                               v13 = load.i64 notrap aligned readonly can_move v12+32
+;; @001b                               v13 = load.i64 notrap aligned readonly can_move region2 v12+32
 ;; @001b                               v11 = uextend.i64 v2
 ;; @001b                               v14 = iadd v13, v11
-;; @001b                               v17 = load.i32 user2 readonly region1 v14
+;; @001b                               v17 = load.i32 user2 readonly region4 v14
 ;; @001b                               v18 = iconst.i32 -1342177280
 ;; @001b                               v19 = band v17, v18  ; v18 = -1342177280
 ;; @001b                               v20 = icmp eq v19, v18  ; v18 = -1342177280

--- a/tests/disas/gc/drc/struct-get.wat
+++ b/tests/disas/gc/drc/struct-get.wat
@@ -25,21 +25,24 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> f32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 268435488 "VMStoreContext+0x20"
+;;     region3 = 268435496 "VMStoreContext+0x28"
+;;     region4 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0033                               trapz v2, user16
 ;; @0033                               v5 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0033                               v6 = load.i64 notrap aligned readonly can_move v5+32
+;; @0033                               v6 = load.i64 notrap aligned readonly can_move region2 v5+32
 ;; @0033                               v4 = uextend.i64 v2
 ;; @0033                               v7 = iadd v6, v4
 ;; @0033                               v8 = iconst.i64 24
 ;; @0033                               v9 = iadd v7, v8  ; v8 = 24
-;; @0033                               v10 = load.f32 user2 little region1 v9
+;; @0033                               v10 = load.f32 user2 little region4 v9
 ;; @0037                               jump block1
 ;;
 ;;                                 block1:
@@ -48,21 +51,24 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 268435488 "VMStoreContext+0x20"
+;;     region3 = 268435496 "VMStoreContext+0x28"
+;;     region4 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @003c                               trapz v2, user16
 ;; @003c                               v5 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @003c                               v6 = load.i64 notrap aligned readonly can_move v5+32
+;; @003c                               v6 = load.i64 notrap aligned readonly can_move region2 v5+32
 ;; @003c                               v4 = uextend.i64 v2
 ;; @003c                               v7 = iadd v6, v4
 ;; @003c                               v8 = iconst.i64 28
 ;; @003c                               v9 = iadd v7, v8  ; v8 = 28
-;; @003c                               v10 = load.i8 user2 little region1 v9
+;; @003c                               v10 = load.i8 user2 little region4 v9
 ;; @0040                               jump block1
 ;;
 ;;                                 block1:
@@ -72,21 +78,24 @@
 ;;
 ;; function u0:2(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 268435488 "VMStoreContext+0x20"
+;;     region3 = 268435496 "VMStoreContext+0x28"
+;;     region4 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0045                               trapz v2, user16
 ;; @0045                               v5 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0045                               v6 = load.i64 notrap aligned readonly can_move v5+32
+;; @0045                               v6 = load.i64 notrap aligned readonly can_move region2 v5+32
 ;; @0045                               v4 = uextend.i64 v2
 ;; @0045                               v7 = iadd v6, v4
 ;; @0045                               v8 = iconst.i64 28
 ;; @0045                               v9 = iadd v7, v8  ; v8 = 28
-;; @0045                               v10 = load.i8 user2 little region1 v9
+;; @0045                               v10 = load.i8 user2 little region4 v9
 ;; @0049                               jump block1
 ;;
 ;;                                 block1:
@@ -97,11 +106,14 @@
 ;; function u0:3(i64 vmctx, i64, i32) -> i32 tail {
 ;;     ss0 = explicit_slot 4, align = 4
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 2147483648 "GcHeap"
-;;     region2 = 32 "VMContext+0x20"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 268435488 "VMStoreContext+0x20"
+;;     region3 = 268435496 "VMStoreContext+0x28"
+;;     region4 = 2147483648 "GcHeap"
+;;     region5 = 32 "VMContext+0x20"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx) -> i8 tail
 ;;     fn0 = colocated u805306368:45 sig0
 ;;     stack_limit = gv2
@@ -109,12 +121,12 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @004e                               trapz v2, user16
 ;; @004e                               v5 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @004e                               v6 = load.i64 notrap aligned readonly can_move v5+32
+;; @004e                               v6 = load.i64 notrap aligned readonly can_move region2 v5+32
 ;; @004e                               v4 = uextend.i64 v2
 ;; @004e                               v7 = iadd v6, v4
 ;; @004e                               v8 = iconst.i64 32
 ;; @004e                               v9 = iadd v7, v8  ; v8 = 32
-;; @004e                               v10 = load.i32 user2 little region1 v9
+;; @004e                               v10 = load.i32 user2 little region4 v9
 ;;                                     v85 = stack_addr.i64 ss0
 ;;                                     store notrap v10, v85
 ;; @004e                               v11 = iconst.i32 1
@@ -128,27 +140,27 @@
 ;;                                 block2:
 ;; @004e                               v17 = uextend.i64 v10
 ;; @004e                               v20 = iadd.i64 v6, v17
-;; @004e                               v21 = load.i32 user2 region1 v20
+;; @004e                               v21 = load.i32 user2 region4 v20
 ;; @004e                               v22 = iconst.i32 2
 ;; @004e                               v23 = band v21, v22  ; v22 = 2
 ;; @004e                               brif v23, block4, block3
 ;;
 ;;                                 block3:
-;; @004e                               v24 = load.i64 notrap aligned readonly can_move region2 v0+32
-;; @004e                               v25 = load.i32 user2 region1 v24
+;; @004e                               v24 = load.i64 notrap aligned readonly can_move region5 v0+32
+;; @004e                               v25 = load.i32 user2 region4 v24
 ;; @004e                               v30 = iconst.i64 16
 ;; @004e                               v31 = iadd.i64 v20, v30  ; v30 = 16
-;; @004e                               store user2 region1 v25, v31
+;; @004e                               store user2 region4 v25, v31
 ;;                                     v86 = iconst.i32 2
 ;;                                     v87 = bor.i32 v21, v86  ; v86 = 2
-;; @004e                               store user2 region1 v87, v20
+;; @004e                               store user2 region4 v87, v20
 ;; @004e                               v42 = iconst.i64 8
 ;; @004e                               v43 = iadd.i64 v20, v42  ; v42 = 8
-;; @004e                               v44 = load.i64 user2 region1 v43
+;; @004e                               v44 = load.i64 user2 region4 v43
 ;; @004e                               v45 = iconst.i64 1
 ;; @004e                               v46 = iadd v44, v45  ; v45 = 1
-;; @004e                               store user2 region1 v46, v43
-;; @004e                               store.i32 user2 region1 v10, v24
+;; @004e                               store user2 region4 v46, v43
+;; @004e                               store.i32 user2 region4 v10, v24
 ;; @004e                               v54 = load.i32 notrap aligned v24+4
 ;;                                     v88 = iconst.i32 1
 ;;                                     v89 = iadd v54, v88  ; v88 = 1

--- a/tests/disas/gc/drc/struct-new-default.wat
+++ b/tests/disas/gc/drc/struct-new-default.wat
@@ -13,41 +13,44 @@
 )
 ;; function u0:0(i64 vmctx, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 40 "VMContext+0x28"
-;;     region2 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 40 "VMContext+0x28"
+;;     region3 = 268435488 "VMStoreContext+0x20"
+;;     region4 = 2147483648 "GcHeap"
+;;     region5 = 268435496 "VMStoreContext+0x28"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
 ;;     fn0 = colocated u805306368:24 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
 ;; @0021                               v7 = iconst.i32 -1342177280
-;; @0021                               v8 = load.i64 notrap aligned readonly can_move region1 v0+40
+;; @0021                               v8 = load.i64 notrap aligned readonly can_move region2 v0+40
 ;; @0021                               v9 = load.i32 notrap aligned readonly can_move v8
 ;; @0021                               v6 = iconst.i32 40
 ;; @0021                               v10 = iconst.i32 8
 ;; @0021                               v11 = call fn0(v0, v7, v9, v6, v10)  ; v7 = -1342177280, v6 = 40, v10 = 8
 ;; @0021                               v3 = f32const 0.0
 ;; @0021                               v12 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0021                               v13 = load.i64 notrap aligned readonly can_move v12+32
+;; @0021                               v13 = load.i64 notrap aligned readonly can_move region3 v12+32
 ;; @0021                               v14 = uextend.i64 v11
 ;; @0021                               v15 = iadd v13, v14
 ;; @0021                               v16 = iconst.i64 24
 ;; @0021                               v17 = iadd v15, v16  ; v16 = 24
-;; @0021                               store user2 little region2 v3, v17  ; v3 = 0.0
+;; @0021                               store user2 little region4 v3, v17  ; v3 = 0.0
 ;; @0021                               v4 = iconst.i32 0
 ;; @0021                               v18 = iconst.i64 28
 ;; @0021                               v19 = iadd v15, v18  ; v18 = 28
-;; @0021                               istore8 user2 little region2 v4, v19  ; v4 = 0
+;; @0021                               istore8 user2 little region4 v4, v19  ; v4 = 0
 ;;                                     jump block3
 ;;
 ;;                                 block3:
 ;;                                     v60 = iconst.i32 0
 ;; @0021                               v20 = iconst.i64 32
 ;; @0021                               v21 = iadd.i64 v15, v20  ; v20 = 32
-;; @0021                               store user2 little region2 v60, v21  ; v60 = 0
+;; @0021                               store user2 little region4 v60, v21  ; v60 = 0
 ;; @0024                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/drc/struct-new.wat
+++ b/tests/disas/gc/drc/struct-new.wat
@@ -14,11 +14,14 @@
 ;; function u0:0(i64 vmctx, i64, f32, i32, i32) -> i32 tail {
 ;;     ss0 = explicit_slot 4, align = 4
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 40 "VMContext+0x28"
-;;     region2 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 40 "VMContext+0x28"
+;;     region3 = 268435488 "VMStoreContext+0x20"
+;;     region4 = 2147483648 "GcHeap"
+;;     region5 = 268435496 "VMStoreContext+0x28"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
 ;;     fn0 = colocated u805306368:24 sig0
 ;;     stack_limit = gv2
@@ -27,21 +30,21 @@
 ;;                                     v53 = stack_addr.i64 ss0
 ;;                                     store notrap v4, v53
 ;; @002a                               v7 = iconst.i32 -1342177280
-;; @002a                               v8 = load.i64 notrap aligned readonly can_move region1 v0+40
+;; @002a                               v8 = load.i64 notrap aligned readonly can_move region2 v0+40
 ;; @002a                               v9 = load.i32 notrap aligned readonly can_move v8
 ;; @002a                               v6 = iconst.i32 40
 ;; @002a                               v10 = iconst.i32 8
 ;; @002a                               v11 = call fn0(v0, v7, v9, v6, v10), stack_map=[i32 @ ss0+0]  ; v7 = -1342177280, v6 = 40, v10 = 8
 ;; @002a                               v12 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @002a                               v13 = load.i64 notrap aligned readonly can_move v12+32
+;; @002a                               v13 = load.i64 notrap aligned readonly can_move region3 v12+32
 ;; @002a                               v14 = uextend.i64 v11
 ;; @002a                               v15 = iadd v13, v14
 ;; @002a                               v16 = iconst.i64 24
 ;; @002a                               v17 = iadd v15, v16  ; v16 = 24
-;; @002a                               store user2 little region2 v2, v17
+;; @002a                               store user2 little region4 v2, v17
 ;; @002a                               v18 = iconst.i64 28
 ;; @002a                               v19 = iadd v15, v18  ; v18 = 28
-;; @002a                               istore8 user2 little region2 v3, v19
+;; @002a                               istore8 user2 little region4 v3, v19
 ;;                                     v52 = load.i32 notrap v53
 ;; @002a                               v22 = iconst.i32 1
 ;; @002a                               v23 = band v52, v22  ; v22 = 1
@@ -56,16 +59,16 @@
 ;; @002a                               v31 = iadd.i64 v13, v28
 ;; @002a                               v32 = iconst.i64 8
 ;; @002a                               v33 = iadd v31, v32  ; v32 = 8
-;; @002a                               v34 = load.i64 user2 region2 v33
+;; @002a                               v34 = load.i64 user2 region4 v33
 ;; @002a                               v35 = iconst.i64 1
 ;; @002a                               v36 = iadd v34, v35  ; v35 = 1
-;; @002a                               store user2 region2 v36, v33
+;; @002a                               store user2 region4 v36, v33
 ;; @002a                               jump block3
 ;;
 ;;                                 block3:
 ;; @002a                               v20 = iconst.i64 32
 ;; @002a                               v21 = iadd.i64 v15, v20  ; v20 = 32
-;; @002a                               store.i32 user2 little region2 v52, v21
+;; @002a                               store.i32 user2 little region4 v52, v21
 ;; @002d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/drc/struct-set.wat
+++ b/tests/disas/gc/drc/struct-set.wat
@@ -21,21 +21,24 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32, f32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 268435488 "VMStoreContext+0x20"
+;;     region3 = 268435496 "VMStoreContext+0x28"
+;;     region4 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: f32):
 ;; @0034                               trapz v2, user16
 ;; @0034                               v5 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0034                               v6 = load.i64 notrap aligned readonly can_move v5+32
+;; @0034                               v6 = load.i64 notrap aligned readonly can_move region2 v5+32
 ;; @0034                               v4 = uextend.i64 v2
 ;; @0034                               v7 = iadd v6, v4
 ;; @0034                               v8 = iconst.i64 24
 ;; @0034                               v9 = iadd v7, v8  ; v8 = 24
-;; @0034                               store user2 little region1 v3, v9
+;; @0034                               store user2 little region4 v3, v9
 ;; @0038                               jump block1
 ;;
 ;;                                 block1:
@@ -44,21 +47,24 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 268435488 "VMStoreContext+0x20"
+;;     region3 = 268435496 "VMStoreContext+0x28"
+;;     region4 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @003f                               trapz v2, user16
 ;; @003f                               v5 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @003f                               v6 = load.i64 notrap aligned readonly can_move v5+32
+;; @003f                               v6 = load.i64 notrap aligned readonly can_move region2 v5+32
 ;; @003f                               v4 = uextend.i64 v2
 ;; @003f                               v7 = iadd v6, v4
 ;; @003f                               v8 = iconst.i64 28
 ;; @003f                               v9 = iadd v7, v8  ; v8 = 28
-;; @003f                               istore8 user2 little region1 v3, v9
+;; @003f                               istore8 user2 little region4 v3, v9
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -67,10 +73,13 @@
 ;;
 ;; function u0:2(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 268435488 "VMStoreContext+0x20"
+;;     region3 = 268435496 "VMStoreContext+0x28"
+;;     region4 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, i32) tail
 ;;     fn0 = colocated u805306368:22 sig0
 ;;     stack_limit = gv2
@@ -78,12 +87,12 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @004a                               trapz v2, user16
 ;; @004a                               v5 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @004a                               v6 = load.i64 notrap aligned readonly can_move v5+32
+;; @004a                               v6 = load.i64 notrap aligned readonly can_move region2 v5+32
 ;; @004a                               v4 = uextend.i64 v2
 ;; @004a                               v7 = iadd v6, v4
 ;; @004a                               v8 = iconst.i64 32
 ;; @004a                               v9 = iadd v7, v8  ; v8 = 32
-;; @004a                               v10 = load.i32 user2 little region1 v9
+;; @004a                               v10 = load.i32 user2 little region4 v9
 ;; @004a                               v11 = iconst.i32 1
 ;; @004a                               v12 = band v3, v11  ; v11 = 1
 ;; @004a                               v13 = iconst.i32 0
@@ -97,15 +106,15 @@
 ;; @004a                               v20 = iadd.i64 v6, v17
 ;; @004a                               v21 = iconst.i64 8
 ;; @004a                               v22 = iadd v20, v21  ; v21 = 8
-;; @004a                               v23 = load.i64 user2 region1 v22
+;; @004a                               v23 = load.i64 user2 region4 v22
 ;; @004a                               v24 = iconst.i64 1
 ;; @004a                               v25 = iadd v23, v24  ; v24 = 1
-;; @004a                               store user2 region1 v25, v22
+;; @004a                               store user2 region4 v25, v22
 ;; @004a                               jump block3
 ;;
 ;;                                 block3:
 ;;                                     v67 = iadd.i64 v7, v8  ; v8 = 32
-;; @004a                               store.i32 user2 little region1 v3, v67
+;; @004a                               store.i32 user2 little region4 v3, v67
 ;;                                     v68 = iconst.i32 1
 ;;                                     v69 = band.i32 v10, v68  ; v68 = 1
 ;;                                     v70 = iconst.i32 0
@@ -119,7 +128,7 @@
 ;; @004a                               v41 = iadd.i64 v6, v38
 ;;                                     v72 = iconst.i64 8
 ;; @004a                               v43 = iadd v41, v72  ; v72 = 8
-;; @004a                               v44 = load.i64 user2 region1 v43
+;; @004a                               v44 = load.i64 user2 region4 v43
 ;;                                     v73 = iconst.i64 1
 ;;                                     v65 = icmp eq v44, v73  ; v73 = 1
 ;; @004a                               brif v65, block5, block6
@@ -132,7 +141,7 @@
 ;; @004a                               v45 = iconst.i64 -1
 ;; @004a                               v46 = iadd.i64 v44, v45  ; v45 = -1
 ;;                                     v74 = iadd.i64 v41, v72  ; v72 = 8
-;; @004a                               store user2 region1 v46, v74
+;; @004a                               store user2 region4 v46, v74
 ;; @004a                               jump block7
 ;;
 ;;                                 block7:

--- a/tests/disas/gc/null/array-fill.wat
+++ b/tests/disas/gc/null/array-fill.wat
@@ -11,28 +11,31 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 268435488 "VMStoreContext+0x20"
+;;     region3 = 268435496 "VMStoreContext+0x28"
+;;     region4 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i64, v5: i32):
 ;; @0027                               trapz v2, user16
 ;; @0027                               v7 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0027                               v8 = load.i64 notrap aligned readonly can_move v7+32
+;; @0027                               v8 = load.i64 notrap aligned readonly can_move region2 v7+32
 ;; @0027                               v6 = uextend.i64 v2
 ;; @0027                               v9 = iadd v8, v6
 ;; @0027                               v10 = iconst.i64 8
 ;; @0027                               v11 = iadd v9, v10  ; v10 = 8
-;; @0027                               v12 = load.i32 user2 readonly region1 v11
+;; @0027                               v12 = load.i32 user2 readonly region4 v11
 ;; @0027                               v14 = uextend.i64 v3
 ;; @0027                               v15 = uextend.i64 v5
 ;; @0027                               v18 = iadd v14, v15
 ;; @0027                               v13 = uextend.i64 v12
 ;; @0027                               v19 = icmp ugt v18, v13
 ;; @0027                               trapnz v19, user17
-;; @0027                               v36 = load.i64 notrap aligned v7+40
+;; @0027                               v36 = load.i64 notrap aligned region3 v7+40
 ;; @0027                               v24 = iconst.i64 16
 ;; @0027                               v25 = iadd v9, v24  ; v24 = 16
 ;;                                     v49 = iconst.i64 3
@@ -49,7 +52,7 @@
 ;; @0027                               brif v42, block3, block2(v29)
 ;;
 ;;                                 block2(v43: i64):
-;; @0027                               store.i64 user2 little region1 v4, v43
+;; @0027                               store.i64 user2 little region4 v4, v43
 ;;                                     v54 = iconst.i64 8
 ;;                                     v55 = iadd v43, v54  ; v54 = 8
 ;; @0027                               v46 = icmp eq v55, v40

--- a/tests/disas/gc/null/array-get-s.wat
+++ b/tests/disas/gc/null/array-get-s.wat
@@ -11,21 +11,24 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 268435488 "VMStoreContext+0x20"
+;;     region3 = 268435496 "VMStoreContext+0x28"
+;;     region4 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0022                               trapz v2, user16
 ;; @0022                               v6 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0022                               v7 = load.i64 notrap aligned readonly can_move v6+32
+;; @0022                               v7 = load.i64 notrap aligned readonly can_move region2 v6+32
 ;; @0022                               v5 = uextend.i64 v2
 ;; @0022                               v8 = iadd v7, v5
 ;; @0022                               v9 = iconst.i64 8
 ;; @0022                               v10 = iadd v8, v9  ; v9 = 8
-;; @0022                               v11 = load.i32 user2 readonly region1 v10
+;; @0022                               v11 = load.i32 user2 readonly region4 v10
 ;; @0022                               v12 = icmp ult v3, v11
 ;; @0022                               trapz v12, user17
 ;; @0022                               v14 = uextend.i64 v11
@@ -41,7 +44,7 @@
 ;; @0022                               v29 = isub v20, v23
 ;; @0022                               v30 = uextend.i64 v29
 ;; @0022                               v31 = isub v28, v30
-;; @0022                               v32 = load.i8 user2 little region1 v31
+;; @0022                               v32 = load.i8 user2 little region4 v31
 ;; @0025                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/null/array-get-u.wat
+++ b/tests/disas/gc/null/array-get-u.wat
@@ -11,21 +11,24 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 268435488 "VMStoreContext+0x20"
+;;     region3 = 268435496 "VMStoreContext+0x28"
+;;     region4 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0022                               trapz v2, user16
 ;; @0022                               v6 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0022                               v7 = load.i64 notrap aligned readonly can_move v6+32
+;; @0022                               v7 = load.i64 notrap aligned readonly can_move region2 v6+32
 ;; @0022                               v5 = uextend.i64 v2
 ;; @0022                               v8 = iadd v7, v5
 ;; @0022                               v9 = iconst.i64 8
 ;; @0022                               v10 = iadd v8, v9  ; v9 = 8
-;; @0022                               v11 = load.i32 user2 readonly region1 v10
+;; @0022                               v11 = load.i32 user2 readonly region4 v10
 ;; @0022                               v12 = icmp ult v3, v11
 ;; @0022                               trapz v12, user17
 ;; @0022                               v14 = uextend.i64 v11
@@ -41,7 +44,7 @@
 ;; @0022                               v29 = isub v20, v23
 ;; @0022                               v30 = uextend.i64 v29
 ;; @0022                               v31 = isub v28, v30
-;; @0022                               v32 = load.i8 user2 little region1 v31
+;; @0022                               v32 = load.i8 user2 little region4 v31
 ;; @0025                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/null/array-get.wat
+++ b/tests/disas/gc/null/array-get.wat
@@ -11,21 +11,24 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32) -> i64 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 268435488 "VMStoreContext+0x20"
+;;     region3 = 268435496 "VMStoreContext+0x28"
+;;     region4 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0022                               trapz v2, user16
 ;; @0022                               v6 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0022                               v7 = load.i64 notrap aligned readonly can_move v6+32
+;; @0022                               v7 = load.i64 notrap aligned readonly can_move region2 v6+32
 ;; @0022                               v5 = uextend.i64 v2
 ;; @0022                               v8 = iadd v7, v5
 ;; @0022                               v9 = iconst.i64 8
 ;; @0022                               v10 = iadd v8, v9  ; v9 = 8
-;; @0022                               v11 = load.i32 user2 readonly region1 v10
+;; @0022                               v11 = load.i32 user2 readonly region4 v10
 ;; @0022                               v12 = icmp ult v3, v11
 ;; @0022                               trapz v12, user17
 ;; @0022                               v14 = uextend.i64 v11
@@ -46,7 +49,7 @@
 ;; @0022                               v29 = isub v20, v23
 ;; @0022                               v30 = uextend.i64 v29
 ;; @0022                               v31 = isub v28, v30
-;; @0022                               v32 = load.i64 user2 little region1 v31
+;; @0022                               v32 = load.i64 user2 little region4 v31
 ;; @0025                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/null/array-len.wat
+++ b/tests/disas/gc/null/array-len.wat
@@ -11,21 +11,24 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 268435488 "VMStoreContext+0x20"
+;;     region3 = 268435496 "VMStoreContext+0x28"
+;;     region4 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @001f                               trapz v2, user16
 ;; @001f                               v5 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @001f                               v6 = load.i64 notrap aligned readonly can_move v5+32
+;; @001f                               v6 = load.i64 notrap aligned readonly can_move region2 v5+32
 ;; @001f                               v4 = uextend.i64 v2
 ;; @001f                               v7 = iadd v6, v4
 ;; @001f                               v8 = iconst.i64 8
 ;; @001f                               v9 = iadd v7, v8  ; v8 = 8
-;; @001f                               v10 = load.i32 user2 readonly region1 v9
+;; @001f                               v10 = load.i32 user2 readonly region4 v9
 ;; @0021                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/null/array-new-fixed-of-gc-refs.wat
+++ b/tests/disas/gc/null/array-new-fixed-of-gc-refs.wat
@@ -14,12 +14,15 @@
 ;;     ss1 = explicit_slot 4, align = 4
 ;;     ss2 = explicit_slot 4, align = 4
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 32 "VMContext+0x20"
-;;     region2 = 2147483648 "GcHeap"
-;;     region3 = 40 "VMContext+0x28"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 32 "VMContext+0x20"
+;;     region3 = 2147483648 "GcHeap"
+;;     region4 = 268435496 "VMStoreContext+0x28"
+;;     region5 = 268435488 "VMStoreContext+0x20"
+;;     region6 = 40 "VMContext+0x28"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, i64) -> i8 tail
 ;;     fn0 = colocated u805306368:23 sig0
 ;;     stack_limit = gv2
@@ -31,8 +34,8 @@
 ;;                                     store notrap v3, v133
 ;;                                     v134 = stack_addr.i64 ss0
 ;;                                     store notrap v4, v134
-;; @0025                               v18 = load.i64 notrap aligned readonly can_move region1 v0+32
-;; @0025                               v19 = load.i32 user2 region2 v18
+;; @0025                               v18 = load.i64 notrap aligned readonly can_move region2 v0+32
+;; @0025                               v19 = load.i32 user2 region3 v18
 ;;                                     v152 = iconst.i32 7
 ;; @0025                               v22 = uadd_overflow_trap v19, v152, user18  ; v152 = 7
 ;;                                     v158 = iconst.i32 -8
@@ -40,26 +43,26 @@
 ;;                                     v145 = iconst.i32 24
 ;; @0025                               v25 = uadd_overflow_trap v24, v145, user18  ; v145 = 24
 ;; @0025                               v27 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0025                               v28 = load.i64 notrap aligned v27+40
+;; @0025                               v28 = load.i64 notrap aligned region4 v27+40
 ;; @0025                               v26 = uextend.i64 v25
 ;; @0025                               v29 = icmp ule v26, v28
 ;; @0025                               brif v29, block2, block3
 ;;
 ;;                                 block2:
 ;;                                     v159 = iconst.i32 -1476394984
-;; @0025                               v33 = load.i64 notrap aligned readonly can_move v27+32
+;; @0025                               v33 = load.i64 notrap aligned readonly can_move region5 v27+32
 ;;                                     v257 = band.i32 v22, v158  ; v158 = -8
 ;;                                     v258 = uextend.i64 v257
 ;; @0025                               v35 = iadd v33, v258
-;; @0025                               store user2 region2 v159, v35  ; v159 = -1476394984
-;; @0025                               v38 = load.i64 notrap aligned readonly can_move region3 v0+40
+;; @0025                               store user2 region3 v159, v35  ; v159 = -1476394984
+;; @0025                               v38 = load.i64 notrap aligned readonly can_move region6 v0+40
 ;; @0025                               v39 = load.i32 notrap aligned readonly can_move v38
-;; @0025                               store user2 region2 v39, v35+4
-;; @0025                               store.i32 user2 region2 v25, v18
+;; @0025                               store user2 region3 v39, v35+4
+;; @0025                               store.i32 user2 region3 v25, v18
 ;; @0025                               v6 = iconst.i32 3
 ;; @0025                               v40 = iconst.i64 8
 ;; @0025                               v41 = iadd v35, v40  ; v40 = 8
-;; @0025                               store user2 region2 v6, v41  ; v6 = 3
+;; @0025                               store user2 region3 v6, v41  ; v6 = 3
 ;; @0025                               trapz v257, user16
 ;;                                     v259 = iconst.i32 24
 ;; @0025                               v62 = uadd_overflow_trap v257, v259, user2  ; v259 = 24
@@ -68,8 +71,8 @@
 ;; @0025                               v66 = iadd v33, v63
 ;;                                     v136 = iconst.i64 12
 ;; @0025                               v69 = isub v66, v136  ; v136 = 12
-;; @0025                               store user2 little region2 v131, v69
-;; @0025                               v77 = load.i32 user2 readonly region2 v41
+;; @0025                               store user2 little region3 v131, v69
+;; @0025                               v77 = load.i32 user2 readonly region3 v41
 ;; @0025                               v70 = iconst.i32 1
 ;;                                     v197 = icmp ugt v77, v70  ; v70 = 1
 ;; @0025                               trapz v197, user17
@@ -91,8 +94,8 @@
 ;; @0025                               v95 = isub v86, v219  ; v219 = 16
 ;; @0025                               v96 = uextend.i64 v95
 ;; @0025                               v97 = isub v94, v96
-;; @0025                               store user2 little region2 v129, v97
-;; @0025                               v105 = load.i32 user2 readonly region2 v41
+;; @0025                               store user2 little region3 v129, v97
+;; @0025                               v105 = load.i32 user2 readonly region3 v41
 ;;                                     v225 = icmp ugt v105, v176  ; v176 = 2
 ;; @0025                               trapz v225, user17
 ;; @0025                               v108 = uextend.i64 v105
@@ -109,7 +112,7 @@
 ;; @0025                               v123 = isub v114, v251  ; v251 = 20
 ;; @0025                               v124 = uextend.i64 v123
 ;; @0025                               v125 = isub v122, v124
-;; @0025                               store user2 little region2 v127, v125
+;; @0025                               store user2 little region3 v127, v125
 ;; @0029                               jump block1
 ;;
 ;;                                 block3 cold:

--- a/tests/disas/gc/null/array-new-fixed.wat
+++ b/tests/disas/gc/null/array-new-fixed.wat
@@ -11,19 +11,22 @@
 )
 ;; function u0:0(i64 vmctx, i64, i64, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 32 "VMContext+0x20"
-;;     region2 = 2147483648 "GcHeap"
-;;     region3 = 40 "VMContext+0x28"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 32 "VMContext+0x20"
+;;     region3 = 2147483648 "GcHeap"
+;;     region4 = 268435496 "VMStoreContext+0x28"
+;;     region5 = 268435488 "VMStoreContext+0x20"
+;;     region6 = 40 "VMContext+0x28"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, i64) -> i8 tail
 ;;     fn0 = colocated u805306368:23 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i64, v4: i64):
-;; @0025                               v18 = load.i64 notrap aligned readonly can_move region1 v0+32
-;; @0025                               v19 = load.i32 user2 region2 v18
+;; @0025                               v18 = load.i64 notrap aligned readonly can_move region2 v0+32
+;; @0025                               v19 = load.i32 user2 region3 v18
 ;;                                     v143 = iconst.i32 7
 ;; @0025                               v22 = uadd_overflow_trap v19, v143, user18  ; v143 = 7
 ;;                                     v149 = iconst.i32 -8
@@ -31,26 +34,26 @@
 ;;                                     v136 = iconst.i32 40
 ;; @0025                               v25 = uadd_overflow_trap v24, v136, user18  ; v136 = 40
 ;; @0025                               v27 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0025                               v28 = load.i64 notrap aligned v27+40
+;; @0025                               v28 = load.i64 notrap aligned region4 v27+40
 ;; @0025                               v26 = uextend.i64 v25
 ;; @0025                               v29 = icmp ule v26, v28
 ;; @0025                               brif v29, block2, block3
 ;;
 ;;                                 block2:
 ;;                                     v150 = iconst.i32 -1476394968
-;; @0025                               v33 = load.i64 notrap aligned readonly can_move v27+32
+;; @0025                               v33 = load.i64 notrap aligned readonly can_move region5 v27+32
 ;;                                     v245 = band.i32 v22, v149  ; v149 = -8
 ;;                                     v246 = uextend.i64 v245
 ;; @0025                               v35 = iadd v33, v246
-;; @0025                               store user2 region2 v150, v35  ; v150 = -1476394968
-;; @0025                               v38 = load.i64 notrap aligned readonly can_move region3 v0+40
+;; @0025                               store user2 region3 v150, v35  ; v150 = -1476394968
+;; @0025                               v38 = load.i64 notrap aligned readonly can_move region6 v0+40
 ;; @0025                               v39 = load.i32 notrap aligned readonly can_move v38
-;; @0025                               store user2 region2 v39, v35+4
-;; @0025                               store.i32 user2 region2 v25, v18
+;; @0025                               store user2 region3 v39, v35+4
+;; @0025                               store.i32 user2 region3 v25, v18
 ;; @0025                               v6 = iconst.i32 3
 ;; @0025                               v9 = iconst.i64 8
 ;; @0025                               v41 = iadd v35, v9  ; v9 = 8
-;; @0025                               store user2 region2 v6, v41  ; v6 = 3
+;; @0025                               store user2 region3 v6, v41  ; v6 = 3
 ;; @0025                               trapz v245, user16
 ;;                                     v247 = iconst.i32 40
 ;; @0025                               v62 = uadd_overflow_trap v245, v247, user2  ; v247 = 40
@@ -58,8 +61,8 @@
 ;; @0025                               v66 = iadd v33, v63
 ;;                                     v127 = iconst.i64 24
 ;; @0025                               v69 = isub v66, v127  ; v127 = 24
-;; @0025                               store.i64 user2 little region2 v2, v69
-;; @0025                               v77 = load.i32 user2 readonly region2 v41
+;; @0025                               store.i64 user2 little region3 v2, v69
+;; @0025                               v77 = load.i32 user2 readonly region3 v41
 ;; @0025                               v70 = iconst.i32 1
 ;;                                     v186 = icmp ugt v77, v70  ; v70 = 1
 ;; @0025                               trapz v186, user17
@@ -79,8 +82,8 @@
 ;; @0025                               v95 = isub v86, v135  ; v135 = 24
 ;; @0025                               v96 = uextend.i64 v95
 ;; @0025                               v97 = isub v94, v96
-;; @0025                               store.i64 user2 little region2 v3, v97
-;; @0025                               v105 = load.i32 user2 readonly region2 v41
+;; @0025                               store.i64 user2 little region3 v3, v97
+;; @0025                               v105 = load.i32 user2 readonly region3 v41
 ;; @0025                               v98 = iconst.i32 2
 ;;                                     v213 = icmp ugt v105, v98  ; v98 = 2
 ;; @0025                               trapz v213, user17
@@ -97,7 +100,7 @@
 ;; @0025                               v123 = isub v114, v239  ; v239 = 32
 ;; @0025                               v124 = uextend.i64 v123
 ;; @0025                               v125 = isub v122, v124
-;; @0025                               store.i64 user2 little region2 v4, v125
+;; @0025                               store.i64 user2 little region3 v4, v125
 ;; @0029                               jump block1
 ;;
 ;;                                 block3 cold:

--- a/tests/disas/gc/null/array-new.wat
+++ b/tests/disas/gc/null/array-new.wat
@@ -11,12 +11,15 @@
 )
 ;; function u0:0(i64 vmctx, i64, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 32 "VMContext+0x20"
-;;     region2 = 2147483648 "GcHeap"
-;;     region3 = 40 "VMContext+0x28"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 32 "VMContext+0x20"
+;;     region3 = 2147483648 "GcHeap"
+;;     region4 = 268435496 "VMStoreContext+0x28"
+;;     region5 = 268435488 "VMStoreContext+0x20"
+;;     region6 = 40 "VMContext+0x28"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, i64) -> i8 tail
 ;;     fn0 = colocated u805306368:23 sig0
 ;;     stack_limit = gv2
@@ -35,15 +38,15 @@
 ;; @0022                               v14 = iconst.i32 -67108864
 ;; @0022                               v15 = band v12, v14  ; v14 = -67108864
 ;; @0022                               trapnz v15, user18
-;; @0022                               v16 = load.i64 notrap aligned readonly can_move region1 v0+32
-;; @0022                               v17 = load.i32 user2 region2 v16
+;; @0022                               v16 = load.i64 notrap aligned readonly can_move region2 v0+32
+;; @0022                               v17 = load.i32 user2 region3 v16
 ;;                                     v93 = iconst.i32 7
 ;; @0022                               v20 = uadd_overflow_trap v17, v93, user18  ; v93 = 7
 ;;                                     v99 = iconst.i32 -8
 ;; @0022                               v22 = band v20, v99  ; v99 = -8
 ;; @0022                               v23 = uadd_overflow_trap v22, v12, user18
 ;; @0022                               v25 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0022                               v26 = load.i64 notrap aligned v25+40
+;; @0022                               v26 = load.i64 notrap aligned region4 v25+40
 ;; @0022                               v24 = uextend.i64 v23
 ;; @0022                               v27 = icmp ule v24, v26
 ;; @0022                               brif v27, block2, block3
@@ -51,20 +54,20 @@
 ;;                                 block2:
 ;; @0022                               v34 = iconst.i32 -1476395008
 ;;                                     v100 = bor.i32 v12, v34  ; v34 = -1476395008
-;; @0022                               v31 = load.i64 notrap aligned readonly can_move v25+32
+;; @0022                               v31 = load.i64 notrap aligned readonly can_move region5 v25+32
 ;;                                     v117 = band.i32 v20, v99  ; v99 = -8
 ;;                                     v118 = uextend.i64 v117
 ;; @0022                               v33 = iadd v31, v118
-;; @0022                               store user2 region2 v100, v33
-;; @0022                               v36 = load.i64 notrap aligned readonly can_move region3 v0+40
+;; @0022                               store user2 region3 v100, v33
+;; @0022                               v36 = load.i64 notrap aligned readonly can_move region6 v0+40
 ;; @0022                               v37 = load.i32 notrap aligned readonly can_move v36
-;; @0022                               store user2 region2 v37, v33+4
-;; @0022                               store.i32 user2 region2 v23, v16
+;; @0022                               store user2 region3 v37, v33+4
+;; @0022                               store.i32 user2 region3 v23, v16
 ;; @0022                               v7 = iconst.i64 8
 ;; @0022                               v39 = iadd v33, v7  ; v7 = 8
-;; @0022                               store.i32 user2 region2 v3, v39
+;; @0022                               store.i32 user2 region3 v3, v39
 ;; @0022                               trapz v117, user16
-;; @0022                               v71 = load.i64 notrap aligned v25+40
+;; @0022                               v71 = load.i64 notrap aligned region4 v25+40
 ;; @0022                               v59 = iconst.i64 16
 ;; @0022                               v60 = iadd v33, v59  ; v59 = 16
 ;; @0022                               v73 = uadd_overflow_trap v60, v83, user2
@@ -77,7 +80,7 @@
 ;; @0022                               brif v77, block5, block4(v60)
 ;;
 ;;                                 block4(v78: i64):
-;; @0022                               store.i64 user2 little region2 v2, v78
+;; @0022                               store.i64 user2 little region3 v2, v78
 ;;                                     v119 = iconst.i64 8
 ;;                                     v120 = iadd v78, v119  ; v119 = 8
 ;; @0022                               v81 = icmp eq v120, v75

--- a/tests/disas/gc/null/array-set.wat
+++ b/tests/disas/gc/null/array-set.wat
@@ -11,21 +11,24 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32, i64) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 268435488 "VMStoreContext+0x20"
+;;     region3 = 268435496 "VMStoreContext+0x28"
+;;     region4 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i64):
 ;; @0024                               trapz v2, user16
 ;; @0024                               v6 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0024                               v7 = load.i64 notrap aligned readonly can_move v6+32
+;; @0024                               v7 = load.i64 notrap aligned readonly can_move region2 v6+32
 ;; @0024                               v5 = uextend.i64 v2
 ;; @0024                               v8 = iadd v7, v5
 ;; @0024                               v9 = iconst.i64 8
 ;; @0024                               v10 = iadd v8, v9  ; v9 = 8
-;; @0024                               v11 = load.i32 user2 readonly region1 v10
+;; @0024                               v11 = load.i32 user2 readonly region4 v10
 ;; @0024                               v12 = icmp ult v3, v11
 ;; @0024                               trapz v12, user17
 ;; @0024                               v14 = uextend.i64 v11
@@ -46,7 +49,7 @@
 ;; @0024                               v29 = isub v20, v23
 ;; @0024                               v30 = uextend.i64 v29
 ;; @0024                               v31 = isub v28, v30
-;; @0024                               store user2 little region1 v4, v31
+;; @0024                               store user2 little region4 v4, v31
 ;; @0027                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/null/br-on-cast-fail.wat
+++ b/tests/disas/gc/null/br-on-cast-fail.wat
@@ -18,15 +18,18 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 40 "VMContext+0x28"
-;;     region2 = 2147483648 "GcHeap"
-;;     region3 = 72 "VMContext+0x48"
-;;     region4 = 56 "VMContext+0x38"
-;;     region5 = 104 "VMContext+0x68"
-;;     region6 = 88 "VMContext+0x58"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 40 "VMContext+0x28"
+;;     region3 = 268435488 "VMStoreContext+0x20"
+;;     region4 = 268435496 "VMStoreContext+0x28"
+;;     region5 = 2147483648 "GcHeap"
+;;     region6 = 72 "VMContext+0x48"
+;;     region7 = 56 "VMContext+0x38"
+;;     region8 = 104 "VMContext+0x68"
+;;     region9 = 88 "VMContext+0x58"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, i64) tail
 ;;     stack_limit = gv2
 ;;
@@ -43,13 +46,13 @@
 ;;
 ;;                                 block4:
 ;; @002e                               v14 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @002e                               v15 = load.i64 notrap aligned readonly can_move v14+32
+;; @002e                               v15 = load.i64 notrap aligned readonly can_move region3 v14+32
 ;; @002e                               v13 = uextend.i64 v2
 ;; @002e                               v16 = iadd v15, v13
 ;; @002e                               v17 = iconst.i64 4
 ;; @002e                               v18 = iadd v16, v17  ; v17 = 4
-;; @002e                               v19 = load.i32 user2 readonly region2 v18
-;; @002e                               v11 = load.i64 notrap aligned readonly can_move region1 v0+40
+;; @002e                               v19 = load.i32 user2 readonly region5 v18
+;; @002e                               v11 = load.i64 notrap aligned readonly can_move region2 v0+40
 ;; @002e                               v12 = load.i32 notrap aligned readonly can_move v11
 ;; @002e                               v20 = icmp eq v19, v12
 ;; @002e                               v21 = uextend.i32 v20
@@ -59,14 +62,14 @@
 ;; @002e                               brif v22, block6, block2
 ;;
 ;;                                 block6:
-;; @0034                               v24 = load.i64 notrap aligned readonly can_move region4 v0+56
-;; @0034                               v23 = load.i64 notrap aligned readonly can_move region3 v0+72
+;; @0034                               v24 = load.i64 notrap aligned readonly can_move region7 v0+56
+;; @0034                               v23 = load.i64 notrap aligned readonly can_move region6 v0+72
 ;; @0034                               call_indirect sig0, v24(v23, v0)
 ;; @0036                               return
 ;;
 ;;                                 block2:
-;; @0038                               v26 = load.i64 notrap aligned readonly can_move region6 v0+88
-;; @0038                               v25 = load.i64 notrap aligned readonly can_move region5 v0+104
+;; @0038                               v26 = load.i64 notrap aligned readonly can_move region9 v0+88
+;; @0038                               v25 = load.i64 notrap aligned readonly can_move region8 v0+104
 ;; @0038                               call_indirect sig0, v26(v25, v0)
 ;; @003a                               return
 ;; }

--- a/tests/disas/gc/null/br-on-cast.wat
+++ b/tests/disas/gc/null/br-on-cast.wat
@@ -18,15 +18,18 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 40 "VMContext+0x28"
-;;     region2 = 2147483648 "GcHeap"
-;;     region3 = 72 "VMContext+0x48"
-;;     region4 = 56 "VMContext+0x38"
-;;     region5 = 104 "VMContext+0x68"
-;;     region6 = 88 "VMContext+0x58"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 40 "VMContext+0x28"
+;;     region3 = 268435488 "VMStoreContext+0x20"
+;;     region4 = 268435496 "VMStoreContext+0x28"
+;;     region5 = 2147483648 "GcHeap"
+;;     region6 = 72 "VMContext+0x48"
+;;     region7 = 56 "VMContext+0x38"
+;;     region8 = 104 "VMContext+0x68"
+;;     region9 = 88 "VMContext+0x58"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, i64) tail
 ;;     stack_limit = gv2
 ;;
@@ -43,13 +46,13 @@
 ;;
 ;;                                 block4:
 ;; @002f                               v14 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @002f                               v15 = load.i64 notrap aligned readonly can_move v14+32
+;; @002f                               v15 = load.i64 notrap aligned readonly can_move region3 v14+32
 ;; @002f                               v13 = uextend.i64 v2
 ;; @002f                               v16 = iadd v15, v13
 ;; @002f                               v17 = iconst.i64 4
 ;; @002f                               v18 = iadd v16, v17  ; v17 = 4
-;; @002f                               v19 = load.i32 user2 readonly region2 v18
-;; @002f                               v11 = load.i64 notrap aligned readonly can_move region1 v0+40
+;; @002f                               v19 = load.i32 user2 readonly region5 v18
+;; @002f                               v11 = load.i64 notrap aligned readonly can_move region2 v0+40
 ;; @002f                               v12 = load.i32 notrap aligned readonly can_move v11
 ;; @002f                               v20 = icmp eq v19, v12
 ;; @002f                               v21 = uextend.i32 v20
@@ -59,14 +62,14 @@
 ;; @002f                               brif v22, block2, block6
 ;;
 ;;                                 block6:
-;; @0035                               v24 = load.i64 notrap aligned readonly can_move region4 v0+56
-;; @0035                               v23 = load.i64 notrap aligned readonly can_move region3 v0+72
+;; @0035                               v24 = load.i64 notrap aligned readonly can_move region7 v0+56
+;; @0035                               v23 = load.i64 notrap aligned readonly can_move region6 v0+72
 ;; @0035                               call_indirect sig0, v24(v23, v0)
 ;; @0037                               return
 ;;
 ;;                                 block2:
-;; @0039                               v26 = load.i64 notrap aligned readonly can_move region6 v0+88
-;; @0039                               v25 = load.i64 notrap aligned readonly can_move region5 v0+104
+;; @0039                               v26 = load.i64 notrap aligned readonly can_move region9 v0+88
+;; @0039                               v25 = load.i64 notrap aligned readonly can_move region8 v0+104
 ;; @0039                               call_indirect sig0, v26(v25, v0)
 ;; @003b                               return
 ;; }

--- a/tests/disas/gc/null/call-indirect-and-subtyping.wat
+++ b/tests/disas/gc/null/call-indirect-and-subtyping.wat
@@ -18,11 +18,12 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 1342177280 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
-;;     region2 = 40 "VMContext+0x28"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 1342177280 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
+;;     region3 = 40 "VMContext+0x28"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, i64) tail
 ;;     sig1 = (i64 vmctx, i32, i64) -> i64 tail
 ;;     sig2 = (i64 vmctx, i32, i32) -> i32 tail
@@ -40,7 +41,7 @@
 ;; @005c                               v8 = ishl v5, v7  ; v7 = 3
 ;; @005c                               v9 = iadd v6, v8
 ;; @005c                               v11 = select_spectre_guard v4, v10, v9  ; v10 = 0
-;; @005c                               v12 = load.i64 user6 aligned region1 v11
+;; @005c                               v12 = load.i64 user6 aligned region2 v11
 ;; @005c                               v13 = iconst.i64 -2
 ;; @005c                               v14 = band v12, v13  ; v13 = -2
 ;; @005c                               brif v12, block3(v14), block2
@@ -52,7 +53,7 @@
 ;;
 ;;                                 block3(v15: i64):
 ;; @005c                               v21 = load.i32 user7 aligned readonly v15+16
-;; @005c                               v19 = load.i64 notrap aligned readonly can_move region2 v0+40
+;; @005c                               v19 = load.i64 notrap aligned readonly can_move region3 v0+40
 ;; @005c                               v20 = load.i32 notrap aligned readonly can_move v19
 ;; @005c                               v22 = icmp eq v21, v20
 ;; @005c                               v23 = uextend.i32 v22

--- a/tests/disas/gc/null/externref-globals.wat
+++ b/tests/disas/gc/null/externref-globals.wat
@@ -14,9 +14,10 @@
 
 ;; function u0:0(i64 vmctx, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
@@ -31,9 +32,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/gc/null/funcref-in-gc-heap-get.wat
+++ b/tests/disas/gc/null/funcref-in-gc-heap-get.wat
@@ -11,10 +11,13 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i64 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 268435488 "VMStoreContext+0x20"
+;;     region3 = 268435496 "VMStoreContext+0x28"
+;;     region4 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, i32, i32) -> i64 tail
 ;;     fn0 = colocated u805306368:26 sig0
 ;;     stack_limit = gv2
@@ -22,12 +25,12 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0020                               trapz v2, user16
 ;; @0020                               v5 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0020                               v6 = load.i64 notrap aligned readonly can_move v5+32
+;; @0020                               v6 = load.i64 notrap aligned readonly can_move region2 v5+32
 ;; @0020                               v4 = uextend.i64 v2
 ;; @0020                               v7 = iadd v6, v4
 ;; @0020                               v8 = iconst.i64 8
 ;; @0020                               v9 = iadd v7, v8  ; v8 = 8
-;; @0020                               v11 = load.i32 user2 little region1 v9
+;; @0020                               v11 = load.i32 user2 little region4 v9
 ;; @0020                               v10 = iconst.i32 -1
 ;; @0020                               v12 = call fn0(v0, v11, v10)  ; v10 = -1
 ;; @0024                               jump block1

--- a/tests/disas/gc/null/funcref-in-gc-heap-new.wat
+++ b/tests/disas/gc/null/funcref-in-gc-heap-new.wat
@@ -11,12 +11,15 @@
 )
 ;; function u0:0(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 32 "VMContext+0x20"
-;;     region2 = 2147483648 "GcHeap"
-;;     region3 = 40 "VMContext+0x28"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 32 "VMContext+0x20"
+;;     region3 = 2147483648 "GcHeap"
+;;     region4 = 268435496 "VMStoreContext+0x28"
+;;     region5 = 268435488 "VMStoreContext+0x20"
+;;     region6 = 40 "VMContext+0x28"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, i64) -> i8 tail
 ;;     sig1 = (i64 vmctx, i64) -> i64 tail
 ;;     fn0 = colocated u805306368:23 sig0
@@ -24,8 +27,8 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0020                               v8 = load.i64 notrap aligned readonly can_move region1 v0+32
-;; @0020                               v9 = load.i32 user2 region2 v8
+;; @0020                               v8 = load.i64 notrap aligned readonly can_move region2 v0+32
+;; @0020                               v9 = load.i32 user2 region3 v8
 ;;                                     v40 = iconst.i32 7
 ;; @0020                               v12 = uadd_overflow_trap v9, v40, user18  ; v40 = 7
 ;;                                     v46 = iconst.i32 -8
@@ -33,27 +36,27 @@
 ;; @0020                               v4 = iconst.i32 16
 ;; @0020                               v15 = uadd_overflow_trap v14, v4, user18  ; v4 = 16
 ;; @0020                               v17 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0020                               v18 = load.i64 notrap aligned v17+40
+;; @0020                               v18 = load.i64 notrap aligned region4 v17+40
 ;; @0020                               v16 = uextend.i64 v15
 ;; @0020                               v19 = icmp ule v16, v18
 ;; @0020                               brif v19, block2, block3
 ;;
 ;;                                 block2:
 ;;                                     v47 = iconst.i32 -1342177264
-;; @0020                               v23 = load.i64 notrap aligned readonly can_move v17+32
+;; @0020                               v23 = load.i64 notrap aligned readonly can_move region5 v17+32
 ;;                                     v53 = band.i32 v12, v46  ; v46 = -8
 ;;                                     v54 = uextend.i64 v53
 ;; @0020                               v25 = iadd v23, v54
-;; @0020                               store user2 region2 v47, v25  ; v47 = -1342177264
-;; @0020                               v28 = load.i64 notrap aligned readonly can_move region3 v0+40
+;; @0020                               store user2 region3 v47, v25  ; v47 = -1342177264
+;; @0020                               v28 = load.i64 notrap aligned readonly can_move region6 v0+40
 ;; @0020                               v29 = load.i32 notrap aligned readonly can_move v28
-;; @0020                               store user2 region2 v29, v25+4
-;; @0020                               store.i32 user2 region2 v15, v8
+;; @0020                               store user2 region3 v29, v25+4
+;; @0020                               store.i32 user2 region3 v15, v8
 ;; @0020                               v32 = call fn1(v0, v2)
 ;; @0020                               v33 = ireduce.i32 v32
 ;; @0020                               v30 = iconst.i64 8
 ;; @0020                               v31 = iadd v25, v30  ; v30 = 8
-;; @0020                               store user2 little region2 v33, v31
+;; @0020                               store user2 little region3 v33, v31
 ;; @0023                               jump block1
 ;;
 ;;                                 block3 cold:

--- a/tests/disas/gc/null/funcref-in-gc-heap-set.wat
+++ b/tests/disas/gc/null/funcref-in-gc-heap-set.wat
@@ -11,10 +11,13 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32, i64) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 268435488 "VMStoreContext+0x20"
+;;     region3 = 268435496 "VMStoreContext+0x28"
+;;     region4 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, i64) -> i64 tail
 ;;     fn0 = colocated u805306368:25 sig0
 ;;     stack_limit = gv2
@@ -24,12 +27,12 @@
 ;; @0022                               v10 = call fn0(v0, v3)
 ;; @0022                               v11 = ireduce.i32 v10
 ;; @0022                               v5 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0022                               v6 = load.i64 notrap aligned readonly can_move v5+32
+;; @0022                               v6 = load.i64 notrap aligned readonly can_move region2 v5+32
 ;; @0022                               v4 = uextend.i64 v2
 ;; @0022                               v7 = iadd v6, v4
 ;; @0022                               v8 = iconst.i64 8
 ;; @0022                               v9 = iadd v7, v8  ; v8 = 8
-;; @0022                               store user2 little region1 v11, v9
+;; @0022                               store user2 little region4 v11, v9
 ;; @0026                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/null/i31ref-globals.wat
+++ b/tests/disas/gc/null/i31ref-globals.wat
@@ -14,9 +14,10 @@
 
 ;; function u0:0(i64 vmctx, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
@@ -31,9 +32,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/gc/null/multiple-array-get.wat
+++ b/tests/disas/gc/null/multiple-array-get.wat
@@ -12,21 +12,24 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32, i32) -> i64, i64 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 268435488 "VMStoreContext+0x20"
+;;     region3 = 268435496 "VMStoreContext+0x28"
+;;     region4 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
 ;; @0024                               trapz v2, user16
 ;; @0024                               v8 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0024                               v9 = load.i64 notrap aligned readonly can_move v8+32
+;; @0024                               v9 = load.i64 notrap aligned readonly can_move region2 v8+32
 ;; @0024                               v7 = uextend.i64 v2
 ;; @0024                               v10 = iadd v9, v7
 ;; @0024                               v11 = iconst.i64 8
 ;; @0024                               v12 = iadd v10, v11  ; v11 = 8
-;; @0024                               v13 = load.i32 user2 readonly region1 v12
+;; @0024                               v13 = load.i32 user2 readonly region4 v12
 ;; @0024                               v14 = icmp ult v3, v13
 ;; @0024                               trapz v14, user17
 ;; @0024                               v16 = uextend.i64 v13
@@ -47,7 +50,7 @@
 ;; @0024                               v31 = isub v22, v25
 ;; @0024                               v32 = uextend.i64 v31
 ;; @0024                               v33 = isub v30, v32
-;; @0024                               v34 = load.i64 user2 little region1 v33
+;; @0024                               v34 = load.i64 user2 little region4 v33
 ;; @002b                               v42 = icmp ult v4, v13
 ;; @002b                               trapz v42, user17
 ;;                                     v82 = ishl v4, v73  ; v73 = 3
@@ -55,7 +58,7 @@
 ;; @002b                               v59 = isub v22, v53
 ;; @002b                               v60 = uextend.i64 v59
 ;; @002b                               v61 = isub v30, v60
-;; @002b                               v62 = load.i64 user2 little region1 v61
+;; @002b                               v62 = load.i64 user2 little region4 v61
 ;; @002e                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/null/multiple-struct-get.wat
+++ b/tests/disas/gc/null/multiple-struct-get.wat
@@ -13,24 +13,27 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> f32, i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 268435488 "VMStoreContext+0x20"
+;;     region3 = 268435496 "VMStoreContext+0x28"
+;;     region4 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0023                               trapz v2, user16
 ;; @0023                               v6 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0023                               v7 = load.i64 notrap aligned readonly can_move v6+32
+;; @0023                               v7 = load.i64 notrap aligned readonly can_move region2 v6+32
 ;; @0023                               v5 = uextend.i64 v2
 ;; @0023                               v8 = iadd v7, v5
 ;; @0023                               v9 = iconst.i64 8
 ;; @0023                               v10 = iadd v8, v9  ; v9 = 8
-;; @0023                               v11 = load.f32 user2 little region1 v10
+;; @0023                               v11 = load.f32 user2 little region4 v10
 ;; @0029                               v16 = iconst.i64 12
 ;; @0029                               v17 = iadd v8, v16  ; v16 = 12
-;; @0029                               v18 = load.i8 user2 little region1 v17
+;; @0029                               v18 = load.i8 user2 little region4 v17
 ;; @002d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/null/ref-cast.wat
+++ b/tests/disas/gc/null/ref-cast.wat
@@ -10,11 +10,14 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 40 "VMContext+0x28"
-;;     region2 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 40 "VMContext+0x28"
+;;     region3 = 268435488 "VMStoreContext+0x20"
+;;     region4 = 268435496 "VMStoreContext+0x28"
+;;     region5 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -30,13 +33,13 @@
 ;;
 ;;                                 block3:
 ;; @001e                               v14 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @001e                               v15 = load.i64 notrap aligned readonly can_move v14+32
+;; @001e                               v15 = load.i64 notrap aligned readonly can_move region3 v14+32
 ;; @001e                               v13 = uextend.i64 v2
 ;; @001e                               v16 = iadd v15, v13
 ;; @001e                               v17 = iconst.i64 4
 ;; @001e                               v18 = iadd v16, v17  ; v17 = 4
-;; @001e                               v19 = load.i32 user2 readonly region2 v18
-;; @001e                               v11 = load.i64 notrap aligned readonly can_move region1 v0+40
+;; @001e                               v19 = load.i32 user2 readonly region5 v18
+;; @001e                               v11 = load.i64 notrap aligned readonly can_move region2 v0+40
 ;; @001e                               v12 = load.i32 notrap aligned readonly can_move v11
 ;; @001e                               v20 = icmp eq v19, v12
 ;; @001e                               v21 = uextend.i32 v20

--- a/tests/disas/gc/null/ref-is-null.wat
+++ b/tests/disas/gc/null/ref-is-null.wat
@@ -12,9 +12,10 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -29,9 +30,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/gc/null/ref-test-any.wat
+++ b/tests/disas/gc/null/ref-test-any.wat
@@ -12,9 +12,10 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -29,9 +30,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/gc/null/ref-test-array.wat
+++ b/tests/disas/gc/null/ref-test-array.wat
@@ -9,10 +9,13 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 268435488 "VMStoreContext+0x20"
+;;     region3 = 268435496 "VMStoreContext+0x28"
+;;     region4 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -28,10 +31,10 @@
 ;;
 ;;                                 block3:
 ;; @001b                               v12 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @001b                               v13 = load.i64 notrap aligned readonly can_move v12+32
+;; @001b                               v13 = load.i64 notrap aligned readonly can_move region2 v12+32
 ;; @001b                               v11 = uextend.i64 v2
 ;; @001b                               v14 = iadd v13, v11
-;; @001b                               v17 = load.i32 user2 readonly region1 v14
+;; @001b                               v17 = load.i32 user2 readonly region4 v14
 ;; @001b                               v18 = iconst.i32 -1476395008
 ;; @001b                               v19 = band v17, v18  ; v18 = -1476395008
 ;; @001b                               v20 = icmp eq v19, v18  ; v18 = -1476395008

--- a/tests/disas/gc/null/ref-test-concrete-func-type.wat
+++ b/tests/disas/gc/null/ref-test-concrete-func-type.wat
@@ -10,11 +10,12 @@
 )
 ;; function u0:0(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 40 "VMContext+0x28"
-;;     region2 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 40 "VMContext+0x28"
+;;     region3 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
@@ -27,8 +28,8 @@
 ;; @0020                               jump block3
 ;;
 ;;                                 block3:
-;; @0020                               v10 = load.i32 user2 readonly region2 v2+16
-;; @0020                               v8 = load.i64 notrap aligned readonly can_move region1 v0+40
+;; @0020                               v10 = load.i32 user2 readonly region3 v2+16
+;; @0020                               v8 = load.i64 notrap aligned readonly can_move region2 v0+40
 ;; @0020                               v9 = load.i32 notrap aligned readonly can_move v8
 ;; @0020                               v11 = icmp eq v10, v9
 ;; @0020                               v12 = uextend.i32 v11

--- a/tests/disas/gc/null/ref-test-concrete-type.wat
+++ b/tests/disas/gc/null/ref-test-concrete-type.wat
@@ -10,11 +10,14 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 40 "VMContext+0x28"
-;;     region2 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 40 "VMContext+0x28"
+;;     region3 = 268435488 "VMStoreContext+0x20"
+;;     region4 = 268435496 "VMStoreContext+0x28"
+;;     region5 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -30,13 +33,13 @@
 ;;
 ;;                                 block3:
 ;; @001d                               v14 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @001d                               v15 = load.i64 notrap aligned readonly can_move v14+32
+;; @001d                               v15 = load.i64 notrap aligned readonly can_move region3 v14+32
 ;; @001d                               v13 = uextend.i64 v2
 ;; @001d                               v16 = iadd v15, v13
 ;; @001d                               v17 = iconst.i64 4
 ;; @001d                               v18 = iadd v16, v17  ; v17 = 4
-;; @001d                               v19 = load.i32 user2 readonly region2 v18
-;; @001d                               v11 = load.i64 notrap aligned readonly can_move region1 v0+40
+;; @001d                               v19 = load.i32 user2 readonly region5 v18
+;; @001d                               v11 = load.i64 notrap aligned readonly can_move region2 v0+40
 ;; @001d                               v12 = load.i32 notrap aligned readonly can_move v11
 ;; @001d                               v20 = icmp eq v19, v12
 ;; @001d                               v21 = uextend.i32 v20

--- a/tests/disas/gc/null/ref-test-eq.wat
+++ b/tests/disas/gc/null/ref-test-eq.wat
@@ -9,10 +9,13 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 268435488 "VMStoreContext+0x20"
+;;     region3 = 268435496 "VMStoreContext+0x28"
+;;     region4 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -27,10 +30,10 @@
 ;;
 ;;                                 block3:
 ;; @001b                               v12 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @001b                               v13 = load.i64 notrap aligned readonly can_move v12+32
+;; @001b                               v13 = load.i64 notrap aligned readonly can_move region2 v12+32
 ;; @001b                               v11 = uextend.i64 v2
 ;; @001b                               v14 = iadd v13, v11
-;; @001b                               v17 = load.i32 user2 readonly region1 v14
+;; @001b                               v17 = load.i32 user2 readonly region4 v14
 ;; @001b                               v18 = iconst.i32 -1610612736
 ;; @001b                               v19 = band v17, v18  ; v18 = -1610612736
 ;; @001b                               v20 = icmp eq v19, v18  ; v18 = -1610612736

--- a/tests/disas/gc/null/ref-test-i31.wat
+++ b/tests/disas/gc/null/ref-test-i31.wat
@@ -9,9 +9,10 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/gc/null/ref-test-none.wat
+++ b/tests/disas/gc/null/ref-test-none.wat
@@ -12,9 +12,10 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -27,9 +28,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/gc/null/ref-test-struct.wat
+++ b/tests/disas/gc/null/ref-test-struct.wat
@@ -9,10 +9,13 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 268435488 "VMStoreContext+0x20"
+;;     region3 = 268435496 "VMStoreContext+0x28"
+;;     region4 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -28,10 +31,10 @@
 ;;
 ;;                                 block3:
 ;; @001b                               v12 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @001b                               v13 = load.i64 notrap aligned readonly can_move v12+32
+;; @001b                               v13 = load.i64 notrap aligned readonly can_move region2 v12+32
 ;; @001b                               v11 = uextend.i64 v2
 ;; @001b                               v14 = iadd v13, v11
-;; @001b                               v17 = load.i32 user2 readonly region1 v14
+;; @001b                               v17 = load.i32 user2 readonly region4 v14
 ;; @001b                               v18 = iconst.i32 -1342177280
 ;; @001b                               v19 = band v17, v18  ; v18 = -1342177280
 ;; @001b                               v20 = icmp eq v19, v18  ; v18 = -1342177280

--- a/tests/disas/gc/null/struct-get-guard-pages.wat
+++ b/tests/disas/gc/null/struct-get-guard-pages.wat
@@ -25,21 +25,24 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> f32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 268435488 "VMStoreContext+0x20"
+;;     region3 = 268435496 "VMStoreContext+0x28"
+;;     region4 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0033                               trapz v2, user16
 ;; @0033                               v5 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0033                               v6 = load.i64 notrap aligned readonly can_move v5+32
+;; @0033                               v6 = load.i64 notrap aligned readonly can_move region2 v5+32
 ;; @0033                               v4 = uextend.i64 v2
 ;; @0033                               v7 = iadd v6, v4
 ;; @0033                               v8 = iconst.i64 8
 ;; @0033                               v9 = iadd v7, v8  ; v8 = 8
-;; @0033                               v10 = load.f32 user2 little region1 v9
+;; @0033                               v10 = load.f32 user2 little region4 v9
 ;; @0037                               jump block1
 ;;
 ;;                                 block1:
@@ -48,21 +51,24 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 268435488 "VMStoreContext+0x20"
+;;     region3 = 268435496 "VMStoreContext+0x28"
+;;     region4 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @003c                               trapz v2, user16
 ;; @003c                               v5 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @003c                               v6 = load.i64 notrap aligned readonly can_move v5+32
+;; @003c                               v6 = load.i64 notrap aligned readonly can_move region2 v5+32
 ;; @003c                               v4 = uextend.i64 v2
 ;; @003c                               v7 = iadd v6, v4
 ;; @003c                               v8 = iconst.i64 12
 ;; @003c                               v9 = iadd v7, v8  ; v8 = 12
-;; @003c                               v10 = load.i8 user2 little region1 v9
+;; @003c                               v10 = load.i8 user2 little region4 v9
 ;; @0040                               jump block1
 ;;
 ;;                                 block1:
@@ -72,21 +78,24 @@
 ;;
 ;; function u0:2(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 268435488 "VMStoreContext+0x20"
+;;     region3 = 268435496 "VMStoreContext+0x28"
+;;     region4 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0045                               trapz v2, user16
 ;; @0045                               v5 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0045                               v6 = load.i64 notrap aligned readonly can_move v5+32
+;; @0045                               v6 = load.i64 notrap aligned readonly can_move region2 v5+32
 ;; @0045                               v4 = uextend.i64 v2
 ;; @0045                               v7 = iadd v6, v4
 ;; @0045                               v8 = iconst.i64 12
 ;; @0045                               v9 = iadd v7, v8  ; v8 = 12
-;; @0045                               v10 = load.i8 user2 little region1 v9
+;; @0045                               v10 = load.i8 user2 little region4 v9
 ;; @0049                               jump block1
 ;;
 ;;                                 block1:
@@ -96,21 +105,24 @@
 ;;
 ;; function u0:3(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 268435488 "VMStoreContext+0x20"
+;;     region3 = 268435496 "VMStoreContext+0x28"
+;;     region4 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @004e                               trapz v2, user16
 ;; @004e                               v5 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @004e                               v6 = load.i64 notrap aligned readonly can_move v5+32
+;; @004e                               v6 = load.i64 notrap aligned readonly can_move region2 v5+32
 ;; @004e                               v4 = uextend.i64 v2
 ;; @004e                               v7 = iadd v6, v4
 ;; @004e                               v8 = iconst.i64 16
 ;; @004e                               v9 = iadd v7, v8  ; v8 = 16
-;; @004e                               v10 = load.i32 user2 little region1 v9
+;; @004e                               v10 = load.i32 user2 little region4 v9
 ;; @0052                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/null/struct-get-no-guard-pages.wat
+++ b/tests/disas/gc/null/struct-get-no-guard-pages.wat
@@ -25,10 +25,13 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> f32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 268435488 "VMStoreContext+0x20"
+;;     region3 = 268435496 "VMStoreContext+0x28"
+;;     region4 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -37,15 +40,15 @@
 ;; @0033                               v5 = iconst.i64 24
 ;; @0033                               v6 = uadd_overflow_trap v4, v5, user2  ; v5 = 24
 ;; @0033                               v7 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0033                               v8 = load.i64 notrap aligned v7+40
-;; @0033                               v11 = load.i64 notrap aligned v7+32
+;; @0033                               v8 = load.i64 notrap aligned region3 v7+40
+;; @0033                               v11 = load.i64 notrap aligned region2 v7+32
 ;; @0033                               v9 = icmp ugt v6, v8
 ;; @0033                               v13 = iconst.i64 0
 ;; @0033                               v12 = iadd v11, v4
 ;; @0033                               v14 = select_spectre_guard v9, v13, v12  ; v13 = 0
 ;; @0033                               v15 = iconst.i64 8
 ;; @0033                               v16 = iadd v14, v15  ; v15 = 8
-;; @0033                               v17 = load.f32 user2 little region1 v16
+;; @0033                               v17 = load.f32 user2 little region4 v16
 ;; @0037                               jump block1
 ;;
 ;;                                 block1:
@@ -54,10 +57,13 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 268435488 "VMStoreContext+0x20"
+;;     region3 = 268435496 "VMStoreContext+0x28"
+;;     region4 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -66,15 +72,15 @@
 ;; @003c                               v5 = iconst.i64 24
 ;; @003c                               v6 = uadd_overflow_trap v4, v5, user2  ; v5 = 24
 ;; @003c                               v7 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @003c                               v8 = load.i64 notrap aligned v7+40
-;; @003c                               v11 = load.i64 notrap aligned v7+32
+;; @003c                               v8 = load.i64 notrap aligned region3 v7+40
+;; @003c                               v11 = load.i64 notrap aligned region2 v7+32
 ;; @003c                               v9 = icmp ugt v6, v8
 ;; @003c                               v13 = iconst.i64 0
 ;; @003c                               v12 = iadd v11, v4
 ;; @003c                               v14 = select_spectre_guard v9, v13, v12  ; v13 = 0
 ;; @003c                               v15 = iconst.i64 12
 ;; @003c                               v16 = iadd v14, v15  ; v15 = 12
-;; @003c                               v17 = load.i8 user2 little region1 v16
+;; @003c                               v17 = load.i8 user2 little region4 v16
 ;; @0040                               jump block1
 ;;
 ;;                                 block1:
@@ -84,10 +90,13 @@
 ;;
 ;; function u0:2(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 268435488 "VMStoreContext+0x20"
+;;     region3 = 268435496 "VMStoreContext+0x28"
+;;     region4 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -96,15 +105,15 @@
 ;; @0045                               v5 = iconst.i64 24
 ;; @0045                               v6 = uadd_overflow_trap v4, v5, user2  ; v5 = 24
 ;; @0045                               v7 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0045                               v8 = load.i64 notrap aligned v7+40
-;; @0045                               v11 = load.i64 notrap aligned v7+32
+;; @0045                               v8 = load.i64 notrap aligned region3 v7+40
+;; @0045                               v11 = load.i64 notrap aligned region2 v7+32
 ;; @0045                               v9 = icmp ugt v6, v8
 ;; @0045                               v13 = iconst.i64 0
 ;; @0045                               v12 = iadd v11, v4
 ;; @0045                               v14 = select_spectre_guard v9, v13, v12  ; v13 = 0
 ;; @0045                               v15 = iconst.i64 12
 ;; @0045                               v16 = iadd v14, v15  ; v15 = 12
-;; @0045                               v17 = load.i8 user2 little region1 v16
+;; @0045                               v17 = load.i8 user2 little region4 v16
 ;; @0049                               jump block1
 ;;
 ;;                                 block1:
@@ -114,10 +123,13 @@
 ;;
 ;; function u0:3(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 268435488 "VMStoreContext+0x20"
+;;     region3 = 268435496 "VMStoreContext+0x28"
+;;     region4 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -126,15 +138,15 @@
 ;; @004e                               v5 = iconst.i64 24
 ;; @004e                               v6 = uadd_overflow_trap v4, v5, user2  ; v5 = 24
 ;; @004e                               v7 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @004e                               v8 = load.i64 notrap aligned v7+40
-;; @004e                               v11 = load.i64 notrap aligned v7+32
+;; @004e                               v8 = load.i64 notrap aligned region3 v7+40
+;; @004e                               v11 = load.i64 notrap aligned region2 v7+32
 ;; @004e                               v9 = icmp ugt v6, v8
 ;; @004e                               v13 = iconst.i64 0
 ;; @004e                               v12 = iadd v11, v4
 ;; @004e                               v14 = select_spectre_guard v9, v13, v12  ; v13 = 0
 ;; @004e                               v15 = iconst.i64 16
 ;; @004e                               v16 = iadd v14, v15  ; v15 = 16
-;; @004e                               v17 = load.i32 user2 little region1 v16
+;; @004e                               v17 = load.i32 user2 little region4 v16
 ;; @0052                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/null/struct-get.wat
+++ b/tests/disas/gc/null/struct-get.wat
@@ -25,21 +25,24 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> f32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 268435488 "VMStoreContext+0x20"
+;;     region3 = 268435496 "VMStoreContext+0x28"
+;;     region4 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0033                               trapz v2, user16
 ;; @0033                               v5 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0033                               v6 = load.i64 notrap aligned readonly can_move v5+32
+;; @0033                               v6 = load.i64 notrap aligned readonly can_move region2 v5+32
 ;; @0033                               v4 = uextend.i64 v2
 ;; @0033                               v7 = iadd v6, v4
 ;; @0033                               v8 = iconst.i64 8
 ;; @0033                               v9 = iadd v7, v8  ; v8 = 8
-;; @0033                               v10 = load.f32 user2 little region1 v9
+;; @0033                               v10 = load.f32 user2 little region4 v9
 ;; @0037                               jump block1
 ;;
 ;;                                 block1:
@@ -48,21 +51,24 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 268435488 "VMStoreContext+0x20"
+;;     region3 = 268435496 "VMStoreContext+0x28"
+;;     region4 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @003c                               trapz v2, user16
 ;; @003c                               v5 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @003c                               v6 = load.i64 notrap aligned readonly can_move v5+32
+;; @003c                               v6 = load.i64 notrap aligned readonly can_move region2 v5+32
 ;; @003c                               v4 = uextend.i64 v2
 ;; @003c                               v7 = iadd v6, v4
 ;; @003c                               v8 = iconst.i64 12
 ;; @003c                               v9 = iadd v7, v8  ; v8 = 12
-;; @003c                               v10 = load.i8 user2 little region1 v9
+;; @003c                               v10 = load.i8 user2 little region4 v9
 ;; @0040                               jump block1
 ;;
 ;;                                 block1:
@@ -72,21 +78,24 @@
 ;;
 ;; function u0:2(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 268435488 "VMStoreContext+0x20"
+;;     region3 = 268435496 "VMStoreContext+0x28"
+;;     region4 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0045                               trapz v2, user16
 ;; @0045                               v5 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0045                               v6 = load.i64 notrap aligned readonly can_move v5+32
+;; @0045                               v6 = load.i64 notrap aligned readonly can_move region2 v5+32
 ;; @0045                               v4 = uextend.i64 v2
 ;; @0045                               v7 = iadd v6, v4
 ;; @0045                               v8 = iconst.i64 12
 ;; @0045                               v9 = iadd v7, v8  ; v8 = 12
-;; @0045                               v10 = load.i8 user2 little region1 v9
+;; @0045                               v10 = load.i8 user2 little region4 v9
 ;; @0049                               jump block1
 ;;
 ;;                                 block1:
@@ -96,21 +105,24 @@
 ;;
 ;; function u0:3(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 268435488 "VMStoreContext+0x20"
+;;     region3 = 268435496 "VMStoreContext+0x28"
+;;     region4 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @004e                               trapz v2, user16
 ;; @004e                               v5 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @004e                               v6 = load.i64 notrap aligned readonly can_move v5+32
+;; @004e                               v6 = load.i64 notrap aligned readonly can_move region2 v5+32
 ;; @004e                               v4 = uextend.i64 v2
 ;; @004e                               v7 = iadd v6, v4
 ;; @004e                               v8 = iconst.i64 16
 ;; @004e                               v9 = iadd v7, v8  ; v8 = 16
-;; @004e                               v10 = load.i32 user2 little region1 v9
+;; @004e                               v10 = load.i32 user2 little region4 v9
 ;; @0052                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/null/struct-new-default.wat
+++ b/tests/disas/gc/null/struct-new-default.wat
@@ -13,19 +13,22 @@
 )
 ;; function u0:0(i64 vmctx, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 32 "VMContext+0x20"
-;;     region2 = 2147483648 "GcHeap"
-;;     region3 = 40 "VMContext+0x28"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 32 "VMContext+0x20"
+;;     region3 = 2147483648 "GcHeap"
+;;     region4 = 268435496 "VMStoreContext+0x28"
+;;     region5 = 268435488 "VMStoreContext+0x20"
+;;     region6 = 40 "VMContext+0x28"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, i64) -> i8 tail
 ;;     fn0 = colocated u805306368:23 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @0021                               v10 = load.i64 notrap aligned readonly can_move region1 v0+32
-;; @0021                               v11 = load.i32 user2 region2 v10
+;; @0021                               v10 = load.i64 notrap aligned readonly can_move region2 v0+32
+;; @0021                               v11 = load.i32 user2 region3 v10
 ;;                                     v43 = iconst.i32 7
 ;; @0021                               v14 = uadd_overflow_trap v11, v43, user18  ; v43 = 7
 ;;                                     v49 = iconst.i32 -8
@@ -33,33 +36,33 @@
 ;; @0021                               v6 = iconst.i32 24
 ;; @0021                               v17 = uadd_overflow_trap v16, v6, user18  ; v6 = 24
 ;; @0021                               v19 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0021                               v20 = load.i64 notrap aligned v19+40
+;; @0021                               v20 = load.i64 notrap aligned region4 v19+40
 ;; @0021                               v18 = uextend.i64 v17
 ;; @0021                               v21 = icmp ule v18, v20
 ;; @0021                               brif v21, block2, block3
 ;;
 ;;                                 block2:
 ;;                                     v50 = iconst.i32 -1342177256
-;; @0021                               v25 = load.i64 notrap aligned readonly can_move v19+32
+;; @0021                               v25 = load.i64 notrap aligned readonly can_move region5 v19+32
 ;;                                     v56 = band.i32 v14, v49  ; v49 = -8
 ;;                                     v57 = uextend.i64 v56
 ;; @0021                               v27 = iadd v25, v57
-;; @0021                               store user2 region2 v50, v27  ; v50 = -1342177256
-;; @0021                               v30 = load.i64 notrap aligned readonly can_move region3 v0+40
+;; @0021                               store user2 region3 v50, v27  ; v50 = -1342177256
+;; @0021                               v30 = load.i64 notrap aligned readonly can_move region6 v0+40
 ;; @0021                               v31 = load.i32 notrap aligned readonly can_move v30
-;; @0021                               store user2 region2 v31, v27+4
-;; @0021                               store.i32 user2 region2 v17, v10
+;; @0021                               store user2 region3 v31, v27+4
+;; @0021                               store.i32 user2 region3 v17, v10
 ;; @0021                               v3 = f32const 0.0
 ;; @0021                               v32 = iconst.i64 8
 ;; @0021                               v33 = iadd v27, v32  ; v32 = 8
-;; @0021                               store user2 little region2 v3, v33  ; v3 = 0.0
+;; @0021                               store user2 little region3 v3, v33  ; v3 = 0.0
 ;; @0021                               v4 = iconst.i32 0
 ;; @0021                               v34 = iconst.i64 12
 ;; @0021                               v35 = iadd v27, v34  ; v34 = 12
-;; @0021                               istore8 user2 little region2 v4, v35  ; v4 = 0
+;; @0021                               istore8 user2 little region3 v4, v35  ; v4 = 0
 ;; @0021                               v36 = iconst.i64 16
 ;; @0021                               v37 = iadd v27, v36  ; v36 = 16
-;; @0021                               store user2 little region2 v4, v37  ; v4 = 0
+;; @0021                               store user2 little region3 v4, v37  ; v4 = 0
 ;; @0024                               jump block1
 ;;
 ;;                                 block3 cold:

--- a/tests/disas/gc/null/struct-new.wat
+++ b/tests/disas/gc/null/struct-new.wat
@@ -14,12 +14,15 @@
 ;; function u0:0(i64 vmctx, i64, f32, i32, i32) -> i32 tail {
 ;;     ss0 = explicit_slot 4, align = 4
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 32 "VMContext+0x20"
-;;     region2 = 2147483648 "GcHeap"
-;;     region3 = 40 "VMContext+0x28"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 32 "VMContext+0x20"
+;;     region3 = 2147483648 "GcHeap"
+;;     region4 = 268435496 "VMStoreContext+0x28"
+;;     region5 = 268435488 "VMStoreContext+0x20"
+;;     region6 = 40 "VMContext+0x28"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, i64) -> i8 tail
 ;;     fn0 = colocated u805306368:23 sig0
 ;;     stack_limit = gv2
@@ -27,8 +30,8 @@
 ;;                                 block0(v0: i64, v1: i64, v2: f32, v3: i32, v4: i32):
 ;;                                     v40 = stack_addr.i64 ss0
 ;;                                     store notrap v4, v40
-;; @002a                               v10 = load.i64 notrap aligned readonly can_move region1 v0+32
-;; @002a                               v11 = load.i32 user2 region2 v10
+;; @002a                               v10 = load.i64 notrap aligned readonly can_move region2 v0+32
+;; @002a                               v11 = load.i32 user2 region3 v10
 ;;                                     v47 = iconst.i32 7
 ;; @002a                               v14 = uadd_overflow_trap v11, v47, user18  ; v47 = 7
 ;;                                     v53 = iconst.i32 -8
@@ -36,32 +39,32 @@
 ;; @002a                               v6 = iconst.i32 24
 ;; @002a                               v17 = uadd_overflow_trap v16, v6, user18  ; v6 = 24
 ;; @002a                               v19 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @002a                               v20 = load.i64 notrap aligned v19+40
+;; @002a                               v20 = load.i64 notrap aligned region4 v19+40
 ;; @002a                               v18 = uextend.i64 v17
 ;; @002a                               v21 = icmp ule v18, v20
 ;; @002a                               brif v21, block2, block3
 ;;
 ;;                                 block2:
 ;;                                     v54 = iconst.i32 -1342177256
-;; @002a                               v25 = load.i64 notrap aligned readonly can_move v19+32
+;; @002a                               v25 = load.i64 notrap aligned readonly can_move region5 v19+32
 ;;                                     v60 = band.i32 v14, v53  ; v53 = -8
 ;;                                     v61 = uextend.i64 v60
 ;; @002a                               v27 = iadd v25, v61
-;; @002a                               store user2 region2 v54, v27  ; v54 = -1342177256
-;; @002a                               v30 = load.i64 notrap aligned readonly can_move region3 v0+40
+;; @002a                               store user2 region3 v54, v27  ; v54 = -1342177256
+;; @002a                               v30 = load.i64 notrap aligned readonly can_move region6 v0+40
 ;; @002a                               v31 = load.i32 notrap aligned readonly can_move v30
-;; @002a                               store user2 region2 v31, v27+4
-;; @002a                               store.i32 user2 region2 v17, v10
+;; @002a                               store user2 region3 v31, v27+4
+;; @002a                               store.i32 user2 region3 v17, v10
 ;; @002a                               v32 = iconst.i64 8
 ;; @002a                               v33 = iadd v27, v32  ; v32 = 8
-;; @002a                               store.f32 user2 little region2 v2, v33
+;; @002a                               store.f32 user2 little region3 v2, v33
 ;; @002a                               v34 = iconst.i64 12
 ;; @002a                               v35 = iadd v27, v34  ; v34 = 12
-;; @002a                               istore8.i32 user2 little region2 v3, v35
+;; @002a                               istore8.i32 user2 little region3 v3, v35
 ;;                                     v39 = load.i32 notrap v40
 ;; @002a                               v36 = iconst.i64 16
 ;; @002a                               v37 = iadd v27, v36  ; v36 = 16
-;; @002a                               store user2 little region2 v39, v37
+;; @002a                               store user2 little region3 v39, v37
 ;; @002d                               jump block1
 ;;
 ;;                                 block3 cold:

--- a/tests/disas/gc/null/struct-set.wat
+++ b/tests/disas/gc/null/struct-set.wat
@@ -21,21 +21,24 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32, f32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 268435488 "VMStoreContext+0x20"
+;;     region3 = 268435496 "VMStoreContext+0x28"
+;;     region4 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: f32):
 ;; @0034                               trapz v2, user16
 ;; @0034                               v5 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0034                               v6 = load.i64 notrap aligned readonly can_move v5+32
+;; @0034                               v6 = load.i64 notrap aligned readonly can_move region2 v5+32
 ;; @0034                               v4 = uextend.i64 v2
 ;; @0034                               v7 = iadd v6, v4
 ;; @0034                               v8 = iconst.i64 8
 ;; @0034                               v9 = iadd v7, v8  ; v8 = 8
-;; @0034                               store user2 little region1 v3, v9
+;; @0034                               store user2 little region4 v3, v9
 ;; @0038                               jump block1
 ;;
 ;;                                 block1:
@@ -44,21 +47,24 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 268435488 "VMStoreContext+0x20"
+;;     region3 = 268435496 "VMStoreContext+0x28"
+;;     region4 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @003f                               trapz v2, user16
 ;; @003f                               v5 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @003f                               v6 = load.i64 notrap aligned readonly can_move v5+32
+;; @003f                               v6 = load.i64 notrap aligned readonly can_move region2 v5+32
 ;; @003f                               v4 = uextend.i64 v2
 ;; @003f                               v7 = iadd v6, v4
 ;; @003f                               v8 = iconst.i64 12
 ;; @003f                               v9 = iadd v7, v8  ; v8 = 12
-;; @003f                               istore8 user2 little region1 v3, v9
+;; @003f                               istore8 user2 little region4 v3, v9
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -67,21 +73,24 @@
 ;;
 ;; function u0:2(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 268435488 "VMStoreContext+0x20"
+;;     region3 = 268435496 "VMStoreContext+0x28"
+;;     region4 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @004a                               trapz v2, user16
 ;; @004a                               v5 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @004a                               v6 = load.i64 notrap aligned readonly can_move v5+32
+;; @004a                               v6 = load.i64 notrap aligned readonly can_move region2 v5+32
 ;; @004a                               v4 = uextend.i64 v2
 ;; @004a                               v7 = iadd v6, v4
 ;; @004a                               v8 = iconst.i64 16
 ;; @004a                               v9 = iadd v7, v8  ; v8 = 16
-;; @004a                               store user2 little region1 v3, v9
+;; @004a                               store user2 little region4 v3, v9
 ;; @004e                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/null/v128-fields.wat
+++ b/tests/disas/gc/null/v128-fields.wat
@@ -13,21 +13,24 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i8x16 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 268435488 "VMStoreContext+0x20"
+;;     region3 = 268435496 "VMStoreContext+0x28"
+;;     region4 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0022                               trapz v2, user16
 ;; @0022                               v5 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0022                               v6 = load.i64 notrap aligned readonly can_move v5+32
+;; @0022                               v6 = load.i64 notrap aligned readonly can_move region2 v5+32
 ;; @0022                               v4 = uextend.i64 v2
 ;; @0022                               v7 = iadd v6, v4
 ;; @0022                               v8 = iconst.i64 16
 ;; @0022                               v9 = iadd v7, v8  ; v8 = 16
-;; @0022                               v10 = load.i8x16 user2 little region1 v9
+;; @0022                               v10 = load.i8x16 user2 little region4 v9
 ;; @002e                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/ref-test-cast-final-type.wat
+++ b/tests/disas/gc/ref-test-cast-final-type.wat
@@ -16,11 +16,14 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 40 "VMContext+0x28"
-;;     region2 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 40 "VMContext+0x28"
+;;     region3 = 268435488 "VMStoreContext+0x20"
+;;     region4 = 268435496 "VMStoreContext+0x28"
+;;     region5 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -36,13 +39,13 @@
 ;;
 ;;                                 block3:
 ;; @0024                               v14 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0024                               v15 = load.i64 notrap aligned readonly can_move v14+32
+;; @0024                               v15 = load.i64 notrap aligned readonly can_move region3 v14+32
 ;; @0024                               v13 = uextend.i64 v2
 ;; @0024                               v16 = iadd v15, v13
 ;; @0024                               v17 = iconst.i64 4
 ;; @0024                               v18 = iadd v16, v17  ; v17 = 4
-;; @0024                               v19 = load.i32 user2 readonly region2 v18
-;; @0024                               v11 = load.i64 notrap aligned readonly can_move region1 v0+40
+;; @0024                               v19 = load.i32 user2 readonly region5 v18
+;; @0024                               v11 = load.i64 notrap aligned readonly can_move region2 v0+40
 ;; @0024                               v12 = load.i32 notrap aligned readonly can_move v11
 ;; @0024                               v20 = icmp eq v19, v12
 ;; @0024                               v21 = uextend.i32 v20
@@ -57,11 +60,14 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 40 "VMContext+0x28"
-;;     region2 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 40 "VMContext+0x28"
+;;     region3 = 268435488 "VMStoreContext+0x20"
+;;     region4 = 268435496 "VMStoreContext+0x28"
+;;     region5 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -77,13 +83,13 @@
 ;;
 ;;                                 block3:
 ;; @002c                               v14 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @002c                               v15 = load.i64 notrap aligned readonly can_move v14+32
+;; @002c                               v15 = load.i64 notrap aligned readonly can_move region3 v14+32
 ;; @002c                               v13 = uextend.i64 v2
 ;; @002c                               v16 = iadd v15, v13
 ;; @002c                               v17 = iconst.i64 4
 ;; @002c                               v18 = iadd v16, v17  ; v17 = 4
-;; @002c                               v19 = load.i32 user2 readonly region2 v18
-;; @002c                               v11 = load.i64 notrap aligned readonly can_move region1 v0+40
+;; @002c                               v19 = load.i32 user2 readonly region5 v18
+;; @002c                               v11 = load.i64 notrap aligned readonly can_move region2 v0+40
 ;; @002c                               v12 = load.i32 notrap aligned readonly can_move v11
 ;; @002c                               v20 = icmp eq v19, v12
 ;; @002c                               v21 = uextend.i32 v20

--- a/tests/disas/gc/struct-new-default.wat
+++ b/tests/disas/gc/struct-new-default.wat
@@ -14,19 +14,21 @@
 )
 ;; function u0:0(i64 vmctx, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 32 "VMContext+0x20"
-;;     region2 = 40 "VMContext+0x28"
-;;     region3 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 32 "VMContext+0x20"
+;;     region3 = 40 "VMContext+0x28"
+;;     region4 = 268435488 "VMStoreContext+0x20"
+;;     region5 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
 ;;     fn0 = colocated u805306368:24 sig0
 ;;     const0 = 0x00000000000000000000000000000000
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @0023                               v8 = load.i64 notrap aligned readonly can_move region1 v0+32
+;; @0023                               v8 = load.i64 notrap aligned readonly can_move region2 v0+32
 ;; @0023                               v9 = load.i32 notrap aligned v8
 ;; @0023                               v10 = load.i32 notrap aligned v8+4
 ;; @0023                               v16 = uextend.i64 v9
@@ -42,10 +44,10 @@
 ;; @0023                               store notrap aligned v61, v8
 ;;                                     v64 = iconst.i32 -1342177246
 ;;                                     v65 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v66 = load.i64 notrap aligned readonly can_move v65+32
+;;                                     v66 = load.i64 notrap aligned readonly can_move region4 v65+32
 ;; @0023                               v33 = iadd v66, v16
 ;; @0023                               store notrap aligned v64, v33  ; v64 = -1342177246
-;;                                     v67 = load.i64 notrap aligned readonly can_move region2 v0+40
+;;                                     v67 = load.i64 notrap aligned readonly can_move region3 v0+40
 ;;                                     v68 = load.i32 notrap aligned readonly can_move v67
 ;; @0023                               store notrap aligned v68, v33+4
 ;;                                     v69 = iconst.i64 48
@@ -54,13 +56,13 @@
 ;;
 ;;                                 block3 cold:
 ;; @0023                               v20 = iconst.i32 -1342177246
-;; @0023                               v21 = load.i64 notrap aligned readonly can_move region2 v0+40
+;; @0023                               v21 = load.i64 notrap aligned readonly can_move region3 v0+40
 ;; @0023                               v22 = load.i32 notrap aligned readonly can_move v21
 ;; @0023                               v7 = iconst.i32 48
 ;; @0023                               v23 = iconst.i32 16
 ;; @0023                               v24 = call fn0(v0, v20, v22, v7, v23)  ; v20 = -1342177246, v7 = 48, v23 = 16
 ;; @0023                               v25 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0023                               v26 = load.i64 notrap aligned readonly can_move v25+32
+;; @0023                               v26 = load.i64 notrap aligned readonly can_move region4 v25+32
 ;; @0023                               v27 = uextend.i64 v24
 ;; @0023                               v28 = iadd v26, v27
 ;; @0023                               jump block4(v24, v28)
@@ -69,18 +71,18 @@
 ;; @0023                               v3 = f32const 0.0
 ;; @0023                               v39 = iconst.i64 16
 ;; @0023                               v40 = iadd v38, v39  ; v39 = 16
-;; @0023                               store user2 little region3 v3, v40  ; v3 = 0.0
+;; @0023                               store user2 little region5 v3, v40  ; v3 = 0.0
 ;; @0023                               v4 = iconst.i32 0
 ;; @0023                               v41 = iconst.i64 20
 ;; @0023                               v42 = iadd v38, v41  ; v41 = 20
-;; @0023                               istore8 user2 little region3 v4, v42  ; v4 = 0
+;; @0023                               istore8 user2 little region5 v4, v42  ; v4 = 0
 ;; @0023                               v43 = iconst.i64 24
 ;; @0023                               v44 = iadd v38, v43  ; v43 = 24
-;; @0023                               store user2 little region3 v4, v44  ; v4 = 0
+;; @0023                               store user2 little region5 v4, v44  ; v4 = 0
 ;; @0023                               v6 = vconst.i8x16 const0
 ;; @0023                               v45 = iconst.i64 32
 ;; @0023                               v46 = iadd v38, v45  ; v45 = 32
-;; @0023                               store user2 little region3 v6, v46  ; v6 = const0
+;; @0023                               store user2 little region5 v6, v46  ; v6 = const0
 ;; @0026                               jump block1(v37)
 ;;
 ;;                                 block1(v2: i32):

--- a/tests/disas/gc/struct-new.wat
+++ b/tests/disas/gc/struct-new.wat
@@ -14,12 +14,14 @@
 ;; function u0:0(i64 vmctx, i64, f32, i32, i32) -> i32 tail {
 ;;     ss0 = explicit_slot 4, align = 4
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 32 "VMContext+0x20"
-;;     region2 = 40 "VMContext+0x28"
-;;     region3 = 2147483648 "GcHeap"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 32 "VMContext+0x20"
+;;     region3 = 40 "VMContext+0x28"
+;;     region4 = 268435488 "VMStoreContext+0x20"
+;;     region5 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
 ;;     fn0 = colocated u805306368:24 sig0
 ;;     stack_limit = gv2
@@ -27,7 +29,7 @@
 ;;                                 block0(v0: i64, v1: i64, v2: f32, v3: i32, v4: i32):
 ;;                                     v46 = stack_addr.i64 ss0
 ;;                                     store notrap v4, v46
-;; @002a                               v7 = load.i64 notrap aligned readonly can_move region1 v0+32
+;; @002a                               v7 = load.i64 notrap aligned readonly can_move region2 v0+32
 ;; @002a                               v8 = load.i32 notrap aligned v7
 ;; @002a                               v9 = load.i32 notrap aligned v7+4
 ;; @002a                               v15 = uextend.i64 v8
@@ -43,10 +45,10 @@
 ;; @002a                               store notrap aligned v61, v7
 ;;                                     v64 = iconst.i32 -1342177246
 ;;                                     v65 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v66 = load.i64 notrap aligned readonly can_move v65+32
+;;                                     v66 = load.i64 notrap aligned readonly can_move region4 v65+32
 ;; @002a                               v32 = iadd v66, v15
 ;; @002a                               store notrap aligned v64, v32  ; v64 = -1342177246
-;;                                     v67 = load.i64 notrap aligned readonly can_move region2 v0+40
+;;                                     v67 = load.i64 notrap aligned readonly can_move region3 v0+40
 ;;                                     v68 = load.i32 notrap aligned readonly can_move v67
 ;; @002a                               store notrap aligned v68, v32+4
 ;;                                     v69 = iconst.i64 32
@@ -55,13 +57,13 @@
 ;;
 ;;                                 block3 cold:
 ;; @002a                               v19 = iconst.i32 -1342177246
-;; @002a                               v20 = load.i64 notrap aligned readonly can_move region2 v0+40
+;; @002a                               v20 = load.i64 notrap aligned readonly can_move region3 v0+40
 ;; @002a                               v21 = load.i32 notrap aligned readonly can_move v20
 ;; @002a                               v6 = iconst.i32 32
 ;; @002a                               v22 = iconst.i32 16
 ;; @002a                               v23 = call fn0(v0, v19, v21, v6, v22), stack_map=[i32 @ ss0+0]  ; v19 = -1342177246, v6 = 32, v22 = 16
 ;; @002a                               v24 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @002a                               v25 = load.i64 notrap aligned readonly can_move v24+32
+;; @002a                               v25 = load.i64 notrap aligned readonly can_move region4 v24+32
 ;; @002a                               v26 = uextend.i64 v23
 ;; @002a                               v27 = iadd v25, v26
 ;; @002a                               jump block4(v23, v27)
@@ -69,14 +71,14 @@
 ;;                                 block4(v36: i32, v37: i64):
 ;; @002a                               v38 = iconst.i64 16
 ;; @002a                               v39 = iadd v37, v38  ; v38 = 16
-;; @002a                               store.f32 user2 little region3 v2, v39
+;; @002a                               store.f32 user2 little region5 v2, v39
 ;; @002a                               v40 = iconst.i64 20
 ;; @002a                               v41 = iadd v37, v40  ; v40 = 20
-;; @002a                               istore8.i32 user2 little region3 v3, v41
+;; @002a                               istore8.i32 user2 little region5 v3, v41
 ;;                                     v45 = load.i32 notrap v46
 ;; @002a                               v42 = iconst.i64 24
 ;; @002a                               v43 = iadd v37, v42  ; v42 = 24
-;; @002a                               store user2 little region3 v45, v43
+;; @002a                               store user2 little region5 v45, v43
 ;; @002d                               jump block1(v36)
 ;;
 ;;                                 block1(v5: i32):

--- a/tests/disas/gc/typed-select-and-stack-maps.wat
+++ b/tests/disas/gc/typed-select-and-stack-maps.wat
@@ -42,13 +42,14 @@
 ;; function u0:0(i64 vmctx, i64, i32, i32, i32) tail {
 ;;     ss0 = explicit_slot 4, align = 4
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 104 "VMContext+0x68"
-;;     region2 = 88 "VMContext+0x58"
-;;     region3 = 72 "VMContext+0x48"
-;;     region4 = 56 "VMContext+0x38"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 104 "VMContext+0x68"
+;;     region3 = 88 "VMContext+0x58"
+;;     region4 = 72 "VMContext+0x48"
+;;     region5 = 56 "VMContext+0x38"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, i64) tail
 ;;     sig1 = (i64 vmctx, i64, i32) tail
 ;;     stack_limit = gv2
@@ -57,12 +58,12 @@
 ;; @0049                               v5 = select v4, v2, v3
 ;;                                     v12 = stack_addr.i64 ss0
 ;;                                     store notrap v5, v12
-;; @004c                               v7 = load.i64 notrap aligned readonly can_move region2 v0+88
-;; @004c                               v6 = load.i64 notrap aligned readonly can_move region1 v0+104
+;; @004c                               v7 = load.i64 notrap aligned readonly can_move region3 v0+88
+;; @004c                               v6 = load.i64 notrap aligned readonly can_move region2 v0+104
 ;; @004c                               call_indirect sig0, v7(v6, v0), stack_map=[i32 @ ss0+0]
 ;;                                     v11 = load.i32 notrap v12
-;; @004e                               v9 = load.i64 notrap aligned readonly can_move region4 v0+56
-;; @004e                               v8 = load.i64 notrap aligned readonly can_move region3 v0+72
+;; @004e                               v9 = load.i64 notrap aligned readonly can_move region5 v0+56
+;; @004e                               v8 = load.i64 notrap aligned readonly can_move region4 v0+72
 ;; @004e                               call_indirect sig1, v9(v8, v0, v11)
 ;; @0050                               jump block1
 ;;
@@ -72,23 +73,24 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 104 "VMContext+0x68"
-;;     region2 = 88 "VMContext+0x58"
-;;     region3 = 72 "VMContext+0x48"
-;;     region4 = 56 "VMContext+0x38"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 104 "VMContext+0x68"
+;;     region3 = 88 "VMContext+0x58"
+;;     region4 = 72 "VMContext+0x48"
+;;     region5 = 56 "VMContext+0x38"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, i64) tail
 ;;     sig1 = (i64 vmctx, i64, i32) tail
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
-;; @005c                               v7 = load.i64 notrap aligned readonly can_move region2 v0+88
-;; @005c                               v6 = load.i64 notrap aligned readonly can_move region1 v0+104
+;; @005c                               v7 = load.i64 notrap aligned readonly can_move region3 v0+88
+;; @005c                               v6 = load.i64 notrap aligned readonly can_move region2 v0+104
 ;; @005c                               call_indirect sig0, v7(v6, v0)
-;; @005e                               v9 = load.i64 notrap aligned readonly can_move region4 v0+56
-;; @005e                               v8 = load.i64 notrap aligned readonly can_move region3 v0+72
+;; @005e                               v9 = load.i64 notrap aligned readonly can_move region5 v0+56
+;; @005e                               v8 = load.i64 notrap aligned readonly can_move region4 v0+72
 ;; @0059                               v5 = select v4, v2, v3
 ;; @005e                               call_indirect sig1, v9(v8, v0, v5)
 ;; @0060                               jump block1

--- a/tests/disas/global-get.wat
+++ b/tests/disas/global-get.wat
@@ -32,16 +32,17 @@
 
 ;; function u0:0(i64 vmctx, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 48 "VMContext+0x30"
-;;     region2 = 1610612736 "PublicGlobal"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 48 "VMContext+0x30"
+;;     region3 = 1610612736 "PublicGlobal"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @003d                               v3 = load.i64 notrap aligned readonly can_move region1 v0+48
-;; @003d                               v4 = load.i32 notrap aligned region2 v3
+;; @003d                               v3 = load.i64 notrap aligned readonly can_move region2 v0+48
+;; @003d                               v4 = load.i32 notrap aligned region3 v3
 ;; @003f                               jump block1
 ;;
 ;;                                 block1:
@@ -50,16 +51,17 @@
 ;;
 ;; function u0:1(i64 vmctx, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 72 "VMContext+0x48"
-;;     region2 = 1610612736 "PublicGlobal"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 72 "VMContext+0x48"
+;;     region3 = 1610612736 "PublicGlobal"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @0042                               v3 = load.i64 notrap aligned readonly can_move region1 v0+72
-;; @0042                               v4 = load.i32 notrap aligned region2 v3
+;; @0042                               v3 = load.i64 notrap aligned readonly can_move region2 v0+72
+;; @0042                               v4 = load.i32 notrap aligned region3 v3
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -68,9 +70,10 @@
 ;;
 ;; function u0:2(i64 vmctx, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
@@ -83,14 +86,15 @@
 ;;
 ;; function u0:3(i64 vmctx, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 1879048193 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(1))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 1879048193 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(1))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @004c                               v3 = load.i32 notrap aligned region1 v0+112
+;; @004c                               v3 = load.i32 notrap aligned region2 v0+112
 ;; @004e                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/globals.wat
+++ b/tests/disas/globals.wat
@@ -11,21 +11,22 @@
 
 ;; function u0:0(i64 vmctx, i64) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 1879048192 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(0))"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 1879048192 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(0))"
+;;     region3 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
 ;; @0027                               v2 = iconst.i32 0
 ;; @0029                               v3 = iconst.i32 0
-;; @002b                               v4 = load.i32 notrap aligned region1 v0+80
+;; @002b                               v4 = load.i32 notrap aligned region2 v0+80
 ;; @002d                               v5 = uextend.i64 v3  ; v3 = 0
 ;; @002d                               v6 = load.i64 notrap aligned readonly can_move v0+56
 ;; @002d                               v7 = iadd v6, v5
-;; @002d                               store little region2 v4, v7
+;; @002d                               store little region3 v4, v7
 ;; @0030                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/i128-cmp.wat
+++ b/tests/disas/i128-cmp.wat
@@ -101,9 +101,10 @@
 )
 ;; function u0:0(i64 vmctx, i64, i64, i64, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i64, v4: i64, v5: i64):
@@ -119,9 +120,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i64, i64, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i64, v4: i64, v5: i64):
@@ -137,9 +139,10 @@
 ;;
 ;; function u0:2(i64 vmctx, i64, i64, i64, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i64, v4: i64, v5: i64):
@@ -155,9 +158,10 @@
 ;;
 ;; function u0:3(i64 vmctx, i64, i64, i64, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i64, v4: i64, v5: i64):
@@ -173,9 +177,10 @@
 ;;
 ;; function u0:4(i64 vmctx, i64, i64, i64, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i64, v4: i64, v5: i64):
@@ -191,9 +196,10 @@
 ;;
 ;; function u0:5(i64 vmctx, i64, i64, i64, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i64, v4: i64, v5: i64):
@@ -209,9 +215,10 @@
 ;;
 ;; function u0:6(i64 vmctx, i64, i64, i64, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i64, v4: i64, v5: i64):
@@ -227,9 +234,10 @@
 ;;
 ;; function u0:7(i64 vmctx, i64, i64, i64, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i64, v4: i64, v5: i64):

--- a/tests/disas/i32-load.wat
+++ b/tests/disas/i32-load.wat
@@ -10,17 +10,18 @@
 
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @002e                               v4 = uextend.i64 v2
 ;; @002e                               v5 = load.i64 notrap aligned readonly can_move v0+56
 ;; @002e                               v6 = iadd v5, v4
-;; @002e                               v7 = load.i32 little region1 v6
+;; @002e                               v7 = load.i32 little region2 v6
 ;; @0031                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/i32-load16-s.wat
+++ b/tests/disas/i32-load16-s.wat
@@ -10,17 +10,18 @@
 
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0032                               v4 = uextend.i64 v2
 ;; @0032                               v5 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0032                               v6 = iadd v5, v4
-;; @0032                               v7 = sload16.i32 little region1 v6
+;; @0032                               v7 = sload16.i32 little region2 v6
 ;; @0035                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/i32-load16-u.wat
+++ b/tests/disas/i32-load16-u.wat
@@ -10,17 +10,18 @@
 
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0032                               v4 = uextend.i64 v2
 ;; @0032                               v5 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0032                               v6 = iadd v5, v4
-;; @0032                               v7 = uload16.i32 little region1 v6
+;; @0032                               v7 = uload16.i32 little region2 v6
 ;; @0035                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/i32-load8-s.wat
+++ b/tests/disas/i32-load8-s.wat
@@ -10,17 +10,18 @@
 
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0031                               v4 = uextend.i64 v2
 ;; @0031                               v5 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0031                               v6 = iadd v5, v4
-;; @0031                               v7 = sload8.i32 little region1 v6
+;; @0031                               v7 = sload8.i32 little region2 v6
 ;; @0034                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/i32-load8-u.wat
+++ b/tests/disas/i32-load8-u.wat
@@ -10,17 +10,18 @@
 
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0031                               v4 = uextend.i64 v2
 ;; @0031                               v5 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0031                               v6 = iadd v5, v4
-;; @0031                               v7 = uload8.i32 little region1 v6
+;; @0031                               v7 = uload8.i32 little region2 v6
 ;; @0034                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/i32-store.wat
+++ b/tests/disas/i32-store.wat
@@ -11,17 +11,18 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0031                               v4 = uextend.i64 v2
 ;; @0031                               v5 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0031                               v6 = iadd v5, v4
-;; @0031                               store little region1 v3, v6
+;; @0031                               store little region2 v3, v6
 ;; @0034                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/i32-store16.wat
+++ b/tests/disas/i32-store16.wat
@@ -11,17 +11,18 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0033                               v4 = uextend.i64 v2
 ;; @0033                               v5 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0033                               v6 = iadd v5, v4
-;; @0033                               istore16 little region1 v3, v6
+;; @0033                               istore16 little region2 v3, v6
 ;; @0036                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/i32-store8.wat
+++ b/tests/disas/i32-store8.wat
@@ -11,17 +11,18 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0032                               v4 = uextend.i64 v2
 ;; @0032                               v5 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0032                               v6 = iadd v5, v4
-;; @0032                               istore8 little region1 v3, v6
+;; @0032                               istore8 little region2 v3, v6
 ;; @0035                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/i64-load.wat
+++ b/tests/disas/i64-load.wat
@@ -10,17 +10,18 @@
 
 ;; function u0:0(i64 vmctx, i64, i32) -> i64 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @002e                               v4 = uextend.i64 v2
 ;; @002e                               v5 = load.i64 notrap aligned readonly can_move v0+56
 ;; @002e                               v6 = iadd v5, v4
-;; @002e                               v7 = load.i64 little region1 v6
+;; @002e                               v7 = load.i64 little region2 v6
 ;; @0031                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/i64-load16-s.wat
+++ b/tests/disas/i64-load16-s.wat
@@ -10,17 +10,18 @@
 
 ;; function u0:0(i64 vmctx, i64, i32) -> i64 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0032                               v4 = uextend.i64 v2
 ;; @0032                               v5 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0032                               v6 = iadd v5, v4
-;; @0032                               v7 = sload16.i64 little region1 v6
+;; @0032                               v7 = sload16.i64 little region2 v6
 ;; @0035                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/i64-load16-u.wat
+++ b/tests/disas/i64-load16-u.wat
@@ -10,17 +10,18 @@
 
 ;; function u0:0(i64 vmctx, i64, i32) -> i64 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0032                               v4 = uextend.i64 v2
 ;; @0032                               v5 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0032                               v6 = iadd v5, v4
-;; @0032                               v7 = uload16.i64 little region1 v6
+;; @0032                               v7 = uload16.i64 little region2 v6
 ;; @0035                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/i64-load8-s.wat
+++ b/tests/disas/i64-load8-s.wat
@@ -10,17 +10,18 @@
 
 ;; function u0:0(i64 vmctx, i64, i32) -> i64 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0031                               v4 = uextend.i64 v2
 ;; @0031                               v5 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0031                               v6 = iadd v5, v4
-;; @0031                               v7 = sload8.i64 little region1 v6
+;; @0031                               v7 = sload8.i64 little region2 v6
 ;; @0034                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/i64-load8-u.wat
+++ b/tests/disas/i64-load8-u.wat
@@ -10,17 +10,18 @@
 
 ;; function u0:0(i64 vmctx, i64, i32) -> i64 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0031                               v4 = uextend.i64 v2
 ;; @0031                               v5 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0031                               v6 = iadd v5, v4
-;; @0031                               v7 = uload8.i64 little region1 v6
+;; @0031                               v7 = uload8.i64 little region2 v6
 ;; @0034                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/i64-store.wat
+++ b/tests/disas/i64-store.wat
@@ -11,17 +11,18 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i64) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i64):
 ;; @0031                               v4 = uextend.i64 v2
 ;; @0031                               v5 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0031                               v6 = iadd v5, v4
-;; @0031                               store little region1 v3, v6
+;; @0031                               store little region2 v3, v6
 ;; @0034                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/i64-store16.wat
+++ b/tests/disas/i64-store16.wat
@@ -11,17 +11,18 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i64) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i64):
 ;; @0033                               v4 = uextend.i64 v2
 ;; @0033                               v5 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0033                               v6 = iadd v5, v4
-;; @0033                               istore16 little region1 v3, v6
+;; @0033                               istore16 little region2 v3, v6
 ;; @0036                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/i64-store32.wat
+++ b/tests/disas/i64-store32.wat
@@ -11,17 +11,18 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i64) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i64):
 ;; @0033                               v4 = uextend.i64 v2
 ;; @0033                               v5 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0033                               v6 = iadd v5, v4
-;; @0033                               istore32 little region1 v3, v6
+;; @0033                               istore32 little region2 v3, v6
 ;; @0036                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/i64-store8.wat
+++ b/tests/disas/i64-store8.wat
@@ -11,17 +11,18 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i64) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i64):
 ;; @0032                               v4 = uextend.i64 v2
 ;; @0032                               v5 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0032                               v6 = iadd v5, v4
-;; @0032                               istore8 little region1 v3, v6
+;; @0032                               istore8 little region2 v3, v6
 ;; @0035                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/icall-loop.wat
+++ b/tests/disas/icall-loop.wat
@@ -24,11 +24,12 @@
 
 ;; function u0:0(i64 vmctx, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 1342177280 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
-;;     region2 = 40 "VMContext+0x28"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 1342177280 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
+;;     region3 = 40 "VMContext+0x28"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, i64) -> i32 tail
 ;;     sig1 = (i64 vmctx, i32, i64) -> i64 tail
 ;;     fn0 = colocated u805306368:7 sig1
@@ -46,12 +47,12 @@
 ;; @002b                               v12 = select_spectre_guard v5, v11, v10  ; v11 = 0
 ;; @002b                               v14 = iconst.i64 -2
 ;; @002b                               v17 = iconst.i32 0
-;; @002b                               v20 = load.i64 notrap aligned readonly can_move region2 v0+40
+;; @002b                               v20 = load.i64 notrap aligned readonly can_move region3 v0+40
 ;; @002b                               v21 = load.i32 notrap aligned readonly can_move v20
 ;; @0027                               jump block2
 ;;
 ;;                                 block2:
-;; @002b                               v13 = load.i64 user6 aligned region1 v12
+;; @002b                               v13 = load.i64 user6 aligned region2 v12
 ;;                                     v29 = iconst.i64 -2
 ;;                                     v30 = band v13, v29  ; v29 = -2
 ;; @002b                               brif v13, block5(v30), block4
@@ -73,11 +74,12 @@
 ;;
 ;; function u0:1(i64 vmctx, i64) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 1342177280 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
-;;     region2 = 40 "VMContext+0x28"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 1342177280 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
+;;     region3 = 40 "VMContext+0x28"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, i64) -> i32 tail
 ;;     sig1 = (i64 vmctx, i32, i64) -> i64 tail
 ;;     fn0 = colocated u805306368:7 sig1
@@ -90,13 +92,13 @@
 ;; @0038                               v13 = iconst.i64 -2
 ;; @0038                               v16 = iconst.i32 0
 ;;                                     v33 = iconst.i64 1
-;; @0038                               v19 = load.i64 notrap aligned readonly can_move region2 v0+40
+;; @0038                               v19 = load.i64 notrap aligned readonly can_move region3 v0+40
 ;; @0038                               v20 = load.i32 notrap aligned readonly can_move v19
 ;; @0034                               jump block2
 ;;
 ;;                                 block2:
 ;;                                     v35 = iadd.i64 v6, v34  ; v34 = 8
-;; @0038                               v12 = load.i64 user6 aligned region1 v35
+;; @0038                               v12 = load.i64 user6 aligned region2 v35
 ;;                                     v36 = iconst.i64 -2
 ;;                                     v37 = band v12, v36  ; v36 = -2
 ;; @0038                               brif v12, block5(v37), block4

--- a/tests/disas/icall-simd.wat
+++ b/tests/disas/icall-simd.wat
@@ -10,11 +10,12 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i8x16) -> i8x16 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 1342177280 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
-;;     region2 = 40 "VMContext+0x28"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 1342177280 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
+;;     region3 = 40 "VMContext+0x28"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, i64, i8x16) -> i8x16 tail
 ;;     sig1 = (i64 vmctx, i32, i64) -> i64 tail
 ;;     fn0 = colocated u805306368:7 sig1
@@ -30,7 +31,7 @@
 ;; @0033                               v11 = iadd v8, v10
 ;; @0033                               v12 = iconst.i64 0
 ;; @0033                               v13 = select_spectre_guard v6, v12, v11  ; v12 = 0
-;; @0033                               v14 = load.i64 user6 aligned region1 v13
+;; @0033                               v14 = load.i64 user6 aligned region2 v13
 ;; @0033                               v15 = iconst.i64 -2
 ;; @0033                               v16 = band v14, v15  ; v15 = -2
 ;; @0033                               brif v14, block3(v16), block2
@@ -42,7 +43,7 @@
 ;; @0033                               jump block3(v20)
 ;;
 ;;                                 block3(v17: i64):
-;; @0033                               v21 = load.i64 notrap aligned readonly can_move region2 v0+40
+;; @0033                               v21 = load.i64 notrap aligned readonly can_move region3 v0+40
 ;; @0033                               v22 = load.i32 notrap aligned readonly can_move v21
 ;; @0033                               v23 = load.i32 user7 aligned readonly v17+16
 ;; @0033                               v24 = icmp eq v23, v22

--- a/tests/disas/icall.wat
+++ b/tests/disas/icall.wat
@@ -10,11 +10,12 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, f32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 1342177280 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
-;;     region2 = 40 "VMContext+0x28"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 1342177280 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
+;;     region3 = 40 "VMContext+0x28"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, i64, f32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i32, i64) -> i64 tail
 ;;     fn0 = colocated u805306368:7 sig1
@@ -30,7 +31,7 @@
 ;; @0033                               v11 = iadd v8, v10
 ;; @0033                               v12 = iconst.i64 0
 ;; @0033                               v13 = select_spectre_guard v6, v12, v11  ; v12 = 0
-;; @0033                               v14 = load.i64 user6 aligned region1 v13
+;; @0033                               v14 = load.i64 user6 aligned region2 v13
 ;; @0033                               v15 = iconst.i64 -2
 ;; @0033                               v16 = band v14, v15  ; v15 = -2
 ;; @0033                               brif v14, block3(v16), block2
@@ -42,7 +43,7 @@
 ;; @0033                               jump block3(v20)
 ;;
 ;;                                 block3(v17: i64):
-;; @0033                               v21 = load.i64 notrap aligned readonly can_move region2 v0+40
+;; @0033                               v21 = load.i64 notrap aligned readonly can_move region3 v0+40
 ;; @0033                               v22 = load.i32 notrap aligned readonly can_move v21
 ;; @0033                               v23 = load.i32 user7 aligned readonly v17+16
 ;; @0033                               v24 = icmp eq v23, v22

--- a/tests/disas/idempotent-store.wat
+++ b/tests/disas/idempotent-store.wat
@@ -16,17 +16,18 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0029                               v5 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0029                               v4 = uextend.i64 v2
 ;; @0029                               v6 = iadd v5, v4
-;; @0029                               store little region1 v3, v6
+;; @0029                               store little region2 v3, v6
 ;; @0033                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/if-reachability-translation-0.wat
+++ b/tests/disas/if-reachability-translation-0.wat
@@ -15,9 +15,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/if-reachability-translation-1.wat
+++ b/tests/disas/if-reachability-translation-1.wat
@@ -15,9 +15,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/if-reachability-translation-2.wat
+++ b/tests/disas/if-reachability-translation-2.wat
@@ -15,9 +15,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/if-reachability-translation-3.wat
+++ b/tests/disas/if-reachability-translation-3.wat
@@ -15,9 +15,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/if-reachability-translation-4.wat
+++ b/tests/disas/if-reachability-translation-4.wat
@@ -15,9 +15,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/if-reachability-translation-5.wat
+++ b/tests/disas/if-reachability-translation-5.wat
@@ -17,9 +17,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):

--- a/tests/disas/if-reachability-translation-6.wat
+++ b/tests/disas/if-reachability-translation-6.wat
@@ -17,9 +17,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):

--- a/tests/disas/if-unreachable-else-params-2.wat
+++ b/tests/disas/if-unreachable-else-params-2.wat
@@ -21,10 +21,11 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) -> f64 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 536870912 "PublicMemory"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 536870912 "PublicMemory"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -36,7 +37,7 @@
 ;; @0058                               v7 = uextend.i64 v2
 ;; @0058                               v8 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0058                               v9 = iadd v8, v7
-;; @0058                               v10 = sload16.i64 little region1 v9
+;; @0058                               v10 = sload16.i64 little region2 v9
 ;; @005c                               jump block3
 ;;
 ;;                                 block3:

--- a/tests/disas/if-unreachable-else-params.wat
+++ b/tests/disas/if-unreachable-else-params.wat
@@ -44,10 +44,11 @@
 
 ;; function u0:0(i64 vmctx, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 536870912 "PublicMemory"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 536870912 "PublicMemory"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -61,7 +62,7 @@
 ;; @004b                               v7 = uextend.i64 v3  ; v3 = 35
 ;; @004b                               v8 = load.i64 notrap aligned readonly can_move v0+56
 ;; @004b                               v9 = iadd v8, v7
-;; @004b                               v10 = sload16.i64 little region1 v9
+;; @004b                               v10 = sload16.i64 little region2 v9
 ;; @004e                               trap user12
 ;;
 ;;                                 block6:

--- a/tests/disas/indirect-call-no-caching.wat
+++ b/tests/disas/indirect-call-no-caching.wat
@@ -22,9 +22,10 @@
  (elem (i32.const 1) func $f1 $f2 $f3))
 ;; function u0:0(i64 vmctx, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
@@ -37,9 +38,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
@@ -52,9 +54,10 @@
 ;;
 ;; function u0:2(i64 vmctx, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
@@ -67,11 +70,12 @@
 ;;
 ;; function u0:3(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 1342177280 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
-;;     region2 = 40 "VMContext+0x28"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 1342177280 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
+;;     region3 = 40 "VMContext+0x28"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, i64) -> i32 tail
 ;;     sig1 = (i64 vmctx, i32, i64) -> i64 tail
 ;;     fn0 = colocated u805306368:7 sig1
@@ -87,7 +91,7 @@
 ;; @0050                               v10 = iadd v7, v9
 ;; @0050                               v11 = iconst.i64 0
 ;; @0050                               v12 = select_spectre_guard v5, v11, v10  ; v11 = 0
-;; @0050                               v13 = load.i64 user6 aligned region1 v12
+;; @0050                               v13 = load.i64 user6 aligned region2 v12
 ;; @0050                               v14 = iconst.i64 -2
 ;; @0050                               v15 = band v13, v14  ; v14 = -2
 ;; @0050                               brif v13, block3(v15), block2
@@ -99,7 +103,7 @@
 ;; @0050                               jump block3(v19)
 ;;
 ;;                                 block3(v16: i64):
-;; @0050                               v20 = load.i64 notrap aligned readonly can_move region2 v0+40
+;; @0050                               v20 = load.i64 notrap aligned readonly can_move region3 v0+40
 ;; @0050                               v21 = load.i32 notrap aligned readonly can_move v20
 ;; @0050                               v22 = load.i32 user7 aligned readonly v16+16
 ;; @0050                               v23 = icmp eq v22, v21

--- a/tests/disas/intra-module-inlining.wat
+++ b/tests/disas/intra-module-inlining.wat
@@ -11,9 +11,10 @@
 
 ;; function u0:0(i64 vmctx, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
@@ -26,12 +27,13 @@
 ;;
 ;; function u0:1(i64 vmctx, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned gv4+24
+;;     gv5 = load.i64 notrap aligned region1 gv4+24
 ;;     sig0 = (i64 vmctx, i64) -> i32 tail
 ;;     fn0 = colocated u0:0 sig0
 ;;     stack_limit = gv2

--- a/tests/disas/issue-10929-v128-icmp-egraphs.wat
+++ b/tests/disas/issue-10929-v128-icmp-egraphs.wat
@@ -12,9 +12,10 @@
 )
 ;; function u0:0(i64 vmctx, i64, i8x16) -> i8x16 tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     const0 = 0xffffffffffffffffffffffffffffffff
 ;;     stack_limit = gv2
 ;;

--- a/tests/disas/issue-5696.wat
+++ b/tests/disas/issue-5696.wat
@@ -11,9 +11,10 @@
 )
 ;; function u0:0(i64 vmctx, i64, i64) -> i64 tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0_offset.wat
@@ -20,10 +20,11 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -35,7 +36,7 @@
 ;; @0040                               trapnz v8, heap_oob
 ;; @0040                               v9 = load.i64 notrap aligned can_move v0+56
 ;; @0040                               v10 = iadd v9, v4
-;; @0040                               store little region1 v3, v10
+;; @0040                               store little region2 v3, v10
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -44,10 +45,11 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -59,7 +61,7 @@
 ;; @0048                               trapnz v8, heap_oob
 ;; @0048                               v9 = load.i64 notrap aligned can_move v0+56
 ;; @0048                               v10 = iadd v9, v4
-;; @0048                               v11 = load.i32 little region1 v10
+;; @0048                               v11 = load.i32 little region2 v10
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -20,10 +20,11 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -37,7 +38,7 @@
 ;; @0040                               v10 = iadd v9, v4
 ;; @0040                               v11 = iconst.i64 4096
 ;; @0040                               v12 = iadd v10, v11  ; v11 = 4096
-;; @0040                               store little region1 v3, v12
+;; @0040                               store little region2 v3, v12
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -46,10 +47,11 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -63,7 +65,7 @@
 ;; @0049                               v10 = iadd v9, v4
 ;; @0049                               v11 = iconst.i64 4096
 ;; @0049                               v12 = iadd v10, v11  ; v11 = 4096
-;; @0049                               v13 = load.i32 little region1 v12
+;; @0049                               v13 = load.i32 little region2 v12
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -20,10 +20,11 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -37,7 +38,7 @@
 ;; @0040                               v10 = iadd v9, v4
 ;; @0040                               v11 = iconst.i64 0xffff_0000
 ;; @0040                               v12 = iadd v10, v11  ; v11 = 0xffff_0000
-;; @0040                               store little region1 v3, v12
+;; @0040                               store little region2 v3, v12
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -46,10 +47,11 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -63,7 +65,7 @@
 ;; @004c                               v10 = iadd v9, v4
 ;; @004c                               v11 = iconst.i64 0xffff_0000
 ;; @004c                               v12 = iadd v10, v11  ; v11 = 0xffff_0000
-;; @004c                               v13 = load.i32 little region1 v12
+;; @004c                               v13 = load.i32 little region2 v12
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0_offset.wat
@@ -20,10 +20,11 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -33,7 +34,7 @@
 ;; @0040                               trapnz v6, heap_oob
 ;; @0040                               v7 = load.i64 notrap aligned can_move v0+56
 ;; @0040                               v8 = iadd v7, v4
-;; @0040                               istore8 little region1 v3, v8
+;; @0040                               istore8 little region2 v3, v8
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -42,10 +43,11 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -55,7 +57,7 @@
 ;; @0048                               trapnz v6, heap_oob
 ;; @0048                               v7 = load.i64 notrap aligned can_move v0+56
 ;; @0048                               v8 = iadd v7, v4
-;; @0048                               v9 = uload8.i32 little region1 v8
+;; @0048                               v9 = uload8.i32 little region2 v8
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -20,10 +20,11 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -37,7 +38,7 @@
 ;; @0040                               v10 = iadd v9, v4
 ;; @0040                               v11 = iconst.i64 4096
 ;; @0040                               v12 = iadd v10, v11  ; v11 = 4096
-;; @0040                               istore8 little region1 v3, v12
+;; @0040                               istore8 little region2 v3, v12
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -46,10 +47,11 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -63,7 +65,7 @@
 ;; @0049                               v10 = iadd v9, v4
 ;; @0049                               v11 = iconst.i64 4096
 ;; @0049                               v12 = iadd v10, v11  ; v11 = 4096
-;; @0049                               v13 = uload8.i32 little region1 v12
+;; @0049                               v13 = uload8.i32 little region2 v12
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -20,10 +20,11 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -37,7 +38,7 @@
 ;; @0040                               v10 = iadd v9, v4
 ;; @0040                               v11 = iconst.i64 0xffff_0000
 ;; @0040                               v12 = iadd v10, v11  ; v11 = 0xffff_0000
-;; @0040                               istore8 little region1 v3, v12
+;; @0040                               istore8 little region2 v3, v12
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -46,10 +47,11 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -63,7 +65,7 @@
 ;; @004c                               v10 = iadd v9, v4
 ;; @004c                               v11 = iconst.i64 0xffff_0000
 ;; @004c                               v12 = iadd v10, v11  ; v11 = 0xffff_0000
-;; @004c                               v13 = uload8.i32 little region1 v12
+;; @004c                               v13 = uload8.i32 little region2 v12
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0_offset.wat
@@ -20,10 +20,11 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -36,7 +37,7 @@
 ;; @0040                               v10 = iadd v9, v4
 ;; @0040                               v11 = iconst.i64 0
 ;; @0040                               v12 = select_spectre_guard v8, v11, v10  ; v11 = 0
-;; @0040                               store little region1 v3, v12
+;; @0040                               store little region2 v3, v12
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -45,10 +46,11 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -61,7 +63,7 @@
 ;; @0048                               v10 = iadd v9, v4
 ;; @0048                               v11 = iconst.i64 0
 ;; @0048                               v12 = select_spectre_guard v8, v11, v10  ; v11 = 0
-;; @0048                               v13 = load.i32 little region1 v12
+;; @0048                               v13 = load.i32 little region2 v12
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -20,10 +20,11 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -38,7 +39,7 @@
 ;; @0040                               v12 = iadd v10, v11  ; v11 = 4096
 ;; @0040                               v13 = iconst.i64 0
 ;; @0040                               v14 = select_spectre_guard v8, v13, v12  ; v13 = 0
-;; @0040                               store little region1 v3, v14
+;; @0040                               store little region2 v3, v14
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -47,10 +48,11 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -65,7 +67,7 @@
 ;; @0049                               v12 = iadd v10, v11  ; v11 = 4096
 ;; @0049                               v13 = iconst.i64 0
 ;; @0049                               v14 = select_spectre_guard v8, v13, v12  ; v13 = 0
-;; @0049                               v15 = load.i32 little region1 v14
+;; @0049                               v15 = load.i32 little region2 v14
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -20,10 +20,11 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -38,7 +39,7 @@
 ;; @0040                               v12 = iadd v10, v11  ; v11 = 0xffff_0000
 ;; @0040                               v13 = iconst.i64 0
 ;; @0040                               v14 = select_spectre_guard v8, v13, v12  ; v13 = 0
-;; @0040                               store little region1 v3, v14
+;; @0040                               store little region2 v3, v14
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -47,10 +48,11 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -65,7 +67,7 @@
 ;; @004c                               v12 = iadd v10, v11  ; v11 = 0xffff_0000
 ;; @004c                               v13 = iconst.i64 0
 ;; @004c                               v14 = select_spectre_guard v8, v13, v12  ; v13 = 0
-;; @004c                               v15 = load.i32 little region1 v14
+;; @004c                               v15 = load.i32 little region2 v14
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0_offset.wat
@@ -20,10 +20,11 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -34,7 +35,7 @@
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               v9 = iconst.i64 0
 ;; @0040                               v10 = select_spectre_guard v6, v9, v8  ; v9 = 0
-;; @0040                               istore8 little region1 v3, v10
+;; @0040                               istore8 little region2 v3, v10
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -43,10 +44,11 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -57,7 +59,7 @@
 ;; @0048                               v8 = iadd v7, v4
 ;; @0048                               v9 = iconst.i64 0
 ;; @0048                               v10 = select_spectre_guard v6, v9, v8  ; v9 = 0
-;; @0048                               v11 = uload8.i32 little region1 v10
+;; @0048                               v11 = uload8.i32 little region2 v10
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -20,10 +20,11 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -38,7 +39,7 @@
 ;; @0040                               v12 = iadd v10, v11  ; v11 = 4096
 ;; @0040                               v13 = iconst.i64 0
 ;; @0040                               v14 = select_spectre_guard v8, v13, v12  ; v13 = 0
-;; @0040                               istore8 little region1 v3, v14
+;; @0040                               istore8 little region2 v3, v14
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -47,10 +48,11 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -65,7 +67,7 @@
 ;; @0049                               v12 = iadd v10, v11  ; v11 = 4096
 ;; @0049                               v13 = iconst.i64 0
 ;; @0049                               v14 = select_spectre_guard v8, v13, v12  ; v13 = 0
-;; @0049                               v15 = uload8.i32 little region1 v14
+;; @0049                               v15 = uload8.i32 little region2 v14
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -20,10 +20,11 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -38,7 +39,7 @@
 ;; @0040                               v12 = iadd v10, v11  ; v11 = 0xffff_0000
 ;; @0040                               v13 = iconst.i64 0
 ;; @0040                               v14 = select_spectre_guard v8, v13, v12  ; v13 = 0
-;; @0040                               istore8 little region1 v3, v14
+;; @0040                               istore8 little region2 v3, v14
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -47,10 +48,11 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -65,7 +67,7 @@
 ;; @004c                               v12 = iadd v10, v11  ; v11 = 0xffff_0000
 ;; @004c                               v13 = iconst.i64 0
 ;; @004c                               v14 = select_spectre_guard v8, v13, v12  ; v13 = 0
-;; @004c                               v15 = uload8.i32 little region1 v14
+;; @004c                               v15 = uload8.i32 little region2 v14
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
@@ -20,10 +20,11 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -33,7 +34,7 @@
 ;; @0040                               trapnz v6, heap_oob
 ;; @0040                               v7 = load.i64 notrap aligned can_move v0+56
 ;; @0040                               v8 = iadd v7, v4
-;; @0040                               store little region1 v3, v8
+;; @0040                               store little region2 v3, v8
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -42,10 +43,11 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -55,7 +57,7 @@
 ;; @0048                               trapnz v6, heap_oob
 ;; @0048                               v7 = load.i64 notrap aligned can_move v0+56
 ;; @0048                               v8 = iadd v7, v4
-;; @0048                               v9 = load.i32 little region1 v8
+;; @0048                               v9 = load.i32 little region2 v8
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -20,10 +20,11 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -35,7 +36,7 @@
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               v9 = iconst.i64 4096
 ;; @0040                               v10 = iadd v8, v9  ; v9 = 4096
-;; @0040                               store little region1 v3, v10
+;; @0040                               store little region2 v3, v10
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -44,10 +45,11 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -59,7 +61,7 @@
 ;; @0049                               v8 = iadd v7, v4
 ;; @0049                               v9 = iconst.i64 4096
 ;; @0049                               v10 = iadd v8, v9  ; v9 = 4096
-;; @0049                               v11 = load.i32 little region1 v10
+;; @0049                               v11 = load.i32 little region2 v10
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -20,10 +20,11 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -35,7 +36,7 @@
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               v9 = iconst.i64 0xffff_0000
 ;; @0040                               v10 = iadd v8, v9  ; v9 = 0xffff_0000
-;; @0040                               store little region1 v3, v10
+;; @0040                               store little region2 v3, v10
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -44,10 +45,11 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -59,7 +61,7 @@
 ;; @004c                               v8 = iadd v7, v4
 ;; @004c                               v9 = iconst.i64 0xffff_0000
 ;; @004c                               v10 = iadd v8, v9  ; v9 = 0xffff_0000
-;; @004c                               v11 = load.i32 little region1 v10
+;; @004c                               v11 = load.i32 little region2 v10
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
@@ -20,10 +20,11 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -33,7 +34,7 @@
 ;; @0040                               trapnz v6, heap_oob
 ;; @0040                               v7 = load.i64 notrap aligned can_move v0+56
 ;; @0040                               v8 = iadd v7, v4
-;; @0040                               istore8 little region1 v3, v8
+;; @0040                               istore8 little region2 v3, v8
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -42,10 +43,11 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -55,7 +57,7 @@
 ;; @0048                               trapnz v6, heap_oob
 ;; @0048                               v7 = load.i64 notrap aligned can_move v0+56
 ;; @0048                               v8 = iadd v7, v4
-;; @0048                               v9 = uload8.i32 little region1 v8
+;; @0048                               v9 = uload8.i32 little region2 v8
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -20,10 +20,11 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -35,7 +36,7 @@
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               v9 = iconst.i64 4096
 ;; @0040                               v10 = iadd v8, v9  ; v9 = 4096
-;; @0040                               istore8 little region1 v3, v10
+;; @0040                               istore8 little region2 v3, v10
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -44,10 +45,11 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -59,7 +61,7 @@
 ;; @0049                               v8 = iadd v7, v4
 ;; @0049                               v9 = iconst.i64 4096
 ;; @0049                               v10 = iadd v8, v9  ; v9 = 4096
-;; @0049                               v11 = uload8.i32 little region1 v10
+;; @0049                               v11 = uload8.i32 little region2 v10
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -20,10 +20,11 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -35,7 +36,7 @@
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               v9 = iconst.i64 0xffff_0000
 ;; @0040                               v10 = iadd v8, v9  ; v9 = 0xffff_0000
-;; @0040                               istore8 little region1 v3, v10
+;; @0040                               istore8 little region2 v3, v10
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -44,10 +45,11 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -59,7 +61,7 @@
 ;; @004c                               v8 = iadd v7, v4
 ;; @004c                               v9 = iconst.i64 0xffff_0000
 ;; @004c                               v10 = iadd v8, v9  ; v9 = 0xffff_0000
-;; @004c                               v11 = uload8.i32 little region1 v10
+;; @004c                               v11 = uload8.i32 little region2 v10
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
@@ -20,10 +20,11 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -34,7 +35,7 @@
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               v9 = iconst.i64 0
 ;; @0040                               v10 = select_spectre_guard v6, v9, v8  ; v9 = 0
-;; @0040                               store little region1 v3, v10
+;; @0040                               store little region2 v3, v10
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -43,10 +44,11 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -57,7 +59,7 @@
 ;; @0048                               v8 = iadd v7, v4
 ;; @0048                               v9 = iconst.i64 0
 ;; @0048                               v10 = select_spectre_guard v6, v9, v8  ; v9 = 0
-;; @0048                               v11 = load.i32 little region1 v10
+;; @0048                               v11 = load.i32 little region2 v10
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -20,10 +20,11 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -36,7 +37,7 @@
 ;; @0040                               v10 = iadd v8, v9  ; v9 = 4096
 ;; @0040                               v11 = iconst.i64 0
 ;; @0040                               v12 = select_spectre_guard v6, v11, v10  ; v11 = 0
-;; @0040                               store little region1 v3, v12
+;; @0040                               store little region2 v3, v12
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -45,10 +46,11 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -61,7 +63,7 @@
 ;; @0049                               v10 = iadd v8, v9  ; v9 = 4096
 ;; @0049                               v11 = iconst.i64 0
 ;; @0049                               v12 = select_spectre_guard v6, v11, v10  ; v11 = 0
-;; @0049                               v13 = load.i32 little region1 v12
+;; @0049                               v13 = load.i32 little region2 v12
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -20,10 +20,11 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -36,7 +37,7 @@
 ;; @0040                               v10 = iadd v8, v9  ; v9 = 0xffff_0000
 ;; @0040                               v11 = iconst.i64 0
 ;; @0040                               v12 = select_spectre_guard v6, v11, v10  ; v11 = 0
-;; @0040                               store little region1 v3, v12
+;; @0040                               store little region2 v3, v12
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -45,10 +46,11 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -61,7 +63,7 @@
 ;; @004c                               v10 = iadd v8, v9  ; v9 = 0xffff_0000
 ;; @004c                               v11 = iconst.i64 0
 ;; @004c                               v12 = select_spectre_guard v6, v11, v10  ; v11 = 0
-;; @004c                               v13 = load.i32 little region1 v12
+;; @004c                               v13 = load.i32 little region2 v12
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
@@ -20,10 +20,11 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -34,7 +35,7 @@
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               v9 = iconst.i64 0
 ;; @0040                               v10 = select_spectre_guard v6, v9, v8  ; v9 = 0
-;; @0040                               istore8 little region1 v3, v10
+;; @0040                               istore8 little region2 v3, v10
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -43,10 +44,11 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -57,7 +59,7 @@
 ;; @0048                               v8 = iadd v7, v4
 ;; @0048                               v9 = iconst.i64 0
 ;; @0048                               v10 = select_spectre_guard v6, v9, v8  ; v9 = 0
-;; @0048                               v11 = uload8.i32 little region1 v10
+;; @0048                               v11 = uload8.i32 little region2 v10
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -20,10 +20,11 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -36,7 +37,7 @@
 ;; @0040                               v10 = iadd v8, v9  ; v9 = 4096
 ;; @0040                               v11 = iconst.i64 0
 ;; @0040                               v12 = select_spectre_guard v6, v11, v10  ; v11 = 0
-;; @0040                               istore8 little region1 v3, v12
+;; @0040                               istore8 little region2 v3, v12
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -45,10 +46,11 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -61,7 +63,7 @@
 ;; @0049                               v10 = iadd v8, v9  ; v9 = 4096
 ;; @0049                               v11 = iconst.i64 0
 ;; @0049                               v12 = select_spectre_guard v6, v11, v10  ; v11 = 0
-;; @0049                               v13 = uload8.i32 little region1 v12
+;; @0049                               v13 = uload8.i32 little region2 v12
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -20,10 +20,11 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -36,7 +37,7 @@
 ;; @0040                               v10 = iadd v8, v9  ; v9 = 0xffff_0000
 ;; @0040                               v11 = iconst.i64 0
 ;; @0040                               v12 = select_spectre_guard v6, v11, v10  ; v11 = 0
-;; @0040                               istore8 little region1 v3, v12
+;; @0040                               istore8 little region2 v3, v12
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -45,10 +46,11 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -61,7 +63,7 @@
 ;; @004c                               v10 = iadd v8, v9  ; v9 = 0xffff_0000
 ;; @004c                               v11 = iconst.i64 0
 ;; @004c                               v12 = select_spectre_guard v6, v11, v10  ; v11 = 0
-;; @004c                               v13 = uload8.i32 little region1 v12
+;; @004c                               v13 = uload8.i32 little region2 v12
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0_offset.wat
@@ -20,10 +20,11 @@
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
@@ -34,7 +35,7 @@
 ;; @0040                               trapnz v7, heap_oob
 ;; @0040                               v8 = load.i64 notrap aligned can_move v0+56
 ;; @0040                               v9 = iadd v8, v2
-;; @0040                               store little region1 v3, v9
+;; @0040                               store little region2 v3, v9
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -43,10 +44,11 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
@@ -57,7 +59,7 @@
 ;; @0048                               trapnz v7, heap_oob
 ;; @0048                               v8 = load.i64 notrap aligned can_move v0+56
 ;; @0048                               v9 = iadd v8, v2
-;; @0048                               v10 = load.i32 little region1 v9
+;; @0048                               v10 = load.i32 little region2 v9
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -20,10 +20,11 @@
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
@@ -36,7 +37,7 @@
 ;; @0040                               v9 = iadd v8, v2
 ;; @0040                               v10 = iconst.i64 4096
 ;; @0040                               v11 = iadd v9, v10  ; v10 = 4096
-;; @0040                               store little region1 v3, v11
+;; @0040                               store little region2 v3, v11
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -45,10 +46,11 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
@@ -61,7 +63,7 @@
 ;; @0049                               v9 = iadd v8, v2
 ;; @0049                               v10 = iconst.i64 4096
 ;; @0049                               v11 = iadd v9, v10  ; v10 = 4096
-;; @0049                               v12 = load.i32 little region1 v11
+;; @0049                               v12 = load.i32 little region2 v11
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -20,10 +20,11 @@
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
@@ -36,7 +37,7 @@
 ;; @0040                               v9 = iadd v8, v2
 ;; @0040                               v10 = iconst.i64 0xffff_0000
 ;; @0040                               v11 = iadd v9, v10  ; v10 = 0xffff_0000
-;; @0040                               store little region1 v3, v11
+;; @0040                               store little region2 v3, v11
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -45,10 +46,11 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
@@ -61,7 +63,7 @@
 ;; @004c                               v9 = iadd v8, v2
 ;; @004c                               v10 = iconst.i64 0xffff_0000
 ;; @004c                               v11 = iadd v9, v10  ; v10 = 0xffff_0000
-;; @004c                               v12 = load.i32 little region1 v11
+;; @004c                               v12 = load.i32 little region2 v11
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0_offset.wat
@@ -20,10 +20,11 @@
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
@@ -32,7 +33,7 @@
 ;; @0040                               trapnz v5, heap_oob
 ;; @0040                               v6 = load.i64 notrap aligned can_move v0+56
 ;; @0040                               v7 = iadd v6, v2
-;; @0040                               istore8 little region1 v3, v7
+;; @0040                               istore8 little region2 v3, v7
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -41,10 +42,11 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
@@ -53,7 +55,7 @@
 ;; @0048                               trapnz v5, heap_oob
 ;; @0048                               v6 = load.i64 notrap aligned can_move v0+56
 ;; @0048                               v7 = iadd v6, v2
-;; @0048                               v8 = uload8.i32 little region1 v7
+;; @0048                               v8 = uload8.i32 little region2 v7
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -20,10 +20,11 @@
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
@@ -36,7 +37,7 @@
 ;; @0040                               v9 = iadd v8, v2
 ;; @0040                               v10 = iconst.i64 4096
 ;; @0040                               v11 = iadd v9, v10  ; v10 = 4096
-;; @0040                               istore8 little region1 v3, v11
+;; @0040                               istore8 little region2 v3, v11
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -45,10 +46,11 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
@@ -61,7 +63,7 @@
 ;; @0049                               v9 = iadd v8, v2
 ;; @0049                               v10 = iconst.i64 4096
 ;; @0049                               v11 = iadd v9, v10  ; v10 = 4096
-;; @0049                               v12 = uload8.i32 little region1 v11
+;; @0049                               v12 = uload8.i32 little region2 v11
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -20,10 +20,11 @@
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
@@ -36,7 +37,7 @@
 ;; @0040                               v9 = iadd v8, v2
 ;; @0040                               v10 = iconst.i64 0xffff_0000
 ;; @0040                               v11 = iadd v9, v10  ; v10 = 0xffff_0000
-;; @0040                               istore8 little region1 v3, v11
+;; @0040                               istore8 little region2 v3, v11
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -45,10 +46,11 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
@@ -61,7 +63,7 @@
 ;; @004c                               v9 = iadd v8, v2
 ;; @004c                               v10 = iconst.i64 0xffff_0000
 ;; @004c                               v11 = iadd v9, v10  ; v10 = 0xffff_0000
-;; @004c                               v12 = uload8.i32 little region1 v11
+;; @004c                               v12 = uload8.i32 little region2 v11
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0_offset.wat
@@ -20,10 +20,11 @@
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
@@ -35,7 +36,7 @@
 ;; @0040                               v9 = iadd v8, v2
 ;; @0040                               v10 = iconst.i64 0
 ;; @0040                               v11 = select_spectre_guard v7, v10, v9  ; v10 = 0
-;; @0040                               store little region1 v3, v11
+;; @0040                               store little region2 v3, v11
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -44,10 +45,11 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
@@ -59,7 +61,7 @@
 ;; @0048                               v9 = iadd v8, v2
 ;; @0048                               v10 = iconst.i64 0
 ;; @0048                               v11 = select_spectre_guard v7, v10, v9  ; v10 = 0
-;; @0048                               v12 = load.i32 little region1 v11
+;; @0048                               v12 = load.i32 little region2 v11
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -20,10 +20,11 @@
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
@@ -37,7 +38,7 @@
 ;; @0040                               v11 = iadd v9, v10  ; v10 = 4096
 ;; @0040                               v12 = iconst.i64 0
 ;; @0040                               v13 = select_spectre_guard v7, v12, v11  ; v12 = 0
-;; @0040                               store little region1 v3, v13
+;; @0040                               store little region2 v3, v13
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -46,10 +47,11 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
@@ -63,7 +65,7 @@
 ;; @0049                               v11 = iadd v9, v10  ; v10 = 4096
 ;; @0049                               v12 = iconst.i64 0
 ;; @0049                               v13 = select_spectre_guard v7, v12, v11  ; v12 = 0
-;; @0049                               v14 = load.i32 little region1 v13
+;; @0049                               v14 = load.i32 little region2 v13
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -20,10 +20,11 @@
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
@@ -37,7 +38,7 @@
 ;; @0040                               v11 = iadd v9, v10  ; v10 = 0xffff_0000
 ;; @0040                               v12 = iconst.i64 0
 ;; @0040                               v13 = select_spectre_guard v7, v12, v11  ; v12 = 0
-;; @0040                               store little region1 v3, v13
+;; @0040                               store little region2 v3, v13
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -46,10 +47,11 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
@@ -63,7 +65,7 @@
 ;; @004c                               v11 = iadd v9, v10  ; v10 = 0xffff_0000
 ;; @004c                               v12 = iconst.i64 0
 ;; @004c                               v13 = select_spectre_guard v7, v12, v11  ; v12 = 0
-;; @004c                               v14 = load.i32 little region1 v13
+;; @004c                               v14 = load.i32 little region2 v13
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0_offset.wat
@@ -20,10 +20,11 @@
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
@@ -33,7 +34,7 @@
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 0
 ;; @0040                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0
-;; @0040                               istore8 little region1 v3, v9
+;; @0040                               istore8 little region2 v3, v9
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -42,10 +43,11 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
@@ -55,7 +57,7 @@
 ;; @0048                               v7 = iadd v6, v2
 ;; @0048                               v8 = iconst.i64 0
 ;; @0048                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0
-;; @0048                               v10 = uload8.i32 little region1 v9
+;; @0048                               v10 = uload8.i32 little region2 v9
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -20,10 +20,11 @@
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
@@ -37,7 +38,7 @@
 ;; @0040                               v11 = iadd v9, v10  ; v10 = 4096
 ;; @0040                               v12 = iconst.i64 0
 ;; @0040                               v13 = select_spectre_guard v7, v12, v11  ; v12 = 0
-;; @0040                               istore8 little region1 v3, v13
+;; @0040                               istore8 little region2 v3, v13
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -46,10 +47,11 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
@@ -63,7 +65,7 @@
 ;; @0049                               v11 = iadd v9, v10  ; v10 = 4096
 ;; @0049                               v12 = iconst.i64 0
 ;; @0049                               v13 = select_spectre_guard v7, v12, v11  ; v12 = 0
-;; @0049                               v14 = uload8.i32 little region1 v13
+;; @0049                               v14 = uload8.i32 little region2 v13
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -20,10 +20,11 @@
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
@@ -37,7 +38,7 @@
 ;; @0040                               v11 = iadd v9, v10  ; v10 = 0xffff_0000
 ;; @0040                               v12 = iconst.i64 0
 ;; @0040                               v13 = select_spectre_guard v7, v12, v11  ; v12 = 0
-;; @0040                               istore8 little region1 v3, v13
+;; @0040                               istore8 little region2 v3, v13
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -46,10 +47,11 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
@@ -63,7 +65,7 @@
 ;; @004c                               v11 = iadd v9, v10  ; v10 = 0xffff_0000
 ;; @004c                               v12 = iconst.i64 0
 ;; @004c                               v13 = select_spectre_guard v7, v12, v11  ; v12 = 0
-;; @004c                               v14 = uload8.i32 little region1 v13
+;; @004c                               v14 = uload8.i32 little region2 v13
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
@@ -20,10 +20,11 @@
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
@@ -32,7 +33,7 @@
 ;; @0040                               trapnz v5, heap_oob
 ;; @0040                               v6 = load.i64 notrap aligned can_move v0+56
 ;; @0040                               v7 = iadd v6, v2
-;; @0040                               store little region1 v3, v7
+;; @0040                               store little region2 v3, v7
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -41,10 +42,11 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
@@ -53,7 +55,7 @@
 ;; @0048                               trapnz v5, heap_oob
 ;; @0048                               v6 = load.i64 notrap aligned can_move v0+56
 ;; @0048                               v7 = iadd v6, v2
-;; @0048                               v8 = load.i32 little region1 v7
+;; @0048                               v8 = load.i32 little region2 v7
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -20,10 +20,11 @@
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
@@ -34,7 +35,7 @@
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 4096
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 4096
-;; @0040                               store little region1 v3, v9
+;; @0040                               store little region2 v3, v9
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -43,10 +44,11 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
@@ -57,7 +59,7 @@
 ;; @0049                               v7 = iadd v6, v2
 ;; @0049                               v8 = iconst.i64 4096
 ;; @0049                               v9 = iadd v7, v8  ; v8 = 4096
-;; @0049                               v10 = load.i32 little region1 v9
+;; @0049                               v10 = load.i32 little region2 v9
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -20,10 +20,11 @@
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
@@ -34,7 +35,7 @@
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 0xffff_0000
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
-;; @0040                               store little region1 v3, v9
+;; @0040                               store little region2 v3, v9
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -43,10 +44,11 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
@@ -57,7 +59,7 @@
 ;; @004c                               v7 = iadd v6, v2
 ;; @004c                               v8 = iconst.i64 0xffff_0000
 ;; @004c                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
-;; @004c                               v10 = load.i32 little region1 v9
+;; @004c                               v10 = load.i32 little region2 v9
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
@@ -20,10 +20,11 @@
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
@@ -32,7 +33,7 @@
 ;; @0040                               trapnz v5, heap_oob
 ;; @0040                               v6 = load.i64 notrap aligned can_move v0+56
 ;; @0040                               v7 = iadd v6, v2
-;; @0040                               istore8 little region1 v3, v7
+;; @0040                               istore8 little region2 v3, v7
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -41,10 +42,11 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
@@ -53,7 +55,7 @@
 ;; @0048                               trapnz v5, heap_oob
 ;; @0048                               v6 = load.i64 notrap aligned can_move v0+56
 ;; @0048                               v7 = iadd v6, v2
-;; @0048                               v8 = uload8.i32 little region1 v7
+;; @0048                               v8 = uload8.i32 little region2 v7
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -20,10 +20,11 @@
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
@@ -34,7 +35,7 @@
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 4096
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 4096
-;; @0040                               istore8 little region1 v3, v9
+;; @0040                               istore8 little region2 v3, v9
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -43,10 +44,11 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
@@ -57,7 +59,7 @@
 ;; @0049                               v7 = iadd v6, v2
 ;; @0049                               v8 = iconst.i64 4096
 ;; @0049                               v9 = iadd v7, v8  ; v8 = 4096
-;; @0049                               v10 = uload8.i32 little region1 v9
+;; @0049                               v10 = uload8.i32 little region2 v9
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -20,10 +20,11 @@
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
@@ -34,7 +35,7 @@
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 0xffff_0000
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
-;; @0040                               istore8 little region1 v3, v9
+;; @0040                               istore8 little region2 v3, v9
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -43,10 +44,11 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
@@ -57,7 +59,7 @@
 ;; @004c                               v7 = iadd v6, v2
 ;; @004c                               v8 = iconst.i64 0xffff_0000
 ;; @004c                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
-;; @004c                               v10 = uload8.i32 little region1 v9
+;; @004c                               v10 = uload8.i32 little region2 v9
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
@@ -20,10 +20,11 @@
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
@@ -33,7 +34,7 @@
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 0
 ;; @0040                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0
-;; @0040                               store little region1 v3, v9
+;; @0040                               store little region2 v3, v9
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -42,10 +43,11 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
@@ -55,7 +57,7 @@
 ;; @0048                               v7 = iadd v6, v2
 ;; @0048                               v8 = iconst.i64 0
 ;; @0048                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0
-;; @0048                               v10 = load.i32 little region1 v9
+;; @0048                               v10 = load.i32 little region2 v9
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -20,10 +20,11 @@
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
@@ -35,7 +36,7 @@
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 4096
 ;; @0040                               v10 = iconst.i64 0
 ;; @0040                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
-;; @0040                               store little region1 v3, v11
+;; @0040                               store little region2 v3, v11
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -44,10 +45,11 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
@@ -59,7 +61,7 @@
 ;; @0049                               v9 = iadd v7, v8  ; v8 = 4096
 ;; @0049                               v10 = iconst.i64 0
 ;; @0049                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
-;; @0049                               v12 = load.i32 little region1 v11
+;; @0049                               v12 = load.i32 little region2 v11
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -20,10 +20,11 @@
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
@@ -35,7 +36,7 @@
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
 ;; @0040                               v10 = iconst.i64 0
 ;; @0040                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
-;; @0040                               store little region1 v3, v11
+;; @0040                               store little region2 v3, v11
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -44,10 +45,11 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
@@ -59,7 +61,7 @@
 ;; @004c                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
 ;; @004c                               v10 = iconst.i64 0
 ;; @004c                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
-;; @004c                               v12 = load.i32 little region1 v11
+;; @004c                               v12 = load.i32 little region2 v11
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
@@ -20,10 +20,11 @@
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
@@ -33,7 +34,7 @@
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 0
 ;; @0040                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0
-;; @0040                               istore8 little region1 v3, v9
+;; @0040                               istore8 little region2 v3, v9
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -42,10 +43,11 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
@@ -55,7 +57,7 @@
 ;; @0048                               v7 = iadd v6, v2
 ;; @0048                               v8 = iconst.i64 0
 ;; @0048                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0
-;; @0048                               v10 = uload8.i32 little region1 v9
+;; @0048                               v10 = uload8.i32 little region2 v9
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -20,10 +20,11 @@
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
@@ -35,7 +36,7 @@
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 4096
 ;; @0040                               v10 = iconst.i64 0
 ;; @0040                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
-;; @0040                               istore8 little region1 v3, v11
+;; @0040                               istore8 little region2 v3, v11
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -44,10 +45,11 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
@@ -59,7 +61,7 @@
 ;; @0049                               v9 = iadd v7, v8  ; v8 = 4096
 ;; @0049                               v10 = iconst.i64 0
 ;; @0049                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
-;; @0049                               v12 = uload8.i32 little region1 v11
+;; @0049                               v12 = uload8.i32 little region2 v11
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -20,10 +20,11 @@
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
@@ -35,7 +36,7 @@
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
 ;; @0040                               v10 = iconst.i64 0
 ;; @0040                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
-;; @0040                               istore8 little region1 v3, v11
+;; @0040                               istore8 little region2 v3, v11
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -44,10 +45,11 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
@@ -59,7 +61,7 @@
 ;; @004c                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
 ;; @004c                               v10 = iconst.i64 0
 ;; @004c                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
-;; @004c                               v12 = uload8.i32 little region1 v11
+;; @004c                               v12 = uload8.i32 little region2 v11
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0_offset.wat
@@ -20,10 +20,11 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -33,7 +34,7 @@
 ;; @0040                               trapnz v6, heap_oob
 ;; @0040                               v7 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0040                               v8 = iadd v7, v4
-;; @0040                               store little region1 v3, v8
+;; @0040                               store little region2 v3, v8
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -42,10 +43,11 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -55,7 +57,7 @@
 ;; @0048                               trapnz v6, heap_oob
 ;; @0048                               v7 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0048                               v8 = iadd v7, v4
-;; @0048                               v9 = load.i32 little region1 v8
+;; @0048                               v9 = load.i32 little region2 v8
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -20,10 +20,11 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -35,7 +36,7 @@
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               v9 = iconst.i64 4096
 ;; @0040                               v10 = iadd v8, v9  ; v9 = 4096
-;; @0040                               store little region1 v3, v10
+;; @0040                               store little region2 v3, v10
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -44,10 +45,11 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -59,7 +61,7 @@
 ;; @0049                               v8 = iadd v7, v4
 ;; @0049                               v9 = iconst.i64 4096
 ;; @0049                               v10 = iadd v8, v9  ; v9 = 4096
-;; @0049                               v11 = load.i32 little region1 v10
+;; @0049                               v11 = load.i32 little region2 v10
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -20,10 +20,11 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -35,7 +36,7 @@
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               v9 = iconst.i64 0xffff_0000
 ;; @0040                               v10 = iadd v8, v9  ; v9 = 0xffff_0000
-;; @0040                               store little region1 v3, v10
+;; @0040                               store little region2 v3, v10
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -44,10 +45,11 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -59,7 +61,7 @@
 ;; @004c                               v8 = iadd v7, v4
 ;; @004c                               v9 = iconst.i64 0xffff_0000
 ;; @004c                               v10 = iadd v8, v9  ; v9 = 0xffff_0000
-;; @004c                               v11 = load.i32 little region1 v10
+;; @004c                               v11 = load.i32 little region2 v10
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0_offset.wat
@@ -20,17 +20,18 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
 ;; @0040                               v5 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0040                               v6 = iadd v5, v4
-;; @0040                               istore8 little region1 v3, v6
+;; @0040                               istore8 little region2 v3, v6
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -39,17 +40,18 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0048                               v4 = uextend.i64 v2
 ;; @0048                               v5 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0048                               v6 = iadd v5, v4
-;; @0048                               v7 = uload8.i32 little region1 v6
+;; @0048                               v7 = uload8.i32 little region2 v6
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -20,10 +20,11 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -35,7 +36,7 @@
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               v9 = iconst.i64 4096
 ;; @0040                               v10 = iadd v8, v9  ; v9 = 4096
-;; @0040                               istore8 little region1 v3, v10
+;; @0040                               istore8 little region2 v3, v10
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -44,10 +45,11 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -59,7 +61,7 @@
 ;; @0049                               v8 = iadd v7, v4
 ;; @0049                               v9 = iconst.i64 4096
 ;; @0049                               v10 = iadd v8, v9  ; v9 = 4096
-;; @0049                               v11 = uload8.i32 little region1 v10
+;; @0049                               v11 = uload8.i32 little region2 v10
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -20,10 +20,11 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -35,7 +36,7 @@
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               v9 = iconst.i64 0xffff_0000
 ;; @0040                               v10 = iadd v8, v9  ; v9 = 0xffff_0000
-;; @0040                               istore8 little region1 v3, v10
+;; @0040                               istore8 little region2 v3, v10
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -44,10 +45,11 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -59,7 +61,7 @@
 ;; @004c                               v8 = iadd v7, v4
 ;; @004c                               v9 = iconst.i64 0xffff_0000
 ;; @004c                               v10 = iadd v8, v9  ; v9 = 0xffff_0000
-;; @004c                               v11 = uload8.i32 little region1 v10
+;; @004c                               v11 = uload8.i32 little region2 v10
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0_offset.wat
@@ -20,10 +20,11 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -34,7 +35,7 @@
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               v9 = iconst.i64 0
 ;; @0040                               v10 = select_spectre_guard v6, v9, v8  ; v9 = 0
-;; @0040                               store little region1 v3, v10
+;; @0040                               store little region2 v3, v10
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -43,10 +44,11 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -57,7 +59,7 @@
 ;; @0048                               v8 = iadd v7, v4
 ;; @0048                               v9 = iconst.i64 0
 ;; @0048                               v10 = select_spectre_guard v6, v9, v8  ; v9 = 0
-;; @0048                               v11 = load.i32 little region1 v10
+;; @0048                               v11 = load.i32 little region2 v10
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -20,10 +20,11 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -36,7 +37,7 @@
 ;; @0040                               v10 = iadd v8, v9  ; v9 = 4096
 ;; @0040                               v11 = iconst.i64 0
 ;; @0040                               v12 = select_spectre_guard v6, v11, v10  ; v11 = 0
-;; @0040                               store little region1 v3, v12
+;; @0040                               store little region2 v3, v12
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -45,10 +46,11 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -61,7 +63,7 @@
 ;; @0049                               v10 = iadd v8, v9  ; v9 = 4096
 ;; @0049                               v11 = iconst.i64 0
 ;; @0049                               v12 = select_spectre_guard v6, v11, v10  ; v11 = 0
-;; @0049                               v13 = load.i32 little region1 v12
+;; @0049                               v13 = load.i32 little region2 v12
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -20,10 +20,11 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -36,7 +37,7 @@
 ;; @0040                               v10 = iadd v8, v9  ; v9 = 0xffff_0000
 ;; @0040                               v11 = iconst.i64 0
 ;; @0040                               v12 = select_spectre_guard v6, v11, v10  ; v11 = 0
-;; @0040                               store little region1 v3, v12
+;; @0040                               store little region2 v3, v12
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -45,10 +46,11 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -61,7 +63,7 @@
 ;; @004c                               v10 = iadd v8, v9  ; v9 = 0xffff_0000
 ;; @004c                               v11 = iconst.i64 0
 ;; @004c                               v12 = select_spectre_guard v6, v11, v10  ; v11 = 0
-;; @004c                               v13 = load.i32 little region1 v12
+;; @004c                               v13 = load.i32 little region2 v12
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i8_access_0_offset.wat
@@ -20,17 +20,18 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
 ;; @0040                               v5 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0040                               v6 = iadd v5, v4
-;; @0040                               istore8 little region1 v3, v6
+;; @0040                               istore8 little region2 v3, v6
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -39,17 +40,18 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0048                               v4 = uextend.i64 v2
 ;; @0048                               v5 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0048                               v6 = iadd v5, v4
-;; @0048                               v7 = uload8.i32 little region1 v6
+;; @0048                               v7 = uload8.i32 little region2 v6
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -20,10 +20,11 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -36,7 +37,7 @@
 ;; @0040                               v10 = iadd v8, v9  ; v9 = 4096
 ;; @0040                               v11 = iconst.i64 0
 ;; @0040                               v12 = select_spectre_guard v6, v11, v10  ; v11 = 0
-;; @0040                               istore8 little region1 v3, v12
+;; @0040                               istore8 little region2 v3, v12
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -45,10 +46,11 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -61,7 +63,7 @@
 ;; @0049                               v10 = iadd v8, v9  ; v9 = 4096
 ;; @0049                               v11 = iconst.i64 0
 ;; @0049                               v12 = select_spectre_guard v6, v11, v10  ; v11 = 0
-;; @0049                               v13 = uload8.i32 little region1 v12
+;; @0049                               v13 = uload8.i32 little region2 v12
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -20,10 +20,11 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -36,7 +37,7 @@
 ;; @0040                               v10 = iadd v8, v9  ; v9 = 0xffff_0000
 ;; @0040                               v11 = iconst.i64 0
 ;; @0040                               v12 = select_spectre_guard v6, v11, v10  ; v11 = 0
-;; @0040                               istore8 little region1 v3, v12
+;; @0040                               istore8 little region2 v3, v12
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -45,10 +46,11 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -61,7 +63,7 @@
 ;; @004c                               v10 = iadd v8, v9  ; v9 = 0xffff_0000
 ;; @004c                               v11 = iconst.i64 0
 ;; @004c                               v12 = select_spectre_guard v6, v11, v10  ; v11 = 0
-;; @004c                               v13 = uload8.i32 little region1 v12
+;; @004c                               v13 = uload8.i32 little region2 v12
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
@@ -20,17 +20,18 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
 ;; @0040                               v5 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0040                               v6 = iadd v5, v4
-;; @0040                               store little region1 v3, v6
+;; @0040                               store little region2 v3, v6
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -39,17 +40,18 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0048                               v4 = uextend.i64 v2
 ;; @0048                               v5 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0048                               v6 = iadd v5, v4
-;; @0048                               v7 = load.i32 little region1 v6
+;; @0048                               v7 = load.i32 little region2 v6
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -20,10 +20,11 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -32,7 +33,7 @@
 ;; @0040                               v6 = iadd v5, v4
 ;; @0040                               v7 = iconst.i64 4096
 ;; @0040                               v8 = iadd v6, v7  ; v7 = 4096
-;; @0040                               store little region1 v3, v8
+;; @0040                               store little region2 v3, v8
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -41,10 +42,11 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -53,7 +55,7 @@
 ;; @0049                               v6 = iadd v5, v4
 ;; @0049                               v7 = iconst.i64 4096
 ;; @0049                               v8 = iadd v6, v7  ; v7 = 4096
-;; @0049                               v9 = load.i32 little region1 v8
+;; @0049                               v9 = load.i32 little region2 v8
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -20,10 +20,11 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -32,7 +33,7 @@
 ;; @0040                               v6 = iadd v5, v4
 ;; @0040                               v7 = iconst.i64 0xffff_0000
 ;; @0040                               v8 = iadd v6, v7  ; v7 = 0xffff_0000
-;; @0040                               store little region1 v3, v8
+;; @0040                               store little region2 v3, v8
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -41,10 +42,11 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -53,7 +55,7 @@
 ;; @004c                               v6 = iadd v5, v4
 ;; @004c                               v7 = iconst.i64 0xffff_0000
 ;; @004c                               v8 = iadd v6, v7  ; v7 = 0xffff_0000
-;; @004c                               v9 = load.i32 little region1 v8
+;; @004c                               v9 = load.i32 little region2 v8
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
@@ -20,17 +20,18 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
 ;; @0040                               v5 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0040                               v6 = iadd v5, v4
-;; @0040                               istore8 little region1 v3, v6
+;; @0040                               istore8 little region2 v3, v6
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -39,17 +40,18 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0048                               v4 = uextend.i64 v2
 ;; @0048                               v5 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0048                               v6 = iadd v5, v4
-;; @0048                               v7 = uload8.i32 little region1 v6
+;; @0048                               v7 = uload8.i32 little region2 v6
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -20,10 +20,11 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -32,7 +33,7 @@
 ;; @0040                               v6 = iadd v5, v4
 ;; @0040                               v7 = iconst.i64 4096
 ;; @0040                               v8 = iadd v6, v7  ; v7 = 4096
-;; @0040                               istore8 little region1 v3, v8
+;; @0040                               istore8 little region2 v3, v8
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -41,10 +42,11 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -53,7 +55,7 @@
 ;; @0049                               v6 = iadd v5, v4
 ;; @0049                               v7 = iconst.i64 4096
 ;; @0049                               v8 = iadd v6, v7  ; v7 = 4096
-;; @0049                               v9 = uload8.i32 little region1 v8
+;; @0049                               v9 = uload8.i32 little region2 v8
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -20,10 +20,11 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -32,7 +33,7 @@
 ;; @0040                               v6 = iadd v5, v4
 ;; @0040                               v7 = iconst.i64 0xffff_0000
 ;; @0040                               v8 = iadd v6, v7  ; v7 = 0xffff_0000
-;; @0040                               istore8 little region1 v3, v8
+;; @0040                               istore8 little region2 v3, v8
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -41,10 +42,11 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -53,7 +55,7 @@
 ;; @004c                               v6 = iadd v5, v4
 ;; @004c                               v7 = iconst.i64 0xffff_0000
 ;; @004c                               v8 = iadd v6, v7  ; v7 = 0xffff_0000
-;; @004c                               v9 = uload8.i32 little region1 v8
+;; @004c                               v9 = uload8.i32 little region2 v8
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
@@ -20,17 +20,18 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
 ;; @0040                               v5 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0040                               v6 = iadd v5, v4
-;; @0040                               store little region1 v3, v6
+;; @0040                               store little region2 v3, v6
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -39,17 +40,18 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0048                               v4 = uextend.i64 v2
 ;; @0048                               v5 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0048                               v6 = iadd v5, v4
-;; @0048                               v7 = load.i32 little region1 v6
+;; @0048                               v7 = load.i32 little region2 v6
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -20,10 +20,11 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -32,7 +33,7 @@
 ;; @0040                               v6 = iadd v5, v4
 ;; @0040                               v7 = iconst.i64 4096
 ;; @0040                               v8 = iadd v6, v7  ; v7 = 4096
-;; @0040                               store little region1 v3, v8
+;; @0040                               store little region2 v3, v8
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -41,10 +42,11 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -53,7 +55,7 @@
 ;; @0049                               v6 = iadd v5, v4
 ;; @0049                               v7 = iconst.i64 4096
 ;; @0049                               v8 = iadd v6, v7  ; v7 = 4096
-;; @0049                               v9 = load.i32 little region1 v8
+;; @0049                               v9 = load.i32 little region2 v8
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -20,10 +20,11 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -32,7 +33,7 @@
 ;; @0040                               v6 = iadd v5, v4
 ;; @0040                               v7 = iconst.i64 0xffff_0000
 ;; @0040                               v8 = iadd v6, v7  ; v7 = 0xffff_0000
-;; @0040                               store little region1 v3, v8
+;; @0040                               store little region2 v3, v8
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -41,10 +42,11 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -53,7 +55,7 @@
 ;; @004c                               v6 = iadd v5, v4
 ;; @004c                               v7 = iconst.i64 0xffff_0000
 ;; @004c                               v8 = iadd v6, v7  ; v7 = 0xffff_0000
-;; @004c                               v9 = load.i32 little region1 v8
+;; @004c                               v9 = load.i32 little region2 v8
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
@@ -20,17 +20,18 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
 ;; @0040                               v5 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0040                               v6 = iadd v5, v4
-;; @0040                               istore8 little region1 v3, v6
+;; @0040                               istore8 little region2 v3, v6
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -39,17 +40,18 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0048                               v4 = uextend.i64 v2
 ;; @0048                               v5 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0048                               v6 = iadd v5, v4
-;; @0048                               v7 = uload8.i32 little region1 v6
+;; @0048                               v7 = uload8.i32 little region2 v6
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -20,10 +20,11 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -32,7 +33,7 @@
 ;; @0040                               v6 = iadd v5, v4
 ;; @0040                               v7 = iconst.i64 4096
 ;; @0040                               v8 = iadd v6, v7  ; v7 = 4096
-;; @0040                               istore8 little region1 v3, v8
+;; @0040                               istore8 little region2 v3, v8
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -41,10 +42,11 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -53,7 +55,7 @@
 ;; @0049                               v6 = iadd v5, v4
 ;; @0049                               v7 = iconst.i64 4096
 ;; @0049                               v8 = iadd v6, v7  ; v7 = 4096
-;; @0049                               v9 = uload8.i32 little region1 v8
+;; @0049                               v9 = uload8.i32 little region2 v8
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -20,10 +20,11 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -32,7 +33,7 @@
 ;; @0040                               v6 = iadd v5, v4
 ;; @0040                               v7 = iconst.i64 0xffff_0000
 ;; @0040                               v8 = iadd v6, v7  ; v7 = 0xffff_0000
-;; @0040                               istore8 little region1 v3, v8
+;; @0040                               istore8 little region2 v3, v8
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -41,10 +42,11 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -53,7 +55,7 @@
 ;; @004c                               v6 = iadd v5, v4
 ;; @004c                               v7 = iconst.i64 0xffff_0000
 ;; @004c                               v8 = iadd v6, v7  ; v7 = 0xffff_0000
-;; @004c                               v9 = uload8.i32 little region1 v8
+;; @004c                               v9 = uload8.i32 little region2 v8
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0_offset.wat
@@ -20,10 +20,11 @@
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
@@ -32,7 +33,7 @@
 ;; @0040                               trapnz v5, heap_oob
 ;; @0040                               v6 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0040                               v7 = iadd v6, v2
-;; @0040                               store little region1 v3, v7
+;; @0040                               store little region2 v3, v7
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -41,10 +42,11 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
@@ -53,7 +55,7 @@
 ;; @0048                               trapnz v5, heap_oob
 ;; @0048                               v6 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0048                               v7 = iadd v6, v2
-;; @0048                               v8 = load.i32 little region1 v7
+;; @0048                               v8 = load.i32 little region2 v7
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -20,10 +20,11 @@
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
@@ -34,7 +35,7 @@
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 4096
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 4096
-;; @0040                               store little region1 v3, v9
+;; @0040                               store little region2 v3, v9
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -43,10 +44,11 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
@@ -57,7 +59,7 @@
 ;; @0049                               v7 = iadd v6, v2
 ;; @0049                               v8 = iconst.i64 4096
 ;; @0049                               v9 = iadd v7, v8  ; v8 = 4096
-;; @0049                               v10 = load.i32 little region1 v9
+;; @0049                               v10 = load.i32 little region2 v9
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -20,10 +20,11 @@
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
@@ -34,7 +35,7 @@
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 0xffff_0000
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
-;; @0040                               store little region1 v3, v9
+;; @0040                               store little region2 v3, v9
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -43,10 +44,11 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
@@ -57,7 +59,7 @@
 ;; @004c                               v7 = iadd v6, v2
 ;; @004c                               v8 = iconst.i64 0xffff_0000
 ;; @004c                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
-;; @004c                               v10 = load.i32 little region1 v9
+;; @004c                               v10 = load.i32 little region2 v9
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0_offset.wat
@@ -20,10 +20,11 @@
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
@@ -32,7 +33,7 @@
 ;; @0040                               trapnz v5, heap_oob
 ;; @0040                               v6 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0040                               v7 = iadd v6, v2
-;; @0040                               istore8 little region1 v3, v7
+;; @0040                               istore8 little region2 v3, v7
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -41,10 +42,11 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
@@ -53,7 +55,7 @@
 ;; @0048                               trapnz v5, heap_oob
 ;; @0048                               v6 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0048                               v7 = iadd v6, v2
-;; @0048                               v8 = uload8.i32 little region1 v7
+;; @0048                               v8 = uload8.i32 little region2 v7
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -20,10 +20,11 @@
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
@@ -34,7 +35,7 @@
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 4096
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 4096
-;; @0040                               istore8 little region1 v3, v9
+;; @0040                               istore8 little region2 v3, v9
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -43,10 +44,11 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
@@ -57,7 +59,7 @@
 ;; @0049                               v7 = iadd v6, v2
 ;; @0049                               v8 = iconst.i64 4096
 ;; @0049                               v9 = iadd v7, v8  ; v8 = 4096
-;; @0049                               v10 = uload8.i32 little region1 v9
+;; @0049                               v10 = uload8.i32 little region2 v9
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -20,10 +20,11 @@
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
@@ -34,7 +35,7 @@
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 0xffff_0000
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
-;; @0040                               istore8 little region1 v3, v9
+;; @0040                               istore8 little region2 v3, v9
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -43,10 +44,11 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
@@ -57,7 +59,7 @@
 ;; @004c                               v7 = iadd v6, v2
 ;; @004c                               v8 = iconst.i64 0xffff_0000
 ;; @004c                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
-;; @004c                               v10 = uload8.i32 little region1 v9
+;; @004c                               v10 = uload8.i32 little region2 v9
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0_offset.wat
@@ -20,10 +20,11 @@
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
@@ -33,7 +34,7 @@
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 0
 ;; @0040                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0
-;; @0040                               store little region1 v3, v9
+;; @0040                               store little region2 v3, v9
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -42,10 +43,11 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
@@ -55,7 +57,7 @@
 ;; @0048                               v7 = iadd v6, v2
 ;; @0048                               v8 = iconst.i64 0
 ;; @0048                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0
-;; @0048                               v10 = load.i32 little region1 v9
+;; @0048                               v10 = load.i32 little region2 v9
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -20,10 +20,11 @@
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
@@ -35,7 +36,7 @@
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 4096
 ;; @0040                               v10 = iconst.i64 0
 ;; @0040                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
-;; @0040                               store little region1 v3, v11
+;; @0040                               store little region2 v3, v11
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -44,10 +45,11 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
@@ -59,7 +61,7 @@
 ;; @0049                               v9 = iadd v7, v8  ; v8 = 4096
 ;; @0049                               v10 = iconst.i64 0
 ;; @0049                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
-;; @0049                               v12 = load.i32 little region1 v11
+;; @0049                               v12 = load.i32 little region2 v11
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -20,10 +20,11 @@
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
@@ -35,7 +36,7 @@
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
 ;; @0040                               v10 = iconst.i64 0
 ;; @0040                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
-;; @0040                               store little region1 v3, v11
+;; @0040                               store little region2 v3, v11
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -44,10 +45,11 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
@@ -59,7 +61,7 @@
 ;; @004c                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
 ;; @004c                               v10 = iconst.i64 0
 ;; @004c                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
-;; @004c                               v12 = load.i32 little region1 v11
+;; @004c                               v12 = load.i32 little region2 v11
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0_offset.wat
@@ -20,10 +20,11 @@
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
@@ -33,7 +34,7 @@
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 0
 ;; @0040                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0
-;; @0040                               istore8 little region1 v3, v9
+;; @0040                               istore8 little region2 v3, v9
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -42,10 +43,11 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
@@ -55,7 +57,7 @@
 ;; @0048                               v7 = iadd v6, v2
 ;; @0048                               v8 = iconst.i64 0
 ;; @0048                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0
-;; @0048                               v10 = uload8.i32 little region1 v9
+;; @0048                               v10 = uload8.i32 little region2 v9
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -20,10 +20,11 @@
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
@@ -35,7 +36,7 @@
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 4096
 ;; @0040                               v10 = iconst.i64 0
 ;; @0040                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
-;; @0040                               istore8 little region1 v3, v11
+;; @0040                               istore8 little region2 v3, v11
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -44,10 +45,11 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
@@ -59,7 +61,7 @@
 ;; @0049                               v9 = iadd v7, v8  ; v8 = 4096
 ;; @0049                               v10 = iconst.i64 0
 ;; @0049                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
-;; @0049                               v12 = uload8.i32 little region1 v11
+;; @0049                               v12 = uload8.i32 little region2 v11
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -20,10 +20,11 @@
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
@@ -35,7 +36,7 @@
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
 ;; @0040                               v10 = iconst.i64 0
 ;; @0040                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
-;; @0040                               istore8 little region1 v3, v11
+;; @0040                               istore8 little region2 v3, v11
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -44,10 +45,11 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
@@ -59,7 +61,7 @@
 ;; @004c                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
 ;; @004c                               v10 = iconst.i64 0
 ;; @004c                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
-;; @004c                               v12 = uload8.i32 little region1 v11
+;; @004c                               v12 = uload8.i32 little region2 v11
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
@@ -20,10 +20,11 @@
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
@@ -32,7 +33,7 @@
 ;; @0040                               trapnz v5, heap_oob
 ;; @0040                               v6 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0040                               v7 = iadd v6, v2
-;; @0040                               store little region1 v3, v7
+;; @0040                               store little region2 v3, v7
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -41,10 +42,11 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
@@ -53,7 +55,7 @@
 ;; @0048                               trapnz v5, heap_oob
 ;; @0048                               v6 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0048                               v7 = iadd v6, v2
-;; @0048                               v8 = load.i32 little region1 v7
+;; @0048                               v8 = load.i32 little region2 v7
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -20,10 +20,11 @@
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
@@ -34,7 +35,7 @@
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 4096
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 4096
-;; @0040                               store little region1 v3, v9
+;; @0040                               store little region2 v3, v9
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -43,10 +44,11 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
@@ -57,7 +59,7 @@
 ;; @0049                               v7 = iadd v6, v2
 ;; @0049                               v8 = iconst.i64 4096
 ;; @0049                               v9 = iadd v7, v8  ; v8 = 4096
-;; @0049                               v10 = load.i32 little region1 v9
+;; @0049                               v10 = load.i32 little region2 v9
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -20,10 +20,11 @@
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
@@ -34,7 +35,7 @@
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 0xffff_0000
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
-;; @0040                               store little region1 v3, v9
+;; @0040                               store little region2 v3, v9
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -43,10 +44,11 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
@@ -57,7 +59,7 @@
 ;; @004c                               v7 = iadd v6, v2
 ;; @004c                               v8 = iconst.i64 0xffff_0000
 ;; @004c                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
-;; @004c                               v10 = load.i32 little region1 v9
+;; @004c                               v10 = load.i32 little region2 v9
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
@@ -20,10 +20,11 @@
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
@@ -32,7 +33,7 @@
 ;; @0040                               trapnz v5, heap_oob
 ;; @0040                               v6 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0040                               v7 = iadd v6, v2
-;; @0040                               istore8 little region1 v3, v7
+;; @0040                               istore8 little region2 v3, v7
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -41,10 +42,11 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
@@ -53,7 +55,7 @@
 ;; @0048                               trapnz v5, heap_oob
 ;; @0048                               v6 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0048                               v7 = iadd v6, v2
-;; @0048                               v8 = uload8.i32 little region1 v7
+;; @0048                               v8 = uload8.i32 little region2 v7
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -20,10 +20,11 @@
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
@@ -34,7 +35,7 @@
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 4096
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 4096
-;; @0040                               istore8 little region1 v3, v9
+;; @0040                               istore8 little region2 v3, v9
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -43,10 +44,11 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
@@ -57,7 +59,7 @@
 ;; @0049                               v7 = iadd v6, v2
 ;; @0049                               v8 = iconst.i64 4096
 ;; @0049                               v9 = iadd v7, v8  ; v8 = 4096
-;; @0049                               v10 = uload8.i32 little region1 v9
+;; @0049                               v10 = uload8.i32 little region2 v9
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -20,10 +20,11 @@
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
@@ -34,7 +35,7 @@
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 0xffff_0000
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
-;; @0040                               istore8 little region1 v3, v9
+;; @0040                               istore8 little region2 v3, v9
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -43,10 +44,11 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
@@ -57,7 +59,7 @@
 ;; @004c                               v7 = iadd v6, v2
 ;; @004c                               v8 = iconst.i64 0xffff_0000
 ;; @004c                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
-;; @004c                               v10 = uload8.i32 little region1 v9
+;; @004c                               v10 = uload8.i32 little region2 v9
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
@@ -20,10 +20,11 @@
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
@@ -33,7 +34,7 @@
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 0
 ;; @0040                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0
-;; @0040                               store little region1 v3, v9
+;; @0040                               store little region2 v3, v9
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -42,10 +43,11 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
@@ -55,7 +57,7 @@
 ;; @0048                               v7 = iadd v6, v2
 ;; @0048                               v8 = iconst.i64 0
 ;; @0048                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0
-;; @0048                               v10 = load.i32 little region1 v9
+;; @0048                               v10 = load.i32 little region2 v9
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -20,10 +20,11 @@
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
@@ -35,7 +36,7 @@
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 4096
 ;; @0040                               v10 = iconst.i64 0
 ;; @0040                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
-;; @0040                               store little region1 v3, v11
+;; @0040                               store little region2 v3, v11
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -44,10 +45,11 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
@@ -59,7 +61,7 @@
 ;; @0049                               v9 = iadd v7, v8  ; v8 = 4096
 ;; @0049                               v10 = iconst.i64 0
 ;; @0049                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
-;; @0049                               v12 = load.i32 little region1 v11
+;; @0049                               v12 = load.i32 little region2 v11
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -20,10 +20,11 @@
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
@@ -35,7 +36,7 @@
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
 ;; @0040                               v10 = iconst.i64 0
 ;; @0040                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
-;; @0040                               store little region1 v3, v11
+;; @0040                               store little region2 v3, v11
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -44,10 +45,11 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
@@ -59,7 +61,7 @@
 ;; @004c                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
 ;; @004c                               v10 = iconst.i64 0
 ;; @004c                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
-;; @004c                               v12 = load.i32 little region1 v11
+;; @004c                               v12 = load.i32 little region2 v11
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
@@ -20,10 +20,11 @@
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
@@ -33,7 +34,7 @@
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 0
 ;; @0040                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0
-;; @0040                               istore8 little region1 v3, v9
+;; @0040                               istore8 little region2 v3, v9
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -42,10 +43,11 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
@@ -55,7 +57,7 @@
 ;; @0048                               v7 = iadd v6, v2
 ;; @0048                               v8 = iconst.i64 0
 ;; @0048                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0
-;; @0048                               v10 = uload8.i32 little region1 v9
+;; @0048                               v10 = uload8.i32 little region2 v9
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -20,10 +20,11 @@
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
@@ -35,7 +36,7 @@
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 4096
 ;; @0040                               v10 = iconst.i64 0
 ;; @0040                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
-;; @0040                               istore8 little region1 v3, v11
+;; @0040                               istore8 little region2 v3, v11
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -44,10 +45,11 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
@@ -59,7 +61,7 @@
 ;; @0049                               v9 = iadd v7, v8  ; v8 = 4096
 ;; @0049                               v10 = iconst.i64 0
 ;; @0049                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
-;; @0049                               v12 = uload8.i32 little region1 v11
+;; @0049                               v12 = uload8.i32 little region2 v11
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -20,10 +20,11 @@
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
@@ -35,7 +36,7 @@
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
 ;; @0040                               v10 = iconst.i64 0
 ;; @0040                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
-;; @0040                               istore8 little region1 v3, v11
+;; @0040                               istore8 little region2 v3, v11
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -44,10 +45,11 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
@@ -59,7 +61,7 @@
 ;; @004c                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
 ;; @004c                               v10 = iconst.i64 0
 ;; @004c                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
-;; @004c                               v12 = uload8.i32 little region1 v11
+;; @004c                               v12 = uload8.i32 little region2 v11
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/memory-copy-epochs.wat
+++ b/tests/disas/memory-copy-epochs.wat
@@ -10,10 +10,12 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 24 "VMContext+0x18"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 24 "VMContext+0x18"
+;;     region3 = 268435464 "VMStoreContext+0x8"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx) -> i64 tail
 ;;     sig1 = (i64 vmctx, i64, i64, i64) tail
 ;;     fn0 = colocated u805306368:13 sig0
@@ -21,10 +23,10 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
-;; @001e                               v5 = load.i64 notrap aligned region1 v0+24
+;; @001e                               v5 = load.i64 notrap aligned region2 v0+24
 ;; @001e                               v6 = load.i64 notrap aligned v5
 ;; @001e                               v7 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @001e                               v8 = load.i64 notrap aligned v7+8
+;; @001e                               v8 = load.i64 notrap aligned region3 v7+8
 ;; @001e                               v9 = icmp uge v6, v8
 ;; @001e                               brif v9, block3, block2(v8)
 ;;
@@ -65,7 +67,7 @@
 ;; @0025                               brif v109, block4(v25, v37, v16, v59), block5(v25, v37, v16, v59)
 ;;
 ;;                                 block9 cold:
-;; @0025                               v50 = load.i64 notrap aligned v7+8
+;; @0025                               v50 = load.i64 notrap aligned region3 v7+8
 ;; @0025                               v51 = icmp.i64 uge v46, v50
 ;; @0025                               brif v51, block10, block8(v50)
 ;;
@@ -94,7 +96,7 @@
 ;; @0025                               brif v72, block14, block13(v71)
 ;;
 ;;                                 block14 cold:
-;; @0025                               v74 = load.i64 notrap aligned v7+8
+;; @0025                               v74 = load.i64 notrap aligned region3 v7+8
 ;; @0025                               v75 = icmp.i64 uge v70, v74
 ;; @0025                               brif v75, block15, block13(v74)
 ;;
@@ -117,7 +119,7 @@
 ;; @0025                               jump block5(v84, v85, v83, v93)
 ;;
 ;;                                 block17 cold:
-;; @0025                               v96 = load.i64 notrap aligned v7+8
+;; @0025                               v96 = load.i64 notrap aligned region3 v7+8
 ;; @0025                               v97 = icmp.i64 uge v91, v96
 ;; @0025                               brif v97, block18, block16
 ;;

--- a/tests/disas/memory-copy-fuel.wat
+++ b/tests/disas/memory-copy-fuel.wat
@@ -10,9 +10,11 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 268435456 "VMStoreContext+0x0"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx) -> i8 tail
 ;;     sig1 = (i64 vmctx, i64, i64, i64) tail
 ;;     fn0 = colocated u805306368:12 sig0
@@ -21,7 +23,7 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
 ;; @001e                               v5 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @001e                               v6 = load.i64 notrap aligned v5
+;; @001e                               v6 = load.i64 notrap aligned region2 v5
 ;; @001e                               v7 = iconst.i64 1
 ;; @001e                               v8 = iadd v6, v7  ; v7 = 1
 ;; @001e                               v9 = iconst.i64 0
@@ -30,9 +32,9 @@
 ;;
 ;;                                 block2:
 ;;                                     v106 = iadd.i64 v6, v7  ; v7 = 1
-;; @001e                               store notrap aligned v106, v5
+;; @001e                               store notrap aligned region2 v106, v5
 ;; @001e                               v12 = call fn0(v0)
-;; @001e                               v14 = load.i64 notrap aligned v5
+;; @001e                               v14 = load.i64 notrap aligned region2 v5
 ;; @001e                               jump block3(v14)
 ;;
 ;;                                 block3(v43: i64):
@@ -73,9 +75,9 @@
 ;;
 ;;                                 block8:
 ;;                                     v122 = iadd.i64 v52, v116  ; v116 = 0x0800_0000
-;; @0025                               store notrap aligned v122, v5
+;; @0025                               store notrap aligned region2 v122, v5
 ;; @0025                               v57 = call fn0(v0)
-;; @0025                               v59 = load.i64 notrap aligned v5
+;; @0025                               v59 = load.i64 notrap aligned region2 v5
 ;; @0025                               jump block9(v59)
 ;;
 ;;                                 block9(v64: i64):
@@ -103,9 +105,9 @@
 ;; @0025                               brif v110, block12, block13(v108)
 ;;
 ;;                                 block12:
-;; @0025                               store.i64 notrap aligned v108, v5
+;; @0025                               store.i64 notrap aligned region2 v108, v5
 ;; @0025                               v78 = call fn0(v0)
-;; @0025                               v80 = load.i64 notrap aligned v5
+;; @0025                               v80 = load.i64 notrap aligned region2 v5
 ;; @0025                               jump block13(v80)
 ;;
 ;;                                 block13(v83: i64):
@@ -123,9 +125,9 @@
 ;; @0025                               jump block5(v87, v88, v86, v93)
 ;;
 ;;                                 block14:
-;; @0025                               store.i64 notrap aligned v94, v5
+;; @0025                               store.i64 notrap aligned region2 v94, v5
 ;; @0025                               v98 = call fn0(v0)
-;; @0025                               v100 = load.i64 notrap aligned v5
+;; @0025                               v100 = load.i64 notrap aligned region2 v5
 ;; @0025                               jump block15(v100)
 ;;
 ;;                                 block15(v102: i64):
@@ -133,6 +135,6 @@
 ;; @0029                               jump block1
 ;;
 ;;                                 block1:
-;; @0029                               store.i64 notrap aligned v102, v5
+;; @0029                               store.i64 notrap aligned region2 v102, v5
 ;; @0029                               return
 ;; }

--- a/tests/disas/memory-copy-inline.wat
+++ b/tests/disas/memory-copy-inline.wat
@@ -13,10 +13,11 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -32,9 +33,9 @@
 ;; @0024                               trapnz v23, heap_oob
 ;; @0024                               v12 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0024                               v28 = iadd v12, v18
-;; @0024                               v30 = load.i8x16 notrap aligned little region1 v28
+;; @0024                               v30 = load.i8x16 notrap aligned little region2 v28
 ;; @0024                               v16 = iadd v12, v6
-;; @0024                               store notrap aligned little region1 v30, v16
+;; @0024                               store notrap aligned little region2 v30, v16
 ;; @0028                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/memory-min-max-same.wat
+++ b/tests/disas/memory-min-max-same.wat
@@ -35,19 +35,20 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 96 "VMContext+0x60"
-;;     region2 = 80 "VMContext+0x50"
-;;     region3 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 96 "VMContext+0x60"
+;;     region3 = 80 "VMContext+0x50"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, i64) tail
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0028                               v3 = iconst.i32 0
-;; @0030                               v6 = load.i64 notrap aligned readonly can_move region2 v0+80
-;; @0030                               v5 = load.i64 notrap aligned readonly can_move region1 v0+96
+;; @0030                               v6 = load.i64 notrap aligned readonly can_move region3 v0+80
+;; @0030                               v5 = load.i64 notrap aligned readonly can_move region2 v0+96
 ;; @0039                               v12 = iconst.i64 0x0001_0000
 ;; @0039                               v16 = iconst.i64 0
 ;; @0039                               v14 = load.i64 notrap aligned readonly can_move v0+56
@@ -64,7 +65,7 @@
 ;; @0039                               v15 = iadd.i64 v14, v11
 ;;                                     v23 = iconst.i64 0
 ;;                                     v24 = select_spectre_guard v22, v23, v15  ; v23 = 0
-;; @0039                               store little region3 v20, v24  ; v20 = 0
+;; @0039                               store little region4 v20, v24  ; v20 = 0
 ;;                                     v25 = iconst.i32 1
 ;;                                     v26 = iadd v8, v25  ; v25 = 1
 ;; @0043                               jump block2(v26)

--- a/tests/disas/memory.wat
+++ b/tests/disas/memory.wat
@@ -14,10 +14,11 @@
 
 ;; function u0:0(i64 vmctx, i64) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
@@ -27,12 +28,12 @@
 ;; @0025                               v5 = uextend.i64 v3  ; v3 = 0
 ;; @0025                               v6 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0025                               v7 = iadd v6, v5
-;; @0025                               store little region1 v4, v7  ; v4 = 0
+;; @0025                               store little region2 v4, v7  ; v4 = 0
 ;; @0028                               v8 = iconst.i32 0
 ;; @002a                               v9 = uextend.i64 v8  ; v8 = 0
 ;; @002a                               v10 = load.i64 notrap aligned readonly can_move v0+56
 ;; @002a                               v11 = iadd v10, v9
-;; @002a                               v12 = load.i32 little region1 v11
+;; @002a                               v12 = load.i32 little region2 v11
 ;; @002d                               brif v12, block2, block4
 ;;
 ;;                                 block2:
@@ -41,7 +42,7 @@
 ;; @0033                               v15 = uextend.i64 v13  ; v13 = 0
 ;; @0033                               v16 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0033                               v17 = iadd v16, v15
-;; @0033                               store little region1 v14, v17  ; v14 = 10
+;; @0033                               store little region2 v14, v17  ; v14 = 10
 ;; @0036                               jump block3
 ;;
 ;;                                 block4:
@@ -50,7 +51,7 @@
 ;; @003b                               v20 = uextend.i64 v18  ; v18 = 0
 ;; @003b                               v21 = load.i64 notrap aligned readonly can_move v0+56
 ;; @003b                               v22 = iadd v21, v20
-;; @003b                               store little region1 v19, v22  ; v19 = 11
+;; @003b                               store little region2 v19, v22  ; v19 = 11
 ;; @003e                               jump block3
 ;;
 ;;                                 block3:

--- a/tests/disas/memory_copy_host64.wat
+++ b/tests/disas/memory_copy_host64.wat
@@ -51,9 +51,10 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, i64, i64, i64) tail
 ;;     fn0 = colocated u805306368:1 sig0
 ;;     stack_limit = gv2
@@ -81,9 +82,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, i64, i64, i64) tail
 ;;     fn0 = colocated u805306368:1 sig0
 ;;     stack_limit = gv2
@@ -113,9 +115,10 @@
 ;;
 ;; function u0:2(i64 vmctx, i64, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, i64, i64, i64) tail
 ;;     fn0 = colocated u805306368:1 sig0
 ;;     stack_limit = gv2
@@ -144,9 +147,10 @@
 ;;
 ;; function u0:3(i64 vmctx, i64, i64, i64, i64) tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, i64, i64, i64) tail
 ;;     fn0 = colocated u805306368:1 sig0
 ;;     stack_limit = gv2
@@ -171,9 +175,10 @@
 ;;
 ;; function u0:4(i64 vmctx, i64, i64, i64, i64) tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, i64, i64, i64) tail
 ;;     fn0 = colocated u805306368:1 sig0
 ;;     stack_limit = gv2
@@ -200,9 +205,10 @@
 ;;
 ;; function u0:5(i64 vmctx, i64, i32, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, i64, i64, i64) tail
 ;;     fn0 = colocated u805306368:1 sig0
 ;;     stack_limit = gv2

--- a/tests/disas/memory_fill_host64.wat
+++ b/tests/disas/memory_fill_host64.wat
@@ -45,9 +45,10 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, i64, i32, i64) tail
 ;;     fn0 = colocated u805306368:2 sig0
 ;;     stack_limit = gv2
@@ -71,9 +72,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i64, i64) tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, i64, i32, i64) tail
 ;;     fn0 = colocated u805306368:2 sig0
 ;;     stack_limit = gv2
@@ -95,9 +97,10 @@
 ;;
 ;; function u0:2(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, i64, i32, i64) tail
 ;;     fn0 = colocated u805306368:2 sig0
 ;;     stack_limit = gv2
@@ -121,9 +124,10 @@
 ;;
 ;; function u0:3(i64 vmctx, i64, i64, i64) tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, i64, i32, i64) tail
 ;;     fn0 = colocated u805306368:2 sig0
 ;;     stack_limit = gv2
@@ -145,9 +149,10 @@
 ;;
 ;; function u0:4(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, i64, i32, i64) tail
 ;;     fn0 = colocated u805306368:2 sig0
 ;;     stack_limit = gv2

--- a/tests/disas/multi-0.wat
+++ b/tests/disas/multi-0.wat
@@ -6,9 +6,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i64) -> i64, i64 tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):

--- a/tests/disas/multi-1.wat
+++ b/tests/disas/multi-1.wat
@@ -9,9 +9,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) -> i32, i64, f64 tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):

--- a/tests/disas/multi-10.wat
+++ b/tests/disas/multi-10.wat
@@ -13,9 +13,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) -> i64, i64 tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):

--- a/tests/disas/multi-11.wat
+++ b/tests/disas/multi-11.wat
@@ -10,9 +10,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i64) -> i64, i64 tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):

--- a/tests/disas/multi-12.wat
+++ b/tests/disas/multi-12.wat
@@ -12,9 +12,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i64, i64, i64) -> i64, i64 tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i64, v4: i64):

--- a/tests/disas/multi-13.wat
+++ b/tests/disas/multi-13.wat
@@ -13,9 +13,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):

--- a/tests/disas/multi-14.wat
+++ b/tests/disas/multi-14.wat
@@ -13,9 +13,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):

--- a/tests/disas/multi-15.wat
+++ b/tests/disas/multi-15.wat
@@ -25,9 +25,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i64, f32, f32, i32, f64, f32, i32, i32, i32, f32, f64, f64, f64, i32, i32, f32) -> f64, f32, i32, i32, i32, i64, f32, i32, i32, f32, f64, f64, i32, f32, i32, f64 tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i64, v4: f32, v5: f32, v6: i32, v7: f64, v8: f32, v9: i32, v10: i32, v11: i32, v12: f32, v13: f64, v14: f64, v15: f64, v16: i32, v17: i32, v18: f32):

--- a/tests/disas/multi-16.wat
+++ b/tests/disas/multi-16.wat
@@ -12,9 +12,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/multi-17.wat
+++ b/tests/disas/multi-17.wat
@@ -29,9 +29,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, i64, i32, i32, i32) -> i32 tail
 ;;     fn0 = colocated u0:0 sig0
 ;;     stack_limit = gv2

--- a/tests/disas/multi-2.wat
+++ b/tests/disas/multi-2.wat
@@ -9,9 +9,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i64, i64) -> i64, i64 tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i64):

--- a/tests/disas/multi-3.wat
+++ b/tests/disas/multi-3.wat
@@ -16,9 +16,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i64, i64) -> i64, i64 tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i64, v4: i64):

--- a/tests/disas/multi-4.wat
+++ b/tests/disas/multi-4.wat
@@ -16,9 +16,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i64, i64) -> i64, i64 tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i64, v4: i64):

--- a/tests/disas/multi-5.wat
+++ b/tests/disas/multi-5.wat
@@ -14,9 +14,10 @@
 
 ;; function u0:0(i64 vmctx, i64) tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):

--- a/tests/disas/multi-6.wat
+++ b/tests/disas/multi-6.wat
@@ -14,9 +14,10 @@
 
 ;; function u0:0(i64 vmctx, i64) tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):

--- a/tests/disas/multi-7.wat
+++ b/tests/disas/multi-7.wat
@@ -12,9 +12,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) -> i64 tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):

--- a/tests/disas/multi-8.wat
+++ b/tests/disas/multi-8.wat
@@ -15,9 +15,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) -> i64 tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):

--- a/tests/disas/multi-9.wat
+++ b/tests/disas/multi-9.wat
@@ -18,9 +18,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) -> i64 tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):

--- a/tests/disas/non-fixed-size-memory.wat
+++ b/tests/disas/non-fixed-size-memory.wat
@@ -22,10 +22,11 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -35,7 +36,7 @@
 ;; @0041                               trapnz v6, heap_oob
 ;; @0041                               v7 = load.i64 notrap aligned can_move v0+56
 ;; @0041                               v8 = iadd v7, v4
-;; @0041                               istore8 little region1 v3, v8
+;; @0041                               istore8 little region2 v3, v8
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -44,10 +45,11 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -57,7 +59,7 @@
 ;; @0049                               trapnz v6, heap_oob
 ;; @0049                               v7 = load.i64 notrap aligned can_move v0+56
 ;; @0049                               v8 = iadd v7, v4
-;; @0049                               v9 = uload8.i32 little region1 v8
+;; @0049                               v9 = uload8.i32 little region2 v8
 ;; @004c                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/nullref.wat
+++ b/tests/disas/nullref.wat
@@ -14,9 +14,10 @@
 
 ;; function u0:0(i64 vmctx, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
@@ -29,9 +30,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):

--- a/tests/disas/passive-data.wat
+++ b/tests/disas/passive-data.wat
@@ -15,11 +15,12 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 152 "VMContext+0x98"
-;;     region2 = 144 "VMContext+0x90"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 152 "VMContext+0x98"
+;;     region3 = 144 "VMContext+0x90"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, i64, i64, i64) tail
 ;;     fn0 = colocated u805306368:1 sig0
 ;;     stack_limit = gv2
@@ -38,7 +39,7 @@
 ;; @003d                               v14 = iconst.i64 1
 ;; @003d                               v15 = imul v13, v14  ; v14 = 1
 ;; @003d                               v16 = iadd v12, v15
-;; @003d                               v17 = load.i32 notrap aligned region1 v0+152
+;; @003d                               v17 = load.i32 notrap aligned region2 v0+152
 ;; @003d                               v18 = uextend.i64 v17
 ;; @003d                               v19 = uextend.i64 v3
 ;; @003d                               v20 = uextend.i64 v4
@@ -47,7 +48,7 @@
 ;; @003d                               v23 = iadd v19, v22
 ;; @003d                               v24 = icmp ugt v23, v18
 ;; @003d                               trapnz v24, heap_oob
-;; @003d                               v25 = load.i64 notrap aligned region2 v0+144
+;; @003d                               v25 = load.i64 notrap aligned region3 v0+144
 ;; @003d                               v26 = uextend.i64 v3
 ;; @003d                               v27 = iadd v25, v26
 ;; @003d                               v28 = uextend.i64 v4
@@ -60,15 +61,16 @@
 ;;
 ;; function u0:1(i64 vmctx, i64) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 152 "VMContext+0x98"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 152 "VMContext+0x98"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
 ;; @0044                               v2 = iconst.i32 0
-;; @0044                               store notrap aligned region1 v2, v0+152  ; v2 = 0
+;; @0044                               store notrap aligned region2 v2, v0+152  ; v2 = 0
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/pic.wat
+++ b/tests/disas/pic.wat
@@ -49,17 +49,18 @@
 )
 ;; function u0:0(i64 vmctx, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
 ;; @005e                               v7 = load.i64 notrap aligned readonly can_move v0+56
 ;;                                     v15 = iconst.i64 0x0010_0000
 ;; @005e                               v8 = iadd v7, v15  ; v15 = 0x0010_0000
-;; @005e                               v9 = load.i32 little region1 v8
+;; @005e                               v9 = load.i32 little region2 v8
 ;; @0061                               jump block1
 ;;
 ;;                                 block1:
@@ -68,39 +69,40 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 1879048192 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(0))"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
-;;     region3 = 96 "VMContext+0x60"
-;;     region4 = 80 "VMContext+0x50"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 1879048192 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(0))"
+;;     region3 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region4 = 96 "VMContext+0x60"
+;;     region5 = 80 "VMContext+0x50"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, i64, i32) tail
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0066                               v5 = load.i32 notrap aligned region1 v0+128
+;; @0066                               v5 = load.i32 notrap aligned region2 v0+128
 ;; @0068                               v6 = iconst.i32 16
 ;; @006a                               v7 = isub v5, v6  ; v6 = 16
-;; @006d                               store notrap aligned region1 v7, v0+128
+;; @006d                               store notrap aligned region2 v7, v0+128
 ;; @0073                               v9 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0073                               v8 = uextend.i64 v2
 ;; @0073                               v10 = iadd v9, v8
-;; @0073                               v11 = load.i32 little region2 v10
+;; @0073                               v11 = load.i32 little region3 v10
 ;; @0078                               v12 = uextend.i64 v7
 ;; @0078                               v14 = iadd v9, v12
 ;; @0078                               v15 = iconst.i64 12
 ;; @0078                               v16 = iadd v14, v15  ; v15 = 12
-;; @0078                               store little region2 v11, v16
-;; @0084                               v21 = load.i64 notrap aligned readonly can_move region4 v0+80
-;; @0084                               v20 = load.i64 notrap aligned readonly can_move region3 v0+96
+;; @0078                               store little region3 v11, v16
+;; @0084                               v21 = load.i64 notrap aligned readonly can_move region5 v0+80
+;; @0084                               v20 = load.i64 notrap aligned readonly can_move region4 v0+96
 ;;                                     v29 = iconst.i32 -4
 ;;                                     v30 = iadd v5, v29  ; v29 = -4
 ;; @0084                               call_indirect sig0, v21(v20, v0, v30)
 ;;                                     v37 = iconst.i64 0x0010_0000
 ;; @0090                               v26 = iadd v9, v37  ; v37 = 0x0010_0000
-;; @0090                               store little region2 v11, v26
-;; @0098                               store notrap aligned region1 v5, v0+128
+;; @0090                               store little region3 v11, v26
+;; @0098                               store notrap aligned region2 v5, v0+128
 ;; @009c                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/pr2303.wat
+++ b/tests/disas/pr2303.wat
@@ -18,10 +18,11 @@
 
 ;; function u0:0(i64 vmctx, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 536870912 "PublicMemory"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 536870912 "PublicMemory"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -30,12 +31,12 @@
 ;; @003a                               v5 = uextend.i64 v4  ; v4 = 0
 ;; @003a                               v6 = load.i64 notrap aligned readonly can_move v0+56
 ;; @003a                               v7 = iadd v6, v5
-;; @003a                               v8 = load.i8x16 little region1 v7
+;; @003a                               v8 = load.i8x16 little region2 v7
 ;; @003e                               v9 = iconst.i32 16
 ;; @0040                               v10 = uextend.i64 v9  ; v9 = 16
 ;; @0040                               v11 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0040                               v12 = iadd v11, v10
-;; @0040                               v13 = load.i8x16 little region1 v12
+;; @0040                               v13 = load.i8x16 little region2 v12
 ;; @0046                               brif v2, block2, block4
 ;;
 ;;                                 block2:
@@ -46,7 +47,7 @@
 ;; @004d                               v20 = uextend.i64 v19  ; v19 = 32
 ;; @004d                               v21 = load.i64 notrap aligned readonly can_move v0+56
 ;; @004d                               v22 = iadd v21, v20
-;; @004d                               v23 = load.i8x16 little region1 v22
+;; @004d                               v23 = load.i8x16 little region2 v22
 ;; @0051                               v26 = bitcast.i8x16 little v18
 ;; @0051                               jump block3(v26, v23)
 ;;
@@ -58,7 +59,7 @@
 ;; @0057                               v31 = uextend.i64 v30  ; v30 = 0
 ;; @0057                               v32 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0057                               v33 = iadd v32, v31
-;; @0057                               v34 = load.i8x16 little region1 v33
+;; @0057                               v34 = load.i8x16 little region2 v33
 ;; @005b                               v35 = bitcast.i8x16 little v29
 ;; @005b                               jump block3(v35, v34)
 ;;
@@ -69,7 +70,7 @@
 ;; @005f                               v39 = uextend.i64 v3  ; v3 = 48
 ;; @005f                               v40 = load.i64 notrap aligned readonly can_move v0+56
 ;; @005f                               v41 = iadd v40, v39
-;; @005f                               store little region1 v38, v41
+;; @005f                               store little region2 v38, v41
 ;; @0063                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/pr2559.wat
+++ b/tests/disas/pr2559.wat
@@ -54,9 +54,10 @@
 
 ;; function u0:0(i64 vmctx, i64) -> i8x16, i8x16, i8x16 tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, i64) -> i8x16, i8x16, i8x16 tail
 ;;     fn0 = colocated u0:0 sig0
 ;;     stack_limit = gv2
@@ -95,9 +96,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64) -> i8x16, i8x16, i8x16 tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, i64) -> i8x16, i8x16, i8x16 tail
 ;;     fn0 = colocated u0:1 sig0
 ;;     stack_limit = gv2

--- a/tests/disas/readonly-funcrefs.wat
+++ b/tests/disas/readonly-funcrefs.wat
@@ -20,9 +20,10 @@
 
 ;; function u0:0(i64 vmctx, i64) tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
@@ -34,11 +35,12 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 1342177280 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
-;;     region2 = 40 "VMContext+0x28"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 1342177280 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
+;;     region3 = 40 "VMContext+0x28"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, i64) tail
 ;;     sig1 = (i64 vmctx, i32, i64) -> i64 tail
 ;;     fn0 = colocated u805306368:7 sig1
@@ -54,7 +56,7 @@
 ;; @0031                               v8 = ishl v5, v7  ; v7 = 3
 ;; @0031                               v9 = iadd v6, v8
 ;; @0031                               v11 = select_spectre_guard v4, v10, v9  ; v10 = 0
-;; @0031                               v12 = load.i64 user6 aligned region1 v11
+;; @0031                               v12 = load.i64 user6 aligned region2 v11
 ;; @0031                               v13 = iconst.i64 -2
 ;; @0031                               v14 = band v12, v13  ; v13 = -2
 ;; @0031                               brif v12, block3(v14), block2
@@ -66,7 +68,7 @@
 ;;
 ;;                                 block3(v15: i64):
 ;; @0031                               v21 = load.i32 user7 aligned readonly v15+16
-;; @0031                               v19 = load.i64 notrap aligned readonly can_move region2 v0+40
+;; @0031                               v19 = load.i64 notrap aligned readonly can_move region3 v0+40
 ;; @0031                               v20 = load.i32 notrap aligned readonly can_move v19
 ;; @0031                               v22 = icmp eq v21, v20
 ;; @0031                               trapz v22, user8

--- a/tests/disas/readonly-heap-base-pointer1.wat
+++ b/tests/disas/readonly-heap-base-pointer1.wat
@@ -9,10 +9,11 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -23,7 +24,7 @@
 ;; @0020                               v7 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0020                               v8 = iadd v7, v4
 ;; @0020                               v10 = select_spectre_guard v6, v9, v8  ; v9 = 0
-;; @0020                               v11 = load.i32 little region1 v10
+;; @0020                               v11 = load.i32 little region2 v10
 ;; @0023                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/readonly-heap-base-pointer2.wat
+++ b/tests/disas/readonly-heap-base-pointer2.wat
@@ -9,11 +9,12 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 48 "VMContext+0x30"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 48 "VMContext+0x30"
+;;     region3 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -21,11 +22,11 @@
 ;; @0022                               v5 = iconst.i64 0x0001_fffc
 ;; @0022                               v6 = icmp ugt v4, v5  ; v5 = 0x0001_fffc
 ;; @0022                               v10 = iconst.i64 0
-;; @0022                               v7 = load.i64 notrap aligned readonly can_move region1 v0+48
+;; @0022                               v7 = load.i64 notrap aligned readonly can_move region2 v0+48
 ;; @0022                               v8 = load.i64 notrap aligned readonly can_move v7
 ;; @0022                               v9 = iadd v8, v4
 ;; @0022                               v11 = select_spectre_guard v6, v10, v9  ; v10 = 0
-;; @0022                               v12 = load.i32 little region2 v11
+;; @0022                               v12 = load.i32 little region3 v11
 ;; @0025                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/readonly-heap-base-pointer3.wat
+++ b/tests/disas/readonly-heap-base-pointer3.wat
@@ -9,10 +9,11 @@
 )
 ;; function u0:0(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
@@ -22,7 +23,7 @@
 ;; @0020                               v6 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0020                               v7 = iadd v6, v2
 ;; @0020                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0
-;; @0020                               v10 = load.i32 little region1 v9
+;; @0020                               v10 = load.i32 little region2 v9
 ;; @0023                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/ref-func-0.wat
+++ b/tests/disas/ref-func-0.wat
@@ -15,10 +15,11 @@
 
 ;; function u0:0(i64 vmctx, i64) -> i32, i32, i64, i64 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 1610612736 "PublicGlobal"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 1610612736 "PublicGlobal"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
@@ -28,8 +29,8 @@
 ;; @0091                               v9 = iconst.i64 96
 ;; @0091                               v10 = iadd v0, v9  ; v9 = 96
 ;; @0091                               v11 = load.i32 notrap aligned v10
-;; @0093                               v12 = load.i64 notrap aligned region1 v0+112
-;; @0095                               v13 = load.i64 notrap aligned region1 v0+128
+;; @0093                               v12 = load.i64 notrap aligned region2 v0+112
+;; @0095                               v13 = load.i64 notrap aligned region2 v0+128
 ;; @0097                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/riscv64-component-builtins.wat
+++ b/tests/disas/riscv64-component-builtins.wat
@@ -12,16 +12,18 @@
 
 ;; function u0:0(i64 vmctx, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 16 "VMContext+0x10"
+;;     region1 = 268435504 "VMStoreContext+0x30"
+;;     region2 = 268435512 "VMStoreContext+0x38"
+;;     region3 = 16 "VMContext+0x10"
 ;;     sig0 = (i64 sext, i32 sext, i32 sext, i32 sext) -> i64 sext system_v
 ;;     sig1 = (i64 sext vmctx) system_v
 ;;
 ;; block0(v0: i64, v1: i64, v2: i32):
 ;;     v4 = get_frame_pointer.i64 
 ;;     v3 = load.i64 notrap aligned readonly can_move region0 v1+8
-;;     store notrap aligned v4, v3+48
+;;     store notrap aligned region1 v4, v3+48
 ;;     v5 = get_return_address.i64 
-;;     store notrap aligned v5, v3+56
+;;     store notrap aligned region2 v5, v3+56
 ;;     v6 = load.i32 notrap aligned v0+32
 ;;     v7 = iconst.i32 1
 ;;     v8 = band v6, v7  ; v7 = 1
@@ -35,7 +37,7 @@
 ;;     brif v15, block2, block1
 ;;
 ;; block1 cold:
-;;     v16 = load.i64 notrap aligned readonly can_move region1 v1+16
+;;     v16 = load.i64 notrap aligned readonly can_move region3 v1+16
 ;;     v17 = load.i64 notrap aligned readonly can_move v16+328
 ;;     call_indirect sig1, v17(v1)
 ;;     trap user1

--- a/tests/disas/select.wat
+++ b/tests/disas/select.wat
@@ -22,9 +22,10 @@
 
 ;; function u0:0(i64 vmctx, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
@@ -40,9 +41,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
@@ -58,9 +60,10 @@
 ;;
 ;; function u0:2(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/simd-store.wat
+++ b/tests/disas/simd-store.wat
@@ -86,10 +86,11 @@
 
 ;; function u0:0(i64 vmctx, i64, i8x16) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -98,7 +99,7 @@
 ;; @0047                               v5 = uextend.i64 v3  ; v3 = 0
 ;; @0047                               v6 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0047                               v7 = iadd v6, v5
-;; @0047                               store little region1 v4, v7
+;; @0047                               store little region2 v4, v7
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:
@@ -107,10 +108,11 @@
 ;;
 ;; function u0:10(i64 vmctx, i64, i8x16) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -121,7 +123,7 @@
 ;; @00df                               v7 = uextend.i64 v3  ; v3 = 0
 ;; @00df                               v8 = load.i64 notrap aligned readonly can_move v0+56
 ;; @00df                               v9 = iadd v8, v7
-;; @00df                               store little region1 v6, v9
+;; @00df                               store little region2 v6, v9
 ;; @00e3                               jump block1
 ;;
 ;;                                 block1:
@@ -130,10 +132,11 @@
 ;;
 ;; function u0:11(i64 vmctx, i64, i8x16) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -144,7 +147,7 @@
 ;; @00ef                               v7 = uextend.i64 v3  ; v3 = 0
 ;; @00ef                               v8 = load.i64 notrap aligned readonly can_move v0+56
 ;; @00ef                               v9 = iadd v8, v7
-;; @00ef                               store little region1 v6, v9
+;; @00ef                               store little region2 v6, v9
 ;; @00f3                               jump block1
 ;;
 ;;                                 block1:
@@ -153,10 +156,11 @@
 ;;
 ;; function u0:12(i64 vmctx, i64, i8x16) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -165,7 +169,7 @@
 ;; @00fe                               v5 = uextend.i64 v3  ; v3 = 0
 ;; @00fe                               v6 = load.i64 notrap aligned readonly can_move v0+56
 ;; @00fe                               v7 = iadd v6, v5
-;; @00fe                               store little region1 v4, v7
+;; @00fe                               store little region2 v4, v7
 ;; @0102                               jump block1
 ;;
 ;;                                 block1:
@@ -174,10 +178,11 @@
 ;;
 ;; function u0:13(i64 vmctx, i64, i8x16) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -188,7 +193,7 @@
 ;; @010d                               v7 = uextend.i64 v3  ; v3 = 0
 ;; @010d                               v8 = load.i64 notrap aligned readonly can_move v0+56
 ;; @010d                               v9 = iadd v8, v7
-;; @010d                               store little region1 v6, v9
+;; @010d                               store little region2 v6, v9
 ;; @0111                               jump block1
 ;;
 ;;                                 block1:
@@ -197,10 +202,11 @@
 ;;
 ;; function u0:14(i64 vmctx, i64, i8x16) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -211,7 +217,7 @@
 ;; @011c                               v7 = uextend.i64 v3  ; v3 = 0
 ;; @011c                               v8 = load.i64 notrap aligned readonly can_move v0+56
 ;; @011c                               v9 = iadd v8, v7
-;; @011c                               store little region1 v6, v9
+;; @011c                               store little region2 v6, v9
 ;; @0120                               jump block1
 ;;
 ;;                                 block1:
@@ -220,10 +226,11 @@
 ;;
 ;; function u0:15(i64 vmctx, i64, i8x16) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -232,7 +239,7 @@
 ;; @012b                               v5 = uextend.i64 v3  ; v3 = 0
 ;; @012b                               v6 = load.i64 notrap aligned readonly can_move v0+56
 ;; @012b                               v7 = iadd v6, v5
-;; @012b                               store little region1 v4, v7
+;; @012b                               store little region2 v4, v7
 ;; @012f                               jump block1
 ;;
 ;;                                 block1:
@@ -241,10 +248,11 @@
 ;;
 ;; function u0:16(i64 vmctx, i64, i8x16) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -255,7 +263,7 @@
 ;; @013a                               v7 = uextend.i64 v3  ; v3 = 0
 ;; @013a                               v8 = load.i64 notrap aligned readonly can_move v0+56
 ;; @013a                               v9 = iadd v8, v7
-;; @013a                               store little region1 v6, v9
+;; @013a                               store little region2 v6, v9
 ;; @013e                               jump block1
 ;;
 ;;                                 block1:
@@ -264,10 +272,11 @@
 ;;
 ;; function u0:17(i64 vmctx, i64, i8x16) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -278,7 +287,7 @@
 ;; @0149                               v7 = uextend.i64 v3  ; v3 = 0
 ;; @0149                               v8 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0149                               v9 = iadd v8, v7
-;; @0149                               store little region1 v6, v9
+;; @0149                               store little region2 v6, v9
 ;; @014d                               jump block1
 ;;
 ;;                                 block1:
@@ -287,10 +296,11 @@
 ;;
 ;; function u0:18(i64 vmctx, i64, i8x16) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -301,7 +311,7 @@
 ;; @0159                               v7 = uextend.i64 v3  ; v3 = 0
 ;; @0159                               v8 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0159                               v9 = iadd v8, v7
-;; @0159                               store little region1 v6, v9
+;; @0159                               store little region2 v6, v9
 ;; @015d                               jump block1
 ;;
 ;;                                 block1:
@@ -310,10 +320,11 @@
 ;;
 ;; function u0:19(i64 vmctx, i64, i8x16) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -322,7 +333,7 @@
 ;; @0168                               v5 = uextend.i64 v3  ; v3 = 0
 ;; @0168                               v6 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0168                               v7 = iadd v6, v5
-;; @0168                               store little region1 v4, v7
+;; @0168                               store little region2 v4, v7
 ;; @016c                               jump block1
 ;;
 ;;                                 block1:
@@ -331,10 +342,11 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i8x16) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -345,7 +357,7 @@
 ;; @0056                               v7 = uextend.i64 v3  ; v3 = 0
 ;; @0056                               v8 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0056                               v9 = iadd v8, v7
-;; @0056                               store little region1 v6, v9
+;; @0056                               store little region2 v6, v9
 ;; @005a                               jump block1
 ;;
 ;;                                 block1:
@@ -354,10 +366,11 @@
 ;;
 ;; function u0:20(i64 vmctx, i64, i8x16) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -368,7 +381,7 @@
 ;; @0177                               v7 = uextend.i64 v3  ; v3 = 0
 ;; @0177                               v8 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0177                               v9 = iadd v8, v7
-;; @0177                               store little region1 v6, v9
+;; @0177                               store little region2 v6, v9
 ;; @017b                               jump block1
 ;;
 ;;                                 block1:
@@ -377,10 +390,11 @@
 ;;
 ;; function u0:21(i64 vmctx, i64, i8x16) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -391,7 +405,7 @@
 ;; @0186                               v7 = uextend.i64 v3  ; v3 = 0
 ;; @0186                               v8 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0186                               v9 = iadd v8, v7
-;; @0186                               store little region1 v6, v9
+;; @0186                               store little region2 v6, v9
 ;; @018a                               jump block1
 ;;
 ;;                                 block1:
@@ -400,10 +414,11 @@
 ;;
 ;; function u0:22(i64 vmctx, i64, i8x16) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -414,7 +429,7 @@
 ;; @0195                               v7 = uextend.i64 v3  ; v3 = 0
 ;; @0195                               v8 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0195                               v9 = iadd v8, v7
-;; @0195                               store little region1 v6, v9
+;; @0195                               store little region2 v6, v9
 ;; @0199                               jump block1
 ;;
 ;;                                 block1:
@@ -423,10 +438,11 @@
 ;;
 ;; function u0:23(i64 vmctx, i64, i8x16) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -437,7 +453,7 @@
 ;; @01a4                               v7 = uextend.i64 v3  ; v3 = 0
 ;; @01a4                               v8 = load.i64 notrap aligned readonly can_move v0+56
 ;; @01a4                               v9 = iadd v8, v7
-;; @01a4                               store little region1 v6, v9
+;; @01a4                               store little region2 v6, v9
 ;; @01a8                               jump block1
 ;;
 ;;                                 block1:
@@ -446,10 +462,11 @@
 ;;
 ;; function u0:24(i64 vmctx, i64, i8x16) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -460,7 +477,7 @@
 ;; @01b3                               v7 = uextend.i64 v3  ; v3 = 0
 ;; @01b3                               v8 = load.i64 notrap aligned readonly can_move v0+56
 ;; @01b3                               v9 = iadd v8, v7
-;; @01b3                               store little region1 v6, v9
+;; @01b3                               store little region2 v6, v9
 ;; @01b7                               jump block1
 ;;
 ;;                                 block1:
@@ -469,10 +486,11 @@
 ;;
 ;; function u0:25(i64 vmctx, i64, i8x16) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -483,7 +501,7 @@
 ;; @01c2                               v7 = uextend.i64 v3  ; v3 = 0
 ;; @01c2                               v8 = load.i64 notrap aligned readonly can_move v0+56
 ;; @01c2                               v9 = iadd v8, v7
-;; @01c2                               store little region1 v6, v9
+;; @01c2                               store little region2 v6, v9
 ;; @01c6                               jump block1
 ;;
 ;;                                 block1:
@@ -492,10 +510,11 @@
 ;;
 ;; function u0:26(i64 vmctx, i64, i8x16) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -506,7 +525,7 @@
 ;; @01d1                               v7 = uextend.i64 v3  ; v3 = 0
 ;; @01d1                               v8 = load.i64 notrap aligned readonly can_move v0+56
 ;; @01d1                               v9 = iadd v8, v7
-;; @01d1                               store little region1 v6, v9
+;; @01d1                               store little region2 v6, v9
 ;; @01d5                               jump block1
 ;;
 ;;                                 block1:
@@ -515,10 +534,11 @@
 ;;
 ;; function u0:27(i64 vmctx, i64, i8x16) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -529,7 +549,7 @@
 ;; @01e0                               v7 = uextend.i64 v3  ; v3 = 0
 ;; @01e0                               v8 = load.i64 notrap aligned readonly can_move v0+56
 ;; @01e0                               v9 = iadd v8, v7
-;; @01e0                               store little region1 v6, v9
+;; @01e0                               store little region2 v6, v9
 ;; @01e4                               jump block1
 ;;
 ;;                                 block1:
@@ -538,10 +558,11 @@
 ;;
 ;; function u0:28(i64 vmctx, i64, i8x16) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -552,7 +573,7 @@
 ;; @01ef                               v7 = uextend.i64 v3  ; v3 = 0
 ;; @01ef                               v8 = load.i64 notrap aligned readonly can_move v0+56
 ;; @01ef                               v9 = iadd v8, v7
-;; @01ef                               store little region1 v6, v9
+;; @01ef                               store little region2 v6, v9
 ;; @01f3                               jump block1
 ;;
 ;;                                 block1:
@@ -561,10 +582,11 @@
 ;;
 ;; function u0:29(i64 vmctx, i64, i8x16) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -575,7 +597,7 @@
 ;; @01fe                               v7 = uextend.i64 v3  ; v3 = 0
 ;; @01fe                               v8 = load.i64 notrap aligned readonly can_move v0+56
 ;; @01fe                               v9 = iadd v8, v7
-;; @01fe                               store little region1 v6, v9
+;; @01fe                               store little region2 v6, v9
 ;; @0202                               jump block1
 ;;
 ;;                                 block1:
@@ -584,10 +606,11 @@
 ;;
 ;; function u0:2(i64 vmctx, i64, i8x16) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -598,7 +621,7 @@
 ;; @0065                               v7 = uextend.i64 v3  ; v3 = 0
 ;; @0065                               v8 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0065                               v9 = iadd v8, v7
-;; @0065                               store little region1 v6, v9
+;; @0065                               store little region2 v6, v9
 ;; @0069                               jump block1
 ;;
 ;;                                 block1:
@@ -607,10 +630,11 @@
 ;;
 ;; function u0:30(i64 vmctx, i64, i8x16) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -621,7 +645,7 @@
 ;; @020d                               v7 = uextend.i64 v3  ; v3 = 0
 ;; @020d                               v8 = load.i64 notrap aligned readonly can_move v0+56
 ;; @020d                               v9 = iadd v8, v7
-;; @020d                               store little region1 v6, v9
+;; @020d                               store little region2 v6, v9
 ;; @0211                               jump block1
 ;;
 ;;                                 block1:
@@ -630,10 +654,11 @@
 ;;
 ;; function u0:31(i64 vmctx, i64, i8x16) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -644,7 +669,7 @@
 ;; @021c                               v7 = uextend.i64 v3  ; v3 = 0
 ;; @021c                               v8 = load.i64 notrap aligned readonly can_move v0+56
 ;; @021c                               v9 = iadd v8, v7
-;; @021c                               store little region1 v6, v9
+;; @021c                               store little region2 v6, v9
 ;; @0220                               jump block1
 ;;
 ;;                                 block1:
@@ -653,10 +678,11 @@
 ;;
 ;; function u0:32(i64 vmctx, i64, i8x16) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -667,7 +693,7 @@
 ;; @022b                               v7 = uextend.i64 v3  ; v3 = 0
 ;; @022b                               v8 = load.i64 notrap aligned readonly can_move v0+56
 ;; @022b                               v9 = iadd v8, v7
-;; @022b                               store little region1 v6, v9
+;; @022b                               store little region2 v6, v9
 ;; @022f                               jump block1
 ;;
 ;;                                 block1:
@@ -676,10 +702,11 @@
 ;;
 ;; function u0:33(i64 vmctx, i64, i8x16) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -690,7 +717,7 @@
 ;; @023a                               v7 = uextend.i64 v3  ; v3 = 0
 ;; @023a                               v8 = load.i64 notrap aligned readonly can_move v0+56
 ;; @023a                               v9 = iadd v8, v7
-;; @023a                               store little region1 v6, v9
+;; @023a                               store little region2 v6, v9
 ;; @023e                               jump block1
 ;;
 ;;                                 block1:
@@ -699,10 +726,11 @@
 ;;
 ;; function u0:3(i64 vmctx, i64, i8x16) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -713,7 +741,7 @@
 ;; @0075                               v7 = uextend.i64 v3  ; v3 = 0
 ;; @0075                               v8 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0075                               v9 = iadd v8, v7
-;; @0075                               store little region1 v6, v9
+;; @0075                               store little region2 v6, v9
 ;; @0079                               jump block1
 ;;
 ;;                                 block1:
@@ -722,10 +750,11 @@
 ;;
 ;; function u0:4(i64 vmctx, i64, i8x16) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -734,7 +763,7 @@
 ;; @0084                               v5 = uextend.i64 v3  ; v3 = 0
 ;; @0084                               v6 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0084                               v7 = iadd v6, v5
-;; @0084                               store little region1 v4, v7
+;; @0084                               store little region2 v4, v7
 ;; @0088                               jump block1
 ;;
 ;;                                 block1:
@@ -743,10 +772,11 @@
 ;;
 ;; function u0:5(i64 vmctx, i64, i8x16) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -757,7 +787,7 @@
 ;; @0093                               v7 = uextend.i64 v3  ; v3 = 0
 ;; @0093                               v8 = load.i64 notrap aligned readonly can_move v0+56
 ;; @0093                               v9 = iadd v8, v7
-;; @0093                               store little region1 v6, v9
+;; @0093                               store little region2 v6, v9
 ;; @0097                               jump block1
 ;;
 ;;                                 block1:
@@ -766,10 +796,11 @@
 ;;
 ;; function u0:6(i64 vmctx, i64, i8x16) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -780,7 +811,7 @@
 ;; @00a2                               v7 = uextend.i64 v3  ; v3 = 0
 ;; @00a2                               v8 = load.i64 notrap aligned readonly can_move v0+56
 ;; @00a2                               v9 = iadd v8, v7
-;; @00a2                               store little region1 v6, v9
+;; @00a2                               store little region2 v6, v9
 ;; @00a6                               jump block1
 ;;
 ;;                                 block1:
@@ -789,10 +820,11 @@
 ;;
 ;; function u0:7(i64 vmctx, i64, i8x16) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -803,7 +835,7 @@
 ;; @00b2                               v7 = uextend.i64 v3  ; v3 = 0
 ;; @00b2                               v8 = load.i64 notrap aligned readonly can_move v0+56
 ;; @00b2                               v9 = iadd v8, v7
-;; @00b2                               store little region1 v6, v9
+;; @00b2                               store little region2 v6, v9
 ;; @00b6                               jump block1
 ;;
 ;;                                 block1:
@@ -812,10 +844,11 @@
 ;;
 ;; function u0:8(i64 vmctx, i64, i8x16) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -824,7 +857,7 @@
 ;; @00c1                               v5 = uextend.i64 v3  ; v3 = 0
 ;; @00c1                               v6 = load.i64 notrap aligned readonly can_move v0+56
 ;; @00c1                               v7 = iadd v6, v5
-;; @00c1                               store little region1 v4, v7
+;; @00c1                               store little region2 v4, v7
 ;; @00c5                               jump block1
 ;;
 ;;                                 block1:
@@ -833,10 +866,11 @@
 ;;
 ;; function u0:9(i64 vmctx, i64, i8x16) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -847,7 +881,7 @@
 ;; @00d0                               v7 = uextend.i64 v3  ; v3 = 0
 ;; @00d0                               v8 = load.i64 notrap aligned readonly can_move v0+56
 ;; @00d0                               v9 = iadd v8, v7
-;; @00d0                               store little region1 v6, v9
+;; @00d0                               store little region2 v6, v9
 ;; @00d4                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/simd.wat
+++ b/tests/disas/simd.wat
@@ -32,9 +32,10 @@
 
 ;; function u0:0(i64 vmctx, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
@@ -49,9 +50,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     const0 = 0x00000000000000000000000000000000
 ;;     stack_limit = gv2
 ;;
@@ -69,9 +71,10 @@
 ;;
 ;; function u0:2(i64 vmctx, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     const0 = 0x00000004000000030000000200000001
 ;;     stack_limit = gv2
 ;;
@@ -87,9 +90,10 @@
 ;;
 ;; function u0:3(i64 vmctx, i64) tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     const0 = 0x00000000000000000000000000000000
 ;;     stack_limit = gv2
 ;;

--- a/tests/disas/simple.wat
+++ b/tests/disas/simple.wat
@@ -20,9 +20,10 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -36,9 +37,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -49,9 +51,10 @@
 ;;
 ;; function u0:2(i64 vmctx, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):

--- a/tests/disas/stack-switching/resume-suspend-data-passing.wat
+++ b/tests/disas/stack-switching/resume-suspend-data-passing.wat
@@ -40,9 +40,11 @@
 ;; function u0:0(i64 vmctx, i64) tail {
 ;;     ss0 = explicit_slot 16, align = 65536
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 268435544 "VMStoreContext+0x58"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
@@ -58,8 +60,8 @@
 ;; @0040                               jump block2(v3)  ; v3 = 10
 ;;
 ;;                                 block2(v4: i32):
-;; @0044                               v8 = load.i64 notrap aligned v7+88
-;; @0044                               v9 = load.i64 notrap aligned v7+96
+;; @0044                               v8 = load.i64 notrap aligned region2 v7+88
+;; @0044                               v9 = load.i64 notrap aligned region2 v7+96
 ;; @0044                               v12 = iconst.i64 1
 ;; @0044                               v16 = iconst.i64 24
 ;; @003a                               v2 = iconst.i32 0
@@ -147,9 +149,12 @@
 ;; function u0:1(i64 vmctx, i64) tail {
 ;;     ss0 = explicit_slot 8, align = 256
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 268435544 "VMStoreContext+0x58"
+;;     region3 = 268435528 "VMStoreContext+0x48"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, i32) -> i64 tail
 ;;     sig1 = (i64 vmctx, i64, i32, i32) -> i64 tail
 ;;     fn0 = colocated u805306368:6 sig0
@@ -200,15 +205,15 @@
 ;;                                     v127 = iadd v22, v126  ; v126 = 1
 ;; @0062                               store notrap aligned v127, v17+72
 ;; @0062                               v26 = load.i64 notrap aligned v17+64
-;; @0062                               v28 = load.i64 notrap aligned v27+88
-;; @0062                               v29 = load.i64 notrap aligned v27+96
+;; @0062                               v28 = load.i64 notrap aligned region2 v27+88
+;; @0062                               v29 = load.i64 notrap aligned region2 v27+96
 ;; @0062                               store notrap aligned v28, v26+48
 ;; @0062                               store notrap aligned v29, v26+56
 ;;                                     v128 = iconst.i64 0
 ;; @0062                               store notrap aligned v128, v17+64  ; v128 = 0
 ;;                                     v129 = iconst.i64 2
-;; @0062                               store notrap aligned v129, v27+88  ; v129 = 2
-;; @0062                               store notrap aligned v17, v27+96
+;; @0062                               store notrap aligned region2 v129, v27+88  ; v129 = 2
+;; @0062                               store notrap aligned region2 v17, v27+96
 ;;                                     v130 = iconst.i32 1
 ;;                                     v131 = iconst.i64 16
 ;;                                     v132 = iadd v17, v131  ; v131 = 16
@@ -216,14 +221,14 @@
 ;;                                     v133 = iconst.i32 2
 ;;                                     v134 = iadd v29, v131  ; v131 = 16
 ;; @0062                               store notrap aligned v133, v134  ; v133 = 2
-;; @0062                               v44 = load.i64 notrap aligned v27+72
+;; @0062                               v44 = load.i64 notrap aligned region3 v27+72
 ;; @0062                               store notrap aligned v44, v29+8
-;; @0062                               v45 = load.i64 notrap aligned v27+24
+;; @0062                               v45 = load.i64 notrap aligned region1 v27+24
 ;; @0062                               store notrap aligned v45, v29
 ;; @0062                               v48 = load.i64 notrap aligned v17
-;; @0062                               store notrap aligned v48, v27+24
+;; @0062                               store notrap aligned region1 v48, v27+24
 ;; @0062                               v49 = load.i64 notrap aligned v17+8
-;; @0062                               store notrap aligned v49, v27+72
+;; @0062                               store notrap aligned region3 v49, v27+72
 ;;                                     v135 = iconst.i64 24
 ;;                                     v136 = iadd v29, v135  ; v135 = 24
 ;; @0062                               store notrap aligned v130, v136+4  ; v130 = 1
@@ -239,10 +244,10 @@
 ;;                                     v141 = iadd v64, v140  ; v140 = -24
 ;;                                     v142 = iconst.i64 0x0001_0000_0000
 ;; @0062                               v67 = stack_switch v141, v141, v142  ; v142 = 0x0001_0000_0000
-;; @0062                               v69 = load.i64 notrap aligned v27+88
-;; @0062                               v70 = load.i64 notrap aligned v27+96
-;; @0062                               store notrap aligned v28, v27+88
-;; @0062                               store notrap aligned v29, v27+96
+;; @0062                               v69 = load.i64 notrap aligned region2 v27+88
+;; @0062                               v70 = load.i64 notrap aligned region2 v27+96
+;; @0062                               store notrap aligned region2 v28, v27+88
+;; @0062                               store notrap aligned region2 v29, v27+96
 ;; @0062                               store notrap aligned v130, v134  ; v130 = 1
 ;;                                     v143 = iconst.i32 0
 ;; @0062                               store notrap aligned v143, v136  ; v143 = 0
@@ -254,12 +259,12 @@
 ;; @0062                               brif v145, block7, block6
 ;;
 ;;                                 block7:
-;; @0062                               v84 = load.i64 notrap aligned v27+72
+;; @0062                               v84 = load.i64 notrap aligned region3 v27+72
 ;; @0062                               store notrap aligned v84, v70+8
 ;; @0062                               v87 = load.i64 notrap aligned v29
-;; @0062                               store notrap aligned v87, v27+24
+;; @0062                               store notrap aligned region1 v87, v27+24
 ;; @0062                               v88 = load.i64 notrap aligned v29+8
-;; @0062                               store notrap aligned v88, v27+72
+;; @0062                               store notrap aligned region3 v88, v27+72
 ;; @0062                               v90 = load.i64 notrap aligned v70+72
 ;; @0062                               jump block8
 ;;
@@ -281,9 +286,9 @@
 ;;
 ;;                                 block6:
 ;; @0062                               v104 = load.i64 notrap aligned v29
-;; @0062                               store notrap aligned v104, v27+24
+;; @0062                               store notrap aligned region1 v104, v27+24
 ;; @0062                               v105 = load.i64 notrap aligned v29+8
-;; @0062                               store notrap aligned v105, v27+72
+;; @0062                               store notrap aligned region3 v105, v27+72
 ;; @0062                               v108 = iconst.i32 4
 ;;                                     v146 = iconst.i64 16
 ;;                                     v147 = iadd.i64 v70, v146  ; v146 = 16

--- a/tests/disas/stack-switching/resume-suspend.wat
+++ b/tests/disas/stack-switching/resume-suspend.wat
@@ -24,15 +24,17 @@
 
 ;; function u0:0(i64 vmctx, i64) tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 268435544 "VMStoreContext+0x58"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
 ;; @003b                               v4 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @003b                               v5 = load.i64 notrap aligned v4+88
-;; @003b                               v6 = load.i64 notrap aligned v4+96
+;; @003b                               v5 = load.i64 notrap aligned region2 v4+88
+;; @003b                               v6 = load.i64 notrap aligned region2 v4+96
 ;; @003b                               v9 = iconst.i64 1
 ;; @003b                               v13 = iconst.i64 24
 ;; @003b                               v17 = iconst.i32 0
@@ -108,9 +110,12 @@
 ;; function u0:1(i64 vmctx, i64) tail {
 ;;     ss0 = explicit_slot 8, align = 256
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 268435544 "VMStoreContext+0x58"
+;;     region3 = 268435528 "VMStoreContext+0x48"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, i32) -> i64 tail
 ;;     sig1 = (i64 vmctx, i64, i32, i32) -> i64 tail
 ;;     fn0 = colocated u805306368:6 sig0
@@ -144,15 +149,15 @@
 ;; @004e                               store notrap aligned v30, v134+72
 ;; @004e                               v31 = load.i64 notrap aligned v134+64
 ;; @004e                               v32 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @004e                               v33 = load.i64 notrap aligned v32+88
-;; @004e                               v34 = load.i64 notrap aligned v32+96
+;; @004e                               v33 = load.i64 notrap aligned region2 v32+88
+;; @004e                               v34 = load.i64 notrap aligned region2 v32+96
 ;; @004e                               store notrap aligned v33, v31+48
 ;; @004e                               store notrap aligned v34, v31+56
 ;; @0040                               v2 = iconst.i64 0
 ;; @004e                               store notrap aligned v2, v134+64  ; v2 = 0
 ;; @004e                               v36 = iconst.i64 2
-;; @004e                               store notrap aligned v36, v32+88  ; v36 = 2
-;; @004e                               store notrap aligned v134, v32+96
+;; @004e                               store notrap aligned region2 v36, v32+88  ; v36 = 2
+;; @004e                               store notrap aligned region2 v134, v32+96
 ;; @004e                               v40 = iconst.i32 1
 ;; @004e                               v41 = iconst.i64 16
 ;; @004e                               v42 = iadd v134, v41  ; v41 = 16
@@ -160,14 +165,14 @@
 ;; @004e                               v43 = iconst.i32 2
 ;; @004e                               v45 = iadd v34, v41  ; v41 = 16
 ;; @004e                               store notrap aligned v43, v45  ; v43 = 2
-;; @004e                               v49 = load.i64 notrap aligned v32+72
+;; @004e                               v49 = load.i64 notrap aligned region3 v32+72
 ;; @004e                               store notrap aligned v49, v34+8
-;; @004e                               v50 = load.i64 notrap aligned v32+24
+;; @004e                               v50 = load.i64 notrap aligned region1 v32+24
 ;; @004e                               store notrap aligned v50, v34
 ;; @004e                               v53 = load.i64 notrap aligned v134
-;; @004e                               store notrap aligned v53, v32+24
+;; @004e                               store notrap aligned region1 v53, v32+24
 ;; @004e                               v54 = load.i64 notrap aligned v134+8
-;; @004e                               store notrap aligned v54, v32+72
+;; @004e                               store notrap aligned region3 v54, v32+72
 ;; @004e                               v55 = iconst.i64 24
 ;; @004e                               v56 = iadd v34, v55  ; v55 = 24
 ;; @004e                               store notrap aligned v40, v56+4  ; v40 = 1
@@ -185,10 +190,10 @@
 ;; @004e                               v71 = iadd v69, v70  ; v70 = -24
 ;;                                     v138 = iconst.i64 0x0001_0000_0000
 ;; @004e                               v72 = stack_switch v71, v71, v138  ; v138 = 0x0001_0000_0000
-;; @004e                               v74 = load.i64 notrap aligned v32+88
-;; @004e                               v75 = load.i64 notrap aligned v32+96
-;; @004e                               store notrap aligned v33, v32+88
-;; @004e                               store notrap aligned v34, v32+96
+;; @004e                               v74 = load.i64 notrap aligned region2 v32+88
+;; @004e                               v75 = load.i64 notrap aligned region2 v32+96
+;; @004e                               store notrap aligned region2 v33, v32+88
+;; @004e                               store notrap aligned region2 v34, v32+96
 ;; @004e                               store notrap aligned v40, v45  ; v40 = 1
 ;;                                     v141 = iconst.i32 0
 ;; @004e                               store notrap aligned v141, v56  ; v141 = 0
@@ -200,12 +205,12 @@
 ;; @004e                               brif v84, block5, block4
 ;;
 ;;                                 block5:
-;; @004e                               v89 = load.i64 notrap aligned v32+72
+;; @004e                               v89 = load.i64 notrap aligned region3 v32+72
 ;; @004e                               store notrap aligned v89, v75+8
 ;; @004e                               v92 = load.i64 notrap aligned v34
-;; @004e                               store notrap aligned v92, v32+24
+;; @004e                               store notrap aligned region1 v92, v32+24
 ;; @004e                               v93 = load.i64 notrap aligned v34+8
-;; @004e                               store notrap aligned v93, v32+72
+;; @004e                               store notrap aligned region3 v93, v32+72
 ;; @004e                               v95 = load.i64 notrap aligned v75+72
 ;; @004e                               jump block6
 ;;
@@ -231,9 +236,9 @@
 ;;
 ;;                                 block4:
 ;; @004e                               v108 = load.i64 notrap aligned v34
-;; @004e                               store notrap aligned v108, v32+24
+;; @004e                               store notrap aligned region1 v108, v32+24
 ;; @004e                               v109 = load.i64 notrap aligned v34+8
-;; @004e                               store notrap aligned v109, v32+72
+;; @004e                               store notrap aligned region3 v109, v32+72
 ;; @004e                               v112 = iconst.i32 4
 ;;                                     v142 = iconst.i64 16
 ;;                                     v143 = iadd.i64 v75, v142  ; v142 = 16

--- a/tests/disas/stack-switching/symmetric-switch.wat
+++ b/tests/disas/stack-switching/symmetric-switch.wat
@@ -28,9 +28,12 @@
 ;; function u0:0(i64 vmctx, i64) tail {
 ;;     ss0 = explicit_slot 24, align = 256
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 268435544 "VMStoreContext+0x58"
+;;     region3 = 268435528 "VMStoreContext+0x48"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, i32) -> i64 tail
 ;;     sig1 = (i64 vmctx, i64, i32, i32) -> i64 tail
 ;;     fn0 = colocated u805306368:6 sig0
@@ -66,8 +69,8 @@
 ;; @003e                               v23 = iconst.i64 48
 ;; @003e                               v24 = iadd v0, v23  ; v23 = 48
 ;; @003e                               v25 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @003e                               v26 = load.i64 notrap aligned v25+88
-;; @003e                               v27 = load.i64 notrap aligned v25+96
+;; @003e                               v26 = load.i64 notrap aligned region2 v25+88
+;; @003e                               v27 = load.i64 notrap aligned region2 v25+96
 ;; @003e                               jump block2(v26, v27)
 ;;
 ;;                                 block2(v28: i64, v29: i64):
@@ -118,7 +121,7 @@
 ;; @003e                               v58 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @003e                               v59 = iconst.i64 0
 ;; @003e                               v60 = iadd v52, v59  ; v59 = 0
-;; @003e                               v61 = load.i64 notrap aligned v58+72
+;; @003e                               v61 = load.i64 notrap aligned region3 v58+72
 ;; @003e                               store notrap aligned v61, v60+8
 ;; @003e                               v62 = load.i64 notrap aligned v27+72
 ;; @003e                               v63 = uextend.i128 v27
@@ -177,14 +180,14 @@
 ;; @003e                               store.i64 notrap aligned v33, v102+56
 ;; @003e                               v103 = iconst.i64 2
 ;; @003e                               v104 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @003e                               store notrap aligned v103, v104+88  ; v103 = 2
-;; @003e                               store.i64 notrap aligned v14, v104+96
+;; @003e                               store notrap aligned region2 v103, v104+88  ; v103 = 2
+;; @003e                               store.i64 notrap aligned region2 v14, v104+96
 ;; @003e                               v105 = iconst.i64 0
 ;; @003e                               v106 = iadd v98, v105  ; v105 = 0
 ;; @003e                               v107 = load.i64 notrap aligned v106
-;; @003e                               store notrap aligned v107, v58+24
+;; @003e                               store notrap aligned region1 v107, v58+24
 ;; @003e                               v108 = load.i64 notrap aligned v106+8
-;; @003e                               store notrap aligned v108, v58+72
+;; @003e                               store notrap aligned region3 v108, v58+72
 ;; @003e                               v109 = iconst.i64 80
 ;; @003e                               v110 = iadd.i64 v29, v109  ; v109 = 80
 ;; @003e                               v111 = load.i64 notrap aligned v110
@@ -229,9 +232,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i128) tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i128):
@@ -244,9 +248,12 @@
 ;; function u0:2(i64 vmctx, i64) tail {
 ;;     ss0 = explicit_slot 8, align = 256
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 268435544 "VMStoreContext+0x58"
+;;     region3 = 268435528 "VMStoreContext+0x48"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, i32) -> i64 tail
 ;;     sig1 = (i64 vmctx, i64, i32, i32) -> i64 tail
 ;;     fn0 = colocated u805306368:6 sig0
@@ -284,16 +291,16 @@
 ;; @004b                               store notrap aligned v22, v14+72
 ;; @004b                               v23 = load.i64 notrap aligned v14+64
 ;; @004b                               v24 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @004b                               v25 = load.i64 notrap aligned v24+88
-;; @004b                               v26 = load.i64 notrap aligned v24+96
+;; @004b                               v25 = load.i64 notrap aligned region2 v24+88
+;; @004b                               v26 = load.i64 notrap aligned region2 v24+96
 ;; @004b                               store notrap aligned v25, v23+48
 ;; @004b                               store notrap aligned v26, v23+56
 ;; @004b                               v27 = iconst.i64 0
 ;; @004b                               store notrap aligned v27, v14+64  ; v27 = 0
 ;; @004b                               v28 = iconst.i64 2
 ;; @004b                               v29 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @004b                               store notrap aligned v28, v29+88  ; v28 = 2
-;; @004b                               store notrap aligned v14, v29+96
+;; @004b                               store notrap aligned region2 v28, v29+88  ; v28 = 2
+;; @004b                               store notrap aligned region2 v14, v29+96
 ;; @004b                               v30 = iconst.i64 0
 ;; @004b                               v31 = iadd v14, v30  ; v30 = 0
 ;; @004b                               v32 = iconst.i32 1
@@ -307,16 +314,16 @@
 ;; @004b                               v38 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @004b                               v39 = iconst.i64 0
 ;; @004b                               v40 = iadd v26, v39  ; v39 = 0
-;; @004b                               v41 = load.i64 notrap aligned v38+72
+;; @004b                               v41 = load.i64 notrap aligned region3 v38+72
 ;; @004b                               store notrap aligned v41, v40+8
-;; @004b                               v42 = load.i64 notrap aligned v38+24
+;; @004b                               v42 = load.i64 notrap aligned region1 v38+24
 ;; @004b                               store notrap aligned v42, v40
 ;; @004b                               v43 = iconst.i64 0
 ;; @004b                               v44 = iadd v31, v43  ; v43 = 0
 ;; @004b                               v45 = load.i64 notrap aligned v44
-;; @004b                               store notrap aligned v45, v38+24
+;; @004b                               store notrap aligned region1 v45, v38+24
 ;; @004b                               v46 = load.i64 notrap aligned v44+8
-;; @004b                               store notrap aligned v46, v38+72
+;; @004b                               store notrap aligned region3 v46, v38+72
 ;; @004b                               v47 = iconst.i64 24
 ;; @004b                               v48 = iadd v26, v47  ; v47 = 24
 ;; @004b                               v49 = iconst.i32 1
@@ -341,11 +348,11 @@
 ;; @004b                               v63 = iadd v61, v62  ; v62 = -24
 ;; @004b                               v64 = stack_switch v63, v63, v58
 ;; @004b                               v65 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @004b                               v66 = load.i64 notrap aligned v65+88
-;; @004b                               v67 = load.i64 notrap aligned v65+96
+;; @004b                               v66 = load.i64 notrap aligned region2 v65+88
+;; @004b                               v67 = load.i64 notrap aligned region2 v65+96
 ;; @004b                               v68 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @004b                               store notrap aligned v25, v68+88
-;; @004b                               store notrap aligned v26, v68+96
+;; @004b                               store notrap aligned region2 v25, v68+88
+;; @004b                               store notrap aligned region2 v26, v68+96
 ;; @004b                               v69 = iconst.i32 1
 ;; @004b                               v70 = iconst.i64 16
 ;; @004b                               v71 = iadd v26, v70  ; v70 = 16
@@ -366,14 +373,14 @@
 ;; @004b                               v78 = iadd.i64 v67, v77  ; v77 = 0
 ;; @004b                               v79 = iconst.i64 0
 ;; @004b                               v80 = iadd v78, v79  ; v79 = 0
-;; @004b                               v81 = load.i64 notrap aligned v38+72
+;; @004b                               v81 = load.i64 notrap aligned region3 v38+72
 ;; @004b                               store notrap aligned v81, v80+8
 ;; @004b                               v82 = iconst.i64 0
 ;; @004b                               v83 = iadd.i64 v26, v82  ; v82 = 0
 ;; @004b                               v84 = load.i64 notrap aligned v83
-;; @004b                               store notrap aligned v84, v38+24
+;; @004b                               store notrap aligned region1 v84, v38+24
 ;; @004b                               v85 = load.i64 notrap aligned v83+8
-;; @004b                               store notrap aligned v85, v38+72
+;; @004b                               store notrap aligned region3 v85, v38+72
 ;; @004b                               v86 = ireduce.i32 v64
 ;; @004b                               v87 = load.i64 notrap aligned v67+72
 ;; @004b                               v88 = uextend.i128 v67
@@ -394,9 +401,9 @@
 ;; @004b                               v94 = iconst.i64 0
 ;; @004b                               v95 = iadd.i64 v26, v94  ; v94 = 0
 ;; @004b                               v96 = load.i64 notrap aligned v95
-;; @004b                               store notrap aligned v96, v38+24
+;; @004b                               store notrap aligned region1 v96, v38+24
 ;; @004b                               v97 = load.i64 notrap aligned v95+8
-;; @004b                               store notrap aligned v97, v38+72
+;; @004b                               store notrap aligned region3 v97, v38+72
 ;; @004b                               v98 = iconst.i64 0
 ;; @004b                               v99 = iadd.i64 v67, v98  ; v98 = 0
 ;; @004b                               v100 = iconst.i32 4

--- a/tests/disas/startup-data-active.wat
+++ b/tests/disas/startup-data-active.wat
@@ -10,6 +10,9 @@
 )
 ;; function u2415919104:1(i64 vmctx, i64, i64, i64) -> i8 system_v {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435528 "VMStoreContext+0x48"
+;;     region2 = 268435520 "VMStoreContext+0x40"
+;;     region3 = 268435536 "VMStoreContext+0x50"
 ;;     sig0 = (i64 vmctx, i64) tail
 ;;     fn0 = colocated u2415919104:0 sig0
 ;;
@@ -19,11 +22,11 @@
 ;; block1:
 ;;     v5 = get_frame_pointer.i64 
 ;;     v4 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;     store notrap aligned v5, v4+72
+;;     store notrap aligned region1 v5, v4+72
 ;;     v6 = get_stack_pointer.i64 
-;;     store notrap aligned v6, v4+64
+;;     store notrap aligned region2 v6, v4+64
 ;;     v7 = get_exception_handler_address.i64 block1, 0
-;;     store notrap aligned v7, v4+80
+;;     store notrap aligned region3 v7, v4+80
 ;;     try_call fn0(v0, v1), sig0, block2, [ default: block3 ]
 ;;
 ;; block2:

--- a/tests/disas/startup-elem-active.wat
+++ b/tests/disas/startup-elem-active.wat
@@ -14,6 +14,9 @@
 )
 ;; function u2415919104:1(i64 vmctx, i64, i64, i64) -> i8 system_v {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435528 "VMStoreContext+0x48"
+;;     region2 = 268435520 "VMStoreContext+0x40"
+;;     region3 = 268435536 "VMStoreContext+0x50"
 ;;     sig0 = (i64 vmctx, i64) tail
 ;;     fn0 = colocated u2415919104:0 sig0
 ;;
@@ -23,11 +26,11 @@
 ;; block1:
 ;;     v5 = get_frame_pointer.i64 
 ;;     v4 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;     store notrap aligned v5, v4+72
+;;     store notrap aligned region1 v5, v4+72
 ;;     v6 = get_stack_pointer.i64 
-;;     store notrap aligned v6, v4+64
+;;     store notrap aligned region2 v6, v4+64
 ;;     v7 = get_exception_handler_address.i64 block1, 0
-;;     store notrap aligned v7, v4+80
+;;     store notrap aligned region3 v7, v4+80
 ;;     try_call fn0(v0, v1), sig0, block2, [ default: block3 ]
 ;;
 ;; block2:

--- a/tests/disas/startup-global.wat
+++ b/tests/disas/startup-global.wat
@@ -7,6 +7,9 @@
 )
 ;; function u2415919104:1(i64 vmctx, i64, i64, i64) -> i8 system_v {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435528 "VMStoreContext+0x48"
+;;     region2 = 268435520 "VMStoreContext+0x40"
+;;     region3 = 268435536 "VMStoreContext+0x50"
 ;;     sig0 = (i64 vmctx, i64) tail
 ;;     fn0 = colocated u2415919104:0 sig0
 ;;
@@ -16,11 +19,11 @@
 ;; block1:
 ;;     v5 = get_frame_pointer.i64 
 ;;     v4 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;     store notrap aligned v5, v4+72
+;;     store notrap aligned region1 v5, v4+72
 ;;     v6 = get_stack_pointer.i64 
-;;     store notrap aligned v6, v4+64
+;;     store notrap aligned region2 v6, v4+64
 ;;     v7 = get_exception_handler_address.i64 block1, 0
-;;     store notrap aligned v7, v4+80
+;;     store notrap aligned region3 v7, v4+80
 ;;     try_call fn0(v0, v1), sig0, block2, [ default: block3 ]
 ;;
 ;; block2:

--- a/tests/disas/startup-passive-segment.wat
+++ b/tests/disas/startup-passive-segment.wat
@@ -8,6 +8,9 @@
 )
 ;; function u2415919104:1(i64 vmctx, i64, i64, i64) -> i8 system_v {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435528 "VMStoreContext+0x48"
+;;     region2 = 268435520 "VMStoreContext+0x40"
+;;     region3 = 268435536 "VMStoreContext+0x50"
 ;;     sig0 = (i64 vmctx, i64) tail
 ;;     fn0 = colocated u2415919104:0 sig0
 ;;
@@ -17,11 +20,11 @@
 ;; block1:
 ;;     v5 = get_frame_pointer.i64 
 ;;     v4 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;     store notrap aligned v5, v4+72
+;;     store notrap aligned region1 v5, v4+72
 ;;     v6 = get_stack_pointer.i64 
-;;     store notrap aligned v6, v4+64
+;;     store notrap aligned region2 v6, v4+64
 ;;     v7 = get_exception_handler_address.i64 block1, 0
-;;     store notrap aligned v7, v4+80
+;;     store notrap aligned region3 v7, v4+80
 ;;     try_call fn0(v0, v1), sig0, block2, [ default: block3 ]
 ;;
 ;; block2:

--- a/tests/disas/startup-start.wat
+++ b/tests/disas/startup-start.wat
@@ -8,6 +8,9 @@
 )
 ;; function u2415919104:1(i64 vmctx, i64, i64, i64) -> i8 system_v {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435528 "VMStoreContext+0x48"
+;;     region2 = 268435520 "VMStoreContext+0x40"
+;;     region3 = 268435536 "VMStoreContext+0x50"
 ;;     sig0 = (i64 vmctx, i64) tail
 ;;     fn0 = colocated u2415919104:0 sig0
 ;;
@@ -17,11 +20,11 @@
 ;; block1:
 ;;     v5 = get_frame_pointer.i64 
 ;;     v4 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;     store notrap aligned v5, v4+72
+;;     store notrap aligned region1 v5, v4+72
 ;;     v6 = get_stack_pointer.i64 
-;;     store notrap aligned v6, v4+64
+;;     store notrap aligned region2 v6, v4+64
 ;;     v7 = get_exception_handler_address.i64 block1, 0
-;;     store notrap aligned v7, v4+80
+;;     store notrap aligned region3 v7, v4+80
 ;;     try_call fn0(v0, v1), sig0, block2, [ default: block3 ]
 ;;
 ;; block2:

--- a/tests/disas/startup-table-initial-value.wat
+++ b/tests/disas/startup-table-initial-value.wat
@@ -8,6 +8,9 @@
 )
 ;; function u2415919104:1(i64 vmctx, i64, i64, i64) -> i8 system_v {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435528 "VMStoreContext+0x48"
+;;     region2 = 268435520 "VMStoreContext+0x40"
+;;     region3 = 268435536 "VMStoreContext+0x50"
 ;;     sig0 = (i64 vmctx, i64) tail
 ;;     fn0 = colocated u2415919104:0 sig0
 ;;
@@ -17,11 +20,11 @@
 ;; block1:
 ;;     v5 = get_frame_pointer.i64 
 ;;     v4 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;     store notrap aligned v5, v4+72
+;;     store notrap aligned region1 v5, v4+72
 ;;     v6 = get_stack_pointer.i64 
-;;     store notrap aligned v6, v4+64
+;;     store notrap aligned region2 v6, v4+64
 ;;     v7 = get_exception_handler_address.i64 block1, 0
-;;     store notrap aligned v7, v4+80
+;;     store notrap aligned region3 v7, v4+80
 ;;     try_call fn0(v0, v1), sig0, block2, [ default: block3 ]
 ;;
 ;; block2:

--- a/tests/disas/sub-global.wat
+++ b/tests/disas/sub-global.wat
@@ -14,17 +14,18 @@
 
 ;; function u0:0(i64 vmctx, i64) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 1879048192 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 1879048192 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @0020                               v2 = load.i32 notrap aligned region1 v0+48
+;; @0020                               v2 = load.i32 notrap aligned region2 v0+48
 ;; @0022                               v3 = iconst.i32 16
 ;; @0024                               v4 = isub v2, v3  ; v3 = 16
-;; @0025                               store notrap aligned region1 v4, v0+48
+;; @0025                               store notrap aligned region2 v4, v0+48
 ;; @0027                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/table-copy.wat
+++ b/tests/disas/table-copy.wat
@@ -25,9 +25,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32, i32, i32, i32, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32, v6: i32, v7: i32):
@@ -39,9 +40,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32, i32, i32, i32, i32, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32, v6: i32, v7: i32):
@@ -53,9 +55,10 @@
 ;;
 ;; function u0:2(i64 vmctx, i64, i32, i32, i32, i32, i32, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32, v6: i32, v7: i32):
@@ -67,17 +70,18 @@
 ;;
 ;; function u0:3(i64 vmctx, i64, i32, i32, i32, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 48 "VMContext+0x30"
-;;     region2 = 1073741824 "PublicTable"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 48 "VMContext+0x30"
+;;     region3 = 1073741824 "PublicTable"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, i32, i64) -> i64 tail
 ;;     fn0 = colocated u805306368:7 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):
-;; @0090                               v7 = load.i64 notrap aligned readonly can_move region1 v0+48
+;; @0090                               v7 = load.i64 notrap aligned readonly can_move region2 v0+48
 ;; @0090                               v8 = load.i64 notrap aligned v7+8
 ;; @0090                               v9 = ireduce.i32 v8
 ;; @0090                               v10 = uextend.i64 v9
@@ -88,7 +92,7 @@
 ;; @0090                               v15 = iadd v11, v14
 ;; @0090                               v16 = icmp ugt v15, v10
 ;; @0090                               trapnz v16, user6
-;; @0090                               v17 = load.i64 notrap aligned readonly can_move region1 v0+48
+;; @0090                               v17 = load.i64 notrap aligned readonly can_move region2 v0+48
 ;; @0090                               v18 = load.i64 notrap aligned v17
 ;; @0090                               v19 = uextend.i64 v3
 ;; @0090                               v20 = iconst.i64 8
@@ -137,7 +141,7 @@
 ;; @0090                               v59 = iadd v56, v58
 ;; @0090                               v60 = iconst.i64 0
 ;; @0090                               v61 = select_spectre_guard v54, v60, v59  ; v60 = 0
-;; @0090                               v62 = load.i64 user6 aligned region2 v61
+;; @0090                               v62 = load.i64 user6 aligned region3 v61
 ;; @0090                               v63 = iconst.i64 -2
 ;; @0090                               v64 = band v62, v63  ; v63 = -2
 ;; @0090                               brif v62, block7(v64), block6
@@ -158,7 +162,7 @@
 ;; @0090                               v93 = iadd v90, v92
 ;; @0090                               v94 = iconst.i64 0
 ;; @0090                               v95 = select_spectre_guard v88, v94, v93  ; v94 = 0
-;; @0090                               v96 = load.i64 user6 aligned region2 v95
+;; @0090                               v96 = load.i64 user6 aligned region3 v95
 ;; @0090                               v97 = iconst.i64 -2
 ;; @0090                               v98 = band v96, v97  ; v97 = -2
 ;; @0090                               brif v96, block9(v98), block8
@@ -204,11 +208,12 @@
 ;;
 ;; function u0:4(i64 vmctx, i64, i32, i32, i32, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 48 "VMContext+0x30"
-;;     region2 = 1073741824 "PublicTable"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 48 "VMContext+0x30"
+;;     region3 = 1073741824 "PublicTable"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, i32, i64) -> i64 tail
 ;;     fn0 = colocated u805306368:7 sig0
 ;;     stack_limit = gv2
@@ -228,7 +233,7 @@
 ;; @009f                               v17 = iconst.i64 8
 ;; @009f                               v18 = imul v16, v17  ; v17 = 8
 ;; @009f                               v19 = iadd v15, v18
-;; @009f                               v20 = load.i64 notrap aligned readonly can_move region1 v0+48
+;; @009f                               v20 = load.i64 notrap aligned readonly can_move region2 v0+48
 ;; @009f                               v21 = load.i64 notrap aligned v20+8
 ;; @009f                               v22 = ireduce.i32 v21
 ;; @009f                               v23 = uextend.i64 v22
@@ -239,7 +244,7 @@
 ;; @009f                               v28 = iadd v24, v27
 ;; @009f                               v29 = icmp ugt v28, v23
 ;; @009f                               trapnz v29, user6
-;; @009f                               v30 = load.i64 notrap aligned readonly can_move region1 v0+48
+;; @009f                               v30 = load.i64 notrap aligned readonly can_move region2 v0+48
 ;; @009f                               v31 = load.i64 notrap aligned v30
 ;; @009f                               v32 = uextend.i64 v4
 ;; @009f                               v33 = iconst.i64 8
@@ -265,19 +270,19 @@
 ;; @009f                               brif v41, block3(v19, v35, v4), block4(v46, v47, v49)
 ;;
 ;;                                 block3(v50: i64, v51: i64, v52: i32):
-;; @009f                               v53 = load.i64 notrap aligned readonly can_move region1 v0+48
+;; @009f                               v53 = load.i64 notrap aligned readonly can_move region2 v0+48
 ;; @009f                               v54 = load.i64 notrap aligned v53+8
 ;; @009f                               v55 = ireduce.i32 v54
 ;; @009f                               v56 = icmp uge v52, v55
 ;; @009f                               v57 = uextend.i64 v52
-;; @009f                               v58 = load.i64 notrap aligned readonly can_move region1 v0+48
+;; @009f                               v58 = load.i64 notrap aligned readonly can_move region2 v0+48
 ;; @009f                               v59 = load.i64 notrap aligned v58
 ;; @009f                               v60 = iconst.i64 3
 ;; @009f                               v61 = ishl v57, v60  ; v60 = 3
 ;; @009f                               v62 = iadd v59, v61
 ;; @009f                               v63 = iconst.i64 0
 ;; @009f                               v64 = select_spectre_guard v56, v63, v62  ; v63 = 0
-;; @009f                               v65 = load.i64 user6 aligned region2 v64
+;; @009f                               v65 = load.i64 user6 aligned region3 v64
 ;; @009f                               v66 = iconst.i64 -2
 ;; @009f                               v67 = band v65, v66  ; v66 = -2
 ;; @009f                               brif v65, block7(v67), block6
@@ -289,19 +294,19 @@
 ;; @009f                               v87 = isub v82, v86  ; v86 = 8
 ;; @009f                               v88 = iconst.i32 1
 ;; @009f                               v89 = isub v83, v88  ; v88 = 1
-;; @009f                               v90 = load.i64 notrap aligned readonly can_move region1 v0+48
+;; @009f                               v90 = load.i64 notrap aligned readonly can_move region2 v0+48
 ;; @009f                               v91 = load.i64 notrap aligned v90+8
 ;; @009f                               v92 = ireduce.i32 v91
 ;; @009f                               v93 = icmp uge v89, v92
 ;; @009f                               v94 = uextend.i64 v89
-;; @009f                               v95 = load.i64 notrap aligned readonly can_move region1 v0+48
+;; @009f                               v95 = load.i64 notrap aligned readonly can_move region2 v0+48
 ;; @009f                               v96 = load.i64 notrap aligned v95
 ;; @009f                               v97 = iconst.i64 3
 ;; @009f                               v98 = ishl v94, v97  ; v97 = 3
 ;; @009f                               v99 = iadd v96, v98
 ;; @009f                               v100 = iconst.i64 0
 ;; @009f                               v101 = select_spectre_guard v93, v100, v99  ; v100 = 0
-;; @009f                               v102 = load.i64 user6 aligned region2 v101
+;; @009f                               v102 = load.i64 user6 aligned region3 v101
 ;; @009f                               v103 = iconst.i64 -2
 ;; @009f                               v104 = band v102, v103  ; v103 = -2
 ;; @009f                               brif v102, block9(v104), block8

--- a/tests/disas/table-get-fixed-size.wat
+++ b/tests/disas/table-get-fixed-size.wat
@@ -17,10 +17,11 @@
 
 ;; function u0:0(i64 vmctx, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 1073741824 "PublicTable"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 1073741824 "PublicTable"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
@@ -34,7 +35,7 @@
 ;; @0054                               v10 = iadd v7, v9
 ;; @0054                               v11 = iconst.i64 0
 ;; @0054                               v12 = select_spectre_guard v5, v11, v10  ; v11 = 0
-;; @0054                               v13 = load.i32 user6 aligned region1 v12
+;; @0054                               v13 = load.i32 user6 aligned region2 v12
 ;; @0056                               jump block1
 ;;
 ;;                                 block1:
@@ -43,10 +44,11 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 1073741824 "PublicTable"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 1073741824 "PublicTable"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -59,7 +61,7 @@
 ;; @005b                               v10 = iadd v7, v9
 ;; @005b                               v11 = iconst.i64 0
 ;; @005b                               v12 = select_spectre_guard v5, v11, v10  ; v11 = 0
-;; @005b                               v13 = load.i32 user6 aligned region1 v12
+;; @005b                               v13 = load.i32 user6 aligned region2 v12
 ;; @005d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/table-get.wat
+++ b/tests/disas/table-get.wat
@@ -16,10 +16,11 @@
 
 ;; function u0:0(i64 vmctx, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 1073741824 "PublicTable"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 1073741824 "PublicTable"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
@@ -34,7 +35,7 @@
 ;; @0053                               v11 = iadd v8, v10
 ;; @0053                               v12 = iconst.i64 0
 ;; @0053                               v13 = select_spectre_guard v6, v12, v11  ; v12 = 0
-;; @0053                               v14 = load.i32 user6 aligned region1 v13
+;; @0053                               v14 = load.i32 user6 aligned region2 v13
 ;; @0055                               jump block1
 ;;
 ;;                                 block1:
@@ -43,10 +44,11 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 1073741824 "PublicTable"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 1073741824 "PublicTable"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -60,7 +62,7 @@
 ;; @005a                               v11 = iadd v8, v10
 ;; @005a                               v12 = iconst.i64 0
 ;; @005a                               v13 = select_spectre_guard v6, v12, v11  ; v12 = 0
-;; @005a                               v14 = load.i32 user6 aligned region1 v13
+;; @005a                               v14 = load.i32 user6 aligned region2 v13
 ;; @005c                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/table-set-fixed-size.wat
+++ b/tests/disas/table-set-fixed-size.wat
@@ -18,10 +18,11 @@
     table.set 0))
 ;; function u0:0(i64 vmctx, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 1073741824 "PublicTable"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 1073741824 "PublicTable"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -35,7 +36,7 @@
 ;; @0056                               v10 = iadd v7, v9
 ;; @0056                               v11 = iconst.i64 0
 ;; @0056                               v12 = select_spectre_guard v5, v11, v10  ; v11 = 0
-;; @0056                               store user6 aligned region1 v2, v12
+;; @0056                               store user6 aligned region2 v2, v12
 ;; @0058                               jump block1
 ;;
 ;;                                 block1:
@@ -44,10 +45,11 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 1073741824 "PublicTable"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 1073741824 "PublicTable"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -60,7 +62,7 @@
 ;; @005f                               v10 = iadd v7, v9
 ;; @005f                               v11 = iconst.i64 0
 ;; @005f                               v12 = select_spectre_guard v5, v11, v10  ; v11 = 0
-;; @005f                               store user6 aligned region1 v3, v12
+;; @005f                               store user6 aligned region2 v3, v12
 ;; @0061                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/table-set.wat
+++ b/tests/disas/table-set.wat
@@ -18,10 +18,11 @@
 
 ;; function u0:0(i64 vmctx, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 1073741824 "PublicTable"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 1073741824 "PublicTable"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -36,7 +37,7 @@
 ;; @0055                               v11 = iadd v8, v10
 ;; @0055                               v12 = iconst.i64 0
 ;; @0055                               v13 = select_spectre_guard v6, v12, v11  ; v12 = 0
-;; @0055                               store user6 aligned region1 v2, v13
+;; @0055                               store user6 aligned region2 v2, v13
 ;; @0057                               jump block1
 ;;
 ;;                                 block1:
@@ -45,10 +46,11 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 1073741824 "PublicTable"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 1073741824 "PublicTable"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -62,7 +64,7 @@
 ;; @005e                               v11 = iadd v8, v10
 ;; @005e                               v12 = iconst.i64 0
 ;; @005e                               v13 = select_spectre_guard v6, v12, v11  ; v12 = 0
-;; @005e                               store user6 aligned region1 v3, v13
+;; @005e                               store user6 aligned region2 v3, v13
 ;; @0060                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/typed-funcrefs-eager-init.wat
+++ b/tests/disas/typed-funcrefs-eager-init.wat
@@ -115,9 +115,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32, i32, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):
@@ -129,10 +130,11 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32, i32, i32, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 1342177280 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 1342177280 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, i64, i32, i32, i32, i32) -> i32 tail
 ;;     stack_limit = gv2
 ;;
@@ -140,13 +142,13 @@
 ;; @0048                               v12 = load.i64 notrap aligned readonly can_move v0+48
 ;;                                     v45 = iconst.i64 8
 ;; @0048                               v15 = iadd v12, v45  ; v45 = 8
-;; @0048                               v18 = load.i64 user6 aligned region1 v15
+;; @0048                               v18 = load.i64 user6 aligned region2 v15
 ;; @004a                               v19 = load.i64 user16 aligned readonly v18+8
 ;; @004a                               v20 = load.i64 notrap aligned readonly v18+24
 ;; @004a                               v21 = call_indirect sig0, v19(v20, v0, v2, v3, v4, v5)
 ;;                                     v52 = iconst.i64 16
 ;; @005b                               v30 = iadd v12, v52  ; v52 = 16
-;; @005b                               v33 = load.i64 user6 aligned region1 v30
+;; @005b                               v33 = load.i64 user6 aligned region2 v30
 ;; @005d                               v34 = load.i64 user16 aligned readonly v33+8
 ;; @005d                               v35 = load.i64 notrap aligned readonly v33+24
 ;; @005d                               v36 = call_indirect sig0, v34(v35, v0, v2, v3, v4, v5)
@@ -159,10 +161,11 @@
 ;;
 ;; function u0:2(i64 vmctx, i64, i32, i32, i32, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 1342177280 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 1342177280 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, i64, i32, i32, i32, i32) -> i32 tail
 ;;     stack_limit = gv2
 ;;
@@ -170,13 +173,13 @@
 ;; @0075                               v12 = load.i64 notrap aligned readonly can_move v0+48
 ;;                                     v45 = iconst.i64 8
 ;; @0075                               v15 = iadd v12, v45  ; v45 = 8
-;; @0075                               v18 = load.i64 user6 aligned region1 v15
+;; @0075                               v18 = load.i64 user6 aligned region2 v15
 ;; @0075                               v19 = load.i64 user7 aligned readonly v18+8
 ;; @0075                               v20 = load.i64 notrap aligned readonly v18+24
 ;; @0075                               v21 = call_indirect sig0, v19(v20, v0, v2, v3, v4, v5)
 ;;                                     v52 = iconst.i64 16
 ;; @0087                               v30 = iadd v12, v52  ; v52 = 16
-;; @0087                               v33 = load.i64 user6 aligned region1 v30
+;; @0087                               v33 = load.i64 user6 aligned region2 v30
 ;; @0087                               v34 = load.i64 user7 aligned readonly v33+8
 ;; @0087                               v35 = load.i64 notrap aligned readonly v33+24
 ;; @0087                               v36 = call_indirect sig0, v34(v35, v0, v2, v3, v4, v5)
@@ -189,20 +192,21 @@
 ;;
 ;; function u0:3(i64 vmctx, i64, i32, i32, i32, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 1879048192 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(0))"
-;;     region2 = 1879048193 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(1))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 1879048192 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(0))"
+;;     region3 = 1879048193 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(1))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, i64, i32, i32, i32, i32) -> i32 tail
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):
-;; @009e                               v8 = load.i64 notrap aligned region1 v0+64
+;; @009e                               v8 = load.i64 notrap aligned region2 v0+64
 ;; @00a0                               v9 = load.i64 user16 aligned readonly v8+8
 ;; @00a0                               v10 = load.i64 notrap aligned readonly v8+24
 ;; @00a0                               v11 = call_indirect sig0, v9(v10, v0, v2, v3, v4, v5)
-;; @00af                               v13 = load.i64 notrap aligned region2 v0+80
+;; @00af                               v13 = load.i64 notrap aligned region3 v0+80
 ;; @00b1                               v14 = load.i64 user16 aligned readonly v13+8
 ;; @00b1                               v15 = load.i64 notrap aligned readonly v13+24
 ;; @00b1                               v16 = call_indirect sig0, v14(v15, v0, v2, v3, v4, v5)

--- a/tests/disas/typed-funcrefs.wat
+++ b/tests/disas/typed-funcrefs.wat
@@ -115,9 +115,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32, i32, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):
@@ -129,10 +130,11 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32, i32, i32, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 1342177280 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 1342177280 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, i32, i64) -> i64 tail
 ;;     sig1 = (i64 vmctx, i64, i32, i32, i32, i32) -> i32 tail
 ;;     fn0 = colocated u805306368:7 sig0
@@ -142,7 +144,7 @@
 ;; @0048                               v12 = load.i64 notrap aligned readonly can_move v0+48
 ;;                                     v63 = iconst.i64 8
 ;; @0048                               v15 = iadd v12, v63  ; v63 = 8
-;; @0048                               v18 = load.i64 user6 aligned region1 v15
+;; @0048                               v18 = load.i64 user6 aligned region2 v15
 ;; @0048                               v19 = iconst.i64 -2
 ;; @0048                               v20 = band v18, v19  ; v19 = -2
 ;; @0048                               brif v18, block3(v20), block2
@@ -159,7 +161,7 @@
 ;; @004a                               v27 = call_indirect sig1, v25(v26, v0, v2, v3, v4, v5)
 ;;                                     v70 = iconst.i64 16
 ;; @005b                               v41 = iadd.i64 v12, v70  ; v70 = 16
-;; @005b                               v44 = load.i64 user6 aligned region1 v41
+;; @005b                               v44 = load.i64 user6 aligned region2 v41
 ;;                                     v71 = iconst.i64 -2
 ;;                                     v72 = band v44, v71  ; v71 = -2
 ;; @005b                               brif v44, block5(v72), block4
@@ -183,10 +185,11 @@
 ;;
 ;; function u0:2(i64 vmctx, i64, i32, i32, i32, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 1342177280 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 1342177280 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, i64, i32, i32, i32, i32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i32, i64) -> i64 tail
 ;;     fn0 = colocated u805306368:7 sig1
@@ -196,7 +199,7 @@
 ;; @0075                               v12 = load.i64 notrap aligned readonly can_move v0+48
 ;;                                     v63 = iconst.i64 8
 ;; @0075                               v15 = iadd v12, v63  ; v63 = 8
-;; @0075                               v18 = load.i64 user6 aligned region1 v15
+;; @0075                               v18 = load.i64 user6 aligned region2 v15
 ;; @0075                               v19 = iconst.i64 -2
 ;; @0075                               v20 = band v18, v19  ; v19 = -2
 ;; @0075                               brif v18, block3(v20), block2
@@ -213,7 +216,7 @@
 ;; @0075                               v27 = call_indirect sig0, v25(v26, v0, v2, v3, v4, v5)
 ;;                                     v70 = iconst.i64 16
 ;; @0087                               v41 = iadd.i64 v12, v70  ; v70 = 16
-;; @0087                               v44 = load.i64 user6 aligned region1 v41
+;; @0087                               v44 = load.i64 user6 aligned region2 v41
 ;;                                     v71 = iconst.i64 -2
 ;;                                     v72 = band v44, v71  ; v71 = -2
 ;; @0087                               brif v44, block5(v72), block4
@@ -237,20 +240,21 @@
 ;;
 ;; function u0:3(i64 vmctx, i64, i32, i32, i32, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 1879048192 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(0))"
-;;     region2 = 1879048193 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(1))"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 1879048192 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(0))"
+;;     region3 = 1879048193 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(1))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, i64, i32, i32, i32, i32) -> i32 tail
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):
-;; @009e                               v8 = load.i64 notrap aligned region1 v0+64
+;; @009e                               v8 = load.i64 notrap aligned region2 v0+64
 ;; @00a0                               v9 = load.i64 user16 aligned readonly v8+8
 ;; @00a0                               v10 = load.i64 notrap aligned readonly v8+24
 ;; @00a0                               v11 = call_indirect sig0, v9(v10, v0, v2, v3, v4, v5)
-;; @00af                               v13 = load.i64 notrap aligned region2 v0+80
+;; @00af                               v13 = load.i64 notrap aligned region3 v0+80
 ;; @00b1                               v14 = load.i64 user16 aligned readonly v13+8
 ;; @00b1                               v15 = load.i64 notrap aligned readonly v13+24
 ;; @00b1                               v16 = call_indirect sig0, v14(v15, v0, v2, v3, v4, v5)

--- a/tests/disas/unreachable_code.wat
+++ b/tests/disas/unreachable_code.wat
@@ -80,9 +80,10 @@
 
 ;; function u0:0(i64 vmctx, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
@@ -91,9 +92,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
@@ -105,9 +107,10 @@
 ;;
 ;; function u0:2(i64 vmctx, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
@@ -138,9 +141,10 @@
 ;;
 ;; function u0:3(i64 vmctx, i64) tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):

--- a/tests/disas/x64-simd-round-without-sse41.wat
+++ b/tests/disas/x64-simd-round-without-sse41.wat
@@ -13,9 +13,10 @@
 )
 ;; function u0:0(i64 vmctx, i64, i8x16) -> i8x16 tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, f32) -> f32 tail
 ;;     fn0 = colocated u805306368:28 sig0
 ;;     const0 = 0x00000000000000000000000000000000
@@ -45,9 +46,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i8x16) -> i8x16 tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, f32) -> f32 tail
 ;;     fn0 = colocated u805306368:30 sig0
 ;;     const0 = 0x00000000000000000000000000000000
@@ -77,9 +79,10 @@
 ;;
 ;; function u0:2(i64 vmctx, i64, i8x16) -> i8x16 tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, f32) -> f32 tail
 ;;     fn0 = colocated u805306368:32 sig0
 ;;     const0 = 0x00000000000000000000000000000000
@@ -109,9 +112,10 @@
 ;;
 ;; function u0:3(i64 vmctx, i64, i8x16) -> i8x16 tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, f32) -> f32 tail
 ;;     fn0 = colocated u805306368:34 sig0
 ;;     const0 = 0x00000000000000000000000000000000
@@ -141,9 +145,10 @@
 ;;
 ;; function u0:4(i64 vmctx, i64, i8x16) -> i8x16 tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, f64) -> f64 tail
 ;;     fn0 = colocated u805306368:29 sig0
 ;;     const0 = 0x00000000000000000000000000000000
@@ -167,9 +172,10 @@
 ;;
 ;; function u0:5(i64 vmctx, i64, i8x16) -> i8x16 tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, f64) -> f64 tail
 ;;     fn0 = colocated u805306368:31 sig0
 ;;     const0 = 0x00000000000000000000000000000000
@@ -193,9 +199,10 @@
 ;;
 ;; function u0:6(i64 vmctx, i64, i8x16) -> i8x16 tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, f64) -> f64 tail
 ;;     fn0 = colocated u805306368:33 sig0
 ;;     const0 = 0x00000000000000000000000000000000
@@ -219,9 +226,10 @@
 ;;
 ;; function u0:7(i64 vmctx, i64, i8x16) -> i8x16 tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, f64) -> f64 tail
 ;;     fn0 = colocated u805306368:35 sig0
 ;;     const0 = 0x00000000000000000000000000000000
@@ -245,9 +253,10 @@
 ;;
 ;; function u0:8(i64 vmctx, i64, i8x16) -> i8x16 tail {
 ;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
-;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     const0 = 0x00000000000000000000000000000000
 ;;     stack_limit = gv2
 ;;


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
