### PR TITLE
Do not use `ir::GlobalValue`s in Wasm table translation

### DIFF
--- a/crates/cranelift/src/alias_region.rs
+++ b/crates/cranelift/src/alias_region.rs
@@ -636,6 +636,21 @@ impl AliasRegions<VMOffsets<u8>> {
         )
     }
 
+    /// Get a `Load` for the imported table's `VMTableImport::from` field (a
+    /// `*mut VMTableDefinition`) out of a `*mut VMContext`.
+    pub fn vmctx_vmtable_from_load(&mut self, func: &mut ir::Function, table: TableIndex) -> Load {
+        let offset = self.offsets.vmctx_vmtable_from(table);
+        let region = self.vmctx_region(func, offset);
+        Load {
+            offset,
+            flags: ir::MemFlagsData::trusted()
+                .with_readonly()
+                .with_can_move()
+                .with_alias_region(Some(region)),
+            ty: self.pointer_type,
+        }
+    }
+
     /// Load the imported global's address (`VMGlobalImport::from`) out of the
     /// `*mut VMContext`.
     pub fn vmctx_vmglobal_import_from(

--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -14,7 +14,7 @@ use crate::{
 };
 use cranelift_codegen::cursor::FuncCursor;
 use cranelift_codegen::ir::condcodes::{FloatCC, IntCC};
-use cranelift_codegen::ir::immediates::{Ieee32, Ieee64, Imm64, Offset32, V128Imm};
+use cranelift_codegen::ir::immediates::{Ieee32, Ieee64, Imm64, V128Imm};
 use cranelift_codegen::ir::{
     self, BlockArg, Endianness, ExceptionTableData, ExceptionTableItem, types,
 };
@@ -1660,94 +1660,93 @@ impl FuncEnvironment<'_> {
     }
 
     fn make_table(&mut self, func: &mut ir::Function, index: TableIndex) -> TableData {
-        let pointer_type = self.pointer_type();
-
-        let (ptr, base_offset, current_elements_offset) = {
-            let vmctx = self.vmctx(func);
-            if let Some(def_index) = self.module.defined_table_index(index) {
-                let base_offset =
-                    i32::try_from(self.offsets.vmctx_vmtable_definition_base(def_index)).unwrap();
-                let current_elements_offset = i32::try_from(
-                    self.offsets
-                        .vmctx_vmtable_definition_current_elements(def_index),
-                )
-                .unwrap();
-                (vmctx, base_offset, current_elements_offset)
-            } else {
-                let from_offset = self.offsets.vmctx_vmtable_from(index);
-                let region = self
-                    .alias_regions
-                    .vmctx_region_for_use_in_ir_global(func, from_offset);
-                let table_flags = func
-                    .dfg
-                    .mem_flags
-                    .insert(
-                        MemFlagsData::trusted()
-                            .with_readonly()
-                            .with_can_move()
-                            .with_alias_region(Some(region)),
-                    )
-                    .unwrap();
-                let table = func.create_global_value(ir::GlobalValueData::Load {
-                    base: vmctx,
-                    offset: Offset32::new(i32::try_from(from_offset).unwrap()),
-                    global_type: pointer_type,
-                    flags: table_flags,
-                });
-                let base_offset = i32::from(self.offsets.vmtable_definition_base());
-                let current_elements_offset =
-                    i32::from(self.offsets.vmtable_definition_current_elements());
-                (table, base_offset, current_elements_offset)
-            }
-        };
-
-        let table = &self.module.tables[index];
+        let table = self.module.tables[index];
         let element_size = if table.ref_type.is_vmgcref_type() {
             // For GC-managed references, tables store `Option<VMGcRef>`s.
             ir::types::I32.bytes()
         } else {
             self.reference_type(table.ref_type.heap_type).0.bytes()
         };
-
-        let base_flags = if Some(table.limits.min) == table.limits.max {
-            func.dfg
-                .mem_flags
-                .insert(MemFlagsData::trusted().with_readonly().with_can_move())
-                .unwrap()
-        } else {
-            func.dfg.mem_flags.insert(MemFlagsData::trusted()).unwrap()
-        };
-        let base_gv = func.create_global_value(ir::GlobalValueData::Load {
-            base: ptr,
-            offset: Offset32::new(base_offset),
-            global_type: pointer_type,
-            // A fixed-size table can't be resized so its base address won't change.
-            flags: base_flags,
-        });
-
-        let bound = if Some(table.limits.min) == table.limits.max {
-            TableSize::Static {
-                bound: table.limits.min,
-            }
-        } else {
-            let bound_flags = func.dfg.mem_flags.insert(MemFlagsData::trusted()).unwrap();
-            TableSize::Dynamic {
-                bound_gv: func.create_global_value(ir::GlobalValueData::Load {
-                    base: ptr,
-                    offset: Offset32::new(current_elements_offset),
-                    global_type: ir::Type::int(
-                        u16::from(self.offsets.size_of_vmtable_definition_current_elements()) * 8,
-                    )
-                    .unwrap(),
-                    flags: bound_flags,
-                }),
-            }
-        };
-
+        let (base, bound) = self.make_table_base_bound(func, index);
         TableData {
-            base_gv,
+            base,
             bound,
             element_size,
+        }
+    }
+
+    fn make_table_base_bound(
+        &mut self,
+        func: &mut ir::Function,
+        index: TableIndex,
+    ) -> (VmctxLoadChain, TableSize) {
+        let pointer_type = self.pointer_type();
+        let table = self.module.tables[index];
+        let bound_ty = ir::Type::int(
+            u16::from(self.offsets.size_of_vmtable_definition_current_elements()) * 8,
+        )
+        .unwrap();
+
+        // A fixed-size table can't be resized, so its base address won't change
+        // and its base load is `readonly` and `can_move`.
+        let is_static = Some(table.limits.min) == table.limits.max;
+        let mut base_flags = ir::MemFlagsData::trusted();
+        if is_static {
+            base_flags = base_flags.with_readonly().with_can_move();
+        }
+
+        let base = |from: Option<Load>, offset| {
+            VmctxLoadChain::new(
+                from.into_iter()
+                    .chain(std::iter::once(Load {
+                        offset,
+                        flags: base_flags,
+                        ty: pointer_type,
+                    }))
+                    .collect(),
+            )
+        };
+        let bound = |from: Option<Load>, offset| {
+            if is_static {
+                TableSize::Static {
+                    bound: table.limits.min,
+                }
+            } else {
+                TableSize::Dynamic {
+                    bound: VmctxLoadChain::new(
+                        from.into_iter()
+                            .chain(std::iter::once(Load {
+                                offset,
+                                flags: ir::MemFlagsData::trusted(),
+                                ty: bound_ty,
+                            }))
+                            .collect(),
+                    ),
+                }
+            }
+        };
+
+        if let Some(def_index) = self.module.defined_table_index(index) {
+            (
+                base(None, self.offsets.vmctx_vmtable_definition_base(def_index)),
+                bound(
+                    None,
+                    self.offsets
+                        .vmctx_vmtable_definition_current_elements(def_index),
+                ),
+            )
+        } else {
+            let from = self.alias_regions.vmctx_vmtable_from_load(func, index);
+            (
+                base(
+                    Some(from),
+                    u32::from(self.offsets.vmtable_definition_base()),
+                ),
+                bound(
+                    Some(from),
+                    u32::from(self.offsets.vmtable_definition_current_elements()),
+                ),
+            )
         }
     }
 
@@ -4051,7 +4050,7 @@ impl FuncEnvironment<'_> {
     pub fn translate_table_size(&mut self, pos: FuncCursor, table_index: TableIndex) -> ir::Value {
         let table_data = self.get_or_create_table(pos.func, table_index);
         let index_type = index_type_to_ir_type(self.table(table_index).idx_type);
-        table_data.bound.bound(&*self.isa, pos, index_type)
+        table_data.bound.bound(pos, index_type)
     }
 
     /// Copies elements from `src_entity` to `dst_entity`.
