### PR TITLE
Do not use `ir::GlobalValue` when translating Wasm globals

### DIFF
--- a/crates/cranelift/src/alias_region.rs
+++ b/crates/cranelift/src/alias_region.rs
@@ -4,8 +4,9 @@ use cranelift_codegen::{
     ir::{self, InstBuilder as _},
 };
 use wasmtime_environ::{
-    DefinedGlobalIndex, DefinedMemoryIndex, DefinedTableIndex, FuncIndex, GetPtrSize, MemoryIndex,
-    PtrSize as _, RuntimeDataIndex, StaticModuleIndex, TableIndex, TagIndex, VMOffsets,
+    DefinedGlobalIndex, DefinedMemoryIndex, DefinedTableIndex, FuncIndex, GetPtrSize, GlobalIndex,
+    MemoryIndex, PtrSize as _, RuntimeDataIndex, StaticModuleIndex, TableIndex, TagIndex,
+    VMOffsets,
 };
 
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
@@ -609,6 +610,24 @@ impl AliasRegions<VMOffsets<u8>> {
             ir::MemFlagsData::trusted().with_readonly().with_can_move(),
             vmctx,
             table_index_offset,
+        )
+    }
+
+    /// Load the imported global's address (`VMGlobalImport::from`) out of the
+    /// `*mut VMContext`.
+    pub fn vmctx_vmglobal_import_from(
+        &mut self,
+        cursor: &mut FuncCursor<'_>,
+        vmctx: ir::Value,
+        global: GlobalIndex,
+    ) -> ir::Value {
+        let from_offset = self.offsets.vmctx_vmglobal_import_from(global);
+        self.vmctx_load(
+            cursor,
+            self.pointer_type,
+            ir::MemFlagsData::trusted().with_readonly().with_can_move(),
+            vmctx,
+            from_offset,
         )
     }
 

--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -451,36 +451,18 @@ impl<'module_environment> FuncEnvironment<'module_environment> {
 
     fn get_global_location(
         &mut self,
-        func: &mut ir::Function,
+        pos: &mut FuncCursor<'_>,
         index: GlobalIndex,
-    ) -> (ir::GlobalValue, i32) {
-        let pointer_type = self.pointer_type();
-        let vmctx = self.vmctx(func);
+    ) -> (ir::Value, i32) {
+        let vmctx = self.vmctx_val(pos);
         if let Some(def_index) = self.module.defined_global_index(index) {
             let offset = i32::try_from(self.offsets.vmctx_vmglobal_definition(def_index)).unwrap();
             (vmctx, offset)
         } else {
-            let from_offset = self.offsets.vmctx_vmglobal_import_from(index);
-            let region = self
+            let addr = self
                 .alias_regions
-                .vmctx_region_for_use_in_ir_global(func, from_offset);
-            let global_flags = func
-                .dfg
-                .mem_flags
-                .insert(
-                    MemFlagsData::trusted()
-                        .with_readonly()
-                        .with_can_move()
-                        .with_alias_region(Some(region)),
-                )
-                .unwrap();
-            let global = func.create_global_value(ir::GlobalValueData::Load {
-                base: vmctx,
-                offset: Offset32::new(i32::try_from(from_offset).unwrap()),
-                global_type: pointer_type,
-                flags: global_flags,
-            });
-            (global, 0)
+                .vmctx_vmglobal_import_from(pos, vmctx, index);
+            (addr, 0)
         }
     }
 
@@ -1576,20 +1558,10 @@ impl FuncEnvironment<'_> {
         get_or_create_table(tables) : make_table : TableIndex => TableData;
     }
 
-    fn make_global(&mut self, func: &mut ir::Function, index: GlobalIndex) -> GlobalVariable {
+    fn make_global(&mut self, _func: &mut ir::Function, index: GlobalIndex) -> GlobalVariable {
         let ty = self.module.globals[index].wasm_ty;
 
-        if ty.is_vmgcref_type() {
-            // Although reference-typed globals live at the same memory location as
-            // any other type of global at the same index would, getting or
-            // setting them requires ref counting barriers. Therefore, we need
-            // to use `GlobalVariable::Custom`, as that is the only kind of
-            // `GlobalVariable` for which translation supports custom
-            // access translation.
-            return GlobalVariable::Custom;
-        }
-
-        if !self.module.globals[index].mutability {
+        if !ty.is_vmgcref_type() && !self.module.globals[index].mutability {
             if let Some(index) = self.module.defined_global_index(index) {
                 if let Ok(i) = self
                     .module
@@ -1602,12 +1574,7 @@ impl FuncEnvironment<'_> {
             }
         }
 
-        let (gv, offset) = self.get_global_location(func, index);
-        GlobalVariable::Memory {
-            gv,
-            offset: offset.into(),
-            ty: super::value_type(self.isa, ty),
-        }
+        GlobalVariable::Reified
     }
 
     pub(crate) fn get_or_create_sig_ref(
@@ -3192,42 +3159,37 @@ impl FuncEnvironment<'_> {
                     Ok(builder.ins().vconst(ir::types::I8X16, handle))
                 }
             },
-            GlobalVariable::Memory { gv, offset, ty } => {
-                let addr = builder.ins().global_value(self.pointer_type(), gv);
-                let mut flags = ir::MemFlagsData::trusted();
-                // Store vector globals in little-endian format to avoid
-                // byte swaps on big-endian platforms since at-rest vectors
-                // should already be in little-endian format anyway.
-                if ty.is_vector() {
-                    flags.set_endianness(ir::Endianness::Little);
-                }
-                let region = self.global_alias_region(builder.func, global_index);
-                flags.set_alias_region(Some(region));
-                Ok(builder.ins().load(ty, flags, addr, offset))
-            }
-            GlobalVariable::Custom => {
+            GlobalVariable::Reified => {
                 let global_ty = self.module.globals[global_index];
                 let wasm_ty = global_ty.wasm_ty;
-                debug_assert!(
-                    wasm_ty.is_vmgcref_type(),
-                    "We only use GlobalVariable::Custom for VMGcRef types"
-                );
-                let WasmValType::Ref(ref_ty) = wasm_ty else {
-                    unreachable!()
-                };
+                let (base, offset) = self.get_global_location(&mut builder.cursor(), global_index);
 
-                let (gv, offset) = self.get_global_location(builder.func, global_index);
-                let gv = builder.ins().global_value(self.pointer_type(), gv);
-                let src = builder.ins().iadd_imm_s(gv, i64::from(offset));
-
-                let flags = if global_ty.mutability || gc::gc_compiler(self)?.is_moving_collector()
-                {
-                    ir::MemFlagsData::trusted()
+                if wasm_ty.is_vmgcref_type() {
+                    let WasmValType::Ref(ref_ty) = wasm_ty else {
+                        unreachable!()
+                    };
+                    let src = builder.ins().iadd_imm_s(base, i64::from(offset));
+                    let flags =
+                        if global_ty.mutability || gc::gc_compiler(self)?.is_moving_collector() {
+                            ir::MemFlagsData::trusted()
+                        } else {
+                            ir::MemFlagsData::trusted().with_readonly().with_can_move()
+                        };
+                    gc::gc_compiler(self)?
+                        .translate_read_gc_reference(self, builder, ref_ty, src, flags)
                 } else {
-                    ir::MemFlagsData::trusted().with_readonly().with_can_move()
-                };
-                gc::gc_compiler(self)?
-                    .translate_read_gc_reference(self, builder, ref_ty, src, flags)
+                    let ty = super::value_type(self.isa, wasm_ty);
+                    let mut flags = ir::MemFlagsData::trusted();
+                    // Store vector globals in little-endian format to avoid
+                    // byte swaps on big-endian platforms since at-rest vectors
+                    // should already be in little-endian format anyway.
+                    if ty.is_vector() {
+                        flags.set_endianness(ir::Endianness::Little);
+                    }
+                    let region = self.global_alias_region(builder.func, global_index);
+                    flags.set_alias_region(Some(region));
+                    Ok(builder.ins().load(ty, flags, base, offset))
+                }
             }
         }
     }
