### PR TITLE
cm-async: Deduplicate/fix future/stream lift/lower

### DIFF
--- a/crates/wasmtime/src/runtime/component/concurrent/futures_and_streams.rs
+++ b/crates/wasmtime/src/runtime/component/concurrent/futures_and_streams.rs
@@ -1492,24 +1492,8 @@ pub(super) fn lift_index_to_future(
 ) -> Result<TableId<TransmitHandle>> {
     match ty {
         InterfaceType::Future(src) => {
-            let handle_table = cx
-                .instance_mut()
-                .table_for_transmit(TransmitIndex::Future(src));
-            let (rep, is_done) = handle_table.future_remove_readable(src, index)?;
-            if is_done {
-                bail!("cannot lift future after being notified that the writable end dropped");
-            }
-            let id = TableId::<TransmitHandle>::new(rep);
-            let concurrent_state = cx.concurrent_state_mut();
-            let future = concurrent_state.get_mut(id)?;
-            future.common.handle = None;
-            let state = future.state;
-
-            if concurrent_state.get_mut(state)?.done {
-                bail!("cannot lift future after previous read succeeded");
-            }
-
-            Ok(id)
+            let (state, instance) = cx.concurrent_state_and_instance_mut();
+            lift_index_to_transmit(instance, state, TransmitIndex::Future(src), index)
         }
         _ => func::bad_type_info(),
     }
@@ -1523,18 +1507,8 @@ pub(super) fn lower_future_to_index<U>(
 ) -> Result<u32> {
     match ty {
         InterfaceType::Future(dst) => {
-            let concurrent_state = cx.store.0.concurrent_state_mut();
-            let state = concurrent_state.get_mut(id)?.state;
-            let rep = concurrent_state.get_mut(state)?.read_handle.rep();
-
-            let handle = cx
-                .instance_mut()
-                .table_for_transmit(TransmitIndex::Future(dst))
-                .future_insert_read(dst, rep)?;
-
-            cx.store.0.concurrent_state_mut().get_mut(id)?.common.handle = Some(handle);
-
-            Ok(handle)
+            cx.instance_handle()
+                .lower_transmit_to_index(cx.store.0, TransmitIndex::Future(dst), id)
         }
         _ => func::bad_type_info(),
     }
@@ -1877,16 +1851,8 @@ pub(super) fn lift_index_to_stream(
 ) -> Result<TableId<TransmitHandle>> {
     match ty {
         InterfaceType::Stream(src) => {
-            let handle_table = cx
-                .instance_mut()
-                .table_for_transmit(TransmitIndex::Stream(src));
-            let (rep, is_done) = handle_table.stream_remove_readable(src, index)?;
-            if is_done {
-                bail!("cannot lift stream after being notified that the writable end dropped");
-            }
-            let id = TableId::<TransmitHandle>::new(rep);
-            cx.concurrent_state_mut().get_mut(id)?.common.handle = None;
-            Ok(id)
+            let (state, instance) = cx.concurrent_state_and_instance_mut();
+            lift_index_to_transmit(instance, state, TransmitIndex::Stream(src), index)
         }
         _ => func::bad_type_info(),
     }
@@ -1900,18 +1866,8 @@ pub(super) fn lower_stream_to_index<U>(
 ) -> Result<u32> {
     match ty {
         InterfaceType::Stream(dst) => {
-            let concurrent_state = cx.store.0.concurrent_state_mut();
-            let state = concurrent_state.get_mut(id)?.state;
-            let rep = concurrent_state.get_mut(state)?.read_handle.rep();
-
-            let handle = cx
-                .instance_mut()
-                .table_for_transmit(TransmitIndex::Stream(dst))
-                .stream_insert_read(dst, rep)?;
-
-            cx.store.0.concurrent_state_mut().get_mut(id)?.common.handle = Some(handle);
-
-            Ok(handle)
+            cx.instance_handle()
+                .lower_transmit_to_index(cx.store.0, TransmitIndex::Stream(dst), id)
         }
         _ => func::bad_type_info(),
     }
@@ -4519,26 +4475,28 @@ impl Instance {
         src: TransmitIndex,
         dst: TransmitIndex,
     ) -> Result<u32> {
-        let mut instance = self.id().get_mut(store);
-        let src_table = instance.as_mut().table_for_transmit(src);
-        let (rep, is_done) = match src {
-            TransmitIndex::Future(idx) => src_table.future_remove_readable(idx, src_idx)?,
-            TransmitIndex::Stream(idx) => src_table.stream_remove_readable(idx, src_idx)?,
-        };
-        if is_done {
-            bail!("cannot lift after being notified that the writable end dropped");
-        }
-        let dst_table = instance.table_for_transmit(dst);
-        let handle = match dst {
-            TransmitIndex::Future(idx) => dst_table.future_insert_read(idx, rep),
-            TransmitIndex::Stream(idx) => dst_table.stream_insert_read(idx, rep),
-        }?;
-        store
-            .concurrent_state_mut()
-            .get_mut(TableId::<TransmitHandle>::new(rep))?
-            .common
-            .handle = Some(handle);
-        Ok(handle)
+        let id = self.lift_index_to_transmit(store, src, src_idx)?;
+        self.lower_transmit_to_index(store, dst, id)
+    }
+
+    fn lift_index_to_transmit(
+        self,
+        store: &mut StoreOpaque,
+        ty: TransmitIndex,
+        src_idx: u32,
+    ) -> Result<TableId<TransmitHandle>> {
+        let (state, _, _, instance) = store.lift_context_parts(self);
+        lift_index_to_transmit(instance, state.concurrent_state_mut(), ty, src_idx)
+    }
+
+    fn lower_transmit_to_index(
+        self,
+        store: &mut StoreOpaque,
+        ty: TransmitIndex,
+        id: TableId<TransmitHandle>,
+    ) -> Result<u32> {
+        let (state, _, _, instance) = store.lift_context_parts(self);
+        lower_transmit_to_index(instance, state.concurrent_state_mut(), ty, id)
     }
 
     /// Implements the `future.new` intrinsic.
@@ -4626,6 +4584,60 @@ impl Instance {
 
         Ok(dst_idx)
     }
+}
+
+/// Performs the opertion of lifting a future or stream from and instance into
+/// the `TransmitHandle` for it.
+///
+/// The `src_idx` is the guest-specified index within `instance` and `ty` is the
+/// expected type of future/stream.
+fn lift_index_to_transmit(
+    instance: Pin<&mut ComponentInstance>,
+    concurrent_state: &mut ConcurrentState,
+    ty: TransmitIndex,
+    src_idx: u32,
+) -> Result<TableId<TransmitHandle>> {
+    let handle_table = instance.table_for_transmit(ty);
+    let (rep, is_done) = match ty {
+        TransmitIndex::Future(idx) => handle_table.future_remove_readable(idx, src_idx)?,
+        TransmitIndex::Stream(idx) => handle_table.stream_remove_readable(idx, src_idx)?,
+    };
+    let desc = match ty {
+        TransmitIndex::Future(_) => "future",
+        TransmitIndex::Stream(_) => "stream",
+    };
+    if is_done {
+        bail!("cannot lift {desc} after being notified that the writable end dropped");
+    }
+    let id = TableId::<TransmitHandle>::new(rep);
+    let future = concurrent_state.get_mut(id)?;
+    future.common.handle = None;
+
+    let state = future.state;
+    if concurrent_state.get_mut(state)?.done {
+        bail!("cannot lift {desc} after previous read succeeded");
+    }
+
+    Ok(id)
+}
+
+/// Performs the opertion of lowering a future or stream `TransmitHandle` into
+/// an instance.
+fn lower_transmit_to_index(
+    instance: Pin<&mut ComponentInstance>,
+    concurrent_state: &mut ConcurrentState,
+    ty: TransmitIndex,
+    id: TableId<TransmitHandle>,
+) -> Result<u32> {
+    let state = concurrent_state.get_mut(id)?.state;
+    debug_assert_eq!(concurrent_state.get_mut(state)?.read_handle, id);
+    let handle_table = instance.table_for_transmit(ty);
+    let handle = match ty {
+        TransmitIndex::Future(idx) => handle_table.future_insert_read(idx, id.rep()),
+        TransmitIndex::Stream(idx) => handle_table.stream_insert_read(idx, id.rep()),
+    }?;
+    concurrent_state.get_mut(id)?.common.handle = Some(handle);
+    Ok(handle)
 }
 
 impl ComponentInstance {

--- a/crates/wasmtime/src/runtime/component/func/options.rs
+++ b/crates/wasmtime/src/runtime/component/func/options.rs
@@ -100,6 +100,11 @@ impl<'a, T: 'static> LowerContext<'a, T> {
         }
     }
 
+    /// Returns the `Instance` that's being lowered into.
+    pub fn instance_handle(&self) -> Instance {
+        self.instance
+    }
+
     /// Returns the `&ComponentInstance` that's being lowered into.
     pub fn instance(&self) -> &ComponentInstance {
         self.instance.id().get(self.store.0)
@@ -398,8 +403,13 @@ impl<'a> LiftContext<'a> {
     }
 
     #[cfg(feature = "component-model-async")]
-    pub(crate) fn concurrent_state_mut(&mut self) -> &mut ConcurrentState {
-        self.task_state.concurrent_state_mut()
+    pub(crate) fn concurrent_state_and_instance_mut(
+        &mut self,
+    ) -> (&mut ConcurrentState, Pin<&mut ComponentInstance>) {
+        (
+            self.task_state.concurrent_state_mut(),
+            self.instance.as_mut(),
+        )
     }
 
     /// Lifts an `own` resource from the guest at the `idx` specified into its

--- a/tests/misc_testsuite/component-model/async/trap-if-done.wast
+++ b/tests/misc_testsuite/component-model/async/trap-if-done.wast
@@ -659,3 +659,63 @@
 (assert_trap (invoke "trap-after-stream-writer-async-dropped" (u8.const 1)) "cannot read after being notified that the writable end dropped")
 (component instance $i9.2 $Tester)
 (assert_trap (invoke "trap-after-stream-writer-async-dropped" (u8.const 2)) "cannot lift stream after being notified that the writable end dropped")
+
+(component
+  (type $f (future u8))
+  (component $A
+    (core func $drop (canon future.drop-readable $f))
+    (func (export "consume") (param "x" $f) (canon lift (core func $drop)))
+  )
+  (instance $a (instantiate $A))
+  (component $B
+    (import "consume" (func $consume-import (param "x" $f)))
+    (core module $libc (memory (export "memory") 1))
+    (core instance $libc (instantiate $libc))
+    (core func $new (canon future.new $f))
+    (core func $read (canon future.read $f async (memory $libc "memory")))
+    (core func $write (canon future.write $f async (memory $libc "memory")))
+    (core func $consume (canon lower (func $consume-import)))
+    (core module $m
+      (import "" "new" (func $new (result i64)))
+      (import "" "read" (func $read (param i32 i32) (result i32)))
+      (import "" "write" (func $write (param i32 i32) (result i32)))
+      (import "" "consume" (func $consume (param i32)))
+      (func (export "run")
+        (local $tmp i64) (local $r i32) (local $w i32)
+        (local.set $tmp (call $new))
+        (local.set $r (i32.wrap_i64 (local.get $tmp)))
+        (local.set $w (i32.wrap_i64 (i64.shr_u (local.get $tmp) (i64.const 32))))
+
+        ;; start an async write which blocks waiting for a reader
+        (call $write (local.get $w) (i32.const 0))
+        i32.const -1 ;; BLOCKED
+        i32.ne
+        if unreachable end
+
+        ;; complete the write with a successful read
+        (call $read (local.get $r) (i32.const 0))
+        i32.const 0 ;; COMPLETED
+        i32.ne
+        if unreachable end
+
+        ;; attempt to transfer the now-`done` read end to the sibling consumer
+        (call $consume (local.get $r))
+      )
+    )
+    (core instance $i (instantiate $m
+      (with "" (instance
+        (export "new" (func $new))
+        (export "read" (func $read))
+        (export "write" (func $write))
+        (export "consume" (func $consume))
+      ))
+    ))
+    (func (export "run") (canon lift (core func $i "run")))
+  )
+  (instance $b (instantiate $B
+    (with "consume" (func $a "consume"))
+  ))
+  (export "run" (func $b "run"))
+)
+
+(assert_trap (invoke "run") "cannot lift future after previous read succeeded")


### PR DESCRIPTION
This commit removes duplication between the `Instance::guest_transfer` function as well as the `lift_{future,stream}_to_transmit` and `lower_transmit_to_{future,stream}` functions. Notably the lift/lower functions had an additional check for futures which `guest_transfer` did not contain, and now additionally there's just one definition of lifting/lowering as opposed to multiple.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
