### PR TITLE
Do not use `ir::GlobalValue` in Wasm memory translation

### DIFF
--- a/crates/cranelift/src/alias_region.rs
+++ b/crates/cranelift/src/alias_region.rs
@@ -1,3 +1,4 @@
+use crate::translate::Load;
 use core::fmt;
 use cranelift_codegen::{
     cursor::FuncCursor,
@@ -359,13 +360,22 @@ where
         cursor: &mut FuncCursor<'_>,
         vmctx: ir::Value,
     ) -> ir::Value {
-        self.vmctx_load(
-            cursor,
-            self.pointer_type,
-            ir::MemFlagsData::trusted().with_readonly().with_can_move(),
-            vmctx,
-            self.offsets.get_ptr_size().vmctx_store_context().into(),
-        )
+        self.vmctx_store_context_load(cursor.func)
+            .emit(cursor, vmctx)
+    }
+
+    /// Get a `Load` for the `*mut VMStoreContext` value out of a `*mut VMContext`.
+    pub fn vmctx_store_context_load(&mut self, func: &mut ir::Function) -> Load {
+        let offset = u32::from(self.offsets.get_ptr_size().vmctx_store_context());
+        let region = self.vmctx_region(func, offset);
+        Load {
+            offset,
+            flags: ir::MemFlagsData::trusted()
+                .with_readonly()
+                .with_can_move()
+                .with_alias_region(Some(region)),
+            ty: self.pointer_type,
+        }
     }
 
     /// Load the `*mut i64` epoch pointer out of the given `*mut VMContext`.
@@ -564,15 +574,28 @@ impl AliasRegions<VMOffsets<u8>> {
         vmctx: ir::Value,
         memory: MemoryIndex,
     ) -> ir::Value {
+        self.vmctx_vmmemory_import_from_load(cursor.func, memory)
+            .emit(cursor, vmctx)
+    }
+
+    /// Get a `Load` for the imported memory's `VMMemoryImport::from` field from
+    /// a `*mut VMContext`.
+    pub fn vmctx_vmmemory_import_from_load(
+        &mut self,
+        func: &mut ir::Function,
+        memory: MemoryIndex,
+    ) -> Load {
         let mem_offset = self.offsets.vmctx_vmmemory_import(memory);
-        let mem_index_offset = mem_offset + u32::from(self.offsets.vmmemory_import_from());
-        self.vmctx_load(
-            cursor,
-            self.pointer_type,
-            ir::MemFlagsData::trusted().with_readonly().with_can_move(),
-            vmctx,
-            mem_index_offset,
-        )
+        let offset = mem_offset + u32::from(self.offsets.vmmemory_import_from());
+        let region = self.vmctx_region(func, offset);
+        Load {
+            offset,
+            flags: ir::MemFlagsData::trusted()
+                .with_readonly()
+                .with_can_move()
+                .with_alias_region(Some(region)),
+            ty: self.pointer_type,
+        }
     }
 
     /// Load the imported table's `VMTableImport::vmctx` field from the `*mut
@@ -639,13 +662,27 @@ impl AliasRegions<VMOffsets<u8>> {
         vmctx: ir::Value,
         memory: DefinedMemoryIndex,
     ) -> ir::Value {
-        self.vmctx_load(
-            cursor,
-            self.pointer_type,
-            ir::MemFlagsData::trusted().with_readonly().with_can_move(),
-            vmctx,
-            self.offsets.vmctx_vmmemory_pointer(memory),
-        )
+        self.vmctx_vmmemory_pointer_load(cursor.func, memory)
+            .emit(cursor, vmctx)
+    }
+
+    /// Get a `Load` for the defined memory's `*mut VMMemoryDefinition` out of a
+    /// `*mut VMContext`.
+    pub fn vmctx_vmmemory_pointer_load(
+        &mut self,
+        func: &mut ir::Function,
+        memory: DefinedMemoryIndex,
+    ) -> Load {
+        let offset = self.offsets.vmctx_vmmemory_pointer(memory);
+        let region = self.vmctx_region(func, offset);
+        Load {
+            offset,
+            flags: ir::MemFlagsData::trusted()
+                .with_readonly()
+                .with_can_move()
+                .with_alias_region(Some(region)),
+            ty: self.pointer_type,
+        }
     }
 
     /// Load the base of the given runtime data out of the `*mut VMContext`.

--- a/crates/cranelift/src/bounds_checks.rs
+++ b/crates/cranelift/src/bounds_checks.rs
@@ -485,6 +485,12 @@ fn bounds_check_field_access(
     ))
 }
 
+fn vmctx(pos: &mut FuncCursor<'_>) -> ir::Value {
+    pos.func
+        .special_param(ir::ArgumentPurpose::VMContext)
+        .expect("missing vmctx parameter")
+}
+
 /// Get the bound of a dynamic heap as an `ir::Value`.
 fn get_dynamic_heap_bound(
     builder: &mut FunctionBuilder,
@@ -496,8 +502,11 @@ fn get_dynamic_heap_bound(
         // bound.
         Some(max_size) => builder.ins().iconst(env.pointer_type(), max_size as i64),
 
-        // Load the heap bound from its global variable.
-        _ => builder.ins().global_value(env.pointer_type(), heap.bound),
+        // Emit the load chain that computes the heap bound.
+        _ => {
+            let vmctx = vmctx(&mut builder.cursor());
+            heap.bound.emit(&mut builder.cursor(), vmctx)
+        }
     }
 }
 
@@ -631,7 +640,8 @@ pub fn compute_addr(
 ) -> ir::Value {
     debug_assert_eq!(pos.func.dfg.value_type(index), addr_ty);
 
-    let heap_base = pos.ins().global_value(addr_ty, heap.base);
+    let vmctx = vmctx(pos);
+    let heap_base = heap.base.emit(pos, vmctx);
     let base_and_index = pos.ins().iadd(heap_base, index);
 
     if offset == 0 {

--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -1634,14 +1634,11 @@ impl FuncEnvironment<'_> {
                 let owned_index = self.module.owned_memory_index(def_index);
                 (
                     VmctxLoadChain::new(smallvec![base_load(
-                        self.offsets
-                            .vmctx_vmmemory_definition_base(owned_index)
-                            .into(),
+                        self.offsets.vmctx_vmmemory_definition_base(owned_index)
                     )]),
                     VmctxLoadChain::new(smallvec![bound_load(
                         self.offsets
                             .vmctx_vmmemory_definition_current_length(owned_index)
-                            .into(),
                     )]),
                 )
             }

--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -4,8 +4,8 @@ pub(crate) mod stack_switching;
 use crate::alias_region::AliasRegions;
 use crate::compiler::Compiler;
 use crate::translate::{
-    FuncTranslationStacks, Heap, HeapData, MemoryKind, StructFieldsVec, TableData, TableSize,
-    TargetEnvironment,
+    FuncTranslationStacks, Heap, HeapData, Load, MemoryKind, StructFieldsVec, TableData, TableSize,
+    TargetEnvironment, VmctxLoadChain,
 };
 use crate::trap::TranslateTrap;
 use crate::{
@@ -161,12 +161,6 @@ pub struct FuncEnvironment<'module_environment> {
 
     gc_heap: Option<Heap>,
 
-    /// The Cranelift global holding the GC heap's base address.
-    gc_heap_base: Option<ir::GlobalValue>,
-
-    /// The Cranelift global holding the GC heap's base address.
-    gc_heap_bound: Option<ir::GlobalValue>,
-
     translation: &'module_environment ModuleTranslation<'module_environment>,
 
     /// Heaps implementing WebAssembly linear memories.
@@ -174,9 +168,6 @@ pub struct FuncEnvironment<'module_environment> {
 
     /// The Cranelift global holding the vmctx address.
     vmctx: Option<ir::GlobalValue>,
-
-    /// The Cranelift global for our vmctx's `*mut VMStoreContext`.
-    vm_store_context: Option<ir::GlobalValue>,
 
     /// Caches of signatures for builtin functions.
     builtin_functions: BuiltinFunctions,
@@ -286,12 +277,9 @@ impl<'module_environment> FuncEnvironment<'module_environment> {
 
             ty_to_gc_layout: std::collections::HashMap::new(),
             gc_heap: None,
-            gc_heap_base: None,
-            gc_heap_bound: None,
 
             heaps: PrimaryMap::default(),
             vmctx: None,
-            vm_store_context: None,
             builtin_functions,
             offsets,
             tunables,
@@ -464,45 +452,6 @@ impl<'module_environment> FuncEnvironment<'module_environment> {
                 .vmctx_vmglobal_import_from(pos, vmctx, index);
             (addr, 0)
         }
-    }
-
-    /// Get or create the `ir::Global` for the `*mut VMStoreContext` in our
-    /// `VMContext`.
-    #[cfg_attr(
-        not(feature = "gc"),
-        expect(
-            dead_code,
-            reason = "only used to derive the GC heap base/bound globals"
-        )
-    )]
-    fn get_vmstore_context_ptr_global(&mut self, func: &mut ir::Function) -> ir::GlobalValue {
-        if let Some(ptr) = self.vm_store_context {
-            return ptr;
-        }
-
-        let offset = self.offsets.ptr.vmctx_store_context();
-        let base = self.vmctx(func);
-        let region = self
-            .alias_regions
-            .vmctx_region_for_use_in_ir_global(func, offset.into());
-        let ptr_flags = func
-            .dfg
-            .mem_flags
-            .insert(
-                ir::MemFlagsData::trusted()
-                    .with_readonly()
-                    .with_can_move()
-                    .with_alias_region(Some(region)),
-            )
-            .unwrap();
-        let ptr = func.create_global_value(ir::GlobalValueData::Load {
-            base,
-            offset: Offset32::new(offset.into()),
-            global_type: self.pointer_type(),
-            flags: ptr_flags,
-        });
-        self.vm_store_context = Some(ptr);
-        ptr
     }
 
     /// Get the `*mut VMStoreContext` value for our `VMContext`.
@@ -1091,39 +1040,6 @@ impl<'module_environment> FuncEnvironment<'module_environment> {
             .copied()
     }
 
-    /// Create an `ir::Global` that does `load(ptr + offset)`.
-    pub(crate) fn global_load(
-        &mut self,
-        func: &mut ir::Function,
-        ptr: ir::GlobalValue,
-        offset: u32,
-        flags: ir::MemFlagsData,
-    ) -> ir::GlobalValue {
-        let flags = func.dfg.mem_flags.insert(flags).unwrap();
-        func.create_global_value(ir::GlobalValueData::Load {
-            base: ptr,
-            offset: Offset32::new(i32::try_from(offset).unwrap()),
-            global_type: self.pointer_type(),
-            flags,
-        })
-    }
-
-    /// Like `global_load` but specialized for loads out of the
-    /// `vmctx`.
-    pub(crate) fn global_load_from_vmctx(
-        &mut self,
-        func: &mut ir::Function,
-        offset: u32,
-        flags: ir::MemFlagsData,
-    ) -> ir::GlobalValue {
-        let vmctx = self.vmctx(func);
-        let region = self
-            .alias_regions
-            .vmctx_region_for_use_in_ir_global(func, offset);
-        let flags = flags.with_alias_region(Some(region));
-        self.global_load(func, vmctx, offset, flags)
-    }
-
     /// Helper used when `!self.clif_instruction_traps_enabled()` is enabled to
     /// test whether the divisor is zero.
     fn guard_zero_divisor(&mut self, builder: &mut FunctionBuilder, rhs: ir::Value) {
@@ -1660,63 +1576,8 @@ impl FuncEnvironment<'_> {
     }
 
     fn make_heap(&mut self, func: &mut ir::Function, index: MemoryIndex) -> Heap {
-        let pointer_type = self.pointer_type();
         let memory = self.module.memories[index];
-        let is_shared = memory.shared;
-
-        let (base_ptr, base_offset, current_length_offset) = {
-            let vmctx = self.vmctx(func);
-            if let Some(def_index) = self.module.defined_memory_index(index) {
-                if is_shared {
-                    // As with imported memory, the `VMMemoryDefinition` for a
-                    // shared memory is stored elsewhere. We store a `*mut
-                    // VMMemoryDefinition` to it and dereference that when
-                    // atomically growing it.
-                    let from_offset = self.offsets.vmctx_vmmemory_pointer(def_index);
-                    let memory = self.global_load_from_vmctx(
-                        func,
-                        from_offset,
-                        ir::MemFlagsData::trusted().with_readonly().with_can_move(),
-                    );
-                    let base_offset = i32::from(self.offsets.ptr.vmmemory_definition_base());
-                    let current_length_offset =
-                        i32::from(self.offsets.ptr.vmmemory_definition_current_length());
-                    (memory, base_offset, current_length_offset)
-                } else {
-                    let owned_index = self.module.owned_memory_index(def_index);
-                    let owned_base_offset =
-                        self.offsets.vmctx_vmmemory_definition_base(owned_index);
-                    let owned_length_offset = self
-                        .offsets
-                        .vmctx_vmmemory_definition_current_length(owned_index);
-                    let current_base_offset = i32::try_from(owned_base_offset).unwrap();
-                    let current_length_offset = i32::try_from(owned_length_offset).unwrap();
-                    (vmctx, current_base_offset, current_length_offset)
-                }
-            } else {
-                let from_offset = self.offsets.vmctx_vmmemory_import_from(index);
-                let memory = self.global_load_from_vmctx(
-                    func,
-                    from_offset,
-                    ir::MemFlagsData::trusted().with_readonly().with_can_move(),
-                );
-                let base_offset = i32::from(self.offsets.ptr.vmmemory_definition_base());
-                let current_length_offset =
-                    i32::from(self.offsets.ptr.vmmemory_definition_current_length());
-                (memory, base_offset, current_length_offset)
-            }
-        };
-
-        let bound_flags = func.dfg.mem_flags.insert(MemFlagsData::trusted()).unwrap();
-        let bound = func.create_global_value(ir::GlobalValueData::Load {
-            base: base_ptr,
-            offset: Offset32::new(current_length_offset),
-            global_type: pointer_type,
-            flags: bound_flags,
-        });
-
-        let base = self.make_heap_base(func, memory, base_ptr, base_offset);
-
+        let (base, bound) = self.make_heap_base_bound(func, index);
         self.heaps.push(HeapData {
             base,
             bound,
@@ -1725,29 +1586,80 @@ impl FuncEnvironment<'_> {
         })
     }
 
-    pub(crate) fn make_heap_base(
-        &self,
-        func: &mut Function,
-        memory: Memory,
-        ptr: ir::GlobalValue,
-        offset: i32,
-    ) -> ir::GlobalValue {
+    fn make_heap_base_bound(
+        &mut self,
+        func: &mut ir::Function,
+        index: MemoryIndex,
+    ) -> (VmctxLoadChain, VmctxLoadChain) {
         let pointer_type = self.pointer_type();
-        let memory_tunables = MemoryTunables::new(self.tunables, MemoryKind::LinearMemory);
+        let memory = self.module.memories[index];
+        let is_shared = memory.shared;
 
+        // The base pointer load is `can_move`, and additionally `readonly` when
+        // this memory's base can never move.
+        let memory_tunables = MemoryTunables::new(self.tunables, MemoryKind::LinearMemory);
         let mut flags = ir::MemFlagsData::trusted().with_can_move();
         if !memory.memory_may_move(&memory_tunables) {
             flags.set_readonly();
         }
 
-        let heap_base_flags = func.dfg.mem_flags.insert(flags).unwrap();
-        let heap_base = func.create_global_value(ir::GlobalValueData::Load {
-            base: ptr,
-            offset: Offset32::new(offset),
-            global_type: pointer_type,
-            flags: heap_base_flags,
-        });
-        heap_base
+        let load = |offset, flags| Load {
+            offset,
+            flags,
+            ty: pointer_type,
+        };
+        let base_load = |offset: u32| load(offset, flags);
+        let bound_load = |offset: u32| load(offset, ir::MemFlagsData::trusted());
+
+        if let Some(def_index) = self.module.defined_memory_index(index) {
+            if is_shared {
+                // As with imported memory, the `VMMemoryDefinition` for a
+                // shared memory is stored elsewhere. We store a `*mut
+                // VMMemoryDefinition` to it and dereference that when
+                // atomically growing it.
+                let mem = self
+                    .alias_regions
+                    .vmctx_vmmemory_pointer_load(func, def_index);
+                (
+                    VmctxLoadChain::new(smallvec![
+                        mem,
+                        base_load(self.offsets.ptr.vmmemory_definition_base().into()),
+                    ]),
+                    VmctxLoadChain::new(smallvec![
+                        mem,
+                        bound_load(self.offsets.ptr.vmmemory_definition_current_length().into()),
+                    ]),
+                )
+            } else {
+                let owned_index = self.module.owned_memory_index(def_index);
+                (
+                    VmctxLoadChain::new(smallvec![base_load(
+                        self.offsets
+                            .vmctx_vmmemory_definition_base(owned_index)
+                            .into(),
+                    )]),
+                    VmctxLoadChain::new(smallvec![bound_load(
+                        self.offsets
+                            .vmctx_vmmemory_definition_current_length(owned_index)
+                            .into(),
+                    )]),
+                )
+            }
+        } else {
+            let mem = self
+                .alias_regions
+                .vmctx_vmmemory_import_from_load(func, index);
+            (
+                VmctxLoadChain::new(smallvec![
+                    mem,
+                    base_load(self.offsets.ptr.vmmemory_definition_base().into()),
+                ]),
+                VmctxLoadChain::new(smallvec![
+                    mem,
+                    bound_load(self.offsets.ptr.vmmemory_definition_current_length().into()),
+                ]),
+            )
+        }
     }
 
     fn make_table(&mut self, func: &mut ir::Function, index: TableIndex) -> TableData {
@@ -4345,8 +4257,10 @@ impl FuncEnvironment<'_> {
         let base = match entity {
             CheckedEntity::Memory(i) => {
                 let heap = self.get_or_create_heap(builder.func, i);
+                // Obtain the vmctx value before borrowing `self.heaps()`.
+                let vmctx = self.vmctx_val(&mut builder.cursor());
                 let heap = &self.heaps()[heap];
-                builder.ins().global_value(pointer_type, heap.base)
+                heap.base.emit(&mut builder.cursor(), vmctx)
             }
             CheckedEntity::Table { table, .. } => {
                 let table = self.get_or_create_table(builder.func, table);

--- a/crates/cranelift/src/func_environ/gc.rs
+++ b/crates/cranelift/src/func_environ/gc.rs
@@ -3,10 +3,11 @@
 use crate::TRAP_ARRAY_OUT_OF_BOUNDS;
 use crate::bounds_checks::BoundsCheck;
 use crate::func_environ::{CheckedEntity, Extension, FuncEnvironment};
-use crate::translate::{Heap, HeapData, MemoryKind, StructFieldsVec, TargetEnvironment};
+use crate::translate::{
+    Heap, HeapData, Load, MemoryKind, StructFieldsVec, TargetEnvironment, VmctxLoadChain,
+};
 use crate::trap::TranslateTrap;
 use crate::{Reachability, TRAP_GC_HEAP_CORRUPT, TRAP_INTERNAL_ASSERT};
-use cranelift_codegen::ir::immediates::Offset32;
 use cranelift_codegen::ir::{BlockArg, ExceptionTableData, ExceptionTableItem};
 use cranelift_codegen::{
     cursor::FuncCursor,
@@ -1435,38 +1436,6 @@ impl FuncEnvironment<'_> {
     }
 
     /// Get or create the global for our GC heap's base pointer.
-    fn get_gc_heap_base_global(&mut self, func: &mut ir::Function) -> ir::GlobalValue {
-        if let Some(base) = self.gc_heap_base {
-            return base;
-        }
-
-        let store_context_ptr = self.get_vmstore_context_ptr_global(func);
-        let offset = self.offsets.ptr.vmstore_context_gc_heap_base();
-
-        let mut flags = ir::MemFlagsData::trusted();
-        let memory_tunables =
-            wasmtime_environ::MemoryTunables::new(self.tunables, MemoryKind::GcHeap);
-        if !self
-            .tunables
-            .gc_heap_memory_type()
-            .memory_may_move(&memory_tunables)
-        {
-            flags.set_readonly();
-            flags.set_can_move();
-        }
-
-        let base_flags = func.dfg.mem_flags.insert(flags).unwrap();
-        let base = func.create_global_value(ir::GlobalValueData::Load {
-            base: store_context_ptr,
-            offset: Offset32::new(offset.into()),
-            global_type: self.pointer_type(),
-            flags: base_flags,
-        });
-
-        self.gc_heap_base = Some(base);
-        base
-    }
-
     /// Get the GC heap's base.
     pub(crate) fn get_gc_heap_base(
         &mut self,
@@ -1497,27 +1466,6 @@ impl FuncEnvironment<'_> {
             .load(pointer_type, flags, store_context_ptr, offset))
     }
 
-    fn get_gc_heap_bound_global(&mut self, func: &mut ir::Function) -> ir::GlobalValue {
-        if let Some(bound) = self.gc_heap_bound {
-            return bound;
-        }
-        let store_context_ptr = self.get_vmstore_context_ptr_global(func);
-        let offset = self.offsets.ptr.vmstore_context_gc_heap_current_length();
-        let bound_flags = func
-            .dfg
-            .mem_flags
-            .insert(ir::MemFlagsData::trusted())
-            .unwrap();
-        let bound = func.create_global_value(ir::GlobalValueData::Load {
-            base: store_context_ptr,
-            offset: Offset32::new(offset.into()),
-            global_type: self.pointer_type(),
-            flags: bound_flags,
-        });
-        self.gc_heap_bound = Some(bound);
-        bound
-    }
-
     /// Get the GC heap's bound.
     pub(crate) fn get_gc_heap_bound(
         &mut self,
@@ -1540,12 +1488,40 @@ impl FuncEnvironment<'_> {
             return heap;
         }
 
-        let base = self.get_gc_heap_base_global(func);
-        let bound = self.get_gc_heap_bound_global(func);
+        let store_ctx = self.alias_regions.vmctx_store_context_load(func);
+
+        // The base pointer's load is `can_move` and `readonly` when the GC
+        // heap's base can never move.
+        let memory_tunables =
+            wasmtime_environ::MemoryTunables::new(self.tunables, MemoryKind::GcHeap);
+        let mut flags = ir::MemFlagsData::trusted();
+        if !self
+            .tunables
+            .gc_heap_memory_type()
+            .memory_may_move(&memory_tunables)
+        {
+            flags.set_readonly();
+            flags.set_can_move();
+        }
+
         let memory = self.tunables.gc_heap_memory_type();
         let heap = self.heaps.push(HeapData {
-            base,
-            bound,
+            base: VmctxLoadChain::new(smallvec![
+                store_ctx,
+                Load {
+                    offset: u32::from(self.offsets.ptr.vmstore_context_gc_heap_base()),
+                    flags,
+                    ty: self.pointer_type(),
+                }
+            ]),
+            bound: VmctxLoadChain::new(smallvec![
+                store_ctx,
+                Load {
+                    offset: u32::from(self.offsets.ptr.vmstore_context_gc_heap_current_length()),
+                    flags: ir::MemFlagsData::trusted(),
+                    ty: self.pointer_type(),
+                }
+            ]),
             memory,
             kind: MemoryKind::GcHeap,
         });

--- a/crates/cranelift/src/translate/heap.rs
+++ b/crates/cranelift/src/translate/heap.rs
@@ -1,10 +1,61 @@
 //! Heaps to implement WebAssembly linear memories.
 
-use cranelift_codegen::ir::{self, GlobalValue, Type};
+use cranelift_codegen::cursor::FuncCursor;
+use cranelift_codegen::ir::{self, InstBuilder, Type};
 use cranelift_entity::entity_impl;
+use smallvec::SmallVec;
 use wasmtime_environ::{IndexType, Memory};
 
 pub use wasmtime_environ::MemoryKind;
+
+/// A single load, relative to some base value.
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+pub struct Load {
+    /// The offset added to the base before loading.
+    pub offset: u32,
+    /// The memory flags for the load.
+    pub flags: ir::MemFlagsData,
+    /// The type loaded. Only the last load in a chain may be non-pointer-typed.
+    pub ty: ir::Type,
+}
+
+impl Load {
+    /// Emit this load, relative to the given `base`.
+    pub fn emit(&self, cursor: &mut FuncCursor<'_>, base: ir::Value) -> ir::Value {
+        cursor.ins().load(
+            self.ty,
+            self.flags,
+            base,
+            i32::try_from(self.offset).unwrap(),
+        )
+    }
+}
+
+/// A chain of loads, rooted at the `vmctx`.
+///
+/// Used to compute a heap's base address or bound.
+#[derive(Clone, PartialEq, Hash)]
+pub struct VmctxLoadChain(SmallVec<[Load; 2]>);
+
+impl VmctxLoadChain {
+    /// Create a new load sequence.
+    ///
+    /// The sequence must be non-empty.
+    pub fn new(loads: SmallVec<[Load; 2]>) -> Self {
+        assert!(!loads.is_empty());
+        VmctxLoadChain(loads)
+    }
+
+    /// Emit the load chain, starting from `vmctx`, returning the final loaded
+    /// value.
+    pub fn emit(&self, cursor: &mut FuncCursor<'_>, vmctx: ir::Value) -> ir::Value {
+        let mut val = vmctx;
+        for load in &self.0 {
+            val = load.emit(cursor, val);
+        }
+        val
+    }
+}
 
 /// An opaque reference to a [`HeapData`][crate::HeapData].
 ///
@@ -40,10 +91,10 @@ entity_impl!(Heap, "heap");
 #[derive(Clone, PartialEq, Hash)]
 pub struct HeapData {
     /// The address of the start of the heap's storage.
-    pub base: GlobalValue,
+    pub base: VmctxLoadChain,
 
     /// The dynamic byte length of this heap, if needed.
-    pub bound: GlobalValue,
+    pub bound: VmctxLoadChain,
 
     /// The type of wasm memory that this heap is operating on.
     pub memory: Memory,

--- a/crates/cranelift/src/translate/mod.rs
+++ b/crates/cranelift/src/translate/mod.rs
@@ -20,7 +20,7 @@ mod translation_utils;
 
 pub use self::environ::{StructFieldsVec, TargetEnvironment};
 pub use self::func_translator::FuncTranslator;
-pub use self::heap::{Heap, HeapData, MemoryKind};
+pub use self::heap::{Heap, HeapData, Load, MemoryKind, VmctxLoadChain};
 pub use self::stack::FuncTranslationStacks;
 pub use self::table::{TableData, TableSize};
 pub use self::translation_utils::*;

--- a/tests/disas/alias-region-memories.wat
+++ b/tests/disas/alias-region-memories.wat
@@ -22,23 +22,17 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region1 gv3+48
-;;     gv5 = load.i64 notrap aligned gv4+8
-;;     gv6 = load.i64 notrap aligned readonly can_move gv4
-;;     gv7 = load.i64 notrap aligned gv3+88
-;;     gv8 = load.i64 notrap aligned readonly can_move gv3+80
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
-;; @003b                               v18 = load.i64 notrap aligned readonly can_move region1 v0+48
-;; @003b                               v6 = load.i64 notrap aligned readonly can_move v18
+;; @003b                               v6 = load.i64 notrap aligned readonly can_move region1 v0+48
+;; @003b                               v7 = load.i64 notrap aligned readonly can_move v6
 ;; @003b                               v5 = uextend.i64 v2
-;; @003b                               v7 = iadd v6, v5
-;; @003b                               store little region2 v3, v7
-;; @0042                               v9 = load.i64 notrap aligned readonly can_move v0+80
-;; @0042                               v10 = iadd v9, v5
-;; @0042                               store little region3 v3, v10
+;; @003b                               v8 = iadd v7, v5
+;; @003b                               store little region2 v3, v8
+;; @0042                               v10 = load.i64 notrap aligned readonly can_move v0+80
+;; @0042                               v11 = iadd v10, v5
+;; @0042                               store little region3 v3, v11
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/array-copy-anyref.wat
+++ b/tests/disas/array-copy-anyref.wat
@@ -15,86 +15,82 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32, v6: i32):
 ;; @002b                               trapz v2, user16
-;; @002b                               v109 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @002b                               v8 = load.i64 notrap aligned readonly can_move v109+32
+;; @002b                               v8 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @002b                               v9 = load.i64 notrap aligned readonly can_move v8+32
 ;; @002b                               v7 = uextend.i64 v2
-;; @002b                               v9 = iadd v8, v7
-;; @002b                               v10 = iconst.i64 16
-;; @002b                               v11 = iadd v9, v10  ; v10 = 16
-;; @002b                               v12 = load.i32 user2 readonly region1 v11
-;; @002b                               v14 = uextend.i64 v3
-;; @002b                               v15 = uextend.i64 v6
-;; @002b                               v18 = iadd v14, v15
-;; @002b                               v13 = uextend.i64 v12
-;; @002b                               v19 = icmp ugt v18, v13
-;; @002b                               trapnz v19, user17
+;; @002b                               v10 = iadd v9, v7
+;; @002b                               v11 = iconst.i64 16
+;; @002b                               v12 = iadd v10, v11  ; v11 = 16
+;; @002b                               v13 = load.i32 user2 readonly region1 v12
+;; @002b                               v15 = uextend.i64 v3
+;; @002b                               v16 = uextend.i64 v6
+;; @002b                               v19 = iadd v15, v16
+;; @002b                               v14 = uextend.i64 v13
+;; @002b                               v20 = icmp ugt v19, v14
+;; @002b                               trapnz v20, user17
 ;; @002b                               trapz v4, user16
-;; @002b                               v30 = uextend.i64 v4
-;; @002b                               v32 = iadd v8, v30
-;; @002b                               v34 = iadd v32, v10  ; v10 = 16
-;; @002b                               v35 = load.i32 user2 readonly region1 v34
-;; @002b                               v37 = uextend.i64 v5
-;; @002b                               v41 = iadd v37, v15
-;; @002b                               v36 = uextend.i64 v35
-;; @002b                               v42 = icmp ugt v41, v36
-;; @002b                               trapnz v42, user17
-;; @002b                               v61 = load.i64 notrap aligned v109+40
-;; @002b                               v24 = iconst.i64 20
-;; @002b                               v25 = iadd v9, v24  ; v24 = 20
-;;                                     v113 = iconst.i64 2
-;;                                     v114 = ishl v14, v113  ; v113 = 2
-;; @002b                               v29 = iadd v25, v114
-;;                                     v118 = ishl v15, v113  ; v113 = 2
-;; @002b                               v63 = uadd_overflow_trap v29, v118, user2
-;; @002b                               v62 = iadd v8, v61
-;; @002b                               v64 = icmp ugt v63, v62
-;; @002b                               trapnz v64, user2
-;; @002b                               v48 = iadd v32, v24  ; v24 = 20
-;;                                     v116 = ishl v37, v113  ; v113 = 2
-;; @002b                               v52 = iadd v48, v116
-;; @002b                               v70 = uadd_overflow_trap v52, v118, user2
-;; @002b                               v71 = icmp ugt v70, v62
-;; @002b                               trapnz v71, user2
+;; @002b                               v31 = uextend.i64 v4
+;; @002b                               v34 = iadd v9, v31
+;; @002b                               v36 = iadd v34, v11  ; v11 = 16
+;; @002b                               v37 = load.i32 user2 readonly region1 v36
+;; @002b                               v39 = uextend.i64 v5
+;; @002b                               v43 = iadd v39, v16
+;; @002b                               v38 = uextend.i64 v37
+;; @002b                               v44 = icmp ugt v43, v38
+;; @002b                               trapnz v44, user17
+;; @002b                               v63 = load.i64 notrap aligned v8+40
+;; @002b                               v25 = iconst.i64 20
+;; @002b                               v26 = iadd v10, v25  ; v25 = 20
+;;                                     v111 = iconst.i64 2
+;;                                     v112 = ishl v15, v111  ; v111 = 2
+;; @002b                               v30 = iadd v26, v112
+;;                                     v116 = ishl v16, v111  ; v111 = 2
+;; @002b                               v65 = uadd_overflow_trap v30, v116, user2
+;; @002b                               v64 = iadd v9, v63
+;; @002b                               v66 = icmp ugt v65, v64
+;; @002b                               trapnz v66, user2
+;; @002b                               v50 = iadd v34, v25  ; v25 = 20
+;;                                     v114 = ishl v39, v111  ; v111 = 2
+;; @002b                               v54 = iadd v50, v114
+;; @002b                               v72 = uadd_overflow_trap v54, v116, user2
+;; @002b                               v73 = icmp ugt v72, v64
+;; @002b                               trapnz v73, user2
 ;; @002b                               brif v6, block2, block5
 ;;
 ;;                                 block2:
-;; @002b                               v72 = icmp.i64 ult v29, v52
-;; @002b                               v77 = iadd.i64 v29, v118
-;; @002b                               v78 = iadd.i64 v52, v118
-;; @002b                               v80 = iadd.i32 v5, v6
-;; @002b                               v27 = iconst.i64 4
-;; @002b                               v103 = iconst.i32 1
-;; @002b                               brif v72, block3(v29, v52, v5), block4(v77, v78, v80)
+;; @002b                               v74 = icmp.i64 ult v30, v54
+;; @002b                               v79 = iadd.i64 v30, v116
+;; @002b                               v80 = iadd.i64 v54, v116
+;; @002b                               v82 = iadd.i32 v5, v6
+;; @002b                               v28 = iconst.i64 4
+;; @002b                               v105 = iconst.i32 1
+;; @002b                               brif v74, block3(v30, v54, v5), block4(v79, v80, v82)
 ;;
-;;                                 block3(v81: i64, v82: i64, v83: i32):
-;; @002b                               v86 = load.i32 user2 little region1 v82
-;; @002b                               store user2 little region1 v86, v81
-;;                                     v125 = iconst.i64 4
-;;                                     v126 = iadd v82, v125  ; v125 = 4
-;; @002b                               v93 = icmp eq v126, v78
-;;                                     v127 = iadd v81, v125  ; v125 = 4
-;;                                     v128 = iconst.i32 1
-;;                                     v129 = iadd v83, v128  ; v128 = 1
-;; @002b                               brif v93, block5, block3(v127, v126, v129)
+;;                                 block3(v83: i64, v84: i64, v85: i32):
+;; @002b                               v88 = load.i32 user2 little region1 v84
+;; @002b                               store user2 little region1 v88, v83
+;;                                     v123 = iconst.i64 4
+;;                                     v124 = iadd v84, v123  ; v123 = 4
+;; @002b                               v95 = icmp eq v124, v80
+;;                                     v125 = iadd v83, v123  ; v123 = 4
+;;                                     v126 = iconst.i32 1
+;;                                     v127 = iadd v85, v126  ; v126 = 1
+;; @002b                               brif v95, block5, block3(v125, v124, v127)
 ;;
-;;                                 block4(v94: i64, v95: i64, v96: i32):
-;;                                     v120 = iconst.i64 4
-;;                                     v121 = isub v95, v120  ; v120 = 4
-;; @002b                               v105 = load.i32 user2 little region1 v121
-;;                                     v122 = isub v94, v120  ; v120 = 4
-;; @002b                               store user2 little region1 v105, v122
-;; @002b                               v106 = icmp eq v121, v52
-;;                                     v123 = iconst.i32 1
-;;                                     v124 = isub v96, v123  ; v123 = 1
-;; @002b                               brif v106, block5, block4(v122, v121, v124)
+;;                                 block4(v96: i64, v97: i64, v98: i32):
+;;                                     v118 = iconst.i64 4
+;;                                     v119 = isub v97, v118  ; v118 = 4
+;; @002b                               v107 = load.i32 user2 little region1 v119
+;;                                     v120 = isub v96, v118  ; v118 = 4
+;; @002b                               store user2 little region1 v107, v120
+;; @002b                               v108 = icmp eq v119, v54
+;;                                     v121 = iconst.i32 1
+;;                                     v122 = isub v98, v121  ; v121 = 1
+;; @002b                               brif v108, block5, block4(v120, v119, v122)
 ;;
 ;;                                 block5:
 ;; @002f                               jump block1

--- a/tests/disas/array-copy-i64.wat
+++ b/tests/disas/array-copy-i64.wat
@@ -15,57 +15,53 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i64, i64, i64) tail
 ;;     fn0 = colocated u805306368:1 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32, v6: i32):
 ;; @002b                               trapz v2, user16
-;; @002b                               v74 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @002b                               v8 = load.i64 notrap aligned readonly can_move v74+32
+;; @002b                               v8 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @002b                               v9 = load.i64 notrap aligned readonly can_move v8+32
 ;; @002b                               v7 = uextend.i64 v2
-;; @002b                               v9 = iadd v8, v7
-;; @002b                               v10 = iconst.i64 16
-;; @002b                               v11 = iadd v9, v10  ; v10 = 16
-;; @002b                               v12 = load.i32 user2 readonly region1 v11
-;; @002b                               v14 = uextend.i64 v3
-;; @002b                               v15 = uextend.i64 v6
-;; @002b                               v18 = iadd v14, v15
-;; @002b                               v13 = uextend.i64 v12
-;; @002b                               v19 = icmp ugt v18, v13
-;; @002b                               trapnz v19, user17
+;; @002b                               v10 = iadd v9, v7
+;; @002b                               v11 = iconst.i64 16
+;; @002b                               v12 = iadd v10, v11  ; v11 = 16
+;; @002b                               v13 = load.i32 user2 readonly region1 v12
+;; @002b                               v15 = uextend.i64 v3
+;; @002b                               v16 = uextend.i64 v6
+;; @002b                               v19 = iadd v15, v16
+;; @002b                               v14 = uextend.i64 v13
+;; @002b                               v20 = icmp ugt v19, v14
+;; @002b                               trapnz v20, user17
 ;; @002b                               trapz v4, user16
-;; @002b                               v30 = uextend.i64 v4
-;; @002b                               v32 = iadd v8, v30
-;; @002b                               v34 = iadd v32, v10  ; v10 = 16
-;; @002b                               v35 = load.i32 user2 readonly region1 v34
-;; @002b                               v37 = uextend.i64 v5
-;; @002b                               v41 = iadd v37, v15
-;; @002b                               v36 = uextend.i64 v35
-;; @002b                               v42 = icmp ugt v41, v36
-;; @002b                               trapnz v42, user17
-;; @002b                               v61 = load.i64 notrap aligned v74+40
-;; @002b                               v24 = iconst.i64 24
-;; @002b                               v25 = iadd v9, v24  ; v24 = 24
-;;                                     v78 = iconst.i64 3
-;;                                     v79 = ishl v14, v78  ; v78 = 3
-;; @002b                               v29 = iadd v25, v79
-;;                                     v83 = ishl v15, v78  ; v78 = 3
-;; @002b                               v63 = uadd_overflow_trap v29, v83, user2
-;; @002b                               v62 = iadd v8, v61
-;; @002b                               v64 = icmp ugt v63, v62
-;; @002b                               trapnz v64, user2
-;; @002b                               v48 = iadd v32, v24  ; v24 = 24
-;;                                     v81 = ishl v37, v78  ; v78 = 3
-;; @002b                               v52 = iadd v48, v81
-;; @002b                               v70 = uadd_overflow_trap v52, v83, user2
-;; @002b                               v71 = icmp ugt v70, v62
-;; @002b                               trapnz v71, user2
-;; @002b                               call fn0(v0, v29, v52, v83)
+;; @002b                               v31 = uextend.i64 v4
+;; @002b                               v34 = iadd v9, v31
+;; @002b                               v36 = iadd v34, v11  ; v11 = 16
+;; @002b                               v37 = load.i32 user2 readonly region1 v36
+;; @002b                               v39 = uextend.i64 v5
+;; @002b                               v43 = iadd v39, v16
+;; @002b                               v38 = uextend.i64 v37
+;; @002b                               v44 = icmp ugt v43, v38
+;; @002b                               trapnz v44, user17
+;; @002b                               v63 = load.i64 notrap aligned v8+40
+;; @002b                               v25 = iconst.i64 24
+;; @002b                               v26 = iadd v10, v25  ; v25 = 24
+;;                                     v76 = iconst.i64 3
+;;                                     v77 = ishl v15, v76  ; v76 = 3
+;; @002b                               v30 = iadd v26, v77
+;;                                     v81 = ishl v16, v76  ; v76 = 3
+;; @002b                               v65 = uadd_overflow_trap v30, v81, user2
+;; @002b                               v64 = iadd v9, v63
+;; @002b                               v66 = icmp ugt v65, v64
+;; @002b                               trapnz v66, user2
+;; @002b                               v50 = iadd v34, v25  ; v25 = 24
+;;                                     v79 = ishl v39, v76  ; v76 = 3
+;; @002b                               v54 = iadd v50, v79
+;; @002b                               v72 = uadd_overflow_trap v54, v81, user2
+;; @002b                               v73 = icmp ugt v72, v64
+;; @002b                               trapnz v73, user2
+;; @002b                               call fn0(v0, v30, v54, v81)
 ;; @002f                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/array-copy-i8.wat
+++ b/tests/disas/array-copy-i8.wat
@@ -15,53 +15,49 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i64, i64, i64) tail
 ;;     fn0 = colocated u805306368:1 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32, v6: i32):
 ;; @002b                               trapz v2, user16
-;; @002b                               v74 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @002b                               v8 = load.i64 notrap aligned readonly can_move v74+32
+;; @002b                               v8 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @002b                               v9 = load.i64 notrap aligned readonly can_move v8+32
 ;; @002b                               v7 = uextend.i64 v2
-;; @002b                               v9 = iadd v8, v7
-;; @002b                               v10 = iconst.i64 16
-;; @002b                               v11 = iadd v9, v10  ; v10 = 16
-;; @002b                               v12 = load.i32 user2 readonly region1 v11
-;; @002b                               v14 = uextend.i64 v3
-;; @002b                               v15 = uextend.i64 v6
-;; @002b                               v18 = iadd v14, v15
-;; @002b                               v13 = uextend.i64 v12
-;; @002b                               v19 = icmp ugt v18, v13
-;; @002b                               trapnz v19, user17
+;; @002b                               v10 = iadd v9, v7
+;; @002b                               v11 = iconst.i64 16
+;; @002b                               v12 = iadd v10, v11  ; v11 = 16
+;; @002b                               v13 = load.i32 user2 readonly region1 v12
+;; @002b                               v15 = uextend.i64 v3
+;; @002b                               v16 = uextend.i64 v6
+;; @002b                               v19 = iadd v15, v16
+;; @002b                               v14 = uextend.i64 v13
+;; @002b                               v20 = icmp ugt v19, v14
+;; @002b                               trapnz v20, user17
 ;; @002b                               trapz v4, user16
-;; @002b                               v30 = uextend.i64 v4
-;; @002b                               v32 = iadd v8, v30
-;; @002b                               v34 = iadd v32, v10  ; v10 = 16
-;; @002b                               v35 = load.i32 user2 readonly region1 v34
-;; @002b                               v37 = uextend.i64 v5
-;; @002b                               v41 = iadd v37, v15
-;; @002b                               v36 = uextend.i64 v35
-;; @002b                               v42 = icmp ugt v41, v36
-;; @002b                               trapnz v42, user17
-;; @002b                               v61 = load.i64 notrap aligned v74+40
-;; @002b                               v24 = iconst.i64 20
-;; @002b                               v25 = iadd v9, v24  ; v24 = 20
-;; @002b                               v29 = iadd v25, v14
-;; @002b                               v63 = uadd_overflow_trap v29, v15, user2
-;; @002b                               v62 = iadd v8, v61
-;; @002b                               v64 = icmp ugt v63, v62
-;; @002b                               trapnz v64, user2
-;; @002b                               v48 = iadd v32, v24  ; v24 = 20
-;; @002b                               v52 = iadd v48, v37
-;; @002b                               v70 = uadd_overflow_trap v52, v15, user2
-;; @002b                               v71 = icmp ugt v70, v62
-;; @002b                               trapnz v71, user2
-;; @002b                               call fn0(v0, v29, v52, v15)
+;; @002b                               v31 = uextend.i64 v4
+;; @002b                               v34 = iadd v9, v31
+;; @002b                               v36 = iadd v34, v11  ; v11 = 16
+;; @002b                               v37 = load.i32 user2 readonly region1 v36
+;; @002b                               v39 = uextend.i64 v5
+;; @002b                               v43 = iadd v39, v16
+;; @002b                               v38 = uextend.i64 v37
+;; @002b                               v44 = icmp ugt v43, v38
+;; @002b                               trapnz v44, user17
+;; @002b                               v63 = load.i64 notrap aligned v8+40
+;; @002b                               v25 = iconst.i64 20
+;; @002b                               v26 = iadd v10, v25  ; v25 = 20
+;; @002b                               v30 = iadd v26, v15
+;; @002b                               v65 = uadd_overflow_trap v30, v16, user2
+;; @002b                               v64 = iadd v9, v63
+;; @002b                               v66 = icmp ugt v65, v64
+;; @002b                               trapnz v66, user2
+;; @002b                               v50 = iadd v34, v25  ; v25 = 20
+;; @002b                               v54 = iadd v50, v39
+;; @002b                               v72 = uadd_overflow_trap v54, v16, user2
+;; @002b                               v73 = icmp ugt v72, v64
+;; @002b                               trapnz v73, user2
+;; @002b                               call fn0(v0, v30, v54, v16)
 ;; @002f                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/array-copy-inline.wat
+++ b/tests/disas/array-copy-inline.wat
@@ -21,60 +21,56 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):
 ;; @002a                               trapz v2, user16
-;; @002a                               v77 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @002a                               v8 = load.i64 notrap aligned readonly can_move v77+32
+;; @002a                               v8 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @002a                               v9 = load.i64 notrap aligned readonly can_move v8+32
 ;; @002a                               v7 = uextend.i64 v2
-;; @002a                               v9 = iadd v8, v7
-;; @002a                               v10 = iconst.i64 16
-;; @002a                               v11 = iadd v9, v10  ; v10 = 16
-;; @002a                               v12 = load.i32 user2 readonly region1 v11
-;; @002a                               v14 = uextend.i64 v3
-;;                                     v79 = iconst.i64 7
-;; @002a                               v18 = iadd v14, v79  ; v79 = 7
-;; @002a                               v13 = uextend.i64 v12
-;; @002a                               v19 = icmp ugt v18, v13
-;; @002a                               trapnz v19, user17
+;; @002a                               v10 = iadd v9, v7
+;; @002a                               v11 = iconst.i64 16
+;; @002a                               v12 = iadd v10, v11  ; v11 = 16
+;; @002a                               v13 = load.i32 user2 readonly region1 v12
+;; @002a                               v15 = uextend.i64 v3
+;;                                     v77 = iconst.i64 7
+;; @002a                               v19 = iadd v15, v77  ; v77 = 7
+;; @002a                               v14 = uextend.i64 v13
+;; @002a                               v20 = icmp ugt v19, v14
+;; @002a                               trapnz v20, user17
 ;; @002a                               trapz v4, user16
-;; @002a                               v30 = uextend.i64 v4
-;; @002a                               v32 = iadd v8, v30
-;; @002a                               v34 = iadd v32, v10  ; v10 = 16
-;; @002a                               v35 = load.i32 user2 readonly region1 v34
-;; @002a                               v37 = uextend.i64 v5
-;; @002a                               v41 = iadd v37, v79  ; v79 = 7
-;; @002a                               v36 = uextend.i64 v35
-;; @002a                               v42 = icmp ugt v41, v36
-;; @002a                               trapnz v42, user17
-;; @002a                               v61 = load.i64 notrap aligned v77+40
-;; @002a                               v24 = iconst.i64 20
-;; @002a                               v25 = iadd v9, v24  ; v24 = 20
-;;                                     v87 = iconst.i64 2
-;;                                     v88 = ishl v14, v87  ; v87 = 2
-;; @002a                               v29 = iadd v25, v88
-;;                                     v92 = iconst.i64 28
-;; @002a                               v63 = uadd_overflow_trap v29, v92, user2  ; v92 = 28
-;; @002a                               v62 = iadd v8, v61
-;; @002a                               v64 = icmp ugt v63, v62
-;; @002a                               trapnz v64, user2
-;; @002a                               v48 = iadd v32, v24  ; v24 = 20
-;;                                     v90 = ishl v37, v87  ; v87 = 2
-;; @002a                               v52 = iadd v48, v90
-;; @002a                               v70 = uadd_overflow_trap v52, v92, user2  ; v92 = 28
-;; @002a                               v71 = icmp ugt v70, v62
-;; @002a                               trapnz v71, user2
-;; @002a                               v72 = load.i8x16 notrap aligned little region1 v52
-;; @002a                               v73 = load.i64 notrap aligned little region1 v52+16
-;; @002a                               v74 = load.i32 notrap aligned little region1 v52+24
-;; @002a                               store notrap aligned little region1 v72, v29
-;; @002a                               store notrap aligned little region1 v73, v29+16
-;; @002a                               store notrap aligned little region1 v74, v29+24
+;; @002a                               v31 = uextend.i64 v4
+;; @002a                               v34 = iadd v9, v31
+;; @002a                               v36 = iadd v34, v11  ; v11 = 16
+;; @002a                               v37 = load.i32 user2 readonly region1 v36
+;; @002a                               v39 = uextend.i64 v5
+;; @002a                               v43 = iadd v39, v77  ; v77 = 7
+;; @002a                               v38 = uextend.i64 v37
+;; @002a                               v44 = icmp ugt v43, v38
+;; @002a                               trapnz v44, user17
+;; @002a                               v63 = load.i64 notrap aligned v8+40
+;; @002a                               v25 = iconst.i64 20
+;; @002a                               v26 = iadd v10, v25  ; v25 = 20
+;;                                     v85 = iconst.i64 2
+;;                                     v86 = ishl v15, v85  ; v85 = 2
+;; @002a                               v30 = iadd v26, v86
+;;                                     v90 = iconst.i64 28
+;; @002a                               v65 = uadd_overflow_trap v30, v90, user2  ; v90 = 28
+;; @002a                               v64 = iadd v9, v63
+;; @002a                               v66 = icmp ugt v65, v64
+;; @002a                               trapnz v66, user2
+;; @002a                               v50 = iadd v34, v25  ; v25 = 20
+;;                                     v88 = ishl v39, v85  ; v85 = 2
+;; @002a                               v54 = iadd v50, v88
+;; @002a                               v72 = uadd_overflow_trap v54, v90, user2  ; v90 = 28
+;; @002a                               v73 = icmp ugt v72, v64
+;; @002a                               trapnz v73, user2
+;; @002a                               v74 = load.i8x16 notrap aligned little region1 v54
+;; @002a                               v75 = load.i64 notrap aligned little region1 v54+16
+;; @002a                               v76 = load.i32 notrap aligned little region1 v54+24
+;; @002a                               store notrap aligned little region1 v74, v30
+;; @002a                               store notrap aligned little region1 v75, v30+16
+;; @002a                               store notrap aligned little region1 v76, v30+24
 ;; @002e                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/array-fill-anyref.wat
+++ b/tests/disas/array-fill-anyref.wat
@@ -23,50 +23,46 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):
 ;; @0030                               trapz v2, user16
-;; @0030                               v46 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0030                               v7 = load.i64 notrap aligned readonly can_move v46+32
+;; @0030                               v7 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @0030                               v8 = load.i64 notrap aligned readonly can_move v7+32
 ;; @0030                               v6 = uextend.i64 v2
-;; @0030                               v8 = iadd v7, v6
-;; @0030                               v9 = iconst.i64 16
-;; @0030                               v10 = iadd v8, v9  ; v9 = 16
-;; @0030                               v11 = load.i32 user2 readonly region1 v10
-;; @0030                               v13 = uextend.i64 v3
-;; @0030                               v14 = uextend.i64 v5
-;; @0030                               v17 = iadd v13, v14
-;; @0030                               v12 = uextend.i64 v11
-;; @0030                               v18 = icmp ugt v17, v12
-;; @0030                               trapnz v18, user17
-;; @0030                               v35 = load.i64 notrap aligned v46+40
-;; @0030                               v23 = iconst.i64 20
-;; @0030                               v24 = iadd v8, v23  ; v23 = 20
-;;                                     v50 = iconst.i64 2
-;;                                     v51 = ishl v13, v50  ; v50 = 2
-;; @0030                               v28 = iadd v24, v51
-;;                                     v53 = ishl v14, v50  ; v50 = 2
-;; @0030                               v37 = uadd_overflow_trap v28, v53, user2
-;; @0030                               v36 = iadd v7, v35
-;; @0030                               v38 = icmp ugt v37, v36
-;; @0030                               trapnz v38, user2
-;;                                     v48 = iconst.i64 0
-;; @0030                               v41 = icmp eq v14, v48  ; v48 = 0
-;; @0030                               v26 = iconst.i64 4
-;; @0030                               v39 = iadd v28, v53
-;; @0030                               brif v41, block3, block2(v28)
+;; @0030                               v9 = iadd v8, v6
+;; @0030                               v10 = iconst.i64 16
+;; @0030                               v11 = iadd v9, v10  ; v10 = 16
+;; @0030                               v12 = load.i32 user2 readonly region1 v11
+;; @0030                               v14 = uextend.i64 v3
+;; @0030                               v15 = uextend.i64 v5
+;; @0030                               v18 = iadd v14, v15
+;; @0030                               v13 = uextend.i64 v12
+;; @0030                               v19 = icmp ugt v18, v13
+;; @0030                               trapnz v19, user17
+;; @0030                               v36 = load.i64 notrap aligned v7+40
+;; @0030                               v24 = iconst.i64 20
+;; @0030                               v25 = iadd v9, v24  ; v24 = 20
+;;                                     v49 = iconst.i64 2
+;;                                     v50 = ishl v14, v49  ; v49 = 2
+;; @0030                               v29 = iadd v25, v50
+;;                                     v52 = ishl v15, v49  ; v49 = 2
+;; @0030                               v38 = uadd_overflow_trap v29, v52, user2
+;; @0030                               v37 = iadd v8, v36
+;; @0030                               v39 = icmp ugt v38, v37
+;; @0030                               trapnz v39, user2
+;;                                     v47 = iconst.i64 0
+;; @0030                               v42 = icmp eq v15, v47  ; v47 = 0
+;; @0030                               v27 = iconst.i64 4
+;; @0030                               v40 = iadd v29, v52
+;; @0030                               brif v42, block3, block2(v29)
 ;;
-;;                                 block2(v42: i64):
-;; @0030                               store.i32 user2 little region1 v4, v42
-;;                                     v55 = iconst.i64 4
-;;                                     v56 = iadd v42, v55  ; v55 = 4
-;; @0030                               v45 = icmp eq v56, v39
-;; @0030                               brif v45, block3, block2(v56)
+;;                                 block2(v43: i64):
+;; @0030                               store.i32 user2 little region1 v4, v43
+;;                                     v54 = iconst.i64 4
+;;                                     v55 = iadd v43, v54  ; v54 = 4
+;; @0030                               v46 = icmp eq v55, v40
+;; @0030                               brif v46, block3, block2(v55)
 ;;
 ;;                                 block3:
 ;; @0033                               jump block1
@@ -81,52 +77,48 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
 ;; @003e                               trapz v2, user16
-;; @003e                               v46 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @003e                               v7 = load.i64 notrap aligned readonly can_move v46+32
+;; @003e                               v7 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @003e                               v8 = load.i64 notrap aligned readonly can_move v7+32
 ;; @003e                               v6 = uextend.i64 v2
-;; @003e                               v8 = iadd v7, v6
-;; @003e                               v9 = iconst.i64 16
-;; @003e                               v10 = iadd v8, v9  ; v9 = 16
-;; @003e                               v11 = load.i32 user2 readonly region1 v10
-;; @003e                               v13 = uextend.i64 v3
-;; @003e                               v14 = uextend.i64 v4
-;; @003e                               v17 = iadd v13, v14
-;; @003e                               v12 = uextend.i64 v11
-;; @003e                               v18 = icmp ugt v17, v12
-;; @003e                               trapnz v18, user17
-;; @003e                               v35 = load.i64 notrap aligned v46+40
-;; @003e                               v23 = iconst.i64 20
-;; @003e                               v24 = iadd v8, v23  ; v23 = 20
-;;                                     v50 = iconst.i64 2
-;;                                     v51 = ishl v13, v50  ; v50 = 2
-;; @003e                               v28 = iadd v24, v51
-;;                                     v53 = ishl v14, v50  ; v50 = 2
-;; @003e                               v37 = uadd_overflow_trap v28, v53, user2
-;; @003e                               v36 = iadd v7, v35
-;; @003e                               v38 = icmp ugt v37, v36
-;; @003e                               trapnz v38, user2
-;;                                     v48 = iconst.i64 0
-;; @003e                               v41 = icmp eq v14, v48  ; v48 = 0
+;; @003e                               v9 = iadd v8, v6
+;; @003e                               v10 = iconst.i64 16
+;; @003e                               v11 = iadd v9, v10  ; v10 = 16
+;; @003e                               v12 = load.i32 user2 readonly region1 v11
+;; @003e                               v14 = uextend.i64 v3
+;; @003e                               v15 = uextend.i64 v4
+;; @003e                               v18 = iadd v14, v15
+;; @003e                               v13 = uextend.i64 v12
+;; @003e                               v19 = icmp ugt v18, v13
+;; @003e                               trapnz v19, user17
+;; @003e                               v36 = load.i64 notrap aligned v7+40
+;; @003e                               v24 = iconst.i64 20
+;; @003e                               v25 = iadd v9, v24  ; v24 = 20
+;;                                     v49 = iconst.i64 2
+;;                                     v50 = ishl v14, v49  ; v49 = 2
+;; @003e                               v29 = iadd v25, v50
+;;                                     v52 = ishl v15, v49  ; v49 = 2
+;; @003e                               v38 = uadd_overflow_trap v29, v52, user2
+;; @003e                               v37 = iadd v8, v36
+;; @003e                               v39 = icmp ugt v38, v37
+;; @003e                               trapnz v39, user2
+;;                                     v47 = iconst.i64 0
+;; @003e                               v42 = icmp eq v15, v47  ; v47 = 0
 ;; @003a                               v5 = iconst.i32 0
-;; @003e                               v26 = iconst.i64 4
-;; @003e                               v39 = iadd v28, v53
-;; @003e                               brif v41, block3, block2(v28)
+;; @003e                               v27 = iconst.i64 4
+;; @003e                               v40 = iadd v29, v52
+;; @003e                               brif v42, block3, block2(v29)
 ;;
-;;                                 block2(v42: i64):
-;;                                     v55 = iconst.i32 0
-;; @003e                               store user2 little region1 v55, v42  ; v55 = 0
-;;                                     v56 = iconst.i64 4
-;;                                     v57 = iadd v42, v56  ; v56 = 4
-;; @003e                               v45 = icmp eq v57, v39
-;; @003e                               brif v45, block3, block2(v57)
+;;                                 block2(v43: i64):
+;;                                     v54 = iconst.i32 0
+;; @003e                               store user2 little region1 v54, v43  ; v54 = 0
+;;                                     v55 = iconst.i64 4
+;;                                     v56 = iadd v43, v55  ; v55 = 4
+;; @003e                               v46 = icmp eq v56, v40
+;; @003e                               brif v46, block3, block2(v56)
 ;;
 ;;                                 block3:
 ;; @0041                               jump block1
@@ -141,52 +133,48 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
 ;; @004e                               trapz v2, user16
-;; @004e                               v50 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @004e                               v11 = load.i64 notrap aligned readonly can_move v50+32
+;; @004e                               v11 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @004e                               v12 = load.i64 notrap aligned readonly can_move v11+32
 ;; @004e                               v10 = uextend.i64 v2
-;; @004e                               v12 = iadd v11, v10
-;; @004e                               v13 = iconst.i64 16
-;; @004e                               v14 = iadd v12, v13  ; v13 = 16
-;; @004e                               v15 = load.i32 user2 readonly region1 v14
-;; @004e                               v17 = uextend.i64 v3
-;; @004e                               v18 = uextend.i64 v4
-;; @004e                               v21 = iadd v17, v18
-;; @004e                               v16 = uextend.i64 v15
-;; @004e                               v22 = icmp ugt v21, v16
-;; @004e                               trapnz v22, user17
-;; @004e                               v39 = load.i64 notrap aligned v50+40
-;; @004e                               v27 = iconst.i64 20
-;; @004e                               v28 = iadd v12, v27  ; v27 = 20
-;;                                     v60 = iconst.i64 2
-;;                                     v61 = ishl v17, v60  ; v60 = 2
-;; @004e                               v32 = iadd v28, v61
-;;                                     v63 = ishl v18, v60  ; v60 = 2
-;; @004e                               v41 = uadd_overflow_trap v32, v63, user2
-;; @004e                               v40 = iadd v11, v39
-;; @004e                               v42 = icmp ugt v41, v40
-;; @004e                               trapnz v42, user2
-;;                                     v58 = iconst.i64 0
-;; @004e                               v45 = icmp eq v18, v58  ; v58 = 0
+;; @004e                               v13 = iadd v12, v10
+;; @004e                               v14 = iconst.i64 16
+;; @004e                               v15 = iadd v13, v14  ; v14 = 16
+;; @004e                               v16 = load.i32 user2 readonly region1 v15
+;; @004e                               v18 = uextend.i64 v3
+;; @004e                               v19 = uextend.i64 v4
+;; @004e                               v22 = iadd v18, v19
+;; @004e                               v17 = uextend.i64 v16
+;; @004e                               v23 = icmp ugt v22, v17
+;; @004e                               trapnz v23, user17
+;; @004e                               v40 = load.i64 notrap aligned v11+40
+;; @004e                               v28 = iconst.i64 20
+;; @004e                               v29 = iadd v13, v28  ; v28 = 20
+;;                                     v59 = iconst.i64 2
+;;                                     v60 = ishl v18, v59  ; v59 = 2
+;; @004e                               v33 = iadd v29, v60
+;;                                     v62 = ishl v19, v59  ; v59 = 2
+;; @004e                               v42 = uadd_overflow_trap v33, v62, user2
+;; @004e                               v41 = iadd v12, v40
+;; @004e                               v43 = icmp ugt v42, v41
+;; @004e                               trapnz v43, user2
+;;                                     v57 = iconst.i64 0
+;; @004e                               v46 = icmp eq v19, v57  ; v57 = 0
 ;; @0048                               v5 = iconst.i32 -1
-;; @004e                               v30 = iconst.i64 4
-;; @004e                               v43 = iadd v32, v63
-;; @004e                               brif v45, block3, block2(v32)
+;; @004e                               v31 = iconst.i64 4
+;; @004e                               v44 = iadd v33, v62
+;; @004e                               brif v46, block3, block2(v33)
 ;;
-;;                                 block2(v46: i64):
-;;                                     v65 = iconst.i32 -1
-;; @004e                               store user2 little region1 v65, v46  ; v65 = -1
-;;                                     v66 = iconst.i64 4
-;;                                     v67 = iadd v46, v66  ; v66 = 4
-;; @004e                               v49 = icmp eq v67, v43
-;; @004e                               brif v49, block3, block2(v67)
+;;                                 block2(v47: i64):
+;;                                     v64 = iconst.i32 -1
+;; @004e                               store user2 little region1 v64, v47  ; v64 = -1
+;;                                     v65 = iconst.i64 4
+;;                                     v66 = iadd v47, v65  ; v65 = 4
+;; @004e                               v50 = icmp eq v66, v44
+;; @004e                               brif v50, block3, block2(v66)
 ;;
 ;;                                 block3:
 ;; @0051                               jump block1

--- a/tests/disas/array-fill-externref.wat
+++ b/tests/disas/array-fill-externref.wat
@@ -19,50 +19,46 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):
 ;; @002f                               trapz v2, user16
-;; @002f                               v46 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @002f                               v7 = load.i64 notrap aligned readonly can_move v46+32
+;; @002f                               v7 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @002f                               v8 = load.i64 notrap aligned readonly can_move v7+32
 ;; @002f                               v6 = uextend.i64 v2
-;; @002f                               v8 = iadd v7, v6
-;; @002f                               v9 = iconst.i64 16
-;; @002f                               v10 = iadd v8, v9  ; v9 = 16
-;; @002f                               v11 = load.i32 user2 readonly region1 v10
-;; @002f                               v13 = uextend.i64 v3
-;; @002f                               v14 = uextend.i64 v5
-;; @002f                               v17 = iadd v13, v14
-;; @002f                               v12 = uextend.i64 v11
-;; @002f                               v18 = icmp ugt v17, v12
-;; @002f                               trapnz v18, user17
-;; @002f                               v35 = load.i64 notrap aligned v46+40
-;; @002f                               v23 = iconst.i64 20
-;; @002f                               v24 = iadd v8, v23  ; v23 = 20
-;;                                     v50 = iconst.i64 2
-;;                                     v51 = ishl v13, v50  ; v50 = 2
-;; @002f                               v28 = iadd v24, v51
-;;                                     v53 = ishl v14, v50  ; v50 = 2
-;; @002f                               v37 = uadd_overflow_trap v28, v53, user2
-;; @002f                               v36 = iadd v7, v35
-;; @002f                               v38 = icmp ugt v37, v36
-;; @002f                               trapnz v38, user2
-;;                                     v48 = iconst.i64 0
-;; @002f                               v41 = icmp eq v14, v48  ; v48 = 0
-;; @002f                               v26 = iconst.i64 4
-;; @002f                               v39 = iadd v28, v53
-;; @002f                               brif v41, block3, block2(v28)
+;; @002f                               v9 = iadd v8, v6
+;; @002f                               v10 = iconst.i64 16
+;; @002f                               v11 = iadd v9, v10  ; v10 = 16
+;; @002f                               v12 = load.i32 user2 readonly region1 v11
+;; @002f                               v14 = uextend.i64 v3
+;; @002f                               v15 = uextend.i64 v5
+;; @002f                               v18 = iadd v14, v15
+;; @002f                               v13 = uextend.i64 v12
+;; @002f                               v19 = icmp ugt v18, v13
+;; @002f                               trapnz v19, user17
+;; @002f                               v36 = load.i64 notrap aligned v7+40
+;; @002f                               v24 = iconst.i64 20
+;; @002f                               v25 = iadd v9, v24  ; v24 = 20
+;;                                     v49 = iconst.i64 2
+;;                                     v50 = ishl v14, v49  ; v49 = 2
+;; @002f                               v29 = iadd v25, v50
+;;                                     v52 = ishl v15, v49  ; v49 = 2
+;; @002f                               v38 = uadd_overflow_trap v29, v52, user2
+;; @002f                               v37 = iadd v8, v36
+;; @002f                               v39 = icmp ugt v38, v37
+;; @002f                               trapnz v39, user2
+;;                                     v47 = iconst.i64 0
+;; @002f                               v42 = icmp eq v15, v47  ; v47 = 0
+;; @002f                               v27 = iconst.i64 4
+;; @002f                               v40 = iadd v29, v52
+;; @002f                               brif v42, block3, block2(v29)
 ;;
-;;                                 block2(v42: i64):
-;; @002f                               store.i32 user2 little region1 v4, v42
-;;                                     v55 = iconst.i64 4
-;;                                     v56 = iadd v42, v55  ; v55 = 4
-;; @002f                               v45 = icmp eq v56, v39
-;; @002f                               brif v45, block3, block2(v56)
+;;                                 block2(v43: i64):
+;; @002f                               store.i32 user2 little region1 v4, v43
+;;                                     v54 = iconst.i64 4
+;;                                     v55 = iadd v43, v54  ; v54 = 4
+;; @002f                               v46 = icmp eq v55, v40
+;; @002f                               brif v46, block3, block2(v55)
 ;;
 ;;                                 block3:
 ;; @0032                               jump block1
@@ -77,52 +73,48 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
 ;; @003d                               trapz v2, user16
-;; @003d                               v46 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @003d                               v7 = load.i64 notrap aligned readonly can_move v46+32
+;; @003d                               v7 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @003d                               v8 = load.i64 notrap aligned readonly can_move v7+32
 ;; @003d                               v6 = uextend.i64 v2
-;; @003d                               v8 = iadd v7, v6
-;; @003d                               v9 = iconst.i64 16
-;; @003d                               v10 = iadd v8, v9  ; v9 = 16
-;; @003d                               v11 = load.i32 user2 readonly region1 v10
-;; @003d                               v13 = uextend.i64 v3
-;; @003d                               v14 = uextend.i64 v4
-;; @003d                               v17 = iadd v13, v14
-;; @003d                               v12 = uextend.i64 v11
-;; @003d                               v18 = icmp ugt v17, v12
-;; @003d                               trapnz v18, user17
-;; @003d                               v35 = load.i64 notrap aligned v46+40
-;; @003d                               v23 = iconst.i64 20
-;; @003d                               v24 = iadd v8, v23  ; v23 = 20
-;;                                     v50 = iconst.i64 2
-;;                                     v51 = ishl v13, v50  ; v50 = 2
-;; @003d                               v28 = iadd v24, v51
-;;                                     v53 = ishl v14, v50  ; v50 = 2
-;; @003d                               v37 = uadd_overflow_trap v28, v53, user2
-;; @003d                               v36 = iadd v7, v35
-;; @003d                               v38 = icmp ugt v37, v36
-;; @003d                               trapnz v38, user2
-;;                                     v48 = iconst.i64 0
-;; @003d                               v41 = icmp eq v14, v48  ; v48 = 0
+;; @003d                               v9 = iadd v8, v6
+;; @003d                               v10 = iconst.i64 16
+;; @003d                               v11 = iadd v9, v10  ; v10 = 16
+;; @003d                               v12 = load.i32 user2 readonly region1 v11
+;; @003d                               v14 = uextend.i64 v3
+;; @003d                               v15 = uextend.i64 v4
+;; @003d                               v18 = iadd v14, v15
+;; @003d                               v13 = uextend.i64 v12
+;; @003d                               v19 = icmp ugt v18, v13
+;; @003d                               trapnz v19, user17
+;; @003d                               v36 = load.i64 notrap aligned v7+40
+;; @003d                               v24 = iconst.i64 20
+;; @003d                               v25 = iadd v9, v24  ; v24 = 20
+;;                                     v49 = iconst.i64 2
+;;                                     v50 = ishl v14, v49  ; v49 = 2
+;; @003d                               v29 = iadd v25, v50
+;;                                     v52 = ishl v15, v49  ; v49 = 2
+;; @003d                               v38 = uadd_overflow_trap v29, v52, user2
+;; @003d                               v37 = iadd v8, v36
+;; @003d                               v39 = icmp ugt v38, v37
+;; @003d                               trapnz v39, user2
+;;                                     v47 = iconst.i64 0
+;; @003d                               v42 = icmp eq v15, v47  ; v47 = 0
 ;; @0039                               v5 = iconst.i32 0
-;; @003d                               v26 = iconst.i64 4
-;; @003d                               v39 = iadd v28, v53
-;; @003d                               brif v41, block3, block2(v28)
+;; @003d                               v27 = iconst.i64 4
+;; @003d                               v40 = iadd v29, v52
+;; @003d                               brif v42, block3, block2(v29)
 ;;
-;;                                 block2(v42: i64):
-;;                                     v55 = iconst.i32 0
-;; @003d                               store user2 little region1 v55, v42  ; v55 = 0
-;;                                     v56 = iconst.i64 4
-;;                                     v57 = iadd v42, v56  ; v56 = 4
-;; @003d                               v45 = icmp eq v57, v39
-;; @003d                               brif v45, block3, block2(v57)
+;;                                 block2(v43: i64):
+;;                                     v54 = iconst.i32 0
+;; @003d                               store user2 little region1 v54, v43  ; v54 = 0
+;;                                     v55 = iconst.i64 4
+;;                                     v56 = iadd v43, v55  ; v55 = 4
+;; @003d                               v46 = icmp eq v56, v40
+;; @003d                               brif v46, block3, block2(v56)
 ;;
 ;;                                 block3:
 ;; @0040                               jump block1

--- a/tests/disas/array-fill-f32.wat
+++ b/tests/disas/array-fill-f32.wat
@@ -23,50 +23,46 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: f32, v5: i32):
 ;; @0030                               trapz v2, user16
-;; @0030                               v46 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0030                               v7 = load.i64 notrap aligned readonly can_move v46+32
+;; @0030                               v7 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @0030                               v8 = load.i64 notrap aligned readonly can_move v7+32
 ;; @0030                               v6 = uextend.i64 v2
-;; @0030                               v8 = iadd v7, v6
-;; @0030                               v9 = iconst.i64 16
-;; @0030                               v10 = iadd v8, v9  ; v9 = 16
-;; @0030                               v11 = load.i32 user2 readonly region1 v10
-;; @0030                               v13 = uextend.i64 v3
-;; @0030                               v14 = uextend.i64 v5
-;; @0030                               v17 = iadd v13, v14
-;; @0030                               v12 = uextend.i64 v11
-;; @0030                               v18 = icmp ugt v17, v12
-;; @0030                               trapnz v18, user17
-;; @0030                               v35 = load.i64 notrap aligned v46+40
-;; @0030                               v23 = iconst.i64 20
-;; @0030                               v24 = iadd v8, v23  ; v23 = 20
-;;                                     v50 = iconst.i64 2
-;;                                     v51 = ishl v13, v50  ; v50 = 2
-;; @0030                               v28 = iadd v24, v51
-;;                                     v53 = ishl v14, v50  ; v50 = 2
-;; @0030                               v37 = uadd_overflow_trap v28, v53, user2
-;; @0030                               v36 = iadd v7, v35
-;; @0030                               v38 = icmp ugt v37, v36
-;; @0030                               trapnz v38, user2
-;;                                     v48 = iconst.i64 0
-;; @0030                               v41 = icmp eq v14, v48  ; v48 = 0
-;; @0030                               v26 = iconst.i64 4
-;; @0030                               v39 = iadd v28, v53
-;; @0030                               brif v41, block3, block2(v28)
+;; @0030                               v9 = iadd v8, v6
+;; @0030                               v10 = iconst.i64 16
+;; @0030                               v11 = iadd v9, v10  ; v10 = 16
+;; @0030                               v12 = load.i32 user2 readonly region1 v11
+;; @0030                               v14 = uextend.i64 v3
+;; @0030                               v15 = uextend.i64 v5
+;; @0030                               v18 = iadd v14, v15
+;; @0030                               v13 = uextend.i64 v12
+;; @0030                               v19 = icmp ugt v18, v13
+;; @0030                               trapnz v19, user17
+;; @0030                               v36 = load.i64 notrap aligned v7+40
+;; @0030                               v24 = iconst.i64 20
+;; @0030                               v25 = iadd v9, v24  ; v24 = 20
+;;                                     v49 = iconst.i64 2
+;;                                     v50 = ishl v14, v49  ; v49 = 2
+;; @0030                               v29 = iadd v25, v50
+;;                                     v52 = ishl v15, v49  ; v49 = 2
+;; @0030                               v38 = uadd_overflow_trap v29, v52, user2
+;; @0030                               v37 = iadd v8, v36
+;; @0030                               v39 = icmp ugt v38, v37
+;; @0030                               trapnz v39, user2
+;;                                     v47 = iconst.i64 0
+;; @0030                               v42 = icmp eq v15, v47  ; v47 = 0
+;; @0030                               v27 = iconst.i64 4
+;; @0030                               v40 = iadd v29, v52
+;; @0030                               brif v42, block3, block2(v29)
 ;;
-;;                                 block2(v42: i64):
-;; @0030                               store.f32 user2 little region1 v4, v42
-;;                                     v55 = iconst.i64 4
-;;                                     v56 = iadd v42, v55  ; v55 = 4
-;; @0030                               v45 = icmp eq v56, v39
-;; @0030                               brif v45, block3, block2(v56)
+;;                                 block2(v43: i64):
+;; @0030                               store.f32 user2 little region1 v4, v43
+;;                                     v54 = iconst.i64 4
+;;                                     v55 = iadd v43, v54  ; v54 = 4
+;; @0030                               v46 = icmp eq v55, v40
+;; @0030                               brif v46, block3, block2(v55)
 ;;
 ;;                                 block3:
 ;; @0033                               jump block1
@@ -81,42 +77,38 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i64, i32, i64) tail
 ;;     fn0 = colocated u805306368:2 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
 ;; @0041                               trapz v2, user16
-;; @0041                               v40 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0041                               v7 = load.i64 notrap aligned readonly can_move v40+32
+;; @0041                               v7 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @0041                               v8 = load.i64 notrap aligned readonly can_move v7+32
 ;; @0041                               v6 = uextend.i64 v2
-;; @0041                               v8 = iadd v7, v6
-;; @0041                               v9 = iconst.i64 16
-;; @0041                               v10 = iadd v8, v9  ; v9 = 16
-;; @0041                               v11 = load.i32 user2 readonly region1 v10
-;; @0041                               v13 = uextend.i64 v3
-;; @0041                               v14 = uextend.i64 v4
-;; @0041                               v17 = iadd v13, v14
-;; @0041                               v12 = uextend.i64 v11
-;; @0041                               v18 = icmp ugt v17, v12
-;; @0041                               trapnz v18, user17
-;; @0041                               v35 = load.i64 notrap aligned v40+40
-;; @0041                               v23 = iconst.i64 20
-;; @0041                               v24 = iadd v8, v23  ; v23 = 20
-;;                                     v44 = iconst.i64 2
-;;                                     v45 = ishl v13, v44  ; v44 = 2
-;; @0041                               v28 = iadd v24, v45
-;;                                     v47 = ishl v14, v44  ; v44 = 2
-;; @0041                               v37 = uadd_overflow_trap v28, v47, user2
-;; @0041                               v36 = iadd v7, v35
-;; @0041                               v38 = icmp ugt v37, v36
-;; @0041                               trapnz v38, user2
-;; @0041                               v39 = iconst.i32 0
-;; @0041                               call fn0(v0, v28, v39, v47)  ; v39 = 0
+;; @0041                               v9 = iadd v8, v6
+;; @0041                               v10 = iconst.i64 16
+;; @0041                               v11 = iadd v9, v10  ; v10 = 16
+;; @0041                               v12 = load.i32 user2 readonly region1 v11
+;; @0041                               v14 = uextend.i64 v3
+;; @0041                               v15 = uextend.i64 v4
+;; @0041                               v18 = iadd v14, v15
+;; @0041                               v13 = uextend.i64 v12
+;; @0041                               v19 = icmp ugt v18, v13
+;; @0041                               trapnz v19, user17
+;; @0041                               v36 = load.i64 notrap aligned v7+40
+;; @0041                               v24 = iconst.i64 20
+;; @0041                               v25 = iadd v9, v24  ; v24 = 20
+;;                                     v43 = iconst.i64 2
+;;                                     v44 = ishl v14, v43  ; v43 = 2
+;; @0041                               v29 = iadd v25, v44
+;;                                     v46 = ishl v15, v43  ; v43 = 2
+;; @0041                               v38 = uadd_overflow_trap v29, v46, user2
+;; @0041                               v37 = iadd v8, v36
+;; @0041                               v39 = icmp ugt v38, v37
+;; @0041                               trapnz v39, user2
+;; @0041                               v40 = iconst.i32 0
+;; @0041                               call fn0(v0, v29, v40, v46)  ; v40 = 0
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -129,52 +121,48 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
 ;; @0052                               trapz v2, user16
-;; @0052                               v46 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0052                               v7 = load.i64 notrap aligned readonly can_move v46+32
+;; @0052                               v7 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @0052                               v8 = load.i64 notrap aligned readonly can_move v7+32
 ;; @0052                               v6 = uextend.i64 v2
-;; @0052                               v8 = iadd v7, v6
-;; @0052                               v9 = iconst.i64 16
-;; @0052                               v10 = iadd v8, v9  ; v9 = 16
-;; @0052                               v11 = load.i32 user2 readonly region1 v10
-;; @0052                               v13 = uextend.i64 v3
-;; @0052                               v14 = uextend.i64 v4
-;; @0052                               v17 = iadd v13, v14
-;; @0052                               v12 = uextend.i64 v11
-;; @0052                               v18 = icmp ugt v17, v12
-;; @0052                               trapnz v18, user17
-;; @0052                               v35 = load.i64 notrap aligned v46+40
-;; @0052                               v23 = iconst.i64 20
-;; @0052                               v24 = iadd v8, v23  ; v23 = 20
-;;                                     v50 = iconst.i64 2
-;;                                     v51 = ishl v13, v50  ; v50 = 2
-;; @0052                               v28 = iadd v24, v51
-;;                                     v53 = ishl v14, v50  ; v50 = 2
-;; @0052                               v37 = uadd_overflow_trap v28, v53, user2
-;; @0052                               v36 = iadd v7, v35
-;; @0052                               v38 = icmp ugt v37, v36
-;; @0052                               trapnz v38, user2
-;;                                     v48 = iconst.i64 0
-;; @0052                               v41 = icmp eq v14, v48  ; v48 = 0
+;; @0052                               v9 = iadd v8, v6
+;; @0052                               v10 = iconst.i64 16
+;; @0052                               v11 = iadd v9, v10  ; v10 = 16
+;; @0052                               v12 = load.i32 user2 readonly region1 v11
+;; @0052                               v14 = uextend.i64 v3
+;; @0052                               v15 = uextend.i64 v4
+;; @0052                               v18 = iadd v14, v15
+;; @0052                               v13 = uextend.i64 v12
+;; @0052                               v19 = icmp ugt v18, v13
+;; @0052                               trapnz v19, user17
+;; @0052                               v36 = load.i64 notrap aligned v7+40
+;; @0052                               v24 = iconst.i64 20
+;; @0052                               v25 = iadd v9, v24  ; v24 = 20
+;;                                     v49 = iconst.i64 2
+;;                                     v50 = ishl v14, v49  ; v49 = 2
+;; @0052                               v29 = iadd v25, v50
+;;                                     v52 = ishl v15, v49  ; v49 = 2
+;; @0052                               v38 = uadd_overflow_trap v29, v52, user2
+;; @0052                               v37 = iadd v8, v36
+;; @0052                               v39 = icmp ugt v38, v37
+;; @0052                               trapnz v39, user2
+;;                                     v47 = iconst.i64 0
+;; @0052                               v42 = icmp eq v15, v47  ; v47 = 0
 ;; @004b                               v5 = f32const 0x1.000000p0
-;; @0052                               v26 = iconst.i64 4
-;; @0052                               v39 = iadd v28, v53
-;; @0052                               brif v41, block3, block2(v28)
+;; @0052                               v27 = iconst.i64 4
+;; @0052                               v40 = iadd v29, v52
+;; @0052                               brif v42, block3, block2(v29)
 ;;
-;;                                 block2(v42: i64):
-;;                                     v55 = f32const 0x1.000000p0
-;; @0052                               store user2 little region1 v55, v42  ; v55 = 0x1.000000p0
-;;                                     v56 = iconst.i64 4
-;;                                     v57 = iadd v42, v56  ; v56 = 4
-;; @0052                               v45 = icmp eq v57, v39
-;; @0052                               brif v45, block3, block2(v57)
+;;                                 block2(v43: i64):
+;;                                     v54 = f32const 0x1.000000p0
+;; @0052                               store user2 little region1 v54, v43  ; v54 = 0x1.000000p0
+;;                                     v55 = iconst.i64 4
+;;                                     v56 = iadd v43, v55  ; v55 = 4
+;; @0052                               v46 = icmp eq v56, v40
+;; @0052                               brif v46, block3, block2(v56)
 ;;
 ;;                                 block3:
 ;; @0055                               jump block1

--- a/tests/disas/array-fill-f64.wat
+++ b/tests/disas/array-fill-f64.wat
@@ -23,50 +23,46 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: f64, v5: i32):
 ;; @0030                               trapz v2, user16
-;; @0030                               v46 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0030                               v7 = load.i64 notrap aligned readonly can_move v46+32
+;; @0030                               v7 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @0030                               v8 = load.i64 notrap aligned readonly can_move v7+32
 ;; @0030                               v6 = uextend.i64 v2
-;; @0030                               v8 = iadd v7, v6
-;; @0030                               v9 = iconst.i64 16
-;; @0030                               v10 = iadd v8, v9  ; v9 = 16
-;; @0030                               v11 = load.i32 user2 readonly region1 v10
-;; @0030                               v13 = uextend.i64 v3
-;; @0030                               v14 = uextend.i64 v5
-;; @0030                               v17 = iadd v13, v14
-;; @0030                               v12 = uextend.i64 v11
-;; @0030                               v18 = icmp ugt v17, v12
-;; @0030                               trapnz v18, user17
-;; @0030                               v35 = load.i64 notrap aligned v46+40
-;; @0030                               v23 = iconst.i64 24
-;; @0030                               v24 = iadd v8, v23  ; v23 = 24
-;;                                     v50 = iconst.i64 3
-;;                                     v51 = ishl v13, v50  ; v50 = 3
-;; @0030                               v28 = iadd v24, v51
-;;                                     v53 = ishl v14, v50  ; v50 = 3
-;; @0030                               v37 = uadd_overflow_trap v28, v53, user2
-;; @0030                               v36 = iadd v7, v35
-;; @0030                               v38 = icmp ugt v37, v36
-;; @0030                               trapnz v38, user2
-;;                                     v48 = iconst.i64 0
-;; @0030                               v41 = icmp eq v14, v48  ; v48 = 0
-;; @0030                               v26 = iconst.i64 8
-;; @0030                               v39 = iadd v28, v53
-;; @0030                               brif v41, block3, block2(v28)
+;; @0030                               v9 = iadd v8, v6
+;; @0030                               v10 = iconst.i64 16
+;; @0030                               v11 = iadd v9, v10  ; v10 = 16
+;; @0030                               v12 = load.i32 user2 readonly region1 v11
+;; @0030                               v14 = uextend.i64 v3
+;; @0030                               v15 = uextend.i64 v5
+;; @0030                               v18 = iadd v14, v15
+;; @0030                               v13 = uextend.i64 v12
+;; @0030                               v19 = icmp ugt v18, v13
+;; @0030                               trapnz v19, user17
+;; @0030                               v36 = load.i64 notrap aligned v7+40
+;; @0030                               v24 = iconst.i64 24
+;; @0030                               v25 = iadd v9, v24  ; v24 = 24
+;;                                     v49 = iconst.i64 3
+;;                                     v50 = ishl v14, v49  ; v49 = 3
+;; @0030                               v29 = iadd v25, v50
+;;                                     v52 = ishl v15, v49  ; v49 = 3
+;; @0030                               v38 = uadd_overflow_trap v29, v52, user2
+;; @0030                               v37 = iadd v8, v36
+;; @0030                               v39 = icmp ugt v38, v37
+;; @0030                               trapnz v39, user2
+;;                                     v47 = iconst.i64 0
+;; @0030                               v42 = icmp eq v15, v47  ; v47 = 0
+;; @0030                               v27 = iconst.i64 8
+;; @0030                               v40 = iadd v29, v52
+;; @0030                               brif v42, block3, block2(v29)
 ;;
-;;                                 block2(v42: i64):
-;; @0030                               store.f64 user2 little region1 v4, v42
-;;                                     v55 = iconst.i64 8
-;;                                     v56 = iadd v42, v55  ; v55 = 8
-;; @0030                               v45 = icmp eq v56, v39
-;; @0030                               brif v45, block3, block2(v56)
+;;                                 block2(v43: i64):
+;; @0030                               store.f64 user2 little region1 v4, v43
+;;                                     v54 = iconst.i64 8
+;;                                     v55 = iadd v43, v54  ; v54 = 8
+;; @0030                               v46 = icmp eq v55, v40
+;; @0030                               brif v46, block3, block2(v55)
 ;;
 ;;                                 block3:
 ;; @0033                               jump block1
@@ -81,42 +77,38 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i64, i32, i64) tail
 ;;     fn0 = colocated u805306368:2 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
 ;; @0045                               trapz v2, user16
-;; @0045                               v40 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0045                               v7 = load.i64 notrap aligned readonly can_move v40+32
+;; @0045                               v7 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @0045                               v8 = load.i64 notrap aligned readonly can_move v7+32
 ;; @0045                               v6 = uextend.i64 v2
-;; @0045                               v8 = iadd v7, v6
-;; @0045                               v9 = iconst.i64 16
-;; @0045                               v10 = iadd v8, v9  ; v9 = 16
-;; @0045                               v11 = load.i32 user2 readonly region1 v10
-;; @0045                               v13 = uextend.i64 v3
-;; @0045                               v14 = uextend.i64 v4
-;; @0045                               v17 = iadd v13, v14
-;; @0045                               v12 = uextend.i64 v11
-;; @0045                               v18 = icmp ugt v17, v12
-;; @0045                               trapnz v18, user17
-;; @0045                               v35 = load.i64 notrap aligned v40+40
-;; @0045                               v23 = iconst.i64 24
-;; @0045                               v24 = iadd v8, v23  ; v23 = 24
-;;                                     v44 = iconst.i64 3
-;;                                     v45 = ishl v13, v44  ; v44 = 3
-;; @0045                               v28 = iadd v24, v45
-;;                                     v47 = ishl v14, v44  ; v44 = 3
-;; @0045                               v37 = uadd_overflow_trap v28, v47, user2
-;; @0045                               v36 = iadd v7, v35
-;; @0045                               v38 = icmp ugt v37, v36
-;; @0045                               trapnz v38, user2
-;; @0045                               v39 = iconst.i32 0
-;; @0045                               call fn0(v0, v28, v39, v47)  ; v39 = 0
+;; @0045                               v9 = iadd v8, v6
+;; @0045                               v10 = iconst.i64 16
+;; @0045                               v11 = iadd v9, v10  ; v10 = 16
+;; @0045                               v12 = load.i32 user2 readonly region1 v11
+;; @0045                               v14 = uextend.i64 v3
+;; @0045                               v15 = uextend.i64 v4
+;; @0045                               v18 = iadd v14, v15
+;; @0045                               v13 = uextend.i64 v12
+;; @0045                               v19 = icmp ugt v18, v13
+;; @0045                               trapnz v19, user17
+;; @0045                               v36 = load.i64 notrap aligned v7+40
+;; @0045                               v24 = iconst.i64 24
+;; @0045                               v25 = iadd v9, v24  ; v24 = 24
+;;                                     v43 = iconst.i64 3
+;;                                     v44 = ishl v14, v43  ; v43 = 3
+;; @0045                               v29 = iadd v25, v44
+;;                                     v46 = ishl v15, v43  ; v43 = 3
+;; @0045                               v38 = uadd_overflow_trap v29, v46, user2
+;; @0045                               v37 = iadd v8, v36
+;; @0045                               v39 = icmp ugt v38, v37
+;; @0045                               trapnz v39, user2
+;; @0045                               v40 = iconst.i32 0
+;; @0045                               call fn0(v0, v29, v40, v46)  ; v40 = 0
 ;; @0048                               jump block1
 ;;
 ;;                                 block1:
@@ -129,52 +121,48 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
 ;; @005a                               trapz v2, user16
-;; @005a                               v46 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @005a                               v7 = load.i64 notrap aligned readonly can_move v46+32
+;; @005a                               v7 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @005a                               v8 = load.i64 notrap aligned readonly can_move v7+32
 ;; @005a                               v6 = uextend.i64 v2
-;; @005a                               v8 = iadd v7, v6
-;; @005a                               v9 = iconst.i64 16
-;; @005a                               v10 = iadd v8, v9  ; v9 = 16
-;; @005a                               v11 = load.i32 user2 readonly region1 v10
-;; @005a                               v13 = uextend.i64 v3
-;; @005a                               v14 = uextend.i64 v4
-;; @005a                               v17 = iadd v13, v14
-;; @005a                               v12 = uextend.i64 v11
-;; @005a                               v18 = icmp ugt v17, v12
-;; @005a                               trapnz v18, user17
-;; @005a                               v35 = load.i64 notrap aligned v46+40
-;; @005a                               v23 = iconst.i64 24
-;; @005a                               v24 = iadd v8, v23  ; v23 = 24
-;;                                     v50 = iconst.i64 3
-;;                                     v51 = ishl v13, v50  ; v50 = 3
-;; @005a                               v28 = iadd v24, v51
-;;                                     v53 = ishl v14, v50  ; v50 = 3
-;; @005a                               v37 = uadd_overflow_trap v28, v53, user2
-;; @005a                               v36 = iadd v7, v35
-;; @005a                               v38 = icmp ugt v37, v36
-;; @005a                               trapnz v38, user2
-;;                                     v48 = iconst.i64 0
-;; @005a                               v41 = icmp eq v14, v48  ; v48 = 0
+;; @005a                               v9 = iadd v8, v6
+;; @005a                               v10 = iconst.i64 16
+;; @005a                               v11 = iadd v9, v10  ; v10 = 16
+;; @005a                               v12 = load.i32 user2 readonly region1 v11
+;; @005a                               v14 = uextend.i64 v3
+;; @005a                               v15 = uextend.i64 v4
+;; @005a                               v18 = iadd v14, v15
+;; @005a                               v13 = uextend.i64 v12
+;; @005a                               v19 = icmp ugt v18, v13
+;; @005a                               trapnz v19, user17
+;; @005a                               v36 = load.i64 notrap aligned v7+40
+;; @005a                               v24 = iconst.i64 24
+;; @005a                               v25 = iadd v9, v24  ; v24 = 24
+;;                                     v49 = iconst.i64 3
+;;                                     v50 = ishl v14, v49  ; v49 = 3
+;; @005a                               v29 = iadd v25, v50
+;;                                     v52 = ishl v15, v49  ; v49 = 3
+;; @005a                               v38 = uadd_overflow_trap v29, v52, user2
+;; @005a                               v37 = iadd v8, v36
+;; @005a                               v39 = icmp ugt v38, v37
+;; @005a                               trapnz v39, user2
+;;                                     v47 = iconst.i64 0
+;; @005a                               v42 = icmp eq v15, v47  ; v47 = 0
 ;; @004f                               v5 = f64const 0x1.0000000000000p0
-;; @005a                               v26 = iconst.i64 8
-;; @005a                               v39 = iadd v28, v53
-;; @005a                               brif v41, block3, block2(v28)
+;; @005a                               v27 = iconst.i64 8
+;; @005a                               v40 = iadd v29, v52
+;; @005a                               brif v42, block3, block2(v29)
 ;;
-;;                                 block2(v42: i64):
-;;                                     v55 = f64const 0x1.0000000000000p0
-;; @005a                               store user2 little region1 v55, v42  ; v55 = 0x1.0000000000000p0
-;;                                     v56 = iconst.i64 8
-;;                                     v57 = iadd v42, v56  ; v56 = 8
-;; @005a                               v45 = icmp eq v57, v39
-;; @005a                               brif v45, block3, block2(v57)
+;;                                 block2(v43: i64):
+;;                                     v54 = f64const 0x1.0000000000000p0
+;; @005a                               store user2 little region1 v54, v43  ; v54 = 0x1.0000000000000p0
+;;                                     v55 = iconst.i64 8
+;;                                     v56 = iadd v43, v55  ; v55 = 8
+;; @005a                               v46 = icmp eq v56, v40
+;; @005a                               brif v46, block3, block2(v56)
 ;;
 ;;                                 block3:
 ;; @005d                               jump block1

--- a/tests/disas/array-fill-funcref.wat
+++ b/tests/disas/array-fill-funcref.wat
@@ -26,54 +26,50 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i64) -> i64 tail
 ;;     fn0 = colocated u805306368:25 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i64, v5: i32):
 ;; @003b                               trapz v2, user16
-;; @003b                               v48 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @003b                               v7 = load.i64 notrap aligned readonly can_move v48+32
+;; @003b                               v7 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @003b                               v8 = load.i64 notrap aligned readonly can_move v7+32
 ;; @003b                               v6 = uextend.i64 v2
-;; @003b                               v8 = iadd v7, v6
-;; @003b                               v9 = iconst.i64 16
-;; @003b                               v10 = iadd v8, v9  ; v9 = 16
-;; @003b                               v11 = load.i32 user2 readonly region1 v10
-;; @003b                               v13 = uextend.i64 v3
-;; @003b                               v14 = uextend.i64 v5
-;; @003b                               v17 = iadd v13, v14
-;; @003b                               v12 = uextend.i64 v11
-;; @003b                               v18 = icmp ugt v17, v12
-;; @003b                               trapnz v18, user17
-;; @003b                               v35 = load.i64 notrap aligned v48+40
-;; @003b                               v23 = iconst.i64 20
-;; @003b                               v24 = iadd v8, v23  ; v23 = 20
-;;                                     v52 = iconst.i64 2
-;;                                     v53 = ishl v13, v52  ; v52 = 2
-;; @003b                               v28 = iadd v24, v53
-;;                                     v55 = ishl v14, v52  ; v52 = 2
-;; @003b                               v37 = uadd_overflow_trap v28, v55, user2
-;; @003b                               v36 = iadd v7, v35
-;; @003b                               v38 = icmp ugt v37, v36
-;; @003b                               trapnz v38, user2
-;; @003b                               v39 = call fn0(v0, v4)
-;;                                     v50 = iconst.i64 0
-;; @003b                               v43 = icmp eq v14, v50  ; v50 = 0
-;; @003b                               v40 = ireduce.i32 v39
-;; @003b                               v26 = iconst.i64 4
-;; @003b                               v41 = iadd v28, v55
-;; @003b                               brif v43, block3, block2(v28)
+;; @003b                               v9 = iadd v8, v6
+;; @003b                               v10 = iconst.i64 16
+;; @003b                               v11 = iadd v9, v10  ; v10 = 16
+;; @003b                               v12 = load.i32 user2 readonly region1 v11
+;; @003b                               v14 = uextend.i64 v3
+;; @003b                               v15 = uextend.i64 v5
+;; @003b                               v18 = iadd v14, v15
+;; @003b                               v13 = uextend.i64 v12
+;; @003b                               v19 = icmp ugt v18, v13
+;; @003b                               trapnz v19, user17
+;; @003b                               v36 = load.i64 notrap aligned v7+40
+;; @003b                               v24 = iconst.i64 20
+;; @003b                               v25 = iadd v9, v24  ; v24 = 20
+;;                                     v51 = iconst.i64 2
+;;                                     v52 = ishl v14, v51  ; v51 = 2
+;; @003b                               v29 = iadd v25, v52
+;;                                     v54 = ishl v15, v51  ; v51 = 2
+;; @003b                               v38 = uadd_overflow_trap v29, v54, user2
+;; @003b                               v37 = iadd v8, v36
+;; @003b                               v39 = icmp ugt v38, v37
+;; @003b                               trapnz v39, user2
+;; @003b                               v40 = call fn0(v0, v4)
+;;                                     v49 = iconst.i64 0
+;; @003b                               v44 = icmp eq v15, v49  ; v49 = 0
+;; @003b                               v41 = ireduce.i32 v40
+;; @003b                               v27 = iconst.i64 4
+;; @003b                               v42 = iadd v29, v54
+;; @003b                               brif v44, block3, block2(v29)
 ;;
-;;                                 block2(v44: i64):
-;; @003b                               store.i32 notrap aligned little v40, v44
-;;                                     v57 = iconst.i64 4
-;;                                     v58 = iadd v44, v57  ; v57 = 4
-;; @003b                               v47 = icmp eq v58, v41
-;; @003b                               brif v47, block3, block2(v58)
+;;                                 block2(v45: i64):
+;; @003b                               store.i32 notrap aligned little v41, v45
+;;                                     v56 = iconst.i64 4
+;;                                     v57 = iadd v45, v56  ; v56 = 4
+;; @003b                               v48 = icmp eq v57, v42
+;; @003b                               brif v48, block3, block2(v57)
 ;;
 ;;                                 block3:
 ;; @003e                               jump block1
@@ -88,54 +84,50 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i64) -> i64 tail
 ;;     fn0 = colocated u805306368:25 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
 ;; @0049                               trapz v2, user16
-;; @0049                               v48 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0049                               v7 = load.i64 notrap aligned readonly can_move v48+32
+;; @0049                               v7 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @0049                               v8 = load.i64 notrap aligned readonly can_move v7+32
 ;; @0049                               v6 = uextend.i64 v2
-;; @0049                               v8 = iadd v7, v6
-;; @0049                               v9 = iconst.i64 16
-;; @0049                               v10 = iadd v8, v9  ; v9 = 16
-;; @0049                               v11 = load.i32 user2 readonly region1 v10
-;; @0049                               v13 = uextend.i64 v3
-;; @0049                               v14 = uextend.i64 v4
-;; @0049                               v17 = iadd v13, v14
-;; @0049                               v12 = uextend.i64 v11
-;; @0049                               v18 = icmp ugt v17, v12
-;; @0049                               trapnz v18, user17
-;; @0049                               v35 = load.i64 notrap aligned v48+40
-;; @0049                               v23 = iconst.i64 20
-;; @0049                               v24 = iadd v8, v23  ; v23 = 20
-;;                                     v51 = iconst.i64 2
-;;                                     v52 = ishl v13, v51  ; v51 = 2
-;; @0049                               v28 = iadd v24, v52
-;;                                     v54 = ishl v14, v51  ; v51 = 2
-;; @0049                               v37 = uadd_overflow_trap v28, v54, user2
-;; @0049                               v36 = iadd v7, v35
-;; @0049                               v38 = icmp ugt v37, v36
-;; @0049                               trapnz v38, user2
+;; @0049                               v9 = iadd v8, v6
+;; @0049                               v10 = iconst.i64 16
+;; @0049                               v11 = iadd v9, v10  ; v10 = 16
+;; @0049                               v12 = load.i32 user2 readonly region1 v11
+;; @0049                               v14 = uextend.i64 v3
+;; @0049                               v15 = uextend.i64 v4
+;; @0049                               v18 = iadd v14, v15
+;; @0049                               v13 = uextend.i64 v12
+;; @0049                               v19 = icmp ugt v18, v13
+;; @0049                               trapnz v19, user17
+;; @0049                               v36 = load.i64 notrap aligned v7+40
+;; @0049                               v24 = iconst.i64 20
+;; @0049                               v25 = iadd v9, v24  ; v24 = 20
+;;                                     v50 = iconst.i64 2
+;;                                     v51 = ishl v14, v50  ; v50 = 2
+;; @0049                               v29 = iadd v25, v51
+;;                                     v53 = ishl v15, v50  ; v50 = 2
+;; @0049                               v38 = uadd_overflow_trap v29, v53, user2
+;; @0049                               v37 = iadd v8, v36
+;; @0049                               v39 = icmp ugt v38, v37
+;; @0049                               trapnz v39, user2
 ;; @0045                               v5 = iconst.i64 0
-;; @0049                               v39 = call fn0(v0, v5)  ; v5 = 0
-;; @0049                               v43 = icmp eq v14, v5  ; v5 = 0
-;; @0049                               v40 = ireduce.i32 v39
-;; @0049                               v26 = iconst.i64 4
-;; @0049                               v41 = iadd v28, v54
-;; @0049                               brif v43, block3, block2(v28)
+;; @0049                               v40 = call fn0(v0, v5)  ; v5 = 0
+;; @0049                               v44 = icmp eq v15, v5  ; v5 = 0
+;; @0049                               v41 = ireduce.i32 v40
+;; @0049                               v27 = iconst.i64 4
+;; @0049                               v42 = iadd v29, v53
+;; @0049                               brif v44, block3, block2(v29)
 ;;
-;;                                 block2(v44: i64):
-;; @0049                               store.i32 notrap aligned little v40, v44
-;;                                     v56 = iconst.i64 4
-;;                                     v57 = iadd v44, v56  ; v56 = 4
-;; @0049                               v47 = icmp eq v57, v41
-;; @0049                               brif v47, block3, block2(v57)
+;;                                 block2(v45: i64):
+;; @0049                               store.i32 notrap aligned little v41, v45
+;;                                     v55 = iconst.i64 4
+;;                                     v56 = iadd v45, v55  ; v55 = 4
+;; @0049                               v48 = icmp eq v56, v42
+;; @0049                               brif v48, block3, block2(v56)
 ;;
 ;;                                 block3:
 ;; @004c                               jump block1
@@ -151,10 +143,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32) -> i64 tail
 ;;     sig1 = (i64 vmctx, i64) -> i64 tail
 ;;     fn0 = colocated u805306368:6 sig0
@@ -162,50 +150,50 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
-;;                                     v55 = stack_addr.i64 ss0
-;;                                     store notrap v2, v55
+;;                                     v56 = stack_addr.i64 ss0
+;;                                     store notrap v2, v56
 ;; @0053                               v5 = iconst.i32 3
 ;; @0053                               v6 = call fn0(v0, v5), stack_map=[i32 @ ss0+0]  ; v5 = 3
-;;                                     v54 = load.i32 notrap v55
-;; @0057                               trapz v54, user16
-;; @0057                               v56 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0057                               v8 = load.i64 notrap aligned readonly can_move v56+32
-;; @0057                               v7 = uextend.i64 v54
-;; @0057                               v9 = iadd v8, v7
-;; @0057                               v10 = iconst.i64 16
-;; @0057                               v11 = iadd v9, v10  ; v10 = 16
-;; @0057                               v12 = load.i32 user2 readonly region1 v11
-;; @0057                               v14 = uextend.i64 v3
-;; @0057                               v15 = uextend.i64 v4
-;; @0057                               v18 = iadd v14, v15
-;; @0057                               v13 = uextend.i64 v12
-;; @0057                               v19 = icmp ugt v18, v13
-;; @0057                               trapnz v19, user17
-;; @0057                               v36 = load.i64 notrap aligned v56+40
-;; @0057                               v24 = iconst.i64 20
-;; @0057                               v25 = iadd v9, v24  ; v24 = 20
-;;                                     v60 = iconst.i64 2
-;;                                     v61 = ishl v14, v60  ; v60 = 2
-;; @0057                               v29 = iadd v25, v61
-;;                                     v63 = ishl v15, v60  ; v60 = 2
-;; @0057                               v38 = uadd_overflow_trap v29, v63, user2
-;; @0057                               v37 = iadd v8, v36
-;; @0057                               v39 = icmp ugt v38, v37
-;; @0057                               trapnz v39, user2
-;; @0057                               v40 = call fn1(v0, v6)
-;;                                     v58 = iconst.i64 0
-;; @0057                               v44 = icmp eq v15, v58  ; v58 = 0
-;; @0057                               v41 = ireduce.i32 v40
-;; @0057                               v27 = iconst.i64 4
-;; @0057                               v42 = iadd v29, v63
-;; @0057                               brif v44, block3, block2(v29)
+;;                                     v55 = load.i32 notrap v56
+;; @0057                               trapz v55, user16
+;; @0057                               v8 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @0057                               v9 = load.i64 notrap aligned readonly can_move v8+32
+;; @0057                               v7 = uextend.i64 v55
+;; @0057                               v10 = iadd v9, v7
+;; @0057                               v11 = iconst.i64 16
+;; @0057                               v12 = iadd v10, v11  ; v11 = 16
+;; @0057                               v13 = load.i32 user2 readonly region1 v12
+;; @0057                               v15 = uextend.i64 v3
+;; @0057                               v16 = uextend.i64 v4
+;; @0057                               v19 = iadd v15, v16
+;; @0057                               v14 = uextend.i64 v13
+;; @0057                               v20 = icmp ugt v19, v14
+;; @0057                               trapnz v20, user17
+;; @0057                               v37 = load.i64 notrap aligned v8+40
+;; @0057                               v25 = iconst.i64 20
+;; @0057                               v26 = iadd v10, v25  ; v25 = 20
+;;                                     v59 = iconst.i64 2
+;;                                     v60 = ishl v15, v59  ; v59 = 2
+;; @0057                               v30 = iadd v26, v60
+;;                                     v62 = ishl v16, v59  ; v59 = 2
+;; @0057                               v39 = uadd_overflow_trap v30, v62, user2
+;; @0057                               v38 = iadd v9, v37
+;; @0057                               v40 = icmp ugt v39, v38
+;; @0057                               trapnz v40, user2
+;; @0057                               v41 = call fn1(v0, v6)
+;;                                     v57 = iconst.i64 0
+;; @0057                               v45 = icmp eq v16, v57  ; v57 = 0
+;; @0057                               v42 = ireduce.i32 v41
+;; @0057                               v28 = iconst.i64 4
+;; @0057                               v43 = iadd v30, v62
+;; @0057                               brif v45, block3, block2(v30)
 ;;
-;;                                 block2(v45: i64):
-;; @0057                               store.i32 notrap aligned little v41, v45
-;;                                     v65 = iconst.i64 4
-;;                                     v66 = iadd v45, v65  ; v65 = 4
-;; @0057                               v48 = icmp eq v66, v42
-;; @0057                               brif v48, block3, block2(v66)
+;;                                 block2(v46: i64):
+;; @0057                               store.i32 notrap aligned little v42, v46
+;;                                     v64 = iconst.i64 4
+;;                                     v65 = iadd v46, v64  ; v64 = 4
+;; @0057                               v49 = icmp eq v65, v43
+;; @0057                               brif v49, block3, block2(v65)
 ;;
 ;;                                 block3:
 ;; @005a                               jump block1

--- a/tests/disas/array-fill-i16.wat
+++ b/tests/disas/array-fill-i16.wat
@@ -27,50 +27,46 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):
 ;; @0031                               trapz v2, user16
-;; @0031                               v46 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0031                               v7 = load.i64 notrap aligned readonly can_move v46+32
+;; @0031                               v7 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @0031                               v8 = load.i64 notrap aligned readonly can_move v7+32
 ;; @0031                               v6 = uextend.i64 v2
-;; @0031                               v8 = iadd v7, v6
-;; @0031                               v9 = iconst.i64 16
-;; @0031                               v10 = iadd v8, v9  ; v9 = 16
-;; @0031                               v11 = load.i32 user2 readonly region1 v10
-;; @0031                               v13 = uextend.i64 v3
-;; @0031                               v14 = uextend.i64 v5
-;; @0031                               v17 = iadd v13, v14
-;; @0031                               v12 = uextend.i64 v11
-;; @0031                               v18 = icmp ugt v17, v12
-;; @0031                               trapnz v18, user17
-;; @0031                               v35 = load.i64 notrap aligned v46+40
-;; @0031                               v23 = iconst.i64 20
-;; @0031                               v24 = iadd v8, v23  ; v23 = 20
-;; @0031                               v15 = iconst.i64 1
-;;                                     v51 = ishl v13, v15  ; v15 = 1
-;; @0031                               v28 = iadd v24, v51
-;;                                     v55 = ishl v14, v15  ; v15 = 1
-;; @0031                               v37 = uadd_overflow_trap v28, v55, user2
-;; @0031                               v36 = iadd v7, v35
-;; @0031                               v38 = icmp ugt v37, v36
-;; @0031                               trapnz v38, user2
-;;                                     v48 = iconst.i64 0
-;; @0031                               v41 = icmp eq v14, v48  ; v48 = 0
-;; @0031                               v26 = iconst.i64 2
-;; @0031                               v39 = iadd v28, v55
-;; @0031                               brif v41, block3, block2(v28)
+;; @0031                               v9 = iadd v8, v6
+;; @0031                               v10 = iconst.i64 16
+;; @0031                               v11 = iadd v9, v10  ; v10 = 16
+;; @0031                               v12 = load.i32 user2 readonly region1 v11
+;; @0031                               v14 = uextend.i64 v3
+;; @0031                               v15 = uextend.i64 v5
+;; @0031                               v18 = iadd v14, v15
+;; @0031                               v13 = uextend.i64 v12
+;; @0031                               v19 = icmp ugt v18, v13
+;; @0031                               trapnz v19, user17
+;; @0031                               v36 = load.i64 notrap aligned v7+40
+;; @0031                               v24 = iconst.i64 20
+;; @0031                               v25 = iadd v9, v24  ; v24 = 20
+;; @0031                               v16 = iconst.i64 1
+;;                                     v50 = ishl v14, v16  ; v16 = 1
+;; @0031                               v29 = iadd v25, v50
+;;                                     v54 = ishl v15, v16  ; v16 = 1
+;; @0031                               v38 = uadd_overflow_trap v29, v54, user2
+;; @0031                               v37 = iadd v8, v36
+;; @0031                               v39 = icmp ugt v38, v37
+;; @0031                               trapnz v39, user2
+;;                                     v47 = iconst.i64 0
+;; @0031                               v42 = icmp eq v15, v47  ; v47 = 0
+;; @0031                               v27 = iconst.i64 2
+;; @0031                               v40 = iadd v29, v54
+;; @0031                               brif v42, block3, block2(v29)
 ;;
-;;                                 block2(v42: i64):
-;; @0031                               istore16.i32 user2 little region1 v4, v42
-;;                                     v58 = iconst.i64 2
-;;                                     v59 = iadd v42, v58  ; v58 = 2
-;; @0031                               v45 = icmp eq v59, v39
-;; @0031                               brif v45, block3, block2(v59)
+;;                                 block2(v43: i64):
+;; @0031                               istore16.i32 user2 little region1 v4, v43
+;;                                     v57 = iconst.i64 2
+;;                                     v58 = iadd v43, v57  ; v57 = 2
+;; @0031                               v46 = icmp eq v58, v40
+;; @0031                               brif v46, block3, block2(v58)
 ;;
 ;;                                 block3:
 ;; @0034                               jump block1
@@ -85,42 +81,38 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i64, i32, i64) tail
 ;;     fn0 = colocated u805306368:2 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
 ;; @003f                               trapz v2, user16
-;; @003f                               v40 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @003f                               v7 = load.i64 notrap aligned readonly can_move v40+32
+;; @003f                               v7 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @003f                               v8 = load.i64 notrap aligned readonly can_move v7+32
 ;; @003f                               v6 = uextend.i64 v2
-;; @003f                               v8 = iadd v7, v6
-;; @003f                               v9 = iconst.i64 16
-;; @003f                               v10 = iadd v8, v9  ; v9 = 16
-;; @003f                               v11 = load.i32 user2 readonly region1 v10
-;; @003f                               v13 = uextend.i64 v3
-;; @003f                               v14 = uextend.i64 v4
-;; @003f                               v17 = iadd v13, v14
-;; @003f                               v12 = uextend.i64 v11
-;; @003f                               v18 = icmp ugt v17, v12
-;; @003f                               trapnz v18, user17
-;; @003f                               v35 = load.i64 notrap aligned v40+40
-;; @003f                               v23 = iconst.i64 20
-;; @003f                               v24 = iadd v8, v23  ; v23 = 20
-;; @003f                               v15 = iconst.i64 1
-;;                                     v45 = ishl v13, v15  ; v15 = 1
-;; @003f                               v28 = iadd v24, v45
-;;                                     v49 = ishl v14, v15  ; v15 = 1
-;; @003f                               v37 = uadd_overflow_trap v28, v49, user2
-;; @003f                               v36 = iadd v7, v35
-;; @003f                               v38 = icmp ugt v37, v36
-;; @003f                               trapnz v38, user2
+;; @003f                               v9 = iadd v8, v6
+;; @003f                               v10 = iconst.i64 16
+;; @003f                               v11 = iadd v9, v10  ; v10 = 16
+;; @003f                               v12 = load.i32 user2 readonly region1 v11
+;; @003f                               v14 = uextend.i64 v3
+;; @003f                               v15 = uextend.i64 v4
+;; @003f                               v18 = iadd v14, v15
+;; @003f                               v13 = uextend.i64 v12
+;; @003f                               v19 = icmp ugt v18, v13
+;; @003f                               trapnz v19, user17
+;; @003f                               v36 = load.i64 notrap aligned v7+40
+;; @003f                               v24 = iconst.i64 20
+;; @003f                               v25 = iadd v9, v24  ; v24 = 20
+;; @003f                               v16 = iconst.i64 1
+;;                                     v44 = ishl v14, v16  ; v16 = 1
+;; @003f                               v29 = iadd v25, v44
+;;                                     v48 = ishl v15, v16  ; v16 = 1
+;; @003f                               v38 = uadd_overflow_trap v29, v48, user2
+;; @003f                               v37 = iadd v8, v36
+;; @003f                               v39 = icmp ugt v38, v37
+;; @003f                               trapnz v39, user2
 ;; @003b                               v5 = iconst.i32 0
-;; @003f                               call fn0(v0, v28, v5, v49)  ; v5 = 0
+;; @003f                               call fn0(v0, v29, v5, v48)  ; v5 = 0
 ;; @0042                               jump block1
 ;;
 ;;                                 block1:
@@ -133,42 +125,38 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i64, i32, i64) tail
 ;;     fn0 = colocated u805306368:2 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
 ;; @004d                               trapz v2, user16
-;; @004d                               v40 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @004d                               v7 = load.i64 notrap aligned readonly can_move v40+32
+;; @004d                               v7 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @004d                               v8 = load.i64 notrap aligned readonly can_move v7+32
 ;; @004d                               v6 = uextend.i64 v2
-;; @004d                               v8 = iadd v7, v6
-;; @004d                               v9 = iconst.i64 16
-;; @004d                               v10 = iadd v8, v9  ; v9 = 16
-;; @004d                               v11 = load.i32 user2 readonly region1 v10
-;; @004d                               v13 = uextend.i64 v3
-;; @004d                               v14 = uextend.i64 v4
-;; @004d                               v17 = iadd v13, v14
-;; @004d                               v12 = uextend.i64 v11
-;; @004d                               v18 = icmp ugt v17, v12
-;; @004d                               trapnz v18, user17
-;; @004d                               v35 = load.i64 notrap aligned v40+40
-;; @004d                               v23 = iconst.i64 20
-;; @004d                               v24 = iadd v8, v23  ; v23 = 20
-;; @004d                               v15 = iconst.i64 1
-;;                                     v45 = ishl v13, v15  ; v15 = 1
-;; @004d                               v28 = iadd v24, v45
-;;                                     v49 = ishl v14, v15  ; v15 = 1
-;; @004d                               v37 = uadd_overflow_trap v28, v49, user2
-;; @004d                               v36 = iadd v7, v35
-;; @004d                               v38 = icmp ugt v37, v36
-;; @004d                               trapnz v38, user2
-;; @004d                               v39 = iconst.i32 255
-;; @004d                               call fn0(v0, v28, v39, v49)  ; v39 = 255
+;; @004d                               v9 = iadd v8, v6
+;; @004d                               v10 = iconst.i64 16
+;; @004d                               v11 = iadd v9, v10  ; v10 = 16
+;; @004d                               v12 = load.i32 user2 readonly region1 v11
+;; @004d                               v14 = uextend.i64 v3
+;; @004d                               v15 = uextend.i64 v4
+;; @004d                               v18 = iadd v14, v15
+;; @004d                               v13 = uextend.i64 v12
+;; @004d                               v19 = icmp ugt v18, v13
+;; @004d                               trapnz v19, user17
+;; @004d                               v36 = load.i64 notrap aligned v7+40
+;; @004d                               v24 = iconst.i64 20
+;; @004d                               v25 = iadd v9, v24  ; v24 = 20
+;; @004d                               v16 = iconst.i64 1
+;;                                     v44 = ishl v14, v16  ; v16 = 1
+;; @004d                               v29 = iadd v25, v44
+;;                                     v48 = ishl v15, v16  ; v16 = 1
+;; @004d                               v38 = uadd_overflow_trap v29, v48, user2
+;; @004d                               v37 = iadd v8, v36
+;; @004d                               v39 = icmp ugt v38, v37
+;; @004d                               trapnz v39, user2
+;; @004d                               v40 = iconst.i32 255
+;; @004d                               call fn0(v0, v29, v40, v48)  ; v40 = 255
 ;; @0050                               jump block1
 ;;
 ;;                                 block1:
@@ -181,52 +169,48 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
 ;; @005d                               trapz v2, user16
-;; @005d                               v46 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @005d                               v7 = load.i64 notrap aligned readonly can_move v46+32
+;; @005d                               v7 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @005d                               v8 = load.i64 notrap aligned readonly can_move v7+32
 ;; @005d                               v6 = uextend.i64 v2
-;; @005d                               v8 = iadd v7, v6
-;; @005d                               v9 = iconst.i64 16
-;; @005d                               v10 = iadd v8, v9  ; v9 = 16
-;; @005d                               v11 = load.i32 user2 readonly region1 v10
-;; @005d                               v13 = uextend.i64 v3
-;; @005d                               v14 = uextend.i64 v4
-;; @005d                               v17 = iadd v13, v14
-;; @005d                               v12 = uextend.i64 v11
-;; @005d                               v18 = icmp ugt v17, v12
-;; @005d                               trapnz v18, user17
-;; @005d                               v35 = load.i64 notrap aligned v46+40
-;; @005d                               v23 = iconst.i64 20
-;; @005d                               v24 = iadd v8, v23  ; v23 = 20
-;; @005d                               v15 = iconst.i64 1
-;;                                     v51 = ishl v13, v15  ; v15 = 1
-;; @005d                               v28 = iadd v24, v51
-;;                                     v55 = ishl v14, v15  ; v15 = 1
-;; @005d                               v37 = uadd_overflow_trap v28, v55, user2
-;; @005d                               v36 = iadd v7, v35
-;; @005d                               v38 = icmp ugt v37, v36
-;; @005d                               trapnz v38, user2
-;;                                     v48 = iconst.i64 0
-;; @005d                               v41 = icmp eq v14, v48  ; v48 = 0
+;; @005d                               v9 = iadd v8, v6
+;; @005d                               v10 = iconst.i64 16
+;; @005d                               v11 = iadd v9, v10  ; v10 = 16
+;; @005d                               v12 = load.i32 user2 readonly region1 v11
+;; @005d                               v14 = uextend.i64 v3
+;; @005d                               v15 = uextend.i64 v4
+;; @005d                               v18 = iadd v14, v15
+;; @005d                               v13 = uextend.i64 v12
+;; @005d                               v19 = icmp ugt v18, v13
+;; @005d                               trapnz v19, user17
+;; @005d                               v36 = load.i64 notrap aligned v7+40
+;; @005d                               v24 = iconst.i64 20
+;; @005d                               v25 = iadd v9, v24  ; v24 = 20
+;; @005d                               v16 = iconst.i64 1
+;;                                     v50 = ishl v14, v16  ; v16 = 1
+;; @005d                               v29 = iadd v25, v50
+;;                                     v54 = ishl v15, v16  ; v16 = 1
+;; @005d                               v38 = uadd_overflow_trap v29, v54, user2
+;; @005d                               v37 = iadd v8, v36
+;; @005d                               v39 = icmp ugt v38, v37
+;; @005d                               trapnz v39, user2
+;;                                     v47 = iconst.i64 0
+;; @005d                               v42 = icmp eq v15, v47  ; v47 = 0
 ;; @0057                               v5 = iconst.i32 0xdead
-;; @005d                               v26 = iconst.i64 2
-;; @005d                               v39 = iadd v28, v55
-;; @005d                               brif v41, block3, block2(v28)
+;; @005d                               v27 = iconst.i64 2
+;; @005d                               v40 = iadd v29, v54
+;; @005d                               brif v42, block3, block2(v29)
 ;;
-;;                                 block2(v42: i64):
-;;                                     v58 = iconst.i32 0xdead
-;; @005d                               istore16 user2 little region1 v58, v42  ; v58 = 0xdead
-;;                                     v59 = iconst.i64 2
-;;                                     v60 = iadd v42, v59  ; v59 = 2
-;; @005d                               v45 = icmp eq v60, v39
-;; @005d                               brif v45, block3, block2(v60)
+;;                                 block2(v43: i64):
+;;                                     v57 = iconst.i32 0xdead
+;; @005d                               istore16 user2 little region1 v57, v43  ; v57 = 0xdead
+;;                                     v58 = iconst.i64 2
+;;                                     v59 = iadd v43, v58  ; v58 = 2
+;; @005d                               v46 = icmp eq v59, v40
+;; @005d                               brif v46, block3, block2(v59)
 ;;
 ;;                                 block3:
 ;; @0060                               jump block1

--- a/tests/disas/array-fill-i31ref.wat
+++ b/tests/disas/array-fill-i31ref.wat
@@ -23,50 +23,46 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):
 ;; @0030                               trapz v2, user16
-;; @0030                               v46 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0030                               v7 = load.i64 notrap aligned readonly can_move v46+32
+;; @0030                               v7 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @0030                               v8 = load.i64 notrap aligned readonly can_move v7+32
 ;; @0030                               v6 = uextend.i64 v2
-;; @0030                               v8 = iadd v7, v6
-;; @0030                               v9 = iconst.i64 16
-;; @0030                               v10 = iadd v8, v9  ; v9 = 16
-;; @0030                               v11 = load.i32 user2 readonly region1 v10
-;; @0030                               v13 = uextend.i64 v3
-;; @0030                               v14 = uextend.i64 v5
-;; @0030                               v17 = iadd v13, v14
-;; @0030                               v12 = uextend.i64 v11
-;; @0030                               v18 = icmp ugt v17, v12
-;; @0030                               trapnz v18, user17
-;; @0030                               v35 = load.i64 notrap aligned v46+40
-;; @0030                               v23 = iconst.i64 20
-;; @0030                               v24 = iadd v8, v23  ; v23 = 20
-;;                                     v50 = iconst.i64 2
-;;                                     v51 = ishl v13, v50  ; v50 = 2
-;; @0030                               v28 = iadd v24, v51
-;;                                     v53 = ishl v14, v50  ; v50 = 2
-;; @0030                               v37 = uadd_overflow_trap v28, v53, user2
-;; @0030                               v36 = iadd v7, v35
-;; @0030                               v38 = icmp ugt v37, v36
-;; @0030                               trapnz v38, user2
-;;                                     v48 = iconst.i64 0
-;; @0030                               v41 = icmp eq v14, v48  ; v48 = 0
-;; @0030                               v26 = iconst.i64 4
-;; @0030                               v39 = iadd v28, v53
-;; @0030                               brif v41, block3, block2(v28)
+;; @0030                               v9 = iadd v8, v6
+;; @0030                               v10 = iconst.i64 16
+;; @0030                               v11 = iadd v9, v10  ; v10 = 16
+;; @0030                               v12 = load.i32 user2 readonly region1 v11
+;; @0030                               v14 = uextend.i64 v3
+;; @0030                               v15 = uextend.i64 v5
+;; @0030                               v18 = iadd v14, v15
+;; @0030                               v13 = uextend.i64 v12
+;; @0030                               v19 = icmp ugt v18, v13
+;; @0030                               trapnz v19, user17
+;; @0030                               v36 = load.i64 notrap aligned v7+40
+;; @0030                               v24 = iconst.i64 20
+;; @0030                               v25 = iadd v9, v24  ; v24 = 20
+;;                                     v49 = iconst.i64 2
+;;                                     v50 = ishl v14, v49  ; v49 = 2
+;; @0030                               v29 = iadd v25, v50
+;;                                     v52 = ishl v15, v49  ; v49 = 2
+;; @0030                               v38 = uadd_overflow_trap v29, v52, user2
+;; @0030                               v37 = iadd v8, v36
+;; @0030                               v39 = icmp ugt v38, v37
+;; @0030                               trapnz v39, user2
+;;                                     v47 = iconst.i64 0
+;; @0030                               v42 = icmp eq v15, v47  ; v47 = 0
+;; @0030                               v27 = iconst.i64 4
+;; @0030                               v40 = iadd v29, v52
+;; @0030                               brif v42, block3, block2(v29)
 ;;
-;;                                 block2(v42: i64):
-;; @0030                               store.i32 user2 little region1 v4, v42
-;;                                     v55 = iconst.i64 4
-;;                                     v56 = iadd v42, v55  ; v55 = 4
-;; @0030                               v45 = icmp eq v56, v39
-;; @0030                               brif v45, block3, block2(v56)
+;;                                 block2(v43: i64):
+;; @0030                               store.i32 user2 little region1 v4, v43
+;;                                     v54 = iconst.i64 4
+;;                                     v55 = iadd v43, v54  ; v54 = 4
+;; @0030                               v46 = icmp eq v55, v40
+;; @0030                               brif v46, block3, block2(v55)
 ;;
 ;;                                 block3:
 ;; @0033                               jump block1
@@ -81,52 +77,48 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
 ;; @003e                               trapz v2, user16
-;; @003e                               v46 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @003e                               v7 = load.i64 notrap aligned readonly can_move v46+32
+;; @003e                               v7 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @003e                               v8 = load.i64 notrap aligned readonly can_move v7+32
 ;; @003e                               v6 = uextend.i64 v2
-;; @003e                               v8 = iadd v7, v6
-;; @003e                               v9 = iconst.i64 16
-;; @003e                               v10 = iadd v8, v9  ; v9 = 16
-;; @003e                               v11 = load.i32 user2 readonly region1 v10
-;; @003e                               v13 = uextend.i64 v3
-;; @003e                               v14 = uextend.i64 v4
-;; @003e                               v17 = iadd v13, v14
-;; @003e                               v12 = uextend.i64 v11
-;; @003e                               v18 = icmp ugt v17, v12
-;; @003e                               trapnz v18, user17
-;; @003e                               v35 = load.i64 notrap aligned v46+40
-;; @003e                               v23 = iconst.i64 20
-;; @003e                               v24 = iadd v8, v23  ; v23 = 20
-;;                                     v50 = iconst.i64 2
-;;                                     v51 = ishl v13, v50  ; v50 = 2
-;; @003e                               v28 = iadd v24, v51
-;;                                     v53 = ishl v14, v50  ; v50 = 2
-;; @003e                               v37 = uadd_overflow_trap v28, v53, user2
-;; @003e                               v36 = iadd v7, v35
-;; @003e                               v38 = icmp ugt v37, v36
-;; @003e                               trapnz v38, user2
-;;                                     v48 = iconst.i64 0
-;; @003e                               v41 = icmp eq v14, v48  ; v48 = 0
+;; @003e                               v9 = iadd v8, v6
+;; @003e                               v10 = iconst.i64 16
+;; @003e                               v11 = iadd v9, v10  ; v10 = 16
+;; @003e                               v12 = load.i32 user2 readonly region1 v11
+;; @003e                               v14 = uextend.i64 v3
+;; @003e                               v15 = uextend.i64 v4
+;; @003e                               v18 = iadd v14, v15
+;; @003e                               v13 = uextend.i64 v12
+;; @003e                               v19 = icmp ugt v18, v13
+;; @003e                               trapnz v19, user17
+;; @003e                               v36 = load.i64 notrap aligned v7+40
+;; @003e                               v24 = iconst.i64 20
+;; @003e                               v25 = iadd v9, v24  ; v24 = 20
+;;                                     v49 = iconst.i64 2
+;;                                     v50 = ishl v14, v49  ; v49 = 2
+;; @003e                               v29 = iadd v25, v50
+;;                                     v52 = ishl v15, v49  ; v49 = 2
+;; @003e                               v38 = uadd_overflow_trap v29, v52, user2
+;; @003e                               v37 = iadd v8, v36
+;; @003e                               v39 = icmp ugt v38, v37
+;; @003e                               trapnz v39, user2
+;;                                     v47 = iconst.i64 0
+;; @003e                               v42 = icmp eq v15, v47  ; v47 = 0
 ;; @003a                               v5 = iconst.i32 0
-;; @003e                               v26 = iconst.i64 4
-;; @003e                               v39 = iadd v28, v53
-;; @003e                               brif v41, block3, block2(v28)
+;; @003e                               v27 = iconst.i64 4
+;; @003e                               v40 = iadd v29, v52
+;; @003e                               brif v42, block3, block2(v29)
 ;;
-;;                                 block2(v42: i64):
-;;                                     v55 = iconst.i32 0
-;; @003e                               store user2 little region1 v55, v42  ; v55 = 0
-;;                                     v56 = iconst.i64 4
-;;                                     v57 = iadd v42, v56  ; v56 = 4
-;; @003e                               v45 = icmp eq v57, v39
-;; @003e                               brif v45, block3, block2(v57)
+;;                                 block2(v43: i64):
+;;                                     v54 = iconst.i32 0
+;; @003e                               store user2 little region1 v54, v43  ; v54 = 0
+;;                                     v55 = iconst.i64 4
+;;                                     v56 = iadd v43, v55  ; v55 = 4
+;; @003e                               v46 = icmp eq v56, v40
+;; @003e                               brif v46, block3, block2(v56)
 ;;
 ;;                                 block3:
 ;; @0041                               jump block1
@@ -141,52 +133,48 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
 ;; @004e                               trapz v2, user16
-;; @004e                               v50 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @004e                               v11 = load.i64 notrap aligned readonly can_move v50+32
+;; @004e                               v11 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @004e                               v12 = load.i64 notrap aligned readonly can_move v11+32
 ;; @004e                               v10 = uextend.i64 v2
-;; @004e                               v12 = iadd v11, v10
-;; @004e                               v13 = iconst.i64 16
-;; @004e                               v14 = iadd v12, v13  ; v13 = 16
-;; @004e                               v15 = load.i32 user2 readonly region1 v14
-;; @004e                               v17 = uextend.i64 v3
-;; @004e                               v18 = uextend.i64 v4
-;; @004e                               v21 = iadd v17, v18
-;; @004e                               v16 = uextend.i64 v15
-;; @004e                               v22 = icmp ugt v21, v16
-;; @004e                               trapnz v22, user17
-;; @004e                               v39 = load.i64 notrap aligned v50+40
-;; @004e                               v27 = iconst.i64 20
-;; @004e                               v28 = iadd v12, v27  ; v27 = 20
-;;                                     v60 = iconst.i64 2
-;;                                     v61 = ishl v17, v60  ; v60 = 2
-;; @004e                               v32 = iadd v28, v61
-;;                                     v63 = ishl v18, v60  ; v60 = 2
-;; @004e                               v41 = uadd_overflow_trap v32, v63, user2
-;; @004e                               v40 = iadd v11, v39
-;; @004e                               v42 = icmp ugt v41, v40
-;; @004e                               trapnz v42, user2
-;;                                     v58 = iconst.i64 0
-;; @004e                               v45 = icmp eq v18, v58  ; v58 = 0
+;; @004e                               v13 = iadd v12, v10
+;; @004e                               v14 = iconst.i64 16
+;; @004e                               v15 = iadd v13, v14  ; v14 = 16
+;; @004e                               v16 = load.i32 user2 readonly region1 v15
+;; @004e                               v18 = uextend.i64 v3
+;; @004e                               v19 = uextend.i64 v4
+;; @004e                               v22 = iadd v18, v19
+;; @004e                               v17 = uextend.i64 v16
+;; @004e                               v23 = icmp ugt v22, v17
+;; @004e                               trapnz v23, user17
+;; @004e                               v40 = load.i64 notrap aligned v11+40
+;; @004e                               v28 = iconst.i64 20
+;; @004e                               v29 = iadd v13, v28  ; v28 = 20
+;;                                     v59 = iconst.i64 2
+;;                                     v60 = ishl v18, v59  ; v59 = 2
+;; @004e                               v33 = iadd v29, v60
+;;                                     v62 = ishl v19, v59  ; v59 = 2
+;; @004e                               v42 = uadd_overflow_trap v33, v62, user2
+;; @004e                               v41 = iadd v12, v40
+;; @004e                               v43 = icmp ugt v42, v41
+;; @004e                               trapnz v43, user2
+;;                                     v57 = iconst.i64 0
+;; @004e                               v46 = icmp eq v19, v57  ; v57 = 0
 ;; @0048                               v5 = iconst.i32 -1
-;; @004e                               v30 = iconst.i64 4
-;; @004e                               v43 = iadd v32, v63
-;; @004e                               brif v45, block3, block2(v32)
+;; @004e                               v31 = iconst.i64 4
+;; @004e                               v44 = iadd v33, v62
+;; @004e                               brif v46, block3, block2(v33)
 ;;
-;;                                 block2(v46: i64):
-;;                                     v65 = iconst.i32 -1
-;; @004e                               store user2 little region1 v65, v46  ; v65 = -1
-;;                                     v66 = iconst.i64 4
-;;                                     v67 = iadd v46, v66  ; v66 = 4
-;; @004e                               v49 = icmp eq v67, v43
-;; @004e                               brif v49, block3, block2(v67)
+;;                                 block2(v47: i64):
+;;                                     v64 = iconst.i32 -1
+;; @004e                               store user2 little region1 v64, v47  ; v64 = -1
+;;                                     v65 = iconst.i64 4
+;;                                     v66 = iadd v47, v65  ; v65 = 4
+;; @004e                               v50 = icmp eq v66, v44
+;; @004e                               brif v50, block3, block2(v66)
 ;;
 ;;                                 block3:
 ;; @0051                               jump block1

--- a/tests/disas/array-fill-i32.wat
+++ b/tests/disas/array-fill-i32.wat
@@ -27,50 +27,46 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):
 ;; @0031                               trapz v2, user16
-;; @0031                               v46 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0031                               v7 = load.i64 notrap aligned readonly can_move v46+32
+;; @0031                               v7 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @0031                               v8 = load.i64 notrap aligned readonly can_move v7+32
 ;; @0031                               v6 = uextend.i64 v2
-;; @0031                               v8 = iadd v7, v6
-;; @0031                               v9 = iconst.i64 16
-;; @0031                               v10 = iadd v8, v9  ; v9 = 16
-;; @0031                               v11 = load.i32 user2 readonly region1 v10
-;; @0031                               v13 = uextend.i64 v3
-;; @0031                               v14 = uextend.i64 v5
-;; @0031                               v17 = iadd v13, v14
-;; @0031                               v12 = uextend.i64 v11
-;; @0031                               v18 = icmp ugt v17, v12
-;; @0031                               trapnz v18, user17
-;; @0031                               v35 = load.i64 notrap aligned v46+40
-;; @0031                               v23 = iconst.i64 20
-;; @0031                               v24 = iadd v8, v23  ; v23 = 20
-;;                                     v50 = iconst.i64 2
-;;                                     v51 = ishl v13, v50  ; v50 = 2
-;; @0031                               v28 = iadd v24, v51
-;;                                     v53 = ishl v14, v50  ; v50 = 2
-;; @0031                               v37 = uadd_overflow_trap v28, v53, user2
-;; @0031                               v36 = iadd v7, v35
-;; @0031                               v38 = icmp ugt v37, v36
-;; @0031                               trapnz v38, user2
-;;                                     v48 = iconst.i64 0
-;; @0031                               v41 = icmp eq v14, v48  ; v48 = 0
-;; @0031                               v26 = iconst.i64 4
-;; @0031                               v39 = iadd v28, v53
-;; @0031                               brif v41, block3, block2(v28)
+;; @0031                               v9 = iadd v8, v6
+;; @0031                               v10 = iconst.i64 16
+;; @0031                               v11 = iadd v9, v10  ; v10 = 16
+;; @0031                               v12 = load.i32 user2 readonly region1 v11
+;; @0031                               v14 = uextend.i64 v3
+;; @0031                               v15 = uextend.i64 v5
+;; @0031                               v18 = iadd v14, v15
+;; @0031                               v13 = uextend.i64 v12
+;; @0031                               v19 = icmp ugt v18, v13
+;; @0031                               trapnz v19, user17
+;; @0031                               v36 = load.i64 notrap aligned v7+40
+;; @0031                               v24 = iconst.i64 20
+;; @0031                               v25 = iadd v9, v24  ; v24 = 20
+;;                                     v49 = iconst.i64 2
+;;                                     v50 = ishl v14, v49  ; v49 = 2
+;; @0031                               v29 = iadd v25, v50
+;;                                     v52 = ishl v15, v49  ; v49 = 2
+;; @0031                               v38 = uadd_overflow_trap v29, v52, user2
+;; @0031                               v37 = iadd v8, v36
+;; @0031                               v39 = icmp ugt v38, v37
+;; @0031                               trapnz v39, user2
+;;                                     v47 = iconst.i64 0
+;; @0031                               v42 = icmp eq v15, v47  ; v47 = 0
+;; @0031                               v27 = iconst.i64 4
+;; @0031                               v40 = iadd v29, v52
+;; @0031                               brif v42, block3, block2(v29)
 ;;
-;;                                 block2(v42: i64):
-;; @0031                               store.i32 user2 little region1 v4, v42
-;;                                     v55 = iconst.i64 4
-;;                                     v56 = iadd v42, v55  ; v55 = 4
-;; @0031                               v45 = icmp eq v56, v39
-;; @0031                               brif v45, block3, block2(v56)
+;;                                 block2(v43: i64):
+;; @0031                               store.i32 user2 little region1 v4, v43
+;;                                     v54 = iconst.i64 4
+;;                                     v55 = iadd v43, v54  ; v54 = 4
+;; @0031                               v46 = icmp eq v55, v40
+;; @0031                               brif v46, block3, block2(v55)
 ;;
 ;;                                 block3:
 ;; @0034                               jump block1
@@ -85,42 +81,38 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i64, i32, i64) tail
 ;;     fn0 = colocated u805306368:2 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
 ;; @003f                               trapz v2, user16
-;; @003f                               v40 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @003f                               v7 = load.i64 notrap aligned readonly can_move v40+32
+;; @003f                               v7 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @003f                               v8 = load.i64 notrap aligned readonly can_move v7+32
 ;; @003f                               v6 = uextend.i64 v2
-;; @003f                               v8 = iadd v7, v6
-;; @003f                               v9 = iconst.i64 16
-;; @003f                               v10 = iadd v8, v9  ; v9 = 16
-;; @003f                               v11 = load.i32 user2 readonly region1 v10
-;; @003f                               v13 = uextend.i64 v3
-;; @003f                               v14 = uextend.i64 v4
-;; @003f                               v17 = iadd v13, v14
-;; @003f                               v12 = uextend.i64 v11
-;; @003f                               v18 = icmp ugt v17, v12
-;; @003f                               trapnz v18, user17
-;; @003f                               v35 = load.i64 notrap aligned v40+40
-;; @003f                               v23 = iconst.i64 20
-;; @003f                               v24 = iadd v8, v23  ; v23 = 20
-;;                                     v44 = iconst.i64 2
-;;                                     v45 = ishl v13, v44  ; v44 = 2
-;; @003f                               v28 = iadd v24, v45
-;;                                     v47 = ishl v14, v44  ; v44 = 2
-;; @003f                               v37 = uadd_overflow_trap v28, v47, user2
-;; @003f                               v36 = iadd v7, v35
-;; @003f                               v38 = icmp ugt v37, v36
-;; @003f                               trapnz v38, user2
+;; @003f                               v9 = iadd v8, v6
+;; @003f                               v10 = iconst.i64 16
+;; @003f                               v11 = iadd v9, v10  ; v10 = 16
+;; @003f                               v12 = load.i32 user2 readonly region1 v11
+;; @003f                               v14 = uextend.i64 v3
+;; @003f                               v15 = uextend.i64 v4
+;; @003f                               v18 = iadd v14, v15
+;; @003f                               v13 = uextend.i64 v12
+;; @003f                               v19 = icmp ugt v18, v13
+;; @003f                               trapnz v19, user17
+;; @003f                               v36 = load.i64 notrap aligned v7+40
+;; @003f                               v24 = iconst.i64 20
+;; @003f                               v25 = iadd v9, v24  ; v24 = 20
+;;                                     v43 = iconst.i64 2
+;;                                     v44 = ishl v14, v43  ; v43 = 2
+;; @003f                               v29 = iadd v25, v44
+;;                                     v46 = ishl v15, v43  ; v43 = 2
+;; @003f                               v38 = uadd_overflow_trap v29, v46, user2
+;; @003f                               v37 = iadd v8, v36
+;; @003f                               v39 = icmp ugt v38, v37
+;; @003f                               trapnz v39, user2
 ;; @003b                               v5 = iconst.i32 0
-;; @003f                               call fn0(v0, v28, v5, v47)  ; v5 = 0
+;; @003f                               call fn0(v0, v29, v5, v46)  ; v5 = 0
 ;; @0042                               jump block1
 ;;
 ;;                                 block1:
@@ -133,42 +125,38 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i64, i32, i64) tail
 ;;     fn0 = colocated u805306368:2 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
 ;; @004d                               trapz v2, user16
-;; @004d                               v40 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @004d                               v7 = load.i64 notrap aligned readonly can_move v40+32
+;; @004d                               v7 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @004d                               v8 = load.i64 notrap aligned readonly can_move v7+32
 ;; @004d                               v6 = uextend.i64 v2
-;; @004d                               v8 = iadd v7, v6
-;; @004d                               v9 = iconst.i64 16
-;; @004d                               v10 = iadd v8, v9  ; v9 = 16
-;; @004d                               v11 = load.i32 user2 readonly region1 v10
-;; @004d                               v13 = uextend.i64 v3
-;; @004d                               v14 = uextend.i64 v4
-;; @004d                               v17 = iadd v13, v14
-;; @004d                               v12 = uextend.i64 v11
-;; @004d                               v18 = icmp ugt v17, v12
-;; @004d                               trapnz v18, user17
-;; @004d                               v35 = load.i64 notrap aligned v40+40
-;; @004d                               v23 = iconst.i64 20
-;; @004d                               v24 = iadd v8, v23  ; v23 = 20
-;;                                     v44 = iconst.i64 2
-;;                                     v45 = ishl v13, v44  ; v44 = 2
-;; @004d                               v28 = iadd v24, v45
-;;                                     v47 = ishl v14, v44  ; v44 = 2
-;; @004d                               v37 = uadd_overflow_trap v28, v47, user2
-;; @004d                               v36 = iadd v7, v35
-;; @004d                               v38 = icmp ugt v37, v36
-;; @004d                               trapnz v38, user2
-;; @004d                               v39 = iconst.i32 255
-;; @004d                               call fn0(v0, v28, v39, v47)  ; v39 = 255
+;; @004d                               v9 = iadd v8, v6
+;; @004d                               v10 = iconst.i64 16
+;; @004d                               v11 = iadd v9, v10  ; v10 = 16
+;; @004d                               v12 = load.i32 user2 readonly region1 v11
+;; @004d                               v14 = uextend.i64 v3
+;; @004d                               v15 = uextend.i64 v4
+;; @004d                               v18 = iadd v14, v15
+;; @004d                               v13 = uextend.i64 v12
+;; @004d                               v19 = icmp ugt v18, v13
+;; @004d                               trapnz v19, user17
+;; @004d                               v36 = load.i64 notrap aligned v7+40
+;; @004d                               v24 = iconst.i64 20
+;; @004d                               v25 = iadd v9, v24  ; v24 = 20
+;;                                     v43 = iconst.i64 2
+;;                                     v44 = ishl v14, v43  ; v43 = 2
+;; @004d                               v29 = iadd v25, v44
+;;                                     v46 = ishl v15, v43  ; v43 = 2
+;; @004d                               v38 = uadd_overflow_trap v29, v46, user2
+;; @004d                               v37 = iadd v8, v36
+;; @004d                               v39 = icmp ugt v38, v37
+;; @004d                               trapnz v39, user2
+;; @004d                               v40 = iconst.i32 255
+;; @004d                               call fn0(v0, v29, v40, v46)  ; v40 = 255
 ;; @0050                               jump block1
 ;;
 ;;                                 block1:
@@ -181,52 +169,48 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
 ;; @005d                               trapz v2, user16
-;; @005d                               v46 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @005d                               v7 = load.i64 notrap aligned readonly can_move v46+32
+;; @005d                               v7 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @005d                               v8 = load.i64 notrap aligned readonly can_move v7+32
 ;; @005d                               v6 = uextend.i64 v2
-;; @005d                               v8 = iadd v7, v6
-;; @005d                               v9 = iconst.i64 16
-;; @005d                               v10 = iadd v8, v9  ; v9 = 16
-;; @005d                               v11 = load.i32 user2 readonly region1 v10
-;; @005d                               v13 = uextend.i64 v3
-;; @005d                               v14 = uextend.i64 v4
-;; @005d                               v17 = iadd v13, v14
-;; @005d                               v12 = uextend.i64 v11
-;; @005d                               v18 = icmp ugt v17, v12
-;; @005d                               trapnz v18, user17
-;; @005d                               v35 = load.i64 notrap aligned v46+40
-;; @005d                               v23 = iconst.i64 20
-;; @005d                               v24 = iadd v8, v23  ; v23 = 20
-;;                                     v50 = iconst.i64 2
-;;                                     v51 = ishl v13, v50  ; v50 = 2
-;; @005d                               v28 = iadd v24, v51
-;;                                     v53 = ishl v14, v50  ; v50 = 2
-;; @005d                               v37 = uadd_overflow_trap v28, v53, user2
-;; @005d                               v36 = iadd v7, v35
-;; @005d                               v38 = icmp ugt v37, v36
-;; @005d                               trapnz v38, user2
-;;                                     v48 = iconst.i64 0
-;; @005d                               v41 = icmp eq v14, v48  ; v48 = 0
+;; @005d                               v9 = iadd v8, v6
+;; @005d                               v10 = iconst.i64 16
+;; @005d                               v11 = iadd v9, v10  ; v10 = 16
+;; @005d                               v12 = load.i32 user2 readonly region1 v11
+;; @005d                               v14 = uextend.i64 v3
+;; @005d                               v15 = uextend.i64 v4
+;; @005d                               v18 = iadd v14, v15
+;; @005d                               v13 = uextend.i64 v12
+;; @005d                               v19 = icmp ugt v18, v13
+;; @005d                               trapnz v19, user17
+;; @005d                               v36 = load.i64 notrap aligned v7+40
+;; @005d                               v24 = iconst.i64 20
+;; @005d                               v25 = iadd v9, v24  ; v24 = 20
+;;                                     v49 = iconst.i64 2
+;;                                     v50 = ishl v14, v49  ; v49 = 2
+;; @005d                               v29 = iadd v25, v50
+;;                                     v52 = ishl v15, v49  ; v49 = 2
+;; @005d                               v38 = uadd_overflow_trap v29, v52, user2
+;; @005d                               v37 = iadd v8, v36
+;; @005d                               v39 = icmp ugt v38, v37
+;; @005d                               trapnz v39, user2
+;;                                     v47 = iconst.i64 0
+;; @005d                               v42 = icmp eq v15, v47  ; v47 = 0
 ;; @0057                               v5 = iconst.i32 0xdead
-;; @005d                               v26 = iconst.i64 4
-;; @005d                               v39 = iadd v28, v53
-;; @005d                               brif v41, block3, block2(v28)
+;; @005d                               v27 = iconst.i64 4
+;; @005d                               v40 = iadd v29, v52
+;; @005d                               brif v42, block3, block2(v29)
 ;;
-;;                                 block2(v42: i64):
-;;                                     v55 = iconst.i32 0xdead
-;; @005d                               store user2 little region1 v55, v42  ; v55 = 0xdead
-;;                                     v56 = iconst.i64 4
-;;                                     v57 = iadd v42, v56  ; v56 = 4
-;; @005d                               v45 = icmp eq v57, v39
-;; @005d                               brif v45, block3, block2(v57)
+;;                                 block2(v43: i64):
+;;                                     v54 = iconst.i32 0xdead
+;; @005d                               store user2 little region1 v54, v43  ; v54 = 0xdead
+;;                                     v55 = iconst.i64 4
+;;                                     v56 = iadd v43, v55  ; v55 = 4
+;; @005d                               v46 = icmp eq v56, v40
+;; @005d                               brif v46, block3, block2(v56)
 ;;
 ;;                                 block3:
 ;; @0060                               jump block1

--- a/tests/disas/array-fill-i64.wat
+++ b/tests/disas/array-fill-i64.wat
@@ -27,50 +27,46 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i64, v5: i32):
 ;; @0031                               trapz v2, user16
-;; @0031                               v46 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0031                               v7 = load.i64 notrap aligned readonly can_move v46+32
+;; @0031                               v7 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @0031                               v8 = load.i64 notrap aligned readonly can_move v7+32
 ;; @0031                               v6 = uextend.i64 v2
-;; @0031                               v8 = iadd v7, v6
-;; @0031                               v9 = iconst.i64 16
-;; @0031                               v10 = iadd v8, v9  ; v9 = 16
-;; @0031                               v11 = load.i32 user2 readonly region1 v10
-;; @0031                               v13 = uextend.i64 v3
-;; @0031                               v14 = uextend.i64 v5
-;; @0031                               v17 = iadd v13, v14
-;; @0031                               v12 = uextend.i64 v11
-;; @0031                               v18 = icmp ugt v17, v12
-;; @0031                               trapnz v18, user17
-;; @0031                               v35 = load.i64 notrap aligned v46+40
-;; @0031                               v23 = iconst.i64 24
-;; @0031                               v24 = iadd v8, v23  ; v23 = 24
-;;                                     v50 = iconst.i64 3
-;;                                     v51 = ishl v13, v50  ; v50 = 3
-;; @0031                               v28 = iadd v24, v51
-;;                                     v53 = ishl v14, v50  ; v50 = 3
-;; @0031                               v37 = uadd_overflow_trap v28, v53, user2
-;; @0031                               v36 = iadd v7, v35
-;; @0031                               v38 = icmp ugt v37, v36
-;; @0031                               trapnz v38, user2
-;;                                     v48 = iconst.i64 0
-;; @0031                               v41 = icmp eq v14, v48  ; v48 = 0
-;; @0031                               v26 = iconst.i64 8
-;; @0031                               v39 = iadd v28, v53
-;; @0031                               brif v41, block3, block2(v28)
+;; @0031                               v9 = iadd v8, v6
+;; @0031                               v10 = iconst.i64 16
+;; @0031                               v11 = iadd v9, v10  ; v10 = 16
+;; @0031                               v12 = load.i32 user2 readonly region1 v11
+;; @0031                               v14 = uextend.i64 v3
+;; @0031                               v15 = uextend.i64 v5
+;; @0031                               v18 = iadd v14, v15
+;; @0031                               v13 = uextend.i64 v12
+;; @0031                               v19 = icmp ugt v18, v13
+;; @0031                               trapnz v19, user17
+;; @0031                               v36 = load.i64 notrap aligned v7+40
+;; @0031                               v24 = iconst.i64 24
+;; @0031                               v25 = iadd v9, v24  ; v24 = 24
+;;                                     v49 = iconst.i64 3
+;;                                     v50 = ishl v14, v49  ; v49 = 3
+;; @0031                               v29 = iadd v25, v50
+;;                                     v52 = ishl v15, v49  ; v49 = 3
+;; @0031                               v38 = uadd_overflow_trap v29, v52, user2
+;; @0031                               v37 = iadd v8, v36
+;; @0031                               v39 = icmp ugt v38, v37
+;; @0031                               trapnz v39, user2
+;;                                     v47 = iconst.i64 0
+;; @0031                               v42 = icmp eq v15, v47  ; v47 = 0
+;; @0031                               v27 = iconst.i64 8
+;; @0031                               v40 = iadd v29, v52
+;; @0031                               brif v42, block3, block2(v29)
 ;;
-;;                                 block2(v42: i64):
-;; @0031                               store.i64 user2 little region1 v4, v42
-;;                                     v55 = iconst.i64 8
-;;                                     v56 = iadd v42, v55  ; v55 = 8
-;; @0031                               v45 = icmp eq v56, v39
-;; @0031                               brif v45, block3, block2(v56)
+;;                                 block2(v43: i64):
+;; @0031                               store.i64 user2 little region1 v4, v43
+;;                                     v54 = iconst.i64 8
+;;                                     v55 = iadd v43, v54  ; v54 = 8
+;; @0031                               v46 = icmp eq v55, v40
+;; @0031                               brif v46, block3, block2(v55)
 ;;
 ;;                                 block3:
 ;; @0034                               jump block1
@@ -85,42 +81,38 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i64, i32, i64) tail
 ;;     fn0 = colocated u805306368:2 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
 ;; @003f                               trapz v2, user16
-;; @003f                               v40 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @003f                               v7 = load.i64 notrap aligned readonly can_move v40+32
+;; @003f                               v7 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @003f                               v8 = load.i64 notrap aligned readonly can_move v7+32
 ;; @003f                               v6 = uextend.i64 v2
-;; @003f                               v8 = iadd v7, v6
-;; @003f                               v9 = iconst.i64 16
-;; @003f                               v10 = iadd v8, v9  ; v9 = 16
-;; @003f                               v11 = load.i32 user2 readonly region1 v10
-;; @003f                               v13 = uextend.i64 v3
-;; @003f                               v14 = uextend.i64 v4
-;; @003f                               v17 = iadd v13, v14
-;; @003f                               v12 = uextend.i64 v11
-;; @003f                               v18 = icmp ugt v17, v12
-;; @003f                               trapnz v18, user17
-;; @003f                               v35 = load.i64 notrap aligned v40+40
-;; @003f                               v23 = iconst.i64 24
-;; @003f                               v24 = iadd v8, v23  ; v23 = 24
-;;                                     v43 = iconst.i64 3
-;;                                     v44 = ishl v13, v43  ; v43 = 3
-;; @003f                               v28 = iadd v24, v44
-;;                                     v46 = ishl v14, v43  ; v43 = 3
-;; @003f                               v37 = uadd_overflow_trap v28, v46, user2
-;; @003f                               v36 = iadd v7, v35
-;; @003f                               v38 = icmp ugt v37, v36
-;; @003f                               trapnz v38, user2
-;; @003f                               v39 = iconst.i32 0
-;; @003f                               call fn0(v0, v28, v39, v46)  ; v39 = 0
+;; @003f                               v9 = iadd v8, v6
+;; @003f                               v10 = iconst.i64 16
+;; @003f                               v11 = iadd v9, v10  ; v10 = 16
+;; @003f                               v12 = load.i32 user2 readonly region1 v11
+;; @003f                               v14 = uextend.i64 v3
+;; @003f                               v15 = uextend.i64 v4
+;; @003f                               v18 = iadd v14, v15
+;; @003f                               v13 = uextend.i64 v12
+;; @003f                               v19 = icmp ugt v18, v13
+;; @003f                               trapnz v19, user17
+;; @003f                               v36 = load.i64 notrap aligned v7+40
+;; @003f                               v24 = iconst.i64 24
+;; @003f                               v25 = iadd v9, v24  ; v24 = 24
+;;                                     v42 = iconst.i64 3
+;;                                     v43 = ishl v14, v42  ; v42 = 3
+;; @003f                               v29 = iadd v25, v43
+;;                                     v45 = ishl v15, v42  ; v42 = 3
+;; @003f                               v38 = uadd_overflow_trap v29, v45, user2
+;; @003f                               v37 = iadd v8, v36
+;; @003f                               v39 = icmp ugt v38, v37
+;; @003f                               trapnz v39, user2
+;; @003f                               v40 = iconst.i32 0
+;; @003f                               call fn0(v0, v29, v40, v45)  ; v40 = 0
 ;; @0042                               jump block1
 ;;
 ;;                                 block1:
@@ -133,42 +125,38 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i64, i32, i64) tail
 ;;     fn0 = colocated u805306368:2 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
 ;; @004d                               trapz v2, user16
-;; @004d                               v40 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @004d                               v7 = load.i64 notrap aligned readonly can_move v40+32
+;; @004d                               v7 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @004d                               v8 = load.i64 notrap aligned readonly can_move v7+32
 ;; @004d                               v6 = uextend.i64 v2
-;; @004d                               v8 = iadd v7, v6
-;; @004d                               v9 = iconst.i64 16
-;; @004d                               v10 = iadd v8, v9  ; v9 = 16
-;; @004d                               v11 = load.i32 user2 readonly region1 v10
-;; @004d                               v13 = uextend.i64 v3
-;; @004d                               v14 = uextend.i64 v4
-;; @004d                               v17 = iadd v13, v14
-;; @004d                               v12 = uextend.i64 v11
-;; @004d                               v18 = icmp ugt v17, v12
-;; @004d                               trapnz v18, user17
-;; @004d                               v35 = load.i64 notrap aligned v40+40
-;; @004d                               v23 = iconst.i64 24
-;; @004d                               v24 = iadd v8, v23  ; v23 = 24
-;;                                     v44 = iconst.i64 3
-;;                                     v45 = ishl v13, v44  ; v44 = 3
-;; @004d                               v28 = iadd v24, v45
-;;                                     v47 = ishl v14, v44  ; v44 = 3
-;; @004d                               v37 = uadd_overflow_trap v28, v47, user2
-;; @004d                               v36 = iadd v7, v35
-;; @004d                               v38 = icmp ugt v37, v36
-;; @004d                               trapnz v38, user2
-;; @004d                               v39 = iconst.i32 255
-;; @004d                               call fn0(v0, v28, v39, v47)  ; v39 = 255
+;; @004d                               v9 = iadd v8, v6
+;; @004d                               v10 = iconst.i64 16
+;; @004d                               v11 = iadd v9, v10  ; v10 = 16
+;; @004d                               v12 = load.i32 user2 readonly region1 v11
+;; @004d                               v14 = uextend.i64 v3
+;; @004d                               v15 = uextend.i64 v4
+;; @004d                               v18 = iadd v14, v15
+;; @004d                               v13 = uextend.i64 v12
+;; @004d                               v19 = icmp ugt v18, v13
+;; @004d                               trapnz v19, user17
+;; @004d                               v36 = load.i64 notrap aligned v7+40
+;; @004d                               v24 = iconst.i64 24
+;; @004d                               v25 = iadd v9, v24  ; v24 = 24
+;;                                     v43 = iconst.i64 3
+;;                                     v44 = ishl v14, v43  ; v43 = 3
+;; @004d                               v29 = iadd v25, v44
+;;                                     v46 = ishl v15, v43  ; v43 = 3
+;; @004d                               v38 = uadd_overflow_trap v29, v46, user2
+;; @004d                               v37 = iadd v8, v36
+;; @004d                               v39 = icmp ugt v38, v37
+;; @004d                               trapnz v39, user2
+;; @004d                               v40 = iconst.i32 255
+;; @004d                               call fn0(v0, v29, v40, v46)  ; v40 = 255
 ;; @0050                               jump block1
 ;;
 ;;                                 block1:
@@ -181,52 +169,48 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
 ;; @005b                               trapz v2, user16
-;; @005b                               v46 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @005b                               v7 = load.i64 notrap aligned readonly can_move v46+32
+;; @005b                               v7 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @005b                               v8 = load.i64 notrap aligned readonly can_move v7+32
 ;; @005b                               v6 = uextend.i64 v2
-;; @005b                               v8 = iadd v7, v6
-;; @005b                               v9 = iconst.i64 16
-;; @005b                               v10 = iadd v8, v9  ; v9 = 16
-;; @005b                               v11 = load.i32 user2 readonly region1 v10
-;; @005b                               v13 = uextend.i64 v3
-;; @005b                               v14 = uextend.i64 v4
-;; @005b                               v17 = iadd v13, v14
-;; @005b                               v12 = uextend.i64 v11
-;; @005b                               v18 = icmp ugt v17, v12
-;; @005b                               trapnz v18, user17
-;; @005b                               v35 = load.i64 notrap aligned v46+40
-;; @005b                               v23 = iconst.i64 24
-;; @005b                               v24 = iadd v8, v23  ; v23 = 24
-;;                                     v50 = iconst.i64 3
-;;                                     v51 = ishl v13, v50  ; v50 = 3
-;; @005b                               v28 = iadd v24, v51
-;;                                     v53 = ishl v14, v50  ; v50 = 3
-;; @005b                               v37 = uadd_overflow_trap v28, v53, user2
-;; @005b                               v36 = iadd v7, v35
-;; @005b                               v38 = icmp ugt v37, v36
-;; @005b                               trapnz v38, user2
-;;                                     v48 = iconst.i64 0
-;; @005b                               v41 = icmp eq v14, v48  ; v48 = 0
+;; @005b                               v9 = iadd v8, v6
+;; @005b                               v10 = iconst.i64 16
+;; @005b                               v11 = iadd v9, v10  ; v10 = 16
+;; @005b                               v12 = load.i32 user2 readonly region1 v11
+;; @005b                               v14 = uextend.i64 v3
+;; @005b                               v15 = uextend.i64 v4
+;; @005b                               v18 = iadd v14, v15
+;; @005b                               v13 = uextend.i64 v12
+;; @005b                               v19 = icmp ugt v18, v13
+;; @005b                               trapnz v19, user17
+;; @005b                               v36 = load.i64 notrap aligned v7+40
+;; @005b                               v24 = iconst.i64 24
+;; @005b                               v25 = iadd v9, v24  ; v24 = 24
+;;                                     v49 = iconst.i64 3
+;;                                     v50 = ishl v14, v49  ; v49 = 3
+;; @005b                               v29 = iadd v25, v50
+;;                                     v52 = ishl v15, v49  ; v49 = 3
+;; @005b                               v38 = uadd_overflow_trap v29, v52, user2
+;; @005b                               v37 = iadd v8, v36
+;; @005b                               v39 = icmp ugt v38, v37
+;; @005b                               trapnz v39, user2
+;;                                     v47 = iconst.i64 0
+;; @005b                               v42 = icmp eq v15, v47  ; v47 = 0
 ;; @0057                               v5 = iconst.i64 1
-;; @005b                               v26 = iconst.i64 8
-;; @005b                               v39 = iadd v28, v53
-;; @005b                               brif v41, block3, block2(v28)
+;; @005b                               v27 = iconst.i64 8
+;; @005b                               v40 = iadd v29, v52
+;; @005b                               brif v42, block3, block2(v29)
 ;;
-;;                                 block2(v42: i64):
-;;                                     v55 = iconst.i64 1
-;; @005b                               store user2 little region1 v55, v42  ; v55 = 1
-;;                                     v56 = iconst.i64 8
-;;                                     v57 = iadd v42, v56  ; v56 = 8
-;; @005b                               v45 = icmp eq v57, v39
-;; @005b                               brif v45, block3, block2(v57)
+;;                                 block2(v43: i64):
+;;                                     v54 = iconst.i64 1
+;; @005b                               store user2 little region1 v54, v43  ; v54 = 1
+;;                                     v55 = iconst.i64 8
+;;                                     v56 = iadd v43, v55  ; v55 = 8
+;; @005b                               v46 = icmp eq v56, v40
+;; @005b                               brif v46, block3, block2(v56)
 ;;
 ;;                                 block3:
 ;; @005e                               jump block1

--- a/tests/disas/basic-wat-test.wat
+++ b/tests/disas/basic-wat-test.wat
@@ -15,9 +15,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):

--- a/tests/disas/bounds-check.wat
+++ b/tests/disas/bounds-check.wat
@@ -30,9 +30,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/duplicate-loads-dynamic-memory.wat
+++ b/tests/disas/duplicate-loads-dynamic-memory.wat
@@ -28,9 +28,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -54,9 +51,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/duplicate-loads-static-memory.wat
+++ b/tests/disas/duplicate-loads-static-memory.wat
@@ -23,9 +23,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -45,9 +42,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/dynamic-memory-no-spectre-access-same-index-different-offsets.wat
+++ b/tests/disas/dynamic-memory-no-spectre-access-same-index-different-offsets.wat
@@ -41,9 +41,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -76,9 +73,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):

--- a/tests/disas/dynamic-memory-yes-spectre-access-same-index-different-offsets.wat
+++ b/tests/disas/dynamic-memory-yes-spectre-access-same-index-different-offsets.wat
@@ -37,9 +37,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -74,9 +71,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):

--- a/tests/disas/f32-load.wat
+++ b/tests/disas/f32-load.wat
@@ -12,9 +12,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/f32-store.wat
+++ b/tests/disas/f32-store.wat
@@ -15,9 +15,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: f32):

--- a/tests/disas/f64-load.wat
+++ b/tests/disas/f64-load.wat
@@ -14,9 +14,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/f64-store.wat
+++ b/tests/disas/f64-store.wat
@@ -15,9 +15,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: f64):

--- a/tests/disas/fibonacci.wat
+++ b/tests/disas/fibonacci.wat
@@ -29,9 +29,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):

--- a/tests/disas/fixed-size-memory.wat
+++ b/tests/disas/fixed-size-memory.wat
@@ -26,9 +26,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -51,9 +48,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/foo.wat
+++ b/tests/disas/foo.wat
@@ -24,11 +24,9 @@
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
-;;     gv6 = load.i64 notrap aligned readonly can_move region2 gv3+72
-;;     gv7 = load.i64 notrap aligned gv6
-;;     gv8 = load.i64 notrap aligned gv6+8
+;;     gv4 = load.i64 notrap aligned readonly can_move region2 gv3+72
+;;     gv5 = load.i64 notrap aligned gv4
+;;     gv6 = load.i64 notrap aligned gv4+8
 ;;     sig0 = (i64 vmctx, i64, i32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i32, i64) -> i64 tail
 ;;     fn0 = colocated u805306368:7 sig1
@@ -39,9 +37,9 @@
 ;; @0040                               v6 = uextend.i64 v3
 ;; @0040                               v8 = iadd v7, v6
 ;; @0040                               v9 = load.i32 little region1 v8
-;; @0043                               v73 = load.i64 notrap aligned readonly can_move region2 v0+72
-;; @0043                               v10 = load.i64 notrap aligned v73+8
-;; @0043                               v14 = load.i64 notrap aligned v73
+;; @0043                               v72 = load.i64 notrap aligned readonly can_move region2 v0+72
+;; @0043                               v10 = load.i64 notrap aligned v72+8
+;; @0043                               v14 = load.i64 notrap aligned v72
 ;; @0043                               v11 = ireduce.i32 v10
 ;; @0043                               v12 = icmp uge v9, v11
 ;; @0043                               v18 = iconst.i64 0
@@ -70,24 +68,24 @@
 ;; @0043                               v33 = load.i64 notrap aligned readonly v23+24
 ;; @0043                               v34 = call_indirect sig0, v32(v33, v0, v2)
 ;; @004a                               v40 = load.i32 little region1 v8
-;; @004d                               v41 = load.i64 notrap aligned v73+8
-;; @004d                               v45 = load.i64 notrap aligned v73
+;; @004d                               v41 = load.i64 notrap aligned v72+8
+;; @004d                               v45 = load.i64 notrap aligned v72
 ;; @004d                               v42 = ireduce.i32 v41
 ;; @004d                               v43 = icmp uge v40, v42
 ;; @004d                               v44 = uextend.i64 v40
-;;                                     v76 = iconst.i64 3
-;;                                     v77 = ishl v44, v76  ; v76 = 3
-;; @004d                               v48 = iadd v45, v77
-;;                                     v78 = iconst.i64 0
-;;                                     v79 = select_spectre_guard v43, v78, v48  ; v78 = 0
-;; @004d                               v51 = load.i64 user6 aligned region3 v79
-;;                                     v80 = iconst.i64 -2
-;;                                     v81 = band v51, v80  ; v80 = -2
-;; @004d                               brif v51, block5(v81), block4
+;;                                     v74 = iconst.i64 3
+;;                                     v75 = ishl v44, v74  ; v74 = 3
+;; @004d                               v48 = iadd v45, v75
+;;                                     v76 = iconst.i64 0
+;;                                     v77 = select_spectre_guard v43, v76, v48  ; v76 = 0
+;; @004d                               v51 = load.i64 user6 aligned region3 v77
+;;                                     v78 = iconst.i64 -2
+;;                                     v79 = band v51, v78  ; v78 = -2
+;; @004d                               brif v51, block5(v79), block4
 ;;
 ;;                                 block4 cold:
-;;                                     v82 = iconst.i32 0
-;; @004d                               v57 = call fn0(v0, v82, v44)  ; v82 = 0
+;;                                     v80 = iconst.i32 0
+;; @004d                               v57 = call fn0(v0, v80, v44)  ; v80 = 0
 ;; @004d                               jump block5(v57)
 ;;
 ;;                                 block5(v54: i64):

--- a/tests/disas/gc/array-copy-with-fuel.wat
+++ b/tests/disas/gc/array-copy-with-fuel.wat
@@ -17,19 +17,15 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx) -> i8 tail
 ;;     fn0 = colocated u805306368:12 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32, v6: i32):
-;;                                     v179 = stack_addr.i64 ss0
-;;                                     store notrap v2, v179
-;;                                     v180 = stack_addr.i64 ss1
-;;                                     store notrap v4, v180
+;;                                     v181 = stack_addr.i64 ss0
+;;                                     store notrap v2, v181
+;;                                     v182 = stack_addr.i64 ss1
+;;                                     store notrap v4, v182
 ;; @0020                               v7 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @0020                               v8 = load.i64 notrap aligned v7
 ;; @0020                               v9 = iconst.i64 1
@@ -39,131 +35,131 @@
 ;; @0020                               brif v12, block2, block3(v10)
 ;;
 ;;                                 block2:
-;;                                     v193 = iadd.i64 v8, v9  ; v9 = 1
-;; @0020                               store notrap aligned v193, v7
+;;                                     v191 = iadd.i64 v8, v9  ; v9 = 1
+;; @0020                               store notrap aligned v191, v7
 ;; @0020                               v14 = call fn0(v0), stack_map=[i32 @ ss0+0, i32 @ ss1+0]
 ;; @0020                               v16 = load.i64 notrap aligned v7
 ;; @0020                               jump block3(v16)
 ;;
-;;                                 block3(v87: i64):
-;;                                     v178 = load.i32 notrap v179
-;; @002b                               trapz v178, user16
-;; @002b                               v23 = load.i64 notrap aligned readonly can_move v7+32
-;; @002b                               v22 = uextend.i64 v178
-;; @002b                               v24 = iadd v23, v22
-;; @002b                               v25 = iconst.i64 16
-;; @002b                               v26 = iadd v24, v25  ; v25 = 16
-;; @002b                               v27 = load.i32 user2 readonly region1 v26
-;; @002b                               v29 = uextend.i64 v3
-;; @002b                               v30 = uextend.i64 v6
-;; @002b                               v33 = iadd v29, v30
-;; @002b                               v28 = uextend.i64 v27
-;; @002b                               v34 = icmp ugt v33, v28
-;; @002b                               trapnz v34, user17
-;;                                     v172 = load.i32 notrap v180
-;; @002b                               trapz v172, user16
-;; @002b                               v45 = uextend.i64 v172
-;; @002b                               v47 = iadd v23, v45
-;; @002b                               v49 = iadd v47, v25  ; v25 = 16
-;; @002b                               v50 = load.i32 user2 readonly region1 v49
-;; @002b                               v52 = uextend.i64 v5
-;; @002b                               v56 = iadd v52, v30
-;; @002b                               v51 = uextend.i64 v50
-;; @002b                               v57 = icmp ugt v56, v51
-;; @002b                               trapnz v57, user17
-;; @002b                               v76 = load.i64 notrap aligned v7+40
-;; @002b                               v39 = iconst.i64 20
-;; @002b                               v40 = iadd v24, v39  ; v39 = 20
-;;                                     v186 = iconst.i64 2
-;;                                     v187 = ishl v29, v186  ; v186 = 2
-;; @002b                               v44 = iadd v40, v187
-;;                                     v191 = ishl v30, v186  ; v186 = 2
-;; @002b                               v78 = uadd_overflow_trap v44, v191, user2
-;; @002b                               v77 = iadd v23, v76
-;; @002b                               v79 = icmp ugt v78, v77
-;; @002b                               trapnz v79, user2
-;; @002b                               v63 = iadd v47, v39  ; v39 = 20
-;;                                     v189 = ishl v52, v186  ; v186 = 2
-;; @002b                               v67 = iadd v63, v189
-;; @002b                               v85 = uadd_overflow_trap v67, v191, user2
-;; @002b                               v86 = icmp ugt v85, v77
-;; @002b                               trapnz v86, user2
-;; @002b                               v88 = iconst.i64 6
-;; @002b                               v89 = iadd v87, v88  ; v88 = 6
-;; @002b                               brif.i32 v6, block4, block7(v89)
+;;                                 block3(v89: i64):
+;;                                     v180 = load.i32 notrap v181
+;; @002b                               trapz v180, user16
+;; @002b                               v24 = load.i64 notrap aligned readonly can_move v7+32
+;; @002b                               v22 = uextend.i64 v180
+;; @002b                               v25 = iadd v24, v22
+;; @002b                               v26 = iconst.i64 16
+;; @002b                               v27 = iadd v25, v26  ; v26 = 16
+;; @002b                               v28 = load.i32 user2 readonly region1 v27
+;; @002b                               v30 = uextend.i64 v3
+;; @002b                               v31 = uextend.i64 v6
+;; @002b                               v34 = iadd v30, v31
+;; @002b                               v29 = uextend.i64 v28
+;; @002b                               v35 = icmp ugt v34, v29
+;; @002b                               trapnz v35, user17
+;;                                     v174 = load.i32 notrap v182
+;; @002b                               trapz v174, user16
+;; @002b                               v46 = uextend.i64 v174
+;; @002b                               v49 = iadd v24, v46
+;; @002b                               v51 = iadd v49, v26  ; v26 = 16
+;; @002b                               v52 = load.i32 user2 readonly region1 v51
+;; @002b                               v54 = uextend.i64 v5
+;; @002b                               v58 = iadd v54, v31
+;; @002b                               v53 = uextend.i64 v52
+;; @002b                               v59 = icmp ugt v58, v53
+;; @002b                               trapnz v59, user17
+;; @002b                               v78 = load.i64 notrap aligned v7+40
+;; @002b                               v40 = iconst.i64 20
+;; @002b                               v41 = iadd v25, v40  ; v40 = 20
+;;                                     v184 = iconst.i64 2
+;;                                     v185 = ishl v30, v184  ; v184 = 2
+;; @002b                               v45 = iadd v41, v185
+;;                                     v189 = ishl v31, v184  ; v184 = 2
+;; @002b                               v80 = uadd_overflow_trap v45, v189, user2
+;; @002b                               v79 = iadd v24, v78
+;; @002b                               v81 = icmp ugt v80, v79
+;; @002b                               trapnz v81, user2
+;; @002b                               v65 = iadd v49, v40  ; v40 = 20
+;;                                     v187 = ishl v54, v184  ; v184 = 2
+;; @002b                               v69 = iadd v65, v187
+;; @002b                               v87 = uadd_overflow_trap v69, v189, user2
+;; @002b                               v88 = icmp ugt v87, v79
+;; @002b                               trapnz v88, user2
+;; @002b                               v90 = iconst.i64 6
+;; @002b                               v91 = iadd v89, v90  ; v90 = 6
+;; @002b                               brif.i32 v6, block4, block7(v91)
 ;;
 ;;                                 block4:
-;;                                     v160 = load.i32 notrap v179
-;;                                     v162 = load.i32 notrap v180
-;; @002b                               v90 = icmp.i64 ult v44, v67
-;;                                     v194 = iadd.i64 v87, v88  ; v88 = 6
-;; @002b                               v95 = iadd.i64 v44, v191
-;; @002b                               v96 = iadd.i64 v67, v191
-;; @002b                               v98 = iadd.i32 v5, v6
-;; @002b                               v42 = iconst.i64 4
-;; @002b                               v139 = iconst.i32 1
-;; @002b                               brif v90, block5(v44, v67, v5, v160, v162, v194), block6(v95, v96, v98, v160, v162, v194)
+;;                                     v162 = load.i32 notrap v181
+;;                                     v164 = load.i32 notrap v182
+;; @002b                               v92 = icmp.i64 ult v45, v69
+;;                                     v192 = iadd.i64 v89, v90  ; v90 = 6
+;; @002b                               v97 = iadd.i64 v45, v189
+;; @002b                               v98 = iadd.i64 v69, v189
+;; @002b                               v100 = iadd.i32 v5, v6
+;; @002b                               v43 = iconst.i64 4
+;; @002b                               v141 = iconst.i32 1
+;; @002b                               brif v92, block5(v45, v69, v5, v162, v164, v192), block6(v97, v98, v100, v162, v164, v192)
 ;;
-;;                                 block5(v99: i64, v100: i64, v101: i32, v102: i32, v103: i32, v104: i64):
-;;                                     store notrap v102, v179
-;;                                     store notrap v103, v180
-;;                                     v204 = iconst.i64 1
-;;                                     v205 = iadd v104, v204  ; v204 = 1
-;;                                     v206 = iconst.i64 0
-;;                                     v207 = icmp sge v205, v206  ; v206 = 0
-;; @002b                               brif v207, block8, block9(v205)
+;;                                 block5(v101: i64, v102: i64, v103: i32, v104: i32, v105: i32, v106: i64):
+;;                                     store notrap v104, v181
+;;                                     store notrap v105, v182
+;;                                     v202 = iconst.i64 1
+;;                                     v203 = iadd v106, v202  ; v202 = 1
+;;                                     v204 = iconst.i64 0
+;;                                     v205 = icmp sge v203, v204  ; v204 = 0
+;; @002b                               brif v205, block8, block9(v203)
 ;;
-;;                                 block6(v121: i64, v122: i64, v123: i32, v124: i32, v125: i32, v126: i64):
-;;                                     store notrap v124, v180
-;;                                     store notrap v125, v179
-;;                                     v195 = iconst.i64 1
-;;                                     v196 = iadd v126, v195  ; v195 = 1
-;;                                     v197 = iconst.i64 0
-;;                                     v198 = icmp sge v196, v197  ; v197 = 0
-;; @002b                               brif v198, block10, block11(v196)
+;;                                 block6(v123: i64, v124: i64, v125: i32, v126: i32, v127: i32, v128: i64):
+;;                                     store notrap v126, v182
+;;                                     store notrap v127, v181
+;;                                     v193 = iconst.i64 1
+;;                                     v194 = iadd v128, v193  ; v193 = 1
+;;                                     v195 = iconst.i64 0
+;;                                     v196 = icmp sge v194, v195  ; v195 = 0
+;; @002b                               brif v196, block10, block11(v194)
 ;;
-;;                                 block7(v146: i64):
+;;                                 block7(v148: i64):
 ;; @002f                               jump block1
 ;;
 ;;                                 block8:
-;; @002b                               store.i64 notrap aligned v205, v7
-;; @002b                               v110 = call fn0(v0), stack_map=[i32 @ ss0+0, i32 @ ss1+0]
-;; @002b                               v112 = load.i64 notrap aligned v7
-;; @002b                               jump block9(v112)
+;; @002b                               store.i64 notrap aligned v203, v7
+;; @002b                               v112 = call fn0(v0), stack_map=[i32 @ ss0+0, i32 @ ss1+0]
+;; @002b                               v114 = load.i64 notrap aligned v7
+;; @002b                               jump block9(v114)
 ;;
-;;                                 block9(v143: i64):
-;; @002b                               v113 = load.i32 user2 little region1 v100
-;; @002b                               store user2 little region1 v113, v99
-;;                                     v148 = load.i32 notrap v179
-;;                                     v150 = load.i32 notrap v180
-;;                                     v208 = iconst.i64 4
-;;                                     v209 = iadd.i64 v100, v208  ; v208 = 4
-;; @002b                               v120 = icmp eq v209, v96
-;;                                     v210 = iadd.i64 v99, v208  ; v208 = 4
-;;                                     v211 = iconst.i32 1
-;;                                     v212 = iadd.i32 v101, v211  ; v211 = 1
-;; @002b                               brif v120, block7(v143), block5(v210, v209, v212, v148, v150, v143)
+;;                                 block9(v145: i64):
+;; @002b                               v115 = load.i32 user2 little region1 v102
+;; @002b                               store user2 little region1 v115, v101
+;;                                     v150 = load.i32 notrap v181
+;;                                     v152 = load.i32 notrap v182
+;;                                     v206 = iconst.i64 4
+;;                                     v207 = iadd.i64 v102, v206  ; v206 = 4
+;; @002b                               v122 = icmp eq v207, v98
+;;                                     v208 = iadd.i64 v101, v206  ; v206 = 4
+;;                                     v209 = iconst.i32 1
+;;                                     v210 = iadd.i32 v103, v209  ; v209 = 1
+;; @002b                               brif v122, block7(v145), block5(v208, v207, v210, v150, v152, v145)
 ;;
 ;;                                 block10:
-;; @002b                               store.i64 notrap aligned v196, v7
-;; @002b                               v132 = call fn0(v0), stack_map=[i32 @ ss1+0, i32 @ ss0+0]
-;; @002b                               v134 = load.i64 notrap aligned v7
-;; @002b                               jump block11(v134)
+;; @002b                               store.i64 notrap aligned v194, v7
+;; @002b                               v134 = call fn0(v0), stack_map=[i32 @ ss1+0, i32 @ ss0+0]
+;; @002b                               v136 = load.i64 notrap aligned v7
+;; @002b                               jump block11(v136)
 ;;
-;;                                 block11(v144: i64):
-;;                                     v199 = iconst.i64 4
-;;                                     v200 = isub.i64 v122, v199  ; v199 = 4
-;; @002b                               v141 = load.i32 user2 little region1 v200
-;;                                     v201 = isub.i64 v121, v199  ; v199 = 4
-;; @002b                               store user2 little region1 v141, v201
-;;                                     v154 = load.i32 notrap v180
-;;                                     v156 = load.i32 notrap v179
-;; @002b                               v142 = icmp eq v200, v67
-;;                                     v202 = iconst.i32 1
-;;                                     v203 = isub.i32 v123, v202  ; v202 = 1
-;; @002b                               brif v142, block7(v144), block6(v201, v200, v203, v154, v156, v144)
+;;                                 block11(v146: i64):
+;;                                     v197 = iconst.i64 4
+;;                                     v198 = isub.i64 v124, v197  ; v197 = 4
+;; @002b                               v143 = load.i32 user2 little region1 v198
+;;                                     v199 = isub.i64 v123, v197  ; v197 = 4
+;; @002b                               store user2 little region1 v143, v199
+;;                                     v156 = load.i32 notrap v182
+;;                                     v158 = load.i32 notrap v181
+;; @002b                               v144 = icmp eq v198, v69
+;;                                     v200 = iconst.i32 1
+;;                                     v201 = isub.i32 v125, v200  ; v200 = 1
+;; @002b                               brif v144, block7(v146), block6(v199, v198, v201, v156, v158, v146)
 ;;
 ;;                                 block1:
-;; @002f                               store.i64 notrap aligned v146, v7
+;; @002f                               store.i64 notrap aligned v148, v7
 ;; @002f                               return
 ;; }

--- a/tests/disas/gc/array-fill-i8.wat
+++ b/tests/disas/gc/array-fill-i8.wat
@@ -15,38 +15,34 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i64, i32, i64) tail
 ;;     fn0 = colocated u805306368:2 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):
 ;; @0027                               trapz v2, user16
-;; @0027                               v39 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0027                               v7 = load.i64 notrap aligned readonly can_move v39+32
+;; @0027                               v7 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @0027                               v8 = load.i64 notrap aligned readonly can_move v7+32
 ;; @0027                               v6 = uextend.i64 v2
-;; @0027                               v8 = iadd v7, v6
-;; @0027                               v9 = iconst.i64 16
-;; @0027                               v10 = iadd v8, v9  ; v9 = 16
-;; @0027                               v11 = load.i32 user2 readonly region1 v10
-;; @0027                               v13 = uextend.i64 v3
-;; @0027                               v14 = uextend.i64 v5
-;; @0027                               v17 = iadd v13, v14
-;; @0027                               v12 = uextend.i64 v11
-;; @0027                               v18 = icmp ugt v17, v12
-;; @0027                               trapnz v18, user17
-;; @0027                               v35 = load.i64 notrap aligned v39+40
-;; @0027                               v23 = iconst.i64 20
-;; @0027                               v24 = iadd v8, v23  ; v23 = 20
-;; @0027                               v28 = iadd v24, v13
-;; @0027                               v37 = uadd_overflow_trap v28, v14, user2
-;; @0027                               v36 = iadd v7, v35
-;; @0027                               v38 = icmp ugt v37, v36
-;; @0027                               trapnz v38, user2
-;; @0027                               call fn0(v0, v28, v4, v14)
+;; @0027                               v9 = iadd v8, v6
+;; @0027                               v10 = iconst.i64 16
+;; @0027                               v11 = iadd v9, v10  ; v10 = 16
+;; @0027                               v12 = load.i32 user2 readonly region1 v11
+;; @0027                               v14 = uextend.i64 v3
+;; @0027                               v15 = uextend.i64 v5
+;; @0027                               v18 = iadd v14, v15
+;; @0027                               v13 = uextend.i64 v12
+;; @0027                               v19 = icmp ugt v18, v13
+;; @0027                               trapnz v19, user17
+;; @0027                               v36 = load.i64 notrap aligned v7+40
+;; @0027                               v24 = iconst.i64 20
+;; @0027                               v25 = iadd v9, v24  ; v24 = 20
+;; @0027                               v29 = iadd v25, v14
+;; @0027                               v38 = uadd_overflow_trap v29, v15, user2
+;; @0027                               v37 = iadd v8, v36
+;; @0027                               v39 = icmp ugt v38, v37
+;; @0027                               trapnz v39, user2
+;; @0027                               call fn0(v0, v29, v4, v15)
 ;; @002a                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/array-init-data.wat
+++ b/tests/disas/gc/array-init-data.wat
@@ -21,46 +21,42 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i64, i64, i64) tail
 ;;     fn0 = colocated u805306368:1 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):
 ;; @002a                               trapz v2, user16
-;; @002a                               v52 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @002a                               v7 = load.i64 notrap aligned readonly can_move v52+32
+;; @002a                               v7 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @002a                               v8 = load.i64 notrap aligned readonly can_move v7+32
 ;; @002a                               v6 = uextend.i64 v2
-;; @002a                               v8 = iadd v7, v6
-;; @002a                               v9 = iconst.i64 16
-;; @002a                               v10 = iadd v8, v9  ; v9 = 16
-;; @002a                               v11 = load.i32 user2 readonly region1 v10
-;; @002a                               v13 = uextend.i64 v3
-;; @002a                               v14 = uextend.i64 v5
-;; @002a                               v17 = iadd v13, v14
-;; @002a                               v12 = uextend.i64 v11
-;; @002a                               v18 = icmp ugt v17, v12
-;; @002a                               trapnz v18, user17
-;; @002a                               v29 = load.i32 notrap aligned region2 v0+56
-;; @002a                               v31 = uextend.i64 v4
-;; @002a                               v35 = iadd v31, v14
-;; @002a                               v30 = uextend.i64 v29
-;; @002a                               v36 = icmp ugt v35, v30
-;; @002a                               trapnz v36, heap_oob
-;; @002a                               v37 = load.i64 notrap aligned region3 v0+48
-;; @002a                               v48 = load.i64 notrap aligned v52+40
-;; @002a                               v23 = iconst.i64 20
-;; @002a                               v24 = iadd v8, v23  ; v23 = 20
-;; @002a                               v28 = iadd v24, v13
-;; @002a                               v50 = uadd_overflow_trap v28, v14, user2
-;; @002a                               v49 = iadd v7, v48
-;; @002a                               v51 = icmp ugt v50, v49
-;; @002a                               trapnz v51, user2
-;; @002a                               v39 = iadd v37, v31
-;; @002a                               call fn0(v0, v28, v39, v14)
+;; @002a                               v9 = iadd v8, v6
+;; @002a                               v10 = iconst.i64 16
+;; @002a                               v11 = iadd v9, v10  ; v10 = 16
+;; @002a                               v12 = load.i32 user2 readonly region1 v11
+;; @002a                               v14 = uextend.i64 v3
+;; @002a                               v15 = uextend.i64 v5
+;; @002a                               v18 = iadd v14, v15
+;; @002a                               v13 = uextend.i64 v12
+;; @002a                               v19 = icmp ugt v18, v13
+;; @002a                               trapnz v19, user17
+;; @002a                               v30 = load.i32 notrap aligned region2 v0+56
+;; @002a                               v32 = uextend.i64 v4
+;; @002a                               v36 = iadd v32, v15
+;; @002a                               v31 = uextend.i64 v30
+;; @002a                               v37 = icmp ugt v36, v31
+;; @002a                               trapnz v37, heap_oob
+;; @002a                               v38 = load.i64 notrap aligned region3 v0+48
+;; @002a                               v49 = load.i64 notrap aligned v7+40
+;; @002a                               v24 = iconst.i64 20
+;; @002a                               v25 = iadd v9, v24  ; v24 = 20
+;; @002a                               v29 = iadd v25, v14
+;; @002a                               v51 = uadd_overflow_trap v29, v15, user2
+;; @002a                               v50 = iadd v8, v49
+;; @002a                               v52 = icmp ugt v51, v50
+;; @002a                               trapnz v52, user2
+;; @002a                               v40 = iadd v38, v32
+;; @002a                               call fn0(v0, v29, v40, v15)
 ;; @002e                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/array-new-data.wat
+++ b/tests/disas/gc/array-new-data.wat
@@ -86,10 +86,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i64, i64, i64) tail
 ;;     fn0 = colocated u805306368:24 sig0
@@ -125,22 +121,22 @@
 ;; @0025                               brif v35, block2, block3
 ;;
 ;;                                 block2:
-;;                                     v122 = iconst.i32 15
-;;                                     v123 = iadd.i32 v23, v122  ; v122 = 15
-;;                                     v126 = iconst.i32 -16
-;;                                     v127 = band v123, v126  ; v126 = -16
-;;                                     v129 = iadd.i32 v25, v127
-;; @0025                               store notrap aligned v129, v24
-;;                                     v143 = iconst.i32 -1476395002
-;;                                     v144 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v145 = load.i64 notrap aligned readonly can_move v144+32
-;; @0025                               v49 = iadd v145, v32
-;; @0025                               store notrap aligned v143, v49  ; v143 = -1476395002
-;;                                     v146 = load.i64 notrap aligned readonly can_move region4 v0+40
-;;                                     v147 = load.i32 notrap aligned readonly can_move v146
-;; @0025                               store notrap aligned v147, v49+4
-;;                                     v148 = band.i64 v30, v29  ; v29 = -16
-;; @0025                               istore32 notrap aligned v148, v49+8
+;;                                     v121 = iconst.i32 15
+;;                                     v122 = iadd.i32 v23, v121  ; v121 = 15
+;;                                     v125 = iconst.i32 -16
+;;                                     v126 = band v122, v125  ; v125 = -16
+;;                                     v128 = iadd.i32 v25, v126
+;; @0025                               store notrap aligned v128, v24
+;;                                     v142 = iconst.i32 -1476395002
+;;                                     v143 = load.i64 notrap aligned readonly can_move region0 v0+8
+;;                                     v144 = load.i64 notrap aligned readonly can_move v143+32
+;; @0025                               v49 = iadd v144, v32
+;; @0025                               store notrap aligned v142, v49  ; v142 = -1476395002
+;;                                     v145 = load.i64 notrap aligned readonly can_move region4 v0+40
+;;                                     v146 = load.i32 notrap aligned readonly can_move v145
+;; @0025                               store notrap aligned v146, v49+4
+;;                                     v147 = band.i64 v30, v29  ; v29 = -16
+;; @0025                               istore32 notrap aligned v147, v49+8
 ;; @0025                               jump block4(v25, v49)
 ;;
 ;;                                 block3 cold:
@@ -156,38 +152,38 @@
 ;; @0025                               jump block4(v40, v44)
 ;;
 ;;                                 block4(v53: i32, v54: i64):
-;;                                     v112 = stack_addr.i64 ss0
-;;                                     store notrap v53, v112
+;;                                     v113 = stack_addr.i64 ss0
+;;                                     store notrap v53, v113
 ;; @0025                               v55 = iconst.i64 16
 ;; @0025                               v56 = iadd v54, v55  ; v55 = 16
 ;; @0025                               store.i32 user2 region5 v3, v56
 ;; @0025                               trapz v53, user16
-;;                                     v149 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v150 = load.i64 notrap aligned readonly can_move v149+32
+;;                                     v148 = load.i64 notrap aligned readonly can_move region0 v0+8
+;;                                     v149 = load.i64 notrap aligned readonly can_move v148+32
 ;; @0025                               v58 = uextend.i64 v53
-;; @0025                               v60 = iadd v150, v58
-;; @0025                               v62 = iadd v60, v55  ; v55 = 16
-;; @0025                               v63 = load.i32 user2 readonly region5 v62
-;; @0025                               v64 = uextend.i64 v63
-;; @0025                               v70 = icmp.i64 ugt v8, v64
-;; @0025                               trapnz v70, user17
-;; @0025                               v81 = load.i32 notrap aligned region1 v0+56
-;; @0025                               v82 = uextend.i64 v81
-;; @0025                               v88 = icmp.i64 ugt v11, v82
-;; @0025                               trapnz v88, heap_oob
-;; @0025                               v89 = load.i64 notrap aligned region2 v0+48
-;; @0025                               v100 = load.i64 notrap aligned v149+40
-;; @0025                               v75 = iconst.i64 20
-;; @0025                               v76 = iadd v60, v75  ; v75 = 20
-;; @0025                               v102 = uadd_overflow_trap v76, v8, user2
-;; @0025                               v101 = iadd v150, v100
-;; @0025                               v103 = icmp ugt v102, v101
-;; @0025                               trapnz v103, user2
-;; @0025                               v91 = iadd v89, v7
-;; @0025                               call fn1(v0, v76, v91, v8), stack_map=[i32 @ ss0+0]
-;;                                     v105 = load.i32 notrap v112
+;; @0025                               v61 = iadd v149, v58
+;; @0025                               v63 = iadd v61, v55  ; v55 = 16
+;; @0025                               v64 = load.i32 user2 readonly region5 v63
+;; @0025                               v65 = uextend.i64 v64
+;; @0025                               v71 = icmp.i64 ugt v8, v65
+;; @0025                               trapnz v71, user17
+;; @0025                               v82 = load.i32 notrap aligned region1 v0+56
+;; @0025                               v83 = uextend.i64 v82
+;; @0025                               v89 = icmp.i64 ugt v11, v83
+;; @0025                               trapnz v89, heap_oob
+;; @0025                               v90 = load.i64 notrap aligned region2 v0+48
+;; @0025                               v101 = load.i64 notrap aligned v148+40
+;; @0025                               v76 = iconst.i64 20
+;; @0025                               v77 = iadd v61, v76  ; v76 = 20
+;; @0025                               v103 = uadd_overflow_trap v77, v8, user2
+;; @0025                               v102 = iadd v149, v101
+;; @0025                               v104 = icmp ugt v103, v102
+;; @0025                               trapnz v104, user2
+;; @0025                               v92 = iadd v90, v7
+;; @0025                               call fn1(v0, v77, v92, v8), stack_map=[i32 @ ss0+0]
+;;                                     v106 = load.i32 notrap v113
 ;; @0029                               jump block1
 ;;
 ;;                                 block1:
-;; @0029                               return v105
+;; @0029                               return v106
 ;; }

--- a/tests/disas/gc/array-new-default-anyref.wat
+++ b/tests/disas/gc/array-new-default-anyref.wat
@@ -17,25 +17,21 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
 ;;     fn0 = colocated u805306368:24 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @001f                               v5 = uextend.i64 v2
-;;                                     v89 = iconst.i64 2
-;;                                     v90 = ishl v5, v89  ; v89 = 2
+;;                                     v88 = iconst.i64 2
+;;                                     v89 = ishl v5, v88  ; v88 = 2
 ;; @001f                               v8 = iconst.i64 32
-;; @001f                               v9 = ushr v90, v8  ; v8 = 32
+;; @001f                               v9 = ushr v89, v8  ; v8 = 32
 ;; @001f                               trapnz v9, user18
 ;; @001f                               v4 = iconst.i32 20
-;;                                     v96 = iconst.i32 2
-;;                                     v97 = ishl v2, v96  ; v96 = 2
-;; @001f                               v11 = uadd_overflow_trap v4, v97, user18  ; v4 = 20
+;;                                     v95 = iconst.i32 2
+;;                                     v96 = ishl v2, v95  ; v95 = 2
+;; @001f                               v11 = uadd_overflow_trap v4, v96, user18  ; v4 = 20
 ;; @001f                               v12 = load.i64 notrap aligned readonly can_move region1 v0+32
 ;; @001f                               v13 = load.i32 notrap aligned v12
 ;; @001f                               v14 = load.i32 notrap aligned v12+4
@@ -51,22 +47,22 @@
 ;; @001f                               brif v23, block2, block3
 ;;
 ;;                                 block2:
-;;                                     v105 = iconst.i32 15
-;;                                     v106 = iadd.i32 v11, v105  ; v105 = 15
-;;                                     v109 = iconst.i32 -16
-;;                                     v110 = band v106, v109  ; v109 = -16
-;;                                     v112 = iadd.i32 v13, v110
-;; @001f                               store notrap aligned v112, v12
-;;                                     v128 = iconst.i32 -1476394994
-;;                                     v129 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v130 = load.i64 notrap aligned readonly can_move v129+32
-;; @001f                               v37 = iadd v130, v20
-;; @001f                               store notrap aligned v128, v37  ; v128 = -1476394994
-;;                                     v131 = load.i64 notrap aligned readonly can_move region2 v0+40
-;;                                     v132 = load.i32 notrap aligned readonly can_move v131
-;; @001f                               store notrap aligned v132, v37+4
-;;                                     v133 = band.i64 v18, v17  ; v17 = -16
-;; @001f                               istore32 notrap aligned v133, v37+8
+;;                                     v104 = iconst.i32 15
+;;                                     v105 = iadd.i32 v11, v104  ; v104 = 15
+;;                                     v108 = iconst.i32 -16
+;;                                     v109 = band v105, v108  ; v108 = -16
+;;                                     v111 = iadd.i32 v13, v109
+;; @001f                               store notrap aligned v111, v12
+;;                                     v127 = iconst.i32 -1476394994
+;;                                     v128 = load.i64 notrap aligned readonly can_move region0 v0+8
+;;                                     v129 = load.i64 notrap aligned readonly can_move v128+32
+;; @001f                               v37 = iadd v129, v20
+;; @001f                               store notrap aligned v127, v37  ; v127 = -1476394994
+;;                                     v130 = load.i64 notrap aligned readonly can_move region2 v0+40
+;;                                     v131 = load.i32 notrap aligned readonly can_move v130
+;; @001f                               store notrap aligned v131, v37+4
+;;                                     v132 = band.i64 v18, v17  ; v17 = -16
+;; @001f                               istore32 notrap aligned v132, v37+8
 ;; @001f                               jump block4(v13, v37)
 ;;
 ;;                                 block3 cold:
@@ -86,36 +82,36 @@
 ;; @001f                               v44 = iadd v42, v43  ; v43 = 16
 ;; @001f                               store.i32 user2 region3 v2, v44
 ;; @001f                               trapz v41, user16
-;;                                     v134 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v135 = load.i64 notrap aligned readonly can_move v134+32
+;;                                     v133 = load.i64 notrap aligned readonly can_move region0 v0+8
+;;                                     v134 = load.i64 notrap aligned readonly can_move v133+32
 ;; @001f                               v47 = uextend.i64 v41
-;; @001f                               v49 = iadd v135, v47
-;; @001f                               v51 = iadd v49, v43  ; v43 = 16
-;; @001f                               v52 = load.i32 user2 readonly region3 v51
-;; @001f                               v53 = uextend.i64 v52
-;; @001f                               v59 = icmp.i64 ugt v5, v53
-;; @001f                               trapnz v59, user17
-;; @001f                               v76 = load.i64 notrap aligned v134+40
-;; @001f                               v64 = iconst.i64 20
-;; @001f                               v65 = iadd v49, v64  ; v64 = 20
-;; @001f                               v78 = uadd_overflow_trap v65, v90, user2
-;; @001f                               v77 = iadd v135, v76
-;; @001f                               v79 = icmp ugt v78, v77
-;; @001f                               trapnz v79, user2
-;;                                     v114 = iconst.i64 0
-;; @001f                               v82 = icmp.i64 eq v5, v114  ; v114 = 0
+;; @001f                               v50 = iadd v134, v47
+;; @001f                               v52 = iadd v50, v43  ; v43 = 16
+;; @001f                               v53 = load.i32 user2 readonly region3 v52
+;; @001f                               v54 = uextend.i64 v53
+;; @001f                               v60 = icmp.i64 ugt v5, v54
+;; @001f                               trapnz v60, user17
+;; @001f                               v77 = load.i64 notrap aligned v133+40
+;; @001f                               v65 = iconst.i64 20
+;; @001f                               v66 = iadd v50, v65  ; v65 = 20
+;; @001f                               v79 = uadd_overflow_trap v66, v89, user2
+;; @001f                               v78 = iadd v134, v77
+;; @001f                               v80 = icmp ugt v79, v78
+;; @001f                               trapnz v80, user2
+;;                                     v113 = iconst.i64 0
+;; @001f                               v83 = icmp.i64 eq v5, v113  ; v113 = 0
 ;; @001f                               v45 = iconst.i32 0
 ;; @001f                               v6 = iconst.i64 4
-;; @001f                               v80 = iadd v65, v90
-;; @001f                               brif v82, block6, block5(v65)
+;; @001f                               v81 = iadd v66, v89
+;; @001f                               brif v83, block6, block5(v66)
 ;;
-;;                                 block5(v83: i64):
-;;                                     v136 = iconst.i32 0
-;; @001f                               store user2 little region3 v136, v83  ; v136 = 0
-;;                                     v137 = iconst.i64 4
-;;                                     v138 = iadd v83, v137  ; v137 = 4
-;; @001f                               v86 = icmp eq v138, v80
-;; @001f                               brif v86, block6, block5(v138)
+;;                                 block5(v84: i64):
+;;                                     v135 = iconst.i32 0
+;; @001f                               store user2 little region3 v135, v84  ; v135 = 0
+;;                                     v136 = iconst.i64 4
+;;                                     v137 = iadd v84, v136  ; v136 = 4
+;; @001f                               v87 = icmp eq v137, v81
+;; @001f                               brif v87, block6, block5(v137)
 ;;
 ;;                                 block6:
 ;; @0022                               jump block1(v41)

--- a/tests/disas/gc/array-new-default-exnref.wat
+++ b/tests/disas/gc/array-new-default-exnref.wat
@@ -17,25 +17,21 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
 ;;     fn0 = colocated u805306368:24 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @001f                               v5 = uextend.i64 v2
-;;                                     v89 = iconst.i64 2
-;;                                     v90 = ishl v5, v89  ; v89 = 2
+;;                                     v88 = iconst.i64 2
+;;                                     v89 = ishl v5, v88  ; v88 = 2
 ;; @001f                               v8 = iconst.i64 32
-;; @001f                               v9 = ushr v90, v8  ; v8 = 32
+;; @001f                               v9 = ushr v89, v8  ; v8 = 32
 ;; @001f                               trapnz v9, user18
 ;; @001f                               v4 = iconst.i32 20
-;;                                     v96 = iconst.i32 2
-;;                                     v97 = ishl v2, v96  ; v96 = 2
-;; @001f                               v11 = uadd_overflow_trap v4, v97, user18  ; v4 = 20
+;;                                     v95 = iconst.i32 2
+;;                                     v96 = ishl v2, v95  ; v95 = 2
+;; @001f                               v11 = uadd_overflow_trap v4, v96, user18  ; v4 = 20
 ;; @001f                               v12 = load.i64 notrap aligned readonly can_move region1 v0+32
 ;; @001f                               v13 = load.i32 notrap aligned v12
 ;; @001f                               v14 = load.i32 notrap aligned v12+4
@@ -51,22 +47,22 @@
 ;; @001f                               brif v23, block2, block3
 ;;
 ;;                                 block2:
-;;                                     v105 = iconst.i32 15
-;;                                     v106 = iadd.i32 v11, v105  ; v105 = 15
-;;                                     v109 = iconst.i32 -16
-;;                                     v110 = band v106, v109  ; v109 = -16
-;;                                     v112 = iadd.i32 v13, v110
-;; @001f                               store notrap aligned v112, v12
-;;                                     v128 = iconst.i32 -1476394994
-;;                                     v129 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v130 = load.i64 notrap aligned readonly can_move v129+32
-;; @001f                               v37 = iadd v130, v20
-;; @001f                               store notrap aligned v128, v37  ; v128 = -1476394994
-;;                                     v131 = load.i64 notrap aligned readonly can_move region2 v0+40
-;;                                     v132 = load.i32 notrap aligned readonly can_move v131
-;; @001f                               store notrap aligned v132, v37+4
-;;                                     v133 = band.i64 v18, v17  ; v17 = -16
-;; @001f                               istore32 notrap aligned v133, v37+8
+;;                                     v104 = iconst.i32 15
+;;                                     v105 = iadd.i32 v11, v104  ; v104 = 15
+;;                                     v108 = iconst.i32 -16
+;;                                     v109 = band v105, v108  ; v108 = -16
+;;                                     v111 = iadd.i32 v13, v109
+;; @001f                               store notrap aligned v111, v12
+;;                                     v127 = iconst.i32 -1476394994
+;;                                     v128 = load.i64 notrap aligned readonly can_move region0 v0+8
+;;                                     v129 = load.i64 notrap aligned readonly can_move v128+32
+;; @001f                               v37 = iadd v129, v20
+;; @001f                               store notrap aligned v127, v37  ; v127 = -1476394994
+;;                                     v130 = load.i64 notrap aligned readonly can_move region2 v0+40
+;;                                     v131 = load.i32 notrap aligned readonly can_move v130
+;; @001f                               store notrap aligned v131, v37+4
+;;                                     v132 = band.i64 v18, v17  ; v17 = -16
+;; @001f                               istore32 notrap aligned v132, v37+8
 ;; @001f                               jump block4(v13, v37)
 ;;
 ;;                                 block3 cold:
@@ -86,36 +82,36 @@
 ;; @001f                               v44 = iadd v42, v43  ; v43 = 16
 ;; @001f                               store.i32 user2 region3 v2, v44
 ;; @001f                               trapz v41, user16
-;;                                     v134 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v135 = load.i64 notrap aligned readonly can_move v134+32
+;;                                     v133 = load.i64 notrap aligned readonly can_move region0 v0+8
+;;                                     v134 = load.i64 notrap aligned readonly can_move v133+32
 ;; @001f                               v47 = uextend.i64 v41
-;; @001f                               v49 = iadd v135, v47
-;; @001f                               v51 = iadd v49, v43  ; v43 = 16
-;; @001f                               v52 = load.i32 user2 readonly region3 v51
-;; @001f                               v53 = uextend.i64 v52
-;; @001f                               v59 = icmp.i64 ugt v5, v53
-;; @001f                               trapnz v59, user17
-;; @001f                               v76 = load.i64 notrap aligned v134+40
-;; @001f                               v64 = iconst.i64 20
-;; @001f                               v65 = iadd v49, v64  ; v64 = 20
-;; @001f                               v78 = uadd_overflow_trap v65, v90, user2
-;; @001f                               v77 = iadd v135, v76
-;; @001f                               v79 = icmp ugt v78, v77
-;; @001f                               trapnz v79, user2
-;;                                     v114 = iconst.i64 0
-;; @001f                               v82 = icmp.i64 eq v5, v114  ; v114 = 0
+;; @001f                               v50 = iadd v134, v47
+;; @001f                               v52 = iadd v50, v43  ; v43 = 16
+;; @001f                               v53 = load.i32 user2 readonly region3 v52
+;; @001f                               v54 = uextend.i64 v53
+;; @001f                               v60 = icmp.i64 ugt v5, v54
+;; @001f                               trapnz v60, user17
+;; @001f                               v77 = load.i64 notrap aligned v133+40
+;; @001f                               v65 = iconst.i64 20
+;; @001f                               v66 = iadd v50, v65  ; v65 = 20
+;; @001f                               v79 = uadd_overflow_trap v66, v89, user2
+;; @001f                               v78 = iadd v134, v77
+;; @001f                               v80 = icmp ugt v79, v78
+;; @001f                               trapnz v80, user2
+;;                                     v113 = iconst.i64 0
+;; @001f                               v83 = icmp.i64 eq v5, v113  ; v113 = 0
 ;; @001f                               v45 = iconst.i32 0
 ;; @001f                               v6 = iconst.i64 4
-;; @001f                               v80 = iadd v65, v90
-;; @001f                               brif v82, block6, block5(v65)
+;; @001f                               v81 = iadd v66, v89
+;; @001f                               brif v83, block6, block5(v66)
 ;;
-;;                                 block5(v83: i64):
-;;                                     v136 = iconst.i32 0
-;; @001f                               store user2 little region3 v136, v83  ; v136 = 0
-;;                                     v137 = iconst.i64 4
-;;                                     v138 = iadd v83, v137  ; v137 = 4
-;; @001f                               v86 = icmp eq v138, v80
-;; @001f                               brif v86, block6, block5(v138)
+;;                                 block5(v84: i64):
+;;                                     v135 = iconst.i32 0
+;; @001f                               store user2 little region3 v135, v84  ; v135 = 0
+;;                                     v136 = iconst.i64 4
+;;                                     v137 = iadd v84, v136  ; v136 = 4
+;; @001f                               v87 = icmp eq v137, v81
+;; @001f                               brif v87, block6, block5(v137)
 ;;
 ;;                                 block6:
 ;; @0022                               jump block1(v41)

--- a/tests/disas/gc/array-new-default-externref.wat
+++ b/tests/disas/gc/array-new-default-externref.wat
@@ -17,25 +17,21 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
 ;;     fn0 = colocated u805306368:24 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @001f                               v5 = uextend.i64 v2
-;;                                     v89 = iconst.i64 2
-;;                                     v90 = ishl v5, v89  ; v89 = 2
+;;                                     v88 = iconst.i64 2
+;;                                     v89 = ishl v5, v88  ; v88 = 2
 ;; @001f                               v8 = iconst.i64 32
-;; @001f                               v9 = ushr v90, v8  ; v8 = 32
+;; @001f                               v9 = ushr v89, v8  ; v8 = 32
 ;; @001f                               trapnz v9, user18
 ;; @001f                               v4 = iconst.i32 20
-;;                                     v96 = iconst.i32 2
-;;                                     v97 = ishl v2, v96  ; v96 = 2
-;; @001f                               v11 = uadd_overflow_trap v4, v97, user18  ; v4 = 20
+;;                                     v95 = iconst.i32 2
+;;                                     v96 = ishl v2, v95  ; v95 = 2
+;; @001f                               v11 = uadd_overflow_trap v4, v96, user18  ; v4 = 20
 ;; @001f                               v12 = load.i64 notrap aligned readonly can_move region1 v0+32
 ;; @001f                               v13 = load.i32 notrap aligned v12
 ;; @001f                               v14 = load.i32 notrap aligned v12+4
@@ -51,22 +47,22 @@
 ;; @001f                               brif v23, block2, block3
 ;;
 ;;                                 block2:
-;;                                     v105 = iconst.i32 15
-;;                                     v106 = iadd.i32 v11, v105  ; v105 = 15
-;;                                     v109 = iconst.i32 -16
-;;                                     v110 = band v106, v109  ; v109 = -16
-;;                                     v112 = iadd.i32 v13, v110
-;; @001f                               store notrap aligned v112, v12
-;;                                     v128 = iconst.i32 -1476394994
-;;                                     v129 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v130 = load.i64 notrap aligned readonly can_move v129+32
-;; @001f                               v37 = iadd v130, v20
-;; @001f                               store notrap aligned v128, v37  ; v128 = -1476394994
-;;                                     v131 = load.i64 notrap aligned readonly can_move region2 v0+40
-;;                                     v132 = load.i32 notrap aligned readonly can_move v131
-;; @001f                               store notrap aligned v132, v37+4
-;;                                     v133 = band.i64 v18, v17  ; v17 = -16
-;; @001f                               istore32 notrap aligned v133, v37+8
+;;                                     v104 = iconst.i32 15
+;;                                     v105 = iadd.i32 v11, v104  ; v104 = 15
+;;                                     v108 = iconst.i32 -16
+;;                                     v109 = band v105, v108  ; v108 = -16
+;;                                     v111 = iadd.i32 v13, v109
+;; @001f                               store notrap aligned v111, v12
+;;                                     v127 = iconst.i32 -1476394994
+;;                                     v128 = load.i64 notrap aligned readonly can_move region0 v0+8
+;;                                     v129 = load.i64 notrap aligned readonly can_move v128+32
+;; @001f                               v37 = iadd v129, v20
+;; @001f                               store notrap aligned v127, v37  ; v127 = -1476394994
+;;                                     v130 = load.i64 notrap aligned readonly can_move region2 v0+40
+;;                                     v131 = load.i32 notrap aligned readonly can_move v130
+;; @001f                               store notrap aligned v131, v37+4
+;;                                     v132 = band.i64 v18, v17  ; v17 = -16
+;; @001f                               istore32 notrap aligned v132, v37+8
 ;; @001f                               jump block4(v13, v37)
 ;;
 ;;                                 block3 cold:
@@ -86,36 +82,36 @@
 ;; @001f                               v44 = iadd v42, v43  ; v43 = 16
 ;; @001f                               store.i32 user2 region3 v2, v44
 ;; @001f                               trapz v41, user16
-;;                                     v134 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v135 = load.i64 notrap aligned readonly can_move v134+32
+;;                                     v133 = load.i64 notrap aligned readonly can_move region0 v0+8
+;;                                     v134 = load.i64 notrap aligned readonly can_move v133+32
 ;; @001f                               v47 = uextend.i64 v41
-;; @001f                               v49 = iadd v135, v47
-;; @001f                               v51 = iadd v49, v43  ; v43 = 16
-;; @001f                               v52 = load.i32 user2 readonly region3 v51
-;; @001f                               v53 = uextend.i64 v52
-;; @001f                               v59 = icmp.i64 ugt v5, v53
-;; @001f                               trapnz v59, user17
-;; @001f                               v76 = load.i64 notrap aligned v134+40
-;; @001f                               v64 = iconst.i64 20
-;; @001f                               v65 = iadd v49, v64  ; v64 = 20
-;; @001f                               v78 = uadd_overflow_trap v65, v90, user2
-;; @001f                               v77 = iadd v135, v76
-;; @001f                               v79 = icmp ugt v78, v77
-;; @001f                               trapnz v79, user2
-;;                                     v114 = iconst.i64 0
-;; @001f                               v82 = icmp.i64 eq v5, v114  ; v114 = 0
+;; @001f                               v50 = iadd v134, v47
+;; @001f                               v52 = iadd v50, v43  ; v43 = 16
+;; @001f                               v53 = load.i32 user2 readonly region3 v52
+;; @001f                               v54 = uextend.i64 v53
+;; @001f                               v60 = icmp.i64 ugt v5, v54
+;; @001f                               trapnz v60, user17
+;; @001f                               v77 = load.i64 notrap aligned v133+40
+;; @001f                               v65 = iconst.i64 20
+;; @001f                               v66 = iadd v50, v65  ; v65 = 20
+;; @001f                               v79 = uadd_overflow_trap v66, v89, user2
+;; @001f                               v78 = iadd v134, v77
+;; @001f                               v80 = icmp ugt v79, v78
+;; @001f                               trapnz v80, user2
+;;                                     v113 = iconst.i64 0
+;; @001f                               v83 = icmp.i64 eq v5, v113  ; v113 = 0
 ;; @001f                               v45 = iconst.i32 0
 ;; @001f                               v6 = iconst.i64 4
-;; @001f                               v80 = iadd v65, v90
-;; @001f                               brif v82, block6, block5(v65)
+;; @001f                               v81 = iadd v66, v89
+;; @001f                               brif v83, block6, block5(v66)
 ;;
-;;                                 block5(v83: i64):
-;;                                     v136 = iconst.i32 0
-;; @001f                               store user2 little region3 v136, v83  ; v136 = 0
-;;                                     v137 = iconst.i64 4
-;;                                     v138 = iadd v83, v137  ; v137 = 4
-;; @001f                               v86 = icmp eq v138, v80
-;; @001f                               brif v86, block6, block5(v138)
+;;                                 block5(v84: i64):
+;;                                     v135 = iconst.i32 0
+;; @001f                               store user2 little region3 v135, v84  ; v135 = 0
+;;                                     v136 = iconst.i64 4
+;;                                     v137 = iadd v84, v136  ; v136 = 4
+;; @001f                               v87 = icmp eq v137, v81
+;; @001f                               brif v87, block6, block5(v137)
 ;;
 ;;                                 block6:
 ;; @0022                               jump block1(v41)

--- a/tests/disas/gc/array-new-default-f32.wat
+++ b/tests/disas/gc/array-new-default-f32.wat
@@ -18,10 +18,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i64, i32, i64) tail
 ;;     fn0 = colocated u805306368:24 sig0
@@ -30,15 +26,15 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @001f                               v5 = uextend.i64 v2
-;;                                     v92 = iconst.i64 2
-;;                                     v93 = ishl v5, v92  ; v92 = 2
+;;                                     v91 = iconst.i64 2
+;;                                     v92 = ishl v5, v91  ; v91 = 2
 ;; @001f                               v8 = iconst.i64 32
-;; @001f                               v9 = ushr v93, v8  ; v8 = 32
+;; @001f                               v9 = ushr v92, v8  ; v8 = 32
 ;; @001f                               trapnz v9, user18
 ;; @001f                               v4 = iconst.i32 20
-;;                                     v99 = iconst.i32 2
-;;                                     v100 = ishl v2, v99  ; v99 = 2
-;; @001f                               v11 = uadd_overflow_trap v4, v100, user18  ; v4 = 20
+;;                                     v98 = iconst.i32 2
+;;                                     v99 = ishl v2, v98  ; v98 = 2
+;; @001f                               v11 = uadd_overflow_trap v4, v99, user18  ; v4 = 20
 ;; @001f                               v12 = load.i64 notrap aligned readonly can_move region1 v0+32
 ;; @001f                               v13 = load.i32 notrap aligned v12
 ;; @001f                               v14 = load.i32 notrap aligned v12+4
@@ -54,22 +50,22 @@
 ;; @001f                               brif v23, block2, block3
 ;;
 ;;                                 block2:
-;;                                     v108 = iconst.i32 15
-;;                                     v109 = iadd.i32 v11, v108  ; v108 = 15
-;;                                     v112 = iconst.i32 -16
-;;                                     v113 = band v109, v112  ; v112 = -16
-;;                                     v115 = iadd.i32 v13, v113
-;; @001f                               store notrap aligned v115, v12
-;;                                     v131 = iconst.i32 -1476395002
-;;                                     v132 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v133 = load.i64 notrap aligned readonly can_move v132+32
-;; @001f                               v37 = iadd v133, v20
-;; @001f                               store notrap aligned v131, v37  ; v131 = -1476395002
-;;                                     v134 = load.i64 notrap aligned readonly can_move region2 v0+40
-;;                                     v135 = load.i32 notrap aligned readonly can_move v134
-;; @001f                               store notrap aligned v135, v37+4
-;;                                     v136 = band.i64 v18, v17  ; v17 = -16
-;; @001f                               istore32 notrap aligned v136, v37+8
+;;                                     v107 = iconst.i32 15
+;;                                     v108 = iadd.i32 v11, v107  ; v107 = 15
+;;                                     v111 = iconst.i32 -16
+;;                                     v112 = band v108, v111  ; v111 = -16
+;;                                     v114 = iadd.i32 v13, v112
+;; @001f                               store notrap aligned v114, v12
+;;                                     v130 = iconst.i32 -1476395002
+;;                                     v131 = load.i64 notrap aligned readonly can_move region0 v0+8
+;;                                     v132 = load.i64 notrap aligned readonly can_move v131+32
+;; @001f                               v37 = iadd v132, v20
+;; @001f                               store notrap aligned v130, v37  ; v130 = -1476395002
+;;                                     v133 = load.i64 notrap aligned readonly can_move region2 v0+40
+;;                                     v134 = load.i32 notrap aligned readonly can_move v133
+;; @001f                               store notrap aligned v134, v37+4
+;;                                     v135 = band.i64 v18, v17  ; v17 = -16
+;; @001f                               istore32 notrap aligned v135, v37+8
 ;; @001f                               jump block4(v13, v37)
 ;;
 ;;                                 block3 cold:
@@ -85,33 +81,33 @@
 ;; @001f                               jump block4(v28, v32)
 ;;
 ;;                                 block4(v41: i32, v42: i64):
-;;                                     v89 = stack_addr.i64 ss0
-;;                                     store notrap v41, v89
+;;                                     v90 = stack_addr.i64 ss0
+;;                                     store notrap v41, v90
 ;; @001f                               v43 = iconst.i64 16
 ;; @001f                               v44 = iadd v42, v43  ; v43 = 16
 ;; @001f                               store.i32 user2 region3 v2, v44
 ;; @001f                               trapz v41, user16
-;;                                     v137 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v138 = load.i64 notrap aligned readonly can_move v137+32
+;;                                     v136 = load.i64 notrap aligned readonly can_move region0 v0+8
+;;                                     v137 = load.i64 notrap aligned readonly can_move v136+32
 ;; @001f                               v47 = uextend.i64 v41
-;; @001f                               v49 = iadd v138, v47
-;; @001f                               v51 = iadd v49, v43  ; v43 = 16
-;; @001f                               v52 = load.i32 user2 readonly region3 v51
-;; @001f                               v53 = uextend.i64 v52
-;; @001f                               v59 = icmp.i64 ugt v5, v53
-;; @001f                               trapnz v59, user17
-;; @001f                               v76 = load.i64 notrap aligned v137+40
-;; @001f                               v64 = iconst.i64 20
-;; @001f                               v65 = iadd v49, v64  ; v64 = 20
-;; @001f                               v78 = uadd_overflow_trap v65, v93, user2
-;; @001f                               v77 = iadd v138, v76
-;; @001f                               v79 = icmp ugt v78, v77
-;; @001f                               trapnz v79, user2
+;; @001f                               v50 = iadd v137, v47
+;; @001f                               v52 = iadd v50, v43  ; v43 = 16
+;; @001f                               v53 = load.i32 user2 readonly region3 v52
+;; @001f                               v54 = uextend.i64 v53
+;; @001f                               v60 = icmp.i64 ugt v5, v54
+;; @001f                               trapnz v60, user17
+;; @001f                               v77 = load.i64 notrap aligned v136+40
+;; @001f                               v65 = iconst.i64 20
+;; @001f                               v66 = iadd v50, v65  ; v65 = 20
+;; @001f                               v79 = uadd_overflow_trap v66, v92, user2
+;; @001f                               v78 = iadd v137, v77
+;; @001f                               v80 = icmp ugt v79, v78
+;; @001f                               trapnz v80, user2
 ;; @001f                               v46 = iconst.i32 0
-;; @001f                               call fn1(v0, v65, v46, v93), stack_map=[i32 @ ss0+0]  ; v46 = 0
-;;                                     v82 = load.i32 notrap v89
+;; @001f                               call fn1(v0, v66, v46, v92), stack_map=[i32 @ ss0+0]  ; v46 = 0
+;;                                     v83 = load.i32 notrap v90
 ;; @0022                               jump block1
 ;;
 ;;                                 block1:
-;; @0022                               return v82
+;; @0022                               return v83
 ;; }

--- a/tests/disas/gc/array-new-default-f64.wat
+++ b/tests/disas/gc/array-new-default-f64.wat
@@ -18,10 +18,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i64, i32, i64) tail
 ;;     fn0 = colocated u805306368:24 sig0
@@ -30,15 +26,15 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @001f                               v5 = uextend.i64 v2
-;;                                     v92 = iconst.i64 3
-;;                                     v93 = ishl v5, v92  ; v92 = 3
+;;                                     v91 = iconst.i64 3
+;;                                     v92 = ishl v5, v91  ; v91 = 3
 ;; @001f                               v8 = iconst.i64 32
-;; @001f                               v9 = ushr v93, v8  ; v8 = 32
+;; @001f                               v9 = ushr v92, v8  ; v8 = 32
 ;; @001f                               trapnz v9, user18
 ;; @001f                               v4 = iconst.i32 24
-;;                                     v99 = iconst.i32 3
-;;                                     v100 = ishl v2, v99  ; v99 = 3
-;; @001f                               v11 = uadd_overflow_trap v4, v100, user18  ; v4 = 24
+;;                                     v98 = iconst.i32 3
+;;                                     v99 = ishl v2, v98  ; v98 = 3
+;; @001f                               v11 = uadd_overflow_trap v4, v99, user18  ; v4 = 24
 ;; @001f                               v12 = load.i64 notrap aligned readonly can_move region1 v0+32
 ;; @001f                               v13 = load.i32 notrap aligned v12
 ;; @001f                               v14 = load.i32 notrap aligned v12+4
@@ -54,22 +50,22 @@
 ;; @001f                               brif v23, block2, block3
 ;;
 ;;                                 block2:
-;;                                     v108 = iconst.i32 15
-;;                                     v109 = iadd.i32 v11, v108  ; v108 = 15
-;;                                     v112 = iconst.i32 -16
-;;                                     v113 = band v109, v112  ; v112 = -16
-;;                                     v115 = iadd.i32 v13, v113
-;; @001f                               store notrap aligned v115, v12
-;;                                     v131 = iconst.i32 -1476395002
-;;                                     v132 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v133 = load.i64 notrap aligned readonly can_move v132+32
-;; @001f                               v37 = iadd v133, v20
-;; @001f                               store notrap aligned v131, v37  ; v131 = -1476395002
-;;                                     v134 = load.i64 notrap aligned readonly can_move region2 v0+40
-;;                                     v135 = load.i32 notrap aligned readonly can_move v134
-;; @001f                               store notrap aligned v135, v37+4
-;;                                     v136 = band.i64 v18, v17  ; v17 = -16
-;; @001f                               istore32 notrap aligned v136, v37+8
+;;                                     v107 = iconst.i32 15
+;;                                     v108 = iadd.i32 v11, v107  ; v107 = 15
+;;                                     v111 = iconst.i32 -16
+;;                                     v112 = band v108, v111  ; v111 = -16
+;;                                     v114 = iadd.i32 v13, v112
+;; @001f                               store notrap aligned v114, v12
+;;                                     v130 = iconst.i32 -1476395002
+;;                                     v131 = load.i64 notrap aligned readonly can_move region0 v0+8
+;;                                     v132 = load.i64 notrap aligned readonly can_move v131+32
+;; @001f                               v37 = iadd v132, v20
+;; @001f                               store notrap aligned v130, v37  ; v130 = -1476395002
+;;                                     v133 = load.i64 notrap aligned readonly can_move region2 v0+40
+;;                                     v134 = load.i32 notrap aligned readonly can_move v133
+;; @001f                               store notrap aligned v134, v37+4
+;;                                     v135 = band.i64 v18, v17  ; v17 = -16
+;; @001f                               istore32 notrap aligned v135, v37+8
 ;; @001f                               jump block4(v13, v37)
 ;;
 ;;                                 block3 cold:
@@ -85,33 +81,33 @@
 ;; @001f                               jump block4(v28, v32)
 ;;
 ;;                                 block4(v41: i32, v42: i64):
-;;                                     v89 = stack_addr.i64 ss0
-;;                                     store notrap v41, v89
+;;                                     v90 = stack_addr.i64 ss0
+;;                                     store notrap v41, v90
 ;; @001f                               v43 = iconst.i64 16
 ;; @001f                               v44 = iadd v42, v43  ; v43 = 16
 ;; @001f                               store.i32 user2 region3 v2, v44
 ;; @001f                               trapz v41, user16
-;;                                     v137 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v138 = load.i64 notrap aligned readonly can_move v137+32
+;;                                     v136 = load.i64 notrap aligned readonly can_move region0 v0+8
+;;                                     v137 = load.i64 notrap aligned readonly can_move v136+32
 ;; @001f                               v47 = uextend.i64 v41
-;; @001f                               v49 = iadd v138, v47
-;; @001f                               v51 = iadd v49, v43  ; v43 = 16
-;; @001f                               v52 = load.i32 user2 readonly region3 v51
-;; @001f                               v53 = uextend.i64 v52
-;; @001f                               v59 = icmp.i64 ugt v5, v53
-;; @001f                               trapnz v59, user17
-;; @001f                               v76 = load.i64 notrap aligned v137+40
-;; @001f                               v64 = iconst.i64 24
-;; @001f                               v65 = iadd v49, v64  ; v64 = 24
-;; @001f                               v78 = uadd_overflow_trap v65, v93, user2
-;; @001f                               v77 = iadd v138, v76
-;; @001f                               v79 = icmp ugt v78, v77
-;; @001f                               trapnz v79, user2
+;; @001f                               v50 = iadd v137, v47
+;; @001f                               v52 = iadd v50, v43  ; v43 = 16
+;; @001f                               v53 = load.i32 user2 readonly region3 v52
+;; @001f                               v54 = uextend.i64 v53
+;; @001f                               v60 = icmp.i64 ugt v5, v54
+;; @001f                               trapnz v60, user17
+;; @001f                               v77 = load.i64 notrap aligned v136+40
+;; @001f                               v65 = iconst.i64 24
+;; @001f                               v66 = iadd v50, v65  ; v65 = 24
+;; @001f                               v79 = uadd_overflow_trap v66, v92, user2
+;; @001f                               v78 = iadd v137, v77
+;; @001f                               v80 = icmp ugt v79, v78
+;; @001f                               trapnz v80, user2
 ;; @001f                               v46 = iconst.i32 0
-;; @001f                               call fn1(v0, v65, v46, v93), stack_map=[i32 @ ss0+0]  ; v46 = 0
-;;                                     v82 = load.i32 notrap v89
+;; @001f                               call fn1(v0, v66, v46, v92), stack_map=[i32 @ ss0+0]  ; v46 = 0
+;;                                     v83 = load.i32 notrap v90
 ;; @0022                               jump block1
 ;;
 ;;                                 block1:
-;; @0022                               return v82
+;; @0022                               return v83
 ;; }

--- a/tests/disas/gc/array-new-default-funcref.wat
+++ b/tests/disas/gc/array-new-default-funcref.wat
@@ -18,10 +18,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i64) -> i64 tail
 ;;     fn0 = colocated u805306368:24 sig0
@@ -30,15 +26,15 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @001f                               v5 = uextend.i64 v2
-;;                                     v100 = iconst.i64 2
-;;                                     v101 = ishl v5, v100  ; v100 = 2
+;;                                     v99 = iconst.i64 2
+;;                                     v100 = ishl v5, v99  ; v99 = 2
 ;; @001f                               v8 = iconst.i64 32
-;; @001f                               v9 = ushr v101, v8  ; v8 = 32
+;; @001f                               v9 = ushr v100, v8  ; v8 = 32
 ;; @001f                               trapnz v9, user18
 ;; @001f                               v4 = iconst.i32 20
-;;                                     v107 = iconst.i32 2
-;;                                     v108 = ishl v2, v107  ; v107 = 2
-;; @001f                               v11 = uadd_overflow_trap v4, v108, user18  ; v4 = 20
+;;                                     v106 = iconst.i32 2
+;;                                     v107 = ishl v2, v106  ; v106 = 2
+;; @001f                               v11 = uadd_overflow_trap v4, v107, user18  ; v4 = 20
 ;; @001f                               v12 = load.i64 notrap aligned readonly can_move region1 v0+32
 ;; @001f                               v13 = load.i32 notrap aligned v12
 ;; @001f                               v14 = load.i32 notrap aligned v12+4
@@ -54,22 +50,22 @@
 ;; @001f                               brif v23, block2, block3
 ;;
 ;;                                 block2:
-;;                                     v116 = iconst.i32 15
-;;                                     v117 = iadd.i32 v11, v116  ; v116 = 15
-;;                                     v120 = iconst.i32 -16
-;;                                     v121 = band v117, v120  ; v120 = -16
-;;                                     v123 = iadd.i32 v13, v121
-;; @001f                               store notrap aligned v123, v12
-;;                                     v138 = iconst.i32 -1476395002
-;;                                     v139 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v140 = load.i64 notrap aligned readonly can_move v139+32
-;; @001f                               v37 = iadd v140, v20
-;; @001f                               store notrap aligned v138, v37  ; v138 = -1476395002
-;;                                     v141 = load.i64 notrap aligned readonly can_move region2 v0+40
-;;                                     v142 = load.i32 notrap aligned readonly can_move v141
-;; @001f                               store notrap aligned v142, v37+4
-;;                                     v143 = band.i64 v18, v17  ; v17 = -16
-;; @001f                               istore32 notrap aligned v143, v37+8
+;;                                     v115 = iconst.i32 15
+;;                                     v116 = iadd.i32 v11, v115  ; v115 = 15
+;;                                     v119 = iconst.i32 -16
+;;                                     v120 = band v116, v119  ; v119 = -16
+;;                                     v122 = iadd.i32 v13, v120
+;; @001f                               store notrap aligned v122, v12
+;;                                     v137 = iconst.i32 -1476395002
+;;                                     v138 = load.i64 notrap aligned readonly can_move region0 v0+8
+;;                                     v139 = load.i64 notrap aligned readonly can_move v138+32
+;; @001f                               v37 = iadd v139, v20
+;; @001f                               store notrap aligned v137, v37  ; v137 = -1476395002
+;;                                     v140 = load.i64 notrap aligned readonly can_move region2 v0+40
+;;                                     v141 = load.i32 notrap aligned readonly can_move v140
+;; @001f                               store notrap aligned v141, v37+4
+;;                                     v142 = band.i64 v18, v17  ; v17 = -16
+;; @001f                               istore32 notrap aligned v142, v37+8
 ;; @001f                               jump block4(v13, v37)
 ;;
 ;;                                 block3 cold:
@@ -85,47 +81,47 @@
 ;; @001f                               jump block4(v28, v32)
 ;;
 ;;                                 block4(v41: i32, v42: i64):
-;;                                     v97 = stack_addr.i64 ss0
-;;                                     store notrap v41, v97
+;;                                     v98 = stack_addr.i64 ss0
+;;                                     store notrap v41, v98
 ;; @001f                               v43 = iconst.i64 16
 ;; @001f                               v44 = iadd v42, v43  ; v43 = 16
 ;; @001f                               store.i32 user2 region3 v2, v44
 ;; @001f                               trapz v41, user16
-;;                                     v144 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v145 = load.i64 notrap aligned readonly can_move v144+32
+;;                                     v143 = load.i64 notrap aligned readonly can_move region0 v0+8
+;;                                     v144 = load.i64 notrap aligned readonly can_move v143+32
 ;; @001f                               v47 = uextend.i64 v41
-;; @001f                               v49 = iadd v145, v47
-;; @001f                               v51 = iadd v49, v43  ; v43 = 16
-;; @001f                               v52 = load.i32 user2 readonly region3 v51
-;; @001f                               v53 = uextend.i64 v52
-;; @001f                               v59 = icmp.i64 ugt v5, v53
-;; @001f                               trapnz v59, user17
-;; @001f                               v76 = load.i64 notrap aligned v144+40
-;; @001f                               v64 = iconst.i64 20
-;; @001f                               v65 = iadd v49, v64  ; v64 = 20
-;; @001f                               v78 = uadd_overflow_trap v65, v101, user2
-;; @001f                               v77 = iadd v145, v76
-;; @001f                               v79 = icmp ugt v78, v77
-;; @001f                               trapnz v79, user2
+;; @001f                               v50 = iadd v144, v47
+;; @001f                               v52 = iadd v50, v43  ; v43 = 16
+;; @001f                               v53 = load.i32 user2 readonly region3 v52
+;; @001f                               v54 = uextend.i64 v53
+;; @001f                               v60 = icmp.i64 ugt v5, v54
+;; @001f                               trapnz v60, user17
+;; @001f                               v77 = load.i64 notrap aligned v143+40
+;; @001f                               v65 = iconst.i64 20
+;; @001f                               v66 = iadd v50, v65  ; v65 = 20
+;; @001f                               v79 = uadd_overflow_trap v66, v100, user2
+;; @001f                               v78 = iadd v144, v77
+;; @001f                               v80 = icmp ugt v79, v78
+;; @001f                               trapnz v80, user2
 ;; @001f                               v45 = iconst.i64 0
-;; @001f                               v80 = call fn1(v0, v45), stack_map=[i32 @ ss0+0]  ; v45 = 0
-;; @001f                               v84 = icmp.i64 eq v5, v45  ; v45 = 0
-;; @001f                               v81 = ireduce.i32 v80
+;; @001f                               v81 = call fn1(v0, v45), stack_map=[i32 @ ss0+0]  ; v45 = 0
+;; @001f                               v85 = icmp.i64 eq v5, v45  ; v45 = 0
+;; @001f                               v82 = ireduce.i32 v81
 ;; @001f                               v6 = iconst.i64 4
-;; @001f                               v82 = iadd v65, v101
-;; @001f                               brif v84, block6, block5(v65)
+;; @001f                               v83 = iadd v66, v100
+;; @001f                               brif v85, block6, block5(v66)
 ;;
-;;                                 block5(v85: i64):
-;; @001f                               store.i32 notrap aligned little v81, v85
-;;                                     v146 = iconst.i64 4
-;;                                     v147 = iadd v85, v146  ; v146 = 4
-;; @001f                               v88 = icmp eq v147, v82
-;; @001f                               brif v88, block6, block5(v147)
+;;                                 block5(v86: i64):
+;; @001f                               store.i32 notrap aligned little v82, v86
+;;                                     v145 = iconst.i64 4
+;;                                     v146 = iadd v86, v145  ; v145 = 4
+;; @001f                               v89 = icmp eq v146, v83
+;; @001f                               brif v89, block6, block5(v146)
 ;;
 ;;                                 block6:
-;;                                     v90 = load.i32 notrap v97
+;;                                     v91 = load.i32 notrap v98
 ;; @0022                               jump block1
 ;;
 ;;                                 block1:
-;; @0022                               return v90
+;; @0022                               return v91
 ;; }

--- a/tests/disas/gc/array-new-default-i16.wat
+++ b/tests/disas/gc/array-new-default-i16.wat
@@ -18,10 +18,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i64, i32, i64) tail
 ;;     fn0 = colocated u805306368:24 sig0
@@ -30,14 +26,14 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @001f                               v5 = uextend.i64 v2
-;;                                     v93 = iconst.i64 1
-;;                                     v94 = ishl v5, v93  ; v93 = 1
+;;                                     v92 = iconst.i64 1
+;;                                     v93 = ishl v5, v92  ; v92 = 1
 ;; @001f                               v8 = iconst.i64 32
-;; @001f                               v9 = ushr v94, v8  ; v8 = 32
+;; @001f                               v9 = ushr v93, v8  ; v8 = 32
 ;; @001f                               trapnz v9, user18
 ;; @001f                               v4 = iconst.i32 20
-;;                                     v98 = iadd v2, v2
-;; @001f                               v11 = uadd_overflow_trap v4, v98, user18  ; v4 = 20
+;;                                     v97 = iadd v2, v2
+;; @001f                               v11 = uadd_overflow_trap v4, v97, user18  ; v4 = 20
 ;; @001f                               v12 = load.i64 notrap aligned readonly can_move region1 v0+32
 ;; @001f                               v13 = load.i32 notrap aligned v12
 ;; @001f                               v14 = load.i32 notrap aligned v12+4
@@ -53,22 +49,22 @@
 ;; @001f                               brif v23, block2, block3
 ;;
 ;;                                 block2:
-;;                                     v113 = iconst.i32 15
-;;                                     v114 = iadd.i32 v11, v113  ; v113 = 15
-;;                                     v117 = iconst.i32 -16
-;;                                     v118 = band v114, v117  ; v117 = -16
-;;                                     v120 = iadd.i32 v13, v118
-;; @001f                               store notrap aligned v120, v12
-;;                                     v141 = iconst.i32 -1476395002
-;;                                     v142 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v143 = load.i64 notrap aligned readonly can_move v142+32
-;; @001f                               v37 = iadd v143, v20
-;; @001f                               store notrap aligned v141, v37  ; v141 = -1476395002
-;;                                     v144 = load.i64 notrap aligned readonly can_move region2 v0+40
-;;                                     v145 = load.i32 notrap aligned readonly can_move v144
-;; @001f                               store notrap aligned v145, v37+4
-;;                                     v146 = band.i64 v18, v17  ; v17 = -16
-;; @001f                               istore32 notrap aligned v146, v37+8
+;;                                     v112 = iconst.i32 15
+;;                                     v113 = iadd.i32 v11, v112  ; v112 = 15
+;;                                     v116 = iconst.i32 -16
+;;                                     v117 = band v113, v116  ; v116 = -16
+;;                                     v119 = iadd.i32 v13, v117
+;; @001f                               store notrap aligned v119, v12
+;;                                     v140 = iconst.i32 -1476395002
+;;                                     v141 = load.i64 notrap aligned readonly can_move region0 v0+8
+;;                                     v142 = load.i64 notrap aligned readonly can_move v141+32
+;; @001f                               v37 = iadd v142, v20
+;; @001f                               store notrap aligned v140, v37  ; v140 = -1476395002
+;;                                     v143 = load.i64 notrap aligned readonly can_move region2 v0+40
+;;                                     v144 = load.i32 notrap aligned readonly can_move v143
+;; @001f                               store notrap aligned v144, v37+4
+;;                                     v145 = band.i64 v18, v17  ; v17 = -16
+;; @001f                               istore32 notrap aligned v145, v37+8
 ;; @001f                               jump block4(v13, v37)
 ;;
 ;;                                 block3 cold:
@@ -84,33 +80,33 @@
 ;; @001f                               jump block4(v28, v32)
 ;;
 ;;                                 block4(v41: i32, v42: i64):
-;;                                     v89 = stack_addr.i64 ss0
-;;                                     store notrap v41, v89
+;;                                     v90 = stack_addr.i64 ss0
+;;                                     store notrap v41, v90
 ;; @001f                               v43 = iconst.i64 16
 ;; @001f                               v44 = iadd v42, v43  ; v43 = 16
 ;; @001f                               store.i32 user2 region3 v2, v44
 ;; @001f                               trapz v41, user16
-;;                                     v147 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v148 = load.i64 notrap aligned readonly can_move v147+32
+;;                                     v146 = load.i64 notrap aligned readonly can_move region0 v0+8
+;;                                     v147 = load.i64 notrap aligned readonly can_move v146+32
 ;; @001f                               v47 = uextend.i64 v41
-;; @001f                               v49 = iadd v148, v47
-;; @001f                               v51 = iadd v49, v43  ; v43 = 16
-;; @001f                               v52 = load.i32 user2 readonly region3 v51
-;; @001f                               v53 = uextend.i64 v52
-;; @001f                               v59 = icmp.i64 ugt v5, v53
-;; @001f                               trapnz v59, user17
-;; @001f                               v76 = load.i64 notrap aligned v147+40
-;; @001f                               v64 = iconst.i64 20
-;; @001f                               v65 = iadd v49, v64  ; v64 = 20
-;; @001f                               v78 = uadd_overflow_trap v65, v94, user2
-;; @001f                               v77 = iadd v148, v76
-;; @001f                               v79 = icmp ugt v78, v77
-;; @001f                               trapnz v79, user2
+;; @001f                               v50 = iadd v147, v47
+;; @001f                               v52 = iadd v50, v43  ; v43 = 16
+;; @001f                               v53 = load.i32 user2 readonly region3 v52
+;; @001f                               v54 = uextend.i64 v53
+;; @001f                               v60 = icmp.i64 ugt v5, v54
+;; @001f                               trapnz v60, user17
+;; @001f                               v77 = load.i64 notrap aligned v146+40
+;; @001f                               v65 = iconst.i64 20
+;; @001f                               v66 = iadd v50, v65  ; v65 = 20
+;; @001f                               v79 = uadd_overflow_trap v66, v93, user2
+;; @001f                               v78 = iadd v147, v77
+;; @001f                               v80 = icmp ugt v79, v78
+;; @001f                               trapnz v80, user2
 ;; @001f                               v45 = iconst.i32 0
-;; @001f                               call fn1(v0, v65, v45, v94), stack_map=[i32 @ ss0+0]  ; v45 = 0
-;;                                     v82 = load.i32 notrap v89
+;; @001f                               call fn1(v0, v66, v45, v93), stack_map=[i32 @ ss0+0]  ; v45 = 0
+;;                                     v83 = load.i32 notrap v90
 ;; @0022                               jump block1
 ;;
 ;;                                 block1:
-;; @0022                               return v82
+;; @0022                               return v83
 ;; }

--- a/tests/disas/gc/array-new-default-i32.wat
+++ b/tests/disas/gc/array-new-default-i32.wat
@@ -18,10 +18,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i64, i32, i64) tail
 ;;     fn0 = colocated u805306368:24 sig0
@@ -30,15 +26,15 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @001f                               v5 = uextend.i64 v2
-;;                                     v92 = iconst.i64 2
-;;                                     v93 = ishl v5, v92  ; v92 = 2
+;;                                     v91 = iconst.i64 2
+;;                                     v92 = ishl v5, v91  ; v91 = 2
 ;; @001f                               v8 = iconst.i64 32
-;; @001f                               v9 = ushr v93, v8  ; v8 = 32
+;; @001f                               v9 = ushr v92, v8  ; v8 = 32
 ;; @001f                               trapnz v9, user18
 ;; @001f                               v4 = iconst.i32 20
-;;                                     v99 = iconst.i32 2
-;;                                     v100 = ishl v2, v99  ; v99 = 2
-;; @001f                               v11 = uadd_overflow_trap v4, v100, user18  ; v4 = 20
+;;                                     v98 = iconst.i32 2
+;;                                     v99 = ishl v2, v98  ; v98 = 2
+;; @001f                               v11 = uadd_overflow_trap v4, v99, user18  ; v4 = 20
 ;; @001f                               v12 = load.i64 notrap aligned readonly can_move region1 v0+32
 ;; @001f                               v13 = load.i32 notrap aligned v12
 ;; @001f                               v14 = load.i32 notrap aligned v12+4
@@ -54,22 +50,22 @@
 ;; @001f                               brif v23, block2, block3
 ;;
 ;;                                 block2:
-;;                                     v108 = iconst.i32 15
-;;                                     v109 = iadd.i32 v11, v108  ; v108 = 15
-;;                                     v112 = iconst.i32 -16
-;;                                     v113 = band v109, v112  ; v112 = -16
-;;                                     v115 = iadd.i32 v13, v113
-;; @001f                               store notrap aligned v115, v12
-;;                                     v131 = iconst.i32 -1476395002
-;;                                     v132 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v133 = load.i64 notrap aligned readonly can_move v132+32
-;; @001f                               v37 = iadd v133, v20
-;; @001f                               store notrap aligned v131, v37  ; v131 = -1476395002
-;;                                     v134 = load.i64 notrap aligned readonly can_move region2 v0+40
-;;                                     v135 = load.i32 notrap aligned readonly can_move v134
-;; @001f                               store notrap aligned v135, v37+4
-;;                                     v136 = band.i64 v18, v17  ; v17 = -16
-;; @001f                               istore32 notrap aligned v136, v37+8
+;;                                     v107 = iconst.i32 15
+;;                                     v108 = iadd.i32 v11, v107  ; v107 = 15
+;;                                     v111 = iconst.i32 -16
+;;                                     v112 = band v108, v111  ; v111 = -16
+;;                                     v114 = iadd.i32 v13, v112
+;; @001f                               store notrap aligned v114, v12
+;;                                     v130 = iconst.i32 -1476395002
+;;                                     v131 = load.i64 notrap aligned readonly can_move region0 v0+8
+;;                                     v132 = load.i64 notrap aligned readonly can_move v131+32
+;; @001f                               v37 = iadd v132, v20
+;; @001f                               store notrap aligned v130, v37  ; v130 = -1476395002
+;;                                     v133 = load.i64 notrap aligned readonly can_move region2 v0+40
+;;                                     v134 = load.i32 notrap aligned readonly can_move v133
+;; @001f                               store notrap aligned v134, v37+4
+;;                                     v135 = band.i64 v18, v17  ; v17 = -16
+;; @001f                               istore32 notrap aligned v135, v37+8
 ;; @001f                               jump block4(v13, v37)
 ;;
 ;;                                 block3 cold:
@@ -85,33 +81,33 @@
 ;; @001f                               jump block4(v28, v32)
 ;;
 ;;                                 block4(v41: i32, v42: i64):
-;;                                     v89 = stack_addr.i64 ss0
-;;                                     store notrap v41, v89
+;;                                     v90 = stack_addr.i64 ss0
+;;                                     store notrap v41, v90
 ;; @001f                               v43 = iconst.i64 16
 ;; @001f                               v44 = iadd v42, v43  ; v43 = 16
 ;; @001f                               store.i32 user2 region3 v2, v44
 ;; @001f                               trapz v41, user16
-;;                                     v137 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v138 = load.i64 notrap aligned readonly can_move v137+32
+;;                                     v136 = load.i64 notrap aligned readonly can_move region0 v0+8
+;;                                     v137 = load.i64 notrap aligned readonly can_move v136+32
 ;; @001f                               v47 = uextend.i64 v41
-;; @001f                               v49 = iadd v138, v47
-;; @001f                               v51 = iadd v49, v43  ; v43 = 16
-;; @001f                               v52 = load.i32 user2 readonly region3 v51
-;; @001f                               v53 = uextend.i64 v52
-;; @001f                               v59 = icmp.i64 ugt v5, v53
-;; @001f                               trapnz v59, user17
-;; @001f                               v76 = load.i64 notrap aligned v137+40
-;; @001f                               v64 = iconst.i64 20
-;; @001f                               v65 = iadd v49, v64  ; v64 = 20
-;; @001f                               v78 = uadd_overflow_trap v65, v93, user2
-;; @001f                               v77 = iadd v138, v76
-;; @001f                               v79 = icmp ugt v78, v77
-;; @001f                               trapnz v79, user2
+;; @001f                               v50 = iadd v137, v47
+;; @001f                               v52 = iadd v50, v43  ; v43 = 16
+;; @001f                               v53 = load.i32 user2 readonly region3 v52
+;; @001f                               v54 = uextend.i64 v53
+;; @001f                               v60 = icmp.i64 ugt v5, v54
+;; @001f                               trapnz v60, user17
+;; @001f                               v77 = load.i64 notrap aligned v136+40
+;; @001f                               v65 = iconst.i64 20
+;; @001f                               v66 = iadd v50, v65  ; v65 = 20
+;; @001f                               v79 = uadd_overflow_trap v66, v92, user2
+;; @001f                               v78 = iadd v137, v77
+;; @001f                               v80 = icmp ugt v79, v78
+;; @001f                               trapnz v80, user2
 ;; @001f                               v45 = iconst.i32 0
-;; @001f                               call fn1(v0, v65, v45, v93), stack_map=[i32 @ ss0+0]  ; v45 = 0
-;;                                     v82 = load.i32 notrap v89
+;; @001f                               call fn1(v0, v66, v45, v92), stack_map=[i32 @ ss0+0]  ; v45 = 0
+;;                                     v83 = load.i32 notrap v90
 ;; @0022                               jump block1
 ;;
 ;;                                 block1:
-;; @0022                               return v82
+;; @0022                               return v83
 ;; }

--- a/tests/disas/gc/array-new-default-i64.wat
+++ b/tests/disas/gc/array-new-default-i64.wat
@@ -18,10 +18,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i64, i32, i64) tail
 ;;     fn0 = colocated u805306368:24 sig0
@@ -30,15 +26,15 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @001f                               v5 = uextend.i64 v2
-;;                                     v92 = iconst.i64 3
-;;                                     v93 = ishl v5, v92  ; v92 = 3
+;;                                     v91 = iconst.i64 3
+;;                                     v92 = ishl v5, v91  ; v91 = 3
 ;; @001f                               v8 = iconst.i64 32
-;; @001f                               v9 = ushr v93, v8  ; v8 = 32
+;; @001f                               v9 = ushr v92, v8  ; v8 = 32
 ;; @001f                               trapnz v9, user18
 ;; @001f                               v4 = iconst.i32 24
-;;                                     v99 = iconst.i32 3
-;;                                     v100 = ishl v2, v99  ; v99 = 3
-;; @001f                               v11 = uadd_overflow_trap v4, v100, user18  ; v4 = 24
+;;                                     v98 = iconst.i32 3
+;;                                     v99 = ishl v2, v98  ; v98 = 3
+;; @001f                               v11 = uadd_overflow_trap v4, v99, user18  ; v4 = 24
 ;; @001f                               v12 = load.i64 notrap aligned readonly can_move region1 v0+32
 ;; @001f                               v13 = load.i32 notrap aligned v12
 ;; @001f                               v14 = load.i32 notrap aligned v12+4
@@ -54,22 +50,22 @@
 ;; @001f                               brif v23, block2, block3
 ;;
 ;;                                 block2:
-;;                                     v108 = iconst.i32 15
-;;                                     v109 = iadd.i32 v11, v108  ; v108 = 15
-;;                                     v112 = iconst.i32 -16
-;;                                     v113 = band v109, v112  ; v112 = -16
-;;                                     v115 = iadd.i32 v13, v113
-;; @001f                               store notrap aligned v115, v12
-;;                                     v130 = iconst.i32 -1476395002
-;;                                     v131 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v132 = load.i64 notrap aligned readonly can_move v131+32
-;; @001f                               v37 = iadd v132, v20
-;; @001f                               store notrap aligned v130, v37  ; v130 = -1476395002
-;;                                     v133 = load.i64 notrap aligned readonly can_move region2 v0+40
-;;                                     v134 = load.i32 notrap aligned readonly can_move v133
-;; @001f                               store notrap aligned v134, v37+4
-;;                                     v135 = band.i64 v18, v17  ; v17 = -16
-;; @001f                               istore32 notrap aligned v135, v37+8
+;;                                     v107 = iconst.i32 15
+;;                                     v108 = iadd.i32 v11, v107  ; v107 = 15
+;;                                     v111 = iconst.i32 -16
+;;                                     v112 = band v108, v111  ; v111 = -16
+;;                                     v114 = iadd.i32 v13, v112
+;; @001f                               store notrap aligned v114, v12
+;;                                     v129 = iconst.i32 -1476395002
+;;                                     v130 = load.i64 notrap aligned readonly can_move region0 v0+8
+;;                                     v131 = load.i64 notrap aligned readonly can_move v130+32
+;; @001f                               v37 = iadd v131, v20
+;; @001f                               store notrap aligned v129, v37  ; v129 = -1476395002
+;;                                     v132 = load.i64 notrap aligned readonly can_move region2 v0+40
+;;                                     v133 = load.i32 notrap aligned readonly can_move v132
+;; @001f                               store notrap aligned v133, v37+4
+;;                                     v134 = band.i64 v18, v17  ; v17 = -16
+;; @001f                               istore32 notrap aligned v134, v37+8
 ;; @001f                               jump block4(v13, v37)
 ;;
 ;;                                 block3 cold:
@@ -85,33 +81,33 @@
 ;; @001f                               jump block4(v28, v32)
 ;;
 ;;                                 block4(v41: i32, v42: i64):
-;;                                     v89 = stack_addr.i64 ss0
-;;                                     store notrap v41, v89
+;;                                     v90 = stack_addr.i64 ss0
+;;                                     store notrap v41, v90
 ;; @001f                               v43 = iconst.i64 16
 ;; @001f                               v44 = iadd v42, v43  ; v43 = 16
 ;; @001f                               store.i32 user2 region3 v2, v44
 ;; @001f                               trapz v41, user16
-;;                                     v136 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v137 = load.i64 notrap aligned readonly can_move v136+32
+;;                                     v135 = load.i64 notrap aligned readonly can_move region0 v0+8
+;;                                     v136 = load.i64 notrap aligned readonly can_move v135+32
 ;; @001f                               v47 = uextend.i64 v41
-;; @001f                               v49 = iadd v137, v47
-;; @001f                               v51 = iadd v49, v43  ; v43 = 16
-;; @001f                               v52 = load.i32 user2 readonly region3 v51
-;; @001f                               v53 = uextend.i64 v52
-;; @001f                               v59 = icmp.i64 ugt v5, v53
-;; @001f                               trapnz v59, user17
-;; @001f                               v76 = load.i64 notrap aligned v136+40
-;; @001f                               v64 = iconst.i64 24
-;; @001f                               v65 = iadd v49, v64  ; v64 = 24
-;; @001f                               v78 = uadd_overflow_trap v65, v93, user2
-;; @001f                               v77 = iadd v137, v76
-;; @001f                               v79 = icmp ugt v78, v77
-;; @001f                               trapnz v79, user2
+;; @001f                               v50 = iadd v136, v47
+;; @001f                               v52 = iadd v50, v43  ; v43 = 16
+;; @001f                               v53 = load.i32 user2 readonly region3 v52
+;; @001f                               v54 = uextend.i64 v53
+;; @001f                               v60 = icmp.i64 ugt v5, v54
+;; @001f                               trapnz v60, user17
+;; @001f                               v77 = load.i64 notrap aligned v135+40
+;; @001f                               v65 = iconst.i64 24
+;; @001f                               v66 = iadd v50, v65  ; v65 = 24
+;; @001f                               v79 = uadd_overflow_trap v66, v92, user2
+;; @001f                               v78 = iadd v136, v77
+;; @001f                               v80 = icmp ugt v79, v78
+;; @001f                               trapnz v80, user2
 ;; @001f                               v46 = iconst.i32 0
-;; @001f                               call fn1(v0, v65, v46, v93), stack_map=[i32 @ ss0+0]  ; v46 = 0
-;;                                     v82 = load.i32 notrap v89
+;; @001f                               call fn1(v0, v66, v46, v92), stack_map=[i32 @ ss0+0]  ; v46 = 0
+;;                                     v83 = load.i32 notrap v90
 ;; @0022                               jump block1
 ;;
 ;;                                 block1:
-;; @0022                               return v82
+;; @0022                               return v83
 ;; }

--- a/tests/disas/gc/array-new-default-i8.wat
+++ b/tests/disas/gc/array-new-default-i8.wat
@@ -18,10 +18,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i64, i32, i64) tail
 ;;     fn0 = colocated u805306368:24 sig0
@@ -50,22 +46,22 @@
 ;; @001f                               brif v23, block2, block3
 ;;
 ;;                                 block2:
-;;                                     v98 = iconst.i32 15
-;;                                     v99 = iadd.i32 v11, v98  ; v98 = 15
-;;                                     v102 = iconst.i32 -16
-;;                                     v103 = band v99, v102  ; v102 = -16
-;;                                     v105 = iadd.i32 v13, v103
-;; @001f                               store notrap aligned v105, v12
-;;                                     v119 = iconst.i32 -1476395002
-;;                                     v120 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v121 = load.i64 notrap aligned readonly can_move v120+32
-;; @001f                               v37 = iadd v121, v20
-;; @001f                               store notrap aligned v119, v37  ; v119 = -1476395002
-;;                                     v122 = load.i64 notrap aligned readonly can_move region2 v0+40
-;;                                     v123 = load.i32 notrap aligned readonly can_move v122
-;; @001f                               store notrap aligned v123, v37+4
-;;                                     v124 = band.i64 v18, v17  ; v17 = -16
-;; @001f                               istore32 notrap aligned v124, v37+8
+;;                                     v97 = iconst.i32 15
+;;                                     v98 = iadd.i32 v11, v97  ; v97 = 15
+;;                                     v101 = iconst.i32 -16
+;;                                     v102 = band v98, v101  ; v101 = -16
+;;                                     v104 = iadd.i32 v13, v102
+;; @001f                               store notrap aligned v104, v12
+;;                                     v118 = iconst.i32 -1476395002
+;;                                     v119 = load.i64 notrap aligned readonly can_move region0 v0+8
+;;                                     v120 = load.i64 notrap aligned readonly can_move v119+32
+;; @001f                               v37 = iadd v120, v20
+;; @001f                               store notrap aligned v118, v37  ; v118 = -1476395002
+;;                                     v121 = load.i64 notrap aligned readonly can_move region2 v0+40
+;;                                     v122 = load.i32 notrap aligned readonly can_move v121
+;; @001f                               store notrap aligned v122, v37+4
+;;                                     v123 = band.i64 v18, v17  ; v17 = -16
+;; @001f                               istore32 notrap aligned v123, v37+8
 ;; @001f                               jump block4(v13, v37)
 ;;
 ;;                                 block3 cold:
@@ -81,33 +77,33 @@
 ;; @001f                               jump block4(v28, v32)
 ;;
 ;;                                 block4(v41: i32, v42: i64):
-;;                                     v88 = stack_addr.i64 ss0
-;;                                     store notrap v41, v88
+;;                                     v89 = stack_addr.i64 ss0
+;;                                     store notrap v41, v89
 ;; @001f                               v43 = iconst.i64 16
 ;; @001f                               v44 = iadd v42, v43  ; v43 = 16
 ;; @001f                               store.i32 user2 region3 v2, v44
 ;; @001f                               trapz v41, user16
-;;                                     v125 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v126 = load.i64 notrap aligned readonly can_move v125+32
+;;                                     v124 = load.i64 notrap aligned readonly can_move region0 v0+8
+;;                                     v125 = load.i64 notrap aligned readonly can_move v124+32
 ;; @001f                               v47 = uextend.i64 v41
-;; @001f                               v49 = iadd v126, v47
-;; @001f                               v51 = iadd v49, v43  ; v43 = 16
-;; @001f                               v52 = load.i32 user2 readonly region3 v51
-;; @001f                               v53 = uextend.i64 v52
-;; @001f                               v59 = icmp.i64 ugt v5, v53
-;; @001f                               trapnz v59, user17
-;; @001f                               v76 = load.i64 notrap aligned v125+40
-;; @001f                               v64 = iconst.i64 20
-;; @001f                               v65 = iadd v49, v64  ; v64 = 20
-;; @001f                               v78 = uadd_overflow_trap v65, v5, user2
-;; @001f                               v77 = iadd v126, v76
-;; @001f                               v79 = icmp ugt v78, v77
-;; @001f                               trapnz v79, user2
+;; @001f                               v50 = iadd v125, v47
+;; @001f                               v52 = iadd v50, v43  ; v43 = 16
+;; @001f                               v53 = load.i32 user2 readonly region3 v52
+;; @001f                               v54 = uextend.i64 v53
+;; @001f                               v60 = icmp.i64 ugt v5, v54
+;; @001f                               trapnz v60, user17
+;; @001f                               v77 = load.i64 notrap aligned v124+40
+;; @001f                               v65 = iconst.i64 20
+;; @001f                               v66 = iadd v50, v65  ; v65 = 20
+;; @001f                               v79 = uadd_overflow_trap v66, v5, user2
+;; @001f                               v78 = iadd v125, v77
+;; @001f                               v80 = icmp ugt v79, v78
+;; @001f                               trapnz v80, user2
 ;; @001f                               v45 = iconst.i32 0
-;; @001f                               call fn1(v0, v65, v45, v5), stack_map=[i32 @ ss0+0]  ; v45 = 0
-;;                                     v81 = load.i32 notrap v88
+;; @001f                               call fn1(v0, v66, v45, v5), stack_map=[i32 @ ss0+0]  ; v45 = 0
+;;                                     v82 = load.i32 notrap v89
 ;; @0022                               jump block1
 ;;
 ;;                                 block1:
-;; @0022                               return v81
+;; @0022                               return v82
 ;; }

--- a/tests/disas/gc/copying/array-fill.wat
+++ b/tests/disas/gc/copying/array-fill.wat
@@ -14,50 +14,46 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i64, v5: i32):
 ;; @0027                               trapz v2, user16
-;; @0027                               v46 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0027                               v7 = load.i64 notrap aligned readonly can_move v46+32
+;; @0027                               v7 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @0027                               v8 = load.i64 notrap aligned readonly can_move v7+32
 ;; @0027                               v6 = uextend.i64 v2
-;; @0027                               v8 = iadd v7, v6
-;; @0027                               v9 = iconst.i64 16
-;; @0027                               v10 = iadd v8, v9  ; v9 = 16
-;; @0027                               v11 = load.i32 user2 readonly region1 v10
-;; @0027                               v13 = uextend.i64 v3
-;; @0027                               v14 = uextend.i64 v5
-;; @0027                               v17 = iadd v13, v14
-;; @0027                               v12 = uextend.i64 v11
-;; @0027                               v18 = icmp ugt v17, v12
-;; @0027                               trapnz v18, user17
-;; @0027                               v35 = load.i64 notrap aligned v46+40
-;; @0027                               v23 = iconst.i64 24
-;; @0027                               v24 = iadd v8, v23  ; v23 = 24
-;;                                     v50 = iconst.i64 3
-;;                                     v51 = ishl v13, v50  ; v50 = 3
-;; @0027                               v28 = iadd v24, v51
-;;                                     v53 = ishl v14, v50  ; v50 = 3
-;; @0027                               v37 = uadd_overflow_trap v28, v53, user2
-;; @0027                               v36 = iadd v7, v35
-;; @0027                               v38 = icmp ugt v37, v36
-;; @0027                               trapnz v38, user2
-;;                                     v48 = iconst.i64 0
-;; @0027                               v41 = icmp eq v14, v48  ; v48 = 0
-;; @0027                               v26 = iconst.i64 8
-;; @0027                               v39 = iadd v28, v53
-;; @0027                               brif v41, block3, block2(v28)
+;; @0027                               v9 = iadd v8, v6
+;; @0027                               v10 = iconst.i64 16
+;; @0027                               v11 = iadd v9, v10  ; v10 = 16
+;; @0027                               v12 = load.i32 user2 readonly region1 v11
+;; @0027                               v14 = uextend.i64 v3
+;; @0027                               v15 = uextend.i64 v5
+;; @0027                               v18 = iadd v14, v15
+;; @0027                               v13 = uextend.i64 v12
+;; @0027                               v19 = icmp ugt v18, v13
+;; @0027                               trapnz v19, user17
+;; @0027                               v36 = load.i64 notrap aligned v7+40
+;; @0027                               v24 = iconst.i64 24
+;; @0027                               v25 = iadd v9, v24  ; v24 = 24
+;;                                     v49 = iconst.i64 3
+;;                                     v50 = ishl v14, v49  ; v49 = 3
+;; @0027                               v29 = iadd v25, v50
+;;                                     v52 = ishl v15, v49  ; v49 = 3
+;; @0027                               v38 = uadd_overflow_trap v29, v52, user2
+;; @0027                               v37 = iadd v8, v36
+;; @0027                               v39 = icmp ugt v38, v37
+;; @0027                               trapnz v39, user2
+;;                                     v47 = iconst.i64 0
+;; @0027                               v42 = icmp eq v15, v47  ; v47 = 0
+;; @0027                               v27 = iconst.i64 8
+;; @0027                               v40 = iadd v29, v52
+;; @0027                               brif v42, block3, block2(v29)
 ;;
-;;                                 block2(v42: i64):
-;; @0027                               store.i64 user2 little region1 v4, v42
-;;                                     v55 = iconst.i64 8
-;;                                     v56 = iadd v42, v55  ; v55 = 8
-;; @0027                               v45 = icmp eq v56, v39
-;; @0027                               brif v45, block3, block2(v56)
+;;                                 block2(v43: i64):
+;; @0027                               store.i64 user2 little region1 v4, v43
+;;                                     v54 = iconst.i64 8
+;;                                     v55 = iadd v43, v54  ; v54 = 8
+;; @0027                               v46 = icmp eq v55, v40
+;; @0027                               brif v46, block3, block2(v55)
 ;;
 ;;                                 block3:
 ;; @002a                               jump block1

--- a/tests/disas/gc/copying/array-get-s.wat
+++ b/tests/disas/gc/copying/array-get-s.wat
@@ -14,40 +14,36 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0022                               trapz v2, user16
-;; @0022                               v34 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0022                               v6 = load.i64 notrap aligned readonly can_move v34+32
+;; @0022                               v6 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @0022                               v7 = load.i64 notrap aligned readonly can_move v6+32
 ;; @0022                               v5 = uextend.i64 v2
-;; @0022                               v7 = iadd v6, v5
-;; @0022                               v8 = iconst.i64 16
-;; @0022                               v9 = iadd v7, v8  ; v8 = 16
-;; @0022                               v10 = load.i32 user2 readonly region1 v9
-;; @0022                               v11 = icmp ult v3, v10
-;; @0022                               trapz v11, user17
-;; @0022                               v13 = uextend.i64 v10
-;; @0022                               v15 = iconst.i64 32
-;; @0022                               v16 = ushr v13, v15  ; v15 = 32
-;; @0022                               trapnz v16, user2
-;; @0022                               v18 = iconst.i32 20
-;; @0022                               v19 = uadd_overflow_trap v10, v18, user2  ; v18 = 20
-;; @0022                               v23 = uadd_overflow_trap v2, v19, user2
-;; @0022                               v24 = uextend.i64 v23
-;; @0022                               v26 = iadd v6, v24
-;; @0022                               v22 = iadd v3, v18  ; v18 = 20
-;; @0022                               v27 = isub v19, v22
-;; @0022                               v28 = uextend.i64 v27
-;; @0022                               v29 = isub v26, v28
-;; @0022                               v30 = load.i8 user2 little region1 v29
+;; @0022                               v8 = iadd v7, v5
+;; @0022                               v9 = iconst.i64 16
+;; @0022                               v10 = iadd v8, v9  ; v9 = 16
+;; @0022                               v11 = load.i32 user2 readonly region1 v10
+;; @0022                               v12 = icmp ult v3, v11
+;; @0022                               trapz v12, user17
+;; @0022                               v14 = uextend.i64 v11
+;; @0022                               v16 = iconst.i64 32
+;; @0022                               v17 = ushr v14, v16  ; v16 = 32
+;; @0022                               trapnz v17, user2
+;; @0022                               v19 = iconst.i32 20
+;; @0022                               v20 = uadd_overflow_trap v11, v19, user2  ; v19 = 20
+;; @0022                               v24 = uadd_overflow_trap v2, v20, user2
+;; @0022                               v25 = uextend.i64 v24
+;; @0022                               v28 = iadd v7, v25
+;; @0022                               v23 = iadd v3, v19  ; v19 = 20
+;; @0022                               v29 = isub v20, v23
+;; @0022                               v30 = uextend.i64 v29
+;; @0022                               v31 = isub v28, v30
+;; @0022                               v32 = load.i8 user2 little region1 v31
 ;; @0025                               jump block1
 ;;
 ;;                                 block1:
-;; @0022                               v31 = sextend.i32 v30
-;; @0025                               return v31
+;; @0022                               v33 = sextend.i32 v32
+;; @0025                               return v33
 ;; }

--- a/tests/disas/gc/copying/array-get-u.wat
+++ b/tests/disas/gc/copying/array-get-u.wat
@@ -14,40 +14,36 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0022                               trapz v2, user16
-;; @0022                               v34 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0022                               v6 = load.i64 notrap aligned readonly can_move v34+32
+;; @0022                               v6 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @0022                               v7 = load.i64 notrap aligned readonly can_move v6+32
 ;; @0022                               v5 = uextend.i64 v2
-;; @0022                               v7 = iadd v6, v5
-;; @0022                               v8 = iconst.i64 16
-;; @0022                               v9 = iadd v7, v8  ; v8 = 16
-;; @0022                               v10 = load.i32 user2 readonly region1 v9
-;; @0022                               v11 = icmp ult v3, v10
-;; @0022                               trapz v11, user17
-;; @0022                               v13 = uextend.i64 v10
-;; @0022                               v15 = iconst.i64 32
-;; @0022                               v16 = ushr v13, v15  ; v15 = 32
-;; @0022                               trapnz v16, user2
-;; @0022                               v18 = iconst.i32 20
-;; @0022                               v19 = uadd_overflow_trap v10, v18, user2  ; v18 = 20
-;; @0022                               v23 = uadd_overflow_trap v2, v19, user2
-;; @0022                               v24 = uextend.i64 v23
-;; @0022                               v26 = iadd v6, v24
-;; @0022                               v22 = iadd v3, v18  ; v18 = 20
-;; @0022                               v27 = isub v19, v22
-;; @0022                               v28 = uextend.i64 v27
-;; @0022                               v29 = isub v26, v28
-;; @0022                               v30 = load.i8 user2 little region1 v29
+;; @0022                               v8 = iadd v7, v5
+;; @0022                               v9 = iconst.i64 16
+;; @0022                               v10 = iadd v8, v9  ; v9 = 16
+;; @0022                               v11 = load.i32 user2 readonly region1 v10
+;; @0022                               v12 = icmp ult v3, v11
+;; @0022                               trapz v12, user17
+;; @0022                               v14 = uextend.i64 v11
+;; @0022                               v16 = iconst.i64 32
+;; @0022                               v17 = ushr v14, v16  ; v16 = 32
+;; @0022                               trapnz v17, user2
+;; @0022                               v19 = iconst.i32 20
+;; @0022                               v20 = uadd_overflow_trap v11, v19, user2  ; v19 = 20
+;; @0022                               v24 = uadd_overflow_trap v2, v20, user2
+;; @0022                               v25 = uextend.i64 v24
+;; @0022                               v28 = iadd v7, v25
+;; @0022                               v23 = iadd v3, v19  ; v19 = 20
+;; @0022                               v29 = isub v20, v23
+;; @0022                               v30 = uextend.i64 v29
+;; @0022                               v31 = isub v28, v30
+;; @0022                               v32 = load.i8 user2 little region1 v31
 ;; @0025                               jump block1
 ;;
 ;;                                 block1:
-;; @0022                               v31 = uextend.i32 v30
-;; @0025                               return v31
+;; @0022                               v33 = uextend.i32 v32
+;; @0025                               return v33
 ;; }

--- a/tests/disas/gc/copying/array-get.wat
+++ b/tests/disas/gc/copying/array-get.wat
@@ -14,44 +14,40 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0022                               trapz v2, user16
-;; @0022                               v33 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0022                               v6 = load.i64 notrap aligned readonly can_move v33+32
+;; @0022                               v6 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @0022                               v7 = load.i64 notrap aligned readonly can_move v6+32
 ;; @0022                               v5 = uextend.i64 v2
-;; @0022                               v7 = iadd v6, v5
-;; @0022                               v8 = iconst.i64 16
-;; @0022                               v9 = iadd v7, v8  ; v8 = 16
-;; @0022                               v10 = load.i32 user2 readonly region1 v9
-;; @0022                               v11 = icmp ult v3, v10
-;; @0022                               trapz v11, user17
-;; @0022                               v13 = uextend.i64 v10
-;;                                     v35 = iconst.i64 3
-;;                                     v36 = ishl v13, v35  ; v35 = 3
-;; @0022                               v15 = iconst.i64 32
-;; @0022                               v16 = ushr v36, v15  ; v15 = 32
-;; @0022                               trapnz v16, user2
-;;                                     v45 = iconst.i32 3
-;;                                     v46 = ishl v10, v45  ; v45 = 3
-;; @0022                               v18 = iconst.i32 24
-;; @0022                               v19 = uadd_overflow_trap v46, v18, user2  ; v18 = 24
-;; @0022                               v23 = uadd_overflow_trap v2, v19, user2
-;; @0022                               v24 = uextend.i64 v23
-;; @0022                               v26 = iadd v6, v24
-;;                                     v52 = ishl v3, v45  ; v45 = 3
-;; @0022                               v22 = iadd v52, v18  ; v18 = 24
-;; @0022                               v27 = isub v19, v22
-;; @0022                               v28 = uextend.i64 v27
-;; @0022                               v29 = isub v26, v28
-;; @0022                               v30 = load.i64 user2 little region1 v29
+;; @0022                               v8 = iadd v7, v5
+;; @0022                               v9 = iconst.i64 16
+;; @0022                               v10 = iadd v8, v9  ; v9 = 16
+;; @0022                               v11 = load.i32 user2 readonly region1 v10
+;; @0022                               v12 = icmp ult v3, v11
+;; @0022                               trapz v12, user17
+;; @0022                               v14 = uextend.i64 v11
+;;                                     v33 = iconst.i64 3
+;;                                     v34 = ishl v14, v33  ; v33 = 3
+;; @0022                               v16 = iconst.i64 32
+;; @0022                               v17 = ushr v34, v16  ; v16 = 32
+;; @0022                               trapnz v17, user2
+;;                                     v43 = iconst.i32 3
+;;                                     v44 = ishl v11, v43  ; v43 = 3
+;; @0022                               v19 = iconst.i32 24
+;; @0022                               v20 = uadd_overflow_trap v44, v19, user2  ; v19 = 24
+;; @0022                               v24 = uadd_overflow_trap v2, v20, user2
+;; @0022                               v25 = uextend.i64 v24
+;; @0022                               v28 = iadd v7, v25
+;;                                     v50 = ishl v3, v43  ; v43 = 3
+;; @0022                               v23 = iadd v50, v19  ; v19 = 24
+;; @0022                               v29 = isub v20, v23
+;; @0022                               v30 = uextend.i64 v29
+;; @0022                               v31 = isub v28, v30
+;; @0022                               v32 = load.i64 user2 little region1 v31
 ;; @0025                               jump block1
 ;;
 ;;                                 block1:
-;; @0025                               return v30
+;; @0025                               return v32
 ;; }

--- a/tests/disas/gc/copying/array-len.wat
+++ b/tests/disas/gc/copying/array-len.wat
@@ -14,23 +14,19 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @001f                               trapz v2, user16
-;; @001f                               v10 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @001f                               v5 = load.i64 notrap aligned readonly can_move v10+32
+;; @001f                               v5 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @001f                               v6 = load.i64 notrap aligned readonly can_move v5+32
 ;; @001f                               v4 = uextend.i64 v2
-;; @001f                               v6 = iadd v5, v4
-;; @001f                               v7 = iconst.i64 16
-;; @001f                               v8 = iadd v6, v7  ; v7 = 16
-;; @001f                               v9 = load.i32 user2 readonly region1 v8
+;; @001f                               v7 = iadd v6, v4
+;; @001f                               v8 = iconst.i64 16
+;; @001f                               v9 = iadd v7, v8  ; v8 = 16
+;; @001f                               v10 = load.i32 user2 readonly region1 v9
 ;; @0021                               jump block1
 ;;
 ;;                                 block1:
-;; @0021                               return v9
+;; @0021                               return v10
 ;; }

--- a/tests/disas/gc/copying/array-new-fixed-of-gc-refs.wat
+++ b/tests/disas/gc/copying/array-new-fixed-of-gc-refs.wat
@@ -19,21 +19,17 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
 ;;     fn0 = colocated u805306368:24 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
-;;                                     v132 = stack_addr.i64 ss2
-;;                                     store notrap v2, v132
-;;                                     v133 = stack_addr.i64 ss1
-;;                                     store notrap v3, v133
-;;                                     v134 = stack_addr.i64 ss0
-;;                                     store notrap v4, v134
+;;                                     v138 = stack_addr.i64 ss2
+;;                                     store notrap v2, v138
+;;                                     v139 = stack_addr.i64 ss1
+;;                                     store notrap v3, v139
+;;                                     v140 = stack_addr.i64 ss0
+;;                                     store notrap v4, v140
 ;; @0025                               v15 = load.i64 notrap aligned readonly can_move region1 v0+32
 ;; @0025                               v16 = load.i32 notrap aligned v15
 ;; @0025                               v17 = load.i32 notrap aligned v15+4
@@ -45,28 +41,28 @@
 ;; @0025                               brif v26, block2, block3
 ;;
 ;;                                 block2:
-;;                                     v266 = iconst.i32 32
-;;                                     v172 = iadd.i32 v16, v266  ; v266 = 32
-;; @0025                               store notrap aligned v172, v15
-;;                                     v267 = iconst.i32 -1476394994
-;;                                     v268 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v269 = load.i64 notrap aligned readonly can_move v268+32
-;; @0025                               v40 = iadd v269, v23
-;; @0025                               store notrap aligned v267, v40  ; v267 = -1476394994
-;;                                     v270 = load.i64 notrap aligned readonly can_move region2 v0+40
-;;                                     v271 = load.i32 notrap aligned readonly can_move v270
-;; @0025                               store notrap aligned v271, v40+4
-;;                                     v272 = iconst.i64 32
-;; @0025                               istore32 notrap aligned v272, v40+8  ; v272 = 32
+;;                                     v260 = iconst.i32 32
+;;                                     v166 = iadd.i32 v16, v260  ; v260 = 32
+;; @0025                               store notrap aligned v166, v15
+;;                                     v261 = iconst.i32 -1476394994
+;;                                     v262 = load.i64 notrap aligned readonly can_move region0 v0+8
+;;                                     v263 = load.i64 notrap aligned readonly can_move v262+32
+;; @0025                               v40 = iadd v263, v23
+;; @0025                               store notrap aligned v261, v40  ; v261 = -1476394994
+;;                                     v264 = load.i64 notrap aligned readonly can_move region2 v0+40
+;;                                     v265 = load.i32 notrap aligned readonly can_move v264
+;; @0025                               store notrap aligned v265, v40+4
+;;                                     v266 = iconst.i64 32
+;; @0025                               istore32 notrap aligned v266, v40+8  ; v266 = 32
 ;; @0025                               jump block4(v16, v40)
 ;;
 ;;                                 block3 cold:
 ;; @0025                               v27 = iconst.i32 -1476394994
 ;; @0025                               v28 = load.i64 notrap aligned readonly can_move region2 v0+40
 ;; @0025                               v29 = load.i32 notrap aligned readonly can_move v28
-;;                                     v158 = iconst.i32 32
+;;                                     v152 = iconst.i32 32
 ;; @0025                               v30 = iconst.i32 16
-;; @0025                               v31 = call fn0(v0, v27, v29, v158, v30), stack_map=[i32 @ ss2+0, i32 @ ss1+0, i32 @ ss0+0]  ; v27 = -1476394994, v158 = 32, v30 = 16
+;; @0025                               v31 = call fn0(v0, v27, v29, v152, v30), stack_map=[i32 @ ss2+0, i32 @ ss1+0, i32 @ ss0+0]  ; v27 = -1476394994, v152 = 32, v30 = 16
 ;; @0025                               v32 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @0025                               v33 = load.i64 notrap aligned readonly can_move v32+32
 ;; @0025                               v34 = uextend.i64 v31
@@ -79,68 +75,68 @@
 ;; @0025                               v47 = iadd v45, v46  ; v46 = 16
 ;; @0025                               store user2 region3 v6, v47  ; v6 = 3
 ;; @0025                               trapz v44, user16
-;;                                     v273 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v274 = load.i64 notrap aligned readonly can_move v273+32
+;;                                     v267 = load.i64 notrap aligned readonly can_move region0 v0+8
+;;                                     v268 = load.i64 notrap aligned readonly can_move v267+32
 ;; @0025                               v49 = uextend.i64 v44
-;; @0025                               v51 = iadd v274, v49
-;; @0025                               v53 = iadd v51, v46  ; v46 = 16
-;; @0025                               v54 = load.i32 user2 readonly region3 v53
-;; @0025                               trapz v54, user17
-;; @0025                               v57 = uextend.i64 v54
-;;                                     v149 = iconst.i64 2
-;;                                     v178 = ishl v57, v149  ; v149 = 2
-;;                                     v275 = iconst.i64 32
-;;                                     v276 = ushr v178, v275  ; v275 = 32
-;; @0025                               trapnz v276, user2
-;;                                     v187 = iconst.i32 2
-;;                                     v188 = ishl v54, v187  ; v187 = 2
+;; @0025                               v52 = iadd v268, v49
+;; @0025                               v54 = iadd v52, v46  ; v46 = 16
+;; @0025                               v55 = load.i32 user2 readonly region3 v54
+;; @0025                               trapz v55, user17
+;; @0025                               v58 = uextend.i64 v55
+;;                                     v143 = iconst.i64 2
+;;                                     v172 = ishl v58, v143  ; v143 = 2
+;;                                     v269 = iconst.i64 32
+;;                                     v270 = ushr v172, v269  ; v269 = 32
+;; @0025                               trapnz v270, user2
+;;                                     v181 = iconst.i32 2
+;;                                     v182 = ishl v55, v181  ; v181 = 2
 ;; @0025                               v7 = iconst.i32 20
-;; @0025                               v63 = uadd_overflow_trap v188, v7, user2  ; v7 = 20
-;; @0025                               v67 = uadd_overflow_trap v44, v63, user2
-;;                                     v131 = load.i32 notrap v132
-;; @0025                               v68 = uextend.i64 v67
-;; @0025                               v70 = iadd v274, v68
-;; @0025                               v71 = isub v63, v7  ; v7 = 20
-;; @0025                               v72 = uextend.i64 v71
-;; @0025                               v73 = isub v70, v72
-;; @0025                               store user2 little region3 v131, v73
-;; @0025                               v80 = load.i32 user2 readonly region3 v53
-;; @0025                               v74 = iconst.i32 1
-;;                                     v205 = icmp ugt v80, v74  ; v74 = 1
-;; @0025                               trapz v205, user17
-;; @0025                               v83 = uextend.i64 v80
-;;                                     v207 = ishl v83, v149  ; v149 = 2
-;;                                     v277 = ushr v207, v275  ; v275 = 32
-;; @0025                               trapnz v277, user2
-;;                                     v214 = ishl v80, v187  ; v187 = 2
-;; @0025                               v89 = uadd_overflow_trap v214, v7, user2  ; v7 = 20
-;; @0025                               v93 = uadd_overflow_trap v44, v89, user2
-;;                                     v129 = load.i32 notrap v133
-;; @0025                               v94 = uextend.i64 v93
-;; @0025                               v96 = iadd v274, v94
-;;                                     v227 = iconst.i32 24
-;; @0025                               v97 = isub v89, v227  ; v227 = 24
-;; @0025                               v98 = uextend.i64 v97
-;; @0025                               v99 = isub v96, v98
-;; @0025                               store user2 little region3 v129, v99
-;; @0025                               v106 = load.i32 user2 readonly region3 v53
-;;                                     v233 = icmp ugt v106, v187  ; v187 = 2
-;; @0025                               trapz v233, user17
-;; @0025                               v109 = uextend.i64 v106
-;;                                     v235 = ishl v109, v149  ; v149 = 2
-;;                                     v278 = ushr v235, v275  ; v275 = 32
-;; @0025                               trapnz v278, user2
-;;                                     v242 = ishl v106, v187  ; v187 = 2
-;; @0025                               v115 = uadd_overflow_trap v242, v7, user2  ; v7 = 20
-;; @0025                               v119 = uadd_overflow_trap v44, v115, user2
-;;                                     v127 = load.i32 notrap v134
-;; @0025                               v120 = uextend.i64 v119
-;; @0025                               v122 = iadd v274, v120
-;;                                     v260 = iconst.i32 28
-;; @0025                               v123 = isub v115, v260  ; v260 = 28
-;; @0025                               v124 = uextend.i64 v123
-;; @0025                               v125 = isub v122, v124
-;; @0025                               store user2 little region3 v127, v125
+;; @0025                               v64 = uadd_overflow_trap v182, v7, user2  ; v7 = 20
+;; @0025                               v68 = uadd_overflow_trap v44, v64, user2
+;;                                     v137 = load.i32 notrap v138
+;; @0025                               v69 = uextend.i64 v68
+;; @0025                               v72 = iadd v268, v69
+;; @0025                               v73 = isub v64, v7  ; v7 = 20
+;; @0025                               v74 = uextend.i64 v73
+;; @0025                               v75 = isub v72, v74
+;; @0025                               store user2 little region3 v137, v75
+;; @0025                               v83 = load.i32 user2 readonly region3 v54
+;; @0025                               v76 = iconst.i32 1
+;;                                     v199 = icmp ugt v83, v76  ; v76 = 1
+;; @0025                               trapz v199, user17
+;; @0025                               v86 = uextend.i64 v83
+;;                                     v201 = ishl v86, v143  ; v143 = 2
+;;                                     v271 = ushr v201, v269  ; v269 = 32
+;; @0025                               trapnz v271, user2
+;;                                     v208 = ishl v83, v181  ; v181 = 2
+;; @0025                               v92 = uadd_overflow_trap v208, v7, user2  ; v7 = 20
+;; @0025                               v96 = uadd_overflow_trap v44, v92, user2
+;;                                     v135 = load.i32 notrap v139
+;; @0025                               v97 = uextend.i64 v96
+;; @0025                               v100 = iadd v268, v97
+;;                                     v221 = iconst.i32 24
+;; @0025                               v101 = isub v92, v221  ; v221 = 24
+;; @0025                               v102 = uextend.i64 v101
+;; @0025                               v103 = isub v100, v102
+;; @0025                               store user2 little region3 v135, v103
+;; @0025                               v111 = load.i32 user2 readonly region3 v54
+;;                                     v227 = icmp ugt v111, v181  ; v181 = 2
+;; @0025                               trapz v227, user17
+;; @0025                               v114 = uextend.i64 v111
+;;                                     v229 = ishl v114, v143  ; v143 = 2
+;;                                     v272 = ushr v229, v269  ; v269 = 32
+;; @0025                               trapnz v272, user2
+;;                                     v236 = ishl v111, v181  ; v181 = 2
+;; @0025                               v120 = uadd_overflow_trap v236, v7, user2  ; v7 = 20
+;; @0025                               v124 = uadd_overflow_trap v44, v120, user2
+;;                                     v133 = load.i32 notrap v140
+;; @0025                               v125 = uextend.i64 v124
+;; @0025                               v128 = iadd v268, v125
+;;                                     v254 = iconst.i32 28
+;; @0025                               v129 = isub v120, v254  ; v254 = 28
+;; @0025                               v130 = uextend.i64 v129
+;; @0025                               v131 = isub v128, v130
+;; @0025                               store user2 little region3 v133, v131
 ;; @0029                               jump block1(v44)
 ;;
 ;;                                 block1(v5: i32):

--- a/tests/disas/gc/copying/array-new-fixed.wat
+++ b/tests/disas/gc/copying/array-new-fixed.wat
@@ -16,10 +16,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
 ;;     fn0 = colocated u805306368:24 sig0
 ;;     stack_limit = gv2
@@ -29,35 +25,35 @@
 ;; @0025                               v16 = load.i32 notrap aligned v15
 ;; @0025                               v17 = load.i32 notrap aligned v15+4
 ;; @0025                               v23 = uextend.i64 v16
-;;                                     v148 = iconst.i64 48
-;; @0025                               v24 = iadd v23, v148  ; v148 = 48
+;;                                     v142 = iconst.i64 48
+;; @0025                               v24 = iadd v23, v142  ; v142 = 48
 ;; @0025                               v25 = uextend.i64 v17
 ;; @0025                               v26 = icmp ule v24, v25
 ;; @0025                               brif v26, block2, block3
 ;;
 ;;                                 block2:
-;;                                     v254 = iconst.i32 48
-;;                                     v162 = iadd.i32 v16, v254  ; v254 = 48
-;; @0025                               store notrap aligned v162, v15
-;;                                     v255 = iconst.i32 -1476395002
-;;                                     v256 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v257 = load.i64 notrap aligned readonly can_move v256+32
-;; @0025                               v40 = iadd v257, v23
-;; @0025                               store notrap aligned v255, v40  ; v255 = -1476395002
-;;                                     v258 = load.i64 notrap aligned readonly can_move region2 v0+40
-;;                                     v259 = load.i32 notrap aligned readonly can_move v258
-;; @0025                               store notrap aligned v259, v40+4
-;;                                     v260 = iconst.i64 48
-;; @0025                               istore32 notrap aligned v260, v40+8  ; v260 = 48
+;;                                     v248 = iconst.i32 48
+;;                                     v156 = iadd.i32 v16, v248  ; v248 = 48
+;; @0025                               store notrap aligned v156, v15
+;;                                     v249 = iconst.i32 -1476395002
+;;                                     v250 = load.i64 notrap aligned readonly can_move region0 v0+8
+;;                                     v251 = load.i64 notrap aligned readonly can_move v250+32
+;; @0025                               v40 = iadd v251, v23
+;; @0025                               store notrap aligned v249, v40  ; v249 = -1476395002
+;;                                     v252 = load.i64 notrap aligned readonly can_move region2 v0+40
+;;                                     v253 = load.i32 notrap aligned readonly can_move v252
+;; @0025                               store notrap aligned v253, v40+4
+;;                                     v254 = iconst.i64 48
+;; @0025                               istore32 notrap aligned v254, v40+8  ; v254 = 48
 ;; @0025                               jump block4(v16, v40)
 ;;
 ;;                                 block3 cold:
 ;; @0025                               v27 = iconst.i32 -1476395002
 ;; @0025                               v28 = load.i64 notrap aligned readonly can_move region2 v0+40
 ;; @0025                               v29 = load.i32 notrap aligned readonly can_move v28
-;;                                     v147 = iconst.i32 48
+;;                                     v141 = iconst.i32 48
 ;; @0025                               v30 = iconst.i32 16
-;; @0025                               v31 = call fn0(v0, v27, v29, v147, v30)  ; v27 = -1476395002, v147 = 48, v30 = 16
+;; @0025                               v31 = call fn0(v0, v27, v29, v141, v30)  ; v27 = -1476395002, v141 = 48, v30 = 16
 ;; @0025                               v32 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @0025                               v33 = load.i64 notrap aligned readonly can_move v32+32
 ;; @0025                               v34 = uextend.i64 v31
@@ -70,65 +66,65 @@
 ;; @0025                               v47 = iadd v45, v46  ; v46 = 16
 ;; @0025                               store user2 region3 v6, v47  ; v6 = 3
 ;; @0025                               trapz v44, user16
-;;                                     v261 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v262 = load.i64 notrap aligned readonly can_move v261+32
+;;                                     v255 = load.i64 notrap aligned readonly can_move region0 v0+8
+;;                                     v256 = load.i64 notrap aligned readonly can_move v255+32
 ;; @0025                               v49 = uextend.i64 v44
-;; @0025                               v51 = iadd v262, v49
-;; @0025                               v53 = iadd v51, v46  ; v46 = 16
-;; @0025                               v54 = load.i32 user2 readonly region3 v53
-;; @0025                               trapz v54, user17
-;; @0025                               v57 = uextend.i64 v54
-;;                                     v138 = iconst.i64 3
-;;                                     v168 = ishl v57, v138  ; v138 = 3
+;; @0025                               v52 = iadd v256, v49
+;; @0025                               v54 = iadd v52, v46  ; v46 = 16
+;; @0025                               v55 = load.i32 user2 readonly region3 v54
+;; @0025                               trapz v55, user17
+;; @0025                               v58 = uextend.i64 v55
+;;                                     v132 = iconst.i64 3
+;;                                     v162 = ishl v58, v132  ; v132 = 3
 ;; @0025                               v11 = iconst.i64 32
-;; @0025                               v60 = ushr v168, v11  ; v11 = 32
-;; @0025                               trapnz v60, user2
-;;                                     v177 = ishl v54, v6  ; v6 = 3
+;; @0025                               v61 = ushr v162, v11  ; v11 = 32
+;; @0025                               trapnz v61, user2
+;;                                     v171 = ishl v55, v6  ; v6 = 3
 ;; @0025                               v7 = iconst.i32 24
-;; @0025                               v63 = uadd_overflow_trap v177, v7, user2  ; v7 = 24
-;; @0025                               v67 = uadd_overflow_trap v44, v63, user2
-;; @0025                               v68 = uextend.i64 v67
-;; @0025                               v70 = iadd v262, v68
-;; @0025                               v71 = isub v63, v7  ; v7 = 24
-;; @0025                               v72 = uextend.i64 v71
-;; @0025                               v73 = isub v70, v72
-;; @0025                               store.i64 user2 little region3 v2, v73
-;; @0025                               v80 = load.i32 user2 readonly region3 v53
-;; @0025                               v74 = iconst.i32 1
-;;                                     v194 = icmp ugt v80, v74  ; v74 = 1
-;; @0025                               trapz v194, user17
-;; @0025                               v83 = uextend.i64 v80
-;;                                     v196 = ishl v83, v138  ; v138 = 3
-;; @0025                               v86 = ushr v196, v11  ; v11 = 32
-;; @0025                               trapnz v86, user2
-;;                                     v203 = ishl v80, v6  ; v6 = 3
-;; @0025                               v89 = uadd_overflow_trap v203, v7, user2  ; v7 = 24
-;; @0025                               v93 = uadd_overflow_trap v44, v89, user2
-;; @0025                               v94 = uextend.i64 v93
-;; @0025                               v96 = iadd v262, v94
-;;                                     v216 = iconst.i32 32
-;; @0025                               v97 = isub v89, v216  ; v216 = 32
-;; @0025                               v98 = uextend.i64 v97
-;; @0025                               v99 = isub v96, v98
-;; @0025                               store.i64 user2 little region3 v3, v99
-;; @0025                               v106 = load.i32 user2 readonly region3 v53
-;; @0025                               v100 = iconst.i32 2
-;;                                     v222 = icmp ugt v106, v100  ; v100 = 2
-;; @0025                               trapz v222, user17
-;; @0025                               v109 = uextend.i64 v106
-;;                                     v224 = ishl v109, v138  ; v138 = 3
-;; @0025                               v112 = ushr v224, v11  ; v11 = 32
-;; @0025                               trapnz v112, user2
-;;                                     v231 = ishl v106, v6  ; v6 = 3
-;; @0025                               v115 = uadd_overflow_trap v231, v7, user2  ; v7 = 24
-;; @0025                               v119 = uadd_overflow_trap v44, v115, user2
-;; @0025                               v120 = uextend.i64 v119
-;; @0025                               v122 = iadd v262, v120
-;;                                     v248 = iconst.i32 40
-;; @0025                               v123 = isub v115, v248  ; v248 = 40
-;; @0025                               v124 = uextend.i64 v123
-;; @0025                               v125 = isub v122, v124
-;; @0025                               store.i64 user2 little region3 v4, v125
+;; @0025                               v64 = uadd_overflow_trap v171, v7, user2  ; v7 = 24
+;; @0025                               v68 = uadd_overflow_trap v44, v64, user2
+;; @0025                               v69 = uextend.i64 v68
+;; @0025                               v72 = iadd v256, v69
+;; @0025                               v73 = isub v64, v7  ; v7 = 24
+;; @0025                               v74 = uextend.i64 v73
+;; @0025                               v75 = isub v72, v74
+;; @0025                               store.i64 user2 little region3 v2, v75
+;; @0025                               v83 = load.i32 user2 readonly region3 v54
+;; @0025                               v76 = iconst.i32 1
+;;                                     v188 = icmp ugt v83, v76  ; v76 = 1
+;; @0025                               trapz v188, user17
+;; @0025                               v86 = uextend.i64 v83
+;;                                     v190 = ishl v86, v132  ; v132 = 3
+;; @0025                               v89 = ushr v190, v11  ; v11 = 32
+;; @0025                               trapnz v89, user2
+;;                                     v197 = ishl v83, v6  ; v6 = 3
+;; @0025                               v92 = uadd_overflow_trap v197, v7, user2  ; v7 = 24
+;; @0025                               v96 = uadd_overflow_trap v44, v92, user2
+;; @0025                               v97 = uextend.i64 v96
+;; @0025                               v100 = iadd v256, v97
+;;                                     v210 = iconst.i32 32
+;; @0025                               v101 = isub v92, v210  ; v210 = 32
+;; @0025                               v102 = uextend.i64 v101
+;; @0025                               v103 = isub v100, v102
+;; @0025                               store.i64 user2 little region3 v3, v103
+;; @0025                               v111 = load.i32 user2 readonly region3 v54
+;; @0025                               v104 = iconst.i32 2
+;;                                     v216 = icmp ugt v111, v104  ; v104 = 2
+;; @0025                               trapz v216, user17
+;; @0025                               v114 = uextend.i64 v111
+;;                                     v218 = ishl v114, v132  ; v132 = 3
+;; @0025                               v117 = ushr v218, v11  ; v11 = 32
+;; @0025                               trapnz v117, user2
+;;                                     v225 = ishl v111, v6  ; v6 = 3
+;; @0025                               v120 = uadd_overflow_trap v225, v7, user2  ; v7 = 24
+;; @0025                               v124 = uadd_overflow_trap v44, v120, user2
+;; @0025                               v125 = uextend.i64 v124
+;; @0025                               v128 = iadd v256, v125
+;;                                     v242 = iconst.i32 40
+;; @0025                               v129 = isub v120, v242  ; v242 = 40
+;; @0025                               v130 = uextend.i64 v129
+;; @0025                               v131 = isub v128, v130
+;; @0025                               store.i64 user2 little region3 v4, v131
 ;; @0029                               jump block1(v44)
 ;;
 ;;                                 block1(v5: i32):

--- a/tests/disas/gc/copying/array-new.wat
+++ b/tests/disas/gc/copying/array-new.wat
@@ -16,25 +16,21 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
 ;;     fn0 = colocated u805306368:24 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0022                               v6 = uextend.i64 v3
-;;                                     v89 = iconst.i64 3
-;;                                     v90 = ishl v6, v89  ; v89 = 3
+;;                                     v88 = iconst.i64 3
+;;                                     v89 = ishl v6, v88  ; v88 = 3
 ;; @0022                               v9 = iconst.i64 32
-;; @0022                               v10 = ushr v90, v9  ; v9 = 32
+;; @0022                               v10 = ushr v89, v9  ; v9 = 32
 ;; @0022                               trapnz v10, user18
 ;; @0022                               v5 = iconst.i32 24
-;;                                     v96 = iconst.i32 3
-;;                                     v97 = ishl v3, v96  ; v96 = 3
-;; @0022                               v12 = uadd_overflow_trap v5, v97, user18  ; v5 = 24
+;;                                     v95 = iconst.i32 3
+;;                                     v96 = ishl v3, v95  ; v95 = 3
+;; @0022                               v12 = uadd_overflow_trap v5, v96, user18  ; v5 = 24
 ;; @0022                               v13 = load.i64 notrap aligned readonly can_move region1 v0+32
 ;; @0022                               v14 = load.i32 notrap aligned v13
 ;; @0022                               v15 = load.i32 notrap aligned v13+4
@@ -50,22 +46,22 @@
 ;; @0022                               brif v24, block2, block3
 ;;
 ;;                                 block2:
-;;                                     v105 = iconst.i32 15
-;;                                     v106 = iadd.i32 v12, v105  ; v105 = 15
-;;                                     v109 = iconst.i32 -16
-;;                                     v110 = band v106, v109  ; v109 = -16
-;;                                     v112 = iadd.i32 v14, v110
-;; @0022                               store notrap aligned v112, v13
-;;                                     v128 = iconst.i32 -1476395002
-;;                                     v129 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v130 = load.i64 notrap aligned readonly can_move v129+32
-;; @0022                               v38 = iadd v130, v21
-;; @0022                               store notrap aligned v128, v38  ; v128 = -1476395002
-;;                                     v131 = load.i64 notrap aligned readonly can_move region2 v0+40
-;;                                     v132 = load.i32 notrap aligned readonly can_move v131
-;; @0022                               store notrap aligned v132, v38+4
-;;                                     v133 = band.i64 v19, v18  ; v18 = -16
-;; @0022                               istore32 notrap aligned v133, v38+8
+;;                                     v104 = iconst.i32 15
+;;                                     v105 = iadd.i32 v12, v104  ; v104 = 15
+;;                                     v108 = iconst.i32 -16
+;;                                     v109 = band v105, v108  ; v108 = -16
+;;                                     v111 = iadd.i32 v14, v109
+;; @0022                               store notrap aligned v111, v13
+;;                                     v127 = iconst.i32 -1476395002
+;;                                     v128 = load.i64 notrap aligned readonly can_move region0 v0+8
+;;                                     v129 = load.i64 notrap aligned readonly can_move v128+32
+;; @0022                               v38 = iadd v129, v21
+;; @0022                               store notrap aligned v127, v38  ; v127 = -1476395002
+;;                                     v130 = load.i64 notrap aligned readonly can_move region2 v0+40
+;;                                     v131 = load.i32 notrap aligned readonly can_move v130
+;; @0022                               store notrap aligned v131, v38+4
+;;                                     v132 = band.i64 v19, v18  ; v18 = -16
+;; @0022                               istore32 notrap aligned v132, v38+8
 ;; @0022                               jump block4(v14, v38)
 ;;
 ;;                                 block3 cold:
@@ -85,34 +81,34 @@
 ;; @0022                               v45 = iadd v43, v44  ; v44 = 16
 ;; @0022                               store.i32 user2 region3 v3, v45
 ;; @0022                               trapz v42, user16
-;;                                     v134 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v135 = load.i64 notrap aligned readonly can_move v134+32
+;;                                     v133 = load.i64 notrap aligned readonly can_move region0 v0+8
+;;                                     v134 = load.i64 notrap aligned readonly can_move v133+32
 ;; @0022                               v47 = uextend.i64 v42
-;; @0022                               v49 = iadd v135, v47
-;; @0022                               v51 = iadd v49, v44  ; v44 = 16
-;; @0022                               v52 = load.i32 user2 readonly region3 v51
-;; @0022                               v53 = uextend.i64 v52
-;; @0022                               v59 = icmp.i64 ugt v6, v53
-;; @0022                               trapnz v59, user17
-;; @0022                               v76 = load.i64 notrap aligned v134+40
-;; @0022                               v64 = iconst.i64 24
-;; @0022                               v65 = iadd v49, v64  ; v64 = 24
-;; @0022                               v78 = uadd_overflow_trap v65, v90, user2
-;; @0022                               v77 = iadd v135, v76
-;; @0022                               v79 = icmp ugt v78, v77
-;; @0022                               trapnz v79, user2
-;;                                     v114 = iconst.i64 0
-;; @0022                               v82 = icmp.i64 eq v6, v114  ; v114 = 0
+;; @0022                               v50 = iadd v134, v47
+;; @0022                               v52 = iadd v50, v44  ; v44 = 16
+;; @0022                               v53 = load.i32 user2 readonly region3 v52
+;; @0022                               v54 = uextend.i64 v53
+;; @0022                               v60 = icmp.i64 ugt v6, v54
+;; @0022                               trapnz v60, user17
+;; @0022                               v77 = load.i64 notrap aligned v133+40
+;; @0022                               v65 = iconst.i64 24
+;; @0022                               v66 = iadd v50, v65  ; v65 = 24
+;; @0022                               v79 = uadd_overflow_trap v66, v89, user2
+;; @0022                               v78 = iadd v134, v77
+;; @0022                               v80 = icmp ugt v79, v78
+;; @0022                               trapnz v80, user2
+;;                                     v113 = iconst.i64 0
+;; @0022                               v83 = icmp.i64 eq v6, v113  ; v113 = 0
 ;; @0022                               v7 = iconst.i64 8
-;; @0022                               v80 = iadd v65, v90
-;; @0022                               brif v82, block6, block5(v65)
+;; @0022                               v81 = iadd v66, v89
+;; @0022                               brif v83, block6, block5(v66)
 ;;
-;;                                 block5(v83: i64):
-;; @0022                               store.i64 user2 little region3 v2, v83
-;;                                     v136 = iconst.i64 8
-;;                                     v137 = iadd v83, v136  ; v136 = 8
-;; @0022                               v86 = icmp eq v137, v80
-;; @0022                               brif v86, block6, block5(v137)
+;;                                 block5(v84: i64):
+;; @0022                               store.i64 user2 little region3 v2, v84
+;;                                     v135 = iconst.i64 8
+;;                                     v136 = iadd v84, v135  ; v135 = 8
+;; @0022                               v87 = icmp eq v136, v81
+;; @0022                               brif v87, block6, block5(v136)
 ;;
 ;;                                 block6:
 ;; @0025                               jump block1(v42)

--- a/tests/disas/gc/copying/array-set.wat
+++ b/tests/disas/gc/copying/array-set.wat
@@ -14,42 +14,38 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i64):
 ;; @0024                               trapz v2, user16
-;; @0024                               v32 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0024                               v6 = load.i64 notrap aligned readonly can_move v32+32
+;; @0024                               v6 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @0024                               v7 = load.i64 notrap aligned readonly can_move v6+32
 ;; @0024                               v5 = uextend.i64 v2
-;; @0024                               v7 = iadd v6, v5
-;; @0024                               v8 = iconst.i64 16
-;; @0024                               v9 = iadd v7, v8  ; v8 = 16
-;; @0024                               v10 = load.i32 user2 readonly region1 v9
-;; @0024                               v11 = icmp ult v3, v10
-;; @0024                               trapz v11, user17
-;; @0024                               v13 = uextend.i64 v10
-;;                                     v34 = iconst.i64 3
-;;                                     v35 = ishl v13, v34  ; v34 = 3
-;; @0024                               v15 = iconst.i64 32
-;; @0024                               v16 = ushr v35, v15  ; v15 = 32
-;; @0024                               trapnz v16, user2
-;;                                     v44 = iconst.i32 3
-;;                                     v45 = ishl v10, v44  ; v44 = 3
-;; @0024                               v18 = iconst.i32 24
-;; @0024                               v19 = uadd_overflow_trap v45, v18, user2  ; v18 = 24
-;; @0024                               v23 = uadd_overflow_trap v2, v19, user2
-;; @0024                               v24 = uextend.i64 v23
-;; @0024                               v26 = iadd v6, v24
-;;                                     v51 = ishl v3, v44  ; v44 = 3
-;; @0024                               v22 = iadd v51, v18  ; v18 = 24
-;; @0024                               v27 = isub v19, v22
-;; @0024                               v28 = uextend.i64 v27
-;; @0024                               v29 = isub v26, v28
-;; @0024                               store user2 little region1 v4, v29
+;; @0024                               v8 = iadd v7, v5
+;; @0024                               v9 = iconst.i64 16
+;; @0024                               v10 = iadd v8, v9  ; v9 = 16
+;; @0024                               v11 = load.i32 user2 readonly region1 v10
+;; @0024                               v12 = icmp ult v3, v11
+;; @0024                               trapz v12, user17
+;; @0024                               v14 = uextend.i64 v11
+;;                                     v32 = iconst.i64 3
+;;                                     v33 = ishl v14, v32  ; v32 = 3
+;; @0024                               v16 = iconst.i64 32
+;; @0024                               v17 = ushr v33, v16  ; v16 = 32
+;; @0024                               trapnz v17, user2
+;;                                     v42 = iconst.i32 3
+;;                                     v43 = ishl v11, v42  ; v42 = 3
+;; @0024                               v19 = iconst.i32 24
+;; @0024                               v20 = uadd_overflow_trap v43, v19, user2  ; v19 = 24
+;; @0024                               v24 = uadd_overflow_trap v2, v20, user2
+;; @0024                               v25 = uextend.i64 v24
+;; @0024                               v28 = iadd v7, v25
+;;                                     v49 = ishl v3, v42  ; v42 = 3
+;; @0024                               v23 = iadd v49, v19  ; v19 = 24
+;; @0024                               v29 = isub v20, v23
+;; @0024                               v30 = uextend.i64 v29
+;; @0024                               v31 = isub v28, v30
+;; @0024                               store user2 little region1 v4, v31
 ;; @0027                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/copying/br-on-cast-fail.wat
+++ b/tests/disas/gc/copying/br-on-cast-fail.wat
@@ -26,10 +26,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i64) tail
 ;;     stack_limit = gv2
 ;;
@@ -41,35 +37,35 @@
 ;;                                 block3:
 ;; @002e                               v8 = iconst.i32 1
 ;; @002e                               v9 = band.i32 v2, v8  ; v8 = 1
-;;                                     v28 = iconst.i32 0
-;; @002e                               brif v9, block5(v28), block4  ; v28 = 0
+;;                                     v27 = iconst.i32 0
+;; @002e                               brif v9, block5(v27), block4  ; v27 = 0
 ;;
 ;;                                 block4:
-;; @002e                               v26 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @002e                               v14 = load.i64 notrap aligned readonly can_move v26+32
+;; @002e                               v14 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @002e                               v15 = load.i64 notrap aligned readonly can_move v14+32
 ;; @002e                               v13 = uextend.i64 v2
-;; @002e                               v15 = iadd v14, v13
-;; @002e                               v16 = iconst.i64 4
-;; @002e                               v17 = iadd v15, v16  ; v16 = 4
-;; @002e                               v18 = load.i32 user2 readonly region2 v17
+;; @002e                               v16 = iadd v15, v13
+;; @002e                               v17 = iconst.i64 4
+;; @002e                               v18 = iadd v16, v17  ; v17 = 4
+;; @002e                               v19 = load.i32 user2 readonly region2 v18
 ;; @002e                               v11 = load.i64 notrap aligned readonly can_move region1 v0+40
 ;; @002e                               v12 = load.i32 notrap aligned readonly can_move v11
-;; @002e                               v19 = icmp eq v18, v12
-;; @002e                               v20 = uextend.i32 v19
-;; @002e                               jump block5(v20)
+;; @002e                               v20 = icmp eq v19, v12
+;; @002e                               v21 = uextend.i32 v20
+;; @002e                               jump block5(v21)
 ;;
-;;                                 block5(v21: i32):
-;; @002e                               brif v21, block6, block2
+;;                                 block5(v22: i32):
+;; @002e                               brif v22, block6, block2
 ;;
 ;;                                 block6:
-;; @0034                               v23 = load.i64 notrap aligned readonly can_move region4 v0+56
-;; @0034                               v22 = load.i64 notrap aligned readonly can_move region3 v0+72
-;; @0034                               call_indirect sig0, v23(v22, v0)
+;; @0034                               v24 = load.i64 notrap aligned readonly can_move region4 v0+56
+;; @0034                               v23 = load.i64 notrap aligned readonly can_move region3 v0+72
+;; @0034                               call_indirect sig0, v24(v23, v0)
 ;; @0036                               return
 ;;
 ;;                                 block2:
-;; @0038                               v25 = load.i64 notrap aligned readonly can_move region6 v0+88
-;; @0038                               v24 = load.i64 notrap aligned readonly can_move region5 v0+104
-;; @0038                               call_indirect sig0, v25(v24, v0)
+;; @0038                               v26 = load.i64 notrap aligned readonly can_move region6 v0+88
+;; @0038                               v25 = load.i64 notrap aligned readonly can_move region5 v0+104
+;; @0038                               call_indirect sig0, v26(v25, v0)
 ;; @003a                               return
 ;; }

--- a/tests/disas/gc/copying/br-on-cast.wat
+++ b/tests/disas/gc/copying/br-on-cast.wat
@@ -26,10 +26,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i64) tail
 ;;     stack_limit = gv2
 ;;
@@ -41,35 +37,35 @@
 ;;                                 block3:
 ;; @002f                               v8 = iconst.i32 1
 ;; @002f                               v9 = band.i32 v2, v8  ; v8 = 1
-;;                                     v28 = iconst.i32 0
-;; @002f                               brif v9, block5(v28), block4  ; v28 = 0
+;;                                     v27 = iconst.i32 0
+;; @002f                               brif v9, block5(v27), block4  ; v27 = 0
 ;;
 ;;                                 block4:
-;; @002f                               v26 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @002f                               v14 = load.i64 notrap aligned readonly can_move v26+32
+;; @002f                               v14 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @002f                               v15 = load.i64 notrap aligned readonly can_move v14+32
 ;; @002f                               v13 = uextend.i64 v2
-;; @002f                               v15 = iadd v14, v13
-;; @002f                               v16 = iconst.i64 4
-;; @002f                               v17 = iadd v15, v16  ; v16 = 4
-;; @002f                               v18 = load.i32 user2 readonly region2 v17
+;; @002f                               v16 = iadd v15, v13
+;; @002f                               v17 = iconst.i64 4
+;; @002f                               v18 = iadd v16, v17  ; v17 = 4
+;; @002f                               v19 = load.i32 user2 readonly region2 v18
 ;; @002f                               v11 = load.i64 notrap aligned readonly can_move region1 v0+40
 ;; @002f                               v12 = load.i32 notrap aligned readonly can_move v11
-;; @002f                               v19 = icmp eq v18, v12
-;; @002f                               v20 = uextend.i32 v19
-;; @002f                               jump block5(v20)
+;; @002f                               v20 = icmp eq v19, v12
+;; @002f                               v21 = uextend.i32 v20
+;; @002f                               jump block5(v21)
 ;;
-;;                                 block5(v21: i32):
-;; @002f                               brif v21, block2, block6
+;;                                 block5(v22: i32):
+;; @002f                               brif v22, block2, block6
 ;;
 ;;                                 block6:
-;; @0035                               v23 = load.i64 notrap aligned readonly can_move region4 v0+56
-;; @0035                               v22 = load.i64 notrap aligned readonly can_move region3 v0+72
-;; @0035                               call_indirect sig0, v23(v22, v0)
+;; @0035                               v24 = load.i64 notrap aligned readonly can_move region4 v0+56
+;; @0035                               v23 = load.i64 notrap aligned readonly can_move region3 v0+72
+;; @0035                               call_indirect sig0, v24(v23, v0)
 ;; @0037                               return
 ;;
 ;;                                 block2:
-;; @0039                               v25 = load.i64 notrap aligned readonly can_move region6 v0+88
-;; @0039                               v24 = load.i64 notrap aligned readonly can_move region5 v0+104
-;; @0039                               call_indirect sig0, v25(v24, v0)
+;; @0039                               v26 = load.i64 notrap aligned readonly can_move region6 v0+88
+;; @0039                               v25 = load.i64 notrap aligned readonly can_move region5 v0+104
+;; @0039                               call_indirect sig0, v26(v25, v0)
 ;; @003b                               return
 ;; }

--- a/tests/disas/gc/copying/funcref-in-gc-heap-get.wat
+++ b/tests/disas/gc/copying/funcref-in-gc-heap-get.wat
@@ -14,27 +14,23 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32) -> i64 tail
 ;;     fn0 = colocated u805306368:26 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0020                               trapz v2, user16
-;; @0020                               v12 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0020                               v5 = load.i64 notrap aligned readonly can_move v12+32
+;; @0020                               v5 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @0020                               v6 = load.i64 notrap aligned readonly can_move v5+32
 ;; @0020                               v4 = uextend.i64 v2
-;; @0020                               v6 = iadd v5, v4
-;; @0020                               v7 = iconst.i64 16
-;; @0020                               v8 = iadd v6, v7  ; v7 = 16
-;; @0020                               v10 = load.i32 user2 little region1 v8
-;; @0020                               v9 = iconst.i32 -1
-;; @0020                               v11 = call fn0(v0, v10, v9)  ; v9 = -1
+;; @0020                               v7 = iadd v6, v4
+;; @0020                               v8 = iconst.i64 16
+;; @0020                               v9 = iadd v7, v8  ; v8 = 16
+;; @0020                               v11 = load.i32 user2 little region1 v9
+;; @0020                               v10 = iconst.i32 -1
+;; @0020                               v12 = call fn0(v0, v11, v10)  ; v10 = -1
 ;; @0024                               jump block1
 ;;
 ;;                                 block1:
-;; @0024                               return v11
+;; @0024                               return v12
 ;; }

--- a/tests/disas/gc/copying/funcref-in-gc-heap-set.wat
+++ b/tests/disas/gc/copying/funcref-in-gc-heap-set.wat
@@ -14,25 +14,21 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i64) -> i64 tail
 ;;     fn0 = colocated u805306368:25 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i64):
 ;; @0022                               trapz v2, user16
-;; @0022                               v9 = call fn0(v0, v3)
-;; @0022                               v10 = ireduce.i32 v9
-;; @0022                               v11 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0022                               v5 = load.i64 notrap aligned readonly can_move v11+32
+;; @0022                               v10 = call fn0(v0, v3)
+;; @0022                               v11 = ireduce.i32 v10
+;; @0022                               v5 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @0022                               v6 = load.i64 notrap aligned readonly can_move v5+32
 ;; @0022                               v4 = uextend.i64 v2
-;; @0022                               v6 = iadd v5, v4
-;; @0022                               v7 = iconst.i64 16
-;; @0022                               v8 = iadd v6, v7  ; v7 = 16
-;; @0022                               store user2 little region1 v10, v8
+;; @0022                               v7 = iadd v6, v4
+;; @0022                               v8 = iconst.i64 16
+;; @0022                               v9 = iadd v7, v8  ; v8 = 16
+;; @0022                               store user2 little region1 v11, v9
 ;; @0026                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/copying/multiple-array-get.wat
+++ b/tests/disas/gc/copying/multiple-array-get.wat
@@ -15,52 +15,48 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
 ;; @0024                               trapz v2, user16
-;; @0024                               v65 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0024                               v8 = load.i64 notrap aligned readonly can_move v65+32
+;; @0024                               v8 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @0024                               v9 = load.i64 notrap aligned readonly can_move v8+32
 ;; @0024                               v7 = uextend.i64 v2
-;; @0024                               v9 = iadd v8, v7
-;; @0024                               v10 = iconst.i64 16
-;; @0024                               v11 = iadd v9, v10  ; v10 = 16
-;; @0024                               v12 = load.i32 user2 readonly region1 v11
-;; @0024                               v13 = icmp ult v3, v12
-;; @0024                               trapz v13, user17
-;; @0024                               v15 = uextend.i64 v12
-;;                                     v67 = iconst.i64 3
-;;                                     v68 = ishl v15, v67  ; v67 = 3
-;; @0024                               v17 = iconst.i64 32
-;; @0024                               v18 = ushr v68, v17  ; v17 = 32
-;; @0024                               trapnz v18, user2
-;;                                     v77 = iconst.i32 3
-;;                                     v78 = ishl v12, v77  ; v77 = 3
-;; @0024                               v20 = iconst.i32 24
-;; @0024                               v21 = uadd_overflow_trap v78, v20, user2  ; v20 = 24
-;; @0024                               v25 = uadd_overflow_trap v2, v21, user2
-;; @0024                               v26 = uextend.i64 v25
-;; @0024                               v28 = iadd v8, v26
-;;                                     v84 = ishl v3, v77  ; v77 = 3
-;; @0024                               v24 = iadd v84, v20  ; v20 = 24
-;; @0024                               v29 = isub v21, v24
-;; @0024                               v30 = uextend.i64 v29
-;; @0024                               v31 = isub v28, v30
-;; @0024                               v32 = load.i64 user2 little region1 v31
-;; @002b                               v39 = icmp ult v4, v12
-;; @002b                               trapz v39, user17
-;;                                     v86 = ishl v4, v77  ; v77 = 3
-;; @002b                               v50 = iadd v86, v20  ; v20 = 24
-;; @002b                               v55 = isub v21, v50
-;; @002b                               v56 = uextend.i64 v55
-;; @002b                               v57 = isub v28, v56
-;; @002b                               v58 = load.i64 user2 little region1 v57
+;; @0024                               v10 = iadd v9, v7
+;; @0024                               v11 = iconst.i64 16
+;; @0024                               v12 = iadd v10, v11  ; v11 = 16
+;; @0024                               v13 = load.i32 user2 readonly region1 v12
+;; @0024                               v14 = icmp ult v3, v13
+;; @0024                               trapz v14, user17
+;; @0024                               v16 = uextend.i64 v13
+;;                                     v63 = iconst.i64 3
+;;                                     v64 = ishl v16, v63  ; v63 = 3
+;; @0024                               v18 = iconst.i64 32
+;; @0024                               v19 = ushr v64, v18  ; v18 = 32
+;; @0024                               trapnz v19, user2
+;;                                     v73 = iconst.i32 3
+;;                                     v74 = ishl v13, v73  ; v73 = 3
+;; @0024                               v21 = iconst.i32 24
+;; @0024                               v22 = uadd_overflow_trap v74, v21, user2  ; v21 = 24
+;; @0024                               v26 = uadd_overflow_trap v2, v22, user2
+;; @0024                               v27 = uextend.i64 v26
+;; @0024                               v30 = iadd v9, v27
+;;                                     v80 = ishl v3, v73  ; v73 = 3
+;; @0024                               v25 = iadd v80, v21  ; v21 = 24
+;; @0024                               v31 = isub v22, v25
+;; @0024                               v32 = uextend.i64 v31
+;; @0024                               v33 = isub v30, v32
+;; @0024                               v34 = load.i64 user2 little region1 v33
+;; @002b                               v42 = icmp ult v4, v13
+;; @002b                               trapz v42, user17
+;;                                     v82 = ishl v4, v73  ; v73 = 3
+;; @002b                               v53 = iadd v82, v21  ; v21 = 24
+;; @002b                               v59 = isub v22, v53
+;; @002b                               v60 = uextend.i64 v59
+;; @002b                               v61 = isub v30, v60
+;; @002b                               v62 = load.i64 user2 little region1 v61
 ;; @002e                               jump block1
 ;;
 ;;                                 block1:
-;; @002e                               return v32, v58
+;; @002e                               return v34, v62
 ;; }

--- a/tests/disas/gc/copying/multiple-struct-get.wat
+++ b/tests/disas/gc/copying/multiple-struct-get.wat
@@ -16,27 +16,23 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0023                               trapz v2, user16
-;; @0023                               v20 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0023                               v6 = load.i64 notrap aligned readonly can_move v20+32
+;; @0023                               v6 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @0023                               v7 = load.i64 notrap aligned readonly can_move v6+32
 ;; @0023                               v5 = uextend.i64 v2
-;; @0023                               v7 = iadd v6, v5
-;; @0023                               v8 = iconst.i64 16
-;; @0023                               v9 = iadd v7, v8  ; v8 = 16
-;; @0023                               v10 = load.f32 user2 little region1 v9
-;; @0029                               v14 = iconst.i64 20
-;; @0029                               v15 = iadd v7, v14  ; v14 = 20
-;; @0029                               v16 = load.i8 user2 little region1 v15
+;; @0023                               v8 = iadd v7, v5
+;; @0023                               v9 = iconst.i64 16
+;; @0023                               v10 = iadd v8, v9  ; v9 = 16
+;; @0023                               v11 = load.f32 user2 little region1 v10
+;; @0029                               v16 = iconst.i64 20
+;; @0029                               v17 = iadd v8, v16  ; v16 = 20
+;; @0029                               v18 = load.i8 user2 little region1 v17
 ;; @002d                               jump block1
 ;;
 ;;                                 block1:
-;; @0029                               v17 = sextend.i32 v16
-;; @002d                               return v10, v17
+;; @0029                               v19 = sextend.i32 v18
+;; @002d                               return v11, v19
 ;; }

--- a/tests/disas/gc/copying/ref-cast.wat
+++ b/tests/disas/gc/copying/ref-cast.wat
@@ -14,10 +14,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -28,25 +24,25 @@
 ;;                                 block2:
 ;; @001e                               v8 = iconst.i32 1
 ;; @001e                               v9 = band.i32 v2, v8  ; v8 = 1
-;;                                     v24 = iconst.i32 0
-;; @001e                               brif v9, block4(v24), block3  ; v24 = 0
+;;                                     v23 = iconst.i32 0
+;; @001e                               brif v9, block4(v23), block3  ; v23 = 0
 ;;
 ;;                                 block3:
-;; @001e                               v22 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @001e                               v14 = load.i64 notrap aligned readonly can_move v22+32
+;; @001e                               v14 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @001e                               v15 = load.i64 notrap aligned readonly can_move v14+32
 ;; @001e                               v13 = uextend.i64 v2
-;; @001e                               v15 = iadd v14, v13
-;; @001e                               v16 = iconst.i64 4
-;; @001e                               v17 = iadd v15, v16  ; v16 = 4
-;; @001e                               v18 = load.i32 user2 readonly region2 v17
+;; @001e                               v16 = iadd v15, v13
+;; @001e                               v17 = iconst.i64 4
+;; @001e                               v18 = iadd v16, v17  ; v17 = 4
+;; @001e                               v19 = load.i32 user2 readonly region2 v18
 ;; @001e                               v11 = load.i64 notrap aligned readonly can_move region1 v0+40
 ;; @001e                               v12 = load.i32 notrap aligned readonly can_move v11
-;; @001e                               v19 = icmp eq v18, v12
-;; @001e                               v20 = uextend.i32 v19
-;; @001e                               jump block4(v20)
+;; @001e                               v20 = icmp eq v19, v12
+;; @001e                               v21 = uextend.i32 v20
+;; @001e                               jump block4(v21)
 ;;
-;;                                 block4(v21: i32):
-;; @001e                               trapz v21, user19
+;;                                 block4(v22: i32):
+;; @001e                               trapz v22, user19
 ;; @0021                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/copying/ref-test-array.wat
+++ b/tests/disas/gc/copying/ref-test-array.wat
@@ -12,10 +12,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -26,23 +22,23 @@
 ;;                                 block2:
 ;; @001b                               v8 = iconst.i32 1
 ;; @001b                               v9 = band.i32 v2, v8  ; v8 = 1
-;;                                     v24 = iconst.i32 0
-;; @001b                               brif v9, block4(v24), block3  ; v24 = 0
+;;                                     v23 = iconst.i32 0
+;; @001b                               brif v9, block4(v23), block3  ; v23 = 0
 ;;
 ;;                                 block3:
-;; @001b                               v22 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @001b                               v12 = load.i64 notrap aligned readonly can_move v22+32
+;; @001b                               v12 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @001b                               v13 = load.i64 notrap aligned readonly can_move v12+32
 ;; @001b                               v11 = uextend.i64 v2
-;; @001b                               v13 = iadd v12, v11
-;; @001b                               v16 = load.i32 user2 readonly region1 v13
-;; @001b                               v17 = iconst.i32 -1476395008
-;; @001b                               v18 = band v16, v17  ; v17 = -1476395008
-;; @001b                               v19 = icmp eq v18, v17  ; v17 = -1476395008
-;; @001b                               v20 = uextend.i32 v19
-;; @001b                               jump block4(v20)
+;; @001b                               v14 = iadd v13, v11
+;; @001b                               v17 = load.i32 user2 readonly region1 v14
+;; @001b                               v18 = iconst.i32 -1476395008
+;; @001b                               v19 = band v17, v18  ; v18 = -1476395008
+;; @001b                               v20 = icmp eq v19, v18  ; v18 = -1476395008
+;; @001b                               v21 = uextend.i32 v20
+;; @001b                               jump block4(v21)
 ;;
-;;                                 block4(v21: i32):
-;; @001e                               jump block1(v21)
+;;                                 block4(v22: i32):
+;; @001e                               jump block1(v22)
 ;;
 ;;                                 block1(v3: i32):
 ;; @001e                               return v3

--- a/tests/disas/gc/copying/ref-test-concrete-type.wat
+++ b/tests/disas/gc/copying/ref-test-concrete-type.wat
@@ -14,10 +14,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -28,25 +24,25 @@
 ;;                                 block2:
 ;; @001d                               v8 = iconst.i32 1
 ;; @001d                               v9 = band.i32 v2, v8  ; v8 = 1
-;;                                     v24 = iconst.i32 0
-;; @001d                               brif v9, block4(v24), block3  ; v24 = 0
+;;                                     v23 = iconst.i32 0
+;; @001d                               brif v9, block4(v23), block3  ; v23 = 0
 ;;
 ;;                                 block3:
-;; @001d                               v22 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @001d                               v14 = load.i64 notrap aligned readonly can_move v22+32
+;; @001d                               v14 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @001d                               v15 = load.i64 notrap aligned readonly can_move v14+32
 ;; @001d                               v13 = uextend.i64 v2
-;; @001d                               v15 = iadd v14, v13
-;; @001d                               v16 = iconst.i64 4
-;; @001d                               v17 = iadd v15, v16  ; v16 = 4
-;; @001d                               v18 = load.i32 user2 readonly region2 v17
+;; @001d                               v16 = iadd v15, v13
+;; @001d                               v17 = iconst.i64 4
+;; @001d                               v18 = iadd v16, v17  ; v17 = 4
+;; @001d                               v19 = load.i32 user2 readonly region2 v18
 ;; @001d                               v11 = load.i64 notrap aligned readonly can_move region1 v0+40
 ;; @001d                               v12 = load.i32 notrap aligned readonly can_move v11
-;; @001d                               v19 = icmp eq v18, v12
-;; @001d                               v20 = uextend.i32 v19
-;; @001d                               jump block4(v20)
+;; @001d                               v20 = icmp eq v19, v12
+;; @001d                               v21 = uextend.i32 v20
+;; @001d                               jump block4(v21)
 ;;
-;;                                 block4(v21: i32):
-;; @0020                               jump block1(v21)
+;;                                 block4(v22: i32):
+;; @0020                               jump block1(v22)
 ;;
 ;;                                 block1(v3: i32):
 ;; @0020                               return v3

--- a/tests/disas/gc/copying/ref-test-eq.wat
+++ b/tests/disas/gc/copying/ref-test-eq.wat
@@ -12,10 +12,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -29,19 +25,19 @@
 ;; @001b                               brif v9, block4(v8), block3  ; v8 = 1
 ;;
 ;;                                 block3:
-;; @001b                               v22 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @001b                               v12 = load.i64 notrap aligned readonly can_move v22+32
+;; @001b                               v12 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @001b                               v13 = load.i64 notrap aligned readonly can_move v12+32
 ;; @001b                               v11 = uextend.i64 v2
-;; @001b                               v13 = iadd v12, v11
-;; @001b                               v16 = load.i32 user2 readonly region1 v13
-;; @001b                               v17 = iconst.i32 -1610612736
-;; @001b                               v18 = band v16, v17  ; v17 = -1610612736
-;; @001b                               v19 = icmp eq v18, v17  ; v17 = -1610612736
-;; @001b                               v20 = uextend.i32 v19
-;; @001b                               jump block4(v20)
+;; @001b                               v14 = iadd v13, v11
+;; @001b                               v17 = load.i32 user2 readonly region1 v14
+;; @001b                               v18 = iconst.i32 -1610612736
+;; @001b                               v19 = band v17, v18  ; v18 = -1610612736
+;; @001b                               v20 = icmp eq v19, v18  ; v18 = -1610612736
+;; @001b                               v21 = uextend.i32 v20
+;; @001b                               jump block4(v21)
 ;;
-;;                                 block4(v21: i32):
-;; @001e                               jump block1(v21)
+;;                                 block4(v22: i32):
+;; @001e                               jump block1(v22)
 ;;
 ;;                                 block1(v3: i32):
 ;; @001e                               return v3

--- a/tests/disas/gc/copying/ref-test-struct.wat
+++ b/tests/disas/gc/copying/ref-test-struct.wat
@@ -12,10 +12,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -26,23 +22,23 @@
 ;;                                 block2:
 ;; @001b                               v8 = iconst.i32 1
 ;; @001b                               v9 = band.i32 v2, v8  ; v8 = 1
-;;                                     v24 = iconst.i32 0
-;; @001b                               brif v9, block4(v24), block3  ; v24 = 0
+;;                                     v23 = iconst.i32 0
+;; @001b                               brif v9, block4(v23), block3  ; v23 = 0
 ;;
 ;;                                 block3:
-;; @001b                               v22 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @001b                               v12 = load.i64 notrap aligned readonly can_move v22+32
+;; @001b                               v12 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @001b                               v13 = load.i64 notrap aligned readonly can_move v12+32
 ;; @001b                               v11 = uextend.i64 v2
-;; @001b                               v13 = iadd v12, v11
-;; @001b                               v16 = load.i32 user2 readonly region1 v13
-;; @001b                               v17 = iconst.i32 -1342177280
-;; @001b                               v18 = band v16, v17  ; v17 = -1342177280
-;; @001b                               v19 = icmp eq v18, v17  ; v17 = -1342177280
-;; @001b                               v20 = uextend.i32 v19
-;; @001b                               jump block4(v20)
+;; @001b                               v14 = iadd v13, v11
+;; @001b                               v17 = load.i32 user2 readonly region1 v14
+;; @001b                               v18 = iconst.i32 -1342177280
+;; @001b                               v19 = band v17, v18  ; v18 = -1342177280
+;; @001b                               v20 = icmp eq v19, v18  ; v18 = -1342177280
+;; @001b                               v21 = uextend.i32 v20
+;; @001b                               jump block4(v21)
 ;;
-;;                                 block4(v21: i32):
-;; @001e                               jump block1(v21)
+;;                                 block4(v22: i32):
+;; @001e                               jump block1(v22)
 ;;
 ;;                                 block1(v3: i32):
 ;; @001e                               return v3

--- a/tests/disas/gc/copying/struct-get.wat
+++ b/tests/disas/gc/copying/struct-get.wat
@@ -28,25 +28,21 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0033                               trapz v2, user16
-;; @0033                               v10 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0033                               v5 = load.i64 notrap aligned readonly can_move v10+32
+;; @0033                               v5 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @0033                               v6 = load.i64 notrap aligned readonly can_move v5+32
 ;; @0033                               v4 = uextend.i64 v2
-;; @0033                               v6 = iadd v5, v4
-;; @0033                               v7 = iconst.i64 16
-;; @0033                               v8 = iadd v6, v7  ; v7 = 16
-;; @0033                               v9 = load.f32 user2 little region1 v8
+;; @0033                               v7 = iadd v6, v4
+;; @0033                               v8 = iconst.i64 16
+;; @0033                               v9 = iadd v7, v8  ; v8 = 16
+;; @0033                               v10 = load.f32 user2 little region1 v9
 ;; @0037                               jump block1
 ;;
 ;;                                 block1:
-;; @0037                               return v9
+;; @0037                               return v10
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
@@ -55,26 +51,22 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @003c                               trapz v2, user16
-;; @003c                               v11 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @003c                               v5 = load.i64 notrap aligned readonly can_move v11+32
+;; @003c                               v5 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @003c                               v6 = load.i64 notrap aligned readonly can_move v5+32
 ;; @003c                               v4 = uextend.i64 v2
-;; @003c                               v6 = iadd v5, v4
-;; @003c                               v7 = iconst.i64 20
-;; @003c                               v8 = iadd v6, v7  ; v7 = 20
-;; @003c                               v9 = load.i8 user2 little region1 v8
+;; @003c                               v7 = iadd v6, v4
+;; @003c                               v8 = iconst.i64 20
+;; @003c                               v9 = iadd v7, v8  ; v8 = 20
+;; @003c                               v10 = load.i8 user2 little region1 v9
 ;; @0040                               jump block1
 ;;
 ;;                                 block1:
-;; @003c                               v10 = sextend.i32 v9
-;; @0040                               return v10
+;; @003c                               v11 = sextend.i32 v10
+;; @0040                               return v11
 ;; }
 ;;
 ;; function u0:2(i64 vmctx, i64, i32) -> i32 tail {
@@ -83,26 +75,22 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0045                               trapz v2, user16
-;; @0045                               v11 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0045                               v5 = load.i64 notrap aligned readonly can_move v11+32
+;; @0045                               v5 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @0045                               v6 = load.i64 notrap aligned readonly can_move v5+32
 ;; @0045                               v4 = uextend.i64 v2
-;; @0045                               v6 = iadd v5, v4
-;; @0045                               v7 = iconst.i64 20
-;; @0045                               v8 = iadd v6, v7  ; v7 = 20
-;; @0045                               v9 = load.i8 user2 little region1 v8
+;; @0045                               v7 = iadd v6, v4
+;; @0045                               v8 = iconst.i64 20
+;; @0045                               v9 = iadd v7, v8  ; v8 = 20
+;; @0045                               v10 = load.i8 user2 little region1 v9
 ;; @0049                               jump block1
 ;;
 ;;                                 block1:
-;; @0045                               v10 = uextend.i32 v9
-;; @0049                               return v10
+;; @0045                               v11 = uextend.i32 v10
+;; @0049                               return v11
 ;; }
 ;;
 ;; function u0:3(i64 vmctx, i64, i32) -> i32 tail {
@@ -111,23 +99,19 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @004e                               trapz v2, user16
-;; @004e                               v10 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @004e                               v5 = load.i64 notrap aligned readonly can_move v10+32
+;; @004e                               v5 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @004e                               v6 = load.i64 notrap aligned readonly can_move v5+32
 ;; @004e                               v4 = uextend.i64 v2
-;; @004e                               v6 = iadd v5, v4
-;; @004e                               v7 = iconst.i64 24
-;; @004e                               v8 = iadd v6, v7  ; v7 = 24
-;; @004e                               v9 = load.i32 user2 little region1 v8
+;; @004e                               v7 = iadd v6, v4
+;; @004e                               v8 = iconst.i64 24
+;; @004e                               v9 = iadd v7, v8  ; v8 = 24
+;; @004e                               v10 = load.i32 user2 little region1 v9
 ;; @0052                               jump block1
 ;;
 ;;                                 block1:
-;; @0052                               return v9
+;; @0052                               return v10
 ;; }

--- a/tests/disas/gc/copying/struct-set.wat
+++ b/tests/disas/gc/copying/struct-set.wat
@@ -24,21 +24,17 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: f32):
 ;; @0034                               trapz v2, user16
-;; @0034                               v9 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0034                               v5 = load.i64 notrap aligned readonly can_move v9+32
+;; @0034                               v5 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @0034                               v6 = load.i64 notrap aligned readonly can_move v5+32
 ;; @0034                               v4 = uextend.i64 v2
-;; @0034                               v6 = iadd v5, v4
-;; @0034                               v7 = iconst.i64 16
-;; @0034                               v8 = iadd v6, v7  ; v7 = 16
-;; @0034                               store user2 little region1 v3, v8
+;; @0034                               v7 = iadd v6, v4
+;; @0034                               v8 = iconst.i64 16
+;; @0034                               v9 = iadd v7, v8  ; v8 = 16
+;; @0034                               store user2 little region1 v3, v9
 ;; @0038                               jump block1
 ;;
 ;;                                 block1:
@@ -51,21 +47,17 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @003f                               trapz v2, user16
-;; @003f                               v9 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @003f                               v5 = load.i64 notrap aligned readonly can_move v9+32
+;; @003f                               v5 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @003f                               v6 = load.i64 notrap aligned readonly can_move v5+32
 ;; @003f                               v4 = uextend.i64 v2
-;; @003f                               v6 = iadd v5, v4
-;; @003f                               v7 = iconst.i64 20
-;; @003f                               v8 = iadd v6, v7  ; v7 = 20
-;; @003f                               istore8 user2 little region1 v3, v8
+;; @003f                               v7 = iadd v6, v4
+;; @003f                               v8 = iconst.i64 20
+;; @003f                               v9 = iadd v7, v8  ; v8 = 20
+;; @003f                               istore8 user2 little region1 v3, v9
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -78,21 +70,17 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @004a                               trapz v2, user16
-;; @004a                               v9 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @004a                               v5 = load.i64 notrap aligned readonly can_move v9+32
+;; @004a                               v5 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @004a                               v6 = load.i64 notrap aligned readonly can_move v5+32
 ;; @004a                               v4 = uextend.i64 v2
-;; @004a                               v6 = iadd v5, v4
-;; @004a                               v7 = iconst.i64 24
-;; @004a                               v8 = iadd v6, v7  ; v7 = 24
-;; @004a                               store user2 little region1 v3, v8
+;; @004a                               v7 = iadd v6, v4
+;; @004a                               v8 = iconst.i64 24
+;; @004a                               v9 = iadd v7, v8  ; v8 = 24
+;; @004a                               store user2 little region1 v3, v9
 ;; @004e                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/copying/v128-fields.wat
+++ b/tests/disas/gc/copying/v128-fields.wat
@@ -16,24 +16,20 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0022                               trapz v2, user16
-;; @0022                               v19 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0022                               v5 = load.i64 notrap aligned readonly can_move v19+32
+;; @0022                               v5 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @0022                               v6 = load.i64 notrap aligned readonly can_move v5+32
 ;; @0022                               v4 = uextend.i64 v2
-;; @0022                               v6 = iadd v5, v4
-;; @0022                               v7 = iconst.i64 16
-;; @0022                               v8 = iadd v6, v7  ; v7 = 16
-;; @0022                               v9 = load.i8x16 user2 little region1 v8
+;; @0022                               v7 = iadd v6, v4
+;; @0022                               v8 = iconst.i64 16
+;; @0022                               v9 = iadd v7, v8  ; v8 = 16
+;; @0022                               v10 = load.i8x16 user2 little region1 v9
 ;; @002e                               jump block1
 ;;
 ;;                                 block1:
-;; @002c                               v16 = bxor.i8x16 v9, v9
-;; @002e                               return v16
+;; @002c                               v18 = bxor.i8x16 v10, v10
+;; @002e                               return v18
 ;; }

--- a/tests/disas/gc/drc/array-fill.wat
+++ b/tests/disas/gc/drc/array-fill.wat
@@ -15,50 +15,46 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i64, v5: i32):
 ;; @0027                               trapz v2, user16
-;; @0027                               v46 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0027                               v7 = load.i64 notrap aligned readonly can_move v46+32
+;; @0027                               v7 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @0027                               v8 = load.i64 notrap aligned readonly can_move v7+32
 ;; @0027                               v6 = uextend.i64 v2
-;; @0027                               v8 = iadd v7, v6
-;; @0027                               v9 = iconst.i64 24
-;; @0027                               v10 = iadd v8, v9  ; v9 = 24
-;; @0027                               v11 = load.i32 user2 readonly region1 v10
-;; @0027                               v13 = uextend.i64 v3
-;; @0027                               v14 = uextend.i64 v5
-;; @0027                               v17 = iadd v13, v14
-;; @0027                               v12 = uextend.i64 v11
-;; @0027                               v18 = icmp ugt v17, v12
-;; @0027                               trapnz v18, user17
-;; @0027                               v35 = load.i64 notrap aligned v46+40
-;; @0027                               v23 = iconst.i64 32
-;; @0027                               v24 = iadd v8, v23  ; v23 = 32
-;;                                     v50 = iconst.i64 3
-;;                                     v51 = ishl v13, v50  ; v50 = 3
-;; @0027                               v28 = iadd v24, v51
-;;                                     v53 = ishl v14, v50  ; v50 = 3
-;; @0027                               v37 = uadd_overflow_trap v28, v53, user2
-;; @0027                               v36 = iadd v7, v35
-;; @0027                               v38 = icmp ugt v37, v36
-;; @0027                               trapnz v38, user2
-;;                                     v48 = iconst.i64 0
-;; @0027                               v41 = icmp eq v14, v48  ; v48 = 0
-;; @0027                               v26 = iconst.i64 8
-;; @0027                               v39 = iadd v28, v53
-;; @0027                               brif v41, block3, block2(v28)
+;; @0027                               v9 = iadd v8, v6
+;; @0027                               v10 = iconst.i64 24
+;; @0027                               v11 = iadd v9, v10  ; v10 = 24
+;; @0027                               v12 = load.i32 user2 readonly region1 v11
+;; @0027                               v14 = uextend.i64 v3
+;; @0027                               v15 = uextend.i64 v5
+;; @0027                               v18 = iadd v14, v15
+;; @0027                               v13 = uextend.i64 v12
+;; @0027                               v19 = icmp ugt v18, v13
+;; @0027                               trapnz v19, user17
+;; @0027                               v36 = load.i64 notrap aligned v7+40
+;; @0027                               v24 = iconst.i64 32
+;; @0027                               v25 = iadd v9, v24  ; v24 = 32
+;;                                     v49 = iconst.i64 3
+;;                                     v50 = ishl v14, v49  ; v49 = 3
+;; @0027                               v29 = iadd v25, v50
+;;                                     v52 = ishl v15, v49  ; v49 = 3
+;; @0027                               v38 = uadd_overflow_trap v29, v52, user2
+;; @0027                               v37 = iadd v8, v36
+;; @0027                               v39 = icmp ugt v38, v37
+;; @0027                               trapnz v39, user2
+;;                                     v47 = iconst.i64 0
+;; @0027                               v42 = icmp eq v15, v47  ; v47 = 0
+;; @0027                               v27 = iconst.i64 8
+;; @0027                               v40 = iadd v29, v52
+;; @0027                               brif v42, block3, block2(v29)
 ;;
-;;                                 block2(v42: i64):
-;; @0027                               store.i64 user2 little region1 v4, v42
-;;                                     v55 = iconst.i64 8
-;;                                     v56 = iadd v42, v55  ; v55 = 8
-;; @0027                               v45 = icmp eq v56, v39
-;; @0027                               brif v45, block3, block2(v56)
+;;                                 block2(v43: i64):
+;; @0027                               store.i64 user2 little region1 v4, v43
+;;                                     v54 = iconst.i64 8
+;;                                     v55 = iadd v43, v54  ; v54 = 8
+;; @0027                               v46 = icmp eq v55, v40
+;; @0027                               brif v46, block3, block2(v55)
 ;;
 ;;                                 block3:
 ;; @002a                               jump block1

--- a/tests/disas/gc/drc/array-get-s.wat
+++ b/tests/disas/gc/drc/array-get-s.wat
@@ -15,40 +15,36 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0022                               trapz v2, user16
-;; @0022                               v34 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0022                               v6 = load.i64 notrap aligned readonly can_move v34+32
+;; @0022                               v6 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @0022                               v7 = load.i64 notrap aligned readonly can_move v6+32
 ;; @0022                               v5 = uextend.i64 v2
-;; @0022                               v7 = iadd v6, v5
-;; @0022                               v8 = iconst.i64 24
-;; @0022                               v9 = iadd v7, v8  ; v8 = 24
-;; @0022                               v10 = load.i32 user2 readonly region1 v9
-;; @0022                               v11 = icmp ult v3, v10
-;; @0022                               trapz v11, user17
-;; @0022                               v13 = uextend.i64 v10
-;; @0022                               v15 = iconst.i64 32
-;; @0022                               v16 = ushr v13, v15  ; v15 = 32
-;; @0022                               trapnz v16, user2
-;; @0022                               v18 = iconst.i32 28
-;; @0022                               v19 = uadd_overflow_trap v10, v18, user2  ; v18 = 28
-;; @0022                               v23 = uadd_overflow_trap v2, v19, user2
-;; @0022                               v24 = uextend.i64 v23
-;; @0022                               v26 = iadd v6, v24
-;; @0022                               v22 = iadd v3, v18  ; v18 = 28
-;; @0022                               v27 = isub v19, v22
-;; @0022                               v28 = uextend.i64 v27
-;; @0022                               v29 = isub v26, v28
-;; @0022                               v30 = load.i8 user2 little region1 v29
+;; @0022                               v8 = iadd v7, v5
+;; @0022                               v9 = iconst.i64 24
+;; @0022                               v10 = iadd v8, v9  ; v9 = 24
+;; @0022                               v11 = load.i32 user2 readonly region1 v10
+;; @0022                               v12 = icmp ult v3, v11
+;; @0022                               trapz v12, user17
+;; @0022                               v14 = uextend.i64 v11
+;; @0022                               v16 = iconst.i64 32
+;; @0022                               v17 = ushr v14, v16  ; v16 = 32
+;; @0022                               trapnz v17, user2
+;; @0022                               v19 = iconst.i32 28
+;; @0022                               v20 = uadd_overflow_trap v11, v19, user2  ; v19 = 28
+;; @0022                               v24 = uadd_overflow_trap v2, v20, user2
+;; @0022                               v25 = uextend.i64 v24
+;; @0022                               v28 = iadd v7, v25
+;; @0022                               v23 = iadd v3, v19  ; v19 = 28
+;; @0022                               v29 = isub v20, v23
+;; @0022                               v30 = uextend.i64 v29
+;; @0022                               v31 = isub v28, v30
+;; @0022                               v32 = load.i8 user2 little region1 v31
 ;; @0025                               jump block1
 ;;
 ;;                                 block1:
-;; @0022                               v31 = sextend.i32 v30
-;; @0025                               return v31
+;; @0022                               v33 = sextend.i32 v32
+;; @0025                               return v33
 ;; }

--- a/tests/disas/gc/drc/array-get-u.wat
+++ b/tests/disas/gc/drc/array-get-u.wat
@@ -15,40 +15,36 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0022                               trapz v2, user16
-;; @0022                               v34 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0022                               v6 = load.i64 notrap aligned readonly can_move v34+32
+;; @0022                               v6 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @0022                               v7 = load.i64 notrap aligned readonly can_move v6+32
 ;; @0022                               v5 = uextend.i64 v2
-;; @0022                               v7 = iadd v6, v5
-;; @0022                               v8 = iconst.i64 24
-;; @0022                               v9 = iadd v7, v8  ; v8 = 24
-;; @0022                               v10 = load.i32 user2 readonly region1 v9
-;; @0022                               v11 = icmp ult v3, v10
-;; @0022                               trapz v11, user17
-;; @0022                               v13 = uextend.i64 v10
-;; @0022                               v15 = iconst.i64 32
-;; @0022                               v16 = ushr v13, v15  ; v15 = 32
-;; @0022                               trapnz v16, user2
-;; @0022                               v18 = iconst.i32 28
-;; @0022                               v19 = uadd_overflow_trap v10, v18, user2  ; v18 = 28
-;; @0022                               v23 = uadd_overflow_trap v2, v19, user2
-;; @0022                               v24 = uextend.i64 v23
-;; @0022                               v26 = iadd v6, v24
-;; @0022                               v22 = iadd v3, v18  ; v18 = 28
-;; @0022                               v27 = isub v19, v22
-;; @0022                               v28 = uextend.i64 v27
-;; @0022                               v29 = isub v26, v28
-;; @0022                               v30 = load.i8 user2 little region1 v29
+;; @0022                               v8 = iadd v7, v5
+;; @0022                               v9 = iconst.i64 24
+;; @0022                               v10 = iadd v8, v9  ; v9 = 24
+;; @0022                               v11 = load.i32 user2 readonly region1 v10
+;; @0022                               v12 = icmp ult v3, v11
+;; @0022                               trapz v12, user17
+;; @0022                               v14 = uextend.i64 v11
+;; @0022                               v16 = iconst.i64 32
+;; @0022                               v17 = ushr v14, v16  ; v16 = 32
+;; @0022                               trapnz v17, user2
+;; @0022                               v19 = iconst.i32 28
+;; @0022                               v20 = uadd_overflow_trap v11, v19, user2  ; v19 = 28
+;; @0022                               v24 = uadd_overflow_trap v2, v20, user2
+;; @0022                               v25 = uextend.i64 v24
+;; @0022                               v28 = iadd v7, v25
+;; @0022                               v23 = iadd v3, v19  ; v19 = 28
+;; @0022                               v29 = isub v20, v23
+;; @0022                               v30 = uextend.i64 v29
+;; @0022                               v31 = isub v28, v30
+;; @0022                               v32 = load.i8 user2 little region1 v31
 ;; @0025                               jump block1
 ;;
 ;;                                 block1:
-;; @0022                               v31 = uextend.i32 v30
-;; @0025                               return v31
+;; @0022                               v33 = uextend.i32 v32
+;; @0025                               return v33
 ;; }

--- a/tests/disas/gc/drc/array-get.wat
+++ b/tests/disas/gc/drc/array-get.wat
@@ -15,44 +15,40 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0022                               trapz v2, user16
-;; @0022                               v33 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0022                               v6 = load.i64 notrap aligned readonly can_move v33+32
+;; @0022                               v6 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @0022                               v7 = load.i64 notrap aligned readonly can_move v6+32
 ;; @0022                               v5 = uextend.i64 v2
-;; @0022                               v7 = iadd v6, v5
-;; @0022                               v8 = iconst.i64 24
-;; @0022                               v9 = iadd v7, v8  ; v8 = 24
-;; @0022                               v10 = load.i32 user2 readonly region1 v9
-;; @0022                               v11 = icmp ult v3, v10
-;; @0022                               trapz v11, user17
-;; @0022                               v13 = uextend.i64 v10
-;;                                     v35 = iconst.i64 3
-;;                                     v36 = ishl v13, v35  ; v35 = 3
-;; @0022                               v15 = iconst.i64 32
-;; @0022                               v16 = ushr v36, v15  ; v15 = 32
-;; @0022                               trapnz v16, user2
-;;                                     v45 = iconst.i32 3
-;;                                     v46 = ishl v10, v45  ; v45 = 3
-;; @0022                               v18 = iconst.i32 32
-;; @0022                               v19 = uadd_overflow_trap v46, v18, user2  ; v18 = 32
-;; @0022                               v23 = uadd_overflow_trap v2, v19, user2
-;; @0022                               v24 = uextend.i64 v23
-;; @0022                               v26 = iadd v6, v24
-;;                                     v52 = ishl v3, v45  ; v45 = 3
-;; @0022                               v22 = iadd v52, v18  ; v18 = 32
-;; @0022                               v27 = isub v19, v22
-;; @0022                               v28 = uextend.i64 v27
-;; @0022                               v29 = isub v26, v28
-;; @0022                               v30 = load.i64 user2 little region1 v29
+;; @0022                               v8 = iadd v7, v5
+;; @0022                               v9 = iconst.i64 24
+;; @0022                               v10 = iadd v8, v9  ; v9 = 24
+;; @0022                               v11 = load.i32 user2 readonly region1 v10
+;; @0022                               v12 = icmp ult v3, v11
+;; @0022                               trapz v12, user17
+;; @0022                               v14 = uextend.i64 v11
+;;                                     v33 = iconst.i64 3
+;;                                     v34 = ishl v14, v33  ; v33 = 3
+;; @0022                               v16 = iconst.i64 32
+;; @0022                               v17 = ushr v34, v16  ; v16 = 32
+;; @0022                               trapnz v17, user2
+;;                                     v43 = iconst.i32 3
+;;                                     v44 = ishl v11, v43  ; v43 = 3
+;; @0022                               v19 = iconst.i32 32
+;; @0022                               v20 = uadd_overflow_trap v44, v19, user2  ; v19 = 32
+;; @0022                               v24 = uadd_overflow_trap v2, v20, user2
+;; @0022                               v25 = uextend.i64 v24
+;; @0022                               v28 = iadd v7, v25
+;;                                     v50 = ishl v3, v43  ; v43 = 3
+;; @0022                               v23 = iadd v50, v19  ; v19 = 32
+;; @0022                               v29 = isub v20, v23
+;; @0022                               v30 = uextend.i64 v29
+;; @0022                               v31 = isub v28, v30
+;; @0022                               v32 = load.i64 user2 little region1 v31
 ;; @0025                               jump block1
 ;;
 ;;                                 block1:
-;; @0025                               return v30
+;; @0025                               return v32
 ;; }

--- a/tests/disas/gc/drc/array-len.wat
+++ b/tests/disas/gc/drc/array-len.wat
@@ -15,23 +15,19 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @001f                               trapz v2, user16
-;; @001f                               v10 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @001f                               v5 = load.i64 notrap aligned readonly can_move v10+32
+;; @001f                               v5 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @001f                               v6 = load.i64 notrap aligned readonly can_move v5+32
 ;; @001f                               v4 = uextend.i64 v2
-;; @001f                               v6 = iadd v5, v4
-;; @001f                               v7 = iconst.i64 24
-;; @001f                               v8 = iadd v6, v7  ; v7 = 24
-;; @001f                               v9 = load.i32 user2 readonly region1 v8
+;; @001f                               v7 = iadd v6, v4
+;; @001f                               v8 = iconst.i64 24
+;; @001f                               v9 = iadd v7, v8  ; v8 = 24
+;; @001f                               v10 = load.i32 user2 readonly region1 v9
 ;; @0021                               jump block1
 ;;
 ;;                                 block1:
-;; @0021                               return v9
+;; @0021                               return v10
 ;; }

--- a/tests/disas/gc/drc/array-new-fixed-of-gc-refs.wat
+++ b/tests/disas/gc/drc/array-new-fixed-of-gc-refs.wat
@@ -19,27 +19,23 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
 ;;     fn0 = colocated u805306368:24 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
-;;                                     v191 = stack_addr.i64 ss2
-;;                                     store notrap v2, v191
-;;                                     v192 = stack_addr.i64 ss1
-;;                                     store notrap v3, v192
-;;                                     v193 = stack_addr.i64 ss0
-;;                                     store notrap v4, v193
+;;                                     v203 = stack_addr.i64 ss2
+;;                                     store notrap v2, v203
+;;                                     v204 = stack_addr.i64 ss1
+;;                                     store notrap v3, v204
+;;                                     v205 = stack_addr.i64 ss0
+;;                                     store notrap v4, v205
 ;; @0025                               v15 = iconst.i32 -1476395008
 ;; @0025                               v16 = load.i64 notrap aligned readonly can_move region1 v0+40
 ;; @0025                               v17 = load.i32 notrap aligned readonly can_move v16
-;;                                     v229 = iconst.i32 40
+;;                                     v217 = iconst.i32 40
 ;; @0025                               v18 = iconst.i32 8
-;; @0025                               v19 = call fn0(v0, v15, v17, v229, v18), stack_map=[i32 @ ss2+0, i32 @ ss1+0, i32 @ ss0+0]  ; v15 = -1476395008, v229 = 40, v18 = 8
+;; @0025                               v19 = call fn0(v0, v15, v17, v217, v18), stack_map=[i32 @ ss2+0, i32 @ ss1+0, i32 @ ss0+0]  ; v15 = -1476395008, v217 = 40, v18 = 8
 ;; @0025                               v6 = iconst.i32 3
 ;; @0025                               v20 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @0025                               v21 = load.i64 notrap aligned readonly can_move v20+32
@@ -49,125 +45,125 @@
 ;; @0025                               v25 = iadd v23, v24  ; v24 = 24
 ;; @0025                               store user2 region2 v6, v25  ; v6 = 3
 ;; @0025                               trapz v19, user16
-;; @0025                               v45 = uadd_overflow_trap v19, v229, user2  ; v229 = 40
-;;                                     v190 = load.i32 notrap v191
-;; @0025                               v52 = iconst.i32 1
-;; @0025                               v53 = band v190, v52  ; v52 = 1
+;; @0025                               v46 = uadd_overflow_trap v19, v217, user2  ; v217 = 40
+;;                                     v202 = load.i32 notrap v203
+;; @0025                               v54 = iconst.i32 1
+;; @0025                               v55 = band v202, v54  ; v54 = 1
 ;; @0025                               v26 = iconst.i32 0
-;; @0025                               v55 = icmp eq v190, v26  ; v26 = 0
-;; @0025                               v56 = uextend.i32 v55
-;; @0025                               v57 = bor v53, v56
-;; @0025                               brif v57, block3, block2
+;; @0025                               v57 = icmp eq v202, v26  ; v26 = 0
+;; @0025                               v58 = uextend.i32 v57
+;; @0025                               v59 = bor v55, v58
+;; @0025                               brif v59, block3, block2
 ;;
 ;;                                 block2:
-;;                                     v186 = load.i32 notrap v191
-;; @0025                               v58 = uextend.i64 v186
-;; @0025                               v60 = iadd.i64 v21, v58
-;; @0025                               v61 = iconst.i64 8
-;; @0025                               v62 = iadd v60, v61  ; v61 = 8
-;; @0025                               v63 = load.i64 user2 region2 v62
-;; @0025                               v64 = iconst.i64 1
-;; @0025                               v65 = iadd v63, v64  ; v64 = 1
-;; @0025                               store user2 region2 v65, v62
+;;                                     v198 = load.i32 notrap v203
+;; @0025                               v60 = uextend.i64 v198
+;; @0025                               v63 = iadd.i64 v21, v60
+;; @0025                               v64 = iconst.i64 8
+;; @0025                               v65 = iadd v63, v64  ; v64 = 8
+;; @0025                               v66 = load.i64 user2 region2 v65
+;; @0025                               v67 = iconst.i64 1
+;; @0025                               v68 = iadd v66, v67  ; v67 = 1
+;; @0025                               store user2 region2 v68, v65
 ;; @0025                               jump block3
 ;;
 ;;                                 block3:
-;;                                     v182 = load.i32 notrap v191
-;; @0025                               v46 = uextend.i64 v45
-;; @0025                               v48 = iadd.i64 v21, v46
-;;                                     v219 = iconst.i64 12
-;; @0025                               v51 = isub v48, v219  ; v219 = 12
-;; @0025                               store user2 little region2 v182, v51
-;;                                     v322 = iadd.i64 v23, v24  ; v24 = 24
-;; @0025                               v77 = load.i32 user2 readonly region2 v322
-;;                                     v323 = iconst.i32 1
-;;                                     v324 = icmp ugt v77, v323  ; v323 = 1
-;; @0025                               trapz v324, user17
-;; @0025                               v80 = uextend.i64 v77
-;;                                     v220 = iconst.i64 2
-;;                                     v264 = ishl v80, v220  ; v220 = 2
+;;                                     v194 = load.i32 notrap v203
+;; @0025                               v47 = uextend.i64 v46
+;; @0025                               v50 = iadd.i64 v21, v47
+;;                                     v207 = iconst.i64 12
+;; @0025                               v53 = isub v50, v207  ; v207 = 12
+;; @0025                               store user2 little region2 v194, v53
+;;                                     v310 = iadd.i64 v23, v24  ; v24 = 24
+;; @0025                               v82 = load.i32 user2 readonly region2 v310
+;;                                     v311 = iconst.i32 1
+;;                                     v312 = icmp ugt v82, v311  ; v311 = 1
+;; @0025                               trapz v312, user17
+;; @0025                               v85 = uextend.i64 v82
+;;                                     v208 = iconst.i64 2
+;;                                     v252 = ishl v85, v208  ; v208 = 2
 ;; @0025                               v11 = iconst.i64 32
-;; @0025                               v83 = ushr v264, v11  ; v11 = 32
-;; @0025                               trapnz v83, user2
-;;                                     v241 = iconst.i32 2
-;;                                     v271 = ishl v77, v241  ; v241 = 2
+;; @0025                               v88 = ushr v252, v11  ; v11 = 32
+;; @0025                               trapnz v88, user2
+;;                                     v229 = iconst.i32 2
+;;                                     v259 = ishl v82, v229  ; v229 = 2
 ;; @0025                               v7 = iconst.i32 28
-;; @0025                               v86 = uadd_overflow_trap v271, v7, user2  ; v7 = 28
-;; @0025                               v90 = uadd_overflow_trap.i32 v19, v86, user2
-;;                                     v180 = load.i32 notrap v192
-;;                                     v325 = band v180, v323  ; v323 = 1
-;;                                     v326 = iconst.i32 0
-;;                                     v327 = icmp eq v180, v326  ; v326 = 0
-;; @0025                               v101 = uextend.i32 v327
-;; @0025                               v102 = bor v325, v101
-;; @0025                               brif v102, block5, block4
+;; @0025                               v91 = uadd_overflow_trap v259, v7, user2  ; v7 = 28
+;; @0025                               v95 = uadd_overflow_trap.i32 v19, v91, user2
+;;                                     v192 = load.i32 notrap v204
+;;                                     v313 = band v192, v311  ; v311 = 1
+;;                                     v314 = iconst.i32 0
+;;                                     v315 = icmp eq v192, v314  ; v314 = 0
+;; @0025                               v107 = uextend.i32 v315
+;; @0025                               v108 = bor v313, v107
+;; @0025                               brif v108, block5, block4
 ;;
 ;;                                 block4:
-;;                                     v176 = load.i32 notrap v192
-;; @0025                               v103 = uextend.i64 v176
-;; @0025                               v105 = iadd.i64 v21, v103
-;;                                     v328 = iconst.i64 8
-;; @0025                               v107 = iadd v105, v328  ; v328 = 8
-;; @0025                               v108 = load.i64 user2 region2 v107
-;;                                     v329 = iconst.i64 1
-;; @0025                               v110 = iadd v108, v329  ; v329 = 1
-;; @0025                               store user2 region2 v110, v107
+;;                                     v188 = load.i32 notrap v204
+;; @0025                               v109 = uextend.i64 v188
+;; @0025                               v112 = iadd.i64 v21, v109
+;;                                     v316 = iconst.i64 8
+;; @0025                               v114 = iadd v112, v316  ; v316 = 8
+;; @0025                               v115 = load.i64 user2 region2 v114
+;;                                     v317 = iconst.i64 1
+;; @0025                               v117 = iadd v115, v317  ; v317 = 1
+;; @0025                               store user2 region2 v117, v114
 ;; @0025                               jump block5
 ;;
 ;;                                 block5:
-;;                                     v172 = load.i32 notrap v192
-;; @0025                               v91 = uextend.i64 v90
-;; @0025                               v93 = iadd.i64 v21, v91
-;;                                     v284 = iconst.i32 32
-;; @0025                               v94 = isub.i32 v86, v284  ; v284 = 32
-;; @0025                               v95 = uextend.i64 v94
-;; @0025                               v96 = isub v93, v95
-;; @0025                               store user2 little region2 v172, v96
-;;                                     v330 = iadd.i64 v23, v24  ; v24 = 24
-;; @0025                               v122 = load.i32 user2 readonly region2 v330
-;;                                     v331 = iconst.i32 2
-;;                                     v332 = icmp ugt v122, v331  ; v331 = 2
-;; @0025                               trapz v332, user17
-;; @0025                               v125 = uextend.i64 v122
-;;                                     v333 = iconst.i64 2
-;;                                     v334 = ishl v125, v333  ; v333 = 2
-;;                                     v335 = iconst.i64 32
-;;                                     v336 = ushr v334, v335  ; v335 = 32
-;; @0025                               trapnz v336, user2
-;;                                     v337 = ishl v122, v331  ; v331 = 2
-;;                                     v338 = iconst.i32 28
-;; @0025                               v131 = uadd_overflow_trap v337, v338, user2  ; v338 = 28
-;; @0025                               v135 = uadd_overflow_trap.i32 v19, v131, user2
-;;                                     v170 = load.i32 notrap v193
-;;                                     v339 = iconst.i32 1
-;;                                     v340 = band v170, v339  ; v339 = 1
-;;                                     v341 = iconst.i32 0
-;;                                     v342 = icmp eq v170, v341  ; v341 = 0
-;; @0025                               v146 = uextend.i32 v342
-;; @0025                               v147 = bor v340, v146
-;; @0025                               brif v147, block7, block6
+;;                                     v184 = load.i32 notrap v204
+;; @0025                               v96 = uextend.i64 v95
+;; @0025                               v99 = iadd.i64 v21, v96
+;;                                     v272 = iconst.i32 32
+;; @0025                               v100 = isub.i32 v91, v272  ; v272 = 32
+;; @0025                               v101 = uextend.i64 v100
+;; @0025                               v102 = isub v99, v101
+;; @0025                               store user2 little region2 v184, v102
+;;                                     v318 = iadd.i64 v23, v24  ; v24 = 24
+;; @0025                               v131 = load.i32 user2 readonly region2 v318
+;;                                     v319 = iconst.i32 2
+;;                                     v320 = icmp ugt v131, v319  ; v319 = 2
+;; @0025                               trapz v320, user17
+;; @0025                               v134 = uextend.i64 v131
+;;                                     v321 = iconst.i64 2
+;;                                     v322 = ishl v134, v321  ; v321 = 2
+;;                                     v323 = iconst.i64 32
+;;                                     v324 = ushr v322, v323  ; v323 = 32
+;; @0025                               trapnz v324, user2
+;;                                     v325 = ishl v131, v319  ; v319 = 2
+;;                                     v326 = iconst.i32 28
+;; @0025                               v140 = uadd_overflow_trap v325, v326, user2  ; v326 = 28
+;; @0025                               v144 = uadd_overflow_trap.i32 v19, v140, user2
+;;                                     v182 = load.i32 notrap v205
+;;                                     v327 = iconst.i32 1
+;;                                     v328 = band v182, v327  ; v327 = 1
+;;                                     v329 = iconst.i32 0
+;;                                     v330 = icmp eq v182, v329  ; v329 = 0
+;; @0025                               v156 = uextend.i32 v330
+;; @0025                               v157 = bor v328, v156
+;; @0025                               brif v157, block7, block6
 ;;
 ;;                                 block6:
-;;                                     v166 = load.i32 notrap v193
-;; @0025                               v148 = uextend.i64 v166
-;; @0025                               v150 = iadd.i64 v21, v148
-;;                                     v343 = iconst.i64 8
-;; @0025                               v152 = iadd v150, v343  ; v343 = 8
-;; @0025                               v153 = load.i64 user2 region2 v152
-;;                                     v344 = iconst.i64 1
-;; @0025                               v155 = iadd v153, v344  ; v344 = 1
-;; @0025                               store user2 region2 v155, v152
+;;                                     v178 = load.i32 notrap v205
+;; @0025                               v158 = uextend.i64 v178
+;; @0025                               v161 = iadd.i64 v21, v158
+;;                                     v331 = iconst.i64 8
+;; @0025                               v163 = iadd v161, v331  ; v331 = 8
+;; @0025                               v164 = load.i64 user2 region2 v163
+;;                                     v332 = iconst.i64 1
+;; @0025                               v166 = iadd v164, v332  ; v332 = 1
+;; @0025                               store user2 region2 v166, v163
 ;; @0025                               jump block7
 ;;
 ;;                                 block7:
-;;                                     v162 = load.i32 notrap v193
-;; @0025                               v136 = uextend.i64 v135
-;; @0025                               v138 = iadd.i64 v21, v136
-;;                                     v316 = iconst.i32 36
-;; @0025                               v139 = isub.i32 v131, v316  ; v316 = 36
-;; @0025                               v140 = uextend.i64 v139
-;; @0025                               v141 = isub v138, v140
-;; @0025                               store user2 little region2 v162, v141
+;;                                     v174 = load.i32 notrap v205
+;; @0025                               v145 = uextend.i64 v144
+;; @0025                               v148 = iadd.i64 v21, v145
+;;                                     v304 = iconst.i32 36
+;; @0025                               v149 = isub.i32 v140, v304  ; v304 = 36
+;; @0025                               v150 = uextend.i64 v149
+;; @0025                               v151 = isub v148, v150
+;; @0025                               store user2 little region2 v174, v151
 ;; @0029                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/drc/array-new-fixed.wat
+++ b/tests/disas/gc/drc/array-new-fixed.wat
@@ -16,10 +16,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
 ;;     fn0 = colocated u805306368:24 sig0
 ;;     stack_limit = gv2
@@ -28,62 +24,62 @@
 ;; @0025                               v15 = iconst.i32 -1476395008
 ;; @0025                               v16 = load.i64 notrap aligned readonly can_move region1 v0+40
 ;; @0025                               v17 = load.i32 notrap aligned readonly can_move v16
-;;                                     v126 = iconst.i32 56
+;;                                     v120 = iconst.i32 56
 ;; @0025                               v18 = iconst.i32 8
-;; @0025                               v19 = call fn0(v0, v15, v17, v126, v18)  ; v15 = -1476395008, v126 = 56, v18 = 8
+;; @0025                               v19 = call fn0(v0, v15, v17, v120, v18)  ; v15 = -1476395008, v120 = 56, v18 = 8
 ;; @0025                               v6 = iconst.i32 3
 ;; @0025                               v20 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @0025                               v21 = load.i64 notrap aligned readonly can_move v20+32
 ;; @0025                               v22 = uextend.i64 v19
 ;; @0025                               v23 = iadd v21, v22
-;;                                     v117 = iconst.i64 24
-;; @0025                               v25 = iadd v23, v117  ; v117 = 24
+;;                                     v111 = iconst.i64 24
+;; @0025                               v25 = iadd v23, v111  ; v111 = 24
 ;; @0025                               store user2 region2 v6, v25  ; v6 = 3
 ;; @0025                               trapz v19, user16
-;; @0025                               v45 = uadd_overflow_trap v19, v126, user2  ; v126 = 56
-;; @0025                               v46 = uextend.i64 v45
-;; @0025                               v48 = iadd v21, v46
-;; @0025                               v51 = isub v48, v117  ; v117 = 24
-;; @0025                               store user2 little region2 v2, v51
-;; @0025                               v58 = load.i32 user2 readonly region2 v25
-;; @0025                               v52 = iconst.i32 1
-;;                                     v157 = icmp ugt v58, v52  ; v52 = 1
-;; @0025                               trapz v157, user17
-;; @0025                               v61 = uextend.i64 v58
-;;                                     v116 = iconst.i64 3
-;;                                     v159 = ishl v61, v116  ; v116 = 3
+;; @0025                               v46 = uadd_overflow_trap v19, v120, user2  ; v120 = 56
+;; @0025                               v47 = uextend.i64 v46
+;; @0025                               v50 = iadd v21, v47
+;; @0025                               v53 = isub v50, v111  ; v111 = 24
+;; @0025                               store user2 little region2 v2, v53
+;; @0025                               v61 = load.i32 user2 readonly region2 v25
+;; @0025                               v54 = iconst.i32 1
+;;                                     v151 = icmp ugt v61, v54  ; v54 = 1
+;; @0025                               trapz v151, user17
+;; @0025                               v64 = uextend.i64 v61
+;;                                     v110 = iconst.i64 3
+;;                                     v153 = ishl v64, v110  ; v110 = 3
 ;; @0025                               v11 = iconst.i64 32
-;; @0025                               v64 = ushr v159, v11  ; v11 = 32
-;; @0025                               trapnz v64, user2
-;;                                     v166 = ishl v58, v6  ; v6 = 3
+;; @0025                               v67 = ushr v153, v11  ; v11 = 32
+;; @0025                               trapnz v67, user2
+;;                                     v160 = ishl v61, v6  ; v6 = 3
 ;; @0025                               v7 = iconst.i32 32
-;; @0025                               v67 = uadd_overflow_trap v166, v7, user2  ; v7 = 32
-;; @0025                               v71 = uadd_overflow_trap v19, v67, user2
-;; @0025                               v72 = uextend.i64 v71
-;; @0025                               v74 = iadd v21, v72
-;;                                     v179 = iconst.i32 40
-;; @0025                               v75 = isub v67, v179  ; v179 = 40
-;; @0025                               v76 = uextend.i64 v75
-;; @0025                               v77 = isub v74, v76
-;; @0025                               store user2 little region2 v3, v77
-;; @0025                               v84 = load.i32 user2 readonly region2 v25
-;; @0025                               v78 = iconst.i32 2
-;;                                     v185 = icmp ugt v84, v78  ; v78 = 2
-;; @0025                               trapz v185, user17
-;; @0025                               v87 = uextend.i64 v84
-;;                                     v187 = ishl v87, v116  ; v116 = 3
-;; @0025                               v90 = ushr v187, v11  ; v11 = 32
-;; @0025                               trapnz v90, user2
-;;                                     v194 = ishl v84, v6  ; v6 = 3
-;; @0025                               v93 = uadd_overflow_trap v194, v7, user2  ; v7 = 32
-;; @0025                               v97 = uadd_overflow_trap v19, v93, user2
-;; @0025                               v98 = uextend.i64 v97
-;; @0025                               v100 = iadd v21, v98
-;;                                     v212 = iconst.i32 48
-;; @0025                               v101 = isub v93, v212  ; v212 = 48
-;; @0025                               v102 = uextend.i64 v101
-;; @0025                               v103 = isub v100, v102
-;; @0025                               store user2 little region2 v4, v103
+;; @0025                               v70 = uadd_overflow_trap v160, v7, user2  ; v7 = 32
+;; @0025                               v74 = uadd_overflow_trap v19, v70, user2
+;; @0025                               v75 = uextend.i64 v74
+;; @0025                               v78 = iadd v21, v75
+;;                                     v173 = iconst.i32 40
+;; @0025                               v79 = isub v70, v173  ; v173 = 40
+;; @0025                               v80 = uextend.i64 v79
+;; @0025                               v81 = isub v78, v80
+;; @0025                               store user2 little region2 v3, v81
+;; @0025                               v89 = load.i32 user2 readonly region2 v25
+;; @0025                               v82 = iconst.i32 2
+;;                                     v179 = icmp ugt v89, v82  ; v82 = 2
+;; @0025                               trapz v179, user17
+;; @0025                               v92 = uextend.i64 v89
+;;                                     v181 = ishl v92, v110  ; v110 = 3
+;; @0025                               v95 = ushr v181, v11  ; v11 = 32
+;; @0025                               trapnz v95, user2
+;;                                     v188 = ishl v89, v6  ; v6 = 3
+;; @0025                               v98 = uadd_overflow_trap v188, v7, user2  ; v7 = 32
+;; @0025                               v102 = uadd_overflow_trap v19, v98, user2
+;; @0025                               v103 = uextend.i64 v102
+;; @0025                               v106 = iadd v21, v103
+;;                                     v206 = iconst.i32 48
+;; @0025                               v107 = isub v98, v206  ; v206 = 48
+;; @0025                               v108 = uextend.i64 v107
+;; @0025                               v109 = isub v106, v108
+;; @0025                               store user2 little region2 v4, v109
 ;; @0029                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/drc/array-new.wat
+++ b/tests/disas/gc/drc/array-new.wat
@@ -16,30 +16,26 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
 ;;     fn0 = colocated u805306368:24 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0022                               v6 = uextend.i64 v3
-;;                                     v67 = iconst.i64 3
-;;                                     v68 = ishl v6, v67  ; v67 = 3
+;;                                     v66 = iconst.i64 3
+;;                                     v67 = ishl v6, v66  ; v66 = 3
 ;; @0022                               v9 = iconst.i64 32
-;; @0022                               v10 = ushr v68, v9  ; v9 = 32
+;; @0022                               v10 = ushr v67, v9  ; v9 = 32
 ;; @0022                               trapnz v10, user18
 ;; @0022                               v5 = iconst.i32 32
-;;                                     v74 = iconst.i32 3
-;;                                     v75 = ishl v3, v74  ; v74 = 3
-;; @0022                               v12 = uadd_overflow_trap v5, v75, user18  ; v5 = 32
+;;                                     v73 = iconst.i32 3
+;;                                     v74 = ishl v3, v73  ; v73 = 3
+;; @0022                               v12 = uadd_overflow_trap v5, v74, user18  ; v5 = 32
 ;; @0022                               v13 = iconst.i32 -1476395008
 ;; @0022                               v14 = load.i64 notrap aligned readonly can_move region1 v0+40
 ;; @0022                               v15 = load.i32 notrap aligned readonly can_move v14
-;;                                     v72 = iconst.i32 8
-;; @0022                               v17 = call fn0(v0, v13, v15, v12, v72)  ; v13 = -1476395008, v72 = 8
+;;                                     v71 = iconst.i32 8
+;; @0022                               v17 = call fn0(v0, v13, v15, v12, v71)  ; v13 = -1476395008, v71 = 8
 ;; @0022                               v18 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @0022                               v19 = load.i64 notrap aligned readonly can_move v18+32
 ;; @0022                               v20 = uextend.i64 v17
@@ -48,24 +44,24 @@
 ;; @0022                               v23 = iadd v21, v22  ; v22 = 24
 ;; @0022                               store user2 region2 v3, v23
 ;; @0022                               trapz v17, user16
-;; @0022                               v54 = load.i64 notrap aligned v18+40
-;; @0022                               v43 = iadd v21, v9  ; v9 = 32
-;; @0022                               v56 = uadd_overflow_trap v43, v68, user2
-;; @0022                               v55 = iadd v19, v54
-;; @0022                               v57 = icmp ugt v56, v55
-;; @0022                               trapnz v57, user2
-;;                                     v78 = iconst.i64 0
-;; @0022                               v60 = icmp eq v6, v78  ; v78 = 0
+;; @0022                               v55 = load.i64 notrap aligned v18+40
+;; @0022                               v44 = iadd v21, v9  ; v9 = 32
+;; @0022                               v57 = uadd_overflow_trap v44, v67, user2
+;; @0022                               v56 = iadd v19, v55
+;; @0022                               v58 = icmp ugt v57, v56
+;; @0022                               trapnz v58, user2
+;;                                     v77 = iconst.i64 0
+;; @0022                               v61 = icmp eq v6, v77  ; v77 = 0
 ;; @0022                               v7 = iconst.i64 8
-;; @0022                               v58 = iadd v43, v68
-;; @0022                               brif v60, block3, block2(v43)
+;; @0022                               v59 = iadd v44, v67
+;; @0022                               brif v61, block3, block2(v44)
 ;;
-;;                                 block2(v61: i64):
-;; @0022                               store.i64 user2 little region2 v2, v61
-;;                                     v93 = iconst.i64 8
-;;                                     v94 = iadd v61, v93  ; v93 = 8
-;; @0022                               v64 = icmp eq v94, v58
-;; @0022                               brif v64, block3, block2(v94)
+;;                                 block2(v62: i64):
+;; @0022                               store.i64 user2 little region2 v2, v62
+;;                                     v92 = iconst.i64 8
+;;                                     v93 = iadd v62, v92  ; v92 = 8
+;; @0022                               v65 = icmp eq v93, v59
+;; @0022                               brif v65, block3, block2(v93)
 ;;
 ;;                                 block3:
 ;; @0025                               jump block1

--- a/tests/disas/gc/drc/array-set.wat
+++ b/tests/disas/gc/drc/array-set.wat
@@ -15,42 +15,38 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i64):
 ;; @0024                               trapz v2, user16
-;; @0024                               v32 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0024                               v6 = load.i64 notrap aligned readonly can_move v32+32
+;; @0024                               v6 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @0024                               v7 = load.i64 notrap aligned readonly can_move v6+32
 ;; @0024                               v5 = uextend.i64 v2
-;; @0024                               v7 = iadd v6, v5
-;; @0024                               v8 = iconst.i64 24
-;; @0024                               v9 = iadd v7, v8  ; v8 = 24
-;; @0024                               v10 = load.i32 user2 readonly region1 v9
-;; @0024                               v11 = icmp ult v3, v10
-;; @0024                               trapz v11, user17
-;; @0024                               v13 = uextend.i64 v10
-;;                                     v34 = iconst.i64 3
-;;                                     v35 = ishl v13, v34  ; v34 = 3
-;; @0024                               v15 = iconst.i64 32
-;; @0024                               v16 = ushr v35, v15  ; v15 = 32
-;; @0024                               trapnz v16, user2
-;;                                     v44 = iconst.i32 3
-;;                                     v45 = ishl v10, v44  ; v44 = 3
-;; @0024                               v18 = iconst.i32 32
-;; @0024                               v19 = uadd_overflow_trap v45, v18, user2  ; v18 = 32
-;; @0024                               v23 = uadd_overflow_trap v2, v19, user2
-;; @0024                               v24 = uextend.i64 v23
-;; @0024                               v26 = iadd v6, v24
-;;                                     v51 = ishl v3, v44  ; v44 = 3
-;; @0024                               v22 = iadd v51, v18  ; v18 = 32
-;; @0024                               v27 = isub v19, v22
-;; @0024                               v28 = uextend.i64 v27
-;; @0024                               v29 = isub v26, v28
-;; @0024                               store user2 little region1 v4, v29
+;; @0024                               v8 = iadd v7, v5
+;; @0024                               v9 = iconst.i64 24
+;; @0024                               v10 = iadd v8, v9  ; v9 = 24
+;; @0024                               v11 = load.i32 user2 readonly region1 v10
+;; @0024                               v12 = icmp ult v3, v11
+;; @0024                               trapz v12, user17
+;; @0024                               v14 = uextend.i64 v11
+;;                                     v32 = iconst.i64 3
+;;                                     v33 = ishl v14, v32  ; v32 = 3
+;; @0024                               v16 = iconst.i64 32
+;; @0024                               v17 = ushr v33, v16  ; v16 = 32
+;; @0024                               trapnz v17, user2
+;;                                     v42 = iconst.i32 3
+;;                                     v43 = ishl v11, v42  ; v42 = 3
+;; @0024                               v19 = iconst.i32 32
+;; @0024                               v20 = uadd_overflow_trap v43, v19, user2  ; v19 = 32
+;; @0024                               v24 = uadd_overflow_trap v2, v20, user2
+;; @0024                               v25 = uextend.i64 v24
+;; @0024                               v28 = iadd v7, v25
+;;                                     v49 = ishl v3, v42  ; v42 = 3
+;; @0024                               v23 = iadd v49, v19  ; v19 = 32
+;; @0024                               v29 = isub v20, v23
+;; @0024                               v30 = uextend.i64 v29
+;; @0024                               v31 = isub v28, v30
+;; @0024                               store user2 little region1 v4, v31
 ;; @0027                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/drc/br-on-cast-fail.wat
+++ b/tests/disas/gc/drc/br-on-cast-fail.wat
@@ -27,10 +27,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i64) tail
 ;;     stack_limit = gv2
 ;;
@@ -42,35 +38,35 @@
 ;;                                 block3:
 ;; @002e                               v8 = iconst.i32 1
 ;; @002e                               v9 = band.i32 v2, v8  ; v8 = 1
-;;                                     v28 = iconst.i32 0
-;; @002e                               brif v9, block5(v28), block4  ; v28 = 0
+;;                                     v27 = iconst.i32 0
+;; @002e                               brif v9, block5(v27), block4  ; v27 = 0
 ;;
 ;;                                 block4:
-;; @002e                               v26 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @002e                               v14 = load.i64 notrap aligned readonly can_move v26+32
+;; @002e                               v14 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @002e                               v15 = load.i64 notrap aligned readonly can_move v14+32
 ;; @002e                               v13 = uextend.i64 v2
-;; @002e                               v15 = iadd v14, v13
-;; @002e                               v16 = iconst.i64 4
-;; @002e                               v17 = iadd v15, v16  ; v16 = 4
-;; @002e                               v18 = load.i32 user2 readonly region2 v17
+;; @002e                               v16 = iadd v15, v13
+;; @002e                               v17 = iconst.i64 4
+;; @002e                               v18 = iadd v16, v17  ; v17 = 4
+;; @002e                               v19 = load.i32 user2 readonly region2 v18
 ;; @002e                               v11 = load.i64 notrap aligned readonly can_move region1 v0+40
 ;; @002e                               v12 = load.i32 notrap aligned readonly can_move v11
-;; @002e                               v19 = icmp eq v18, v12
-;; @002e                               v20 = uextend.i32 v19
-;; @002e                               jump block5(v20)
+;; @002e                               v20 = icmp eq v19, v12
+;; @002e                               v21 = uextend.i32 v20
+;; @002e                               jump block5(v21)
 ;;
-;;                                 block5(v21: i32):
-;; @002e                               brif v21, block6, block2
+;;                                 block5(v22: i32):
+;; @002e                               brif v22, block6, block2
 ;;
 ;;                                 block6:
-;; @0034                               v23 = load.i64 notrap aligned readonly can_move region4 v0+56
-;; @0034                               v22 = load.i64 notrap aligned readonly can_move region3 v0+72
-;; @0034                               call_indirect sig0, v23(v22, v0)
+;; @0034                               v24 = load.i64 notrap aligned readonly can_move region4 v0+56
+;; @0034                               v23 = load.i64 notrap aligned readonly can_move region3 v0+72
+;; @0034                               call_indirect sig0, v24(v23, v0)
 ;; @0036                               return
 ;;
 ;;                                 block2:
-;; @0038                               v25 = load.i64 notrap aligned readonly can_move region6 v0+88
-;; @0038                               v24 = load.i64 notrap aligned readonly can_move region5 v0+104
-;; @0038                               call_indirect sig0, v25(v24, v0)
+;; @0038                               v26 = load.i64 notrap aligned readonly can_move region6 v0+88
+;; @0038                               v25 = load.i64 notrap aligned readonly can_move region5 v0+104
+;; @0038                               call_indirect sig0, v26(v25, v0)
 ;; @003a                               return
 ;; }

--- a/tests/disas/gc/drc/br-on-cast.wat
+++ b/tests/disas/gc/drc/br-on-cast.wat
@@ -27,10 +27,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i64) tail
 ;;     stack_limit = gv2
 ;;
@@ -42,35 +38,35 @@
 ;;                                 block3:
 ;; @002f                               v8 = iconst.i32 1
 ;; @002f                               v9 = band.i32 v2, v8  ; v8 = 1
-;;                                     v28 = iconst.i32 0
-;; @002f                               brif v9, block5(v28), block4  ; v28 = 0
+;;                                     v27 = iconst.i32 0
+;; @002f                               brif v9, block5(v27), block4  ; v27 = 0
 ;;
 ;;                                 block4:
-;; @002f                               v26 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @002f                               v14 = load.i64 notrap aligned readonly can_move v26+32
+;; @002f                               v14 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @002f                               v15 = load.i64 notrap aligned readonly can_move v14+32
 ;; @002f                               v13 = uextend.i64 v2
-;; @002f                               v15 = iadd v14, v13
-;; @002f                               v16 = iconst.i64 4
-;; @002f                               v17 = iadd v15, v16  ; v16 = 4
-;; @002f                               v18 = load.i32 user2 readonly region2 v17
+;; @002f                               v16 = iadd v15, v13
+;; @002f                               v17 = iconst.i64 4
+;; @002f                               v18 = iadd v16, v17  ; v17 = 4
+;; @002f                               v19 = load.i32 user2 readonly region2 v18
 ;; @002f                               v11 = load.i64 notrap aligned readonly can_move region1 v0+40
 ;; @002f                               v12 = load.i32 notrap aligned readonly can_move v11
-;; @002f                               v19 = icmp eq v18, v12
-;; @002f                               v20 = uextend.i32 v19
-;; @002f                               jump block5(v20)
+;; @002f                               v20 = icmp eq v19, v12
+;; @002f                               v21 = uextend.i32 v20
+;; @002f                               jump block5(v21)
 ;;
-;;                                 block5(v21: i32):
-;; @002f                               brif v21, block2, block6
+;;                                 block5(v22: i32):
+;; @002f                               brif v22, block2, block6
 ;;
 ;;                                 block6:
-;; @0035                               v23 = load.i64 notrap aligned readonly can_move region4 v0+56
-;; @0035                               v22 = load.i64 notrap aligned readonly can_move region3 v0+72
-;; @0035                               call_indirect sig0, v23(v22, v0)
+;; @0035                               v24 = load.i64 notrap aligned readonly can_move region4 v0+56
+;; @0035                               v23 = load.i64 notrap aligned readonly can_move region3 v0+72
+;; @0035                               call_indirect sig0, v24(v23, v0)
 ;; @0037                               return
 ;;
 ;;                                 block2:
-;; @0039                               v25 = load.i64 notrap aligned readonly can_move region6 v0+88
-;; @0039                               v24 = load.i64 notrap aligned readonly can_move region5 v0+104
-;; @0039                               call_indirect sig0, v25(v24, v0)
+;; @0039                               v26 = load.i64 notrap aligned readonly can_move region6 v0+88
+;; @0039                               v25 = load.i64 notrap aligned readonly can_move region5 v0+104
+;; @0039                               call_indirect sig0, v26(v25, v0)
 ;; @003b                               return
 ;; }

--- a/tests/disas/gc/drc/externref-globals.wat
+++ b/tests/disas/gc/drc/externref-globals.wat
@@ -20,10 +20,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx) -> i8 tail
 ;;     fn0 = colocated u805306368:45 sig0
 ;;     stack_limit = gv2
@@ -32,8 +28,8 @@
 ;; @0034                               v3 = iconst.i64 48
 ;; @0034                               v4 = iadd v0, v3  ; v3 = 48
 ;; @0034                               v5 = load.i32 notrap aligned v4
-;;                                     v75 = stack_addr.i64 ss0
-;;                                     store notrap v5, v75
+;;                                     v80 = stack_addr.i64 ss0
+;;                                     store notrap v5, v80
 ;; @0034                               v6 = iconst.i32 1
 ;; @0034                               v7 = band v5, v6  ; v6 = 1
 ;; @0034                               v8 = iconst.i32 0
@@ -43,55 +39,55 @@
 ;; @0034                               brif v11, block4, block2
 ;;
 ;;                                 block2:
-;; @0034                               v84 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0034                               v13 = load.i64 notrap aligned readonly can_move v84+32
+;; @0034                               v13 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @0034                               v14 = load.i64 notrap aligned readonly can_move v13+32
 ;; @0034                               v12 = uextend.i64 v5
-;; @0034                               v14 = iadd v13, v12
-;; @0034                               v15 = load.i32 user2 region1 v14
-;; @0034                               v16 = iconst.i32 2
-;; @0034                               v17 = band v15, v16  ; v16 = 2
-;; @0034                               brif v17, block4, block3
+;; @0034                               v15 = iadd v14, v12
+;; @0034                               v16 = load.i32 user2 region1 v15
+;; @0034                               v17 = iconst.i32 2
+;; @0034                               v18 = band v16, v17  ; v17 = 2
+;; @0034                               brif v18, block4, block3
 ;;
 ;;                                 block3:
-;; @0034                               v18 = load.i64 notrap aligned readonly can_move region2 v0+32
-;; @0034                               v19 = load.i32 user2 region1 v18
-;; @0034                               v23 = iconst.i64 16
-;; @0034                               v24 = iadd.i64 v14, v23  ; v23 = 16
-;; @0034                               store user2 region1 v19, v24
-;;                                     v86 = iconst.i32 2
-;;                                     v87 = bor.i32 v15, v86  ; v86 = 2
-;; @0034                               store user2 region1 v87, v14
-;; @0034                               v33 = iconst.i64 8
-;; @0034                               v34 = iadd.i64 v14, v33  ; v33 = 8
-;; @0034                               v35 = load.i64 user2 region1 v34
-;; @0034                               v36 = iconst.i64 1
-;; @0034                               v37 = iadd v35, v36  ; v36 = 1
-;; @0034                               store user2 region1 v37, v34
-;; @0034                               store.i32 user2 region1 v5, v18
-;; @0034                               v44 = load.i32 notrap aligned v18+4
-;;                                     v88 = iconst.i32 1
-;;                                     v89 = iadd v44, v88  ; v88 = 1
-;; @0034                               store notrap aligned v89, v18+4
-;; @0034                               v51 = load.i32 notrap aligned v18+8
-;; @0034                               v52 = iadd v51, v51
-;; @0034                               v53 = iconst.i32 1024
-;; @0034                               v54 = umax v52, v53  ; v53 = 1024
-;; @0034                               v55 = icmp uge v89, v54
-;; @0034                               brif v55, block5, block6
+;; @0034                               v19 = load.i64 notrap aligned readonly can_move region2 v0+32
+;; @0034                               v20 = load.i32 user2 region1 v19
+;; @0034                               v25 = iconst.i64 16
+;; @0034                               v26 = iadd.i64 v15, v25  ; v25 = 16
+;; @0034                               store user2 region1 v20, v26
+;;                                     v81 = iconst.i32 2
+;;                                     v82 = bor.i32 v16, v81  ; v81 = 2
+;; @0034                               store user2 region1 v82, v15
+;; @0034                               v37 = iconst.i64 8
+;; @0034                               v38 = iadd.i64 v15, v37  ; v37 = 8
+;; @0034                               v39 = load.i64 user2 region1 v38
+;; @0034                               v40 = iconst.i64 1
+;; @0034                               v41 = iadd v39, v40  ; v40 = 1
+;; @0034                               store user2 region1 v41, v38
+;; @0034                               store.i32 user2 region1 v5, v19
+;; @0034                               v49 = load.i32 notrap aligned v19+4
+;;                                     v83 = iconst.i32 1
+;;                                     v84 = iadd v49, v83  ; v83 = 1
+;; @0034                               store notrap aligned v84, v19+4
+;; @0034                               v56 = load.i32 notrap aligned v19+8
+;; @0034                               v57 = iadd v56, v56
+;; @0034                               v58 = iconst.i32 1024
+;; @0034                               v59 = umax v57, v58  ; v58 = 1024
+;; @0034                               v60 = icmp uge v84, v59
+;; @0034                               brif v60, block5, block6
 ;;
 ;;                                 block5 cold:
-;; @0034                               v56 = call fn0(v0), stack_map=[i32 @ ss0+0]
+;; @0034                               v61 = call fn0(v0), stack_map=[i32 @ ss0+0]
 ;; @0034                               jump block6
 ;;
 ;;                                 block6:
 ;; @0034                               jump block4
 ;;
 ;;                                 block4:
-;;                                     v58 = load.i32 notrap v75
+;;                                     v63 = load.i32 notrap v80
 ;; @0036                               jump block1
 ;;
 ;;                                 block1:
-;; @0036                               return v58
+;; @0036                               return v63
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) tail {
@@ -100,10 +96,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32) tail
 ;;     fn0 = colocated u805306368:22 sig0
 ;;     stack_limit = gv2
@@ -121,50 +113,50 @@
 ;; @003b                               brif v11, block3, block2
 ;;
 ;;                                 block2:
-;; @003b                               v52 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @003b                               v13 = load.i64 notrap aligned readonly can_move v52+32
+;; @003b                               v13 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @003b                               v14 = load.i64 notrap aligned readonly can_move v13+32
 ;; @003b                               v12 = uextend.i64 v2
-;; @003b                               v14 = iadd v13, v12
-;; @003b                               v15 = iconst.i64 8
-;; @003b                               v16 = iadd v14, v15  ; v15 = 8
-;; @003b                               v17 = load.i64 user2 region1 v16
-;; @003b                               v18 = iconst.i64 1
-;; @003b                               v19 = iadd v17, v18  ; v18 = 1
-;; @003b                               store user2 region1 v19, v16
+;; @003b                               v15 = iadd v14, v12
+;; @003b                               v16 = iconst.i64 8
+;; @003b                               v17 = iadd v15, v16  ; v16 = 8
+;; @003b                               v18 = load.i64 user2 region1 v17
+;; @003b                               v19 = iconst.i64 1
+;; @003b                               v20 = iadd v18, v19  ; v19 = 1
+;; @003b                               store user2 region1 v20, v17
 ;; @003b                               jump block3
 ;;
 ;;                                 block3:
-;;                                     v66 = iadd.i64 v0, v3  ; v3 = 48
-;; @003b                               store.i32 notrap aligned v2, v66
-;;                                     v67 = iconst.i32 1
-;;                                     v68 = band.i32 v5, v67  ; v67 = 1
-;;                                     v69 = iconst.i32 0
-;;                                     v70 = icmp.i32 eq v5, v69  ; v69 = 0
-;; @003b                               v29 = uextend.i32 v70
-;; @003b                               v30 = bor v68, v29
-;; @003b                               brif v30, block7, block4
+;;                                     v62 = iadd.i64 v0, v3  ; v3 = 48
+;; @003b                               store.i32 notrap aligned v2, v62
+;;                                     v63 = iconst.i32 1
+;;                                     v64 = band.i32 v5, v63  ; v63 = 1
+;;                                     v65 = iconst.i32 0
+;;                                     v66 = icmp.i32 eq v5, v65  ; v65 = 0
+;; @003b                               v31 = uextend.i32 v66
+;; @003b                               v32 = bor v64, v31
+;; @003b                               brif v32, block7, block4
 ;;
 ;;                                 block4:
-;;                                     v71 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v72 = load.i64 notrap aligned readonly can_move v71+32
-;; @003b                               v31 = uextend.i64 v5
-;; @003b                               v33 = iadd v72, v31
-;;                                     v73 = iconst.i64 8
-;; @003b                               v35 = iadd v33, v73  ; v73 = 8
-;; @003b                               v36 = load.i64 user2 region1 v35
-;;                                     v74 = iconst.i64 1
-;;                                     v64 = icmp eq v36, v74  ; v74 = 1
-;; @003b                               brif v64, block5, block6
+;;                                     v67 = load.i64 notrap aligned readonly can_move region0 v0+8
+;;                                     v68 = load.i64 notrap aligned readonly can_move v67+32
+;; @003b                               v33 = uextend.i64 v5
+;; @003b                               v36 = iadd v68, v33
+;;                                     v69 = iconst.i64 8
+;; @003b                               v38 = iadd v36, v69  ; v69 = 8
+;; @003b                               v39 = load.i64 user2 region1 v38
+;;                                     v70 = iconst.i64 1
+;;                                     v60 = icmp eq v39, v70  ; v70 = 1
+;; @003b                               brif v60, block5, block6
 ;;
 ;;                                 block5 cold:
 ;; @003b                               call fn0(v0, v5)
 ;; @003b                               jump block7
 ;;
 ;;                                 block6:
-;; @003b                               v37 = iconst.i64 -1
-;; @003b                               v38 = iadd.i64 v36, v37  ; v37 = -1
-;;                                     v75 = iadd.i64 v33, v73  ; v73 = 8
-;; @003b                               store user2 region1 v38, v75
+;; @003b                               v40 = iconst.i64 -1
+;; @003b                               v41 = iadd.i64 v39, v40  ; v40 = -1
+;;                                     v71 = iadd.i64 v36, v69  ; v69 = 8
+;; @003b                               store user2 region1 v41, v71
 ;; @003b                               jump block7
 ;;
 ;;                                 block7:

--- a/tests/disas/gc/drc/funcref-in-gc-heap-get.wat
+++ b/tests/disas/gc/drc/funcref-in-gc-heap-get.wat
@@ -15,27 +15,23 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32) -> i64 tail
 ;;     fn0 = colocated u805306368:26 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0020                               trapz v2, user16
-;; @0020                               v12 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0020                               v5 = load.i64 notrap aligned readonly can_move v12+32
+;; @0020                               v5 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @0020                               v6 = load.i64 notrap aligned readonly can_move v5+32
 ;; @0020                               v4 = uextend.i64 v2
-;; @0020                               v6 = iadd v5, v4
-;; @0020                               v7 = iconst.i64 24
-;; @0020                               v8 = iadd v6, v7  ; v7 = 24
-;; @0020                               v10 = load.i32 user2 little region1 v8
-;; @0020                               v9 = iconst.i32 -1
-;; @0020                               v11 = call fn0(v0, v10, v9)  ; v9 = -1
+;; @0020                               v7 = iadd v6, v4
+;; @0020                               v8 = iconst.i64 24
+;; @0020                               v9 = iadd v7, v8  ; v8 = 24
+;; @0020                               v11 = load.i32 user2 little region1 v9
+;; @0020                               v10 = iconst.i32 -1
+;; @0020                               v12 = call fn0(v0, v11, v10)  ; v10 = -1
 ;; @0024                               jump block1
 ;;
 ;;                                 block1:
-;; @0024                               return v11
+;; @0024                               return v12
 ;; }

--- a/tests/disas/gc/drc/funcref-in-gc-heap-set.wat
+++ b/tests/disas/gc/drc/funcref-in-gc-heap-set.wat
@@ -15,25 +15,21 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i64) -> i64 tail
 ;;     fn0 = colocated u805306368:25 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i64):
 ;; @0022                               trapz v2, user16
-;; @0022                               v9 = call fn0(v0, v3)
-;; @0022                               v10 = ireduce.i32 v9
-;; @0022                               v11 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0022                               v5 = load.i64 notrap aligned readonly can_move v11+32
+;; @0022                               v10 = call fn0(v0, v3)
+;; @0022                               v11 = ireduce.i32 v10
+;; @0022                               v5 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @0022                               v6 = load.i64 notrap aligned readonly can_move v5+32
 ;; @0022                               v4 = uextend.i64 v2
-;; @0022                               v6 = iadd v5, v4
-;; @0022                               v7 = iconst.i64 24
-;; @0022                               v8 = iadd v6, v7  ; v7 = 24
-;; @0022                               store user2 little region1 v10, v8
+;; @0022                               v7 = iadd v6, v4
+;; @0022                               v8 = iconst.i64 24
+;; @0022                               v9 = iadd v7, v8  ; v8 = 24
+;; @0022                               store user2 little region1 v11, v9
 ;; @0026                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/drc/multiple-array-get.wat
+++ b/tests/disas/gc/drc/multiple-array-get.wat
@@ -16,52 +16,48 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
 ;; @0024                               trapz v2, user16
-;; @0024                               v65 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0024                               v8 = load.i64 notrap aligned readonly can_move v65+32
+;; @0024                               v8 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @0024                               v9 = load.i64 notrap aligned readonly can_move v8+32
 ;; @0024                               v7 = uextend.i64 v2
-;; @0024                               v9 = iadd v8, v7
-;; @0024                               v10 = iconst.i64 24
-;; @0024                               v11 = iadd v9, v10  ; v10 = 24
-;; @0024                               v12 = load.i32 user2 readonly region1 v11
-;; @0024                               v13 = icmp ult v3, v12
-;; @0024                               trapz v13, user17
-;; @0024                               v15 = uextend.i64 v12
-;;                                     v67 = iconst.i64 3
-;;                                     v68 = ishl v15, v67  ; v67 = 3
-;; @0024                               v17 = iconst.i64 32
-;; @0024                               v18 = ushr v68, v17  ; v17 = 32
-;; @0024                               trapnz v18, user2
-;;                                     v77 = iconst.i32 3
-;;                                     v78 = ishl v12, v77  ; v77 = 3
-;; @0024                               v20 = iconst.i32 32
-;; @0024                               v21 = uadd_overflow_trap v78, v20, user2  ; v20 = 32
-;; @0024                               v25 = uadd_overflow_trap v2, v21, user2
-;; @0024                               v26 = uextend.i64 v25
-;; @0024                               v28 = iadd v8, v26
-;;                                     v84 = ishl v3, v77  ; v77 = 3
-;; @0024                               v24 = iadd v84, v20  ; v20 = 32
-;; @0024                               v29 = isub v21, v24
-;; @0024                               v30 = uextend.i64 v29
-;; @0024                               v31 = isub v28, v30
-;; @0024                               v32 = load.i64 user2 little region1 v31
-;; @002b                               v39 = icmp ult v4, v12
-;; @002b                               trapz v39, user17
-;;                                     v86 = ishl v4, v77  ; v77 = 3
-;; @002b                               v50 = iadd v86, v20  ; v20 = 32
-;; @002b                               v55 = isub v21, v50
-;; @002b                               v56 = uextend.i64 v55
-;; @002b                               v57 = isub v28, v56
-;; @002b                               v58 = load.i64 user2 little region1 v57
+;; @0024                               v10 = iadd v9, v7
+;; @0024                               v11 = iconst.i64 24
+;; @0024                               v12 = iadd v10, v11  ; v11 = 24
+;; @0024                               v13 = load.i32 user2 readonly region1 v12
+;; @0024                               v14 = icmp ult v3, v13
+;; @0024                               trapz v14, user17
+;; @0024                               v16 = uextend.i64 v13
+;;                                     v63 = iconst.i64 3
+;;                                     v64 = ishl v16, v63  ; v63 = 3
+;; @0024                               v18 = iconst.i64 32
+;; @0024                               v19 = ushr v64, v18  ; v18 = 32
+;; @0024                               trapnz v19, user2
+;;                                     v73 = iconst.i32 3
+;;                                     v74 = ishl v13, v73  ; v73 = 3
+;; @0024                               v21 = iconst.i32 32
+;; @0024                               v22 = uadd_overflow_trap v74, v21, user2  ; v21 = 32
+;; @0024                               v26 = uadd_overflow_trap v2, v22, user2
+;; @0024                               v27 = uextend.i64 v26
+;; @0024                               v30 = iadd v9, v27
+;;                                     v80 = ishl v3, v73  ; v73 = 3
+;; @0024                               v25 = iadd v80, v21  ; v21 = 32
+;; @0024                               v31 = isub v22, v25
+;; @0024                               v32 = uextend.i64 v31
+;; @0024                               v33 = isub v30, v32
+;; @0024                               v34 = load.i64 user2 little region1 v33
+;; @002b                               v42 = icmp ult v4, v13
+;; @002b                               trapz v42, user17
+;;                                     v82 = ishl v4, v73  ; v73 = 3
+;; @002b                               v53 = iadd v82, v21  ; v21 = 32
+;; @002b                               v59 = isub v22, v53
+;; @002b                               v60 = uextend.i64 v59
+;; @002b                               v61 = isub v30, v60
+;; @002b                               v62 = load.i64 user2 little region1 v61
 ;; @002e                               jump block1
 ;;
 ;;                                 block1:
-;; @002e                               return v32, v58
+;; @002e                               return v34, v62
 ;; }

--- a/tests/disas/gc/drc/multiple-struct-get.wat
+++ b/tests/disas/gc/drc/multiple-struct-get.wat
@@ -17,27 +17,23 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0023                               trapz v2, user16
-;; @0023                               v20 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0023                               v6 = load.i64 notrap aligned readonly can_move v20+32
+;; @0023                               v6 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @0023                               v7 = load.i64 notrap aligned readonly can_move v6+32
 ;; @0023                               v5 = uextend.i64 v2
-;; @0023                               v7 = iadd v6, v5
-;; @0023                               v8 = iconst.i64 24
-;; @0023                               v9 = iadd v7, v8  ; v8 = 24
-;; @0023                               v10 = load.f32 user2 little region1 v9
-;; @0029                               v14 = iconst.i64 28
-;; @0029                               v15 = iadd v7, v14  ; v14 = 28
-;; @0029                               v16 = load.i8 user2 little region1 v15
+;; @0023                               v8 = iadd v7, v5
+;; @0023                               v9 = iconst.i64 24
+;; @0023                               v10 = iadd v8, v9  ; v9 = 24
+;; @0023                               v11 = load.f32 user2 little region1 v10
+;; @0029                               v16 = iconst.i64 28
+;; @0029                               v17 = iadd v8, v16  ; v16 = 28
+;; @0029                               v18 = load.i8 user2 little region1 v17
 ;; @002d                               jump block1
 ;;
 ;;                                 block1:
-;; @0029                               v17 = sextend.i32 v16
-;; @002d                               return v10, v17
+;; @0029                               v19 = sextend.i32 v18
+;; @002d                               return v11, v19
 ;; }

--- a/tests/disas/gc/drc/ref-cast.wat
+++ b/tests/disas/gc/drc/ref-cast.wat
@@ -15,10 +15,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -29,25 +25,25 @@
 ;;                                 block2:
 ;; @001e                               v8 = iconst.i32 1
 ;; @001e                               v9 = band.i32 v2, v8  ; v8 = 1
-;;                                     v24 = iconst.i32 0
-;; @001e                               brif v9, block4(v24), block3  ; v24 = 0
+;;                                     v23 = iconst.i32 0
+;; @001e                               brif v9, block4(v23), block3  ; v23 = 0
 ;;
 ;;                                 block3:
-;; @001e                               v22 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @001e                               v14 = load.i64 notrap aligned readonly can_move v22+32
+;; @001e                               v14 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @001e                               v15 = load.i64 notrap aligned readonly can_move v14+32
 ;; @001e                               v13 = uextend.i64 v2
-;; @001e                               v15 = iadd v14, v13
-;; @001e                               v16 = iconst.i64 4
-;; @001e                               v17 = iadd v15, v16  ; v16 = 4
-;; @001e                               v18 = load.i32 user2 readonly region2 v17
+;; @001e                               v16 = iadd v15, v13
+;; @001e                               v17 = iconst.i64 4
+;; @001e                               v18 = iadd v16, v17  ; v17 = 4
+;; @001e                               v19 = load.i32 user2 readonly region2 v18
 ;; @001e                               v11 = load.i64 notrap aligned readonly can_move region1 v0+40
 ;; @001e                               v12 = load.i32 notrap aligned readonly can_move v11
-;; @001e                               v19 = icmp eq v18, v12
-;; @001e                               v20 = uextend.i32 v19
-;; @001e                               jump block4(v20)
+;; @001e                               v20 = icmp eq v19, v12
+;; @001e                               v21 = uextend.i32 v20
+;; @001e                               jump block4(v21)
 ;;
-;;                                 block4(v21: i32):
-;; @001e                               trapz v21, user19
+;;                                 block4(v22: i32):
+;; @001e                               trapz v22, user19
 ;; @0021                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/drc/ref-test-array.wat
+++ b/tests/disas/gc/drc/ref-test-array.wat
@@ -13,10 +13,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -27,23 +23,23 @@
 ;;                                 block2:
 ;; @001b                               v8 = iconst.i32 1
 ;; @001b                               v9 = band.i32 v2, v8  ; v8 = 1
-;;                                     v24 = iconst.i32 0
-;; @001b                               brif v9, block4(v24), block3  ; v24 = 0
+;;                                     v23 = iconst.i32 0
+;; @001b                               brif v9, block4(v23), block3  ; v23 = 0
 ;;
 ;;                                 block3:
-;; @001b                               v22 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @001b                               v12 = load.i64 notrap aligned readonly can_move v22+32
+;; @001b                               v12 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @001b                               v13 = load.i64 notrap aligned readonly can_move v12+32
 ;; @001b                               v11 = uextend.i64 v2
-;; @001b                               v13 = iadd v12, v11
-;; @001b                               v16 = load.i32 user2 readonly region1 v13
-;; @001b                               v17 = iconst.i32 -1476395008
-;; @001b                               v18 = band v16, v17  ; v17 = -1476395008
-;; @001b                               v19 = icmp eq v18, v17  ; v17 = -1476395008
-;; @001b                               v20 = uextend.i32 v19
-;; @001b                               jump block4(v20)
+;; @001b                               v14 = iadd v13, v11
+;; @001b                               v17 = load.i32 user2 readonly region1 v14
+;; @001b                               v18 = iconst.i32 -1476395008
+;; @001b                               v19 = band v17, v18  ; v18 = -1476395008
+;; @001b                               v20 = icmp eq v19, v18  ; v18 = -1476395008
+;; @001b                               v21 = uextend.i32 v20
+;; @001b                               jump block4(v21)
 ;;
-;;                                 block4(v21: i32):
-;; @001e                               jump block1(v21)
+;;                                 block4(v22: i32):
+;; @001e                               jump block1(v22)
 ;;
 ;;                                 block1(v3: i32):
 ;; @001e                               return v3

--- a/tests/disas/gc/drc/ref-test-concrete-type.wat
+++ b/tests/disas/gc/drc/ref-test-concrete-type.wat
@@ -15,10 +15,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -29,25 +25,25 @@
 ;;                                 block2:
 ;; @001d                               v8 = iconst.i32 1
 ;; @001d                               v9 = band.i32 v2, v8  ; v8 = 1
-;;                                     v24 = iconst.i32 0
-;; @001d                               brif v9, block4(v24), block3  ; v24 = 0
+;;                                     v23 = iconst.i32 0
+;; @001d                               brif v9, block4(v23), block3  ; v23 = 0
 ;;
 ;;                                 block3:
-;; @001d                               v22 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @001d                               v14 = load.i64 notrap aligned readonly can_move v22+32
+;; @001d                               v14 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @001d                               v15 = load.i64 notrap aligned readonly can_move v14+32
 ;; @001d                               v13 = uextend.i64 v2
-;; @001d                               v15 = iadd v14, v13
-;; @001d                               v16 = iconst.i64 4
-;; @001d                               v17 = iadd v15, v16  ; v16 = 4
-;; @001d                               v18 = load.i32 user2 readonly region2 v17
+;; @001d                               v16 = iadd v15, v13
+;; @001d                               v17 = iconst.i64 4
+;; @001d                               v18 = iadd v16, v17  ; v17 = 4
+;; @001d                               v19 = load.i32 user2 readonly region2 v18
 ;; @001d                               v11 = load.i64 notrap aligned readonly can_move region1 v0+40
 ;; @001d                               v12 = load.i32 notrap aligned readonly can_move v11
-;; @001d                               v19 = icmp eq v18, v12
-;; @001d                               v20 = uextend.i32 v19
-;; @001d                               jump block4(v20)
+;; @001d                               v20 = icmp eq v19, v12
+;; @001d                               v21 = uextend.i32 v20
+;; @001d                               jump block4(v21)
 ;;
-;;                                 block4(v21: i32):
-;; @0020                               jump block1(v21)
+;;                                 block4(v22: i32):
+;; @0020                               jump block1(v22)
 ;;
 ;;                                 block1(v3: i32):
 ;; @0020                               return v3

--- a/tests/disas/gc/drc/ref-test-eq.wat
+++ b/tests/disas/gc/drc/ref-test-eq.wat
@@ -13,10 +13,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -30,19 +26,19 @@
 ;; @001b                               brif v9, block4(v8), block3  ; v8 = 1
 ;;
 ;;                                 block3:
-;; @001b                               v22 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @001b                               v12 = load.i64 notrap aligned readonly can_move v22+32
+;; @001b                               v12 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @001b                               v13 = load.i64 notrap aligned readonly can_move v12+32
 ;; @001b                               v11 = uextend.i64 v2
-;; @001b                               v13 = iadd v12, v11
-;; @001b                               v16 = load.i32 user2 readonly region1 v13
-;; @001b                               v17 = iconst.i32 -1610612736
-;; @001b                               v18 = band v16, v17  ; v17 = -1610612736
-;; @001b                               v19 = icmp eq v18, v17  ; v17 = -1610612736
-;; @001b                               v20 = uextend.i32 v19
-;; @001b                               jump block4(v20)
+;; @001b                               v14 = iadd v13, v11
+;; @001b                               v17 = load.i32 user2 readonly region1 v14
+;; @001b                               v18 = iconst.i32 -1610612736
+;; @001b                               v19 = band v17, v18  ; v18 = -1610612736
+;; @001b                               v20 = icmp eq v19, v18  ; v18 = -1610612736
+;; @001b                               v21 = uextend.i32 v20
+;; @001b                               jump block4(v21)
 ;;
-;;                                 block4(v21: i32):
-;; @001e                               jump block1(v21)
+;;                                 block4(v22: i32):
+;; @001e                               jump block1(v22)
 ;;
 ;;                                 block1(v3: i32):
 ;; @001e                               return v3

--- a/tests/disas/gc/drc/ref-test-struct.wat
+++ b/tests/disas/gc/drc/ref-test-struct.wat
@@ -13,10 +13,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -27,23 +23,23 @@
 ;;                                 block2:
 ;; @001b                               v8 = iconst.i32 1
 ;; @001b                               v9 = band.i32 v2, v8  ; v8 = 1
-;;                                     v24 = iconst.i32 0
-;; @001b                               brif v9, block4(v24), block3  ; v24 = 0
+;;                                     v23 = iconst.i32 0
+;; @001b                               brif v9, block4(v23), block3  ; v23 = 0
 ;;
 ;;                                 block3:
-;; @001b                               v22 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @001b                               v12 = load.i64 notrap aligned readonly can_move v22+32
+;; @001b                               v12 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @001b                               v13 = load.i64 notrap aligned readonly can_move v12+32
 ;; @001b                               v11 = uextend.i64 v2
-;; @001b                               v13 = iadd v12, v11
-;; @001b                               v16 = load.i32 user2 readonly region1 v13
-;; @001b                               v17 = iconst.i32 -1342177280
-;; @001b                               v18 = band v16, v17  ; v17 = -1342177280
-;; @001b                               v19 = icmp eq v18, v17  ; v17 = -1342177280
-;; @001b                               v20 = uextend.i32 v19
-;; @001b                               jump block4(v20)
+;; @001b                               v14 = iadd v13, v11
+;; @001b                               v17 = load.i32 user2 readonly region1 v14
+;; @001b                               v18 = iconst.i32 -1342177280
+;; @001b                               v19 = band v17, v18  ; v18 = -1342177280
+;; @001b                               v20 = icmp eq v19, v18  ; v18 = -1342177280
+;; @001b                               v21 = uextend.i32 v20
+;; @001b                               jump block4(v21)
 ;;
-;;                                 block4(v21: i32):
-;; @001e                               jump block1(v21)
+;;                                 block4(v22: i32):
+;; @001e                               jump block1(v22)
 ;;
 ;;                                 block1(v3: i32):
 ;; @001e                               return v3

--- a/tests/disas/gc/drc/struct-get.wat
+++ b/tests/disas/gc/drc/struct-get.wat
@@ -29,25 +29,21 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0033                               trapz v2, user16
-;; @0033                               v10 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0033                               v5 = load.i64 notrap aligned readonly can_move v10+32
+;; @0033                               v5 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @0033                               v6 = load.i64 notrap aligned readonly can_move v5+32
 ;; @0033                               v4 = uextend.i64 v2
-;; @0033                               v6 = iadd v5, v4
-;; @0033                               v7 = iconst.i64 24
-;; @0033                               v8 = iadd v6, v7  ; v7 = 24
-;; @0033                               v9 = load.f32 user2 little region1 v8
+;; @0033                               v7 = iadd v6, v4
+;; @0033                               v8 = iconst.i64 24
+;; @0033                               v9 = iadd v7, v8  ; v8 = 24
+;; @0033                               v10 = load.f32 user2 little region1 v9
 ;; @0037                               jump block1
 ;;
 ;;                                 block1:
-;; @0037                               return v9
+;; @0037                               return v10
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
@@ -56,26 +52,22 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @003c                               trapz v2, user16
-;; @003c                               v11 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @003c                               v5 = load.i64 notrap aligned readonly can_move v11+32
+;; @003c                               v5 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @003c                               v6 = load.i64 notrap aligned readonly can_move v5+32
 ;; @003c                               v4 = uextend.i64 v2
-;; @003c                               v6 = iadd v5, v4
-;; @003c                               v7 = iconst.i64 28
-;; @003c                               v8 = iadd v6, v7  ; v7 = 28
-;; @003c                               v9 = load.i8 user2 little region1 v8
+;; @003c                               v7 = iadd v6, v4
+;; @003c                               v8 = iconst.i64 28
+;; @003c                               v9 = iadd v7, v8  ; v8 = 28
+;; @003c                               v10 = load.i8 user2 little region1 v9
 ;; @0040                               jump block1
 ;;
 ;;                                 block1:
-;; @003c                               v10 = sextend.i32 v9
-;; @0040                               return v10
+;; @003c                               v11 = sextend.i32 v10
+;; @0040                               return v11
 ;; }
 ;;
 ;; function u0:2(i64 vmctx, i64, i32) -> i32 tail {
@@ -84,26 +76,22 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0045                               trapz v2, user16
-;; @0045                               v11 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0045                               v5 = load.i64 notrap aligned readonly can_move v11+32
+;; @0045                               v5 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @0045                               v6 = load.i64 notrap aligned readonly can_move v5+32
 ;; @0045                               v4 = uextend.i64 v2
-;; @0045                               v6 = iadd v5, v4
-;; @0045                               v7 = iconst.i64 28
-;; @0045                               v8 = iadd v6, v7  ; v7 = 28
-;; @0045                               v9 = load.i8 user2 little region1 v8
+;; @0045                               v7 = iadd v6, v4
+;; @0045                               v8 = iconst.i64 28
+;; @0045                               v9 = iadd v7, v8  ; v8 = 28
+;; @0045                               v10 = load.i8 user2 little region1 v9
 ;; @0049                               jump block1
 ;;
 ;;                                 block1:
-;; @0045                               v10 = uextend.i32 v9
-;; @0049                               return v10
+;; @0045                               v11 = uextend.i32 v10
+;; @0049                               return v11
 ;; }
 ;;
 ;; function u0:3(i64 vmctx, i64, i32) -> i32 tail {
@@ -114,79 +102,75 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx) -> i8 tail
 ;;     fn0 = colocated u805306368:45 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @004e                               trapz v2, user16
-;; @004e                               v90 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @004e                               v5 = load.i64 notrap aligned readonly can_move v90+32
+;; @004e                               v5 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @004e                               v6 = load.i64 notrap aligned readonly can_move v5+32
 ;; @004e                               v4 = uextend.i64 v2
-;; @004e                               v6 = iadd v5, v4
-;; @004e                               v7 = iconst.i64 32
-;; @004e                               v8 = iadd v6, v7  ; v7 = 32
-;; @004e                               v9 = load.i32 user2 little region1 v8
-;;                                     v79 = stack_addr.i64 ss0
-;;                                     store notrap v9, v79
-;; @004e                               v10 = iconst.i32 1
-;; @004e                               v11 = band v9, v10  ; v10 = 1
-;; @004e                               v12 = iconst.i32 0
-;; @004e                               v13 = icmp eq v9, v12  ; v12 = 0
-;; @004e                               v14 = uextend.i32 v13
-;; @004e                               v15 = bor v11, v14
-;; @004e                               brif v15, block4, block2
+;; @004e                               v7 = iadd v6, v4
+;; @004e                               v8 = iconst.i64 32
+;; @004e                               v9 = iadd v7, v8  ; v8 = 32
+;; @004e                               v10 = load.i32 user2 little region1 v9
+;;                                     v85 = stack_addr.i64 ss0
+;;                                     store notrap v10, v85
+;; @004e                               v11 = iconst.i32 1
+;; @004e                               v12 = band v10, v11  ; v11 = 1
+;; @004e                               v13 = iconst.i32 0
+;; @004e                               v14 = icmp eq v10, v13  ; v13 = 0
+;; @004e                               v15 = uextend.i32 v14
+;; @004e                               v16 = bor v12, v15
+;; @004e                               brif v16, block4, block2
 ;;
 ;;                                 block2:
-;; @004e                               v16 = uextend.i64 v9
-;; @004e                               v18 = iadd.i64 v5, v16
-;; @004e                               v19 = load.i32 user2 region1 v18
-;; @004e                               v20 = iconst.i32 2
-;; @004e                               v21 = band v19, v20  ; v20 = 2
-;; @004e                               brif v21, block4, block3
+;; @004e                               v17 = uextend.i64 v10
+;; @004e                               v20 = iadd.i64 v6, v17
+;; @004e                               v21 = load.i32 user2 region1 v20
+;; @004e                               v22 = iconst.i32 2
+;; @004e                               v23 = band v21, v22  ; v22 = 2
+;; @004e                               brif v23, block4, block3
 ;;
 ;;                                 block3:
-;; @004e                               v22 = load.i64 notrap aligned readonly can_move region2 v0+32
-;; @004e                               v23 = load.i32 user2 region1 v22
-;; @004e                               v27 = iconst.i64 16
-;; @004e                               v28 = iadd.i64 v18, v27  ; v27 = 16
-;; @004e                               store user2 region1 v23, v28
-;;                                     v92 = iconst.i32 2
-;;                                     v93 = bor.i32 v19, v92  ; v92 = 2
-;; @004e                               store user2 region1 v93, v18
-;; @004e                               v37 = iconst.i64 8
-;; @004e                               v38 = iadd.i64 v18, v37  ; v37 = 8
-;; @004e                               v39 = load.i64 user2 region1 v38
-;; @004e                               v40 = iconst.i64 1
-;; @004e                               v41 = iadd v39, v40  ; v40 = 1
-;; @004e                               store user2 region1 v41, v38
-;; @004e                               store.i32 user2 region1 v9, v22
-;; @004e                               v48 = load.i32 notrap aligned v22+4
-;;                                     v94 = iconst.i32 1
-;;                                     v95 = iadd v48, v94  ; v94 = 1
-;; @004e                               store notrap aligned v95, v22+4
-;; @004e                               v55 = load.i32 notrap aligned v22+8
-;; @004e                               v56 = iadd v55, v55
-;; @004e                               v57 = iconst.i32 1024
-;; @004e                               v58 = umax v56, v57  ; v57 = 1024
-;; @004e                               v59 = icmp uge v95, v58
-;; @004e                               brif v59, block5, block6
+;; @004e                               v24 = load.i64 notrap aligned readonly can_move region2 v0+32
+;; @004e                               v25 = load.i32 user2 region1 v24
+;; @004e                               v30 = iconst.i64 16
+;; @004e                               v31 = iadd.i64 v20, v30  ; v30 = 16
+;; @004e                               store user2 region1 v25, v31
+;;                                     v86 = iconst.i32 2
+;;                                     v87 = bor.i32 v21, v86  ; v86 = 2
+;; @004e                               store user2 region1 v87, v20
+;; @004e                               v42 = iconst.i64 8
+;; @004e                               v43 = iadd.i64 v20, v42  ; v42 = 8
+;; @004e                               v44 = load.i64 user2 region1 v43
+;; @004e                               v45 = iconst.i64 1
+;; @004e                               v46 = iadd v44, v45  ; v45 = 1
+;; @004e                               store user2 region1 v46, v43
+;; @004e                               store.i32 user2 region1 v10, v24
+;; @004e                               v54 = load.i32 notrap aligned v24+4
+;;                                     v88 = iconst.i32 1
+;;                                     v89 = iadd v54, v88  ; v88 = 1
+;; @004e                               store notrap aligned v89, v24+4
+;; @004e                               v61 = load.i32 notrap aligned v24+8
+;; @004e                               v62 = iadd v61, v61
+;; @004e                               v63 = iconst.i32 1024
+;; @004e                               v64 = umax v62, v63  ; v63 = 1024
+;; @004e                               v65 = icmp uge v89, v64
+;; @004e                               brif v65, block5, block6
 ;;
 ;;                                 block5 cold:
-;; @004e                               v60 = call fn0(v0), stack_map=[i32 @ ss0+0]
+;; @004e                               v66 = call fn0(v0), stack_map=[i32 @ ss0+0]
 ;; @004e                               jump block6
 ;;
 ;;                                 block6:
 ;; @004e                               jump block4
 ;;
 ;;                                 block4:
-;;                                     v62 = load.i32 notrap v79
+;;                                     v68 = load.i32 notrap v85
 ;; @0052                               jump block1
 ;;
 ;;                                 block1:
-;; @0052                               return v62
+;; @0052                               return v68
 ;; }

--- a/tests/disas/gc/drc/struct-new-default.wat
+++ b/tests/disas/gc/drc/struct-new-default.wat
@@ -18,10 +18,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
 ;;     fn0 = colocated u805306368:24 sig0
 ;;     stack_limit = gv2
@@ -48,10 +44,10 @@
 ;;                                     jump block3
 ;;
 ;;                                 block3:
-;;                                     v62 = iconst.i32 0
+;;                                     v60 = iconst.i32 0
 ;; @0021                               v20 = iconst.i64 32
 ;; @0021                               v21 = iadd.i64 v15, v20  ; v20 = 32
-;; @0021                               store user2 little region2 v62, v21  ; v62 = 0
+;; @0021                               store user2 little region2 v60, v21  ; v60 = 0
 ;; @0024                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/drc/struct-new.wat
+++ b/tests/disas/gc/drc/struct-new.wat
@@ -19,17 +19,13 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
 ;;     fn0 = colocated u805306368:24 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: f32, v3: i32, v4: i32):
-;;                                     v51 = stack_addr.i64 ss0
-;;                                     store notrap v4, v51
+;;                                     v53 = stack_addr.i64 ss0
+;;                                     store notrap v4, v53
 ;; @002a                               v7 = iconst.i32 -1342177280
 ;; @002a                               v8 = load.i64 notrap aligned readonly can_move region1 v0+40
 ;; @002a                               v9 = load.i32 notrap aligned readonly can_move v8
@@ -46,30 +42,30 @@
 ;; @002a                               v18 = iconst.i64 28
 ;; @002a                               v19 = iadd v15, v18  ; v18 = 28
 ;; @002a                               istore8 user2 little region2 v3, v19
-;;                                     v50 = load.i32 notrap v51
+;;                                     v52 = load.i32 notrap v53
 ;; @002a                               v22 = iconst.i32 1
-;; @002a                               v23 = band v50, v22  ; v22 = 1
+;; @002a                               v23 = band v52, v22  ; v22 = 1
 ;; @002a                               v24 = iconst.i32 0
-;; @002a                               v25 = icmp eq v50, v24  ; v24 = 0
+;; @002a                               v25 = icmp eq v52, v24  ; v24 = 0
 ;; @002a                               v26 = uextend.i32 v25
 ;; @002a                               v27 = bor v23, v26
 ;; @002a                               brif v27, block3, block2
 ;;
 ;;                                 block2:
-;; @002a                               v28 = uextend.i64 v50
-;; @002a                               v30 = iadd.i64 v13, v28
-;; @002a                               v31 = iconst.i64 8
-;; @002a                               v32 = iadd v30, v31  ; v31 = 8
-;; @002a                               v33 = load.i64 user2 region2 v32
-;; @002a                               v34 = iconst.i64 1
-;; @002a                               v35 = iadd v33, v34  ; v34 = 1
-;; @002a                               store user2 region2 v35, v32
+;; @002a                               v28 = uextend.i64 v52
+;; @002a                               v31 = iadd.i64 v13, v28
+;; @002a                               v32 = iconst.i64 8
+;; @002a                               v33 = iadd v31, v32  ; v32 = 8
+;; @002a                               v34 = load.i64 user2 region2 v33
+;; @002a                               v35 = iconst.i64 1
+;; @002a                               v36 = iadd v34, v35  ; v35 = 1
+;; @002a                               store user2 region2 v36, v33
 ;; @002a                               jump block3
 ;;
 ;;                                 block3:
 ;; @002a                               v20 = iconst.i64 32
 ;; @002a                               v21 = iadd.i64 v15, v20  ; v20 = 32
-;; @002a                               store.i32 user2 little region2 v50, v21
+;; @002a                               store.i32 user2 little region2 v52, v21
 ;; @002d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/drc/struct-set.wat
+++ b/tests/disas/gc/drc/struct-set.wat
@@ -25,21 +25,17 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: f32):
 ;; @0034                               trapz v2, user16
-;; @0034                               v9 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0034                               v5 = load.i64 notrap aligned readonly can_move v9+32
+;; @0034                               v5 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @0034                               v6 = load.i64 notrap aligned readonly can_move v5+32
 ;; @0034                               v4 = uextend.i64 v2
-;; @0034                               v6 = iadd v5, v4
-;; @0034                               v7 = iconst.i64 24
-;; @0034                               v8 = iadd v6, v7  ; v7 = 24
-;; @0034                               store user2 little region1 v3, v8
+;; @0034                               v7 = iadd v6, v4
+;; @0034                               v8 = iconst.i64 24
+;; @0034                               v9 = iadd v7, v8  ; v8 = 24
+;; @0034                               store user2 little region1 v3, v9
 ;; @0038                               jump block1
 ;;
 ;;                                 block1:
@@ -52,21 +48,17 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @003f                               trapz v2, user16
-;; @003f                               v9 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @003f                               v5 = load.i64 notrap aligned readonly can_move v9+32
+;; @003f                               v5 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @003f                               v6 = load.i64 notrap aligned readonly can_move v5+32
 ;; @003f                               v4 = uextend.i64 v2
-;; @003f                               v6 = iadd v5, v4
-;; @003f                               v7 = iconst.i64 28
-;; @003f                               v8 = iadd v6, v7  ; v7 = 28
-;; @003f                               istore8 user2 little region1 v3, v8
+;; @003f                               v7 = iadd v6, v4
+;; @003f                               v8 = iconst.i64 28
+;; @003f                               v9 = iadd v7, v8  ; v8 = 28
+;; @003f                               istore8 user2 little region1 v3, v9
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -79,72 +71,68 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32) tail
 ;;     fn0 = colocated u805306368:22 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @004a                               trapz v2, user16
-;; @004a                               v58 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @004a                               v5 = load.i64 notrap aligned readonly can_move v58+32
+;; @004a                               v5 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @004a                               v6 = load.i64 notrap aligned readonly can_move v5+32
 ;; @004a                               v4 = uextend.i64 v2
-;; @004a                               v6 = iadd v5, v4
-;; @004a                               v7 = iconst.i64 32
-;; @004a                               v8 = iadd v6, v7  ; v7 = 32
-;; @004a                               v9 = load.i32 user2 little region1 v8
-;; @004a                               v10 = iconst.i32 1
-;; @004a                               v11 = band v3, v10  ; v10 = 1
-;; @004a                               v12 = iconst.i32 0
-;; @004a                               v13 = icmp eq v3, v12  ; v12 = 0
-;; @004a                               v14 = uextend.i32 v13
-;; @004a                               v15 = bor v11, v14
-;; @004a                               brif v15, block3, block2
+;; @004a                               v7 = iadd v6, v4
+;; @004a                               v8 = iconst.i64 32
+;; @004a                               v9 = iadd v7, v8  ; v8 = 32
+;; @004a                               v10 = load.i32 user2 little region1 v9
+;; @004a                               v11 = iconst.i32 1
+;; @004a                               v12 = band v3, v11  ; v11 = 1
+;; @004a                               v13 = iconst.i32 0
+;; @004a                               v14 = icmp eq v3, v13  ; v13 = 0
+;; @004a                               v15 = uextend.i32 v14
+;; @004a                               v16 = bor v12, v15
+;; @004a                               brif v16, block3, block2
 ;;
 ;;                                 block2:
-;; @004a                               v16 = uextend.i64 v3
-;; @004a                               v18 = iadd.i64 v5, v16
-;; @004a                               v19 = iconst.i64 8
-;; @004a                               v20 = iadd v18, v19  ; v19 = 8
-;; @004a                               v21 = load.i64 user2 region1 v20
-;; @004a                               v22 = iconst.i64 1
-;; @004a                               v23 = iadd v21, v22  ; v22 = 1
-;; @004a                               store user2 region1 v23, v20
+;; @004a                               v17 = uextend.i64 v3
+;; @004a                               v20 = iadd.i64 v6, v17
+;; @004a                               v21 = iconst.i64 8
+;; @004a                               v22 = iadd v20, v21  ; v21 = 8
+;; @004a                               v23 = load.i64 user2 region1 v22
+;; @004a                               v24 = iconst.i64 1
+;; @004a                               v25 = iadd v23, v24  ; v24 = 1
+;; @004a                               store user2 region1 v25, v22
 ;; @004a                               jump block3
 ;;
 ;;                                 block3:
-;;                                     v72 = iadd.i64 v6, v7  ; v7 = 32
-;; @004a                               store.i32 user2 little region1 v3, v72
-;;                                     v73 = iconst.i32 1
-;;                                     v74 = band.i32 v9, v73  ; v73 = 1
-;;                                     v75 = iconst.i32 0
-;;                                     v76 = icmp.i32 eq v9, v75  ; v75 = 0
-;; @004a                               v33 = uextend.i32 v76
-;; @004a                               v34 = bor v74, v33
-;; @004a                               brif v34, block7, block4
+;;                                     v67 = iadd.i64 v7, v8  ; v8 = 32
+;; @004a                               store.i32 user2 little region1 v3, v67
+;;                                     v68 = iconst.i32 1
+;;                                     v69 = band.i32 v10, v68  ; v68 = 1
+;;                                     v70 = iconst.i32 0
+;;                                     v71 = icmp.i32 eq v10, v70  ; v70 = 0
+;; @004a                               v36 = uextend.i32 v71
+;; @004a                               v37 = bor v69, v36
+;; @004a                               brif v37, block7, block4
 ;;
 ;;                                 block4:
-;; @004a                               v35 = uextend.i64 v9
-;; @004a                               v37 = iadd.i64 v5, v35
-;;                                     v77 = iconst.i64 8
-;; @004a                               v39 = iadd v37, v77  ; v77 = 8
-;; @004a                               v40 = load.i64 user2 region1 v39
-;;                                     v78 = iconst.i64 1
-;;                                     v70 = icmp eq v40, v78  ; v78 = 1
-;; @004a                               brif v70, block5, block6
+;; @004a                               v38 = uextend.i64 v10
+;; @004a                               v41 = iadd.i64 v6, v38
+;;                                     v72 = iconst.i64 8
+;; @004a                               v43 = iadd v41, v72  ; v72 = 8
+;; @004a                               v44 = load.i64 user2 region1 v43
+;;                                     v73 = iconst.i64 1
+;;                                     v65 = icmp eq v44, v73  ; v73 = 1
+;; @004a                               brif v65, block5, block6
 ;;
 ;;                                 block5 cold:
-;; @004a                               call fn0(v0, v9)
+;; @004a                               call fn0(v0, v10)
 ;; @004a                               jump block7
 ;;
 ;;                                 block6:
-;; @004a                               v41 = iconst.i64 -1
-;; @004a                               v42 = iadd.i64 v40, v41  ; v41 = -1
-;;                                     v79 = iadd.i64 v37, v77  ; v77 = 8
-;; @004a                               store user2 region1 v42, v79
+;; @004a                               v45 = iconst.i64 -1
+;; @004a                               v46 = iadd.i64 v44, v45  ; v45 = -1
+;;                                     v74 = iadd.i64 v41, v72  ; v72 = 8
+;; @004a                               store user2 region1 v46, v74
 ;; @004a                               jump block7
 ;;
 ;;                                 block7:

--- a/tests/disas/gc/null/array-fill.wat
+++ b/tests/disas/gc/null/array-fill.wat
@@ -15,49 +15,45 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i64, v5: i32):
 ;; @0027                               trapz v2, user16
-;; @0027                               v46 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0027                               v7 = load.i64 notrap aligned readonly can_move v46+32
+;; @0027                               v7 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @0027                               v8 = load.i64 notrap aligned readonly can_move v7+32
 ;; @0027                               v6 = uextend.i64 v2
-;; @0027                               v8 = iadd v7, v6
-;; @0027                               v9 = iconst.i64 8
-;; @0027                               v10 = iadd v8, v9  ; v9 = 8
-;; @0027                               v11 = load.i32 user2 readonly region1 v10
-;; @0027                               v13 = uextend.i64 v3
-;; @0027                               v14 = uextend.i64 v5
-;; @0027                               v17 = iadd v13, v14
-;; @0027                               v12 = uextend.i64 v11
-;; @0027                               v18 = icmp ugt v17, v12
-;; @0027                               trapnz v18, user17
-;; @0027                               v35 = load.i64 notrap aligned v46+40
-;; @0027                               v23 = iconst.i64 16
-;; @0027                               v24 = iadd v8, v23  ; v23 = 16
-;;                                     v50 = iconst.i64 3
-;;                                     v51 = ishl v13, v50  ; v50 = 3
-;; @0027                               v28 = iadd v24, v51
-;;                                     v53 = ishl v14, v50  ; v50 = 3
-;; @0027                               v37 = uadd_overflow_trap v28, v53, user2
-;; @0027                               v36 = iadd v7, v35
-;; @0027                               v38 = icmp ugt v37, v36
-;; @0027                               trapnz v38, user2
-;;                                     v48 = iconst.i64 0
-;; @0027                               v41 = icmp eq v14, v48  ; v48 = 0
-;; @0027                               v39 = iadd v28, v53
-;; @0027                               brif v41, block3, block2(v28)
+;; @0027                               v9 = iadd v8, v6
+;; @0027                               v10 = iconst.i64 8
+;; @0027                               v11 = iadd v9, v10  ; v10 = 8
+;; @0027                               v12 = load.i32 user2 readonly region1 v11
+;; @0027                               v14 = uextend.i64 v3
+;; @0027                               v15 = uextend.i64 v5
+;; @0027                               v18 = iadd v14, v15
+;; @0027                               v13 = uextend.i64 v12
+;; @0027                               v19 = icmp ugt v18, v13
+;; @0027                               trapnz v19, user17
+;; @0027                               v36 = load.i64 notrap aligned v7+40
+;; @0027                               v24 = iconst.i64 16
+;; @0027                               v25 = iadd v9, v24  ; v24 = 16
+;;                                     v49 = iconst.i64 3
+;;                                     v50 = ishl v14, v49  ; v49 = 3
+;; @0027                               v29 = iadd v25, v50
+;;                                     v52 = ishl v15, v49  ; v49 = 3
+;; @0027                               v38 = uadd_overflow_trap v29, v52, user2
+;; @0027                               v37 = iadd v8, v36
+;; @0027                               v39 = icmp ugt v38, v37
+;; @0027                               trapnz v39, user2
+;;                                     v47 = iconst.i64 0
+;; @0027                               v42 = icmp eq v15, v47  ; v47 = 0
+;; @0027                               v40 = iadd v29, v52
+;; @0027                               brif v42, block3, block2(v29)
 ;;
-;;                                 block2(v42: i64):
-;; @0027                               store.i64 user2 little region1 v4, v42
-;;                                     v55 = iconst.i64 8
-;;                                     v56 = iadd v42, v55  ; v55 = 8
-;; @0027                               v45 = icmp eq v56, v39
-;; @0027                               brif v45, block3, block2(v56)
+;;                                 block2(v43: i64):
+;; @0027                               store.i64 user2 little region1 v4, v43
+;;                                     v54 = iconst.i64 8
+;;                                     v55 = iadd v43, v54  ; v54 = 8
+;; @0027                               v46 = icmp eq v55, v40
+;; @0027                               brif v46, block3, block2(v55)
 ;;
 ;;                                 block3:
 ;; @002a                               jump block1

--- a/tests/disas/gc/null/array-get-s.wat
+++ b/tests/disas/gc/null/array-get-s.wat
@@ -15,40 +15,36 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0022                               trapz v2, user16
-;; @0022                               v34 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0022                               v6 = load.i64 notrap aligned readonly can_move v34+32
+;; @0022                               v6 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @0022                               v7 = load.i64 notrap aligned readonly can_move v6+32
 ;; @0022                               v5 = uextend.i64 v2
-;; @0022                               v7 = iadd v6, v5
-;; @0022                               v8 = iconst.i64 8
-;; @0022                               v9 = iadd v7, v8  ; v8 = 8
-;; @0022                               v10 = load.i32 user2 readonly region1 v9
-;; @0022                               v11 = icmp ult v3, v10
-;; @0022                               trapz v11, user17
-;; @0022                               v13 = uextend.i64 v10
-;; @0022                               v15 = iconst.i64 32
-;; @0022                               v16 = ushr v13, v15  ; v15 = 32
-;; @0022                               trapnz v16, user2
-;; @0022                               v18 = iconst.i32 12
-;; @0022                               v19 = uadd_overflow_trap v10, v18, user2  ; v18 = 12
-;; @0022                               v23 = uadd_overflow_trap v2, v19, user2
-;; @0022                               v24 = uextend.i64 v23
-;; @0022                               v26 = iadd v6, v24
-;; @0022                               v22 = iadd v3, v18  ; v18 = 12
-;; @0022                               v27 = isub v19, v22
-;; @0022                               v28 = uextend.i64 v27
-;; @0022                               v29 = isub v26, v28
-;; @0022                               v30 = load.i8 user2 little region1 v29
+;; @0022                               v8 = iadd v7, v5
+;; @0022                               v9 = iconst.i64 8
+;; @0022                               v10 = iadd v8, v9  ; v9 = 8
+;; @0022                               v11 = load.i32 user2 readonly region1 v10
+;; @0022                               v12 = icmp ult v3, v11
+;; @0022                               trapz v12, user17
+;; @0022                               v14 = uextend.i64 v11
+;; @0022                               v16 = iconst.i64 32
+;; @0022                               v17 = ushr v14, v16  ; v16 = 32
+;; @0022                               trapnz v17, user2
+;; @0022                               v19 = iconst.i32 12
+;; @0022                               v20 = uadd_overflow_trap v11, v19, user2  ; v19 = 12
+;; @0022                               v24 = uadd_overflow_trap v2, v20, user2
+;; @0022                               v25 = uextend.i64 v24
+;; @0022                               v28 = iadd v7, v25
+;; @0022                               v23 = iadd v3, v19  ; v19 = 12
+;; @0022                               v29 = isub v20, v23
+;; @0022                               v30 = uextend.i64 v29
+;; @0022                               v31 = isub v28, v30
+;; @0022                               v32 = load.i8 user2 little region1 v31
 ;; @0025                               jump block1
 ;;
 ;;                                 block1:
-;; @0022                               v31 = sextend.i32 v30
-;; @0025                               return v31
+;; @0022                               v33 = sextend.i32 v32
+;; @0025                               return v33
 ;; }

--- a/tests/disas/gc/null/array-get-u.wat
+++ b/tests/disas/gc/null/array-get-u.wat
@@ -15,40 +15,36 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0022                               trapz v2, user16
-;; @0022                               v34 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0022                               v6 = load.i64 notrap aligned readonly can_move v34+32
+;; @0022                               v6 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @0022                               v7 = load.i64 notrap aligned readonly can_move v6+32
 ;; @0022                               v5 = uextend.i64 v2
-;; @0022                               v7 = iadd v6, v5
-;; @0022                               v8 = iconst.i64 8
-;; @0022                               v9 = iadd v7, v8  ; v8 = 8
-;; @0022                               v10 = load.i32 user2 readonly region1 v9
-;; @0022                               v11 = icmp ult v3, v10
-;; @0022                               trapz v11, user17
-;; @0022                               v13 = uextend.i64 v10
-;; @0022                               v15 = iconst.i64 32
-;; @0022                               v16 = ushr v13, v15  ; v15 = 32
-;; @0022                               trapnz v16, user2
-;; @0022                               v18 = iconst.i32 12
-;; @0022                               v19 = uadd_overflow_trap v10, v18, user2  ; v18 = 12
-;; @0022                               v23 = uadd_overflow_trap v2, v19, user2
-;; @0022                               v24 = uextend.i64 v23
-;; @0022                               v26 = iadd v6, v24
-;; @0022                               v22 = iadd v3, v18  ; v18 = 12
-;; @0022                               v27 = isub v19, v22
-;; @0022                               v28 = uextend.i64 v27
-;; @0022                               v29 = isub v26, v28
-;; @0022                               v30 = load.i8 user2 little region1 v29
+;; @0022                               v8 = iadd v7, v5
+;; @0022                               v9 = iconst.i64 8
+;; @0022                               v10 = iadd v8, v9  ; v9 = 8
+;; @0022                               v11 = load.i32 user2 readonly region1 v10
+;; @0022                               v12 = icmp ult v3, v11
+;; @0022                               trapz v12, user17
+;; @0022                               v14 = uextend.i64 v11
+;; @0022                               v16 = iconst.i64 32
+;; @0022                               v17 = ushr v14, v16  ; v16 = 32
+;; @0022                               trapnz v17, user2
+;; @0022                               v19 = iconst.i32 12
+;; @0022                               v20 = uadd_overflow_trap v11, v19, user2  ; v19 = 12
+;; @0022                               v24 = uadd_overflow_trap v2, v20, user2
+;; @0022                               v25 = uextend.i64 v24
+;; @0022                               v28 = iadd v7, v25
+;; @0022                               v23 = iadd v3, v19  ; v19 = 12
+;; @0022                               v29 = isub v20, v23
+;; @0022                               v30 = uextend.i64 v29
+;; @0022                               v31 = isub v28, v30
+;; @0022                               v32 = load.i8 user2 little region1 v31
 ;; @0025                               jump block1
 ;;
 ;;                                 block1:
-;; @0022                               v31 = uextend.i32 v30
-;; @0025                               return v31
+;; @0022                               v33 = uextend.i32 v32
+;; @0025                               return v33
 ;; }

--- a/tests/disas/gc/null/array-get.wat
+++ b/tests/disas/gc/null/array-get.wat
@@ -15,44 +15,40 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0022                               trapz v2, user16
-;; @0022                               v33 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0022                               v6 = load.i64 notrap aligned readonly can_move v33+32
+;; @0022                               v6 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @0022                               v7 = load.i64 notrap aligned readonly can_move v6+32
 ;; @0022                               v5 = uextend.i64 v2
-;; @0022                               v7 = iadd v6, v5
-;; @0022                               v8 = iconst.i64 8
-;; @0022                               v9 = iadd v7, v8  ; v8 = 8
-;; @0022                               v10 = load.i32 user2 readonly region1 v9
-;; @0022                               v11 = icmp ult v3, v10
-;; @0022                               trapz v11, user17
-;; @0022                               v13 = uextend.i64 v10
-;;                                     v35 = iconst.i64 3
-;;                                     v36 = ishl v13, v35  ; v35 = 3
-;; @0022                               v15 = iconst.i64 32
-;; @0022                               v16 = ushr v36, v15  ; v15 = 32
-;; @0022                               trapnz v16, user2
-;;                                     v45 = iconst.i32 3
-;;                                     v46 = ishl v10, v45  ; v45 = 3
-;; @0022                               v18 = iconst.i32 16
-;; @0022                               v19 = uadd_overflow_trap v46, v18, user2  ; v18 = 16
-;; @0022                               v23 = uadd_overflow_trap v2, v19, user2
-;; @0022                               v24 = uextend.i64 v23
-;; @0022                               v26 = iadd v6, v24
-;;                                     v52 = ishl v3, v45  ; v45 = 3
-;; @0022                               v22 = iadd v52, v18  ; v18 = 16
-;; @0022                               v27 = isub v19, v22
-;; @0022                               v28 = uextend.i64 v27
-;; @0022                               v29 = isub v26, v28
-;; @0022                               v30 = load.i64 user2 little region1 v29
+;; @0022                               v8 = iadd v7, v5
+;; @0022                               v9 = iconst.i64 8
+;; @0022                               v10 = iadd v8, v9  ; v9 = 8
+;; @0022                               v11 = load.i32 user2 readonly region1 v10
+;; @0022                               v12 = icmp ult v3, v11
+;; @0022                               trapz v12, user17
+;; @0022                               v14 = uextend.i64 v11
+;;                                     v33 = iconst.i64 3
+;;                                     v34 = ishl v14, v33  ; v33 = 3
+;; @0022                               v16 = iconst.i64 32
+;; @0022                               v17 = ushr v34, v16  ; v16 = 32
+;; @0022                               trapnz v17, user2
+;;                                     v43 = iconst.i32 3
+;;                                     v44 = ishl v11, v43  ; v43 = 3
+;; @0022                               v19 = iconst.i32 16
+;; @0022                               v20 = uadd_overflow_trap v44, v19, user2  ; v19 = 16
+;; @0022                               v24 = uadd_overflow_trap v2, v20, user2
+;; @0022                               v25 = uextend.i64 v24
+;; @0022                               v28 = iadd v7, v25
+;;                                     v50 = ishl v3, v43  ; v43 = 3
+;; @0022                               v23 = iadd v50, v19  ; v19 = 16
+;; @0022                               v29 = isub v20, v23
+;; @0022                               v30 = uextend.i64 v29
+;; @0022                               v31 = isub v28, v30
+;; @0022                               v32 = load.i64 user2 little region1 v31
 ;; @0025                               jump block1
 ;;
 ;;                                 block1:
-;; @0025                               return v30
+;; @0025                               return v32
 ;; }

--- a/tests/disas/gc/null/array-len.wat
+++ b/tests/disas/gc/null/array-len.wat
@@ -15,23 +15,19 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @001f                               trapz v2, user16
-;; @001f                               v10 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @001f                               v5 = load.i64 notrap aligned readonly can_move v10+32
+;; @001f                               v5 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @001f                               v6 = load.i64 notrap aligned readonly can_move v5+32
 ;; @001f                               v4 = uextend.i64 v2
-;; @001f                               v6 = iadd v5, v4
-;; @001f                               v7 = iconst.i64 8
-;; @001f                               v8 = iadd v6, v7  ; v7 = 8
-;; @001f                               v9 = load.i32 user2 readonly region1 v8
+;; @001f                               v7 = iadd v6, v4
+;; @001f                               v8 = iconst.i64 8
+;; @001f                               v9 = iadd v7, v8  ; v8 = 8
+;; @001f                               v10 = load.i32 user2 readonly region1 v9
 ;; @0021                               jump block1
 ;;
 ;;                                 block1:
-;; @0021                               return v9
+;; @0021                               return v10
 ;; }

--- a/tests/disas/gc/null/array-new-fixed-of-gc-refs.wat
+++ b/tests/disas/gc/null/array-new-fixed-of-gc-refs.wat
@@ -20,29 +20,25 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i64) -> i8 tail
 ;;     fn0 = colocated u805306368:23 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
-;;                                     v126 = stack_addr.i64 ss2
-;;                                     store notrap v2, v126
-;;                                     v127 = stack_addr.i64 ss1
-;;                                     store notrap v3, v127
-;;                                     v128 = stack_addr.i64 ss0
-;;                                     store notrap v4, v128
+;;                                     v132 = stack_addr.i64 ss2
+;;                                     store notrap v2, v132
+;;                                     v133 = stack_addr.i64 ss1
+;;                                     store notrap v3, v133
+;;                                     v134 = stack_addr.i64 ss0
+;;                                     store notrap v4, v134
 ;; @0025                               v18 = load.i64 notrap aligned readonly can_move region1 v0+32
 ;; @0025                               v19 = load.i32 user2 region2 v18
-;;                                     v158 = iconst.i32 7
-;; @0025                               v22 = uadd_overflow_trap v19, v158, user18  ; v158 = 7
-;;                                     v164 = iconst.i32 -8
-;; @0025                               v24 = band v22, v164  ; v164 = -8
-;;                                     v151 = iconst.i32 24
-;; @0025                               v25 = uadd_overflow_trap v24, v151, user18  ; v151 = 24
+;;                                     v152 = iconst.i32 7
+;; @0025                               v22 = uadd_overflow_trap v19, v152, user18  ; v152 = 7
+;;                                     v158 = iconst.i32 -8
+;; @0025                               v24 = band v22, v158  ; v158 = -8
+;;                                     v145 = iconst.i32 24
+;; @0025                               v25 = uadd_overflow_trap v24, v145, user18  ; v145 = 24
 ;; @0025                               v27 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @0025                               v28 = load.i64 notrap aligned v27+40
 ;; @0025                               v26 = uextend.i64 v25
@@ -50,12 +46,12 @@
 ;; @0025                               brif v29, block2, block3
 ;;
 ;;                                 block2:
-;;                                     v165 = iconst.i32 -1476394984
+;;                                     v159 = iconst.i32 -1476394984
 ;; @0025                               v33 = load.i64 notrap aligned readonly can_move v27+32
-;;                                     v263 = band.i32 v22, v164  ; v164 = -8
-;;                                     v264 = uextend.i64 v263
-;; @0025                               v35 = iadd v33, v264
-;; @0025                               store user2 region2 v165, v35  ; v165 = -1476394984
+;;                                     v257 = band.i32 v22, v158  ; v158 = -8
+;;                                     v258 = uextend.i64 v257
+;; @0025                               v35 = iadd v33, v258
+;; @0025                               store user2 region2 v159, v35  ; v159 = -1476394984
 ;; @0025                               v38 = load.i64 notrap aligned readonly can_move region3 v0+40
 ;; @0025                               v39 = load.i32 notrap aligned readonly can_move v38
 ;; @0025                               store user2 region2 v39, v35+4
@@ -64,56 +60,56 @@
 ;; @0025                               v40 = iconst.i64 8
 ;; @0025                               v41 = iadd v35, v40  ; v40 = 8
 ;; @0025                               store user2 region2 v6, v41  ; v6 = 3
-;; @0025                               trapz v263, user16
-;;                                     v265 = iconst.i32 24
-;; @0025                               v61 = uadd_overflow_trap v263, v265, user2  ; v265 = 24
-;;                                     v125 = load.i32 notrap v126
-;; @0025                               v62 = uextend.i64 v61
-;; @0025                               v64 = iadd v33, v62
-;;                                     v142 = iconst.i64 12
-;; @0025                               v67 = isub v64, v142  ; v142 = 12
-;; @0025                               store user2 little region2 v125, v67
-;; @0025                               v74 = load.i32 user2 readonly region2 v41
-;; @0025                               v68 = iconst.i32 1
-;;                                     v203 = icmp ugt v74, v68  ; v68 = 1
-;; @0025                               trapz v203, user17
-;; @0025                               v77 = uextend.i64 v74
-;;                                     v143 = iconst.i64 2
-;;                                     v205 = ishl v77, v143  ; v143 = 2
+;; @0025                               trapz v257, user16
+;;                                     v259 = iconst.i32 24
+;; @0025                               v62 = uadd_overflow_trap v257, v259, user2  ; v259 = 24
+;;                                     v131 = load.i32 notrap v132
+;; @0025                               v63 = uextend.i64 v62
+;; @0025                               v66 = iadd v33, v63
+;;                                     v136 = iconst.i64 12
+;; @0025                               v69 = isub v66, v136  ; v136 = 12
+;; @0025                               store user2 little region2 v131, v69
+;; @0025                               v77 = load.i32 user2 readonly region2 v41
+;; @0025                               v70 = iconst.i32 1
+;;                                     v197 = icmp ugt v77, v70  ; v70 = 1
+;; @0025                               trapz v197, user17
+;; @0025                               v80 = uextend.i64 v77
+;;                                     v137 = iconst.i64 2
+;;                                     v199 = ishl v80, v137  ; v137 = 2
 ;; @0025                               v11 = iconst.i64 32
-;; @0025                               v80 = ushr v205, v11  ; v11 = 32
-;; @0025                               trapnz v80, user2
-;;                                     v182 = iconst.i32 2
-;;                                     v212 = ishl v74, v182  ; v182 = 2
+;; @0025                               v83 = ushr v199, v11  ; v11 = 32
+;; @0025                               trapnz v83, user2
+;;                                     v176 = iconst.i32 2
+;;                                     v206 = ishl v77, v176  ; v176 = 2
 ;; @0025                               v7 = iconst.i32 12
-;; @0025                               v83 = uadd_overflow_trap v212, v7, user2  ; v7 = 12
-;; @0025                               v87 = uadd_overflow_trap v263, v83, user2
-;;                                     v123 = load.i32 notrap v127
-;; @0025                               v88 = uextend.i64 v87
-;; @0025                               v90 = iadd v33, v88
-;;                                     v225 = iconst.i32 16
-;; @0025                               v91 = isub v83, v225  ; v225 = 16
-;; @0025                               v92 = uextend.i64 v91
-;; @0025                               v93 = isub v90, v92
-;; @0025                               store user2 little region2 v123, v93
-;; @0025                               v100 = load.i32 user2 readonly region2 v41
-;;                                     v231 = icmp ugt v100, v182  ; v182 = 2
-;; @0025                               trapz v231, user17
-;; @0025                               v103 = uextend.i64 v100
-;;                                     v233 = ishl v103, v143  ; v143 = 2
-;; @0025                               v106 = ushr v233, v11  ; v11 = 32
-;; @0025                               trapnz v106, user2
-;;                                     v240 = ishl v100, v182  ; v182 = 2
-;; @0025                               v109 = uadd_overflow_trap v240, v7, user2  ; v7 = 12
-;; @0025                               v113 = uadd_overflow_trap v263, v109, user2
-;;                                     v121 = load.i32 notrap v128
-;; @0025                               v114 = uextend.i64 v113
-;; @0025                               v116 = iadd v33, v114
-;;                                     v257 = iconst.i32 20
-;; @0025                               v117 = isub v109, v257  ; v257 = 20
-;; @0025                               v118 = uextend.i64 v117
-;; @0025                               v119 = isub v116, v118
-;; @0025                               store user2 little region2 v121, v119
+;; @0025                               v86 = uadd_overflow_trap v206, v7, user2  ; v7 = 12
+;; @0025                               v90 = uadd_overflow_trap v257, v86, user2
+;;                                     v129 = load.i32 notrap v133
+;; @0025                               v91 = uextend.i64 v90
+;; @0025                               v94 = iadd v33, v91
+;;                                     v219 = iconst.i32 16
+;; @0025                               v95 = isub v86, v219  ; v219 = 16
+;; @0025                               v96 = uextend.i64 v95
+;; @0025                               v97 = isub v94, v96
+;; @0025                               store user2 little region2 v129, v97
+;; @0025                               v105 = load.i32 user2 readonly region2 v41
+;;                                     v225 = icmp ugt v105, v176  ; v176 = 2
+;; @0025                               trapz v225, user17
+;; @0025                               v108 = uextend.i64 v105
+;;                                     v227 = ishl v108, v137  ; v137 = 2
+;; @0025                               v111 = ushr v227, v11  ; v11 = 32
+;; @0025                               trapnz v111, user2
+;;                                     v234 = ishl v105, v176  ; v176 = 2
+;; @0025                               v114 = uadd_overflow_trap v234, v7, user2  ; v7 = 12
+;; @0025                               v118 = uadd_overflow_trap v257, v114, user2
+;;                                     v127 = load.i32 notrap v134
+;; @0025                               v119 = uextend.i64 v118
+;; @0025                               v122 = iadd v33, v119
+;;                                     v251 = iconst.i32 20
+;; @0025                               v123 = isub v114, v251  ; v251 = 20
+;; @0025                               v124 = uextend.i64 v123
+;; @0025                               v125 = isub v122, v124
+;; @0025                               store user2 little region2 v127, v125
 ;; @0029                               jump block1
 ;;
 ;;                                 block3 cold:
@@ -122,6 +118,6 @@
 ;; @0025                               jump block2
 ;;
 ;;                                 block1:
-;;                                     v266 = band.i32 v22, v164  ; v164 = -8
-;; @0029                               return v266
+;;                                     v260 = band.i32 v22, v158  ; v158 = -8
+;; @0029                               return v260
 ;; }

--- a/tests/disas/gc/null/array-new-fixed.wat
+++ b/tests/disas/gc/null/array-new-fixed.wat
@@ -17,10 +17,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i64) -> i8 tail
 ;;     fn0 = colocated u805306368:23 sig0
 ;;     stack_limit = gv2
@@ -28,12 +24,12 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i64, v4: i64):
 ;; @0025                               v18 = load.i64 notrap aligned readonly can_move region1 v0+32
 ;; @0025                               v19 = load.i32 user2 region2 v18
-;;                                     v149 = iconst.i32 7
-;; @0025                               v22 = uadd_overflow_trap v19, v149, user18  ; v149 = 7
-;;                                     v155 = iconst.i32 -8
-;; @0025                               v24 = band v22, v155  ; v155 = -8
-;;                                     v142 = iconst.i32 40
-;; @0025                               v25 = uadd_overflow_trap v24, v142, user18  ; v142 = 40
+;;                                     v143 = iconst.i32 7
+;; @0025                               v22 = uadd_overflow_trap v19, v143, user18  ; v143 = 7
+;;                                     v149 = iconst.i32 -8
+;; @0025                               v24 = band v22, v149  ; v149 = -8
+;;                                     v136 = iconst.i32 40
+;; @0025                               v25 = uadd_overflow_trap v24, v136, user18  ; v136 = 40
 ;; @0025                               v27 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @0025                               v28 = load.i64 notrap aligned v27+40
 ;; @0025                               v26 = uextend.i64 v25
@@ -41,12 +37,12 @@
 ;; @0025                               brif v29, block2, block3
 ;;
 ;;                                 block2:
-;;                                     v156 = iconst.i32 -1476394968
+;;                                     v150 = iconst.i32 -1476394968
 ;; @0025                               v33 = load.i64 notrap aligned readonly can_move v27+32
-;;                                     v251 = band.i32 v22, v155  ; v155 = -8
-;;                                     v252 = uextend.i64 v251
-;; @0025                               v35 = iadd v33, v252
-;; @0025                               store user2 region2 v156, v35  ; v156 = -1476394968
+;;                                     v245 = band.i32 v22, v149  ; v149 = -8
+;;                                     v246 = uextend.i64 v245
+;; @0025                               v35 = iadd v33, v246
+;; @0025                               store user2 region2 v150, v35  ; v150 = -1476394968
 ;; @0025                               v38 = load.i64 notrap aligned readonly can_move region3 v0+40
 ;; @0025                               v39 = load.i32 notrap aligned readonly can_move v38
 ;; @0025                               store user2 region2 v39, v35+4
@@ -55,53 +51,53 @@
 ;; @0025                               v9 = iconst.i64 8
 ;; @0025                               v41 = iadd v35, v9  ; v9 = 8
 ;; @0025                               store user2 region2 v6, v41  ; v6 = 3
-;; @0025                               trapz v251, user16
-;;                                     v253 = iconst.i32 40
-;; @0025                               v61 = uadd_overflow_trap v251, v253, user2  ; v253 = 40
-;; @0025                               v62 = uextend.i64 v61
-;; @0025                               v64 = iadd v33, v62
-;;                                     v133 = iconst.i64 24
-;; @0025                               v67 = isub v64, v133  ; v133 = 24
-;; @0025                               store.i64 user2 little region2 v2, v67
-;; @0025                               v74 = load.i32 user2 readonly region2 v41
-;; @0025                               v68 = iconst.i32 1
-;;                                     v192 = icmp ugt v74, v68  ; v68 = 1
-;; @0025                               trapz v192, user17
-;; @0025                               v77 = uextend.i64 v74
-;;                                     v132 = iconst.i64 3
-;;                                     v194 = ishl v77, v132  ; v132 = 3
+;; @0025                               trapz v245, user16
+;;                                     v247 = iconst.i32 40
+;; @0025                               v62 = uadd_overflow_trap v245, v247, user2  ; v247 = 40
+;; @0025                               v63 = uextend.i64 v62
+;; @0025                               v66 = iadd v33, v63
+;;                                     v127 = iconst.i64 24
+;; @0025                               v69 = isub v66, v127  ; v127 = 24
+;; @0025                               store.i64 user2 little region2 v2, v69
+;; @0025                               v77 = load.i32 user2 readonly region2 v41
+;; @0025                               v70 = iconst.i32 1
+;;                                     v186 = icmp ugt v77, v70  ; v70 = 1
+;; @0025                               trapz v186, user17
+;; @0025                               v80 = uextend.i64 v77
+;;                                     v126 = iconst.i64 3
+;;                                     v188 = ishl v80, v126  ; v126 = 3
 ;; @0025                               v11 = iconst.i64 32
-;; @0025                               v80 = ushr v194, v11  ; v11 = 32
-;; @0025                               trapnz v80, user2
-;;                                     v201 = ishl v74, v6  ; v6 = 3
+;; @0025                               v83 = ushr v188, v11  ; v11 = 32
+;; @0025                               trapnz v83, user2
+;;                                     v195 = ishl v77, v6  ; v6 = 3
 ;; @0025                               v7 = iconst.i32 16
-;; @0025                               v83 = uadd_overflow_trap v201, v7, user2  ; v7 = 16
-;; @0025                               v87 = uadd_overflow_trap v251, v83, user2
-;; @0025                               v88 = uextend.i64 v87
-;; @0025                               v90 = iadd v33, v88
-;;                                     v141 = iconst.i32 24
-;; @0025                               v91 = isub v83, v141  ; v141 = 24
-;; @0025                               v92 = uextend.i64 v91
-;; @0025                               v93 = isub v90, v92
-;; @0025                               store.i64 user2 little region2 v3, v93
-;; @0025                               v100 = load.i32 user2 readonly region2 v41
-;; @0025                               v94 = iconst.i32 2
-;;                                     v219 = icmp ugt v100, v94  ; v94 = 2
-;; @0025                               trapz v219, user17
-;; @0025                               v103 = uextend.i64 v100
-;;                                     v221 = ishl v103, v132  ; v132 = 3
-;; @0025                               v106 = ushr v221, v11  ; v11 = 32
-;; @0025                               trapnz v106, user2
-;;                                     v228 = ishl v100, v6  ; v6 = 3
-;; @0025                               v109 = uadd_overflow_trap v228, v7, user2  ; v7 = 16
-;; @0025                               v113 = uadd_overflow_trap v251, v109, user2
-;; @0025                               v114 = uextend.i64 v113
-;; @0025                               v116 = iadd v33, v114
-;;                                     v245 = iconst.i32 32
-;; @0025                               v117 = isub v109, v245  ; v245 = 32
-;; @0025                               v118 = uextend.i64 v117
-;; @0025                               v119 = isub v116, v118
-;; @0025                               store.i64 user2 little region2 v4, v119
+;; @0025                               v86 = uadd_overflow_trap v195, v7, user2  ; v7 = 16
+;; @0025                               v90 = uadd_overflow_trap v245, v86, user2
+;; @0025                               v91 = uextend.i64 v90
+;; @0025                               v94 = iadd v33, v91
+;;                                     v135 = iconst.i32 24
+;; @0025                               v95 = isub v86, v135  ; v135 = 24
+;; @0025                               v96 = uextend.i64 v95
+;; @0025                               v97 = isub v94, v96
+;; @0025                               store.i64 user2 little region2 v3, v97
+;; @0025                               v105 = load.i32 user2 readonly region2 v41
+;; @0025                               v98 = iconst.i32 2
+;;                                     v213 = icmp ugt v105, v98  ; v98 = 2
+;; @0025                               trapz v213, user17
+;; @0025                               v108 = uextend.i64 v105
+;;                                     v215 = ishl v108, v126  ; v126 = 3
+;; @0025                               v111 = ushr v215, v11  ; v11 = 32
+;; @0025                               trapnz v111, user2
+;;                                     v222 = ishl v105, v6  ; v6 = 3
+;; @0025                               v114 = uadd_overflow_trap v222, v7, user2  ; v7 = 16
+;; @0025                               v118 = uadd_overflow_trap v245, v114, user2
+;; @0025                               v119 = uextend.i64 v118
+;; @0025                               v122 = iadd v33, v119
+;;                                     v239 = iconst.i32 32
+;; @0025                               v123 = isub v114, v239  ; v239 = 32
+;; @0025                               v124 = uextend.i64 v123
+;; @0025                               v125 = isub v122, v124
+;; @0025                               store.i64 user2 little region2 v4, v125
 ;; @0029                               jump block1
 ;;
 ;;                                 block3 cold:
@@ -110,6 +106,6 @@
 ;; @0025                               jump block2
 ;;
 ;;                                 block1:
-;;                                     v254 = band.i32 v22, v155  ; v155 = -8
-;; @0029                               return v254
+;;                                     v248 = band.i32 v22, v149  ; v149 = -8
+;; @0029                               return v248
 ;; }

--- a/tests/disas/gc/null/array-new.wat
+++ b/tests/disas/gc/null/array-new.wat
@@ -17,34 +17,30 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i64) -> i8 tail
 ;;     fn0 = colocated u805306368:23 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0022                               v6 = uextend.i64 v3
-;;                                     v83 = iconst.i64 3
-;;                                     v84 = ishl v6, v83  ; v83 = 3
+;;                                     v82 = iconst.i64 3
+;;                                     v83 = ishl v6, v82  ; v82 = 3
 ;; @0022                               v9 = iconst.i64 32
-;; @0022                               v10 = ushr v84, v9  ; v9 = 32
+;; @0022                               v10 = ushr v83, v9  ; v9 = 32
 ;; @0022                               trapnz v10, user18
 ;; @0022                               v5 = iconst.i32 16
-;;                                     v90 = iconst.i32 3
-;;                                     v91 = ishl v3, v90  ; v90 = 3
-;; @0022                               v12 = uadd_overflow_trap v5, v91, user18  ; v5 = 16
+;;                                     v89 = iconst.i32 3
+;;                                     v90 = ishl v3, v89  ; v89 = 3
+;; @0022                               v12 = uadd_overflow_trap v5, v90, user18  ; v5 = 16
 ;; @0022                               v14 = iconst.i32 -67108864
 ;; @0022                               v15 = band v12, v14  ; v14 = -67108864
 ;; @0022                               trapnz v15, user18
 ;; @0022                               v16 = load.i64 notrap aligned readonly can_move region1 v0+32
 ;; @0022                               v17 = load.i32 user2 region2 v16
-;;                                     v94 = iconst.i32 7
-;; @0022                               v20 = uadd_overflow_trap v17, v94, user18  ; v94 = 7
-;;                                     v100 = iconst.i32 -8
-;; @0022                               v22 = band v20, v100  ; v100 = -8
+;;                                     v93 = iconst.i32 7
+;; @0022                               v20 = uadd_overflow_trap v17, v93, user18  ; v93 = 7
+;;                                     v99 = iconst.i32 -8
+;; @0022                               v22 = band v20, v99  ; v99 = -8
 ;; @0022                               v23 = uadd_overflow_trap v22, v12, user18
 ;; @0022                               v25 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @0022                               v26 = load.i64 notrap aligned v25+40
@@ -54,12 +50,12 @@
 ;;
 ;;                                 block2:
 ;; @0022                               v34 = iconst.i32 -1476395008
-;;                                     v101 = bor.i32 v12, v34  ; v34 = -1476395008
+;;                                     v100 = bor.i32 v12, v34  ; v34 = -1476395008
 ;; @0022                               v31 = load.i64 notrap aligned readonly can_move v25+32
-;;                                     v118 = band.i32 v20, v100  ; v100 = -8
-;;                                     v119 = uextend.i64 v118
-;; @0022                               v33 = iadd v31, v119
-;; @0022                               store user2 region2 v101, v33
+;;                                     v117 = band.i32 v20, v99  ; v99 = -8
+;;                                     v118 = uextend.i64 v117
+;; @0022                               v33 = iadd v31, v118
+;; @0022                               store user2 region2 v100, v33
 ;; @0022                               v36 = load.i64 notrap aligned readonly can_move region3 v0+40
 ;; @0022                               v37 = load.i32 notrap aligned readonly can_move v36
 ;; @0022                               store user2 region2 v37, v33+4
@@ -67,25 +63,25 @@
 ;; @0022                               v7 = iconst.i64 8
 ;; @0022                               v39 = iadd v33, v7  ; v7 = 8
 ;; @0022                               store.i32 user2 region2 v3, v39
-;; @0022                               trapz v118, user16
-;; @0022                               v70 = load.i64 notrap aligned v25+40
-;; @0022                               v58 = iconst.i64 16
-;; @0022                               v59 = iadd v33, v58  ; v58 = 16
-;; @0022                               v72 = uadd_overflow_trap v59, v84, user2
-;; @0022                               v71 = iadd v31, v70
-;; @0022                               v73 = icmp ugt v72, v71
-;; @0022                               trapnz v73, user2
-;;                                     v103 = iconst.i64 0
-;; @0022                               v76 = icmp.i64 eq v6, v103  ; v103 = 0
-;; @0022                               v74 = iadd v59, v84
-;; @0022                               brif v76, block5, block4(v59)
+;; @0022                               trapz v117, user16
+;; @0022                               v71 = load.i64 notrap aligned v25+40
+;; @0022                               v59 = iconst.i64 16
+;; @0022                               v60 = iadd v33, v59  ; v59 = 16
+;; @0022                               v73 = uadd_overflow_trap v60, v83, user2
+;; @0022                               v72 = iadd v31, v71
+;; @0022                               v74 = icmp ugt v73, v72
+;; @0022                               trapnz v74, user2
+;;                                     v102 = iconst.i64 0
+;; @0022                               v77 = icmp.i64 eq v6, v102  ; v102 = 0
+;; @0022                               v75 = iadd v60, v83
+;; @0022                               brif v77, block5, block4(v60)
 ;;
-;;                                 block4(v77: i64):
-;; @0022                               store.i64 user2 little region2 v2, v77
-;;                                     v120 = iconst.i64 8
-;;                                     v121 = iadd v77, v120  ; v120 = 8
-;; @0022                               v80 = icmp eq v121, v74
-;; @0022                               brif v80, block5, block4(v121)
+;;                                 block4(v78: i64):
+;; @0022                               store.i64 user2 little region2 v2, v78
+;;                                     v119 = iconst.i64 8
+;;                                     v120 = iadd v78, v119  ; v119 = 8
+;; @0022                               v81 = icmp eq v120, v75
+;; @0022                               brif v81, block5, block4(v120)
 ;;
 ;;                                 block5:
 ;; @0025                               jump block1
@@ -96,6 +92,6 @@
 ;; @0022                               jump block2
 ;;
 ;;                                 block1:
-;;                                     v122 = band.i32 v20, v100  ; v100 = -8
-;; @0025                               return v122
+;;                                     v121 = band.i32 v20, v99  ; v99 = -8
+;; @0025                               return v121
 ;; }

--- a/tests/disas/gc/null/array-set.wat
+++ b/tests/disas/gc/null/array-set.wat
@@ -15,42 +15,38 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i64):
 ;; @0024                               trapz v2, user16
-;; @0024                               v32 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0024                               v6 = load.i64 notrap aligned readonly can_move v32+32
+;; @0024                               v6 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @0024                               v7 = load.i64 notrap aligned readonly can_move v6+32
 ;; @0024                               v5 = uextend.i64 v2
-;; @0024                               v7 = iadd v6, v5
-;; @0024                               v8 = iconst.i64 8
-;; @0024                               v9 = iadd v7, v8  ; v8 = 8
-;; @0024                               v10 = load.i32 user2 readonly region1 v9
-;; @0024                               v11 = icmp ult v3, v10
-;; @0024                               trapz v11, user17
-;; @0024                               v13 = uextend.i64 v10
-;;                                     v34 = iconst.i64 3
-;;                                     v35 = ishl v13, v34  ; v34 = 3
-;; @0024                               v15 = iconst.i64 32
-;; @0024                               v16 = ushr v35, v15  ; v15 = 32
-;; @0024                               trapnz v16, user2
-;;                                     v44 = iconst.i32 3
-;;                                     v45 = ishl v10, v44  ; v44 = 3
-;; @0024                               v18 = iconst.i32 16
-;; @0024                               v19 = uadd_overflow_trap v45, v18, user2  ; v18 = 16
-;; @0024                               v23 = uadd_overflow_trap v2, v19, user2
-;; @0024                               v24 = uextend.i64 v23
-;; @0024                               v26 = iadd v6, v24
-;;                                     v51 = ishl v3, v44  ; v44 = 3
-;; @0024                               v22 = iadd v51, v18  ; v18 = 16
-;; @0024                               v27 = isub v19, v22
-;; @0024                               v28 = uextend.i64 v27
-;; @0024                               v29 = isub v26, v28
-;; @0024                               store user2 little region1 v4, v29
+;; @0024                               v8 = iadd v7, v5
+;; @0024                               v9 = iconst.i64 8
+;; @0024                               v10 = iadd v8, v9  ; v9 = 8
+;; @0024                               v11 = load.i32 user2 readonly region1 v10
+;; @0024                               v12 = icmp ult v3, v11
+;; @0024                               trapz v12, user17
+;; @0024                               v14 = uextend.i64 v11
+;;                                     v32 = iconst.i64 3
+;;                                     v33 = ishl v14, v32  ; v32 = 3
+;; @0024                               v16 = iconst.i64 32
+;; @0024                               v17 = ushr v33, v16  ; v16 = 32
+;; @0024                               trapnz v17, user2
+;;                                     v42 = iconst.i32 3
+;;                                     v43 = ishl v11, v42  ; v42 = 3
+;; @0024                               v19 = iconst.i32 16
+;; @0024                               v20 = uadd_overflow_trap v43, v19, user2  ; v19 = 16
+;; @0024                               v24 = uadd_overflow_trap v2, v20, user2
+;; @0024                               v25 = uextend.i64 v24
+;; @0024                               v28 = iadd v7, v25
+;;                                     v49 = ishl v3, v42  ; v42 = 3
+;; @0024                               v23 = iadd v49, v19  ; v19 = 16
+;; @0024                               v29 = isub v20, v23
+;; @0024                               v30 = uextend.i64 v29
+;; @0024                               v31 = isub v28, v30
+;; @0024                               store user2 little region1 v4, v31
 ;; @0027                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/null/br-on-cast-fail.wat
+++ b/tests/disas/gc/null/br-on-cast-fail.wat
@@ -27,10 +27,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i64) tail
 ;;     stack_limit = gv2
 ;;
@@ -42,35 +38,35 @@
 ;;                                 block3:
 ;; @002e                               v8 = iconst.i32 1
 ;; @002e                               v9 = band.i32 v2, v8  ; v8 = 1
-;;                                     v28 = iconst.i32 0
-;; @002e                               brif v9, block5(v28), block4  ; v28 = 0
+;;                                     v27 = iconst.i32 0
+;; @002e                               brif v9, block5(v27), block4  ; v27 = 0
 ;;
 ;;                                 block4:
-;; @002e                               v26 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @002e                               v14 = load.i64 notrap aligned readonly can_move v26+32
+;; @002e                               v14 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @002e                               v15 = load.i64 notrap aligned readonly can_move v14+32
 ;; @002e                               v13 = uextend.i64 v2
-;; @002e                               v15 = iadd v14, v13
-;; @002e                               v16 = iconst.i64 4
-;; @002e                               v17 = iadd v15, v16  ; v16 = 4
-;; @002e                               v18 = load.i32 user2 readonly region2 v17
+;; @002e                               v16 = iadd v15, v13
+;; @002e                               v17 = iconst.i64 4
+;; @002e                               v18 = iadd v16, v17  ; v17 = 4
+;; @002e                               v19 = load.i32 user2 readonly region2 v18
 ;; @002e                               v11 = load.i64 notrap aligned readonly can_move region1 v0+40
 ;; @002e                               v12 = load.i32 notrap aligned readonly can_move v11
-;; @002e                               v19 = icmp eq v18, v12
-;; @002e                               v20 = uextend.i32 v19
-;; @002e                               jump block5(v20)
+;; @002e                               v20 = icmp eq v19, v12
+;; @002e                               v21 = uextend.i32 v20
+;; @002e                               jump block5(v21)
 ;;
-;;                                 block5(v21: i32):
-;; @002e                               brif v21, block6, block2
+;;                                 block5(v22: i32):
+;; @002e                               brif v22, block6, block2
 ;;
 ;;                                 block6:
-;; @0034                               v23 = load.i64 notrap aligned readonly can_move region4 v0+56
-;; @0034                               v22 = load.i64 notrap aligned readonly can_move region3 v0+72
-;; @0034                               call_indirect sig0, v23(v22, v0)
+;; @0034                               v24 = load.i64 notrap aligned readonly can_move region4 v0+56
+;; @0034                               v23 = load.i64 notrap aligned readonly can_move region3 v0+72
+;; @0034                               call_indirect sig0, v24(v23, v0)
 ;; @0036                               return
 ;;
 ;;                                 block2:
-;; @0038                               v25 = load.i64 notrap aligned readonly can_move region6 v0+88
-;; @0038                               v24 = load.i64 notrap aligned readonly can_move region5 v0+104
-;; @0038                               call_indirect sig0, v25(v24, v0)
+;; @0038                               v26 = load.i64 notrap aligned readonly can_move region6 v0+88
+;; @0038                               v25 = load.i64 notrap aligned readonly can_move region5 v0+104
+;; @0038                               call_indirect sig0, v26(v25, v0)
 ;; @003a                               return
 ;; }

--- a/tests/disas/gc/null/br-on-cast.wat
+++ b/tests/disas/gc/null/br-on-cast.wat
@@ -27,10 +27,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i64) tail
 ;;     stack_limit = gv2
 ;;
@@ -42,35 +38,35 @@
 ;;                                 block3:
 ;; @002f                               v8 = iconst.i32 1
 ;; @002f                               v9 = band.i32 v2, v8  ; v8 = 1
-;;                                     v28 = iconst.i32 0
-;; @002f                               brif v9, block5(v28), block4  ; v28 = 0
+;;                                     v27 = iconst.i32 0
+;; @002f                               brif v9, block5(v27), block4  ; v27 = 0
 ;;
 ;;                                 block4:
-;; @002f                               v26 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @002f                               v14 = load.i64 notrap aligned readonly can_move v26+32
+;; @002f                               v14 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @002f                               v15 = load.i64 notrap aligned readonly can_move v14+32
 ;; @002f                               v13 = uextend.i64 v2
-;; @002f                               v15 = iadd v14, v13
-;; @002f                               v16 = iconst.i64 4
-;; @002f                               v17 = iadd v15, v16  ; v16 = 4
-;; @002f                               v18 = load.i32 user2 readonly region2 v17
+;; @002f                               v16 = iadd v15, v13
+;; @002f                               v17 = iconst.i64 4
+;; @002f                               v18 = iadd v16, v17  ; v17 = 4
+;; @002f                               v19 = load.i32 user2 readonly region2 v18
 ;; @002f                               v11 = load.i64 notrap aligned readonly can_move region1 v0+40
 ;; @002f                               v12 = load.i32 notrap aligned readonly can_move v11
-;; @002f                               v19 = icmp eq v18, v12
-;; @002f                               v20 = uextend.i32 v19
-;; @002f                               jump block5(v20)
+;; @002f                               v20 = icmp eq v19, v12
+;; @002f                               v21 = uextend.i32 v20
+;; @002f                               jump block5(v21)
 ;;
-;;                                 block5(v21: i32):
-;; @002f                               brif v21, block2, block6
+;;                                 block5(v22: i32):
+;; @002f                               brif v22, block2, block6
 ;;
 ;;                                 block6:
-;; @0035                               v23 = load.i64 notrap aligned readonly can_move region4 v0+56
-;; @0035                               v22 = load.i64 notrap aligned readonly can_move region3 v0+72
-;; @0035                               call_indirect sig0, v23(v22, v0)
+;; @0035                               v24 = load.i64 notrap aligned readonly can_move region4 v0+56
+;; @0035                               v23 = load.i64 notrap aligned readonly can_move region3 v0+72
+;; @0035                               call_indirect sig0, v24(v23, v0)
 ;; @0037                               return
 ;;
 ;;                                 block2:
-;; @0039                               v25 = load.i64 notrap aligned readonly can_move region6 v0+88
-;; @0039                               v24 = load.i64 notrap aligned readonly can_move region5 v0+104
-;; @0039                               call_indirect sig0, v25(v24, v0)
+;; @0039                               v26 = load.i64 notrap aligned readonly can_move region6 v0+88
+;; @0039                               v25 = load.i64 notrap aligned readonly can_move region5 v0+104
+;; @0039                               call_indirect sig0, v26(v25, v0)
 ;; @003b                               return
 ;; }

--- a/tests/disas/gc/null/funcref-in-gc-heap-get.wat
+++ b/tests/disas/gc/null/funcref-in-gc-heap-get.wat
@@ -15,27 +15,23 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32) -> i64 tail
 ;;     fn0 = colocated u805306368:26 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0020                               trapz v2, user16
-;; @0020                               v12 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0020                               v5 = load.i64 notrap aligned readonly can_move v12+32
+;; @0020                               v5 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @0020                               v6 = load.i64 notrap aligned readonly can_move v5+32
 ;; @0020                               v4 = uextend.i64 v2
-;; @0020                               v6 = iadd v5, v4
-;; @0020                               v7 = iconst.i64 8
-;; @0020                               v8 = iadd v6, v7  ; v7 = 8
-;; @0020                               v10 = load.i32 user2 little region1 v8
-;; @0020                               v9 = iconst.i32 -1
-;; @0020                               v11 = call fn0(v0, v10, v9)  ; v9 = -1
+;; @0020                               v7 = iadd v6, v4
+;; @0020                               v8 = iconst.i64 8
+;; @0020                               v9 = iadd v7, v8  ; v8 = 8
+;; @0020                               v11 = load.i32 user2 little region1 v9
+;; @0020                               v10 = iconst.i32 -1
+;; @0020                               v12 = call fn0(v0, v11, v10)  ; v10 = -1
 ;; @0024                               jump block1
 ;;
 ;;                                 block1:
-;; @0024                               return v11
+;; @0024                               return v12
 ;; }

--- a/tests/disas/gc/null/funcref-in-gc-heap-set.wat
+++ b/tests/disas/gc/null/funcref-in-gc-heap-set.wat
@@ -15,25 +15,21 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i64) -> i64 tail
 ;;     fn0 = colocated u805306368:25 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i64):
 ;; @0022                               trapz v2, user16
-;; @0022                               v9 = call fn0(v0, v3)
-;; @0022                               v10 = ireduce.i32 v9
-;; @0022                               v11 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0022                               v5 = load.i64 notrap aligned readonly can_move v11+32
+;; @0022                               v10 = call fn0(v0, v3)
+;; @0022                               v11 = ireduce.i32 v10
+;; @0022                               v5 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @0022                               v6 = load.i64 notrap aligned readonly can_move v5+32
 ;; @0022                               v4 = uextend.i64 v2
-;; @0022                               v6 = iadd v5, v4
-;; @0022                               v7 = iconst.i64 8
-;; @0022                               v8 = iadd v6, v7  ; v7 = 8
-;; @0022                               store user2 little region1 v10, v8
+;; @0022                               v7 = iadd v6, v4
+;; @0022                               v8 = iconst.i64 8
+;; @0022                               v9 = iadd v7, v8  ; v8 = 8
+;; @0022                               store user2 little region1 v11, v9
 ;; @0026                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/null/multiple-array-get.wat
+++ b/tests/disas/gc/null/multiple-array-get.wat
@@ -16,52 +16,48 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
 ;; @0024                               trapz v2, user16
-;; @0024                               v65 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0024                               v8 = load.i64 notrap aligned readonly can_move v65+32
+;; @0024                               v8 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @0024                               v9 = load.i64 notrap aligned readonly can_move v8+32
 ;; @0024                               v7 = uextend.i64 v2
-;; @0024                               v9 = iadd v8, v7
-;; @0024                               v10 = iconst.i64 8
-;; @0024                               v11 = iadd v9, v10  ; v10 = 8
-;; @0024                               v12 = load.i32 user2 readonly region1 v11
-;; @0024                               v13 = icmp ult v3, v12
-;; @0024                               trapz v13, user17
-;; @0024                               v15 = uextend.i64 v12
-;;                                     v67 = iconst.i64 3
-;;                                     v68 = ishl v15, v67  ; v67 = 3
-;; @0024                               v17 = iconst.i64 32
-;; @0024                               v18 = ushr v68, v17  ; v17 = 32
-;; @0024                               trapnz v18, user2
-;;                                     v77 = iconst.i32 3
-;;                                     v78 = ishl v12, v77  ; v77 = 3
-;; @0024                               v20 = iconst.i32 16
-;; @0024                               v21 = uadd_overflow_trap v78, v20, user2  ; v20 = 16
-;; @0024                               v25 = uadd_overflow_trap v2, v21, user2
-;; @0024                               v26 = uextend.i64 v25
-;; @0024                               v28 = iadd v8, v26
-;;                                     v84 = ishl v3, v77  ; v77 = 3
-;; @0024                               v24 = iadd v84, v20  ; v20 = 16
-;; @0024                               v29 = isub v21, v24
-;; @0024                               v30 = uextend.i64 v29
-;; @0024                               v31 = isub v28, v30
-;; @0024                               v32 = load.i64 user2 little region1 v31
-;; @002b                               v39 = icmp ult v4, v12
-;; @002b                               trapz v39, user17
-;;                                     v86 = ishl v4, v77  ; v77 = 3
-;; @002b                               v50 = iadd v86, v20  ; v20 = 16
-;; @002b                               v55 = isub v21, v50
-;; @002b                               v56 = uextend.i64 v55
-;; @002b                               v57 = isub v28, v56
-;; @002b                               v58 = load.i64 user2 little region1 v57
+;; @0024                               v10 = iadd v9, v7
+;; @0024                               v11 = iconst.i64 8
+;; @0024                               v12 = iadd v10, v11  ; v11 = 8
+;; @0024                               v13 = load.i32 user2 readonly region1 v12
+;; @0024                               v14 = icmp ult v3, v13
+;; @0024                               trapz v14, user17
+;; @0024                               v16 = uextend.i64 v13
+;;                                     v63 = iconst.i64 3
+;;                                     v64 = ishl v16, v63  ; v63 = 3
+;; @0024                               v18 = iconst.i64 32
+;; @0024                               v19 = ushr v64, v18  ; v18 = 32
+;; @0024                               trapnz v19, user2
+;;                                     v73 = iconst.i32 3
+;;                                     v74 = ishl v13, v73  ; v73 = 3
+;; @0024                               v21 = iconst.i32 16
+;; @0024                               v22 = uadd_overflow_trap v74, v21, user2  ; v21 = 16
+;; @0024                               v26 = uadd_overflow_trap v2, v22, user2
+;; @0024                               v27 = uextend.i64 v26
+;; @0024                               v30 = iadd v9, v27
+;;                                     v80 = ishl v3, v73  ; v73 = 3
+;; @0024                               v25 = iadd v80, v21  ; v21 = 16
+;; @0024                               v31 = isub v22, v25
+;; @0024                               v32 = uextend.i64 v31
+;; @0024                               v33 = isub v30, v32
+;; @0024                               v34 = load.i64 user2 little region1 v33
+;; @002b                               v42 = icmp ult v4, v13
+;; @002b                               trapz v42, user17
+;;                                     v82 = ishl v4, v73  ; v73 = 3
+;; @002b                               v53 = iadd v82, v21  ; v21 = 16
+;; @002b                               v59 = isub v22, v53
+;; @002b                               v60 = uextend.i64 v59
+;; @002b                               v61 = isub v30, v60
+;; @002b                               v62 = load.i64 user2 little region1 v61
 ;; @002e                               jump block1
 ;;
 ;;                                 block1:
-;; @002e                               return v32, v58
+;; @002e                               return v34, v62
 ;; }

--- a/tests/disas/gc/null/multiple-struct-get.wat
+++ b/tests/disas/gc/null/multiple-struct-get.wat
@@ -17,27 +17,23 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0023                               trapz v2, user16
-;; @0023                               v20 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0023                               v6 = load.i64 notrap aligned readonly can_move v20+32
+;; @0023                               v6 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @0023                               v7 = load.i64 notrap aligned readonly can_move v6+32
 ;; @0023                               v5 = uextend.i64 v2
-;; @0023                               v7 = iadd v6, v5
-;; @0023                               v8 = iconst.i64 8
-;; @0023                               v9 = iadd v7, v8  ; v8 = 8
-;; @0023                               v10 = load.f32 user2 little region1 v9
-;; @0029                               v14 = iconst.i64 12
-;; @0029                               v15 = iadd v7, v14  ; v14 = 12
-;; @0029                               v16 = load.i8 user2 little region1 v15
+;; @0023                               v8 = iadd v7, v5
+;; @0023                               v9 = iconst.i64 8
+;; @0023                               v10 = iadd v8, v9  ; v9 = 8
+;; @0023                               v11 = load.f32 user2 little region1 v10
+;; @0029                               v16 = iconst.i64 12
+;; @0029                               v17 = iadd v8, v16  ; v16 = 12
+;; @0029                               v18 = load.i8 user2 little region1 v17
 ;; @002d                               jump block1
 ;;
 ;;                                 block1:
-;; @0029                               v17 = sextend.i32 v16
-;; @002d                               return v10, v17
+;; @0029                               v19 = sextend.i32 v18
+;; @002d                               return v11, v19
 ;; }

--- a/tests/disas/gc/null/ref-cast.wat
+++ b/tests/disas/gc/null/ref-cast.wat
@@ -15,10 +15,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -29,25 +25,25 @@
 ;;                                 block2:
 ;; @001e                               v8 = iconst.i32 1
 ;; @001e                               v9 = band.i32 v2, v8  ; v8 = 1
-;;                                     v24 = iconst.i32 0
-;; @001e                               brif v9, block4(v24), block3  ; v24 = 0
+;;                                     v23 = iconst.i32 0
+;; @001e                               brif v9, block4(v23), block3  ; v23 = 0
 ;;
 ;;                                 block3:
-;; @001e                               v22 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @001e                               v14 = load.i64 notrap aligned readonly can_move v22+32
+;; @001e                               v14 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @001e                               v15 = load.i64 notrap aligned readonly can_move v14+32
 ;; @001e                               v13 = uextend.i64 v2
-;; @001e                               v15 = iadd v14, v13
-;; @001e                               v16 = iconst.i64 4
-;; @001e                               v17 = iadd v15, v16  ; v16 = 4
-;; @001e                               v18 = load.i32 user2 readonly region2 v17
+;; @001e                               v16 = iadd v15, v13
+;; @001e                               v17 = iconst.i64 4
+;; @001e                               v18 = iadd v16, v17  ; v17 = 4
+;; @001e                               v19 = load.i32 user2 readonly region2 v18
 ;; @001e                               v11 = load.i64 notrap aligned readonly can_move region1 v0+40
 ;; @001e                               v12 = load.i32 notrap aligned readonly can_move v11
-;; @001e                               v19 = icmp eq v18, v12
-;; @001e                               v20 = uextend.i32 v19
-;; @001e                               jump block4(v20)
+;; @001e                               v20 = icmp eq v19, v12
+;; @001e                               v21 = uextend.i32 v20
+;; @001e                               jump block4(v21)
 ;;
-;;                                 block4(v21: i32):
-;; @001e                               trapz v21, user19
+;;                                 block4(v22: i32):
+;; @001e                               trapz v22, user19
 ;; @0021                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/null/ref-test-array.wat
+++ b/tests/disas/gc/null/ref-test-array.wat
@@ -13,10 +13,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -27,23 +23,23 @@
 ;;                                 block2:
 ;; @001b                               v8 = iconst.i32 1
 ;; @001b                               v9 = band.i32 v2, v8  ; v8 = 1
-;;                                     v24 = iconst.i32 0
-;; @001b                               brif v9, block4(v24), block3  ; v24 = 0
+;;                                     v23 = iconst.i32 0
+;; @001b                               brif v9, block4(v23), block3  ; v23 = 0
 ;;
 ;;                                 block3:
-;; @001b                               v22 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @001b                               v12 = load.i64 notrap aligned readonly can_move v22+32
+;; @001b                               v12 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @001b                               v13 = load.i64 notrap aligned readonly can_move v12+32
 ;; @001b                               v11 = uextend.i64 v2
-;; @001b                               v13 = iadd v12, v11
-;; @001b                               v16 = load.i32 user2 readonly region1 v13
-;; @001b                               v17 = iconst.i32 -1476395008
-;; @001b                               v18 = band v16, v17  ; v17 = -1476395008
-;; @001b                               v19 = icmp eq v18, v17  ; v17 = -1476395008
-;; @001b                               v20 = uextend.i32 v19
-;; @001b                               jump block4(v20)
+;; @001b                               v14 = iadd v13, v11
+;; @001b                               v17 = load.i32 user2 readonly region1 v14
+;; @001b                               v18 = iconst.i32 -1476395008
+;; @001b                               v19 = band v17, v18  ; v18 = -1476395008
+;; @001b                               v20 = icmp eq v19, v18  ; v18 = -1476395008
+;; @001b                               v21 = uextend.i32 v20
+;; @001b                               jump block4(v21)
 ;;
-;;                                 block4(v21: i32):
-;; @001e                               jump block1(v21)
+;;                                 block4(v22: i32):
+;; @001e                               jump block1(v22)
 ;;
 ;;                                 block1(v3: i32):
 ;; @001e                               return v3

--- a/tests/disas/gc/null/ref-test-concrete-type.wat
+++ b/tests/disas/gc/null/ref-test-concrete-type.wat
@@ -15,10 +15,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -29,25 +25,25 @@
 ;;                                 block2:
 ;; @001d                               v8 = iconst.i32 1
 ;; @001d                               v9 = band.i32 v2, v8  ; v8 = 1
-;;                                     v24 = iconst.i32 0
-;; @001d                               brif v9, block4(v24), block3  ; v24 = 0
+;;                                     v23 = iconst.i32 0
+;; @001d                               brif v9, block4(v23), block3  ; v23 = 0
 ;;
 ;;                                 block3:
-;; @001d                               v22 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @001d                               v14 = load.i64 notrap aligned readonly can_move v22+32
+;; @001d                               v14 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @001d                               v15 = load.i64 notrap aligned readonly can_move v14+32
 ;; @001d                               v13 = uextend.i64 v2
-;; @001d                               v15 = iadd v14, v13
-;; @001d                               v16 = iconst.i64 4
-;; @001d                               v17 = iadd v15, v16  ; v16 = 4
-;; @001d                               v18 = load.i32 user2 readonly region2 v17
+;; @001d                               v16 = iadd v15, v13
+;; @001d                               v17 = iconst.i64 4
+;; @001d                               v18 = iadd v16, v17  ; v17 = 4
+;; @001d                               v19 = load.i32 user2 readonly region2 v18
 ;; @001d                               v11 = load.i64 notrap aligned readonly can_move region1 v0+40
 ;; @001d                               v12 = load.i32 notrap aligned readonly can_move v11
-;; @001d                               v19 = icmp eq v18, v12
-;; @001d                               v20 = uextend.i32 v19
-;; @001d                               jump block4(v20)
+;; @001d                               v20 = icmp eq v19, v12
+;; @001d                               v21 = uextend.i32 v20
+;; @001d                               jump block4(v21)
 ;;
-;;                                 block4(v21: i32):
-;; @0020                               jump block1(v21)
+;;                                 block4(v22: i32):
+;; @0020                               jump block1(v22)
 ;;
 ;;                                 block1(v3: i32):
 ;; @0020                               return v3

--- a/tests/disas/gc/null/ref-test-eq.wat
+++ b/tests/disas/gc/null/ref-test-eq.wat
@@ -13,10 +13,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -30,19 +26,19 @@
 ;; @001b                               brif v9, block4(v8), block3  ; v8 = 1
 ;;
 ;;                                 block3:
-;; @001b                               v22 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @001b                               v12 = load.i64 notrap aligned readonly can_move v22+32
+;; @001b                               v12 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @001b                               v13 = load.i64 notrap aligned readonly can_move v12+32
 ;; @001b                               v11 = uextend.i64 v2
-;; @001b                               v13 = iadd v12, v11
-;; @001b                               v16 = load.i32 user2 readonly region1 v13
-;; @001b                               v17 = iconst.i32 -1610612736
-;; @001b                               v18 = band v16, v17  ; v17 = -1610612736
-;; @001b                               v19 = icmp eq v18, v17  ; v17 = -1610612736
-;; @001b                               v20 = uextend.i32 v19
-;; @001b                               jump block4(v20)
+;; @001b                               v14 = iadd v13, v11
+;; @001b                               v17 = load.i32 user2 readonly region1 v14
+;; @001b                               v18 = iconst.i32 -1610612736
+;; @001b                               v19 = band v17, v18  ; v18 = -1610612736
+;; @001b                               v20 = icmp eq v19, v18  ; v18 = -1610612736
+;; @001b                               v21 = uextend.i32 v20
+;; @001b                               jump block4(v21)
 ;;
-;;                                 block4(v21: i32):
-;; @001e                               jump block1(v21)
+;;                                 block4(v22: i32):
+;; @001e                               jump block1(v22)
 ;;
 ;;                                 block1(v3: i32):
 ;; @001e                               return v3

--- a/tests/disas/gc/null/ref-test-struct.wat
+++ b/tests/disas/gc/null/ref-test-struct.wat
@@ -13,10 +13,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -27,23 +23,23 @@
 ;;                                 block2:
 ;; @001b                               v8 = iconst.i32 1
 ;; @001b                               v9 = band.i32 v2, v8  ; v8 = 1
-;;                                     v24 = iconst.i32 0
-;; @001b                               brif v9, block4(v24), block3  ; v24 = 0
+;;                                     v23 = iconst.i32 0
+;; @001b                               brif v9, block4(v23), block3  ; v23 = 0
 ;;
 ;;                                 block3:
-;; @001b                               v22 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @001b                               v12 = load.i64 notrap aligned readonly can_move v22+32
+;; @001b                               v12 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @001b                               v13 = load.i64 notrap aligned readonly can_move v12+32
 ;; @001b                               v11 = uextend.i64 v2
-;; @001b                               v13 = iadd v12, v11
-;; @001b                               v16 = load.i32 user2 readonly region1 v13
-;; @001b                               v17 = iconst.i32 -1342177280
-;; @001b                               v18 = band v16, v17  ; v17 = -1342177280
-;; @001b                               v19 = icmp eq v18, v17  ; v17 = -1342177280
-;; @001b                               v20 = uextend.i32 v19
-;; @001b                               jump block4(v20)
+;; @001b                               v14 = iadd v13, v11
+;; @001b                               v17 = load.i32 user2 readonly region1 v14
+;; @001b                               v18 = iconst.i32 -1342177280
+;; @001b                               v19 = band v17, v18  ; v18 = -1342177280
+;; @001b                               v20 = icmp eq v19, v18  ; v18 = -1342177280
+;; @001b                               v21 = uextend.i32 v20
+;; @001b                               jump block4(v21)
 ;;
-;;                                 block4(v21: i32):
-;; @001e                               jump block1(v21)
+;;                                 block4(v22: i32):
+;; @001e                               jump block1(v22)
 ;;
 ;;                                 block1(v3: i32):
 ;; @001e                               return v3

--- a/tests/disas/gc/null/struct-get-guard-pages.wat
+++ b/tests/disas/gc/null/struct-get-guard-pages.wat
@@ -29,25 +29,21 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0033                               trapz v2, user16
-;; @0033                               v10 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0033                               v5 = load.i64 notrap aligned readonly can_move v10+32
+;; @0033                               v5 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @0033                               v6 = load.i64 notrap aligned readonly can_move v5+32
 ;; @0033                               v4 = uextend.i64 v2
-;; @0033                               v6 = iadd v5, v4
-;; @0033                               v7 = iconst.i64 8
-;; @0033                               v8 = iadd v6, v7  ; v7 = 8
-;; @0033                               v9 = load.f32 user2 little region1 v8
+;; @0033                               v7 = iadd v6, v4
+;; @0033                               v8 = iconst.i64 8
+;; @0033                               v9 = iadd v7, v8  ; v8 = 8
+;; @0033                               v10 = load.f32 user2 little region1 v9
 ;; @0037                               jump block1
 ;;
 ;;                                 block1:
-;; @0037                               return v9
+;; @0037                               return v10
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
@@ -56,26 +52,22 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @003c                               trapz v2, user16
-;; @003c                               v11 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @003c                               v5 = load.i64 notrap aligned readonly can_move v11+32
+;; @003c                               v5 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @003c                               v6 = load.i64 notrap aligned readonly can_move v5+32
 ;; @003c                               v4 = uextend.i64 v2
-;; @003c                               v6 = iadd v5, v4
-;; @003c                               v7 = iconst.i64 12
-;; @003c                               v8 = iadd v6, v7  ; v7 = 12
-;; @003c                               v9 = load.i8 user2 little region1 v8
+;; @003c                               v7 = iadd v6, v4
+;; @003c                               v8 = iconst.i64 12
+;; @003c                               v9 = iadd v7, v8  ; v8 = 12
+;; @003c                               v10 = load.i8 user2 little region1 v9
 ;; @0040                               jump block1
 ;;
 ;;                                 block1:
-;; @003c                               v10 = sextend.i32 v9
-;; @0040                               return v10
+;; @003c                               v11 = sextend.i32 v10
+;; @0040                               return v11
 ;; }
 ;;
 ;; function u0:2(i64 vmctx, i64, i32) -> i32 tail {
@@ -84,26 +76,22 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0045                               trapz v2, user16
-;; @0045                               v11 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0045                               v5 = load.i64 notrap aligned readonly can_move v11+32
+;; @0045                               v5 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @0045                               v6 = load.i64 notrap aligned readonly can_move v5+32
 ;; @0045                               v4 = uextend.i64 v2
-;; @0045                               v6 = iadd v5, v4
-;; @0045                               v7 = iconst.i64 12
-;; @0045                               v8 = iadd v6, v7  ; v7 = 12
-;; @0045                               v9 = load.i8 user2 little region1 v8
+;; @0045                               v7 = iadd v6, v4
+;; @0045                               v8 = iconst.i64 12
+;; @0045                               v9 = iadd v7, v8  ; v8 = 12
+;; @0045                               v10 = load.i8 user2 little region1 v9
 ;; @0049                               jump block1
 ;;
 ;;                                 block1:
-;; @0045                               v10 = uextend.i32 v9
-;; @0049                               return v10
+;; @0045                               v11 = uextend.i32 v10
+;; @0049                               return v11
 ;; }
 ;;
 ;; function u0:3(i64 vmctx, i64, i32) -> i32 tail {
@@ -112,23 +100,19 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @004e                               trapz v2, user16
-;; @004e                               v10 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @004e                               v5 = load.i64 notrap aligned readonly can_move v10+32
+;; @004e                               v5 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @004e                               v6 = load.i64 notrap aligned readonly can_move v5+32
 ;; @004e                               v4 = uextend.i64 v2
-;; @004e                               v6 = iadd v5, v4
-;; @004e                               v7 = iconst.i64 16
-;; @004e                               v8 = iadd v6, v7  ; v7 = 16
-;; @004e                               v9 = load.i32 user2 little region1 v8
+;; @004e                               v7 = iadd v6, v4
+;; @004e                               v8 = iconst.i64 16
+;; @004e                               v9 = iadd v7, v8  ; v8 = 16
+;; @004e                               v10 = load.i32 user2 little region1 v9
 ;; @0052                               jump block1
 ;;
 ;;                                 block1:
-;; @0052                               return v9
+;; @0052                               return v10
 ;; }

--- a/tests/disas/gc/null/struct-get-no-guard-pages.wat
+++ b/tests/disas/gc/null/struct-get-no-guard-pages.wat
@@ -29,10 +29,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -40,20 +36,20 @@
 ;; @0033                               v4 = uextend.i64 v2
 ;; @0033                               v5 = iconst.i64 24
 ;; @0033                               v6 = uadd_overflow_trap v4, v5, user2  ; v5 = 24
-;; @0033                               v18 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0033                               v7 = load.i64 notrap aligned v18+40
-;; @0033                               v9 = load.i64 notrap aligned v18+32
-;; @0033                               v8 = icmp ugt v6, v7
-;; @0033                               v11 = iconst.i64 0
-;; @0033                               v10 = iadd v9, v4
-;; @0033                               v12 = select_spectre_guard v8, v11, v10  ; v11 = 0
-;; @0033                               v13 = iconst.i64 8
-;; @0033                               v14 = iadd v12, v13  ; v13 = 8
-;; @0033                               v15 = load.f32 user2 little region1 v14
+;; @0033                               v7 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @0033                               v8 = load.i64 notrap aligned v7+40
+;; @0033                               v11 = load.i64 notrap aligned v7+32
+;; @0033                               v9 = icmp ugt v6, v8
+;; @0033                               v13 = iconst.i64 0
+;; @0033                               v12 = iadd v11, v4
+;; @0033                               v14 = select_spectre_guard v9, v13, v12  ; v13 = 0
+;; @0033                               v15 = iconst.i64 8
+;; @0033                               v16 = iadd v14, v15  ; v15 = 8
+;; @0033                               v17 = load.f32 user2 little region1 v16
 ;; @0037                               jump block1
 ;;
 ;;                                 block1:
-;; @0037                               return v15
+;; @0037                               return v17
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
@@ -62,10 +58,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -73,21 +65,21 @@
 ;; @003c                               v4 = uextend.i64 v2
 ;; @003c                               v5 = iconst.i64 24
 ;; @003c                               v6 = uadd_overflow_trap v4, v5, user2  ; v5 = 24
-;; @003c                               v19 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @003c                               v7 = load.i64 notrap aligned v19+40
-;; @003c                               v9 = load.i64 notrap aligned v19+32
-;; @003c                               v8 = icmp ugt v6, v7
-;; @003c                               v11 = iconst.i64 0
-;; @003c                               v10 = iadd v9, v4
-;; @003c                               v12 = select_spectre_guard v8, v11, v10  ; v11 = 0
-;; @003c                               v13 = iconst.i64 12
-;; @003c                               v14 = iadd v12, v13  ; v13 = 12
-;; @003c                               v15 = load.i8 user2 little region1 v14
+;; @003c                               v7 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @003c                               v8 = load.i64 notrap aligned v7+40
+;; @003c                               v11 = load.i64 notrap aligned v7+32
+;; @003c                               v9 = icmp ugt v6, v8
+;; @003c                               v13 = iconst.i64 0
+;; @003c                               v12 = iadd v11, v4
+;; @003c                               v14 = select_spectre_guard v9, v13, v12  ; v13 = 0
+;; @003c                               v15 = iconst.i64 12
+;; @003c                               v16 = iadd v14, v15  ; v15 = 12
+;; @003c                               v17 = load.i8 user2 little region1 v16
 ;; @0040                               jump block1
 ;;
 ;;                                 block1:
-;; @003c                               v16 = sextend.i32 v15
-;; @0040                               return v16
+;; @003c                               v18 = sextend.i32 v17
+;; @0040                               return v18
 ;; }
 ;;
 ;; function u0:2(i64 vmctx, i64, i32) -> i32 tail {
@@ -96,10 +88,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -107,21 +95,21 @@
 ;; @0045                               v4 = uextend.i64 v2
 ;; @0045                               v5 = iconst.i64 24
 ;; @0045                               v6 = uadd_overflow_trap v4, v5, user2  ; v5 = 24
-;; @0045                               v19 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0045                               v7 = load.i64 notrap aligned v19+40
-;; @0045                               v9 = load.i64 notrap aligned v19+32
-;; @0045                               v8 = icmp ugt v6, v7
-;; @0045                               v11 = iconst.i64 0
-;; @0045                               v10 = iadd v9, v4
-;; @0045                               v12 = select_spectre_guard v8, v11, v10  ; v11 = 0
-;; @0045                               v13 = iconst.i64 12
-;; @0045                               v14 = iadd v12, v13  ; v13 = 12
-;; @0045                               v15 = load.i8 user2 little region1 v14
+;; @0045                               v7 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @0045                               v8 = load.i64 notrap aligned v7+40
+;; @0045                               v11 = load.i64 notrap aligned v7+32
+;; @0045                               v9 = icmp ugt v6, v8
+;; @0045                               v13 = iconst.i64 0
+;; @0045                               v12 = iadd v11, v4
+;; @0045                               v14 = select_spectre_guard v9, v13, v12  ; v13 = 0
+;; @0045                               v15 = iconst.i64 12
+;; @0045                               v16 = iadd v14, v15  ; v15 = 12
+;; @0045                               v17 = load.i8 user2 little region1 v16
 ;; @0049                               jump block1
 ;;
 ;;                                 block1:
-;; @0045                               v16 = uextend.i32 v15
-;; @0049                               return v16
+;; @0045                               v18 = uextend.i32 v17
+;; @0049                               return v18
 ;; }
 ;;
 ;; function u0:3(i64 vmctx, i64, i32) -> i32 tail {
@@ -130,10 +118,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -141,18 +125,18 @@
 ;; @004e                               v4 = uextend.i64 v2
 ;; @004e                               v5 = iconst.i64 24
 ;; @004e                               v6 = uadd_overflow_trap v4, v5, user2  ; v5 = 24
-;; @004e                               v18 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @004e                               v7 = load.i64 notrap aligned v18+40
-;; @004e                               v9 = load.i64 notrap aligned v18+32
-;; @004e                               v8 = icmp ugt v6, v7
-;; @004e                               v11 = iconst.i64 0
-;; @004e                               v10 = iadd v9, v4
-;; @004e                               v12 = select_spectre_guard v8, v11, v10  ; v11 = 0
-;; @004e                               v13 = iconst.i64 16
-;; @004e                               v14 = iadd v12, v13  ; v13 = 16
-;; @004e                               v15 = load.i32 user2 little region1 v14
+;; @004e                               v7 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @004e                               v8 = load.i64 notrap aligned v7+40
+;; @004e                               v11 = load.i64 notrap aligned v7+32
+;; @004e                               v9 = icmp ugt v6, v8
+;; @004e                               v13 = iconst.i64 0
+;; @004e                               v12 = iadd v11, v4
+;; @004e                               v14 = select_spectre_guard v9, v13, v12  ; v13 = 0
+;; @004e                               v15 = iconst.i64 16
+;; @004e                               v16 = iadd v14, v15  ; v15 = 16
+;; @004e                               v17 = load.i32 user2 little region1 v16
 ;; @0052                               jump block1
 ;;
 ;;                                 block1:
-;; @0052                               return v15
+;; @0052                               return v17
 ;; }

--- a/tests/disas/gc/null/struct-get.wat
+++ b/tests/disas/gc/null/struct-get.wat
@@ -29,25 +29,21 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0033                               trapz v2, user16
-;; @0033                               v10 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0033                               v5 = load.i64 notrap aligned readonly can_move v10+32
+;; @0033                               v5 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @0033                               v6 = load.i64 notrap aligned readonly can_move v5+32
 ;; @0033                               v4 = uextend.i64 v2
-;; @0033                               v6 = iadd v5, v4
-;; @0033                               v7 = iconst.i64 8
-;; @0033                               v8 = iadd v6, v7  ; v7 = 8
-;; @0033                               v9 = load.f32 user2 little region1 v8
+;; @0033                               v7 = iadd v6, v4
+;; @0033                               v8 = iconst.i64 8
+;; @0033                               v9 = iadd v7, v8  ; v8 = 8
+;; @0033                               v10 = load.f32 user2 little region1 v9
 ;; @0037                               jump block1
 ;;
 ;;                                 block1:
-;; @0037                               return v9
+;; @0037                               return v10
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
@@ -56,26 +52,22 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @003c                               trapz v2, user16
-;; @003c                               v11 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @003c                               v5 = load.i64 notrap aligned readonly can_move v11+32
+;; @003c                               v5 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @003c                               v6 = load.i64 notrap aligned readonly can_move v5+32
 ;; @003c                               v4 = uextend.i64 v2
-;; @003c                               v6 = iadd v5, v4
-;; @003c                               v7 = iconst.i64 12
-;; @003c                               v8 = iadd v6, v7  ; v7 = 12
-;; @003c                               v9 = load.i8 user2 little region1 v8
+;; @003c                               v7 = iadd v6, v4
+;; @003c                               v8 = iconst.i64 12
+;; @003c                               v9 = iadd v7, v8  ; v8 = 12
+;; @003c                               v10 = load.i8 user2 little region1 v9
 ;; @0040                               jump block1
 ;;
 ;;                                 block1:
-;; @003c                               v10 = sextend.i32 v9
-;; @0040                               return v10
+;; @003c                               v11 = sextend.i32 v10
+;; @0040                               return v11
 ;; }
 ;;
 ;; function u0:2(i64 vmctx, i64, i32) -> i32 tail {
@@ -84,26 +76,22 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0045                               trapz v2, user16
-;; @0045                               v11 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0045                               v5 = load.i64 notrap aligned readonly can_move v11+32
+;; @0045                               v5 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @0045                               v6 = load.i64 notrap aligned readonly can_move v5+32
 ;; @0045                               v4 = uextend.i64 v2
-;; @0045                               v6 = iadd v5, v4
-;; @0045                               v7 = iconst.i64 12
-;; @0045                               v8 = iadd v6, v7  ; v7 = 12
-;; @0045                               v9 = load.i8 user2 little region1 v8
+;; @0045                               v7 = iadd v6, v4
+;; @0045                               v8 = iconst.i64 12
+;; @0045                               v9 = iadd v7, v8  ; v8 = 12
+;; @0045                               v10 = load.i8 user2 little region1 v9
 ;; @0049                               jump block1
 ;;
 ;;                                 block1:
-;; @0045                               v10 = uextend.i32 v9
-;; @0049                               return v10
+;; @0045                               v11 = uextend.i32 v10
+;; @0049                               return v11
 ;; }
 ;;
 ;; function u0:3(i64 vmctx, i64, i32) -> i32 tail {
@@ -112,23 +100,19 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @004e                               trapz v2, user16
-;; @004e                               v10 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @004e                               v5 = load.i64 notrap aligned readonly can_move v10+32
+;; @004e                               v5 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @004e                               v6 = load.i64 notrap aligned readonly can_move v5+32
 ;; @004e                               v4 = uextend.i64 v2
-;; @004e                               v6 = iadd v5, v4
-;; @004e                               v7 = iconst.i64 16
-;; @004e                               v8 = iadd v6, v7  ; v7 = 16
-;; @004e                               v9 = load.i32 user2 little region1 v8
+;; @004e                               v7 = iadd v6, v4
+;; @004e                               v8 = iconst.i64 16
+;; @004e                               v9 = iadd v7, v8  ; v8 = 16
+;; @004e                               v10 = load.i32 user2 little region1 v9
 ;; @0052                               jump block1
 ;;
 ;;                                 block1:
-;; @0052                               return v9
+;; @0052                               return v10
 ;; }

--- a/tests/disas/gc/null/struct-set.wat
+++ b/tests/disas/gc/null/struct-set.wat
@@ -25,21 +25,17 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: f32):
 ;; @0034                               trapz v2, user16
-;; @0034                               v9 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0034                               v5 = load.i64 notrap aligned readonly can_move v9+32
+;; @0034                               v5 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @0034                               v6 = load.i64 notrap aligned readonly can_move v5+32
 ;; @0034                               v4 = uextend.i64 v2
-;; @0034                               v6 = iadd v5, v4
-;; @0034                               v7 = iconst.i64 8
-;; @0034                               v8 = iadd v6, v7  ; v7 = 8
-;; @0034                               store user2 little region1 v3, v8
+;; @0034                               v7 = iadd v6, v4
+;; @0034                               v8 = iconst.i64 8
+;; @0034                               v9 = iadd v7, v8  ; v8 = 8
+;; @0034                               store user2 little region1 v3, v9
 ;; @0038                               jump block1
 ;;
 ;;                                 block1:
@@ -52,21 +48,17 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @003f                               trapz v2, user16
-;; @003f                               v9 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @003f                               v5 = load.i64 notrap aligned readonly can_move v9+32
+;; @003f                               v5 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @003f                               v6 = load.i64 notrap aligned readonly can_move v5+32
 ;; @003f                               v4 = uextend.i64 v2
-;; @003f                               v6 = iadd v5, v4
-;; @003f                               v7 = iconst.i64 12
-;; @003f                               v8 = iadd v6, v7  ; v7 = 12
-;; @003f                               istore8 user2 little region1 v3, v8
+;; @003f                               v7 = iadd v6, v4
+;; @003f                               v8 = iconst.i64 12
+;; @003f                               v9 = iadd v7, v8  ; v8 = 12
+;; @003f                               istore8 user2 little region1 v3, v9
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -79,21 +71,17 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @004a                               trapz v2, user16
-;; @004a                               v9 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @004a                               v5 = load.i64 notrap aligned readonly can_move v9+32
+;; @004a                               v5 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @004a                               v6 = load.i64 notrap aligned readonly can_move v5+32
 ;; @004a                               v4 = uextend.i64 v2
-;; @004a                               v6 = iadd v5, v4
-;; @004a                               v7 = iconst.i64 16
-;; @004a                               v8 = iadd v6, v7  ; v7 = 16
-;; @004a                               store user2 little region1 v3, v8
+;; @004a                               v7 = iadd v6, v4
+;; @004a                               v8 = iconst.i64 16
+;; @004a                               v9 = iadd v7, v8  ; v8 = 16
+;; @004a                               store user2 little region1 v3, v9
 ;; @004e                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/null/v128-fields.wat
+++ b/tests/disas/gc/null/v128-fields.wat
@@ -17,24 +17,20 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0022                               trapz v2, user16
-;; @0022                               v19 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0022                               v5 = load.i64 notrap aligned readonly can_move v19+32
+;; @0022                               v5 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @0022                               v6 = load.i64 notrap aligned readonly can_move v5+32
 ;; @0022                               v4 = uextend.i64 v2
-;; @0022                               v6 = iadd v5, v4
-;; @0022                               v7 = iconst.i64 16
-;; @0022                               v8 = iadd v6, v7  ; v7 = 16
-;; @0022                               v9 = load.i8x16 user2 little region1 v8
+;; @0022                               v7 = iadd v6, v4
+;; @0022                               v8 = iconst.i64 16
+;; @0022                               v9 = iadd v7, v8  ; v8 = 16
+;; @0022                               v10 = load.i8x16 user2 little region1 v9
 ;; @002e                               jump block1
 ;;
 ;;                                 block1:
-;; @002c                               v16 = bxor.i8x16 v9, v9
-;; @002e                               return v16
+;; @002c                               v18 = bxor.i8x16 v10, v10
+;; @002e                               return v18
 ;; }

--- a/tests/disas/gc/ref-test-cast-final-type.wat
+++ b/tests/disas/gc/ref-test-cast-final-type.wat
@@ -21,10 +21,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -35,25 +31,25 @@
 ;;                                 block2:
 ;; @0024                               v8 = iconst.i32 1
 ;; @0024                               v9 = band.i32 v2, v8  ; v8 = 1
-;;                                     v24 = iconst.i32 0
-;; @0024                               brif v9, block4(v24), block3  ; v24 = 0
+;;                                     v23 = iconst.i32 0
+;; @0024                               brif v9, block4(v23), block3  ; v23 = 0
 ;;
 ;;                                 block3:
-;; @0024                               v22 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0024                               v14 = load.i64 notrap aligned readonly can_move v22+32
+;; @0024                               v14 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @0024                               v15 = load.i64 notrap aligned readonly can_move v14+32
 ;; @0024                               v13 = uextend.i64 v2
-;; @0024                               v15 = iadd v14, v13
-;; @0024                               v16 = iconst.i64 4
-;; @0024                               v17 = iadd v15, v16  ; v16 = 4
-;; @0024                               v18 = load.i32 user2 readonly region2 v17
+;; @0024                               v16 = iadd v15, v13
+;; @0024                               v17 = iconst.i64 4
+;; @0024                               v18 = iadd v16, v17  ; v17 = 4
+;; @0024                               v19 = load.i32 user2 readonly region2 v18
 ;; @0024                               v11 = load.i64 notrap aligned readonly can_move region1 v0+40
 ;; @0024                               v12 = load.i32 notrap aligned readonly can_move v11
-;; @0024                               v19 = icmp eq v18, v12
-;; @0024                               v20 = uextend.i32 v19
-;; @0024                               jump block4(v20)
+;; @0024                               v20 = icmp eq v19, v12
+;; @0024                               v21 = uextend.i32 v20
+;; @0024                               jump block4(v21)
 ;;
-;;                                 block4(v21: i32):
-;; @0027                               jump block1(v21)
+;;                                 block4(v22: i32):
+;; @0027                               jump block1(v22)
 ;;
 ;;                                 block1(v3: i32):
 ;; @0027                               return v3
@@ -66,10 +62,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region0 gv3+8
-;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
-;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -80,25 +72,25 @@
 ;;                                 block2:
 ;; @002c                               v8 = iconst.i32 1
 ;; @002c                               v9 = band.i32 v2, v8  ; v8 = 1
-;;                                     v24 = iconst.i32 0
-;; @002c                               brif v9, block4(v24), block3  ; v24 = 0
+;;                                     v23 = iconst.i32 0
+;; @002c                               brif v9, block4(v23), block3  ; v23 = 0
 ;;
 ;;                                 block3:
-;; @002c                               v22 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @002c                               v14 = load.i64 notrap aligned readonly can_move v22+32
+;; @002c                               v14 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @002c                               v15 = load.i64 notrap aligned readonly can_move v14+32
 ;; @002c                               v13 = uextend.i64 v2
-;; @002c                               v15 = iadd v14, v13
-;; @002c                               v16 = iconst.i64 4
-;; @002c                               v17 = iadd v15, v16  ; v16 = 4
-;; @002c                               v18 = load.i32 user2 readonly region2 v17
+;; @002c                               v16 = iadd v15, v13
+;; @002c                               v17 = iconst.i64 4
+;; @002c                               v18 = iadd v16, v17  ; v17 = 4
+;; @002c                               v19 = load.i32 user2 readonly region2 v18
 ;; @002c                               v11 = load.i64 notrap aligned readonly can_move region1 v0+40
 ;; @002c                               v12 = load.i32 notrap aligned readonly can_move v11
-;; @002c                               v19 = icmp eq v18, v12
-;; @002c                               v20 = uextend.i32 v19
-;; @002c                               jump block4(v20)
+;; @002c                               v20 = icmp eq v19, v12
+;; @002c                               v21 = uextend.i32 v20
+;; @002c                               jump block4(v21)
 ;;
-;;                                 block4(v21: i32):
-;; @002c                               trapz v21, user19
+;;                                 block4(v22: i32):
+;; @002c                               trapz v22, user19
 ;; @002f                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/globals.wat
+++ b/tests/disas/globals.wat
@@ -16,9 +16,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):

--- a/tests/disas/i32-load.wat
+++ b/tests/disas/i32-load.wat
@@ -14,9 +14,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/i32-load16-s.wat
+++ b/tests/disas/i32-load16-s.wat
@@ -14,9 +14,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/i32-load16-u.wat
+++ b/tests/disas/i32-load16-u.wat
@@ -14,9 +14,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/i32-load8-s.wat
+++ b/tests/disas/i32-load8-s.wat
@@ -14,9 +14,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/i32-load8-u.wat
+++ b/tests/disas/i32-load8-u.wat
@@ -14,9 +14,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/i32-store.wat
+++ b/tests/disas/i32-store.wat
@@ -15,9 +15,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):

--- a/tests/disas/i32-store16.wat
+++ b/tests/disas/i32-store16.wat
@@ -15,9 +15,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):

--- a/tests/disas/i32-store8.wat
+++ b/tests/disas/i32-store8.wat
@@ -15,9 +15,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):

--- a/tests/disas/i64-load.wat
+++ b/tests/disas/i64-load.wat
@@ -14,9 +14,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/i64-load16-s.wat
+++ b/tests/disas/i64-load16-s.wat
@@ -14,9 +14,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/i64-load16-u.wat
+++ b/tests/disas/i64-load16-u.wat
@@ -14,9 +14,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/i64-load8-s.wat
+++ b/tests/disas/i64-load8-s.wat
@@ -14,9 +14,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/i64-load8-u.wat
+++ b/tests/disas/i64-load8-u.wat
@@ -14,9 +14,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/i64-store.wat
+++ b/tests/disas/i64-store.wat
@@ -15,9 +15,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i64):

--- a/tests/disas/i64-store16.wat
+++ b/tests/disas/i64-store16.wat
@@ -15,9 +15,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i64):

--- a/tests/disas/i64-store32.wat
+++ b/tests/disas/i64-store32.wat
@@ -15,9 +15,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i64):

--- a/tests/disas/i64-store8.wat
+++ b/tests/disas/i64-store8.wat
@@ -15,9 +15,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i64):

--- a/tests/disas/idempotent-store.wat
+++ b/tests/disas/idempotent-store.wat
@@ -20,9 +20,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):

--- a/tests/disas/if-unreachable-else-params-2.wat
+++ b/tests/disas/if-unreachable-else-params-2.wat
@@ -25,9 +25,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):

--- a/tests/disas/if-unreachable-else-params.wat
+++ b/tests/disas/if-unreachable-else-params.wat
@@ -48,9 +48,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0_offset.wat
@@ -24,9 +24,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -51,9 +48,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -24,9 +24,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -53,9 +50,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -24,9 +24,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -53,9 +50,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0_offset.wat
@@ -24,9 +24,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -49,9 +46,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -24,9 +24,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -53,9 +50,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -24,9 +24,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -53,9 +50,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0_offset.wat
@@ -24,9 +24,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -52,9 +49,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -24,9 +24,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -54,9 +51,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -24,9 +24,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -54,9 +51,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0_offset.wat
@@ -24,9 +24,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -50,9 +47,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -24,9 +24,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -54,9 +51,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -24,9 +24,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -54,9 +51,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
@@ -24,9 +24,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -49,9 +46,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -24,9 +24,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -51,9 +48,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -24,9 +24,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -51,9 +48,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
@@ -24,9 +24,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -49,9 +46,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -24,9 +24,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -51,9 +48,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -24,9 +24,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -51,9 +48,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
@@ -24,9 +24,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -50,9 +47,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -24,9 +24,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -52,9 +49,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -24,9 +24,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -52,9 +49,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
@@ -24,9 +24,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -50,9 +47,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -24,9 +24,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -52,9 +49,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -24,9 +24,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -52,9 +49,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0_offset.wat
@@ -24,9 +24,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
@@ -50,9 +47,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -24,9 +24,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
@@ -52,9 +49,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -24,9 +24,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
@@ -52,9 +49,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0_offset.wat
@@ -24,9 +24,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
@@ -48,9 +45,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -24,9 +24,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
@@ -52,9 +49,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -24,9 +24,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
@@ -52,9 +49,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0_offset.wat
@@ -24,9 +24,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
@@ -51,9 +48,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -24,9 +24,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
@@ -53,9 +50,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -24,9 +24,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
@@ -53,9 +50,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0_offset.wat
@@ -24,9 +24,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
@@ -49,9 +46,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -24,9 +24,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
@@ -53,9 +50,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -24,9 +24,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
@@ -53,9 +50,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
@@ -24,9 +24,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
@@ -48,9 +45,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -24,9 +24,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
@@ -50,9 +47,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -24,9 +24,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
@@ -50,9 +47,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
@@ -24,9 +24,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
@@ -48,9 +45,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -24,9 +24,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
@@ -50,9 +47,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -24,9 +24,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
@@ -50,9 +47,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
@@ -24,9 +24,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
@@ -49,9 +46,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -24,9 +24,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
@@ -51,9 +48,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -24,9 +24,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
@@ -51,9 +48,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
@@ -24,9 +24,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
@@ -49,9 +46,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -24,9 +24,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
@@ -51,9 +48,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -24,9 +24,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
@@ -51,9 +48,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0_offset.wat
@@ -24,9 +24,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -49,9 +46,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -24,9 +24,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -51,9 +48,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -24,9 +24,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -51,9 +48,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0_offset.wat
@@ -24,9 +24,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -46,9 +43,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -24,9 +24,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -51,9 +48,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -24,9 +24,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -51,9 +48,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0_offset.wat
@@ -24,9 +24,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -50,9 +47,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -24,9 +24,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -52,9 +49,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -24,9 +24,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -52,9 +49,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i8_access_0_offset.wat
@@ -24,9 +24,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -46,9 +43,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -24,9 +24,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -52,9 +49,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -24,9 +24,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -52,9 +49,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
@@ -24,9 +24,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -46,9 +43,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -24,9 +24,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -48,9 +45,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -24,9 +24,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -48,9 +45,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
@@ -24,9 +24,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -46,9 +43,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -24,9 +24,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -48,9 +45,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -24,9 +24,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -48,9 +45,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
@@ -24,9 +24,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -46,9 +43,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -24,9 +24,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -48,9 +45,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -24,9 +24,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -48,9 +45,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
@@ -24,9 +24,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -46,9 +43,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -24,9 +24,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -48,9 +45,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -24,9 +24,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -48,9 +45,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0_offset.wat
@@ -24,9 +24,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
@@ -48,9 +45,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -24,9 +24,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
@@ -50,9 +47,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -24,9 +24,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
@@ -50,9 +47,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0_offset.wat
@@ -24,9 +24,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
@@ -48,9 +45,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -24,9 +24,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
@@ -50,9 +47,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -24,9 +24,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
@@ -50,9 +47,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0_offset.wat
@@ -24,9 +24,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
@@ -49,9 +46,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -24,9 +24,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
@@ -51,9 +48,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -24,9 +24,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
@@ -51,9 +48,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0_offset.wat
@@ -24,9 +24,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
@@ -49,9 +46,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -24,9 +24,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
@@ -51,9 +48,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -24,9 +24,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
@@ -51,9 +48,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
@@ -24,9 +24,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
@@ -48,9 +45,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -24,9 +24,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
@@ -50,9 +47,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -24,9 +24,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
@@ -50,9 +47,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
@@ -24,9 +24,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
@@ -48,9 +45,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -24,9 +24,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
@@ -50,9 +47,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -24,9 +24,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
@@ -50,9 +47,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
@@ -24,9 +24,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
@@ -49,9 +46,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -24,9 +24,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
@@ -51,9 +48,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -24,9 +24,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
@@ -51,9 +48,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
@@ -24,9 +24,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
@@ -49,9 +46,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -24,9 +24,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
@@ -51,9 +48,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -24,9 +24,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
@@ -51,9 +48,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):

--- a/tests/disas/memory-copy-epochs.wat
+++ b/tests/disas/memory-copy-epochs.wat
@@ -15,8 +15,6 @@
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     sig0 = (i64 vmctx) -> i64 tail
 ;;     sig1 = (i64 vmctx, i64, i64, i64) tail
 ;;     fn0 = colocated u805306368:13 sig0
@@ -63,9 +61,9 @@
 ;; @0025                               brif v96, block17, block16
 ;;
 ;;                                 block6:
-;;                                     v112 = iconst.i64 0x0800_0000
-;;                                     v113 = icmp.i64 ugt v17, v112  ; v112 = 0x0800_0000
-;; @0025                               brif v113, block4(v26, v39, v17, v61), block5(v26, v39, v17, v61)
+;;                                     v110 = iconst.i64 0x0800_0000
+;;                                     v111 = icmp.i64 ugt v17, v110  ; v110 = 0x0800_0000
+;; @0025                               brif v111, block4(v26, v39, v17, v61), block5(v26, v39, v17, v61)
 ;;
 ;;                                 block9 cold:
 ;; @0025                               v52 = load.i64 notrap aligned v7+8
@@ -77,11 +75,11 @@
 ;; @0025                               jump block8(v54)
 ;;
 ;;                                 block8(v62: i64):
-;; @0025                               call fn1(v0, v44, v45, v112)  ; v112 = 0x0800_0000
-;; @0025                               v57 = isub.i64 v46, v112  ; v112 = 0x0800_0000
-;; @0025                               v58 = icmp ugt v57, v112  ; v112 = 0x0800_0000
-;; @0025                               v55 = iadd.i64 v44, v112  ; v112 = 0x0800_0000
-;; @0025                               v56 = iadd.i64 v45, v112  ; v112 = 0x0800_0000
+;; @0025                               call fn1(v0, v44, v45, v110)  ; v110 = 0x0800_0000
+;; @0025                               v57 = isub.i64 v46, v110  ; v110 = 0x0800_0000
+;; @0025                               v58 = icmp ugt v57, v110  ; v110 = 0x0800_0000
+;; @0025                               v55 = iadd.i64 v44, v110  ; v110 = 0x0800_0000
+;; @0025                               v56 = iadd.i64 v45, v110  ; v110 = 0x0800_0000
 ;; @0025                               brif v58, block4(v55, v56, v57, v62), block5(v55, v56, v57, v62)
 ;;
 ;;                                 block7:
@@ -106,13 +104,13 @@
 ;; @0025                               jump block13(v78)
 ;;
 ;;                                 block13(v82: i64):
-;;                                     v107 = iconst.i64 0x0800_0000
-;;                                     v108 = isub.i64 v66, v107  ; v107 = 0x0800_0000
-;;                                     v109 = isub.i64 v67, v107  ; v107 = 0x0800_0000
-;; @0025                               call fn1(v0, v108, v109, v107)  ; v107 = 0x0800_0000
-;;                                     v110 = isub.i64 v68, v107  ; v107 = 0x0800_0000
-;;                                     v111 = icmp ugt v110, v107  ; v107 = 0x0800_0000
-;; @0025                               brif v111, block11(v108, v109, v110, v82), block12(v108, v109, v110, v82)
+;;                                     v105 = iconst.i64 0x0800_0000
+;;                                     v106 = isub.i64 v66, v105  ; v105 = 0x0800_0000
+;;                                     v107 = isub.i64 v67, v105  ; v105 = 0x0800_0000
+;; @0025                               call fn1(v0, v106, v107, v105)  ; v105 = 0x0800_0000
+;;                                     v108 = isub.i64 v68, v105  ; v105 = 0x0800_0000
+;;                                     v109 = icmp ugt v108, v105  ; v105 = 0x0800_0000
+;; @0025                               brif v109, block11(v106, v107, v108, v82), block12(v106, v107, v108, v82)
 ;;
 ;;                                 block12(v83: i64, v84: i64, v85: i64, v95: i64):
 ;; @0025                               v86 = isub v83, v85

--- a/tests/disas/memory-copy-fuel.wat
+++ b/tests/disas/memory-copy-fuel.wat
@@ -14,8 +14,6 @@
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     sig0 = (i64 vmctx) -> i8 tail
 ;;     sig1 = (i64 vmctx, i64, i64, i64) tail
 ;;     fn0 = colocated u805306368:12 sig0
@@ -32,8 +30,8 @@
 ;; @001e                               brif v10, block2, block3(v8)
 ;;
 ;;                                 block2:
-;;                                     v110 = iadd.i64 v6, v7  ; v7 = 1
-;; @001e                               store notrap aligned v110, v5
+;;                                     v108 = iadd.i64 v6, v7  ; v7 = 1
+;; @001e                               store notrap aligned v108, v5
 ;; @001e                               v12 = call fn0(v0)
 ;; @001e                               v14 = load.i64 notrap aligned v5
 ;; @001e                               jump block3(v14)
@@ -56,37 +54,37 @@
 ;; @0025                               brif v49, block6, block7
 ;;
 ;;                                 block4(v51: i64, v52: i64, v53: i64, v54: i64):
-;; @0025                               v55 = iadd v54, v120  ; v120 = 0x0800_0000
-;;                                     v124 = iconst.i64 0
-;;                                     v125 = icmp sge v55, v124  ; v124 = 0
-;; @0025                               brif v125, block8, block9(v55)
+;; @0025                               v55 = iadd v54, v118  ; v118 = 0x0800_0000
+;;                                     v122 = iconst.i64 0
+;;                                     v123 = icmp sge v55, v122  ; v122 = 0
+;; @0025                               brif v123, block8, block9(v55)
 ;;
 ;;                                 block5(v91: i64, v92: i64, v93: i64, v94: i64):
 ;; @0025                               v96 = iadd v94, v93
-;;                                     v127 = iconst.i64 0
-;;                                     v128 = icmp sge v96, v127  ; v127 = 0
-;; @0025                               brif v128, block14, block15(v96)
+;;                                     v125 = iconst.i64 0
+;;                                     v126 = icmp sge v96, v125  ; v125 = 0
+;; @0025                               brif v126, block14, block15(v96)
 ;;
 ;;                                 block6:
-;;                                     v120 = iconst.i64 0x0800_0000
-;;                                     v121 = icmp.i64 ugt v21, v120  ; v120 = 0x0800_0000
-;;                                     v122 = iconst.i64 4
-;;                                     v123 = iadd.i64 v45, v122  ; v122 = 4
-;; @0025                               brif v121, block4(v30, v43, v21, v123), block5(v30, v43, v21, v123)
+;;                                     v118 = iconst.i64 0x0800_0000
+;;                                     v119 = icmp.i64 ugt v21, v118  ; v118 = 0x0800_0000
+;;                                     v120 = iconst.i64 4
+;;                                     v121 = iadd.i64 v45, v120  ; v120 = 4
+;; @0025                               brif v119, block4(v30, v43, v21, v121), block5(v30, v43, v21, v121)
 ;;
 ;;                                 block8:
-;;                                     v126 = iadd.i64 v54, v120  ; v120 = 0x0800_0000
-;; @0025                               store notrap aligned v126, v5
+;;                                     v124 = iadd.i64 v54, v118  ; v118 = 0x0800_0000
+;; @0025                               store notrap aligned v124, v5
 ;; @0025                               v59 = call fn0(v0)
 ;; @0025                               v61 = load.i64 notrap aligned v5
 ;; @0025                               jump block9(v61)
 ;;
 ;;                                 block9(v66: i64):
-;; @0025                               call fn1(v0, v51, v52, v120)  ; v120 = 0x0800_0000
-;; @0025                               v64 = isub.i64 v53, v120  ; v120 = 0x0800_0000
-;; @0025                               v65 = icmp ugt v64, v120  ; v120 = 0x0800_0000
-;; @0025                               v62 = iadd.i64 v51, v120  ; v120 = 0x0800_0000
-;; @0025                               v63 = iadd.i64 v52, v120  ; v120 = 0x0800_0000
+;; @0025                               call fn1(v0, v51, v52, v118)  ; v118 = 0x0800_0000
+;; @0025                               v64 = isub.i64 v53, v118  ; v118 = 0x0800_0000
+;; @0025                               v65 = icmp ugt v64, v118  ; v118 = 0x0800_0000
+;; @0025                               v62 = iadd.i64 v51, v118  ; v118 = 0x0800_0000
+;; @0025                               v63 = iadd.i64 v52, v118  ; v118 = 0x0800_0000
 ;; @0025                               brif v65, block4(v62, v63, v64, v66), block5(v62, v63, v64, v66)
 ;;
 ;;                                 block7:
@@ -99,26 +97,26 @@
 ;; @0025                               brif v69, block10(v67, v68, v21, v47), block11(v67, v68, v21, v47)
 ;;
 ;;                                 block10(v70: i64, v71: i64, v72: i64, v75: i64):
-;;                                     v111 = iconst.i64 0x0800_0000
-;;                                     v112 = iadd v75, v111  ; v111 = 0x0800_0000
-;;                                     v113 = iconst.i64 0
-;;                                     v114 = icmp sge v112, v113  ; v113 = 0
-;; @0025                               brif v114, block12, block13(v112)
+;;                                     v109 = iconst.i64 0x0800_0000
+;;                                     v110 = iadd v75, v109  ; v109 = 0x0800_0000
+;;                                     v111 = iconst.i64 0
+;;                                     v112 = icmp sge v110, v111  ; v111 = 0
+;; @0025                               brif v112, block12, block13(v110)
 ;;
 ;;                                 block12:
-;; @0025                               store.i64 notrap aligned v112, v5
+;; @0025                               store.i64 notrap aligned v110, v5
 ;; @0025                               v80 = call fn0(v0)
 ;; @0025                               v82 = load.i64 notrap aligned v5
 ;; @0025                               jump block13(v82)
 ;;
 ;;                                 block13(v85: i64):
-;;                                     v115 = iconst.i64 0x0800_0000
-;;                                     v116 = isub.i64 v70, v115  ; v115 = 0x0800_0000
-;;                                     v117 = isub.i64 v71, v115  ; v115 = 0x0800_0000
-;; @0025                               call fn1(v0, v116, v117, v115)  ; v115 = 0x0800_0000
-;;                                     v118 = isub.i64 v72, v115  ; v115 = 0x0800_0000
-;;                                     v119 = icmp ugt v118, v115  ; v115 = 0x0800_0000
-;; @0025                               brif v119, block10(v116, v117, v118, v85), block11(v116, v117, v118, v85)
+;;                                     v113 = iconst.i64 0x0800_0000
+;;                                     v114 = isub.i64 v70, v113  ; v113 = 0x0800_0000
+;;                                     v115 = isub.i64 v71, v113  ; v113 = 0x0800_0000
+;; @0025                               call fn1(v0, v114, v115, v113)  ; v113 = 0x0800_0000
+;;                                     v116 = isub.i64 v72, v113  ; v113 = 0x0800_0000
+;;                                     v117 = icmp ugt v116, v113  ; v113 = 0x0800_0000
+;; @0025                               brif v117, block10(v114, v115, v116, v85), block11(v114, v115, v116, v85)
 ;;
 ;;                                 block11(v86: i64, v87: i64, v88: i64, v95: i64):
 ;; @0025                               v89 = isub v86, v88

--- a/tests/disas/memory-copy-inline.wat
+++ b/tests/disas/memory-copy-inline.wat
@@ -18,19 +18,17 @@
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0024                               v6 = load.i64 notrap aligned v0+64
 ;; @0024                               v7 = uextend.i64 v2
-;;                                     v35 = iconst.i64 16
-;; @0024                               v11 = iadd v7, v35  ; v35 = 16
+;;                                     v33 = iconst.i64 16
+;; @0024                               v11 = iadd v7, v33  ; v33 = 16
 ;; @0024                               v12 = icmp ugt v11, v6
 ;; @0024                               trapnz v12, heap_oob
 ;; @0024                               v20 = uextend.i64 v3
-;; @0024                               v24 = iadd v20, v35  ; v35 = 16
+;; @0024                               v24 = iadd v20, v33  ; v33 = 16
 ;; @0024                               v25 = icmp ugt v24, v6
 ;; @0024                               trapnz v25, heap_oob
 ;; @0024                               v13 = load.i64 notrap aligned readonly can_move v0+56

--- a/tests/disas/memory-min-max-same.wat
+++ b/tests/disas/memory-min-max-same.wat
@@ -41,9 +41,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     sig0 = (i64 vmctx, i64) tail
 ;;     stack_limit = gv2
 ;;
@@ -59,16 +56,16 @@
 ;;
 ;;                                 block2(v8: i32):
 ;; @0030                               call_indirect.i64 sig0, v6(v5, v0)
-;;                                     v21 = iconst.i32 0
+;;                                     v20 = iconst.i32 0
 ;; @0036                               v9 = iadd.i32 v2, v8
 ;; @0039                               v11 = uextend.i64 v9
-;;                                     v22 = iconst.i64 0x0001_0000
-;;                                     v23 = icmp ugt v11, v22  ; v22 = 0x0001_0000
+;;                                     v21 = iconst.i64 0x0001_0000
+;;                                     v22 = icmp ugt v11, v21  ; v21 = 0x0001_0000
 ;; @0039                               v15 = iadd.i64 v14, v11
-;;                                     v24 = iconst.i64 0
-;;                                     v25 = select_spectre_guard v23, v24, v15  ; v24 = 0
-;; @0039                               store little region3 v21, v25  ; v21 = 0
-;;                                     v26 = iconst.i32 1
-;;                                     v27 = iadd v8, v26  ; v26 = 1
-;; @0043                               jump block2(v27)
+;;                                     v23 = iconst.i64 0
+;;                                     v24 = select_spectre_guard v22, v23, v15  ; v23 = 0
+;; @0039                               store little region3 v20, v24  ; v20 = 0
+;;                                     v25 = iconst.i32 1
+;;                                     v26 = iadd v8, v25  ; v25 = 1
+;; @0043                               jump block2(v26)
 ;; }

--- a/tests/disas/memory.wat
+++ b/tests/disas/memory.wat
@@ -18,9 +18,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):

--- a/tests/disas/memory_copy_host32.wat
+++ b/tests/disas/memory_copy_host32.wat
@@ -51,8 +51,6 @@
 )
 ;; function u0:0(i32 vmctx, i32, i32, i32, i32) tail {
 ;;     gv0 = vmctx
-;;     gv1 = load.i32 notrap aligned gv0+44
-;;     gv2 = load.i32 notrap aligned can_move gv0+40
 ;;     sig0 = (i32 vmctx, i32, i32, i32) tail
 ;;     fn0 = colocated u805306368:1 sig0
 ;;
@@ -80,10 +78,6 @@
 ;;
 ;; function u0:1(i32 vmctx, i32, i32, i32, i32) tail {
 ;;     gv0 = vmctx
-;;     gv1 = load.i32 notrap aligned gv0+44
-;;     gv2 = load.i32 notrap aligned can_move gv0+40
-;;     gv3 = load.i32 notrap aligned gv0+52
-;;     gv4 = load.i32 notrap aligned can_move gv0+48
 ;;     sig0 = (i32 vmctx, i32, i32, i32) tail
 ;;     fn0 = colocated u805306368:1 sig0
 ;;
@@ -114,10 +108,6 @@
 ;;
 ;; function u0:2(i32 vmctx, i32, i64, i32, i32) tail {
 ;;     gv0 = vmctx
-;;     gv1 = load.i32 notrap aligned gv0+44
-;;     gv2 = load.i32 notrap aligned can_move gv0+40
-;;     gv3 = load.i32 notrap aligned gv0+60
-;;     gv4 = load.i32 notrap aligned can_move gv0+56
 ;;     sig0 = (i32 vmctx, i32, i32, i32) tail
 ;;     fn0 = colocated u805306368:1 sig0
 ;;
@@ -148,8 +138,6 @@
 ;;
 ;; function u0:3(i32 vmctx, i32, i64, i64, i64) tail {
 ;;     gv0 = vmctx
-;;     gv1 = load.i32 notrap aligned gv0+60
-;;     gv2 = load.i32 notrap aligned can_move gv0+56
 ;;     sig0 = (i32 vmctx, i32, i32, i32) tail
 ;;     fn0 = colocated u805306368:1 sig0
 ;;
@@ -177,10 +165,6 @@
 ;;
 ;; function u0:4(i32 vmctx, i32, i64, i64, i64) tail {
 ;;     gv0 = vmctx
-;;     gv1 = load.i32 notrap aligned gv0+60
-;;     gv2 = load.i32 notrap aligned can_move gv0+56
-;;     gv3 = load.i32 notrap aligned gv0+68
-;;     gv4 = load.i32 notrap aligned can_move gv0+64
 ;;     sig0 = (i32 vmctx, i32, i32, i32) tail
 ;;     fn0 = colocated u805306368:1 sig0
 ;;
@@ -211,10 +195,6 @@
 ;;
 ;; function u0:5(i32 vmctx, i32, i32, i64, i32) tail {
 ;;     gv0 = vmctx
-;;     gv1 = load.i32 notrap aligned gv0+60
-;;     gv2 = load.i32 notrap aligned can_move gv0+56
-;;     gv3 = load.i32 notrap aligned gv0+44
-;;     gv4 = load.i32 notrap aligned can_move gv0+40
 ;;     sig0 = (i32 vmctx, i32, i32, i32) tail
 ;;     fn0 = colocated u805306368:1 sig0
 ;;

--- a/tests/disas/memory_copy_host64.wat
+++ b/tests/disas/memory_copy_host64.wat
@@ -55,8 +55,6 @@
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+88
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+80
 ;;     sig0 = (i64 vmctx, i64, i64, i64) tail
 ;;     fn0 = colocated u805306368:1 sig0
 ;;     stack_limit = gv2
@@ -88,10 +86,6 @@
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+88
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+80
-;;     gv6 = load.i64 notrap aligned gv3+104
-;;     gv7 = load.i64 notrap aligned readonly can_move gv3+96
 ;;     sig0 = (i64 vmctx, i64, i64, i64) tail
 ;;     fn0 = colocated u805306368:1 sig0
 ;;     stack_limit = gv2
@@ -125,10 +119,6 @@
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+88
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+80
-;;     gv6 = load.i64 notrap aligned gv3+120
-;;     gv7 = load.i64 notrap aligned can_move gv3+112
 ;;     sig0 = (i64 vmctx, i64, i64, i64) tail
 ;;     fn0 = colocated u805306368:1 sig0
 ;;     stack_limit = gv2
@@ -161,8 +151,6 @@
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+120
-;;     gv5 = load.i64 notrap aligned can_move gv3+112
 ;;     sig0 = (i64 vmctx, i64, i64, i64) tail
 ;;     fn0 = colocated u805306368:1 sig0
 ;;     stack_limit = gv2
@@ -191,10 +179,6 @@
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+120
-;;     gv5 = load.i64 notrap aligned can_move gv3+112
-;;     gv6 = load.i64 notrap aligned gv3+136
-;;     gv7 = load.i64 notrap aligned can_move gv3+128
 ;;     sig0 = (i64 vmctx, i64, i64, i64) tail
 ;;     fn0 = colocated u805306368:1 sig0
 ;;     stack_limit = gv2
@@ -225,10 +209,6 @@
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+120
-;;     gv5 = load.i64 notrap aligned can_move gv3+112
-;;     gv6 = load.i64 notrap aligned gv3+88
-;;     gv7 = load.i64 notrap aligned readonly can_move gv3+80
 ;;     sig0 = (i64 vmctx, i64, i64, i64) tail
 ;;     fn0 = colocated u805306368:1 sig0
 ;;     stack_limit = gv2

--- a/tests/disas/memory_fill_host32.wat
+++ b/tests/disas/memory_fill_host32.wat
@@ -48,8 +48,6 @@
 )
 ;; function u0:0(i32 vmctx, i32, i32, i32) tail {
 ;;     gv0 = vmctx
-;;     gv1 = load.i32 notrap aligned gv0+48
-;;     gv2 = load.i32 notrap aligned can_move gv0+44
 ;;     sig0 = (i32 vmctx, i32, i32, i32) tail
 ;;     fn0 = colocated u805306368:2 sig0
 ;;
@@ -73,8 +71,6 @@
 ;;
 ;; function u0:1(i32 vmctx, i32, i64, i64) tail {
 ;;     gv0 = vmctx
-;;     gv1 = load.i32 notrap aligned gv0+56
-;;     gv2 = load.i32 notrap aligned can_move gv0+52
 ;;     sig0 = (i32 vmctx, i32, i32, i32) tail
 ;;     fn0 = colocated u805306368:2 sig0
 ;;
@@ -98,8 +94,6 @@
 ;;
 ;; function u0:2(i32 vmctx, i32, i32, i32) tail {
 ;;     gv0 = vmctx
-;;     gv1 = load.i32 notrap aligned gv0+64
-;;     gv2 = load.i32 notrap aligned can_move gv0+60
 ;;     sig0 = (i32 vmctx, i32, i32, i32) tail
 ;;     fn0 = colocated u805306368:2 sig0
 ;;
@@ -123,8 +117,6 @@
 ;;
 ;; function u0:3(i32 vmctx, i32, i64, i64) tail {
 ;;     gv0 = vmctx
-;;     gv1 = load.i32 notrap aligned gv0+72
-;;     gv2 = load.i32 notrap aligned can_move gv0+68
 ;;     sig0 = (i32 vmctx, i32, i32, i32) tail
 ;;     fn0 = colocated u805306368:2 sig0
 ;;
@@ -148,8 +140,6 @@
 ;;
 ;; function u0:4(i32 vmctx, i32, i32, i32) tail {
 ;;     gv0 = vmctx
-;;     gv1 = load.i32 notrap aligned gv0+80
-;;     gv2 = load.i32 notrap aligned readonly can_move gv0+76
 ;;     sig0 = (i32 vmctx, i32, i32, i32) tail
 ;;     fn0 = colocated u805306368:2 sig0
 ;;

--- a/tests/disas/memory_fill_host64.wat
+++ b/tests/disas/memory_fill_host64.wat
@@ -49,8 +49,6 @@
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+88
 ;;     sig0 = (i64 vmctx, i64, i32, i64) tail
 ;;     fn0 = colocated u805306368:2 sig0
 ;;     stack_limit = gv2
@@ -78,8 +76,6 @@
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+112
-;;     gv5 = load.i64 notrap aligned can_move gv3+104
 ;;     sig0 = (i64 vmctx, i64, i32, i64) tail
 ;;     fn0 = colocated u805306368:2 sig0
 ;;     stack_limit = gv2
@@ -105,8 +101,6 @@
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+128
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+120
 ;;     sig0 = (i64 vmctx, i64, i32, i64) tail
 ;;     fn0 = colocated u805306368:2 sig0
 ;;     stack_limit = gv2
@@ -134,8 +128,6 @@
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+144
-;;     gv5 = load.i64 notrap aligned can_move gv3+136
 ;;     sig0 = (i64 vmctx, i64, i32, i64) tail
 ;;     fn0 = colocated u805306368:2 sig0
 ;;     stack_limit = gv2
@@ -161,8 +153,6 @@
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+160
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+152
 ;;     sig0 = (i64 vmctx, i64, i32, i64) tail
 ;;     fn0 = colocated u805306368:2 sig0
 ;;     stack_limit = gv2

--- a/tests/disas/non-fixed-size-memory.wat
+++ b/tests/disas/non-fixed-size-memory.wat
@@ -26,9 +26,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -51,9 +48,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/passive-data.wat
+++ b/tests/disas/passive-data.wat
@@ -21,8 +21,6 @@
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     sig0 = (i64 vmctx, i64, i64, i64) tail
 ;;     fn0 = colocated u805306368:1 sig0
 ;;     stack_limit = gv2

--- a/tests/disas/pic.wat
+++ b/tests/disas/pic.wat
@@ -53,15 +53,12 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
 ;; @005e                               v7 = load.i64 notrap aligned readonly can_move v0+56
-;;                                     v16 = iconst.i64 0x0010_0000
-;; @005e                               v8 = iadd v7, v16  ; v16 = 0x0010_0000
+;;                                     v15 = iconst.i64 0x0010_0000
+;; @005e                               v8 = iadd v7, v15  ; v15 = 0x0010_0000
 ;; @005e                               v9 = load.i32 little region1 v8
 ;; @0061                               jump block1
 ;;
@@ -78,9 +75,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     sig0 = (i64 vmctx, i64, i32) tail
 ;;     stack_limit = gv2
 ;;
@@ -100,11 +94,11 @@
 ;; @0078                               store little region2 v11, v16
 ;; @0084                               v21 = load.i64 notrap aligned readonly can_move region4 v0+80
 ;; @0084                               v20 = load.i64 notrap aligned readonly can_move region3 v0+96
-;;                                     v32 = iconst.i32 -4
-;;                                     v33 = iadd v5, v32  ; v32 = -4
-;; @0084                               call_indirect sig0, v21(v20, v0, v33)
-;;                                     v40 = iconst.i64 0x0010_0000
-;; @0090                               v26 = iadd v9, v40  ; v40 = 0x0010_0000
+;;                                     v29 = iconst.i32 -4
+;;                                     v30 = iadd v5, v29  ; v29 = -4
+;; @0084                               call_indirect sig0, v21(v20, v0, v30)
+;;                                     v37 = iconst.i64 0x0010_0000
+;; @0090                               v26 = iadd v9, v37  ; v37 = 0x0010_0000
 ;; @0090                               store little region2 v11, v26
 ;; @0098                               store notrap aligned region1 v5, v0+128
 ;; @009c                               jump block1

--- a/tests/disas/pr2303.wat
+++ b/tests/disas/pr2303.wat
@@ -22,9 +22,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/readonly-heap-base-pointer1.wat
+++ b/tests/disas/readonly-heap-base-pointer1.wat
@@ -13,9 +13,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/readonly-heap-base-pointer2.wat
+++ b/tests/disas/readonly-heap-base-pointer2.wat
@@ -14,24 +14,20 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region1 gv3+48
-;;     gv5 = load.i64 notrap aligned gv4+8
-;;     gv6 = load.i64 notrap aligned readonly can_move gv4
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0022                               v4 = uextend.i64 v2
 ;; @0022                               v5 = iconst.i64 0x0001_fffc
 ;; @0022                               v6 = icmp ugt v4, v5  ; v5 = 0x0001_fffc
-;; @0022                               v9 = iconst.i64 0
-;; @0022                               v12 = load.i64 notrap aligned readonly can_move region1 v0+48
-;; @0022                               v7 = load.i64 notrap aligned readonly can_move v12
-;; @0022                               v8 = iadd v7, v4
-;; @0022                               v10 = select_spectre_guard v6, v9, v8  ; v9 = 0
-;; @0022                               v11 = load.i32 little region2 v10
+;; @0022                               v10 = iconst.i64 0
+;; @0022                               v7 = load.i64 notrap aligned readonly can_move region1 v0+48
+;; @0022                               v8 = load.i64 notrap aligned readonly can_move v7
+;; @0022                               v9 = iadd v8, v4
+;; @0022                               v11 = select_spectre_guard v6, v10, v9  ; v10 = 0
+;; @0022                               v12 = load.i32 little region2 v11
 ;; @0025                               jump block1
 ;;
 ;;                                 block1:
-;; @0025                               return v11
+;; @0025                               return v12
 ;; }

--- a/tests/disas/readonly-heap-base-pointer3.wat
+++ b/tests/disas/readonly-heap-base-pointer3.wat
@@ -13,9 +13,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):

--- a/tests/disas/simd-store.wat
+++ b/tests/disas/simd-store.wat
@@ -90,9 +90,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -114,9 +111,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -140,9 +134,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -166,9 +157,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -190,9 +178,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -216,9 +201,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -242,9 +224,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -266,9 +245,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -292,9 +268,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -318,9 +291,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -344,9 +314,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -368,9 +335,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -394,9 +358,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -420,9 +381,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -446,9 +404,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -472,9 +427,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -498,9 +450,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -524,9 +473,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -550,9 +496,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -576,9 +519,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -602,9 +542,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -628,9 +565,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -654,9 +588,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -680,9 +611,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -706,9 +634,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -732,9 +657,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -758,9 +680,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -784,9 +703,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -810,9 +726,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -834,9 +747,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -860,9 +770,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -886,9 +793,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -912,9 +816,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -936,9 +837,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+64
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):

--- a/tests/disas/startup-data-active.wat
+++ b/tests/disas/startup-data-active.wat
@@ -39,8 +39,6 @@
 ;;     region0 = 112 "VMContext+0x70"
 ;;     region1 = 120 "VMContext+0x78"
 ;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned gv0+64
-;;     gv2 = load.i64 notrap aligned readonly can_move gv0+56
 ;;     sig0 = (i64 vmctx, i64, i64, i64) tail
 ;;     fn0 = colocated u805306368:1 sig0
 ;;


### PR DESCRIPTION
Instead, define a new `VmctxLoadChain` type which describes a chain of loads starting from the `vmctx` and which ultimately reaches a memory's base or bound. This will also be reused for table bases and bounds in a future commit.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