@@ -4261,7 +4260,8 @@ impl FuncEnvironment<'_> {
             }
             CheckedEntity::Table { table, .. } => {
                 let table = self.get_or_create_table(builder.func, table);
-                builder.ins().global_value(pointer_type, table.base_gv)
+                let vmctx = self.vmctx_val(&mut builder.cursor());
+                table.base.emit(&mut builder.cursor(), vmctx)
             }
             CheckedEntity::Data { segment, .. } => match self.translation.runtime_data_map[segment]
             {

--- a/crates/cranelift/src/translate/table.rs
+++ b/crates/cranelift/src/translate/table.rs
@@ -1,8 +1,8 @@
 use crate::func_environ::FuncEnvironment;
+use crate::translate::VmctxLoadChain;
 use crate::trap::TranslateTrap;
 use cranelift_codegen::cursor::FuncCursor;
 use cranelift_codegen::ir::{self, InstBuilder, condcodes::IntCC, immediates::Imm64};
-use cranelift_codegen::isa::TargetIsa;
 use cranelift_frontend::FunctionBuilder;
 use wasmtime_environ::TableIndex;
 
@@ -16,27 +16,27 @@ pub enum TableSize {
     },
     /// Resizable table.
     Dynamic {
-        /// Resizable tables declare a Cranelift global value to load the
-        /// current size from.
-        bound_gv: ir::GlobalValue,
+        /// Resizable tables load their current size from the `vmctx`.
+        bound: VmctxLoadChain,
     },
 }
 
 impl TableSize {
     /// Get a CLIF value representing the current bounds of this table.
-    pub fn bound(&self, isa: &dyn TargetIsa, mut pos: FuncCursor, index_ty: ir::Type) -> ir::Value {
-        match *self {
+    pub fn bound(&self, mut pos: FuncCursor, index_ty: ir::Type) -> ir::Value {
+        match self {
             // Instead of `i64::try_from(bound)`, here we just want to directly interpret `bound` as an i64.
-            TableSize::Static { bound } => pos.ins().iconst(index_ty, Imm64::new(bound as i64)),
-            TableSize::Dynamic { bound_gv } => {
-                let ty = pos.func.global_values[bound_gv].global_type(isa);
-                let gv = pos.ins().global_value(ty, bound_gv);
+            TableSize::Static { bound } => pos.ins().iconst(index_ty, Imm64::new(*bound as i64)),
+            TableSize::Dynamic { bound } => {
+                let vmctx = vmctx(&mut pos);
+                let bound = bound.emit(&mut pos, vmctx);
+                let ty = pos.func.dfg.value_type(bound);
                 if index_ty == ty {
-                    gv
+                    bound
                 } else if index_ty.bytes() < ty.bytes() {
-                    pos.ins().ireduce(index_ty, gv)
+                    pos.ins().ireduce(index_ty, bound)
                 } else {
-                    pos.ins().uextend(index_ty, gv)
+                    pos.ins().uextend(index_ty, bound)
                 }
             }
         }
@@ -46,8 +46,8 @@ impl TableSize {
 /// An implementation of a WebAssembly table.
 #[derive(Clone)]
 pub struct TableData {
-    /// Global value giving the address of the start of the table.
-    pub base_gv: ir::GlobalValue,
+    /// The load chain giving the address of the start of the table.
+    pub base: VmctxLoadChain,
 
     /// The size of the table, in elements.
     pub bound: TableSize,
@@ -73,7 +73,7 @@ impl TableData {
                 && env.clif_memory_traps_enabled();
 
         // Start with the bounds check. Trap if `index + 1 > bound`.
-        let bound = self.bound.bound(env.isa(), pos.cursor(), index_ty);
+        let bound = self.bound.bound(pos.cursor(), index_ty);
 
         // `index > bound - 1` is the same as `index >= bound`.
         let oob = pos
@@ -92,7 +92,8 @@ impl TableData {
         }
 
         // Add the table base address base
-        let base = pos.ins().global_value(addr_ty, self.base_gv);
+        let vmctx = vmctx(&mut pos.cursor());
+        let base = self.base.emit(&mut pos.cursor(), vmctx);
 
         let element_size = self.element_size;
         let offset = if element_size == 1 {
@@ -123,4 +124,11 @@ impl TableData {
             (element_addr, base_flags.with_trap_code(None))
         }
     }
+}
+
+/// Read the `vmctx` value out of the function's special `VMContext` parameter.
+fn vmctx(pos: &mut FuncCursor<'_>) -> ir::Value {
+    pos.func
+        .special_param(ir::ArgumentPurpose::VMContext)
+        .expect("missing vmctx parameter")
 }

--- a/tests/disas/alias-region-tables.wat
+++ b/tests/disas/alias-region-tables.wat
@@ -24,59 +24,53 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region1 gv3+48
-;;     gv5 = load.i64 notrap aligned gv4
-;;     gv6 = load.i64 notrap aligned gv4+8
-;;     gv7 = load.i64 notrap aligned gv3+72
-;;     gv8 = load.i64 notrap aligned gv3+80
 ;;     sig0 = (i64 vmctx, i64) -> i32 tail
 ;;     sig1 = (i64 vmctx, i32, i64) -> i64 tail
 ;;     fn0 = colocated u805306368:7 sig1
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i64):
-;; @0043                               v62 = load.i64 notrap aligned readonly can_move region1 v0+48
-;; @0043                               v5 = load.i64 notrap aligned v62+8
-;; @0043                               v9 = load.i64 notrap aligned v62
-;; @0043                               v15 = iconst.i64 1
-;; @0043                               v16 = bor v3, v15  ; v15 = 1
-;; @0043                               v6 = ireduce.i32 v5
-;; @0043                               v7 = icmp uge v2, v6
-;; @0043                               v13 = iconst.i64 0
-;; @0043                               v8 = uextend.i64 v2
-;; @0043                               v10 = iconst.i64 3
-;; @0043                               v11 = ishl v8, v10  ; v10 = 3
-;; @0043                               v12 = iadd v9, v11
-;; @0043                               v14 = select_spectre_guard v7, v13, v12  ; v13 = 0
-;; @0043                               store user6 aligned region2 v16, v14
-;; @0049                               v17 = load.i64 notrap aligned v0+80
-;; @0049                               v21 = load.i64 notrap aligned v0+72
-;; @0049                               v18 = ireduce.i32 v17
-;; @0049                               v19 = icmp uge v2, v18
-;; @0049                               v24 = iadd v21, v11
-;; @0049                               v26 = select_spectre_guard v19, v13, v24  ; v13 = 0
-;; @0049                               store user6 aligned region3 v16, v26
-;; @004d                               v40 = iconst.i64 -2
-;; @004d                               v41 = band v16, v40  ; v40 = -2
-;; @004d                               brif v16, block3(v41), block2
+;; @0043                               v5 = load.i64 notrap aligned readonly can_move region1 v0+48
+;; @0043                               v6 = load.i64 notrap aligned v5+8
+;; @0043                               v11 = load.i64 notrap aligned v5
+;; @0043                               v17 = iconst.i64 1
+;; @0043                               v18 = bor v3, v17  ; v17 = 1
+;; @0043                               v7 = ireduce.i32 v6
+;; @0043                               v8 = icmp uge v2, v7
+;; @0043                               v15 = iconst.i64 0
+;; @0043                               v9 = uextend.i64 v2
+;; @0043                               v12 = iconst.i64 3
+;; @0043                               v13 = ishl v9, v12  ; v12 = 3
+;; @0043                               v14 = iadd v11, v13
+;; @0043                               v16 = select_spectre_guard v8, v15, v14  ; v15 = 0
+;; @0043                               store user6 aligned region2 v18, v16
+;; @0049                               v19 = load.i64 notrap aligned v0+80
+;; @0049                               v23 = load.i64 notrap aligned v0+72
+;; @0049                               v20 = ireduce.i32 v19
+;; @0049                               v21 = icmp uge v2, v20
+;; @0049                               v26 = iadd v23, v13
+;; @0049                               v28 = select_spectre_guard v21, v15, v26  ; v15 = 0
+;; @0049                               store user6 aligned region3 v18, v28
+;; @004d                               v44 = iconst.i64 -2
+;; @004d                               v45 = band v18, v44  ; v44 = -2
+;; @004d                               brif v18, block3(v45), block2
 ;;
 ;;                                 block2 cold:
-;; @004d                               v43 = iconst.i32 0
-;; @004d                               v45 = call fn0(v0, v43, v8)  ; v43 = 0
-;; @004d                               jump block3(v45)
+;; @004d                               v47 = iconst.i32 0
+;; @004d                               v49 = call fn0(v0, v47, v9)  ; v47 = 0
+;; @004d                               jump block3(v49)
 ;;
-;;                                 block3(v42: i64):
-;; @004d                               v48 = load.i32 user7 aligned readonly v42+16
-;; @004d                               v46 = load.i64 notrap aligned readonly can_move region4 v0+40
-;; @004d                               v47 = load.i32 notrap aligned readonly can_move v46
-;; @004d                               v49 = icmp eq v48, v47
-;; @004d                               trapz v49, user8
-;; @004d                               v51 = load.i64 notrap aligned readonly v42+8
-;; @004d                               v52 = load.i64 notrap aligned readonly v42+24
-;; @004d                               v53 = call_indirect sig0, v51(v52, v0)
+;;                                 block3(v46: i64):
+;; @004d                               v52 = load.i32 user7 aligned readonly v46+16
+;; @004d                               v50 = load.i64 notrap aligned readonly can_move region4 v0+40
+;; @004d                               v51 = load.i32 notrap aligned readonly can_move v50
+;; @004d                               v53 = icmp eq v52, v51
+;; @004d                               trapz v53, user8
+;; @004d                               v55 = load.i64 notrap aligned readonly v46+8
+;; @004d                               v56 = load.i64 notrap aligned readonly v46+24
+;; @004d                               v57 = call_indirect sig0, v55(v56, v0)
 ;; @0050                               jump block1
 ;;
 ;;                                 block1:
-;; @0050                               return v53
+;; @0050                               return v57
 ;; }

--- a/tests/disas/call-indirect-with-gc.wat
+++ b/tests/disas/call-indirect-with-gc.wat
@@ -16,9 +16,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+48
-;;     gv5 = load.i64 notrap aligned gv3+56
 ;;     sig0 = (i64 vmctx, i64, i32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i32, i64) -> i64 tail
 ;;     fn0 = colocated u805306368:7 sig1

--- a/tests/disas/call-indirect-without-gc.wat
+++ b/tests/disas/call-indirect-without-gc.wat
@@ -16,9 +16,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+48
-;;     gv5 = load.i64 notrap aligned gv3+56
 ;;     sig0 = (i64 vmctx, i64, i32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i32, i64) -> i64 tail
 ;;     fn0 = colocated u805306368:7 sig1

--- a/tests/disas/call-indirect.wat
+++ b/tests/disas/call-indirect.wat
@@ -14,9 +14,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+48
-;;     gv5 = load.i64 notrap aligned gv3+56
 ;;     sig0 = (i64 vmctx, i64, i32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i32, i64) -> i64 tail
 ;;     fn0 = colocated u805306368:7 sig1

--- a/tests/disas/duplicate-function-types.wat
+++ b/tests/disas/duplicate-function-types.wat
@@ -24,84 +24,80 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region1 gv3+48
-;;     gv5 = load.i64 notrap aligned gv4
-;;     gv6 = load.i64 notrap aligned gv4+8
 ;;     sig0 = (i64 vmctx, i64) -> i32 tail
 ;;     sig1 = (i64 vmctx, i32, i64) -> i64 tail
 ;;     fn0 = colocated u805306368:7 sig1
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @002d                               v62 = load.i64 notrap aligned readonly can_move region1 v0+48
-;; @002d                               v5 = load.i64 notrap aligned v62+8
-;; @002d                               v6 = ireduce.i32 v5
-;; @002d                               v7 = icmp uge v2, v6
-;; @002d                               v8 = uextend.i64 v2
-;; @002d                               v60 = load.i64 notrap aligned readonly can_move region1 v0+48
-;; @002d                               v9 = load.i64 notrap aligned v60
-;; @002d                               v10 = iconst.i64 3
-;; @002d                               v11 = ishl v8, v10  ; v10 = 3
-;; @002d                               v12 = iadd v9, v11
-;; @002d                               v13 = iconst.i64 0
-;; @002d                               v14 = select_spectre_guard v7, v13, v12  ; v13 = 0
-;; @002d                               v15 = load.i64 user6 aligned region2 v14
-;; @002d                               v16 = iconst.i64 -2
-;; @002d                               v17 = band v15, v16  ; v16 = -2
-;; @002d                               brif v15, block3(v17), block2
+;; @002d                               v5 = load.i64 notrap aligned readonly can_move region1 v0+48
+;; @002d                               v6 = load.i64 notrap aligned v5+8
+;; @002d                               v7 = ireduce.i32 v6
+;; @002d                               v8 = icmp uge v2, v7
+;; @002d                               v9 = uextend.i64 v2
+;; @002d                               v10 = load.i64 notrap aligned readonly can_move region1 v0+48
+;; @002d                               v11 = load.i64 notrap aligned v10
+;; @002d                               v12 = iconst.i64 3
+;; @002d                               v13 = ishl v9, v12  ; v12 = 3
+;; @002d                               v14 = iadd v11, v13
+;; @002d                               v15 = iconst.i64 0
+;; @002d                               v16 = select_spectre_guard v8, v15, v14  ; v15 = 0
+;; @002d                               v17 = load.i64 user6 aligned region2 v16
+;; @002d                               v18 = iconst.i64 -2
+;; @002d                               v19 = band v17, v18  ; v18 = -2
+;; @002d                               brif v17, block3(v19), block2
 ;;
 ;;                                 block2 cold:
-;; @002d                               v19 = iconst.i32 0
-;; @002d                               v20 = uextend.i64 v2
-;; @002d                               v21 = call fn0(v0, v19, v20)  ; v19 = 0
-;; @002d                               jump block3(v21)
+;; @002d                               v21 = iconst.i32 0
+;; @002d                               v22 = uextend.i64 v2
+;; @002d                               v23 = call fn0(v0, v21, v22)  ; v21 = 0
+;; @002d                               jump block3(v23)
 ;;
-;;                                 block3(v18: i64):
-;; @002d                               v22 = load.i64 notrap aligned readonly can_move region3 v0+40
-;; @002d                               v23 = load.i32 notrap aligned readonly can_move v22
-;; @002d                               v24 = load.i32 user7 aligned readonly v18+16
-;; @002d                               v25 = icmp eq v24, v23
-;; @002d                               v26 = uextend.i32 v25
-;; @002d                               trapz v26, user8
-;; @002d                               v27 = load.i64 notrap aligned readonly v18+8
-;; @002d                               v28 = load.i64 notrap aligned readonly v18+24
-;; @002d                               v29 = call_indirect sig0, v27(v28, v0)
-;; @0032                               v58 = load.i64 notrap aligned readonly can_move region1 v0+48
-;; @0032                               v31 = load.i64 notrap aligned v58+8
-;; @0032                               v32 = ireduce.i32 v31
-;; @0032                               v33 = icmp.i32 uge v2, v32
-;; @0032                               v34 = uextend.i64 v2
-;; @0032                               v56 = load.i64 notrap aligned readonly can_move region1 v0+48
-;; @0032                               v35 = load.i64 notrap aligned v56
-;; @0032                               v36 = iconst.i64 3
-;; @0032                               v37 = ishl v34, v36  ; v36 = 3
-;; @0032                               v38 = iadd v35, v37
-;; @0032                               v39 = iconst.i64 0
-;; @0032                               v40 = select_spectre_guard v33, v39, v38  ; v39 = 0
-;; @0032                               v41 = load.i64 user6 aligned region2 v40
-;; @0032                               v42 = iconst.i64 -2
-;; @0032                               v43 = band v41, v42  ; v42 = -2
-;; @0032                               brif v41, block5(v43), block4
+;;                                 block3(v20: i64):
+;; @002d                               v24 = load.i64 notrap aligned readonly can_move region3 v0+40
+;; @002d                               v25 = load.i32 notrap aligned readonly can_move v24
+;; @002d                               v26 = load.i32 user7 aligned readonly v20+16
+;; @002d                               v27 = icmp eq v26, v25
+;; @002d                               v28 = uextend.i32 v27
+;; @002d                               trapz v28, user8
+;; @002d                               v29 = load.i64 notrap aligned readonly v20+8
+;; @002d                               v30 = load.i64 notrap aligned readonly v20+24
+;; @002d                               v31 = call_indirect sig0, v29(v30, v0)
+;; @0032                               v33 = load.i64 notrap aligned readonly can_move region1 v0+48
+;; @0032                               v34 = load.i64 notrap aligned v33+8
+;; @0032                               v35 = ireduce.i32 v34
+;; @0032                               v36 = icmp.i32 uge v2, v35
+;; @0032                               v37 = uextend.i64 v2
+;; @0032                               v38 = load.i64 notrap aligned readonly can_move region1 v0+48
+;; @0032                               v39 = load.i64 notrap aligned v38
+;; @0032                               v40 = iconst.i64 3
+;; @0032                               v41 = ishl v37, v40  ; v40 = 3
+;; @0032                               v42 = iadd v39, v41
+;; @0032                               v43 = iconst.i64 0
+;; @0032                               v44 = select_spectre_guard v36, v43, v42  ; v43 = 0
+;; @0032                               v45 = load.i64 user6 aligned region2 v44
+;; @0032                               v46 = iconst.i64 -2
+;; @0032                               v47 = band v45, v46  ; v46 = -2
+;; @0032                               brif v45, block5(v47), block4
 ;;
 ;;                                 block4 cold:
-;; @0032                               v45 = iconst.i32 0
-;; @0032                               v46 = uextend.i64 v2
-;; @0032                               v47 = call fn0(v0, v45, v46)  ; v45 = 0
-;; @0032                               jump block5(v47)
+;; @0032                               v49 = iconst.i32 0
+;; @0032                               v50 = uextend.i64 v2
+;; @0032                               v51 = call fn0(v0, v49, v50)  ; v49 = 0
+;; @0032                               jump block5(v51)
 ;;
-;;                                 block5(v44: i64):
-;; @0032                               v48 = load.i64 notrap aligned readonly can_move region3 v0+40
-;; @0032                               v49 = load.i32 notrap aligned readonly can_move v48
-;; @0032                               v50 = load.i32 user7 aligned readonly v44+16
-;; @0032                               v51 = icmp eq v50, v49
-;; @0032                               v52 = uextend.i32 v51
-;; @0032                               trapz v52, user8
-;; @0032                               v53 = load.i64 notrap aligned readonly v44+8
-;; @0032                               v54 = load.i64 notrap aligned readonly v44+24
-;; @0032                               v55 = call_indirect sig0, v53(v54, v0)
+;;                                 block5(v48: i64):
+;; @0032                               v52 = load.i64 notrap aligned readonly can_move region3 v0+40
+;; @0032                               v53 = load.i32 notrap aligned readonly can_move v52
+;; @0032                               v54 = load.i32 user7 aligned readonly v48+16
+;; @0032                               v55 = icmp eq v54, v53
+;; @0032                               v56 = uextend.i32 v55
+;; @0032                               trapz v56, user8
+;; @0032                               v57 = load.i64 notrap aligned readonly v48+8
+;; @0032                               v58 = load.i64 notrap aligned readonly v48+24
+;; @0032                               v59 = call_indirect sig0, v57(v58, v0)
 ;; @0035                               jump block1
 ;;
 ;;                                 block1:
-;; @0035                               return v29, v55
+;; @0035                               return v31, v59
 ;; }

--- a/tests/disas/foo.wat
+++ b/tests/disas/foo.wat
@@ -23,10 +23,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region2 gv3+72
-;;     gv5 = load.i64 notrap aligned gv4
-;;     gv6 = load.i64 notrap aligned gv4+8
 ;;     sig0 = (i64 vmctx, i64, i32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i32, i64) -> i64 tail
 ;;     fn0 = colocated u805306368:7 sig1
@@ -37,66 +33,66 @@
 ;; @0040                               v6 = uextend.i64 v3
 ;; @0040                               v8 = iadd v7, v6
 ;; @0040                               v9 = load.i32 little region1 v8
-;; @0043                               v72 = load.i64 notrap aligned readonly can_move region2 v0+72
-;; @0043                               v10 = load.i64 notrap aligned v72+8
-;; @0043                               v14 = load.i64 notrap aligned v72
-;; @0043                               v11 = ireduce.i32 v10
-;; @0043                               v12 = icmp uge v9, v11
-;; @0043                               v18 = iconst.i64 0
-;; @0043                               v13 = uextend.i64 v9
-;; @0043                               v15 = iconst.i64 3
-;; @0043                               v16 = ishl v13, v15  ; v15 = 3
-;; @0043                               v17 = iadd v14, v16
-;; @0043                               v19 = select_spectre_guard v12, v18, v17  ; v18 = 0
-;; @0043                               v20 = load.i64 user6 aligned region3 v19
-;; @0043                               v21 = iconst.i64 -2
-;; @0043                               v22 = band v20, v21  ; v21 = -2
-;; @0043                               brif v20, block3(v22), block2
+;; @0043                               v10 = load.i64 notrap aligned readonly can_move region2 v0+72
+;; @0043                               v11 = load.i64 notrap aligned v10+8
+;; @0043                               v16 = load.i64 notrap aligned v10
+;; @0043                               v12 = ireduce.i32 v11
+;; @0043                               v13 = icmp uge v9, v12
+;; @0043                               v20 = iconst.i64 0
+;; @0043                               v14 = uextend.i64 v9
+;; @0043                               v17 = iconst.i64 3
+;; @0043                               v18 = ishl v14, v17  ; v17 = 3
+;; @0043                               v19 = iadd v16, v18
+;; @0043                               v21 = select_spectre_guard v13, v20, v19  ; v20 = 0
+;; @0043                               v22 = load.i64 user6 aligned region3 v21
+;; @0043                               v23 = iconst.i64 -2
+;; @0043                               v24 = band v22, v23  ; v23 = -2
+;; @0043                               brif v22, block3(v24), block2
 ;;
 ;;                                 block2 cold:
-;; @0043                               v24 = iconst.i32 0
-;; @0043                               v26 = call fn0(v0, v24, v13)  ; v24 = 0
-;; @0043                               jump block3(v26)
+;; @0043                               v26 = iconst.i32 0
+;; @0043                               v28 = call fn0(v0, v26, v14)  ; v26 = 0
+;; @0043                               jump block3(v28)
 ;;
-;;                                 block3(v23: i64):
-;; @0043                               v29 = load.i32 user7 aligned readonly v23+16
-;; @0043                               v27 = load.i64 notrap aligned readonly can_move region4 v0+40
-;; @0043                               v28 = load.i32 notrap aligned readonly can_move v27+4
-;; @0043                               v30 = icmp eq v29, v28
-;; @0043                               trapz v30, user8
-;; @0043                               v32 = load.i64 notrap aligned readonly v23+8
-;; @0043                               v33 = load.i64 notrap aligned readonly v23+24
-;; @0043                               v34 = call_indirect sig0, v32(v33, v0, v2)
-;; @004a                               v40 = load.i32 little region1 v8
-;; @004d                               v41 = load.i64 notrap aligned v72+8
-;; @004d                               v45 = load.i64 notrap aligned v72
-;; @004d                               v42 = ireduce.i32 v41
-;; @004d                               v43 = icmp uge v40, v42
-;; @004d                               v44 = uextend.i64 v40
-;;                                     v74 = iconst.i64 3
-;;                                     v75 = ishl v44, v74  ; v74 = 3
-;; @004d                               v48 = iadd v45, v75
-;;                                     v76 = iconst.i64 0
-;;                                     v77 = select_spectre_guard v43, v76, v48  ; v76 = 0
-;; @004d                               v51 = load.i64 user6 aligned region3 v77
-;;                                     v78 = iconst.i64 -2
-;;                                     v79 = band v51, v78  ; v78 = -2
-;; @004d                               brif v51, block5(v79), block4
+;;                                 block3(v25: i64):
+;; @0043                               v31 = load.i32 user7 aligned readonly v25+16
+;; @0043                               v29 = load.i64 notrap aligned readonly can_move region4 v0+40
+;; @0043                               v30 = load.i32 notrap aligned readonly can_move v29+4
+;; @0043                               v32 = icmp eq v31, v30
+;; @0043                               trapz v32, user8
+;; @0043                               v34 = load.i64 notrap aligned readonly v25+8
+;; @0043                               v35 = load.i64 notrap aligned readonly v25+24
+;; @0043                               v36 = call_indirect sig0, v34(v35, v0, v2)
+;; @004a                               v42 = load.i32 little region1 v8
+;; @004d                               v44 = load.i64 notrap aligned v10+8
+;; @004d                               v49 = load.i64 notrap aligned v10
+;; @004d                               v45 = ireduce.i32 v44
+;; @004d                               v46 = icmp uge v42, v45
+;; @004d                               v47 = uextend.i64 v42
+;;                                     v70 = iconst.i64 3
+;;                                     v71 = ishl v47, v70  ; v70 = 3
+;; @004d                               v52 = iadd v49, v71
+;;                                     v72 = iconst.i64 0
+;;                                     v73 = select_spectre_guard v46, v72, v52  ; v72 = 0
+;; @004d                               v55 = load.i64 user6 aligned region3 v73
+;;                                     v74 = iconst.i64 -2
+;;                                     v75 = band v55, v74  ; v74 = -2
+;; @004d                               brif v55, block5(v75), block4
 ;;
 ;;                                 block4 cold:
-;;                                     v80 = iconst.i32 0
-;; @004d                               v57 = call fn0(v0, v80, v44)  ; v80 = 0
-;; @004d                               jump block5(v57)
+;;                                     v76 = iconst.i32 0
+;; @004d                               v61 = call fn0(v0, v76, v47)  ; v76 = 0
+;; @004d                               jump block5(v61)
 ;;
-;;                                 block5(v54: i64):
-;; @004d                               v60 = load.i32 user7 aligned readonly v54+16
-;; @004d                               v61 = icmp eq v60, v28
-;; @004d                               trapz v61, user8
-;; @004d                               v63 = load.i64 notrap aligned readonly v54+8
-;; @004d                               v64 = load.i64 notrap aligned readonly v54+24
-;; @004d                               v65 = call_indirect sig0, v63(v64, v0, v2)
+;;                                 block5(v58: i64):
+;; @004d                               v64 = load.i32 user7 aligned readonly v58+16
+;; @004d                               v65 = icmp eq v64, v30
+;; @004d                               trapz v65, user8
+;; @004d                               v67 = load.i64 notrap aligned readonly v58+8
+;; @004d                               v68 = load.i64 notrap aligned readonly v58+24
+;; @004d                               v69 = call_indirect sig0, v67(v68, v0, v2)
 ;; @0050                               jump block1
 ;;
 ;;                                 block1:
-;; @0050                               return v34, v65
+;; @0050                               return v36, v69
 ;; }

--- a/tests/disas/gc/call-indirect-final-type.wat
+++ b/tests/disas/gc/call-indirect-final-type.wat
@@ -22,9 +22,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+48
-;;     gv5 = load.i64 notrap aligned gv3+56
 ;;     sig0 = (i64 vmctx, i64, i32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i32, i64) -> i64 tail
 ;;     fn0 = colocated u805306368:7 sig1
@@ -73,9 +70,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+48
-;;     gv5 = load.i64 notrap aligned gv3+56
 ;;     sig0 = (i64 vmctx, i64, i32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i32, i64) -> i64 tail
 ;;     fn0 = colocated u805306368:7 sig1

--- a/tests/disas/gc/copying/call-indirect-and-subtyping.wat
+++ b/tests/disas/gc/copying/call-indirect-and-subtyping.wat
@@ -22,8 +22,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+112
 ;;     sig0 = (i64 vmctx, i64) tail
 ;;     sig1 = (i64 vmctx, i32, i64) -> i64 tail
 ;;     sig2 = (i64 vmctx, i32, i32) -> i32 tail

--- a/tests/disas/gc/drc/call-indirect-and-subtyping.wat
+++ b/tests/disas/gc/drc/call-indirect-and-subtyping.wat
@@ -23,8 +23,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+112
 ;;     sig0 = (i64 vmctx, i64) tail
 ;;     sig1 = (i64 vmctx, i32, i64) -> i64 tail
 ;;     sig2 = (i64 vmctx, i32, i32) -> i32 tail

--- a/tests/disas/gc/null/call-indirect-and-subtyping.wat
+++ b/tests/disas/gc/null/call-indirect-and-subtyping.wat
@@ -23,8 +23,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+112
 ;;     sig0 = (i64 vmctx, i64) tail
 ;;     sig1 = (i64 vmctx, i32, i64) -> i64 tail
 ;;     sig2 = (i64 vmctx, i32, i32) -> i32 tail

--- a/tests/disas/icall-loop.wat
+++ b/tests/disas/icall-loop.wat
@@ -29,8 +29,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+48
 ;;     sig0 = (i64 vmctx, i64) -> i32 tail
 ;;     sig1 = (i64 vmctx, i32, i64) -> i64 tail
 ;;     fn0 = colocated u805306368:7 sig1
@@ -54,13 +52,13 @@
 ;;
 ;;                                 block2:
 ;; @002b                               v13 = load.i64 user6 aligned region1 v12
-;;                                     v30 = iconst.i64 -2
-;;                                     v31 = band v13, v30  ; v30 = -2
-;; @002b                               brif v13, block5(v31), block4
+;;                                     v29 = iconst.i64 -2
+;;                                     v30 = band v13, v29  ; v29 = -2
+;; @002b                               brif v13, block5(v30), block4
 ;;
 ;;                                 block4 cold:
-;;                                     v32 = iconst.i32 0
-;; @002b                               v19 = call fn0(v0, v32, v6)  ; v32 = 0
+;;                                     v31 = iconst.i32 0
+;; @002b                               v19 = call fn0(v0, v31, v6)  ; v31 = 0
 ;; @002b                               jump block5(v19)
 ;;
 ;;                                 block5(v16: i64):
@@ -80,8 +78,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+48
 ;;     sig0 = (i64 vmctx, i64) -> i32 tail
 ;;     sig1 = (i64 vmctx, i32, i64) -> i64 tail
 ;;     fn0 = colocated u805306368:7 sig1
@@ -89,26 +85,26 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64):
 ;; @0038                               v6 = load.i64 notrap aligned readonly can_move v0+48
-;;                                     v35 = iconst.i64 8
-;; @0038                               v9 = iadd v6, v35  ; v35 = 8
+;;                                     v34 = iconst.i64 8
+;; @0038                               v9 = iadd v6, v34  ; v34 = 8
 ;; @0038                               v13 = iconst.i64 -2
 ;; @0038                               v16 = iconst.i32 0
-;;                                     v34 = iconst.i64 1
+;;                                     v33 = iconst.i64 1
 ;; @0038                               v19 = load.i64 notrap aligned readonly can_move region2 v0+40
 ;; @0038                               v20 = load.i32 notrap aligned readonly can_move v19
 ;; @0034                               jump block2
 ;;
 ;;                                 block2:
-;;                                     v36 = iadd.i64 v6, v35  ; v35 = 8
-;; @0038                               v12 = load.i64 user6 aligned region1 v36
-;;                                     v37 = iconst.i64 -2
-;;                                     v38 = band v12, v37  ; v37 = -2
-;; @0038                               brif v12, block5(v38), block4
+;;                                     v35 = iadd.i64 v6, v34  ; v34 = 8
+;; @0038                               v12 = load.i64 user6 aligned region1 v35
+;;                                     v36 = iconst.i64 -2
+;;                                     v37 = band v12, v36  ; v36 = -2
+;; @0038                               brif v12, block5(v37), block4
 ;;
 ;;                                 block4 cold:
-;;                                     v39 = iconst.i32 0
-;;                                     v40 = iconst.i64 1
-;; @0038                               v18 = call fn0(v0, v39, v40)  ; v39 = 0, v40 = 1
+;;                                     v38 = iconst.i32 0
+;;                                     v39 = iconst.i64 1
+;; @0038                               v18 = call fn0(v0, v38, v39)  ; v38 = 0, v39 = 1
 ;; @0038                               jump block5(v18)
 ;;
 ;;                                 block5(v15: i64):

--- a/tests/disas/icall-simd.wat
+++ b/tests/disas/icall-simd.wat
@@ -15,8 +15,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+48
 ;;     sig0 = (i64 vmctx, i64, i8x16) -> i8x16 tail
 ;;     sig1 = (i64 vmctx, i32, i64) -> i64 tail
 ;;     fn0 = colocated u805306368:7 sig1

--- a/tests/disas/icall.wat
+++ b/tests/disas/icall.wat
@@ -15,8 +15,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+48
 ;;     sig0 = (i64 vmctx, i64, f32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i32, i64) -> i64 tail
 ;;     fn0 = colocated u805306368:7 sig1

--- a/tests/disas/indirect-call-no-caching.wat
+++ b/tests/disas/indirect-call-no-caching.wat
@@ -72,8 +72,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+48
 ;;     sig0 = (i64 vmctx, i64) -> i32 tail
 ;;     sig1 = (i64 vmctx, i32, i64) -> i64 tail
 ;;     fn0 = colocated u805306368:7 sig1

--- a/tests/disas/readonly-funcrefs.wat
+++ b/tests/disas/readonly-funcrefs.wat
@@ -39,8 +39,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+48
 ;;     sig0 = (i64 vmctx, i64) tail
 ;;     sig1 = (i64 vmctx, i32, i64) -> i64 tail
 ;;     fn0 = colocated u805306368:7 sig1

--- a/tests/disas/startup-elem-active.wat
+++ b/tests/disas/startup-elem-active.wat
@@ -41,38 +41,35 @@
 ;;
 ;; function u2415919104:0(i64 vmctx, i64) tail {
 ;;     region0 = 1342177280 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
-;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned gv0+48
-;;     gv2 = load.i64 notrap aligned gv0+56
 ;;
 ;; block0(v0: i64, v1: i64):
 ;;     v4 = load.i64 notrap aligned v0+56
 ;;     v5 = ireduce.i32 v4
 ;;     v6 = uextend.i64 v5
-;;     v86 = iconst.i64 4
-;;     v92 = icmp ult v6, v86  ; v86 = 4
-;;     trapnz v92, user6
+;;     v78 = iconst.i64 4
+;;     v84 = icmp ult v6, v78  ; v78 = 4
+;;     trapnz v84, user6
 ;;     v13 = load.i64 notrap aligned v0+48
-;;     v103 = iconst.i32 21
+;;     v95 = iconst.i32 21
 ;;     v2 = iconst.i32 1
-;;     v114 = icmp ule v5, v2  ; v2 = 1
-;;     v79 = iconst.i64 0
-;;     v17 = iadd v13, v86  ; v86 = 4
-;;     v34 = select_spectre_guard v114, v79, v17  ; v79 = 0
-;;     store user6 aligned region0 v103, v34  ; v103 = 21
-;;     v117 = iconst.i32 23
-;;     v123 = iconst.i32 2
-;;     v129 = icmp ule v5, v123  ; v123 = 2
-;;     v131 = iconst.i64 8
-;;     v49 = iadd v13, v131  ; v131 = 8
-;;     v51 = select_spectre_guard v129, v79, v49  ; v79 = 0
-;;     store user6 aligned region0 v117, v51  ; v117 = 23
-;;     v133 = iconst.i32 25
+;;     v106 = icmp ule v5, v2  ; v2 = 1
+;;     v71 = iconst.i64 0
+;;     v17 = iadd v13, v78  ; v78 = 4
+;;     v34 = select_spectre_guard v106, v71, v17  ; v71 = 0
+;;     store user6 aligned region0 v95, v34  ; v95 = 21
+;;     v109 = iconst.i32 23
+;;     v115 = iconst.i32 2
+;;     v121 = icmp ule v5, v115  ; v115 = 2
+;;     v123 = iconst.i64 8
+;;     v49 = iadd v13, v123  ; v123 = 8
+;;     v51 = select_spectre_guard v121, v71, v49  ; v71 = 0
+;;     store user6 aligned region0 v109, v51  ; v109 = 23
+;;     v125 = iconst.i32 25
 ;;     v3 = iconst.i32 3
-;;     v144 = icmp ule v5, v3  ; v3 = 3
-;;     v146 = iconst.i64 12
-;;     v66 = iadd v13, v146  ; v146 = 12
-;;     v68 = select_spectre_guard v144, v79, v66  ; v79 = 0
-;;     store user6 aligned region0 v133, v68  ; v133 = 25
+;;     v136 = icmp ule v5, v3  ; v3 = 3
+;;     v138 = iconst.i64 12
+;;     v66 = iadd v13, v138  ; v138 = 12
+;;     v68 = select_spectre_guard v136, v71, v66  ; v71 = 0
+;;     store user6 aligned region0 v125, v68  ; v125 = 25
 ;;     return
 ;; }

--- a/tests/disas/startup-table-initial-value.wat
+++ b/tests/disas/startup-table-initial-value.wat
@@ -34,32 +34,28 @@
 ;; }
 ;;
 ;; function u2415919104:0(i64 vmctx, i64) tail {
-;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned gv0+48
-;;     gv2 = load.i64 notrap aligned gv0+56
-;;
 ;; block0(v0: i64, v1: i64):
 ;;     v9 = load.i64 notrap aligned v0+56
 ;;     v10 = ireduce.i32 v9
 ;;     v11 = uextend.i64 v10
-;;     v41 = iconst.i64 10
-;;     v53 = icmp ult v11, v41  ; v41 = 10
-;;     trapnz v53, user6
+;;     v39 = iconst.i64 10
+;;     v51 = icmp ult v11, v39  ; v39 = 10
+;;     trapnz v51, user6
 ;;     v18 = load.i64 notrap aligned v0+48
 ;;     v3 = iconst.i32 1
-;;     v83 = iconst.i64 36
-;;     v85 = iadd v18, v83  ; v83 = 36
+;;     v81 = iconst.i64 36
+;;     v83 = iadd v18, v81  ; v81 = 36
 ;;     v20 = iconst.i64 4
 ;;     jump block1(v18)
 ;;
 ;; block1(v29: i64):
-;;     v88 = iconst.i32 1
-;;     store notrap aligned v88, v29  ; v88 = 1
-;;     v89 = iadd.i64 v18, v83  ; v83 = 36
-;;     v90 = icmp eq v29, v89
-;;     v91 = iconst.i64 4
-;;     v92 = iadd v29, v91  ; v91 = 4
-;;     brif v90, block2, block1(v92)
+;;     v86 = iconst.i32 1
+;;     store notrap aligned v86, v29  ; v86 = 1
+;;     v87 = iadd.i64 v18, v81  ; v81 = 36
+;;     v88 = icmp eq v29, v87
+;;     v89 = iconst.i64 4
+;;     v90 = iadd v29, v89  ; v89 = 4
+;;     brif v88, block2, block1(v90)
 ;;
 ;; block2:
 ;;     return

--- a/tests/disas/table-copy.wat
+++ b/tests/disas/table-copy.wat
@@ -72,136 +72,131 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move region1 gv3+48
-;;     gv5 = load.i64 notrap aligned gv4
-;;     gv6 = load.i64 notrap aligned gv4+8
-;;     gv7 = load.i64 notrap aligned readonly can_move gv3+72
 ;;     sig0 = (i64 vmctx, i32, i64) -> i64 tail
 ;;     fn0 = colocated u805306368:7 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):
-;; @0090                               v109 = load.i64 notrap aligned readonly can_move region1 v0+48
-;; @0090                               v7 = load.i64 notrap aligned v109+8
-;; @0090                               v8 = ireduce.i32 v7
-;; @0090                               v9 = uextend.i64 v8
-;; @0090                               v10 = uextend.i64 v3
-;; @0090                               v11 = uextend.i64 v5
-;; @0090                               v12 = iconst.i64 1
-;; @0090                               v13 = imul v11, v12  ; v12 = 1
-;; @0090                               v14 = iadd v10, v13
-;; @0090                               v15 = icmp ugt v14, v9
-;; @0090                               trapnz v15, user6
-;; @0090                               v107 = load.i64 notrap aligned readonly can_move region1 v0+48
-;; @0090                               v16 = load.i64 notrap aligned v107
-;; @0090                               v17 = uextend.i64 v3
-;; @0090                               v18 = iconst.i64 8
-;; @0090                               v19 = imul v17, v18  ; v18 = 8
-;; @0090                               v20 = iadd v16, v19
-;; @0090                               v21 = iconst.i32 6
-;; @0090                               v22 = uextend.i64 v21  ; v21 = 6
-;; @0090                               v23 = uextend.i64 v4
-;; @0090                               v24 = uextend.i64 v5
-;; @0090                               v25 = iconst.i64 1
-;; @0090                               v26 = imul v24, v25  ; v25 = 1
-;; @0090                               v27 = iadd v23, v26
-;; @0090                               v28 = icmp ugt v27, v22
-;; @0090                               trapnz v28, user6
-;; @0090                               v29 = load.i64 notrap aligned readonly can_move v0+72
-;; @0090                               v30 = uextend.i64 v4
-;; @0090                               v31 = iconst.i64 8
-;; @0090                               v32 = imul v30, v31  ; v31 = 8
-;; @0090                               v33 = iadd v29, v32
-;; @0090                               v34 = uextend.i64 v5
-;; @0090                               v35 = iconst.i64 8
-;; @0090                               v36 = imul v34, v35  ; v35 = 8
+;; @0090                               v7 = load.i64 notrap aligned readonly can_move region1 v0+48
+;; @0090                               v8 = load.i64 notrap aligned v7+8
+;; @0090                               v9 = ireduce.i32 v8
+;; @0090                               v10 = uextend.i64 v9
+;; @0090                               v11 = uextend.i64 v3
+;; @0090                               v12 = uextend.i64 v5
+;; @0090                               v13 = iconst.i64 1
+;; @0090                               v14 = imul v12, v13  ; v13 = 1
+;; @0090                               v15 = iadd v11, v14
+;; @0090                               v16 = icmp ugt v15, v10
+;; @0090                               trapnz v16, user6
+;; @0090                               v17 = load.i64 notrap aligned readonly can_move region1 v0+48
+;; @0090                               v18 = load.i64 notrap aligned v17
+;; @0090                               v19 = uextend.i64 v3
+;; @0090                               v20 = iconst.i64 8
+;; @0090                               v21 = imul v19, v20  ; v20 = 8
+;; @0090                               v22 = iadd v18, v21
+;; @0090                               v23 = iconst.i32 6
+;; @0090                               v24 = uextend.i64 v23  ; v23 = 6
+;; @0090                               v25 = uextend.i64 v4
+;; @0090                               v26 = uextend.i64 v5
+;; @0090                               v27 = iconst.i64 1
+;; @0090                               v28 = imul v26, v27  ; v27 = 1
+;; @0090                               v29 = iadd v25, v28
+;; @0090                               v30 = icmp ugt v29, v24
+;; @0090                               trapnz v30, user6
+;; @0090                               v31 = load.i64 notrap aligned readonly can_move v0+72
+;; @0090                               v32 = uextend.i64 v4
+;; @0090                               v33 = iconst.i64 8
+;; @0090                               v34 = imul v32, v33  ; v33 = 8
+;; @0090                               v35 = iadd v31, v34
+;; @0090                               v36 = uextend.i64 v5
 ;; @0090                               v37 = iconst.i64 8
-;; @0090                               v38 = imul v34, v37  ; v37 = 8
-;; @0090                               brif v34, block2, block5
+;; @0090                               v38 = imul v36, v37  ; v37 = 8
+;; @0090                               v39 = iconst.i64 8
+;; @0090                               v40 = imul v36, v39  ; v39 = 8
+;; @0090                               brif v36, block2, block5
 ;;
 ;;                                 block2:
-;; @0090                               v39 = icmp.i64 ult v20, v33
-;; @0090                               v40 = iconst.i64 8
-;; @0090                               v41 = imul.i64 v34, v40  ; v40 = 8
+;; @0090                               v41 = icmp.i64 ult v22, v35
 ;; @0090                               v42 = iconst.i64 8
-;; @0090                               v43 = imul.i64 v34, v42  ; v42 = 8
-;; @0090                               v44 = iadd.i64 v20, v41
-;; @0090                               v45 = iadd.i64 v33, v43
-;; @0090                               v46 = ireduce.i32 v34
-;; @0090                               v47 = iadd.i32 v4, v46
-;; @0090                               brif v39, block3(v20, v33, v4), block4(v44, v45, v47)
+;; @0090                               v43 = imul.i64 v36, v42  ; v42 = 8
+;; @0090                               v44 = iconst.i64 8
+;; @0090                               v45 = imul.i64 v36, v44  ; v44 = 8
+;; @0090                               v46 = iadd.i64 v22, v43
+;; @0090                               v47 = iadd.i64 v35, v45
+;; @0090                               v48 = ireduce.i32 v36
+;; @0090                               v49 = iadd.i32 v4, v48
+;; @0090                               brif v41, block3(v22, v35, v4), block4(v46, v47, v49)
 ;;
-;;                                 block3(v48: i64, v49: i64, v50: i32):
-;; @0090                               v51 = iconst.i32 6
-;; @0090                               v52 = icmp uge v50, v51  ; v51 = 6
-;; @0090                               v53 = uextend.i64 v50
-;; @0090                               v54 = load.i64 notrap aligned readonly can_move v0+72
-;; @0090                               v55 = iconst.i64 3
-;; @0090                               v56 = ishl v53, v55  ; v55 = 3
-;; @0090                               v57 = iadd v54, v56
-;; @0090                               v58 = iconst.i64 0
-;; @0090                               v59 = select_spectre_guard v52, v58, v57  ; v58 = 0
-;; @0090                               v60 = load.i64 user6 aligned region2 v59
-;; @0090                               v61 = iconst.i64 -2
-;; @0090                               v62 = band v60, v61  ; v61 = -2
-;; @0090                               brif v60, block7(v62), block6
+;;                                 block3(v50: i64, v51: i64, v52: i32):
+;; @0090                               v53 = iconst.i32 6
+;; @0090                               v54 = icmp uge v52, v53  ; v53 = 6
+;; @0090                               v55 = uextend.i64 v52
+;; @0090                               v56 = load.i64 notrap aligned readonly can_move v0+72
+;; @0090                               v57 = iconst.i64 3
+;; @0090                               v58 = ishl v55, v57  ; v57 = 3
+;; @0090                               v59 = iadd v56, v58
+;; @0090                               v60 = iconst.i64 0
+;; @0090                               v61 = select_spectre_guard v54, v60, v59  ; v60 = 0
+;; @0090                               v62 = load.i64 user6 aligned region2 v61
+;; @0090                               v63 = iconst.i64 -2
+;; @0090                               v64 = band v62, v63  ; v63 = -2
+;; @0090                               brif v62, block7(v64), block6
 ;;
-;;                                 block4(v76: i64, v77: i64, v78: i32):
-;; @0090                               v79 = iconst.i64 8
-;; @0090                               v80 = isub v76, v79  ; v79 = 8
+;;                                 block4(v78: i64, v79: i64, v80: i32):
 ;; @0090                               v81 = iconst.i64 8
-;; @0090                               v82 = isub v77, v81  ; v81 = 8
-;; @0090                               v83 = iconst.i32 1
-;; @0090                               v84 = isub v78, v83  ; v83 = 1
-;; @0090                               v85 = iconst.i32 6
-;; @0090                               v86 = icmp uge v84, v85  ; v85 = 6
-;; @0090                               v87 = uextend.i64 v84
-;; @0090                               v88 = load.i64 notrap aligned readonly can_move v0+72
-;; @0090                               v89 = iconst.i64 3
-;; @0090                               v90 = ishl v87, v89  ; v89 = 3
-;; @0090                               v91 = iadd v88, v90
-;; @0090                               v92 = iconst.i64 0
-;; @0090                               v93 = select_spectre_guard v86, v92, v91  ; v92 = 0
-;; @0090                               v94 = load.i64 user6 aligned region2 v93
-;; @0090                               v95 = iconst.i64 -2
-;; @0090                               v96 = band v94, v95  ; v95 = -2
-;; @0090                               brif v94, block9(v96), block8
+;; @0090                               v82 = isub v78, v81  ; v81 = 8
+;; @0090                               v83 = iconst.i64 8
+;; @0090                               v84 = isub v79, v83  ; v83 = 8
+;; @0090                               v85 = iconst.i32 1
+;; @0090                               v86 = isub v80, v85  ; v85 = 1
+;; @0090                               v87 = iconst.i32 6
+;; @0090                               v88 = icmp uge v86, v87  ; v87 = 6
+;; @0090                               v89 = uextend.i64 v86
+;; @0090                               v90 = load.i64 notrap aligned readonly can_move v0+72
+;; @0090                               v91 = iconst.i64 3
+;; @0090                               v92 = ishl v89, v91  ; v91 = 3
+;; @0090                               v93 = iadd v90, v92
+;; @0090                               v94 = iconst.i64 0
+;; @0090                               v95 = select_spectre_guard v88, v94, v93  ; v94 = 0
+;; @0090                               v96 = load.i64 user6 aligned region2 v95
+;; @0090                               v97 = iconst.i64 -2
+;; @0090                               v98 = band v96, v97  ; v97 = -2
+;; @0090                               brif v96, block9(v98), block8
 ;;
 ;;                                 block5:
 ;; @0094                               jump block1
 ;;
 ;;                                 block6 cold:
-;; @0090                               v64 = iconst.i32 1
-;; @0090                               v65 = uextend.i64 v50
-;; @0090                               v66 = call fn0(v0, v64, v65)  ; v64 = 1
-;; @0090                               jump block7(v66)
+;; @0090                               v66 = iconst.i32 1
+;; @0090                               v67 = uextend.i64 v52
+;; @0090                               v68 = call fn0(v0, v66, v67)  ; v66 = 1
+;; @0090                               jump block7(v68)
 ;;
-;;                                 block7(v63: i64):
-;; @0090                               v67 = iconst.i64 1
-;; @0090                               v68 = bor v63, v67  ; v67 = 1
-;; @0090                               store notrap aligned v68, v48
-;; @0090                               v69 = iconst.i64 8
-;; @0090                               v70 = iadd.i64 v48, v69  ; v69 = 8
+;;                                 block7(v65: i64):
+;; @0090                               v69 = iconst.i64 1
+;; @0090                               v70 = bor v65, v69  ; v69 = 1
+;; @0090                               store notrap aligned v70, v50
 ;; @0090                               v71 = iconst.i64 8
-;; @0090                               v72 = iadd.i64 v49, v71  ; v71 = 8
-;; @0090                               v73 = iconst.i32 1
-;; @0090                               v74 = iadd.i32 v50, v73  ; v73 = 1
-;; @0090                               v75 = icmp eq v72, v45
-;; @0090                               brif v75, block5, block3(v70, v72, v74)
+;; @0090                               v72 = iadd.i64 v50, v71  ; v71 = 8
+;; @0090                               v73 = iconst.i64 8
+;; @0090                               v74 = iadd.i64 v51, v73  ; v73 = 8
+;; @0090                               v75 = iconst.i32 1
+;; @0090                               v76 = iadd.i32 v52, v75  ; v75 = 1
+;; @0090                               v77 = icmp eq v74, v47
+;; @0090                               brif v77, block5, block3(v72, v74, v76)
 ;;
 ;;                                 block8 cold:
-;; @0090                               v98 = iconst.i32 1
-;; @0090                               v99 = uextend.i64 v84
-;; @0090                               v100 = call fn0(v0, v98, v99)  ; v98 = 1
-;; @0090                               jump block9(v100)
+;; @0090                               v100 = iconst.i32 1
+;; @0090                               v101 = uextend.i64 v86
+;; @0090                               v102 = call fn0(v0, v100, v101)  ; v100 = 1
+;; @0090                               jump block9(v102)
 ;;
-;;                                 block9(v97: i64):
-;; @0090                               v101 = iconst.i64 1
-;; @0090                               v102 = bor v97, v101  ; v101 = 1
-;; @0090                               store notrap aligned v102, v80
-;; @0090                               v103 = icmp.i64 eq v82, v33
-;; @0090                               brif v103, block5, block4(v80, v82, v84)
+;;                                 block9(v99: i64):
+;; @0090                               v103 = iconst.i64 1
+;; @0090                               v104 = bor v99, v103  ; v103 = 1
+;; @0090                               store notrap aligned v104, v82
+;; @0090                               v105 = icmp.i64 eq v84, v35
+;; @0090                               brif v105, block5, block4(v82, v84, v86)
 ;;
 ;;                                 block1:
 ;; @0094                               return v2
@@ -214,11 +209,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+72
-;;     gv5 = load.i64 notrap aligned readonly can_move region1 gv3+48
-;;     gv6 = load.i64 notrap aligned gv5
-;;     gv7 = load.i64 notrap aligned gv5+8
 ;;     sig0 = (i64 vmctx, i32, i64) -> i64 tail
 ;;     fn0 = colocated u805306368:7 sig0
 ;;     stack_limit = gv2
@@ -238,118 +228,118 @@
 ;; @009f                               v17 = iconst.i64 8
 ;; @009f                               v18 = imul v16, v17  ; v17 = 8
 ;; @009f                               v19 = iadd v15, v18
-;; @009f                               v116 = load.i64 notrap aligned readonly can_move region1 v0+48
-;; @009f                               v20 = load.i64 notrap aligned v116+8
-;; @009f                               v21 = ireduce.i32 v20
-;; @009f                               v22 = uextend.i64 v21
-;; @009f                               v23 = uextend.i64 v4
-;; @009f                               v24 = uextend.i64 v5
-;; @009f                               v25 = iconst.i64 1
-;; @009f                               v26 = imul v24, v25  ; v25 = 1
-;; @009f                               v27 = iadd v23, v26
-;; @009f                               v28 = icmp ugt v27, v22
-;; @009f                               trapnz v28, user6
-;; @009f                               v114 = load.i64 notrap aligned readonly can_move region1 v0+48
-;; @009f                               v29 = load.i64 notrap aligned v114
-;; @009f                               v30 = uextend.i64 v4
-;; @009f                               v31 = iconst.i64 8
-;; @009f                               v32 = imul v30, v31  ; v31 = 8
-;; @009f                               v33 = iadd v29, v32
-;; @009f                               v34 = uextend.i64 v5
-;; @009f                               v35 = iconst.i64 8
-;; @009f                               v36 = imul v34, v35  ; v35 = 8
+;; @009f                               v20 = load.i64 notrap aligned readonly can_move region1 v0+48
+;; @009f                               v21 = load.i64 notrap aligned v20+8
+;; @009f                               v22 = ireduce.i32 v21
+;; @009f                               v23 = uextend.i64 v22
+;; @009f                               v24 = uextend.i64 v4
+;; @009f                               v25 = uextend.i64 v5
+;; @009f                               v26 = iconst.i64 1
+;; @009f                               v27 = imul v25, v26  ; v26 = 1
+;; @009f                               v28 = iadd v24, v27
+;; @009f                               v29 = icmp ugt v28, v23
+;; @009f                               trapnz v29, user6
+;; @009f                               v30 = load.i64 notrap aligned readonly can_move region1 v0+48
+;; @009f                               v31 = load.i64 notrap aligned v30
+;; @009f                               v32 = uextend.i64 v4
+;; @009f                               v33 = iconst.i64 8
+;; @009f                               v34 = imul v32, v33  ; v33 = 8
+;; @009f                               v35 = iadd v31, v34
+;; @009f                               v36 = uextend.i64 v5
 ;; @009f                               v37 = iconst.i64 8
-;; @009f                               v38 = imul v34, v37  ; v37 = 8
-;; @009f                               brif v34, block2, block5
+;; @009f                               v38 = imul v36, v37  ; v37 = 8
+;; @009f                               v39 = iconst.i64 8
+;; @009f                               v40 = imul v36, v39  ; v39 = 8
+;; @009f                               brif v36, block2, block5
 ;;
 ;;                                 block2:
-;; @009f                               v39 = icmp.i64 ult v19, v33
-;; @009f                               v40 = iconst.i64 8
-;; @009f                               v41 = imul.i64 v34, v40  ; v40 = 8
+;; @009f                               v41 = icmp.i64 ult v19, v35
 ;; @009f                               v42 = iconst.i64 8
-;; @009f                               v43 = imul.i64 v34, v42  ; v42 = 8
-;; @009f                               v44 = iadd.i64 v19, v41
-;; @009f                               v45 = iadd.i64 v33, v43
-;; @009f                               v46 = ireduce.i32 v34
-;; @009f                               v47 = iadd.i32 v4, v46
-;; @009f                               brif v39, block3(v19, v33, v4), block4(v44, v45, v47)
+;; @009f                               v43 = imul.i64 v36, v42  ; v42 = 8
+;; @009f                               v44 = iconst.i64 8
+;; @009f                               v45 = imul.i64 v36, v44  ; v44 = 8
+;; @009f                               v46 = iadd.i64 v19, v43
+;; @009f                               v47 = iadd.i64 v35, v45
+;; @009f                               v48 = ireduce.i32 v36
+;; @009f                               v49 = iadd.i32 v4, v48
+;; @009f                               brif v41, block3(v19, v35, v4), block4(v46, v47, v49)
 ;;
-;;                                 block3(v48: i64, v49: i64, v50: i32):
-;; @009f                               v112 = load.i64 notrap aligned readonly can_move region1 v0+48
-;; @009f                               v51 = load.i64 notrap aligned v112+8
-;; @009f                               v52 = ireduce.i32 v51
-;; @009f                               v53 = icmp uge v50, v52
-;; @009f                               v54 = uextend.i64 v50
-;; @009f                               v110 = load.i64 notrap aligned readonly can_move region1 v0+48
-;; @009f                               v55 = load.i64 notrap aligned v110
-;; @009f                               v56 = iconst.i64 3
-;; @009f                               v57 = ishl v54, v56  ; v56 = 3
-;; @009f                               v58 = iadd v55, v57
-;; @009f                               v59 = iconst.i64 0
-;; @009f                               v60 = select_spectre_guard v53, v59, v58  ; v59 = 0
-;; @009f                               v61 = load.i64 user6 aligned region2 v60
-;; @009f                               v62 = iconst.i64 -2
-;; @009f                               v63 = band v61, v62  ; v62 = -2
-;; @009f                               brif v61, block7(v63), block6
+;;                                 block3(v50: i64, v51: i64, v52: i32):
+;; @009f                               v53 = load.i64 notrap aligned readonly can_move region1 v0+48
+;; @009f                               v54 = load.i64 notrap aligned v53+8
+;; @009f                               v55 = ireduce.i32 v54
+;; @009f                               v56 = icmp uge v52, v55
+;; @009f                               v57 = uextend.i64 v52
+;; @009f                               v58 = load.i64 notrap aligned readonly can_move region1 v0+48
+;; @009f                               v59 = load.i64 notrap aligned v58
+;; @009f                               v60 = iconst.i64 3
+;; @009f                               v61 = ishl v57, v60  ; v60 = 3
+;; @009f                               v62 = iadd v59, v61
+;; @009f                               v63 = iconst.i64 0
+;; @009f                               v64 = select_spectre_guard v56, v63, v62  ; v63 = 0
+;; @009f                               v65 = load.i64 user6 aligned region2 v64
+;; @009f                               v66 = iconst.i64 -2
+;; @009f                               v67 = band v65, v66  ; v66 = -2
+;; @009f                               brif v65, block7(v67), block6
 ;;
-;;                                 block4(v77: i64, v78: i64, v79: i32):
-;; @009f                               v80 = iconst.i64 8
-;; @009f                               v81 = isub v77, v80  ; v80 = 8
-;; @009f                               v82 = iconst.i64 8
-;; @009f                               v83 = isub v78, v82  ; v82 = 8
-;; @009f                               v84 = iconst.i32 1
-;; @009f                               v85 = isub v79, v84  ; v84 = 1
-;; @009f                               v108 = load.i64 notrap aligned readonly can_move region1 v0+48
-;; @009f                               v86 = load.i64 notrap aligned v108+8
-;; @009f                               v87 = ireduce.i32 v86
-;; @009f                               v88 = icmp uge v85, v87
-;; @009f                               v89 = uextend.i64 v85
-;; @009f                               v106 = load.i64 notrap aligned readonly can_move region1 v0+48
-;; @009f                               v90 = load.i64 notrap aligned v106
-;; @009f                               v91 = iconst.i64 3
-;; @009f                               v92 = ishl v89, v91  ; v91 = 3
-;; @009f                               v93 = iadd v90, v92
-;; @009f                               v94 = iconst.i64 0
-;; @009f                               v95 = select_spectre_guard v88, v94, v93  ; v94 = 0
-;; @009f                               v96 = load.i64 user6 aligned region2 v95
-;; @009f                               v97 = iconst.i64 -2
-;; @009f                               v98 = band v96, v97  ; v97 = -2
-;; @009f                               brif v96, block9(v98), block8
+;;                                 block4(v81: i64, v82: i64, v83: i32):
+;; @009f                               v84 = iconst.i64 8
+;; @009f                               v85 = isub v81, v84  ; v84 = 8
+;; @009f                               v86 = iconst.i64 8
+;; @009f                               v87 = isub v82, v86  ; v86 = 8
+;; @009f                               v88 = iconst.i32 1
+;; @009f                               v89 = isub v83, v88  ; v88 = 1
+;; @009f                               v90 = load.i64 notrap aligned readonly can_move region1 v0+48
+;; @009f                               v91 = load.i64 notrap aligned v90+8
+;; @009f                               v92 = ireduce.i32 v91
+;; @009f                               v93 = icmp uge v89, v92
+;; @009f                               v94 = uextend.i64 v89
+;; @009f                               v95 = load.i64 notrap aligned readonly can_move region1 v0+48
+;; @009f                               v96 = load.i64 notrap aligned v95
+;; @009f                               v97 = iconst.i64 3
+;; @009f                               v98 = ishl v94, v97  ; v97 = 3
+;; @009f                               v99 = iadd v96, v98
+;; @009f                               v100 = iconst.i64 0
+;; @009f                               v101 = select_spectre_guard v93, v100, v99  ; v100 = 0
+;; @009f                               v102 = load.i64 user6 aligned region2 v101
+;; @009f                               v103 = iconst.i64 -2
+;; @009f                               v104 = band v102, v103  ; v103 = -2
+;; @009f                               brif v102, block9(v104), block8
 ;;
 ;;                                 block5:
 ;; @00a3                               jump block1
 ;;
 ;;                                 block6 cold:
-;; @009f                               v65 = iconst.i32 0
-;; @009f                               v66 = uextend.i64 v50
-;; @009f                               v67 = call fn0(v0, v65, v66)  ; v65 = 0
-;; @009f                               jump block7(v67)
+;; @009f                               v69 = iconst.i32 0
+;; @009f                               v70 = uextend.i64 v52
+;; @009f                               v71 = call fn0(v0, v69, v70)  ; v69 = 0
+;; @009f                               jump block7(v71)
 ;;
-;;                                 block7(v64: i64):
-;; @009f                               v68 = iconst.i64 1
-;; @009f                               v69 = bor v64, v68  ; v68 = 1
-;; @009f                               store notrap aligned v69, v48
-;; @009f                               v70 = iconst.i64 8
-;; @009f                               v71 = iadd.i64 v48, v70  ; v70 = 8
-;; @009f                               v72 = iconst.i64 8
-;; @009f                               v73 = iadd.i64 v49, v72  ; v72 = 8
-;; @009f                               v74 = iconst.i32 1
-;; @009f                               v75 = iadd.i32 v50, v74  ; v74 = 1
-;; @009f                               v76 = icmp eq v73, v45
-;; @009f                               brif v76, block5, block3(v71, v73, v75)
+;;                                 block7(v68: i64):
+;; @009f                               v72 = iconst.i64 1
+;; @009f                               v73 = bor v68, v72  ; v72 = 1
+;; @009f                               store notrap aligned v73, v50
+;; @009f                               v74 = iconst.i64 8
+;; @009f                               v75 = iadd.i64 v50, v74  ; v74 = 8
+;; @009f                               v76 = iconst.i64 8
+;; @009f                               v77 = iadd.i64 v51, v76  ; v76 = 8
+;; @009f                               v78 = iconst.i32 1
+;; @009f                               v79 = iadd.i32 v52, v78  ; v78 = 1
+;; @009f                               v80 = icmp eq v77, v47
+;; @009f                               brif v80, block5, block3(v75, v77, v79)
 ;;
 ;;                                 block8 cold:
-;; @009f                               v100 = iconst.i32 0
-;; @009f                               v101 = uextend.i64 v85
-;; @009f                               v102 = call fn0(v0, v100, v101)  ; v100 = 0
-;; @009f                               jump block9(v102)
+;; @009f                               v106 = iconst.i32 0
+;; @009f                               v107 = uextend.i64 v89
+;; @009f                               v108 = call fn0(v0, v106, v107)  ; v106 = 0
+;; @009f                               jump block9(v108)
 ;;
-;;                                 block9(v99: i64):
-;; @009f                               v103 = iconst.i64 1
-;; @009f                               v104 = bor v99, v103  ; v103 = 1
-;; @009f                               store notrap aligned v104, v81
-;; @009f                               v105 = icmp.i64 eq v83, v33
-;; @009f                               brif v105, block5, block4(v81, v83, v85)
+;;                                 block9(v105: i64):
+;; @009f                               v109 = iconst.i64 1
+;; @009f                               v110 = bor v105, v109  ; v109 = 1
+;; @009f                               store notrap aligned v110, v85
+;; @009f                               v111 = icmp.i64 eq v87, v35
+;; @009f                               brif v111, block5, block4(v85, v87, v89)
 ;;
 ;;                                 block1:
 ;; @00a3                               return v2

--- a/tests/disas/table-get-fixed-size.wat
+++ b/tests/disas/table-get-fixed-size.wat
@@ -21,8 +21,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+48
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
@@ -49,8 +47,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+48
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/table-get.wat
+++ b/tests/disas/table-get.wat
@@ -20,9 +20,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+48
-;;     gv5 = load.i64 notrap aligned gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
@@ -50,9 +47,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+48
-;;     gv5 = load.i64 notrap aligned gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/table-set-fixed-size.wat
+++ b/tests/disas/table-set-fixed-size.wat
@@ -22,8 +22,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+48
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -50,8 +48,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+48
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):