@@ -3257,52 +3219,48 @@ impl FuncEnvironment<'_> {
             GlobalVariable::Constant { .. } => {
                 unreachable!("validation checks that Wasm cannot `global.set` constant globals")
             }
-            GlobalVariable::Memory { gv, offset, ty } => {
-                let addr = builder.ins().global_value(self.pointer_type(), gv);
-                let mut flags = ir::MemFlagsData::trusted();
-                // Like `global.get`, store globals in little-endian format.
-                if ty.is_vector() {
-                    flags.set_endianness(ir::Endianness::Little);
-                }
-                let region = self.global_alias_region(builder.func, global_index);
-                flags.set_alias_region(Some(region));
-                debug_assert_eq!(ty, builder.func.dfg.value_type(val));
-                builder.ins().store(flags, val, addr, offset);
-                self.update_global(builder, global_index, val);
-            }
-            GlobalVariable::Custom => {
-                let ty = self.module.globals[global_index].wasm_ty;
-                debug_assert!(
-                    ty.is_vmgcref_type(),
-                    "We only use GlobalVariable::Custom for VMGcRef types"
-                );
-                let WasmValType::Ref(ty) = ty else {
-                    unreachable!()
-                };
+            GlobalVariable::Reified => {
+                let wasm_ty = self.module.globals[global_index].wasm_ty;
+                let (base, offset) = self.get_global_location(&mut builder.cursor(), global_index);
 
-                let (gv, offset) = self.get_global_location(builder.func, global_index);
-                let gv = builder.ins().global_value(self.pointer_type(), gv);
-                let src = builder.ins().iadd_imm_s(gv, i64::from(offset));
-
-                let mut gc = gc::gc_compiler(self)?;
-                if initialized {
-                    gc.translate_write_gc_reference(
-                        self,
-                        builder,
-                        ty,
-                        src,
-                        val,
-                        ir::MemFlagsData::trusted(),
-                    )?;
+                if wasm_ty.is_vmgcref_type() {
+                    let WasmValType::Ref(ty) = wasm_ty else {
+                        unreachable!()
+                    };
+                    let offset = builder.ins().iconst(self.pointer_type(), offset);
+                    let src = builder.ins().iadd(base, offset);
+                    let mut gc = gc::gc_compiler(self)?;
+                    if initialized {
+                        gc.translate_write_gc_reference(
+                            self,
+                            builder,
+                            ty,
+                            src,
+                            val,
+                            ir::MemFlagsData::trusted(),
+                        )?;
+                    } else {
+                        gc.translate_init_gc_reference(
+                            self,
+                            builder,
+                            ty,
+                            src,
+                            val,
+                            ir::MemFlagsData::trusted(),
+                        )?;
+                    }
                 } else {
-                    gc.translate_init_gc_reference(
-                        self,
-                        builder,
-                        ty,
-                        src,
-                        val,
-                        ir::MemFlagsData::trusted(),
-                    )?;
+                    let ty = super::value_type(self.isa, wasm_ty);
+                    let mut flags = ir::MemFlagsData::trusted();
+                    // Like `global.get`, store globals in little-endian format.
+                    if ty.is_vector() {
+                        flags.set_endianness(ir::Endianness::Little);
+                    }
+                    let region = self.global_alias_region(builder.func, global_index);
+                    flags.set_alias_region(Some(region));
+                    debug_assert_eq!(ty, builder.func.dfg.value_type(val));
+                    builder.ins().store(flags, val, base, offset);
+                    self.update_global(builder, global_index, val);
                 }
             }
         }

--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -4,8 +4,8 @@ pub(crate) mod stack_switching;
 use crate::alias_region::AliasRegions;
 use crate::compiler::Compiler;
 use crate::translate::{
-    FuncTranslationStacks, GlobalVariable, Heap, HeapData, MemoryKind, StructFieldsVec, TableData,
-    TableSize, TargetEnvironment,
+    FuncTranslationStacks, Heap, HeapData, MemoryKind, StructFieldsVec, TableData, TableSize,
+    TargetEnvironment,
 };
 use crate::trap::TranslateTrap;
 use crate::{
@@ -1505,10 +1505,6 @@ impl TranslateTrap<VMOffsets<u8>> for FuncEnvironment<'_> {
 
 #[derive(Default)]
 pub(crate) struct WasmEntities {
-    /// Map from a Wasm global index from this module to its implementation in
-    /// the Cranelift function we are building.
-    pub(crate) globals: SecondaryMap<GlobalIndex, Option<GlobalVariable>>,
-
     /// Map from a Wasm memory index to its `Heap` implementation in the
     /// Cranelift function we are building.
     pub(crate) memories: SecondaryMap<MemoryIndex, PackedOption<Heap>>,
@@ -1550,7 +1546,6 @@ macro_rules! define_get_or_create_methods {
 
 impl FuncEnvironment<'_> {
     define_get_or_create_methods! {
-        get_or_create_global(globals) : make_global : GlobalIndex => GlobalVariable;
         get_or_create_heap(memories) : make_heap : MemoryIndex => Heap;
         get_or_create_interned_sig_ref(sig_refs) : make_sig_ref : ModuleInternedTypeIndex => ir::SigRef;
         get_or_create_defined_func_ref(defined_func_refs) : make_defined_func_ref : DefinedFuncIndex => ir::FuncRef;
@@ -1558,7 +1553,7 @@ impl FuncEnvironment<'_> {
         get_or_create_table(tables) : make_table : TableIndex => TableData;
     }
 
-    fn make_global(&mut self, _func: &mut ir::Function, index: GlobalIndex) -> GlobalVariable {
+    fn get_const_value_for_global(&mut self, index: GlobalIndex) -> Option<GlobalConstValue> {
         let ty = self.module.globals[index].wasm_ty;
 
         if !ty.is_vmgcref_type() && !self.module.globals[index].mutability {
@@ -1569,12 +1564,12 @@ impl FuncEnvironment<'_> {
                     .binary_search_by_key(&index, |(def_index, _)| *def_index)
                 {
                     let (_, value) = self.module.global_initializers[i];
-                    return GlobalVariable::Constant { value };
+                    return Some(value);
                 }
             }
         }
 
-        GlobalVariable::Reified
+        None
     }
 
     pub(crate) fn get_or_create_sig_ref(
@@ -3143,8 +3138,8 @@ impl FuncEnvironment<'_> {
         builder: &mut FunctionBuilder<'_>,
         global_index: GlobalIndex,
     ) -> WasmResult<ir::Value> {
-        match self.get_or_create_global(builder.func, global_index) {
-            GlobalVariable::Constant { value } => match value {
+        match self.get_const_value_for_global(global_index) {
+            Some(value) => match value {
                 GlobalConstValue::I32(x) => Ok(builder.ins().iconst(ir::types::I32, i64::from(x))),
                 GlobalConstValue::I64(x) => Ok(builder.ins().iconst(ir::types::I64, x)),
                 GlobalConstValue::F32(x) => {
@@ -3159,7 +3154,7 @@ impl FuncEnvironment<'_> {
                     Ok(builder.ins().vconst(ir::types::I8X16, handle))
                 }
             },
-            GlobalVariable::Reified => {
+            None => {
                 let global_ty = self.module.globals[global_index];
                 let wasm_ty = global_ty.wasm_ty;
                 let (base, offset) = self.get_global_location(&mut builder.cursor(), global_index);
@@ -3215,54 +3210,52 @@ impl FuncEnvironment<'_> {
         val: ir::Value,
         initialized: bool,
     ) -> WasmResult<()> {
-        match self.get_or_create_global(builder.func, global_index) {
-            GlobalVariable::Constant { .. } => {
-                unreachable!("validation checks that Wasm cannot `global.set` constant globals")
-            }
-            GlobalVariable::Reified => {
-                let wasm_ty = self.module.globals[global_index].wasm_ty;
-                let (base, offset) = self.get_global_location(&mut builder.cursor(), global_index);
+        debug_assert!(
+            self.get_const_value_for_global(global_index).is_none(),
+            "validation checks that Wasm cannot `global.set` constant globals"
+        );
 
-                if wasm_ty.is_vmgcref_type() {
-                    let WasmValType::Ref(ty) = wasm_ty else {
-                        unreachable!()
-                    };
-                    let offset = builder.ins().iconst(self.pointer_type(), i64::from(offset));
-                    let src = builder.ins().iadd(base, offset);
-                    let mut gc = gc::gc_compiler(self)?;
-                    if initialized {
-                        gc.translate_write_gc_reference(
-                            self,
-                            builder,
-                            ty,
-                            src,
-                            val,
-                            ir::MemFlagsData::trusted(),
-                        )?;
-                    } else {
-                        gc.translate_init_gc_reference(
-                            self,
-                            builder,
-                            ty,
-                            src,
-                            val,
-                            ir::MemFlagsData::trusted(),
-                        )?;
-                    }
-                } else {
-                    let ty = super::value_type(self.isa, wasm_ty);
-                    let mut flags = ir::MemFlagsData::trusted();
-                    // Like `global.get`, store globals in little-endian format.
-                    if ty.is_vector() {
-                        flags.set_endianness(ir::Endianness::Little);
-                    }
-                    let region = self.global_alias_region(builder.func, global_index);
-                    flags.set_alias_region(Some(region));
-                    debug_assert_eq!(ty, builder.func.dfg.value_type(val));
-                    builder.ins().store(flags, val, base, offset);
-                    self.update_global(builder, global_index, val);
-                }
+        let wasm_ty = self.module.globals[global_index].wasm_ty;
+        let (base, offset) = self.get_global_location(&mut builder.cursor(), global_index);
+
+        if wasm_ty.is_vmgcref_type() {
+            let WasmValType::Ref(ty) = wasm_ty else {
+                unreachable!()
+            };
+            let offset = builder.ins().iconst(self.pointer_type(), i64::from(offset));
+            let src = builder.ins().iadd(base, offset);
+            let mut gc = gc::gc_compiler(self)?;
+            if initialized {
+                gc.translate_write_gc_reference(
+                    self,
+                    builder,
+                    ty,
+                    src,
+                    val,
+                    ir::MemFlagsData::trusted(),
+                )?;
+            } else {
+                gc.translate_init_gc_reference(
+                    self,
+                    builder,
+                    ty,
+                    src,
+                    val,
+                    ir::MemFlagsData::trusted(),
+                )?;
             }
+        } else {
+            let ty = super::value_type(self.isa, wasm_ty);
+            let mut flags = ir::MemFlagsData::trusted();
+            // Like `global.get`, store globals in little-endian format.
+            if ty.is_vector() {
+                flags.set_endianness(ir::Endianness::Little);
+            }
+            let region = self.global_alias_region(builder.func, global_index);
+            flags.set_alias_region(Some(region));
+            debug_assert_eq!(ty, builder.func.dfg.value_type(val));
+            builder.ins().store(flags, val, base, offset);
+            self.update_global(builder, global_index, val);
         }
         Ok(())
     }

--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -3227,7 +3227,7 @@ impl FuncEnvironment<'_> {
                     let WasmValType::Ref(ty) = wasm_ty else {
                         unreachable!()
                     };
-                    let offset = builder.ins().iconst(self.pointer_type(), offset);
+                    let offset = builder.ins().iconst(self.pointer_type(), i64::from(offset));
                     let src = builder.ins().iadd(base, offset);
                     let mut gc = gc::gc_compiler(self)?;
                     if initialized {

--- a/crates/cranelift/src/translate/environ/mod.rs
+++ b/crates/cranelift/src/translate/environ/mod.rs
@@ -3,4 +3,4 @@
 #[macro_use]
 mod spec;
 
-pub use crate::translate::environ::spec::{GlobalVariable, StructFieldsVec, TargetEnvironment};
+pub use crate::translate::environ::spec::{StructFieldsVec, TargetEnvironment};

--- a/crates/cranelift/src/translate/environ/spec.rs
+++ b/crates/cranelift/src/translate/environ/spec.rs
@@ -9,20 +9,7 @@
 use cranelift_codegen::ir;
 use cranelift_codegen::isa::TargetFrontendConfig;
 use smallvec::SmallVec;
-use wasmtime_environ::{GlobalConstValue, Tunables, TypeConvert, WasmHeapType};
-
-/// The value of a WebAssembly global variable.
-#[derive(Clone, Copy)]
-pub enum GlobalVariable {
-    /// The global is known to be a constant value.
-    Constant {
-        /// The global's known value.
-        value: GlobalConstValue,
-    },
-
-    /// This global is reified in memory.
-    Reified,
-}
+use wasmtime_environ::{Tunables, TypeConvert, WasmHeapType};
 
 /// Environment affecting the translation of a WebAssembly.
 pub trait TargetEnvironment: TypeConvert {

--- a/crates/cranelift/src/translate/environ/spec.rs
+++ b/crates/cranelift/src/translate/environ/spec.rs
@@ -7,7 +7,6 @@
 //! [Wasmtime]: https://github.com/bytecodealliance/wasmtime
 
 use cranelift_codegen::ir;
-use cranelift_codegen::ir::immediates::Offset32;
 use cranelift_codegen::isa::TargetFrontendConfig;
 use smallvec::SmallVec;
 use wasmtime_environ::{GlobalConstValue, Tunables, TypeConvert, WasmHeapType};
@@ -21,18 +20,8 @@ pub enum GlobalVariable {
         value: GlobalConstValue,
     },
 
-    /// This is a variable in memory that should be referenced through a `GlobalValue`.
-    Memory {
-        /// The address of the global variable storage.
-        gv: ir::GlobalValue,
-        /// An offset to add to the address.
-        offset: Offset32,
-        /// The global variable's type.
-        ty: ir::Type,
-    },
-
-    /// This is a global variable that needs to be handled by the environment.
-    Custom,
+    /// This global is reified in memory.
+    Reified,
 }
 
 /// Environment affecting the translation of a WebAssembly.

--- a/crates/cranelift/src/translate/mod.rs
+++ b/crates/cranelift/src/translate/mod.rs
@@ -18,7 +18,7 @@ mod stack;
 mod table;
 mod translation_utils;
 
-pub use self::environ::{GlobalVariable, StructFieldsVec, TargetEnvironment};
+pub use self::environ::{StructFieldsVec, TargetEnvironment};
 pub use self::func_translator::FuncTranslator;
 pub use self::heap::{Heap, HeapData, MemoryKind};
 pub use self::stack::FuncTranslationStacks;

--- a/tests/disas/alias-region-globals.wat
+++ b/tests/disas/alias-region-globals.wat
@@ -22,8 +22,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region1 gv3+48
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/branch-hinting.wat
+++ b/tests/disas/branch-hinting.wat
@@ -172,7 +172,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -184,8 +183,8 @@
 ;; @009f                               jump block3
 ;;
 ;;                                 block4 cold:
-;; @00a0                               v5 = iconst.i32 2
-;; @00a2                               store notrap aligned region1 v5, v0+48  ; v5 = 2
+;; @00a0                               v4 = iconst.i32 2
+;; @00a2                               store notrap aligned region1 v4, v0+48  ; v4 = 2
 ;; @00a4                               jump block3
 ;;
 ;;                                 block3:

--- a/tests/disas/component-model/direct-adapter-calls-inlining.wat
+++ b/tests/disas/component-model/direct-adapter-calls-inlining.wat
@@ -58,10 +58,10 @@
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 72 "VMContext+0x48"
 ;;     region2 = 136 "VMContext+0x88"
-;;     region3 = 112 "VMContext+0x70"
-;;     region4 = 1610612736 "PublicGlobal"
-;;     region5 = 104 "VMContext+0x68"
-;;     region6 = 88 "VMContext+0x58"
+;;     region3 = 1610612736 "PublicGlobal"
+;;     region4 = 104 "VMContext+0x68"
+;;     region5 = 88 "VMContext+0x58"
+;;     region6 = 112 "VMContext+0x70"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -69,11 +69,8 @@
 ;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
 ;;     gv5 = load.i64 notrap aligned gv4+24
 ;;     gv6 = vmctx
-;;     gv7 = load.i64 notrap aligned readonly can_move region2 gv6+136
-;;     gv8 = load.i64 notrap aligned readonly can_move region3 gv6+112
-;;     gv9 = vmctx
-;;     gv10 = load.i64 notrap aligned readonly can_move region0 gv9+8
-;;     gv11 = load.i64 notrap aligned gv10+24
+;;     gv7 = load.i64 notrap aligned readonly can_move region0 gv6+8
+;;     gv8 = load.i64 notrap aligned gv7+24
 ;;     sig0 = (i64 vmctx, i64, i32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i64, i32) tail
 ;;     sig2 = (i64 vmctx, i64, i32) -> i32 tail
@@ -93,7 +90,7 @@
 ;;                                 block6:
 ;; @00ee                               v4 = load.i64 notrap aligned readonly can_move region1 v0+72
 ;;                                     v14 = load.i64 notrap aligned readonly can_move region2 v4+136
-;;                                     v15 = load.i32 notrap aligned region4 v14
+;;                                     v15 = load.i32 notrap aligned region3 v14
 ;;                                     v16 = iconst.i32 1
 ;;                                     v17 = band v15, v16  ; v16 = 1
 ;;                                     v13 = iconst.i32 0
@@ -101,8 +98,8 @@
 ;;                                     brif v19, block9, block10
 ;;
 ;;                                 block9:
-;;                                     v23 = load.i64 notrap aligned readonly can_move region6 v4+88
-;;                                     v22 = load.i64 notrap aligned readonly can_move region5 v4+104
+;;                                     v23 = load.i64 notrap aligned readonly can_move region5 v4+88
+;;                                     v22 = load.i64 notrap aligned readonly can_move region4 v4+104
 ;;                                     v21 = iconst.i32 23
 ;;                                     try_call_indirect v23(v22, v4, v21), sig1, block11, [ context v4, default: block8(exn0) ]  ; v21 = 23
 ;;
@@ -110,14 +107,14 @@
 ;;                                     trap user12
 ;;
 ;;                                 block10:
-;;                                     v28 = load.i64 notrap aligned readonly can_move region3 v4+112
-;;                                     v29 = load.i32 notrap aligned region4 v28
+;;                                     v28 = load.i64 notrap aligned readonly can_move region6 v4+112
+;;                                     v29 = load.i32 notrap aligned region3 v28
 ;;                                     v30 = iconst.i32 -2
 ;;                                     v31 = band v29, v30  ; v30 = -2
-;;                                     store notrap aligned region4 v31, v28
+;;                                     store notrap aligned region3 v31, v28
 ;;                                     v61 = iconst.i32 1
 ;;                                     v62 = bor v29, v61  ; v61 = 1
-;;                                     store notrap aligned region4 v62, v28
+;;                                     store notrap aligned region3 v62, v28
 ;;                                     jump block13
 ;;
 ;;                                 block13:
@@ -127,13 +124,13 @@
 ;;                                     jump block12
 ;;
 ;;                                 block12:
-;;                                     v42 = load.i32 notrap aligned region4 v14
+;;                                     v42 = load.i32 notrap aligned region3 v14
 ;;                                     v63 = iconst.i32 -2
 ;;                                     v64 = band v42, v63  ; v63 = -2
-;;                                     store notrap aligned region4 v64, v14
+;;                                     store notrap aligned region3 v64, v14
 ;;                                     v65 = iconst.i32 1
 ;;                                     v66 = bor v42, v65  ; v65 = 1
-;;                                     store notrap aligned region4 v66, v14
+;;                                     store notrap aligned region3 v66, v14
 ;;                                     jump block7
 ;;
 ;;                                 block7:

--- a/tests/disas/component-model/direct-adapter-calls.wat
+++ b/tests/disas/component-model/direct-adapter-calls.wat
@@ -104,9 +104,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region1 gv3+136
-;;     gv5 = load.i64 notrap aligned readonly can_move region5 gv3+112
 ;;     sig0 = (i64 vmctx, i64, i32) tail
 ;;     sig1 = (i64 vmctx, i64, i32) -> i32 tail
 ;;     fn0 = colocated u0:0 sig1
@@ -142,30 +139,30 @@
 ;; @0090                               v21 = iconst.i32 -2
 ;; @0092                               v22 = band v20, v21  ; v21 = -2
 ;; @0093                               store notrap aligned region2 v22, v19
-;;                                     v57 = iconst.i32 1
-;;                                     v58 = bor v20, v57  ; v57 = 1
-;; @009c                               store notrap aligned region2 v58, v19
+;;                                     v48 = iconst.i32 1
+;;                                     v49 = bor v20, v48  ; v48 = 1
+;; @009c                               store notrap aligned region2 v49, v19
 ;; @009e                               v29 = load.i64 notrap aligned readonly can_move region6 v0+72
 ;; @009e                               try_call fn0(v29, v0, v2), sig1, block10(ret0), [ context v0, default: block6(exn0) ]
 ;;
 ;;                                 block10(v30: i32):
 ;; @00a2                               v32 = load.i32 notrap aligned region2 v9
-;;                                     v59 = iconst.i32 -2
-;;                                     v60 = band v32, v59  ; v59 = -2
-;; @00a7                               store notrap aligned region2 v60, v9
-;;                                     v61 = iconst.i32 1
-;;                                     v62 = bor v32, v61  ; v61 = 1
-;; @00b0                               store notrap aligned region2 v62, v9
+;;                                     v50 = iconst.i32 -2
+;;                                     v51 = band v32, v50  ; v50 = -2
+;; @00a7                               store notrap aligned region2 v51, v9
+;;                                     v52 = iconst.i32 1
+;;                                     v53 = bor v32, v52  ; v52 = 1
+;; @00b0                               store notrap aligned region2 v53, v9
 ;; @00b2                               jump block5(v30)
 ;;
 ;;                                 block5(v6: i32):
 ;; @00b3                               jump block2(v6)
 ;;
 ;;                                 block3:
-;;                                     v63 = load.i64 notrap aligned readonly can_move region4 v0+88
-;;                                     v64 = load.i64 notrap aligned readonly can_move region3 v0+104
+;;                                     v54 = load.i64 notrap aligned readonly can_move region4 v0+88
+;;                                     v55 = load.i64 notrap aligned readonly can_move region3 v0+104
 ;; @00b6                               v41 = iconst.i32 49
-;; @00b8                               call_indirect sig0, v63(v64, v0, v41)  ; v41 = 49
+;; @00b8                               call_indirect sig0, v54(v55, v0, v41)  ; v41 = 49
 ;; @00ba                               trap user12
 ;;
 ;;                                 block2(v5: i32):

--- a/tests/disas/gc/copying/externref-globals.wat
+++ b/tests/disas/gc/copying/externref-globals.wat
@@ -15,17 +15,16 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @0034                               v4 = iconst.i64 48
-;; @0034                               v5 = iadd v0, v4  ; v4 = 48
-;; @0034                               v6 = load.i32 notrap aligned v5
+;; @0034                               v3 = iconst.i64 48
+;; @0034                               v4 = iadd v0, v3  ; v3 = 48
+;; @0034                               v5 = load.i32 notrap aligned v4
 ;; @0036                               jump block1
 ;;
 ;;                                 block1:
-;; @0036                               return v6
+;; @0036                               return v5
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) tail {
@@ -33,13 +32,12 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @003b                               v4 = iconst.i64 48
-;; @003b                               v5 = iadd v0, v4  ; v4 = 48
-;; @003b                               store notrap aligned v2, v5
+;; @003b                               v3 = iconst.i64 48
+;; @003b                               v4 = iadd v0, v3  ; v3 = 48
+;; @003b                               store notrap aligned v2, v4
 ;; @003d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/copying/i31ref-globals.wat
+++ b/tests/disas/gc/copying/i31ref-globals.wat
@@ -15,17 +15,16 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @0036                               v4 = iconst.i64 48
-;; @0036                               v5 = iadd v0, v4  ; v4 = 48
-;; @0036                               v6 = load.i32 notrap aligned v5
+;; @0036                               v3 = iconst.i64 48
+;; @0036                               v4 = iadd v0, v3  ; v3 = 48
+;; @0036                               v5 = load.i32 notrap aligned v4
 ;; @0038                               jump block1
 ;;
 ;;                                 block1:
-;; @0038                               return v6
+;; @0038                               return v5
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) tail {
@@ -33,13 +32,12 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @003d                               v4 = iconst.i64 48
-;; @003d                               v5 = iadd v0, v4  ; v4 = 48
-;; @003d                               store notrap aligned v2, v5
+;; @003d                               v3 = iconst.i64 48
+;; @003d                               v4 = iadd v0, v3  ; v3 = 48
+;; @003d                               store notrap aligned v2, v4
 ;; @003f                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/drc/externref-globals.wat
+++ b/tests/disas/gc/drc/externref-globals.wat
@@ -29,69 +29,69 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @0034                               v4 = iconst.i64 48
-;; @0034                               v5 = iadd v0, v4  ; v4 = 48
-;; @0034                               v6 = load.i32 notrap aligned v5
-;;                                     v76 = stack_addr.i64 ss0
-;;                                     store notrap v6, v76
-;; @0034                               v7 = iconst.i32 1
-;; @0034                               v8 = band v6, v7  ; v7 = 1
-;; @0034                               v9 = iconst.i32 0
-;; @0034                               v10 = icmp eq v6, v9  ; v9 = 0
-;; @0034                               v11 = uextend.i32 v10
-;; @0034                               v12 = bor v8, v11
-;; @0034                               brif v12, block4, block2
+;; @0034                               v3 = iconst.i64 48
+;; @0034                               v4 = iadd v0, v3  ; v3 = 48
+;; @0034                               v5 = load.i32 notrap aligned v4
+;;                                     v75 = stack_addr.i64 ss0
+;;                                     store notrap v5, v75
+;; @0034                               v6 = iconst.i32 1
+;; @0034                               v7 = band v5, v6  ; v6 = 1
+;; @0034                               v8 = iconst.i32 0
+;; @0034                               v9 = icmp eq v5, v8  ; v8 = 0
+;; @0034                               v10 = uextend.i32 v9
+;; @0034                               v11 = bor v7, v10
+;; @0034                               brif v11, block4, block2
 ;;
 ;;                                 block2:
-;; @0034                               v85 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0034                               v14 = load.i64 notrap aligned readonly can_move v85+32
-;; @0034                               v13 = uextend.i64 v6
-;; @0034                               v15 = iadd v14, v13
-;; @0034                               v16 = load.i32 user2 region1 v15
-;; @0034                               v17 = iconst.i32 2
-;; @0034                               v18 = band v16, v17  ; v17 = 2
-;; @0034                               brif v18, block4, block3
+;; @0034                               v84 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @0034                               v13 = load.i64 notrap aligned readonly can_move v84+32
+;; @0034                               v12 = uextend.i64 v5
+;; @0034                               v14 = iadd v13, v12
+;; @0034                               v15 = load.i32 user2 region1 v14
+;; @0034                               v16 = iconst.i32 2
+;; @0034                               v17 = band v15, v16  ; v16 = 2
+;; @0034                               brif v17, block4, block3
 ;;
 ;;                                 block3:
-;; @0034                               v19 = load.i64 notrap aligned readonly can_move region2 v0+32
-;; @0034                               v20 = load.i32 user2 region1 v19
-;; @0034                               v24 = iconst.i64 16
-;; @0034                               v25 = iadd.i64 v15, v24  ; v24 = 16
-;; @0034                               store user2 region1 v20, v25
-;;                                     v87 = iconst.i32 2
-;;                                     v88 = bor.i32 v16, v87  ; v87 = 2
-;; @0034                               store user2 region1 v88, v15
-;; @0034                               v34 = iconst.i64 8
-;; @0034                               v35 = iadd.i64 v15, v34  ; v34 = 8
-;; @0034                               v36 = load.i64 user2 region1 v35
-;; @0034                               v37 = iconst.i64 1
-;; @0034                               v38 = iadd v36, v37  ; v37 = 1
-;; @0034                               store user2 region1 v38, v35
-;; @0034                               store.i32 user2 region1 v6, v19
-;; @0034                               v45 = load.i32 notrap aligned v19+4
-;;                                     v89 = iconst.i32 1
-;;                                     v90 = iadd v45, v89  ; v89 = 1
-;; @0034                               store notrap aligned v90, v19+4
-;; @0034                               v52 = load.i32 notrap aligned v19+8
-;; @0034                               v53 = iadd v52, v52
-;; @0034                               v54 = iconst.i32 1024
-;; @0034                               v55 = umax v53, v54  ; v54 = 1024
-;; @0034                               v56 = icmp uge v90, v55
-;; @0034                               brif v56, block5, block6
+;; @0034                               v18 = load.i64 notrap aligned readonly can_move region2 v0+32
+;; @0034                               v19 = load.i32 user2 region1 v18
+;; @0034                               v23 = iconst.i64 16
+;; @0034                               v24 = iadd.i64 v14, v23  ; v23 = 16
+;; @0034                               store user2 region1 v19, v24
+;;                                     v86 = iconst.i32 2
+;;                                     v87 = bor.i32 v15, v86  ; v86 = 2
+;; @0034                               store user2 region1 v87, v14
+;; @0034                               v33 = iconst.i64 8
+;; @0034                               v34 = iadd.i64 v14, v33  ; v33 = 8
+;; @0034                               v35 = load.i64 user2 region1 v34
+;; @0034                               v36 = iconst.i64 1
+;; @0034                               v37 = iadd v35, v36  ; v36 = 1
+;; @0034                               store user2 region1 v37, v34
+;; @0034                               store.i32 user2 region1 v5, v18
+;; @0034                               v44 = load.i32 notrap aligned v18+4
+;;                                     v88 = iconst.i32 1
+;;                                     v89 = iadd v44, v88  ; v88 = 1
+;; @0034                               store notrap aligned v89, v18+4
+;; @0034                               v51 = load.i32 notrap aligned v18+8
+;; @0034                               v52 = iadd v51, v51
+;; @0034                               v53 = iconst.i32 1024
+;; @0034                               v54 = umax v52, v53  ; v53 = 1024
+;; @0034                               v55 = icmp uge v89, v54
+;; @0034                               brif v55, block5, block6
 ;;
 ;;                                 block5 cold:
-;; @0034                               v57 = call fn0(v0), stack_map=[i32 @ ss0+0]
+;; @0034                               v56 = call fn0(v0), stack_map=[i32 @ ss0+0]
 ;; @0034                               jump block6
 ;;
 ;;                                 block6:
 ;; @0034                               jump block4
 ;;
 ;;                                 block4:
-;;                                     v59 = load.i32 notrap v76
+;;                                     v58 = load.i32 notrap v75
 ;; @0036                               jump block1
 ;;
 ;;                                 block1:
-;; @0036                               return v59
+;; @0036                               return v58
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) tail {
@@ -109,62 +109,62 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @003b                               v4 = iconst.i64 48
-;; @003b                               v5 = iadd v0, v4  ; v4 = 48
-;; @003b                               v6 = load.i32 notrap aligned v5
-;; @003b                               v7 = iconst.i32 1
-;; @003b                               v8 = band v2, v7  ; v7 = 1
-;; @003b                               v9 = iconst.i32 0
-;; @003b                               v10 = icmp eq v2, v9  ; v9 = 0
-;; @003b                               v11 = uextend.i32 v10
-;; @003b                               v12 = bor v8, v11
-;; @003b                               brif v12, block3, block2
+;; @003b                               v3 = iconst.i64 48
+;; @003b                               v4 = iadd v0, v3  ; v3 = 48
+;; @003b                               v5 = load.i32 notrap aligned v4
+;; @003b                               v6 = iconst.i32 1
+;; @003b                               v7 = band v2, v6  ; v6 = 1
+;; @003b                               v8 = iconst.i32 0
+;; @003b                               v9 = icmp eq v2, v8  ; v8 = 0
+;; @003b                               v10 = uextend.i32 v9
+;; @003b                               v11 = bor v7, v10
+;; @003b                               brif v11, block3, block2
 ;;
 ;;                                 block2:
-;; @003b                               v53 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @003b                               v14 = load.i64 notrap aligned readonly can_move v53+32
-;; @003b                               v13 = uextend.i64 v2
-;; @003b                               v15 = iadd v14, v13
-;; @003b                               v16 = iconst.i64 8
-;; @003b                               v17 = iadd v15, v16  ; v16 = 8
-;; @003b                               v18 = load.i64 user2 region1 v17
-;; @003b                               v19 = iconst.i64 1
-;; @003b                               v20 = iadd v18, v19  ; v19 = 1
-;; @003b                               store user2 region1 v20, v17
+;; @003b                               v52 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @003b                               v13 = load.i64 notrap aligned readonly can_move v52+32
+;; @003b                               v12 = uextend.i64 v2
+;; @003b                               v14 = iadd v13, v12
+;; @003b                               v15 = iconst.i64 8
+;; @003b                               v16 = iadd v14, v15  ; v15 = 8
+;; @003b                               v17 = load.i64 user2 region1 v16
+;; @003b                               v18 = iconst.i64 1
+;; @003b                               v19 = iadd v17, v18  ; v18 = 1
+;; @003b                               store user2 region1 v19, v16
 ;; @003b                               jump block3
 ;;
 ;;                                 block3:
-;;                                     v67 = iadd.i64 v0, v4  ; v4 = 48
-;; @003b                               store.i32 notrap aligned v2, v67
-;;                                     v68 = iconst.i32 1
-;;                                     v69 = band.i32 v6, v68  ; v68 = 1
-;;                                     v70 = iconst.i32 0
-;;                                     v71 = icmp.i32 eq v6, v70  ; v70 = 0
-;; @003b                               v30 = uextend.i32 v71
-;; @003b                               v31 = bor v69, v30
-;; @003b                               brif v31, block7, block4
+;;                                     v66 = iadd.i64 v0, v3  ; v3 = 48
+;; @003b                               store.i32 notrap aligned v2, v66
+;;                                     v67 = iconst.i32 1
+;;                                     v68 = band.i32 v5, v67  ; v67 = 1
+;;                                     v69 = iconst.i32 0
+;;                                     v70 = icmp.i32 eq v5, v69  ; v69 = 0
+;; @003b                               v29 = uextend.i32 v70
+;; @003b                               v30 = bor v68, v29
+;; @003b                               brif v30, block7, block4
 ;;
 ;;                                 block4:
-;;                                     v72 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v73 = load.i64 notrap aligned readonly can_move v72+32
-;; @003b                               v32 = uextend.i64 v6
-;; @003b                               v34 = iadd v73, v32
-;;                                     v74 = iconst.i64 8
-;; @003b                               v36 = iadd v34, v74  ; v74 = 8
-;; @003b                               v37 = load.i64 user2 region1 v36
-;;                                     v75 = iconst.i64 1
-;;                                     v65 = icmp eq v37, v75  ; v75 = 1
-;; @003b                               brif v65, block5, block6
+;;                                     v71 = load.i64 notrap aligned readonly can_move region0 v0+8
+;;                                     v72 = load.i64 notrap aligned readonly can_move v71+32
+;; @003b                               v31 = uextend.i64 v5
+;; @003b                               v33 = iadd v72, v31
+;;                                     v73 = iconst.i64 8
+;; @003b                               v35 = iadd v33, v73  ; v73 = 8
+;; @003b                               v36 = load.i64 user2 region1 v35
+;;                                     v74 = iconst.i64 1
+;;                                     v64 = icmp eq v36, v74  ; v74 = 1
+;; @003b                               brif v64, block5, block6
 ;;
 ;;                                 block5 cold:
-;; @003b                               call fn0(v0, v6)
+;; @003b                               call fn0(v0, v5)
 ;; @003b                               jump block7
 ;;
 ;;                                 block6:
-;; @003b                               v38 = iconst.i64 -1
-;; @003b                               v39 = iadd.i64 v37, v38  ; v38 = -1
-;;                                     v76 = iadd.i64 v34, v74  ; v74 = 8
-;; @003b                               store user2 region1 v39, v76
+;; @003b                               v37 = iconst.i64 -1
+;; @003b                               v38 = iadd.i64 v36, v37  ; v37 = -1
+;;                                     v75 = iadd.i64 v33, v73  ; v73 = 8
+;; @003b                               store user2 region1 v38, v75
 ;; @003b                               jump block7
 ;;
 ;;                                 block7:

--- a/tests/disas/gc/drc/i31ref-globals.wat
+++ b/tests/disas/gc/drc/i31ref-globals.wat
@@ -17,17 +17,16 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @0036                               v4 = iconst.i64 48
-;; @0036                               v5 = iadd v0, v4  ; v4 = 48
-;; @0036                               v6 = load.i32 notrap aligned v5
+;; @0036                               v3 = iconst.i64 48
+;; @0036                               v4 = iadd v0, v3  ; v3 = 48
+;; @0036                               v5 = load.i32 notrap aligned v4
 ;; @0038                               jump block1
 ;;
 ;;                                 block1:
-;; @0038                               return v6
+;; @0038                               return v5
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) tail {
@@ -35,13 +34,12 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @003d                               v4 = iconst.i64 48
-;; @003d                               v5 = iadd v0, v4  ; v4 = 48
-;; @003d                               store notrap aligned v2, v5
+;; @003d                               v3 = iconst.i64 48
+;; @003d                               v4 = iadd v0, v3  ; v3 = 48
+;; @003d                               store notrap aligned v2, v4
 ;; @003f                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/null/externref-globals.wat
+++ b/tests/disas/gc/null/externref-globals.wat
@@ -17,17 +17,16 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @0034                               v4 = iconst.i64 48
-;; @0034                               v5 = iadd v0, v4  ; v4 = 48
-;; @0034                               v6 = load.i32 notrap aligned v5
+;; @0034                               v3 = iconst.i64 48
+;; @0034                               v4 = iadd v0, v3  ; v3 = 48
+;; @0034                               v5 = load.i32 notrap aligned v4
 ;; @0036                               jump block1
 ;;
 ;;                                 block1:
-;; @0036                               return v6
+;; @0036                               return v5
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) tail {
@@ -35,13 +34,12 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @003b                               v4 = iconst.i64 48
-;; @003b                               v5 = iadd v0, v4  ; v4 = 48
-;; @003b                               store notrap aligned v2, v5
+;; @003b                               v3 = iconst.i64 48
+;; @003b                               v4 = iadd v0, v3  ; v3 = 48
+;; @003b                               store notrap aligned v2, v4
 ;; @003d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/null/i31ref-globals.wat
+++ b/tests/disas/gc/null/i31ref-globals.wat
@@ -17,17 +17,16 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @0036                               v4 = iconst.i64 48
-;; @0036                               v5 = iadd v0, v4  ; v4 = 48
-;; @0036                               v6 = load.i32 notrap aligned v5
+;; @0036                               v3 = iconst.i64 48
+;; @0036                               v4 = iadd v0, v3  ; v3 = 48
+;; @0036                               v5 = load.i32 notrap aligned v4
 ;; @0038                               jump block1
 ;;
 ;;                                 block1:
-;; @0038                               return v6
+;; @0038                               return v5
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) tail {
@@ -35,13 +34,12 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @003d                               v4 = iconst.i64 48
-;; @003d                               v5 = iadd v0, v4  ; v4 = 48
-;; @003d                               store notrap aligned v2, v5
+;; @003d                               v3 = iconst.i64 48
+;; @003d                               v4 = iadd v0, v3  ; v3 = 48
+;; @003d                               store notrap aligned v2, v4
 ;; @003f                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/global-get.wat
+++ b/tests/disas/global-get.wat
@@ -37,8 +37,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region1 gv3+48
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
@@ -57,8 +55,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region1 gv3+72
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
@@ -91,13 +87,12 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @004c                               v4 = load.i32 notrap aligned region1 v0+112
+;; @004c                               v3 = load.i32 notrap aligned region1 v0+112
 ;; @004e                               jump block1
 ;;
 ;;                                 block1:
-;; @004e                               return v4
+;; @004e                               return v3
 ;; }

--- a/tests/disas/globals.wat
+++ b/tests/disas/globals.wat
@@ -24,11 +24,11 @@
 ;;                                 block0(v0: i64, v1: i64):
 ;; @0027                               v2 = iconst.i32 0
 ;; @0029                               v3 = iconst.i32 0
-;; @002b                               v5 = load.i32 notrap aligned region1 v0+80
-;; @002d                               v6 = uextend.i64 v3  ; v3 = 0
-;; @002d                               v7 = load.i64 notrap aligned readonly can_move v0+56
-;; @002d                               v8 = iadd v7, v6
-;; @002d                               store little region2 v5, v8
+;; @002b                               v4 = load.i32 notrap aligned region1 v0+80
+;; @002d                               v5 = uextend.i64 v3  ; v3 = 0
+;; @002d                               v6 = load.i64 notrap aligned readonly can_move v0+56
+;; @002d                               v7 = iadd v6, v5
+;; @002d                               store little region2 v4, v7
 ;; @0030                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/pic.wat
+++ b/tests/disas/pic.wat
@@ -85,30 +85,30 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0066                               v6 = load.i32 notrap aligned region1 v0+128
-;; @0068                               v7 = iconst.i32 16
-;; @006a                               v8 = isub v6, v7  ; v7 = 16
-;; @006d                               store notrap aligned region1 v8, v0+128
-;; @0073                               v11 = load.i64 notrap aligned readonly can_move v0+56
-;; @0073                               v10 = uextend.i64 v2
-;; @0073                               v12 = iadd v11, v10
-;; @0073                               v13 = load.i32 little region2 v12
-;; @0078                               v14 = uextend.i64 v8
-;; @0078                               v16 = iadd v11, v14
-;; @0078                               v17 = iconst.i64 12
-;; @0078                               v18 = iadd v16, v17  ; v17 = 12
-;; @0078                               store little region2 v13, v18
-;; @0084                               v23 = load.i64 notrap aligned readonly can_move region4 v0+80
-;; @0084                               v22 = load.i64 notrap aligned readonly can_move region3 v0+96
-;;                                     v35 = iconst.i32 -4
-;;                                     v36 = iadd v6, v35  ; v35 = -4
-;; @0084                               call_indirect sig0, v23(v22, v0, v36)
-;;                                     v43 = iconst.i64 0x0010_0000
-;; @0090                               v28 = iadd v11, v43  ; v43 = 0x0010_0000
-;; @0090                               store little region2 v13, v28
-;; @0098                               store notrap aligned region1 v6, v0+128
+;; @0066                               v5 = load.i32 notrap aligned region1 v0+128
+;; @0068                               v6 = iconst.i32 16
+;; @006a                               v7 = isub v5, v6  ; v6 = 16
+;; @006d                               store notrap aligned region1 v7, v0+128
+;; @0073                               v9 = load.i64 notrap aligned readonly can_move v0+56
+;; @0073                               v8 = uextend.i64 v2
+;; @0073                               v10 = iadd v9, v8
+;; @0073                               v11 = load.i32 little region2 v10
+;; @0078                               v12 = uextend.i64 v7
+;; @0078                               v14 = iadd v9, v12
+;; @0078                               v15 = iconst.i64 12
+;; @0078                               v16 = iadd v14, v15  ; v15 = 12
+;; @0078                               store little region2 v11, v16
+;; @0084                               v21 = load.i64 notrap aligned readonly can_move region4 v0+80
+;; @0084                               v20 = load.i64 notrap aligned readonly can_move region3 v0+96
+;;                                     v32 = iconst.i32 -4
+;;                                     v33 = iadd v5, v32  ; v32 = -4
+;; @0084                               call_indirect sig0, v21(v20, v0, v33)
+;;                                     v40 = iconst.i64 0x0010_0000
+;; @0090                               v26 = iadd v9, v40  ; v40 = 0x0010_0000
+;; @0090                               store little region2 v11, v26
+;; @0098                               store notrap aligned region1 v5, v0+128
 ;; @009c                               jump block1
 ;;
 ;;                                 block1:
-;; @009c                               return v13
+;; @009c                               return v11
 ;; }

--- a/tests/disas/ref-func-0.wat
+++ b/tests/disas/ref-func-0.wat
@@ -19,20 +19,19 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @008f                               v7 = iconst.i64 80
-;; @008f                               v8 = iadd v0, v7  ; v7 = 80
-;; @008f                               v9 = load.i32 notrap aligned v8
-;; @0091                               v11 = iconst.i64 96
-;; @0091                               v12 = iadd v0, v11  ; v11 = 96
-;; @0091                               v13 = load.i32 notrap aligned v12
-;; @0093                               v15 = load.i64 notrap aligned region1 v0+112
-;; @0095                               v17 = load.i64 notrap aligned region1 v0+128
+;; @008f                               v6 = iconst.i64 80
+;; @008f                               v7 = iadd v0, v6  ; v6 = 80
+;; @008f                               v8 = load.i32 notrap aligned v7
+;; @0091                               v9 = iconst.i64 96
+;; @0091                               v10 = iadd v0, v9  ; v9 = 96
+;; @0091                               v11 = load.i32 notrap aligned v10
+;; @0093                               v12 = load.i64 notrap aligned region1 v0+112
+;; @0095                               v13 = load.i64 notrap aligned region1 v0+128
 ;; @0097                               jump block1
 ;;
 ;;                                 block1:
-;; @0097                               return v9, v13, v15, v17
+;; @0097                               return v8, v11, v12, v13
 ;; }

--- a/tests/disas/startup-global.wat
+++ b/tests/disas/startup-global.wat
@@ -34,7 +34,6 @@
 ;;
 ;; function u2415919104:0(i64 vmctx, i64) tail {
 ;;     region0 = 1879048192 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(0))"
-;;     gv0 = vmctx
 ;;
 ;; block0(v0: i64, v1: i64):
 ;;     v2 = iconst.i64 0

--- a/tests/disas/sub-global.wat
+++ b/tests/disas/sub-global.wat
@@ -18,14 +18,13 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @0020                               v3 = load.i32 notrap aligned region1 v0+48
-;; @0022                               v4 = iconst.i32 16
-;; @0024                               v5 = isub v3, v4  ; v4 = 16
-;; @0025                               store notrap aligned region1 v5, v0+48
+;; @0020                               v2 = load.i32 notrap aligned region1 v0+48
+;; @0022                               v3 = iconst.i32 16
+;; @0024                               v4 = isub v2, v3  ; v3 = 16
+;; @0025                               store notrap aligned region1 v4, v0+48
 ;; @0027                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/typed-funcrefs-eager-init.wat
+++ b/tests/disas/typed-funcrefs-eager-init.wat
@@ -198,22 +198,21 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, i64, i32, i32, i32, i32) -> i32 tail
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):
-;; @009e                               v9 = load.i64 notrap aligned region1 v0+64
-;; @00a0                               v10 = load.i64 user16 aligned readonly v9+8
-;; @00a0                               v11 = load.i64 notrap aligned readonly v9+24
-;; @00a0                               v12 = call_indirect sig0, v10(v11, v0, v2, v3, v4, v5)
-;; @00af                               v15 = load.i64 notrap aligned region2 v0+80
-;; @00b1                               v16 = load.i64 user16 aligned readonly v15+8
-;; @00b1                               v17 = load.i64 notrap aligned readonly v15+24
-;; @00b1                               v18 = call_indirect sig0, v16(v17, v0, v2, v3, v4, v5)
+;; @009e                               v8 = load.i64 notrap aligned region1 v0+64
+;; @00a0                               v9 = load.i64 user16 aligned readonly v8+8
+;; @00a0                               v10 = load.i64 notrap aligned readonly v8+24
+;; @00a0                               v11 = call_indirect sig0, v9(v10, v0, v2, v3, v4, v5)
+;; @00af                               v13 = load.i64 notrap aligned region2 v0+80
+;; @00b1                               v14 = load.i64 user16 aligned readonly v13+8
+;; @00b1                               v15 = load.i64 notrap aligned readonly v13+24
+;; @00b1                               v16 = call_indirect sig0, v14(v15, v0, v2, v3, v4, v5)
 ;; @00ba                               jump block1
 ;;
 ;;                                 block1:
-;; @00b5                               v19 = iadd.i32 v18, v12
-;; @00ba                               return v19
+;; @00b5                               v17 = iadd.i32 v16, v11
+;; @00ba                               return v17
 ;; }

--- a/tests/disas/typed-funcrefs.wat
+++ b/tests/disas/typed-funcrefs.wat
@@ -246,22 +246,21 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, i64, i32, i32, i32, i32) -> i32 tail
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):
-;; @009e                               v9 = load.i64 notrap aligned region1 v0+64
-;; @00a0                               v10 = load.i64 user16 aligned readonly v9+8
-;; @00a0                               v11 = load.i64 notrap aligned readonly v9+24
-;; @00a0                               v12 = call_indirect sig0, v10(v11, v0, v2, v3, v4, v5)
-;; @00af                               v15 = load.i64 notrap aligned region2 v0+80
-;; @00b1                               v16 = load.i64 user16 aligned readonly v15+8
-;; @00b1                               v17 = load.i64 notrap aligned readonly v15+24
-;; @00b1                               v18 = call_indirect sig0, v16(v17, v0, v2, v3, v4, v5)
+;; @009e                               v8 = load.i64 notrap aligned region1 v0+64
+;; @00a0                               v9 = load.i64 user16 aligned readonly v8+8
+;; @00a0                               v10 = load.i64 notrap aligned readonly v8+24
+;; @00a0                               v11 = call_indirect sig0, v9(v10, v0, v2, v3, v4, v5)
+;; @00af                               v13 = load.i64 notrap aligned region2 v0+80
+;; @00b1                               v14 = load.i64 user16 aligned readonly v13+8
+;; @00b1                               v15 = load.i64 notrap aligned readonly v13+24
+;; @00b1                               v16 = call_indirect sig0, v14(v15, v0, v2, v3, v4, v5)
 ;; @00ba                               jump block1
 ;;
 ;;                                 block1:
-;; @00b5                               v19 = iadd.i32 v18, v12
-;; @00ba                               return v19
+;; @00b5                               v17 = iadd.i32 v16, v11
+;; @00ba                               return v17
 ;; }


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
