### PR TITLE
Trap if futures/streams are transferred while in a waitable set

### DIFF
--- a/crates/test-util/src/wast.rs
+++ b/crates/test-util/src/wast.rs
@@ -192,6 +192,7 @@ fn component_test_config(test: &Path) -> TestConfig {
     ret.spec_test = Some(true);
     ret.reference_types = Some(true);
     ret.multi_memory = Some(true);
+    ret.component_model_implements = Some(true);
 
     if let Some(parent) = test.parent() {
         if parent.ends_with("async")

--- a/crates/wasmtime/src/runtime/component/concurrent/futures_and_streams.rs
+++ b/crates/wasmtime/src/runtime/component/concurrent/futures_and_streams.rs
@@ -4611,6 +4611,9 @@ fn lift_index_to_transmit(
     }
     let id = TableId::<TransmitHandle>::new(rep);
     let future = concurrent_state.get_mut(id)?;
+    if future.common.set.is_some() {
+        bail!("cannot lift {desc} while it's in a waitable set");
+    }
     future.common.handle = None;
 
     let state = future.state;

--- a/tests/misc_testsuite/component-model/async/trap-if-done.wast
+++ b/tests/misc_testsuite/component-model/async/trap-if-done.wast
@@ -413,6 +413,7 @@
           (then unreachable))
         (if (i32.ne (i32.const 42) (i32.load (i32.const 16)))
           (then unreachable))
+        (call $waitable.join (local.get $fr) (i32.const 0))
 
         (call $future-read-expect-trap (local.get $fr) (i32.and (local.get $flags) (i32.const 0x03)))
       )

--- a/tests/misc_testsuite/component-model/async/trap-if-transfer-in-waitable-set.wast
+++ b/tests/misc_testsuite/component-model/async/trap-if-transfer-in-waitable-set.wast
@@ -1,0 +1,51 @@
+;;! component_model_async = true
+
+;; NB: currently a copy of the test added in
+;; https://github.com/WebAssembly/component-model/pull/666
+
+(component definition $Tester
+  (core module $Memory (memory (export "mem") 1))
+  (core instance $memory (instantiate $Memory))
+  (core module $M
+    (import "" "waitable.join" (func $waitable.join (param i32 i32)))
+    (import "" "waitable-set.new" (func $waitable-set.new (result i32)))
+    (import "" "future.new" (func $future.new (result i64)))
+    (import "" "stream.new" (func $stream.new (result i64)))
+
+    (func $return-future-in-set (export "return-future-in-set") (result i32)
+      (local $ret64 i64) (local $rx i32) (local $ws i32)
+      (local.set $ret64 (call $future.new))
+      (local.set $rx (i32.wrap_i64 (local.get $ret64)))
+      (local.set $ws (call $waitable-set.new))
+      (call $waitable.join (local.get $rx) (local.get $ws))
+      (local.get $rx)
+    )
+    (func $return-stream-in-set (export "return-stream-in-set") (result i32)
+      (local $ret64 i64) (local $rx i32) (local $ws i32)
+      (local.set $ret64 (call $stream.new))
+      (local.set $rx (i32.wrap_i64 (local.get $ret64)))
+      (local.set $ws (call $waitable-set.new))
+      (call $waitable.join (local.get $rx) (local.get $ws))
+      (local.get $rx)
+    )
+  )
+  (type $FT (future u8))
+  (type $ST (stream u8))
+  (canon waitable.join (core func $waitable.join))
+  (canon waitable-set.new (core func $waitable-set.new))
+  (canon future.new $FT (core func $future.new))
+  (canon stream.new $ST (core func $stream.new))
+  (core instance $m (instantiate $M (with "" (instance
+    (export "waitable.join" (func $waitable.join))
+    (export "waitable-set.new" (func $waitable-set.new))
+    (export "future.new" (func $future.new))
+    (export "stream.new" (func $stream.new))
+  ))))
+  (func (export "return-future-in-set") async (result $FT) (canon lift (core func $m "return-future-in-set")))
+  (func (export "return-stream-in-set") async (result $ST) (canon lift (core func $m "return-stream-in-set")))
+)
+
+(component instance $i1 $Tester)
+(assert_trap (invoke "return-future-in-set") "cannot lift future while it's in a waitable set")
+(component instance $i2 $Tester)
+(assert_trap (invoke "return-stream-in-set") "cannot lift stream while it's in a waitable set")


### PR DESCRIPTION
Adjust behavior to account for WebAssembly/component-model#664

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