--- a/tests/disas/table-set.wat
+++ b/tests/disas/table-set.wat
@@ -22,9 +22,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+48
-;;     gv5 = load.i64 notrap aligned gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -52,9 +49,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned gv3+48
-;;     gv5 = load.i64 notrap aligned gv3+56
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):

--- a/tests/disas/typed-funcrefs-eager-init.wat
+++ b/tests/disas/typed-funcrefs-eager-init.wat
@@ -133,21 +133,19 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+48
 ;;     sig0 = (i64 vmctx, i64, i32, i32, i32, i32) -> i32 tail
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):
 ;; @0048                               v12 = load.i64 notrap aligned readonly can_move v0+48
-;;                                     v47 = iconst.i64 8
-;; @0048                               v15 = iadd v12, v47  ; v47 = 8
+;;                                     v45 = iconst.i64 8
+;; @0048                               v15 = iadd v12, v45  ; v45 = 8
 ;; @0048                               v18 = load.i64 user6 aligned region1 v15
 ;; @004a                               v19 = load.i64 user16 aligned readonly v18+8
 ;; @004a                               v20 = load.i64 notrap aligned readonly v18+24
 ;; @004a                               v21 = call_indirect sig0, v19(v20, v0, v2, v3, v4, v5)
-;;                                     v54 = iconst.i64 16
-;; @005b                               v30 = iadd v12, v54  ; v54 = 16
+;;                                     v52 = iconst.i64 16
+;; @005b                               v30 = iadd v12, v52  ; v52 = 16
 ;; @005b                               v33 = load.i64 user6 aligned region1 v30
 ;; @005d                               v34 = load.i64 user16 aligned readonly v33+8
 ;; @005d                               v35 = load.i64 notrap aligned readonly v33+24
