### PR TITLE
Increase timeout for `p3_cli_stdout_flush`

### DIFF
--- a/tests/all/cli_tests.rs
+++ b/tests/all/cli_tests.rs
@@ -2948,7 +2948,7 @@ start a print 1234
             let _ = tx.send(res);
         });
 
-        let buf = match rx.recv_timeout(std::time::Duration::from_secs(10)) {
+        let buf = match rx.recv_timeout(std::time::Duration::from_secs(100)) {
             Ok(Ok(buf)) => buf,
             Ok(Err(e)) => {
                 let _ = child.kill();


### PR DESCRIPTION
Turns out s390x emulation can be quite slow, so prevent spurious failures by increasing the timeout.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
