### PR TITLE
Add bounds check in VMContinuationStack::initialize for args buffer size

### DIFF
--- a/crates/wasmtime/src/runtime/vm/stack_switching.rs
+++ b/crates/wasmtime/src/runtime/vm/stack_switching.rs
@@ -327,7 +327,7 @@ pub fn cont_new(
         contref_args_ptr,
         param_count,
         result_count,
-    );
+    )?;
 
     // Now that the initial stack pointer was set by the initialization
     // function, use it to determine stack limit.

--- a/crates/wasmtime/src/runtime/vm/stack_switching/stack.rs
+++ b/crates/wasmtime/src/runtime/vm/stack_switching/stack.rs
@@ -105,7 +105,7 @@ impl VMContinuationStack {
         args: *mut VMHostArray<ValRaw>,
         parameter_count: u32,
         return_value_count: u32,
-    ) {
+    ) -> Result<()> {
         self.0.initialize(
             func_ref,
             caller_vmctx,

--- a/crates/wasmtime/src/runtime/vm/stack_switching/stack/dummy.rs
+++ b/crates/wasmtime/src/runtime/vm/stack_switching/stack/dummy.rs
@@ -62,6 +62,7 @@ impl VMContinuationStack {
         _args: *mut VMHostArray<ValRaw>,
         _parameter_count: u32,
         _return_value_count: u32,
-    ) {
+    ) -> Result<()> {
+        Ok(())
     }
 }

--- a/crates/wasmtime/src/runtime/vm/stack_switching/stack/unix.rs
+++ b/crates/wasmtime/src/runtime/vm/stack_switching/stack/unix.rs
@@ -286,10 +286,7 @@ impl VMContinuationStack {
                 (0x28 + args_data_size, func_ref.addr()),
                 (0x30 + args_data_size, caller_vmctx.addr()),
                 (0x38 + args_data_size, args.addr()),
-                (
-                    0x40 + args_data_size,
-                    usize::try_from(return_value_count)?,
-                ),
+                (0x40 + args_data_size, usize::try_from(return_value_count)?),
             ];
 
             for (offset, data) in to_store {

--- a/crates/wasmtime/src/runtime/vm/stack_switching/stack/unix.rs
+++ b/crates/wasmtime/src/runtime/vm/stack_switching/stack/unix.rs
@@ -246,8 +246,7 @@ impl VMContinuationStack {
             debug_assert_eq!(args_ref.capacity, 0);
             debug_assert_eq!(args_ref.length, 0);
 
-            let args_data_size = usize::try_from(args_capacity)
-                .unwrap()
+            let total_control_size = usize::try_from(args_capacity)?
                 .checked_mul(std::mem::size_of::<ValRaw>())
                 .and_then(|s| s.checked_add(0x40))
                 .ok_or_else(|| {
@@ -256,15 +255,12 @@ impl VMContinuationStack {
                          overflows stack control data size calculation"
                     )
                 })?;
-            // `args_data_size` now includes the 0x40 bytes of fixed control
-            // data. Subtract it back for the raw buffer size used below.
-            let args_data_size = args_data_size - 0x40;
+            let args_data_size = total_control_size - 0x40;
 
             // Ensure the control data (fixed header + args buffer) fits
             // within the stack allocation. Without this check, a
             // high-arity function type could write past the guard page
             // into adjacent memory.
-            let total_control_size = 0x40 + args_data_size;
             ensure!(
                 total_control_size <= self.len,
                 "continuation function type requires {total_control_size} bytes \
@@ -284,15 +280,15 @@ impl VMContinuationStack {
                 // Data near top of stack:
                 (0x08, wasmtime_continuation_start_address().addr()),
                 (0x10, tos.sub(0x10).addr()),
-                (0x18, tos.sub(0x40 + args_data_size).addr()),
-                (0x20, usize::try_from(args_capacity).unwrap()),
+                (0x18, tos.sub(total_control_size).addr()),
+                (0x20, usize::try_from(args_capacity)?),
                 // Data after the args buffer:
                 (0x28 + args_data_size, func_ref.addr()),
                 (0x30 + args_data_size, caller_vmctx.addr()),
                 (0x38 + args_data_size, args.addr()),
                 (
                     0x40 + args_data_size,
-                    usize::try_from(return_value_count).unwrap(),
+                    usize::try_from(return_value_count)?,
                 ),
             ];
 

--- a/crates/wasmtime/src/runtime/vm/stack_switching/stack/unix.rs
+++ b/crates/wasmtime/src/runtime/vm/stack_switching/stack/unix.rs
@@ -63,6 +63,7 @@ use std::io;
 use std::ops::Range;
 use std::ptr;
 
+use crate::prelude::*;
 use crate::runtime::vm::stack_switching::VMHostArray;
 use crate::runtime::vm::{VMContext, VMFuncRef, ValRaw};
 
@@ -230,7 +231,7 @@ impl VMContinuationStack {
         args: *mut VMHostArray<ValRaw>,
         parameter_count: u32,
         return_value_count: u32,
-    ) {
+    ) -> Result<()> {
         let tos = self.top;
 
         unsafe {
@@ -245,8 +246,31 @@ impl VMContinuationStack {
             debug_assert_eq!(args_ref.capacity, 0);
             debug_assert_eq!(args_ref.length, 0);
 
-            let args_data_size =
-                usize::try_from(args_capacity).unwrap() * std::mem::size_of::<ValRaw>();
+            let args_data_size = usize::try_from(args_capacity)
+                .unwrap()
+                .checked_mul(std::mem::size_of::<ValRaw>())
+                .and_then(|s| s.checked_add(0x40))
+                .ok_or_else(|| {
+                    format_err!(
+                        "continuation function type with {args_capacity} args \
+                         overflows stack control data size calculation"
+                    )
+                })?;
+            // `args_data_size` now includes the 0x40 bytes of fixed control
+            // data. Subtract it back for the raw buffer size used below.
+            let args_data_size = args_data_size - 0x40;
+
+            // Ensure the control data (fixed header + args buffer) fits
+            // within the stack allocation. Without this check, a
+            // high-arity function type could write past the guard page
+            // into adjacent memory.
+            let total_control_size = 0x40 + args_data_size;
+            ensure!(
+                total_control_size <= self.len,
+                "continuation function type requires {total_control_size} bytes \
+                 of stack control data, which exceeds the {}-byte stack allocation",
+                self.len,
+            );
             let args_data_ptr = if args_capacity == 0 {
                 ptr::null_mut()
             } else {
@@ -276,6 +300,8 @@ impl VMContinuationStack {
                 store(offset, data);
             }
         }
+
+        Ok(())
     }
 }
 

--- a/tests/all/tags.rs
+++ b/tests/all/tags.rs
@@ -102,7 +102,7 @@ fn stack_switching_cont_new_high_arity_rejected() -> Result<()> {
 
     let Ok(engine) = Engine::new(&config) else {
         // Stack switching is not supported on all platforms; skip gracefully.
-        assert!(!cfg!(target_arch = "x86_64"));
+        assert!(!(cfg!(target_arch = "x86_64") && cfg!(unix)));
         return Ok(());
     };
 

--- a/tests/all/tags.rs
+++ b/tests/all/tags.rs
@@ -80,6 +80,59 @@ fn wasm_import_tags() -> Result<()> {
     return Ok(());
 }
 
+// Tests that `cont.new` with a function type whose arity exceeds the
+// continuation stack size produces an error rather than writing past the
+// stack allocation.
+#[test]
+#[cfg_attr(miri, ignore)]
+fn stack_switching_cont_new_high_arity_rejected() -> Result<()> {
+    let mut config = Config::new();
+    config.wasm_stack_switching(true);
+    config.wasm_exceptions(true);
+    config.wasm_function_references(true);
+
+    // Use a small continuation stack so we can overflow it with fewer
+    // than 1000 params (the wasmparser limit for function params).
+    // With async_stack_size = 8192:
+    //   VMContinuationStack::new rounds to page size (8192), adds a
+    //   guard page, so self.len = 8192 + 4096 = 12288.
+    //   800 params * 16 bytes + 64 byte header = 12864 > 12288.
+    config.async_stack_size(8192);
+    config.max_wasm_stack(4096);
+
+    let Ok(engine) = Engine::new(&config) else {
+        // Stack switching is not supported on all platforms; skip gracefully.
+        return Ok(());
+    };
+
+    // Build a WAT module with a high-arity function type.
+    // 800 params stays under wasmparser's MAX_WASM_FUNCTION_PARAMS (1000)
+    // but exceeds the 12288-byte stack allocation.
+    let n_params = 800;
+    let params: String = (0..n_params).map(|_| " i32").collect();
+    let wat = format!(
+        r#"(module
+            (type $ft (func (param{params})))
+            (type $ct (cont $ft))
+            (func $target (type $ft))
+            (elem declare func $target)
+            (func (export "run")
+                (drop (cont.new $ct (ref.func $target)))
+            )
+        )"#
+    );
+
+    let module = Module::new(&engine, &wat)?;
+    let mut store = Store::new(&engine, ());
+    let instance = Instance::new(&mut store, &module, &[])?;
+    let run = instance.get_typed_func::<(), ()>(&mut store, "run")?;
+
+    let err = run.call(&mut store, ()).unwrap_err();
+    err.assert_contains("exceeds");
+
+    return Ok(());
+}
+
 // Tests that enabling inlining with stack switching, for now, returns an error.
 // If the support in Cranelift is fixed to the point that this is fine to
 // enable, then delete this test and the check in `config.rs` as well.

--- a/tests/all/tags.rs
+++ b/tests/all/tags.rs
@@ -102,6 +102,7 @@ fn stack_switching_cont_new_high_arity_rejected() -> Result<()> {
 
     let Ok(engine) = Engine::new(&config) else {
         // Stack switching is not supported on all platforms; skip gracefully.
+        assert!(!cfg!(target_arch = "x86_64"));
         return Ok(());
     };
 


### PR DESCRIPTION
`VMContinuationStack::initialize` writes control data and an args buffer at offsets below the top of the continuation stack, but does not verify that the total size fits within the allocated stack region.

### The problem

A Wasm module can define a continuation function type with a large number of parameters or return values. When `cont.new` is executed, the call chain reaches `initialize()` (`stack/unix.rs:226`), which computes:

`args_data_size = max(param_count, return_count) * size_of::<ValRaw>()`

The fixed header occupies 0x40 (64) bytes. If the total control data size (header + args buffer) exceeds the stack allocation, the write loop stores values past the stack region into adjacent memory. With the default 2 MiB stack, this requires 131,069+ params; with a smaller `async_stack_size`, fewer params suffice (e.g., 800 params on an 8 KiB stack).

Without this fix, the out-of-bounds write hits the guard page and crashes with SIGSEGV. With the fix, a clean error is returned instead.

### The fix

1. Replace the unchecked multiplication with `checked_mul` + `checked_add`, returning an error on arithmetic overflow.
2. Add a bounds check (`ensure!(total_control_size <= self.len)`) before any writes, so a high-arity function type produces a clean trap instead of a crash.
3. Change the return type of `initialize` from `()` to `Result<()>` and propagate the error through the `stack.rs` wrapper and the `cont_new` caller (which already returns `Result`).

### Test

A regression test (`stack_switching_cont_new_high_arity_rejected`) creates a function type with 800 `i32` params on an 8 KiB continuation stack, verifying that `cont.new` returns an error instead of crashing. The test skips gracefully on platforms where stack switching is not supported.

### Bug origin

Introduced in #10388 ("Stack switching: Infrastructure and runtime support", Frank Emrich, 2025-06-04).