@@ -165,21 +163,19 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+48
 ;;     sig0 = (i64 vmctx, i64, i32, i32, i32, i32) -> i32 tail
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):
 ;; @0075                               v12 = load.i64 notrap aligned readonly can_move v0+48
-;;                                     v47 = iconst.i64 8
-;; @0075                               v15 = iadd v12, v47  ; v47 = 8
+;;                                     v45 = iconst.i64 8
+;; @0075                               v15 = iadd v12, v45  ; v45 = 8
 ;; @0075                               v18 = load.i64 user6 aligned region1 v15
 ;; @0075                               v19 = load.i64 user7 aligned readonly v18+8
 ;; @0075                               v20 = load.i64 notrap aligned readonly v18+24
 ;; @0075                               v21 = call_indirect sig0, v19(v20, v0, v2, v3, v4, v5)
-;;                                     v54 = iconst.i64 16
-;; @0087                               v30 = iadd v12, v54  ; v54 = 16
+;;                                     v52 = iconst.i64 16
+;; @0087                               v30 = iadd v12, v52  ; v52 = 16
 ;; @0087                               v33 = load.i64 user6 aligned region1 v30
 ;; @0087                               v34 = load.i64 user7 aligned readonly v33+8
 ;; @0087                               v35 = load.i64 notrap aligned readonly v33+24

