### PR TITLE
cm-async: Fix leaking transmit state with "half hosts"

### DIFF
--- a/crates/test-programs/src/bin/p3_cli_many_stream.rs
+++ b/crates/test-programs/src/bin/p3_cli_many_stream.rs
@@ -6,7 +6,7 @@ test_programs::p3::export!(Component);
 
 impl test_programs::p3::exports::wasi::cli::run::Guest for Component {
     async fn run() -> Result<(), ()> {
-        for i in 0..200 {
+        for _ in 0..200 {
             let (tx, rx) = wit_stream::new();
             let _future = wasip3::cli::stdout::write_via_stream(rx);
             drop(tx);

--- a/crates/test-programs/src/bin/p3_cli_many_stream.rs
+++ b/crates/test-programs/src/bin/p3_cli_many_stream.rs
@@ -1,0 +1,20 @@
+use test_programs::p3::{wasi as wasip3, wit_stream};
+
+struct Component;
+
+test_programs::p3::export!(Component);
+
+impl test_programs::p3::exports::wasi::cli::run::Guest for Component {
+    async fn run() -> Result<(), ()> {
+        for i in 0..200 {
+            let (tx, rx) = wit_stream::new();
+            let _future = wasip3::cli::stdout::write_via_stream(rx);
+            drop(tx);
+        }
+        Ok(())
+    }
+}
+
+fn main() {
+    unreachable!();
+}

--- a/crates/wasmtime/src/runtime/component/concurrent/futures_and_streams.rs
+++ b/crates/wasmtime/src/runtime/component/concurrent/futures_and_streams.rs
@@ -2478,8 +2478,6 @@ impl StoreOpaque {
                 )?;
             }
 
-            WriteState::HostReady { .. } => {}
-
             WriteState::Open => {
                 state.update_event(
                     write_handle.rep(),
@@ -2496,7 +2494,11 @@ impl StoreOpaque {
                 )?;
             }
 
-            WriteState::Dropped => {
+            // If the writer has already been dropped, then this cleans out the
+            // state that the reader is using. If the write is host-owned then
+            // by cleaning this out we run the host's `Drop` implementation
+            // which notifies it of this drop.
+            WriteState::Dropped | WriteState::HostReady { .. } => {
                 log::trace!("host_drop_reader delete {transmit_id:?}");
                 state.delete_transmit(transmit_id)?;
             }
@@ -2577,8 +2579,6 @@ impl StoreOpaque {
                 )?;
             }
 
-            ReadState::HostReady { .. } | ReadState::HostToHost { .. } => {}
-
             // If the read state is open, then there are no registered readers of the stream/future
             ReadState::Open => {
                 self.concurrent_state_mut().update_event(
@@ -2596,9 +2596,13 @@ impl StoreOpaque {
                 )?;
             }
 
-            // If the read state was already dropped, then we can remove the transmit state completely
-            // (both writer and reader have been dropped)
-            ReadState::Dropped => {
+            // If the read state was already dropped, then we can remove the
+            // transmit state completely (both writer and reader have been
+            // dropped). If the read state is host-owned then it's additionally
+            // deleted here as a notification that the read end has gone away.
+            // Running the host's `Drop` implementation is what notifies it of
+            // this event.
+            ReadState::Dropped | ReadState::HostReady { .. } | ReadState::HostToHost { .. } => {
                 log::trace!("host_drop_writer delete {transmit_id:?}");
                 self.concurrent_state_mut().delete_transmit(transmit_id)?;
             }

--- a/tests/all/cli_tests.rs
+++ b/tests/all/cli_tests.rs
@@ -2951,6 +2951,12 @@ start a print 1234
         assert!(stdout.contains("please see me"));
         Ok(())
     }
+
+    #[test]
+    fn p3_cli_many_stream() -> Result<()> {
+        run_wasmtime(&["run", "-Smax-resources=100", P3_CLI_MANY_STREAM_COMPONENT])?;
+        Ok(())
+    }
 }
 
 #[test]


### PR DESCRIPTION
This commit fixes issues in the implementation of futures and streams for component-model-async where when a guest dropped its half of a future/stream connection, and the other half was owned by the host, then the host-owned half would be leaked within the store.

This is similar in spirit to #13515 but has a smaller test and additionally takes into account some review comments.

Closes #13514
Closes #13515

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