--- a/tests/disas/typed-funcrefs.wat
+++ b/tests/disas/typed-funcrefs.wat
@@ -133,8 +133,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+48
 ;;     sig0 = (i64 vmctx, i32, i64) -> i64 tail
 ;;     sig1 = (i64 vmctx, i64, i32, i32, i32, i32) -> i32 tail
 ;;     fn0 = colocated u805306368:7 sig0
@@ -142,8 +140,8 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):
 ;; @0048                               v12 = load.i64 notrap aligned readonly can_move v0+48
-;;                                     v65 = iconst.i64 8
-;; @0048                               v15 = iadd v12, v65  ; v65 = 8
+;;                                     v63 = iconst.i64 8
+;; @0048                               v15 = iadd v12, v63  ; v63 = 8
 ;; @0048                               v18 = load.i64 user6 aligned region1 v15
 ;; @0048                               v19 = iconst.i64 -2
 ;; @0048                               v20 = band v18, v19  ; v19 = -2
@@ -151,25 +149,25 @@
 ;;
 ;;                                 block2 cold:
 ;; @003c                               v7 = iconst.i32 0
-;;                                     v64 = iconst.i64 1
-;; @0048                               v24 = call fn0(v0, v7, v64)  ; v7 = 0, v64 = 1
+;;                                     v62 = iconst.i64 1
+;; @0048                               v24 = call fn0(v0, v7, v62)  ; v7 = 0, v62 = 1
 ;; @0048                               jump block3(v24)
 ;;
 ;;                                 block3(v21: i64):
 ;; @004a                               v25 = load.i64 user16 aligned readonly v21+8
 ;; @004a                               v26 = load.i64 notrap aligned readonly v21+24
 ;; @004a                               v27 = call_indirect sig1, v25(v26, v0, v2, v3, v4, v5)
-;;                                     v72 = iconst.i64 16
-;; @005b                               v41 = iadd.i64 v12, v72  ; v72 = 16
+;;                                     v70 = iconst.i64 16
+;; @005b                               v41 = iadd.i64 v12, v70  ; v70 = 16
 ;; @005b                               v44 = load.i64 user6 aligned region1 v41
-;;                                     v73 = iconst.i64 -2
-;;                                     v74 = band v44, v73  ; v73 = -2
-;; @005b                               brif v44, block5(v74), block4
+;;                                     v71 = iconst.i64 -2
+;;                                     v72 = band v44, v71  ; v71 = -2
+;; @005b                               brif v44, block5(v72), block4
 ;;
 ;;                                 block4 cold:
-;;                                     v75 = iconst.i32 0
-;;                                     v71 = iconst.i64 2
-;; @005b                               v50 = call fn0(v0, v75, v71)  ; v75 = 0, v71 = 2
+;;                                     v73 = iconst.i32 0
+;;                                     v69 = iconst.i64 2
+;; @005b                               v50 = call fn0(v0, v73, v69)  ; v73 = 0, v69 = 2
 ;; @005b                               jump block5(v50)
 ;;
 ;;                                 block5(v47: i64):
@@ -189,8 +187,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+48
 ;;     sig0 = (i64 vmctx, i64, i32, i32, i32, i32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i32, i64) -> i64 tail
 ;;     fn0 = colocated u805306368:7 sig1
@@ -198,8 +194,8 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):
 ;; @0075                               v12 = load.i64 notrap aligned readonly can_move v0+48
-;;                                     v65 = iconst.i64 8
-;; @0075                               v15 = iadd v12, v65  ; v65 = 8
+;;                                     v63 = iconst.i64 8
+;; @0075                               v15 = iadd v12, v63  ; v63 = 8
 ;; @0075                               v18 = load.i64 user6 aligned region1 v15
 ;; @0075                               v19 = iconst.i64 -2
 ;; @0075                               v20 = band v18, v19  ; v19 = -2
@@ -207,25 +203,25 @@
 ;;
 ;;                                 block2 cold:
 ;; @0069                               v7 = iconst.i32 0
-;;                                     v64 = iconst.i64 1
-;; @0075                               v24 = call fn0(v0, v7, v64)  ; v7 = 0, v64 = 1
+;;                                     v62 = iconst.i64 1
+;; @0075                               v24 = call fn0(v0, v7, v62)  ; v7 = 0, v62 = 1
 ;; @0075                               jump block3(v24)
 ;;
 ;;                                 block3(v21: i64):
 ;; @0075                               v25 = load.i64 user7 aligned readonly v21+8
 ;; @0075                               v26 = load.i64 notrap aligned readonly v21+24
 ;; @0075                               v27 = call_indirect sig0, v25(v26, v0, v2, v3, v4, v5)
-;;                                     v72 = iconst.i64 16
-;; @0087                               v41 = iadd.i64 v12, v72  ; v72 = 16
+;;                                     v70 = iconst.i64 16
+;; @0087                               v41 = iadd.i64 v12, v70  ; v70 = 16
 ;; @0087                               v44 = load.i64 user6 aligned region1 v41
-;;                                     v73 = iconst.i64 -2
-;;                                     v74 = band v44, v73  ; v73 = -2
-;; @0087                               brif v44, block5(v74), block4
+;;                                     v71 = iconst.i64 -2
+;;                                     v72 = band v44, v71  ; v71 = -2
+;; @0087                               brif v44, block5(v72), block4
 ;;
 ;;                                 block4 cold:
-;;                                     v75 = iconst.i32 0
-;;                                     v71 = iconst.i64 2
-;; @0087                               v50 = call fn0(v0, v75, v71)  ; v75 = 0, v71 = 2
+;;                                     v73 = iconst.i32 0
+;;                                     v69 = iconst.i64 2
+;; @0087                               v50 = call fn0(v0, v73, v69)  ; v73 = 0, v69 = 2
 ;; @0087                               jump block5(v50)
 ;;
 ;;                                 block5(v47: i64):


### PR DESCRIPTION
Use the new `VmctxLoadChain` instead.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
