### PR TITLE
Remove the `FuncEnvironment::vmctx` method, which returned an `ir::GlobalValue`

### DIFF
--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -166,9 +166,6 @@ pub struct FuncEnvironment<'module_environment> {
     /// Heaps implementing WebAssembly linear memories.
     heaps: PrimaryMap<Heap, HeapData>,
 
-    /// The Cranelift global holding the vmctx address.
-    vmctx: Option<ir::GlobalValue>,
-
     /// Caches of signatures for builtin functions.
     builtin_functions: BuiltinFunctions,
 
@@ -279,7 +276,6 @@ impl<'module_environment> FuncEnvironment<'module_environment> {
             gc_heap: None,
 
             heaps: PrimaryMap::default(),
-            vmctx: None,
             builtin_functions,
             offsets,
             tunables,
@@ -336,14 +332,6 @@ impl<'module_environment> FuncEnvironment<'module_environment> {
 
     pub(crate) fn pointer_type(&self) -> ir::Type {
         self.isa.pointer_type()
-    }
-
-    pub(crate) fn vmctx(&mut self, func: &mut Function) -> ir::GlobalValue {
-        self.vmctx.unwrap_or_else(|| {
-            let vmctx = func.create_global_value(ir::GlobalValueData::VMContext);
-            self.vmctx = Some(vmctx);
-            vmctx
-        })
     }
 
     pub(crate) fn memory_alias_region(
@@ -3345,15 +3333,14 @@ impl FuncEnvironment<'_> {
     /// size in bytes.
     fn memory_size_in_bytes(&mut self, pos: &mut FuncCursor<'_>, index: MemoryIndex) -> ir::Value {
         let pointer_type = self.pointer_type();
-        let vmctx = self.vmctx(&mut pos.func);
+        let vmctx = self.vmctx_val(pos);
         let is_shared = self.module.memories[index].shared;
-        let base = pos.ins().global_value(pointer_type, vmctx);
         match self.module.defined_memory_index(index) {
             Some(def_index) => {
                 if is_shared {
                     let vmmemory_ptr = self
                         .alias_regions
-                        .vmctx_vmmemory_pointer(pos, base, def_index);
+                        .vmctx_vmmemory_pointer(pos, vmctx, def_index);
                     let vmmemory_definition_offset =
                         i64::from(self.offsets.ptr.vmmemory_definition_current_length());
                     let vmmemory_definition_ptr = pos
@@ -3378,13 +3365,13 @@ impl FuncEnvironment<'_> {
                     )
                     .unwrap();
                     pos.ins()
-                        .load(pointer_type, ir::MemFlagsData::trusted(), base, offset)
+                        .load(pointer_type, ir::MemFlagsData::trusted(), vmctx, offset)
                 }
             }
             None => {
                 let vmmemory_ptr = self
                     .alias_regions
-                    .vmctx_vmmemory_import_from(pos, base, index);
+                    .vmctx_vmmemory_import_from(pos, vmctx, index);
                 if is_shared {
                     let vmmemory_definition_offset =
                         i64::from(self.offsets.ptr.vmmemory_definition_current_length());

--- a/tests/disas/memory-copy-epochs.wat
+++ b/tests/disas/memory-copy-epochs.wat
@@ -14,7 +14,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx) -> i64 tail
 ;;     sig1 = (i64 vmctx, i64, i64, i64) tail
 ;;     fn0 = colocated u805306368:13 sig0
@@ -33,101 +32,101 @@
 ;; @001e                               v10 = call fn0(v0)
 ;; @001e                               jump block2(v10)
 ;;
-;;                                 block2(v61: i64):
-;; @0025                               v15 = load.i64 notrap aligned v0+64
-;; @0025                               v16 = uextend.i64 v2
-;; @0025                               v17 = uextend.i64 v4
-;; @0025                               v20 = iadd v16, v17
-;; @0025                               v21 = icmp ugt v20, v15
-;; @0025                               trapnz v21, heap_oob
-;; @0025                               v29 = uextend.i64 v3
-;; @0025                               v33 = iadd v29, v17
-;; @0025                               v34 = icmp ugt v33, v15
-;; @0025                               trapnz v34, heap_oob
-;; @0025                               v22 = load.i64 notrap aligned readonly can_move v0+56
-;; @0025                               v39 = iadd v22, v29
-;; @0025                               v26 = iadd v22, v16
-;; @0025                               v42 = icmp ugt v39, v26
-;; @0025                               brif v42, block6, block7
+;;                                 block2(v59: i64):
+;; @0025                               v14 = load.i64 notrap aligned v0+64
+;; @0025                               v15 = uextend.i64 v2
+;; @0025                               v16 = uextend.i64 v4
+;; @0025                               v19 = iadd v15, v16
+;; @0025                               v20 = icmp ugt v19, v14
+;; @0025                               trapnz v20, heap_oob
+;; @0025                               v27 = uextend.i64 v3
+;; @0025                               v31 = iadd v27, v16
+;; @0025                               v32 = icmp ugt v31, v14
+;; @0025                               trapnz v32, heap_oob
+;; @0025                               v21 = load.i64 notrap aligned readonly can_move v0+56
+;; @0025                               v37 = iadd v21, v27
+;; @0025                               v25 = iadd v21, v15
+;; @0025                               v40 = icmp ugt v37, v25
+;; @0025                               brif v40, block6, block7
 ;;
-;;                                 block4(v44: i64, v45: i64, v46: i64, v49: i64):
-;; @0025                               v48 = load.i64 notrap aligned v5
-;; @0025                               v50 = icmp uge v48, v49
-;; @0025                               brif v50, block9, block8(v49)
+;;                                 block4(v42: i64, v43: i64, v44: i64, v47: i64):
+;; @0025                               v46 = load.i64 notrap aligned v5
+;; @0025                               v48 = icmp uge v46, v47
+;; @0025                               brif v48, block9, block8(v47)
 ;;
-;;                                 block5(v88: i64, v89: i64, v90: i64, v94: i64):
-;; @0025                               v93 = load.i64 notrap aligned v5
-;; @0025                               v96 = icmp uge v93, v94
-;; @0025                               brif v96, block17, block16
+;;                                 block5(v86: i64, v87: i64, v88: i64, v92: i64):
+;; @0025                               v91 = load.i64 notrap aligned v5
+;; @0025                               v94 = icmp uge v91, v92
+;; @0025                               brif v94, block17, block16
 ;;
 ;;                                 block6:
-;;                                     v110 = iconst.i64 0x0800_0000
-;;                                     v111 = icmp.i64 ugt v17, v110  ; v110 = 0x0800_0000
-;; @0025                               brif v111, block4(v26, v39, v17, v61), block5(v26, v39, v17, v61)
+;;                                     v108 = iconst.i64 0x0800_0000
+;;                                     v109 = icmp.i64 ugt v16, v108  ; v108 = 0x0800_0000
+;; @0025                               brif v109, block4(v25, v37, v16, v59), block5(v25, v37, v16, v59)
 ;;
 ;;                                 block9 cold:
-;; @0025                               v52 = load.i64 notrap aligned v7+8
-;; @0025                               v53 = icmp.i64 uge v48, v52
-;; @0025                               brif v53, block10, block8(v52)
+;; @0025                               v50 = load.i64 notrap aligned v7+8
+;; @0025                               v51 = icmp.i64 uge v46, v50
+;; @0025                               brif v51, block10, block8(v50)
 ;;
 ;;                                 block10 cold:
-;; @0025                               v54 = call fn0(v0)
-;; @0025                               jump block8(v54)
+;; @0025                               v52 = call fn0(v0)
+;; @0025                               jump block8(v52)
 ;;
-;;                                 block8(v62: i64):
-;; @0025                               call fn1(v0, v44, v45, v110)  ; v110 = 0x0800_0000
-;; @0025                               v57 = isub.i64 v46, v110  ; v110 = 0x0800_0000
-;; @0025                               v58 = icmp ugt v57, v110  ; v110 = 0x0800_0000
-;; @0025                               v55 = iadd.i64 v44, v110  ; v110 = 0x0800_0000
-;; @0025                               v56 = iadd.i64 v45, v110  ; v110 = 0x0800_0000
-;; @0025                               brif v58, block4(v55, v56, v57, v62), block5(v55, v56, v57, v62)
+;;                                 block8(v60: i64):
+;; @0025                               call fn1(v0, v42, v43, v108)  ; v108 = 0x0800_0000
+;; @0025                               v55 = isub.i64 v44, v108  ; v108 = 0x0800_0000
+;; @0025                               v56 = icmp ugt v55, v108  ; v108 = 0x0800_0000
+;; @0025                               v53 = iadd.i64 v42, v108  ; v108 = 0x0800_0000
+;; @0025                               v54 = iadd.i64 v43, v108  ; v108 = 0x0800_0000
+;; @0025                               brif v56, block4(v53, v54, v55, v60), block5(v53, v54, v55, v60)
 ;;
 ;;                                 block7:
-;; @0025                               v41 = iconst.i64 0x0800_0000
-;; @0025                               v65 = icmp.i64 ugt v17, v41  ; v41 = 0x0800_0000
-;; @0025                               v63 = iadd.i64 v26, v17
-;; @0025                               v64 = iadd.i64 v39, v17
-;; @0025                               brif v65, block11(v63, v64, v17, v61), block12(v63, v64, v17, v61)
+;; @0025                               v39 = iconst.i64 0x0800_0000
+;; @0025                               v63 = icmp.i64 ugt v16, v39  ; v39 = 0x0800_0000
+;; @0025                               v61 = iadd.i64 v25, v16
+;; @0025                               v62 = iadd.i64 v37, v16
+;; @0025                               brif v63, block11(v61, v62, v16, v59), block12(v61, v62, v16, v59)
 ;;
-;;                                 block11(v66: i64, v67: i64, v68: i64, v73: i64):
-;; @0025                               v72 = load.i64 notrap aligned v5
-;; @0025                               v74 = icmp uge v72, v73
-;; @0025                               brif v74, block14, block13(v73)
+;;                                 block11(v64: i64, v65: i64, v66: i64, v71: i64):
+;; @0025                               v70 = load.i64 notrap aligned v5
+;; @0025                               v72 = icmp uge v70, v71
+;; @0025                               brif v72, block14, block13(v71)
 ;;
 ;;                                 block14 cold:
-;; @0025                               v76 = load.i64 notrap aligned v7+8
-;; @0025                               v77 = icmp.i64 uge v72, v76
-;; @0025                               brif v77, block15, block13(v76)
+;; @0025                               v74 = load.i64 notrap aligned v7+8
+;; @0025                               v75 = icmp.i64 uge v70, v74
+;; @0025                               brif v75, block15, block13(v74)
 ;;
 ;;                                 block15 cold:
-;; @0025                               v78 = call fn0(v0)
-;; @0025                               jump block13(v78)
+;; @0025                               v76 = call fn0(v0)
+;; @0025                               jump block13(v76)
 ;;
-;;                                 block13(v82: i64):
-;;                                     v105 = iconst.i64 0x0800_0000
-;;                                     v106 = isub.i64 v66, v105  ; v105 = 0x0800_0000
-;;                                     v107 = isub.i64 v67, v105  ; v105 = 0x0800_0000
-;; @0025                               call fn1(v0, v106, v107, v105)  ; v105 = 0x0800_0000
-;;                                     v108 = isub.i64 v68, v105  ; v105 = 0x0800_0000
-;;                                     v109 = icmp ugt v108, v105  ; v105 = 0x0800_0000
-;; @0025                               brif v109, block11(v106, v107, v108, v82), block12(v106, v107, v108, v82)
+;;                                 block13(v80: i64):
+;;                                     v103 = iconst.i64 0x0800_0000
+;;                                     v104 = isub.i64 v64, v103  ; v103 = 0x0800_0000
+;;                                     v105 = isub.i64 v65, v103  ; v103 = 0x0800_0000
+;; @0025                               call fn1(v0, v104, v105, v103)  ; v103 = 0x0800_0000
+;;                                     v106 = isub.i64 v66, v103  ; v103 = 0x0800_0000
+;;                                     v107 = icmp ugt v106, v103  ; v103 = 0x0800_0000
+;; @0025                               brif v107, block11(v104, v105, v106, v80), block12(v104, v105, v106, v80)
 ;;
-;;                                 block12(v83: i64, v84: i64, v85: i64, v95: i64):
-;; @0025                               v86 = isub v83, v85
-;; @0025                               v87 = isub v84, v85
-;; @0025                               jump block5(v86, v87, v85, v95)
+;;                                 block12(v81: i64, v82: i64, v83: i64, v93: i64):
+;; @0025                               v84 = isub v81, v83
+;; @0025                               v85 = isub v82, v83
+;; @0025                               jump block5(v84, v85, v83, v93)
 ;;
 ;;                                 block17 cold:
-;; @0025                               v98 = load.i64 notrap aligned v7+8
-;; @0025                               v99 = icmp.i64 uge v93, v98
-;; @0025                               brif v99, block18, block16
+;; @0025                               v96 = load.i64 notrap aligned v7+8
+;; @0025                               v97 = icmp.i64 uge v91, v96
+;; @0025                               brif v97, block18, block16
 ;;
 ;;                                 block18 cold:
-;; @0025                               v100 = call fn0(v0)
+;; @0025                               v98 = call fn0(v0)
 ;; @0025                               jump block16
 ;;
 ;;                                 block16:
-;; @0025                               call fn1(v0, v88, v89, v90)
+;; @0025                               call fn1(v0, v86, v87, v88)
 ;; @0029                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/memory-copy-fuel.wat
+++ b/tests/disas/memory-copy-fuel.wat
@@ -13,7 +13,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx) -> i8 tail
 ;;     sig1 = (i64 vmctx, i64, i64, i64) tail
 ;;     fn0 = colocated u805306368:12 sig0
@@ -30,110 +29,110 @@
 ;; @001e                               brif v10, block2, block3(v8)
 ;;
 ;;                                 block2:
-;;                                     v108 = iadd.i64 v6, v7  ; v7 = 1
-;; @001e                               store notrap aligned v108, v5
+;;                                     v106 = iadd.i64 v6, v7  ; v7 = 1
+;; @001e                               store notrap aligned v106, v5
 ;; @001e                               v12 = call fn0(v0)
 ;; @001e                               v14 = load.i64 notrap aligned v5
 ;; @001e                               jump block3(v14)
 ;;
-;;                                 block3(v45: i64):
-;; @0025                               v19 = load.i64 notrap aligned v0+64
-;; @0025                               v20 = uextend.i64 v2
-;; @0025                               v21 = uextend.i64 v4
-;; @0025                               v24 = iadd v20, v21
-;; @0025                               v25 = icmp ugt v24, v19
-;; @0025                               trapnz v25, heap_oob
-;; @0025                               v33 = uextend.i64 v3
-;; @0025                               v37 = iadd v33, v21
-;; @0025                               v38 = icmp ugt v37, v19
-;; @0025                               trapnz v38, heap_oob
-;; @0025                               v26 = load.i64 notrap aligned readonly can_move v0+56
-;; @0025                               v43 = iadd v26, v33
-;; @0025                               v30 = iadd v26, v20
-;; @0025                               v49 = icmp ugt v43, v30
-;; @0025                               brif v49, block6, block7
+;;                                 block3(v43: i64):
+;; @0025                               v18 = load.i64 notrap aligned v0+64
+;; @0025                               v19 = uextend.i64 v2
+;; @0025                               v20 = uextend.i64 v4
+;; @0025                               v23 = iadd v19, v20
+;; @0025                               v24 = icmp ugt v23, v18
+;; @0025                               trapnz v24, heap_oob
+;; @0025                               v31 = uextend.i64 v3
+;; @0025                               v35 = iadd v31, v20
+;; @0025                               v36 = icmp ugt v35, v18
+;; @0025                               trapnz v36, heap_oob
+;; @0025                               v25 = load.i64 notrap aligned readonly can_move v0+56
+;; @0025                               v41 = iadd v25, v31
+;; @0025                               v29 = iadd v25, v19
+;; @0025                               v47 = icmp ugt v41, v29
+;; @0025                               brif v47, block6, block7
 ;;
-;;                                 block4(v51: i64, v52: i64, v53: i64, v54: i64):
-;; @0025                               v55 = iadd v54, v118  ; v118 = 0x0800_0000
-;;                                     v122 = iconst.i64 0
-;;                                     v123 = icmp sge v55, v122  ; v122 = 0
-;; @0025                               brif v123, block8, block9(v55)
+;;                                 block4(v49: i64, v50: i64, v51: i64, v52: i64):
+;; @0025                               v53 = iadd v52, v116  ; v116 = 0x0800_0000
+;;                                     v120 = iconst.i64 0
+;;                                     v121 = icmp sge v53, v120  ; v120 = 0
+;; @0025                               brif v121, block8, block9(v53)
 ;;
-;;                                 block5(v91: i64, v92: i64, v93: i64, v94: i64):
-;; @0025                               v96 = iadd v94, v93
-;;                                     v125 = iconst.i64 0
-;;                                     v126 = icmp sge v96, v125  ; v125 = 0
-;; @0025                               brif v126, block14, block15(v96)
+;;                                 block5(v89: i64, v90: i64, v91: i64, v92: i64):
+;; @0025                               v94 = iadd v92, v91
+;;                                     v123 = iconst.i64 0
+;;                                     v124 = icmp sge v94, v123  ; v123 = 0
+;; @0025                               brif v124, block14, block15(v94)
 ;;
 ;;                                 block6:
-;;                                     v118 = iconst.i64 0x0800_0000
-;;                                     v119 = icmp.i64 ugt v21, v118  ; v118 = 0x0800_0000
-;;                                     v120 = iconst.i64 4
-;;                                     v121 = iadd.i64 v45, v120  ; v120 = 4
-;; @0025                               brif v119, block4(v30, v43, v21, v121), block5(v30, v43, v21, v121)
+;;                                     v116 = iconst.i64 0x0800_0000
+;;                                     v117 = icmp.i64 ugt v20, v116  ; v116 = 0x0800_0000
+;;                                     v118 = iconst.i64 4
+;;                                     v119 = iadd.i64 v43, v118  ; v118 = 4
+;; @0025                               brif v117, block4(v29, v41, v20, v119), block5(v29, v41, v20, v119)
 ;;
 ;;                                 block8:
-;;                                     v124 = iadd.i64 v54, v118  ; v118 = 0x0800_0000
-;; @0025                               store notrap aligned v124, v5
-;; @0025                               v59 = call fn0(v0)
-;; @0025                               v61 = load.i64 notrap aligned v5
-;; @0025                               jump block9(v61)
+;;                                     v122 = iadd.i64 v52, v116  ; v116 = 0x0800_0000
+;; @0025                               store notrap aligned v122, v5
+;; @0025                               v57 = call fn0(v0)
+;; @0025                               v59 = load.i64 notrap aligned v5
+;; @0025                               jump block9(v59)
 ;;
-;;                                 block9(v66: i64):
-;; @0025                               call fn1(v0, v51, v52, v118)  ; v118 = 0x0800_0000
-;; @0025                               v64 = isub.i64 v53, v118  ; v118 = 0x0800_0000
-;; @0025                               v65 = icmp ugt v64, v118  ; v118 = 0x0800_0000
-;; @0025                               v62 = iadd.i64 v51, v118  ; v118 = 0x0800_0000
-;; @0025                               v63 = iadd.i64 v52, v118  ; v118 = 0x0800_0000
-;; @0025                               brif v65, block4(v62, v63, v64, v66), block5(v62, v63, v64, v66)
+;;                                 block9(v64: i64):
+;; @0025                               call fn1(v0, v49, v50, v116)  ; v116 = 0x0800_0000
+;; @0025                               v62 = isub.i64 v51, v116  ; v116 = 0x0800_0000
+;; @0025                               v63 = icmp ugt v62, v116  ; v116 = 0x0800_0000
+;; @0025                               v60 = iadd.i64 v49, v116  ; v116 = 0x0800_0000
+;; @0025                               v61 = iadd.i64 v50, v116  ; v116 = 0x0800_0000
+;; @0025                               brif v63, block4(v60, v61, v62, v64), block5(v60, v61, v62, v64)
 ;;
 ;;                                 block7:
-;; @0025                               v48 = iconst.i64 0x0800_0000
-;; @0025                               v69 = icmp.i64 ugt v21, v48  ; v48 = 0x0800_0000
-;; @0025                               v67 = iadd.i64 v30, v21
-;; @0025                               v68 = iadd.i64 v43, v21
-;; @0025                               v46 = iconst.i64 4
-;; @0025                               v47 = iadd.i64 v45, v46  ; v46 = 4
-;; @0025                               brif v69, block10(v67, v68, v21, v47), block11(v67, v68, v21, v47)
+;; @0025                               v46 = iconst.i64 0x0800_0000
+;; @0025                               v67 = icmp.i64 ugt v20, v46  ; v46 = 0x0800_0000
+;; @0025                               v65 = iadd.i64 v29, v20
+;; @0025                               v66 = iadd.i64 v41, v20
+;; @0025                               v44 = iconst.i64 4
+;; @0025                               v45 = iadd.i64 v43, v44  ; v44 = 4
+;; @0025                               brif v67, block10(v65, v66, v20, v45), block11(v65, v66, v20, v45)
 ;;
-;;                                 block10(v70: i64, v71: i64, v72: i64, v75: i64):
-;;                                     v109 = iconst.i64 0x0800_0000
-;;                                     v110 = iadd v75, v109  ; v109 = 0x0800_0000
-;;                                     v111 = iconst.i64 0
-;;                                     v112 = icmp sge v110, v111  ; v111 = 0
-;; @0025                               brif v112, block12, block13(v110)
+;;                                 block10(v68: i64, v69: i64, v70: i64, v73: i64):
+;;                                     v107 = iconst.i64 0x0800_0000
+;;                                     v108 = iadd v73, v107  ; v107 = 0x0800_0000
+;;                                     v109 = iconst.i64 0
+;;                                     v110 = icmp sge v108, v109  ; v109 = 0
+;; @0025                               brif v110, block12, block13(v108)
 ;;
 ;;                                 block12:
-;; @0025                               store.i64 notrap aligned v110, v5
-;; @0025                               v80 = call fn0(v0)
-;; @0025                               v82 = load.i64 notrap aligned v5
-;; @0025                               jump block13(v82)
+;; @0025                               store.i64 notrap aligned v108, v5
+;; @0025                               v78 = call fn0(v0)
+;; @0025                               v80 = load.i64 notrap aligned v5
+;; @0025                               jump block13(v80)
 ;;
-;;                                 block13(v85: i64):
-;;                                     v113 = iconst.i64 0x0800_0000
-;;                                     v114 = isub.i64 v70, v113  ; v113 = 0x0800_0000
-;;                                     v115 = isub.i64 v71, v113  ; v113 = 0x0800_0000
-;; @0025                               call fn1(v0, v114, v115, v113)  ; v113 = 0x0800_0000
-;;                                     v116 = isub.i64 v72, v113  ; v113 = 0x0800_0000
-;;                                     v117 = icmp ugt v116, v113  ; v113 = 0x0800_0000
-;; @0025                               brif v117, block10(v114, v115, v116, v85), block11(v114, v115, v116, v85)
+;;                                 block13(v83: i64):
+;;                                     v111 = iconst.i64 0x0800_0000
+;;                                     v112 = isub.i64 v68, v111  ; v111 = 0x0800_0000
+;;                                     v113 = isub.i64 v69, v111  ; v111 = 0x0800_0000
+;; @0025                               call fn1(v0, v112, v113, v111)  ; v111 = 0x0800_0000
+;;                                     v114 = isub.i64 v70, v111  ; v111 = 0x0800_0000
+;;                                     v115 = icmp ugt v114, v111  ; v111 = 0x0800_0000
+;; @0025                               brif v115, block10(v112, v113, v114, v83), block11(v112, v113, v114, v83)
 ;;
-;;                                 block11(v86: i64, v87: i64, v88: i64, v95: i64):
-;; @0025                               v89 = isub v86, v88
-;; @0025                               v90 = isub v87, v88
-;; @0025                               jump block5(v89, v90, v88, v95)
+;;                                 block11(v84: i64, v85: i64, v86: i64, v93: i64):
+;; @0025                               v87 = isub v84, v86
+;; @0025                               v88 = isub v85, v86
+;; @0025                               jump block5(v87, v88, v86, v93)
 ;;
 ;;                                 block14:
-;; @0025                               store.i64 notrap aligned v96, v5
-;; @0025                               v100 = call fn0(v0)
-;; @0025                               v102 = load.i64 notrap aligned v5
-;; @0025                               jump block15(v102)
+;; @0025                               store.i64 notrap aligned v94, v5
+;; @0025                               v98 = call fn0(v0)
+;; @0025                               v100 = load.i64 notrap aligned v5
+;; @0025                               jump block15(v100)
 ;;
-;;                                 block15(v104: i64):
-;; @0025                               call fn1(v0, v91, v92, v93)
+;;                                 block15(v102: i64):
+;; @0025                               call fn1(v0, v89, v90, v91)
 ;; @0029                               jump block1
 ;;
 ;;                                 block1:
-;; @0029                               store.i64 notrap aligned v104, v5
+;; @0029                               store.i64 notrap aligned v102, v5
 ;; @0029                               return
 ;; }

--- a/tests/disas/memory-copy-inline.wat
+++ b/tests/disas/memory-copy-inline.wat
@@ -17,25 +17,24 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
-;; @0024                               v6 = load.i64 notrap aligned v0+64
-;; @0024                               v7 = uextend.i64 v2
-;;                                     v33 = iconst.i64 16
-;; @0024                               v11 = iadd v7, v33  ; v33 = 16
-;; @0024                               v12 = icmp ugt v11, v6
-;; @0024                               trapnz v12, heap_oob
-;; @0024                               v20 = uextend.i64 v3
-;; @0024                               v24 = iadd v20, v33  ; v33 = 16
-;; @0024                               v25 = icmp ugt v24, v6
-;; @0024                               trapnz v25, heap_oob
-;; @0024                               v13 = load.i64 notrap aligned readonly can_move v0+56
-;; @0024                               v30 = iadd v13, v20
-;; @0024                               v32 = load.i8x16 notrap aligned little region1 v30
-;; @0024                               v17 = iadd v13, v7
-;; @0024                               store notrap aligned little region1 v32, v17
+;; @0024                               v5 = load.i64 notrap aligned v0+64
+;; @0024                               v6 = uextend.i64 v2
+;;                                     v31 = iconst.i64 16
+;; @0024                               v10 = iadd v6, v31  ; v31 = 16
+;; @0024                               v11 = icmp ugt v10, v5
+;; @0024                               trapnz v11, heap_oob
+;; @0024                               v18 = uextend.i64 v3
+;; @0024                               v22 = iadd v18, v31  ; v31 = 16
+;; @0024                               v23 = icmp ugt v22, v5
+;; @0024                               trapnz v23, heap_oob
+;; @0024                               v12 = load.i64 notrap aligned readonly can_move v0+56
+;; @0024                               v28 = iadd v12, v18
+;; @0024                               v30 = load.i8x16 notrap aligned little region1 v28
+;; @0024                               v16 = iadd v12, v6
+;; @0024                               store notrap aligned little region1 v30, v16
 ;; @0028                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/memory_copy_host32.wat
+++ b/tests/disas/memory_copy_host32.wat
@@ -50,26 +50,25 @@
   )
 )
 ;; function u0:0(i32 vmctx, i32, i32, i32, i32) tail {
-;;     gv0 = vmctx
 ;;     sig0 = (i32 vmctx, i32, i32, i32) tail
 ;;     fn0 = colocated u805306368:1 sig0
 ;;
 ;;                                 block0(v0: i32, v1: i32, v2: i32, v3: i32, v4: i32):
-;; @0042                               v6 = load.i32 notrap aligned v0+44
-;; @0042                               v7 = uextend.i64 v2
-;; @0042                               v8 = uextend.i64 v4
-;; @0042                               v11 = iadd v7, v8
-;; @0042                               v12 = uextend.i64 v6
-;; @0042                               v13 = icmp ugt v11, v12
-;; @0042                               trapnz v13, heap_oob
-;; @0042                               v14 = load.i32 notrap aligned can_move v0+40
-;; @0042                               v20 = uextend.i64 v3
-;; @0042                               v24 = iadd v20, v8
-;; @0042                               v26 = icmp ugt v24, v12
-;; @0042                               trapnz v26, heap_oob
-;; @0042                               v17 = iadd v14, v2
-;; @0042                               v30 = iadd v14, v3
-;; @0042                               call fn0(v0, v17, v30, v4)
+;; @0042                               v5 = load.i32 notrap aligned v0+44
+;; @0042                               v6 = uextend.i64 v2
+;; @0042                               v7 = uextend.i64 v4
+;; @0042                               v10 = iadd v6, v7
+;; @0042                               v11 = uextend.i64 v5
+;; @0042                               v12 = icmp ugt v10, v11
+;; @0042                               trapnz v12, heap_oob
+;; @0042                               v13 = load.i32 notrap aligned can_move v0+40
+;; @0042                               v18 = uextend.i64 v3
+;; @0042                               v22 = iadd v18, v7
+;; @0042                               v24 = icmp ugt v22, v11
+;; @0042                               trapnz v24, heap_oob
+;; @0042                               v16 = iadd v13, v2
+;; @0042                               v28 = iadd v13, v3
+;; @0042                               call fn0(v0, v16, v28, v4)
 ;; @0046                               jump block1
 ;;
 ;;                                 block1:
@@ -77,29 +76,28 @@
 ;; }
 ;;
 ;; function u0:1(i32 vmctx, i32, i32, i32, i32) tail {
-;;     gv0 = vmctx
 ;;     sig0 = (i32 vmctx, i32, i32, i32) tail
 ;;     fn0 = colocated u805306368:1 sig0
 ;;
 ;;                                 block0(v0: i32, v1: i32, v2: i32, v3: i32, v4: i32):
-;; @004f                               v6 = load.i32 notrap aligned v0+52
-;; @004f                               v7 = uextend.i64 v2
-;; @004f                               v8 = uextend.i64 v4
-;; @004f                               v11 = iadd v7, v8
-;; @004f                               v12 = uextend.i64 v6
-;; @004f                               v13 = icmp ugt v11, v12
-;; @004f                               trapnz v13, heap_oob
-;; @004f                               v14 = load.i32 notrap aligned can_move v0+48
-;; @004f                               v19 = load.i32 notrap aligned v0+44
-;; @004f                               v20 = uextend.i64 v3
-;; @004f                               v24 = iadd v20, v8
-;; @004f                               v25 = uextend.i64 v19
-;; @004f                               v26 = icmp ugt v24, v25
-;; @004f                               trapnz v26, heap_oob
-;; @004f                               v27 = load.i32 notrap aligned can_move v0+40
-;; @004f                               v17 = iadd v14, v2
-;; @004f                               v30 = iadd v27, v3
-;; @004f                               call fn0(v0, v17, v30, v4)
+;; @004f                               v5 = load.i32 notrap aligned v0+52
+;; @004f                               v6 = uextend.i64 v2
+;; @004f                               v7 = uextend.i64 v4
+;; @004f                               v10 = iadd v6, v7
+;; @004f                               v11 = uextend.i64 v5
+;; @004f                               v12 = icmp ugt v10, v11
+;; @004f                               trapnz v12, heap_oob
+;; @004f                               v13 = load.i32 notrap aligned can_move v0+48
+;; @004f                               v17 = load.i32 notrap aligned v0+44
+;; @004f                               v18 = uextend.i64 v3
+;; @004f                               v22 = iadd v18, v7
+;; @004f                               v23 = uextend.i64 v17
+;; @004f                               v24 = icmp ugt v22, v23
+;; @004f                               trapnz v24, heap_oob
+;; @004f                               v25 = load.i32 notrap aligned can_move v0+40
+;; @004f                               v16 = iadd v13, v2
+;; @004f                               v28 = iadd v25, v3
+;; @004f                               call fn0(v0, v16, v28, v4)
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:
@@ -107,29 +105,28 @@
 ;; }
 ;;
 ;; function u0:2(i32 vmctx, i32, i64, i32, i32) tail {
-;;     gv0 = vmctx
 ;;     sig0 = (i32 vmctx, i32, i32, i32) tail
 ;;     fn0 = colocated u805306368:1 sig0
 ;;
 ;;                                 block0(v0: i32, v1: i32, v2: i64, v3: i32, v4: i32):
-;; @005c                               v7 = load.i32 notrap aligned v0+60
+;; @005c                               v6 = load.i32 notrap aligned v0+60
 ;; @005c                               v5 = uextend.i64 v4
-;; @005c                               v8 = uadd_overflow_trap v2, v5, heap_oob
-;; @005c                               v9 = uextend.i64 v7
-;; @005c                               v10 = icmp ugt v8, v9
-;; @005c                               trapnz v10, heap_oob
-;; @005c                               v11 = load.i32 notrap aligned can_move v0+56
-;; @005c                               v17 = load.i32 notrap aligned v0+44
-;; @005c                               v18 = uextend.i64 v3
-;; @005c                               v22 = iadd v18, v5
-;; @005c                               v23 = uextend.i64 v17
-;; @005c                               v24 = icmp ugt v22, v23
-;; @005c                               trapnz v24, heap_oob
-;; @005c                               v25 = load.i32 notrap aligned can_move v0+40
-;; @005c                               v12 = ireduce.i32 v2
-;; @005c                               v15 = iadd v11, v12
-;; @005c                               v28 = iadd v25, v3
-;; @005c                               call fn0(v0, v15, v28, v4)
+;; @005c                               v7 = uadd_overflow_trap v2, v5, heap_oob
+;; @005c                               v8 = uextend.i64 v6
+;; @005c                               v9 = icmp ugt v7, v8
+;; @005c                               trapnz v9, heap_oob
+;; @005c                               v10 = load.i32 notrap aligned can_move v0+56
+;; @005c                               v15 = load.i32 notrap aligned v0+44
+;; @005c                               v16 = uextend.i64 v3
+;; @005c                               v20 = iadd v16, v5
+;; @005c                               v21 = uextend.i64 v15
+;; @005c                               v22 = icmp ugt v20, v21
+;; @005c                               trapnz v22, heap_oob
+;; @005c                               v23 = load.i32 notrap aligned can_move v0+40
+;; @005c                               v11 = ireduce.i32 v2
+;; @005c                               v14 = iadd v10, v11
+;; @005c                               v26 = iadd v23, v3
+;; @005c                               call fn0(v0, v14, v26, v4)
 ;; @0060                               jump block1
 ;;
 ;;                                 block1:
@@ -137,26 +134,25 @@
 ;; }
 ;;
 ;; function u0:3(i32 vmctx, i32, i64, i64, i64) tail {
-;;     gv0 = vmctx
 ;;     sig0 = (i32 vmctx, i32, i32, i32) tail
 ;;     fn0 = colocated u805306368:1 sig0
 ;;
 ;;                                 block0(v0: i32, v1: i32, v2: i64, v3: i64, v4: i64):
-;; @0069                               v6 = load.i32 notrap aligned v0+60
-;; @0069                               v7 = uadd_overflow_trap v2, v4, heap_oob
-;; @0069                               v8 = uextend.i64 v6
-;; @0069                               v9 = icmp ugt v7, v8
-;; @0069                               trapnz v9, heap_oob
-;; @0069                               v10 = load.i32 notrap aligned can_move v0+56
-;; @0069                               v17 = uadd_overflow_trap v3, v4, heap_oob
-;; @0069                               v19 = icmp ugt v17, v8
-;; @0069                               trapnz v19, heap_oob
-;; @0069                               v11 = ireduce.i32 v2
-;; @0069                               v14 = iadd v10, v11
-;; @0069                               v21 = ireduce.i32 v3
-;; @0069                               v24 = iadd v10, v21
-;; @0069                               v25 = ireduce.i32 v4
-;; @0069                               call fn0(v0, v14, v24, v25)
+;; @0069                               v5 = load.i32 notrap aligned v0+60
+;; @0069                               v6 = uadd_overflow_trap v2, v4, heap_oob
+;; @0069                               v7 = uextend.i64 v5
+;; @0069                               v8 = icmp ugt v6, v7
+;; @0069                               trapnz v8, heap_oob
+;; @0069                               v9 = load.i32 notrap aligned can_move v0+56
+;; @0069                               v15 = uadd_overflow_trap v3, v4, heap_oob
+;; @0069                               v17 = icmp ugt v15, v7
+;; @0069                               trapnz v17, heap_oob
+;; @0069                               v10 = ireduce.i32 v2
+;; @0069                               v13 = iadd v9, v10
+;; @0069                               v19 = ireduce.i32 v3
+;; @0069                               v22 = iadd v9, v19
+;; @0069                               v23 = ireduce.i32 v4
+;; @0069                               call fn0(v0, v13, v22, v23)
 ;; @006d                               jump block1
 ;;
 ;;                                 block1:
@@ -164,29 +160,28 @@
 ;; }
 ;;
 ;; function u0:4(i32 vmctx, i32, i64, i64, i64) tail {
-;;     gv0 = vmctx
 ;;     sig0 = (i32 vmctx, i32, i32, i32) tail
 ;;     fn0 = colocated u805306368:1 sig0
 ;;
 ;;                                 block0(v0: i32, v1: i32, v2: i64, v3: i64, v4: i64):
-;; @0076                               v6 = load.i32 notrap aligned v0+68
-;; @0076                               v7 = uadd_overflow_trap v2, v4, heap_oob
-;; @0076                               v8 = uextend.i64 v6
-;; @0076                               v9 = icmp ugt v7, v8
-;; @0076                               trapnz v9, heap_oob
-;; @0076                               v10 = load.i32 notrap aligned can_move v0+64
-;; @0076                               v16 = load.i32 notrap aligned v0+60
-;; @0076                               v17 = uadd_overflow_trap v3, v4, heap_oob
-;; @0076                               v18 = uextend.i64 v16
-;; @0076                               v19 = icmp ugt v17, v18
-;; @0076                               trapnz v19, heap_oob
-;; @0076                               v20 = load.i32 notrap aligned can_move v0+56
-;; @0076                               v11 = ireduce.i32 v2
-;; @0076                               v14 = iadd v10, v11
-;; @0076                               v21 = ireduce.i32 v3
-;; @0076                               v24 = iadd v20, v21
-;; @0076                               v25 = ireduce.i32 v4
-;; @0076                               call fn0(v0, v14, v24, v25)
+;; @0076                               v5 = load.i32 notrap aligned v0+68
+;; @0076                               v6 = uadd_overflow_trap v2, v4, heap_oob
+;; @0076                               v7 = uextend.i64 v5
+;; @0076                               v8 = icmp ugt v6, v7
+;; @0076                               trapnz v8, heap_oob
+;; @0076                               v9 = load.i32 notrap aligned can_move v0+64
+;; @0076                               v14 = load.i32 notrap aligned v0+60
+;; @0076                               v15 = uadd_overflow_trap v3, v4, heap_oob
+;; @0076                               v16 = uextend.i64 v14
+;; @0076                               v17 = icmp ugt v15, v16
+;; @0076                               trapnz v17, heap_oob
+;; @0076                               v18 = load.i32 notrap aligned can_move v0+56
+;; @0076                               v10 = ireduce.i32 v2
+;; @0076                               v13 = iadd v9, v10
+;; @0076                               v19 = ireduce.i32 v3
+;; @0076                               v22 = iadd v18, v19
+;; @0076                               v23 = ireduce.i32 v4
+;; @0076                               call fn0(v0, v13, v22, v23)
 ;; @007a                               jump block1
 ;;
 ;;                                 block1:
@@ -194,29 +189,28 @@
 ;; }
 ;;
 ;; function u0:5(i32 vmctx, i32, i32, i64, i32) tail {
-;;     gv0 = vmctx
 ;;     sig0 = (i32 vmctx, i32, i32, i32) tail
 ;;     fn0 = colocated u805306368:1 sig0
 ;;
 ;;                                 block0(v0: i32, v1: i32, v2: i32, v3: i64, v4: i32):
-;; @0083                               v7 = load.i32 notrap aligned v0+44
-;; @0083                               v8 = uextend.i64 v2
+;; @0083                               v6 = load.i32 notrap aligned v0+44
+;; @0083                               v7 = uextend.i64 v2
 ;; @0083                               v5 = uextend.i64 v4
-;; @0083                               v12 = iadd v8, v5
-;; @0083                               v13 = uextend.i64 v7
-;; @0083                               v14 = icmp ugt v12, v13
-;; @0083                               trapnz v14, heap_oob
-;; @0083                               v15 = load.i32 notrap aligned can_move v0+40
-;; @0083                               v20 = load.i32 notrap aligned v0+60
-;; @0083                               v21 = uadd_overflow_trap v3, v5, heap_oob
-;; @0083                               v22 = uextend.i64 v20
-;; @0083                               v23 = icmp ugt v21, v22
-;; @0083                               trapnz v23, heap_oob
-;; @0083                               v24 = load.i32 notrap aligned can_move v0+56
-;; @0083                               v18 = iadd v15, v2
-;; @0083                               v25 = ireduce.i32 v3
-;; @0083                               v28 = iadd v24, v25
-;; @0083                               call fn0(v0, v18, v28, v4)
+;; @0083                               v11 = iadd v7, v5
+;; @0083                               v12 = uextend.i64 v6
+;; @0083                               v13 = icmp ugt v11, v12
+;; @0083                               trapnz v13, heap_oob
+;; @0083                               v14 = load.i32 notrap aligned can_move v0+40
+;; @0083                               v18 = load.i32 notrap aligned v0+60
+;; @0083                               v19 = uadd_overflow_trap v3, v5, heap_oob
+;; @0083                               v20 = uextend.i64 v18
+;; @0083                               v21 = icmp ugt v19, v20
+;; @0083                               trapnz v21, heap_oob
+;; @0083                               v22 = load.i32 notrap aligned can_move v0+56
+;; @0083                               v17 = iadd v14, v2
+;; @0083                               v23 = ireduce.i32 v3
+;; @0083                               v26 = iadd v22, v23
+;; @0083                               call fn0(v0, v17, v26, v4)
 ;; @0087                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/memory_copy_host64.wat
+++ b/tests/disas/memory_copy_host64.wat
@@ -54,26 +54,25 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, i64, i64, i64) tail
 ;;     fn0 = colocated u805306368:1 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
-;; @0042                               v6 = load.i64 notrap aligned v0+88
-;; @0042                               v7 = uextend.i64 v2
-;; @0042                               v8 = uextend.i64 v4
-;; @0042                               v11 = iadd v7, v8
-;; @0042                               v12 = icmp ugt v11, v6
-;; @0042                               trapnz v12, heap_oob
-;; @0042                               v20 = uextend.i64 v3
-;; @0042                               v24 = iadd v20, v8
-;; @0042                               v25 = icmp ugt v24, v6
-;; @0042                               trapnz v25, heap_oob
-;; @0042                               v13 = load.i64 notrap aligned readonly can_move v0+80
-;; @0042                               v17 = iadd v13, v7
-;; @0042                               v30 = iadd v13, v20
-;; @0042                               call fn0(v0, v17, v30, v8)
+;; @0042                               v5 = load.i64 notrap aligned v0+88
+;; @0042                               v6 = uextend.i64 v2
+;; @0042                               v7 = uextend.i64 v4
+;; @0042                               v10 = iadd v6, v7
+;; @0042                               v11 = icmp ugt v10, v5
+;; @0042                               trapnz v11, heap_oob
+;; @0042                               v18 = uextend.i64 v3
+;; @0042                               v22 = iadd v18, v7
+;; @0042                               v23 = icmp ugt v22, v5
+;; @0042                               trapnz v23, heap_oob
+;; @0042                               v12 = load.i64 notrap aligned readonly can_move v0+80
+;; @0042                               v16 = iadd v12, v6
+;; @0042                               v28 = iadd v12, v18
+;; @0042                               call fn0(v0, v16, v28, v7)
 ;; @0046                               jump block1
 ;;
 ;;                                 block1:
@@ -85,28 +84,27 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, i64, i64, i64) tail
 ;;     fn0 = colocated u805306368:1 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
-;; @004f                               v6 = load.i64 notrap aligned v0+104
-;; @004f                               v7 = uextend.i64 v2
-;; @004f                               v8 = uextend.i64 v4
-;; @004f                               v11 = iadd v7, v8
-;; @004f                               v12 = icmp ugt v11, v6
-;; @004f                               trapnz v12, heap_oob
-;; @004f                               v19 = load.i64 notrap aligned v0+88
-;; @004f                               v20 = uextend.i64 v3
-;; @004f                               v24 = iadd v20, v8
-;; @004f                               v25 = icmp ugt v24, v19
-;; @004f                               trapnz v25, heap_oob
-;; @004f                               v13 = load.i64 notrap aligned readonly can_move v0+96
-;; @004f                               v17 = iadd v13, v7
-;; @004f                               v26 = load.i64 notrap aligned readonly can_move v0+80
-;; @004f                               v30 = iadd v26, v20
-;; @004f                               call fn0(v0, v17, v30, v8)
+;; @004f                               v5 = load.i64 notrap aligned v0+104
+;; @004f                               v6 = uextend.i64 v2
+;; @004f                               v7 = uextend.i64 v4
+;; @004f                               v10 = iadd v6, v7
+;; @004f                               v11 = icmp ugt v10, v5
+;; @004f                               trapnz v11, heap_oob
+;; @004f                               v17 = load.i64 notrap aligned v0+88
+;; @004f                               v18 = uextend.i64 v3
+;; @004f                               v22 = iadd v18, v7
+;; @004f                               v23 = icmp ugt v22, v17
+;; @004f                               trapnz v23, heap_oob
+;; @004f                               v12 = load.i64 notrap aligned readonly can_move v0+96
+;; @004f                               v16 = iadd v12, v6
+;; @004f                               v24 = load.i64 notrap aligned readonly can_move v0+80
+;; @004f                               v28 = iadd v24, v18
+;; @004f                               call fn0(v0, v16, v28, v7)
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:
@@ -118,27 +116,26 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, i64, i64, i64) tail
 ;;     fn0 = colocated u805306368:1 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32, v4: i32):
-;; @005c                               v7 = load.i64 notrap aligned v0+120
+;; @005c                               v6 = load.i64 notrap aligned v0+120
 ;; @005c                               v5 = uextend.i64 v4
-;; @005c                               v8 = uadd_overflow_trap v2, v5, heap_oob
-;; @005c                               v9 = icmp ugt v8, v7
-;; @005c                               trapnz v9, heap_oob
-;; @005c                               v10 = load.i64 notrap aligned can_move v0+112
-;; @005c                               v15 = load.i64 notrap aligned v0+88
-;; @005c                               v16 = uextend.i64 v3
-;; @005c                               v20 = iadd v16, v5
-;; @005c                               v21 = icmp ugt v20, v15
-;; @005c                               trapnz v21, heap_oob
-;; @005c                               v13 = iadd v10, v2
-;; @005c                               v22 = load.i64 notrap aligned readonly can_move v0+80
-;; @005c                               v26 = iadd v22, v16
-;; @005c                               call fn0(v0, v13, v26, v5)
+;; @005c                               v7 = uadd_overflow_trap v2, v5, heap_oob
+;; @005c                               v8 = icmp ugt v7, v6
+;; @005c                               trapnz v8, heap_oob
+;; @005c                               v9 = load.i64 notrap aligned can_move v0+112
+;; @005c                               v13 = load.i64 notrap aligned v0+88
+;; @005c                               v14 = uextend.i64 v3
+;; @005c                               v18 = iadd v14, v5
+;; @005c                               v19 = icmp ugt v18, v13
+;; @005c                               trapnz v19, heap_oob
+;; @005c                               v12 = iadd v9, v2
+;; @005c                               v20 = load.i64 notrap aligned readonly can_move v0+80
+;; @005c                               v24 = iadd v20, v14
+;; @005c                               call fn0(v0, v12, v24, v5)
 ;; @0060                               jump block1
 ;;
 ;;                                 block1:
@@ -150,23 +147,22 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, i64, i64, i64) tail
 ;;     fn0 = colocated u805306368:1 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i64, v4: i64):
-;; @0069                               v6 = load.i64 notrap aligned v0+120
-;; @0069                               v7 = uadd_overflow_trap v2, v4, heap_oob
-;; @0069                               v8 = icmp ugt v7, v6
-;; @0069                               trapnz v8, heap_oob
-;; @0069                               v9 = load.i64 notrap aligned can_move v0+112
-;; @0069                               v15 = uadd_overflow_trap v3, v4, heap_oob
-;; @0069                               v16 = icmp ugt v15, v6
-;; @0069                               trapnz v16, heap_oob
-;; @0069                               v12 = iadd v9, v2
-;; @0069                               v20 = iadd v9, v3
-;; @0069                               call fn0(v0, v12, v20, v4)
+;; @0069                               v5 = load.i64 notrap aligned v0+120
+;; @0069                               v6 = uadd_overflow_trap v2, v4, heap_oob
+;; @0069                               v7 = icmp ugt v6, v5
+;; @0069                               trapnz v7, heap_oob
+;; @0069                               v8 = load.i64 notrap aligned can_move v0+112
+;; @0069                               v13 = uadd_overflow_trap v3, v4, heap_oob
+;; @0069                               v14 = icmp ugt v13, v5
+;; @0069                               trapnz v14, heap_oob
+;; @0069                               v11 = iadd v8, v2
+;; @0069                               v18 = iadd v8, v3
+;; @0069                               call fn0(v0, v11, v18, v4)
 ;; @006d                               jump block1
 ;;
 ;;                                 block1:
@@ -178,25 +174,24 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, i64, i64, i64) tail
 ;;     fn0 = colocated u805306368:1 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i64, v4: i64):
-;; @0076                               v6 = load.i64 notrap aligned v0+136
-;; @0076                               v7 = uadd_overflow_trap v2, v4, heap_oob
-;; @0076                               v8 = icmp ugt v7, v6
-;; @0076                               trapnz v8, heap_oob
-;; @0076                               v9 = load.i64 notrap aligned can_move v0+128
-;; @0076                               v14 = load.i64 notrap aligned v0+120
-;; @0076                               v15 = uadd_overflow_trap v3, v4, heap_oob
-;; @0076                               v16 = icmp ugt v15, v14
-;; @0076                               trapnz v16, heap_oob
-;; @0076                               v17 = load.i64 notrap aligned can_move v0+112
-;; @0076                               v12 = iadd v9, v2
-;; @0076                               v20 = iadd v17, v3
-;; @0076                               call fn0(v0, v12, v20, v4)
+;; @0076                               v5 = load.i64 notrap aligned v0+136
+;; @0076                               v6 = uadd_overflow_trap v2, v4, heap_oob
+;; @0076                               v7 = icmp ugt v6, v5
+;; @0076                               trapnz v7, heap_oob
+;; @0076                               v8 = load.i64 notrap aligned can_move v0+128
+;; @0076                               v12 = load.i64 notrap aligned v0+120
+;; @0076                               v13 = uadd_overflow_trap v3, v4, heap_oob
+;; @0076                               v14 = icmp ugt v13, v12
+;; @0076                               trapnz v14, heap_oob
+;; @0076                               v15 = load.i64 notrap aligned can_move v0+112
+;; @0076                               v11 = iadd v8, v2
+;; @0076                               v18 = iadd v15, v3
+;; @0076                               call fn0(v0, v11, v18, v4)
 ;; @007a                               jump block1
 ;;
 ;;                                 block1:
@@ -208,27 +203,26 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, i64, i64, i64) tail
 ;;     fn0 = colocated u805306368:1 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i64, v4: i32):
-;; @0083                               v7 = load.i64 notrap aligned v0+88
-;; @0083                               v8 = uextend.i64 v2
+;; @0083                               v6 = load.i64 notrap aligned v0+88
+;; @0083                               v7 = uextend.i64 v2
 ;; @0083                               v5 = uextend.i64 v4
-;; @0083                               v12 = iadd v8, v5
-;; @0083                               v13 = icmp ugt v12, v7
-;; @0083                               trapnz v13, heap_oob
-;; @0083                               v20 = load.i64 notrap aligned v0+120
-;; @0083                               v21 = uadd_overflow_trap v3, v5, heap_oob
-;; @0083                               v22 = icmp ugt v21, v20
-;; @0083                               trapnz v22, heap_oob
-;; @0083                               v23 = load.i64 notrap aligned can_move v0+112
-;; @0083                               v14 = load.i64 notrap aligned readonly can_move v0+80
-;; @0083                               v18 = iadd v14, v8
-;; @0083                               v26 = iadd v23, v3
-;; @0083                               call fn0(v0, v18, v26, v5)
+;; @0083                               v11 = iadd v7, v5
+;; @0083                               v12 = icmp ugt v11, v6
+;; @0083                               trapnz v12, heap_oob
+;; @0083                               v18 = load.i64 notrap aligned v0+120
+;; @0083                               v19 = uadd_overflow_trap v3, v5, heap_oob
+;; @0083                               v20 = icmp ugt v19, v18
+;; @0083                               trapnz v20, heap_oob
+;; @0083                               v21 = load.i64 notrap aligned can_move v0+112
+;; @0083                               v13 = load.i64 notrap aligned readonly can_move v0+80
+;; @0083                               v17 = iadd v13, v7
+;; @0083                               v24 = iadd v21, v3
+;; @0083                               call fn0(v0, v17, v24, v5)
 ;; @0087                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/memory_fill_host32.wat
+++ b/tests/disas/memory_fill_host32.wat
@@ -47,22 +47,21 @@
   )
 )
 ;; function u0:0(i32 vmctx, i32, i32, i32) tail {
-;;     gv0 = vmctx
 ;;     sig0 = (i32 vmctx, i32, i32, i32) tail
 ;;     fn0 = colocated u805306368:2 sig0
 ;;
 ;;                                 block0(v0: i32, v1: i32, v2: i32, v3: i32):
-;; @003c                               v6 = load.i32 notrap aligned v0+48
-;; @003c                               v7 = uextend.i64 v2
-;; @003c                               v8 = uextend.i64 v3
-;; @003c                               v11 = iadd v7, v8
-;; @003c                               v12 = uextend.i64 v6
-;; @003c                               v13 = icmp ugt v11, v12
-;; @003c                               trapnz v13, heap_oob
-;; @003c                               v14 = load.i32 notrap aligned can_move v0+44
-;; @003c                               v17 = iadd v14, v2
+;; @003c                               v5 = load.i32 notrap aligned v0+48
+;; @003c                               v6 = uextend.i64 v2
+;; @003c                               v7 = uextend.i64 v3
+;; @003c                               v10 = iadd v6, v7
+;; @003c                               v11 = uextend.i64 v5
+;; @003c                               v12 = icmp ugt v10, v11
+;; @003c                               trapnz v12, heap_oob
+;; @003c                               v13 = load.i32 notrap aligned can_move v0+44
+;; @003c                               v16 = iadd v13, v2
 ;; @0038                               v4 = iconst.i32 0
-;; @003c                               call fn0(v0, v17, v4, v3)  ; v4 = 0
+;; @003c                               call fn0(v0, v16, v4, v3)  ; v4 = 0
 ;; @003f                               jump block1
 ;;
 ;;                                 block1:
@@ -70,22 +69,21 @@
 ;; }
 ;;
 ;; function u0:1(i32 vmctx, i32, i64, i64) tail {
-;;     gv0 = vmctx
 ;;     sig0 = (i32 vmctx, i32, i32, i32) tail
 ;;     fn0 = colocated u805306368:2 sig0
 ;;
 ;;                                 block0(v0: i32, v1: i32, v2: i64, v3: i64):
-;; @0048                               v6 = load.i32 notrap aligned v0+56
-;; @0048                               v7 = uadd_overflow_trap v2, v3, heap_oob
-;; @0048                               v8 = uextend.i64 v6
-;; @0048                               v9 = icmp ugt v7, v8
-;; @0048                               trapnz v9, heap_oob
-;; @0048                               v10 = load.i32 notrap aligned can_move v0+52
-;; @0048                               v11 = ireduce.i32 v2
-;; @0048                               v14 = iadd v10, v11
+;; @0048                               v5 = load.i32 notrap aligned v0+56
+;; @0048                               v6 = uadd_overflow_trap v2, v3, heap_oob
+;; @0048                               v7 = uextend.i64 v5
+;; @0048                               v8 = icmp ugt v6, v7
+;; @0048                               trapnz v8, heap_oob
+;; @0048                               v9 = load.i32 notrap aligned can_move v0+52
+;; @0048                               v10 = ireduce.i32 v2
+;; @0048                               v13 = iadd v9, v10
 ;; @0044                               v4 = iconst.i32 0
-;; @0048                               v15 = ireduce.i32 v3
-;; @0048                               call fn0(v0, v14, v4, v15)  ; v4 = 0
+;; @0048                               v14 = ireduce.i32 v3
+;; @0048                               call fn0(v0, v13, v4, v14)  ; v4 = 0
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:
@@ -93,22 +91,21 @@
 ;; }
 ;;
 ;; function u0:2(i32 vmctx, i32, i32, i32) tail {
-;;     gv0 = vmctx
 ;;     sig0 = (i32 vmctx, i32, i32, i32) tail
 ;;     fn0 = colocated u805306368:2 sig0
 ;;
 ;;                                 block0(v0: i32, v1: i32, v2: i32, v3: i32):
-;; @0054                               v6 = load.i32 notrap aligned v0+64
-;; @0054                               v7 = uextend.i64 v2
-;; @0054                               v8 = uextend.i64 v3
-;; @0054                               v11 = iadd v7, v8
-;; @0054                               v12 = uextend.i64 v6
-;; @0054                               v13 = icmp ugt v11, v12
-;; @0054                               trapnz v13, heap_oob
-;; @0054                               v14 = load.i32 notrap aligned can_move v0+60
-;; @0054                               v17 = iadd v14, v2
+;; @0054                               v5 = load.i32 notrap aligned v0+64
+;; @0054                               v6 = uextend.i64 v2
+;; @0054                               v7 = uextend.i64 v3
+;; @0054                               v10 = iadd v6, v7
+;; @0054                               v11 = uextend.i64 v5
+;; @0054                               v12 = icmp ugt v10, v11
+;; @0054                               trapnz v12, heap_oob
+;; @0054                               v13 = load.i32 notrap aligned can_move v0+60
+;; @0054                               v16 = iadd v13, v2
 ;; @0050                               v4 = iconst.i32 0
-;; @0054                               call fn0(v0, v17, v4, v3)  ; v4 = 0
+;; @0054                               call fn0(v0, v16, v4, v3)  ; v4 = 0
 ;; @0057                               jump block1
 ;;
 ;;                                 block1:
@@ -116,22 +113,21 @@
 ;; }
 ;;
 ;; function u0:3(i32 vmctx, i32, i64, i64) tail {
-;;     gv0 = vmctx
 ;;     sig0 = (i32 vmctx, i32, i32, i32) tail
 ;;     fn0 = colocated u805306368:2 sig0
 ;;
 ;;                                 block0(v0: i32, v1: i32, v2: i64, v3: i64):
-;; @0060                               v6 = load.i32 notrap aligned v0+72
-;; @0060                               v7 = uadd_overflow_trap v2, v3, heap_oob
-;; @0060                               v8 = uextend.i64 v6
-;; @0060                               v9 = icmp ugt v7, v8
-;; @0060                               trapnz v9, heap_oob
-;; @0060                               v10 = load.i32 notrap aligned can_move v0+68
-;; @0060                               v11 = ireduce.i32 v2
-;; @0060                               v14 = iadd v10, v11
+;; @0060                               v5 = load.i32 notrap aligned v0+72
+;; @0060                               v6 = uadd_overflow_trap v2, v3, heap_oob
+;; @0060                               v7 = uextend.i64 v5
+;; @0060                               v8 = icmp ugt v6, v7
+;; @0060                               trapnz v8, heap_oob
+;; @0060                               v9 = load.i32 notrap aligned can_move v0+68
+;; @0060                               v10 = ireduce.i32 v2
+;; @0060                               v13 = iadd v9, v10
 ;; @005c                               v4 = iconst.i32 0
-;; @0060                               v15 = ireduce.i32 v3
-;; @0060                               call fn0(v0, v14, v4, v15)  ; v4 = 0
+;; @0060                               v14 = ireduce.i32 v3
+;; @0060                               call fn0(v0, v13, v4, v14)  ; v4 = 0
 ;; @0063                               jump block1
 ;;
 ;;                                 block1:
@@ -139,22 +135,21 @@
 ;; }
 ;;
 ;; function u0:4(i32 vmctx, i32, i32, i32) tail {
-;;     gv0 = vmctx
 ;;     sig0 = (i32 vmctx, i32, i32, i32) tail
 ;;     fn0 = colocated u805306368:2 sig0
 ;;
 ;;                                 block0(v0: i32, v1: i32, v2: i32, v3: i32):
-;; @006c                               v6 = load.i32 notrap aligned v0+80
-;; @006c                               v7 = uextend.i64 v2
-;; @006c                               v8 = uextend.i64 v3
-;; @006c                               v11 = iadd v7, v8
-;; @006c                               v12 = uextend.i64 v6
-;; @006c                               v13 = icmp ugt v11, v12
-;; @006c                               trapnz v13, heap_oob
-;; @006c                               v14 = load.i32 notrap aligned readonly can_move v0+76
-;; @006c                               v17 = iadd v14, v2
+;; @006c                               v5 = load.i32 notrap aligned v0+80
+;; @006c                               v6 = uextend.i64 v2
+;; @006c                               v7 = uextend.i64 v3
+;; @006c                               v10 = iadd v6, v7
+;; @006c                               v11 = uextend.i64 v5
+;; @006c                               v12 = icmp ugt v10, v11
+;; @006c                               trapnz v12, heap_oob
+;; @006c                               v13 = load.i32 notrap aligned readonly can_move v0+76
+;; @006c                               v16 = iadd v13, v2
 ;; @0068                               v4 = iconst.i32 0
-;; @006c                               call fn0(v0, v17, v4, v3)  ; v4 = 0
+;; @006c                               call fn0(v0, v16, v4, v3)  ; v4 = 0
 ;; @006f                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/memory_fill_host64.wat
+++ b/tests/disas/memory_fill_host64.wat
@@ -48,22 +48,21 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, i64, i32, i64) tail
 ;;     fn0 = colocated u805306368:2 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
-;; @003c                               v6 = load.i64 notrap aligned v0+96
-;; @003c                               v7 = uextend.i64 v2
-;; @003c                               v8 = uextend.i64 v3
-;; @003c                               v11 = iadd v7, v8
-;; @003c                               v12 = icmp ugt v11, v6
-;; @003c                               trapnz v12, heap_oob
-;; @003c                               v13 = load.i64 notrap aligned readonly can_move v0+88
-;; @003c                               v17 = iadd v13, v7
+;; @003c                               v5 = load.i64 notrap aligned v0+96
+;; @003c                               v6 = uextend.i64 v2
+;; @003c                               v7 = uextend.i64 v3
+;; @003c                               v10 = iadd v6, v7
+;; @003c                               v11 = icmp ugt v10, v5
+;; @003c                               trapnz v11, heap_oob
+;; @003c                               v12 = load.i64 notrap aligned readonly can_move v0+88
+;; @003c                               v16 = iadd v12, v6
 ;; @0038                               v4 = iconst.i32 0
-;; @003c                               call fn0(v0, v17, v4, v8)  ; v4 = 0
+;; @003c                               call fn0(v0, v16, v4, v7)  ; v4 = 0
 ;; @003f                               jump block1
 ;;
 ;;                                 block1:
@@ -75,20 +74,19 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, i64, i32, i64) tail
 ;;     fn0 = colocated u805306368:2 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i64):
-;; @0048                               v6 = load.i64 notrap aligned v0+112
-;; @0048                               v7 = uadd_overflow_trap v2, v3, heap_oob
-;; @0048                               v8 = icmp ugt v7, v6
-;; @0048                               trapnz v8, heap_oob
-;; @0048                               v9 = load.i64 notrap aligned can_move v0+104
-;; @0048                               v12 = iadd v9, v2
+;; @0048                               v5 = load.i64 notrap aligned v0+112
+;; @0048                               v6 = uadd_overflow_trap v2, v3, heap_oob
+;; @0048                               v7 = icmp ugt v6, v5
+;; @0048                               trapnz v7, heap_oob
+;; @0048                               v8 = load.i64 notrap aligned can_move v0+104
+;; @0048                               v11 = iadd v8, v2
 ;; @0044                               v4 = iconst.i32 0
-;; @0048                               call fn0(v0, v12, v4, v3)  ; v4 = 0
+;; @0048                               call fn0(v0, v11, v4, v3)  ; v4 = 0
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:
@@ -100,22 +98,21 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, i64, i32, i64) tail
 ;;     fn0 = colocated u805306368:2 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
-;; @0054                               v6 = load.i64 notrap aligned v0+128
-;; @0054                               v7 = uextend.i64 v2
-;; @0054                               v8 = uextend.i64 v3
-;; @0054                               v11 = iadd v7, v8
-;; @0054                               v12 = icmp ugt v11, v6
-;; @0054                               trapnz v12, heap_oob
-;; @0054                               v13 = load.i64 notrap aligned readonly can_move v0+120
-;; @0054                               v17 = iadd v13, v7
+;; @0054                               v5 = load.i64 notrap aligned v0+128
+;; @0054                               v6 = uextend.i64 v2
+;; @0054                               v7 = uextend.i64 v3
+;; @0054                               v10 = iadd v6, v7
+;; @0054                               v11 = icmp ugt v10, v5
+;; @0054                               trapnz v11, heap_oob
+;; @0054                               v12 = load.i64 notrap aligned readonly can_move v0+120
+;; @0054                               v16 = iadd v12, v6
 ;; @0050                               v4 = iconst.i32 0
-;; @0054                               call fn0(v0, v17, v4, v8)  ; v4 = 0
+;; @0054                               call fn0(v0, v16, v4, v7)  ; v4 = 0
 ;; @0057                               jump block1
 ;;
 ;;                                 block1:
@@ -127,20 +124,19 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, i64, i32, i64) tail
 ;;     fn0 = colocated u805306368:2 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i64):
-;; @0060                               v6 = load.i64 notrap aligned v0+144
-;; @0060                               v7 = uadd_overflow_trap v2, v3, heap_oob
-;; @0060                               v8 = icmp ugt v7, v6
-;; @0060                               trapnz v8, heap_oob
-;; @0060                               v9 = load.i64 notrap aligned can_move v0+136
-;; @0060                               v12 = iadd v9, v2
+;; @0060                               v5 = load.i64 notrap aligned v0+144
+;; @0060                               v6 = uadd_overflow_trap v2, v3, heap_oob
+;; @0060                               v7 = icmp ugt v6, v5
+;; @0060                               trapnz v7, heap_oob
+;; @0060                               v8 = load.i64 notrap aligned can_move v0+136
+;; @0060                               v11 = iadd v8, v2
 ;; @005c                               v4 = iconst.i32 0
-;; @0060                               call fn0(v0, v12, v4, v3)  ; v4 = 0
+;; @0060                               call fn0(v0, v11, v4, v3)  ; v4 = 0
 ;; @0063                               jump block1
 ;;
 ;;                                 block1:
@@ -152,22 +148,21 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, i64, i32, i64) tail
 ;;     fn0 = colocated u805306368:2 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
-;; @006c                               v6 = load.i64 notrap aligned v0+160
-;; @006c                               v7 = uextend.i64 v2
-;; @006c                               v8 = uextend.i64 v3
-;; @006c                               v11 = iadd v7, v8
-;; @006c                               v12 = icmp ugt v11, v6
-;; @006c                               trapnz v12, heap_oob
-;; @006c                               v13 = load.i64 notrap aligned readonly can_move v0+152
-;; @006c                               v17 = iadd v13, v7
+;; @006c                               v5 = load.i64 notrap aligned v0+160
+;; @006c                               v6 = uextend.i64 v2
+;; @006c                               v7 = uextend.i64 v3
+;; @006c                               v10 = iadd v6, v7
+;; @006c                               v11 = icmp ugt v10, v5
+;; @006c                               trapnz v11, heap_oob
+;; @006c                               v12 = load.i64 notrap aligned readonly can_move v0+152
+;; @006c                               v16 = iadd v12, v6
 ;; @0068                               v4 = iconst.i32 0
-;; @006c                               call fn0(v0, v17, v4, v8)  ; v4 = 0
+;; @006c                               call fn0(v0, v16, v4, v7)  ; v4 = 0
 ;; @006f                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/passive-data.wat
+++ b/tests/disas/passive-data.wat
@@ -20,39 +20,38 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
-;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, i64, i64, i64) tail
 ;;     fn0 = colocated u805306368:1 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
-;; @003d                               v6 = load.i64 notrap aligned v0+64
-;; @003d                               v7 = uextend.i64 v2
-;; @003d                               v8 = uextend.i64 v4
-;; @003d                               v9 = iconst.i64 1
-;; @003d                               v10 = imul v8, v9  ; v9 = 1
-;; @003d                               v11 = iadd v7, v10
-;; @003d                               v12 = icmp ugt v11, v6
-;; @003d                               trapnz v12, heap_oob
-;; @003d                               v13 = load.i64 notrap aligned readonly can_move v0+56
-;; @003d                               v14 = uextend.i64 v2
-;; @003d                               v15 = iconst.i64 1
-;; @003d                               v16 = imul v14, v15  ; v15 = 1
-;; @003d                               v17 = iadd v13, v16
-;; @003d                               v18 = load.i32 notrap aligned region1 v0+152
-;; @003d                               v19 = uextend.i64 v18
-;; @003d                               v20 = uextend.i64 v3
-;; @003d                               v21 = uextend.i64 v4
-;; @003d                               v22 = iconst.i64 1
-;; @003d                               v23 = imul v21, v22  ; v22 = 1
-;; @003d                               v24 = iadd v20, v23
-;; @003d                               v25 = icmp ugt v24, v19
-;; @003d                               trapnz v25, heap_oob
-;; @003d                               v26 = load.i64 notrap aligned region2 v0+144
-;; @003d                               v27 = uextend.i64 v3
-;; @003d                               v28 = iadd v26, v27
-;; @003d                               v29 = uextend.i64 v4
-;; @003d                               call fn0(v0, v17, v28, v29)
+;; @003d                               v5 = load.i64 notrap aligned v0+64
+;; @003d                               v6 = uextend.i64 v2
+;; @003d                               v7 = uextend.i64 v4
+;; @003d                               v8 = iconst.i64 1
+;; @003d                               v9 = imul v7, v8  ; v8 = 1
+;; @003d                               v10 = iadd v6, v9
+;; @003d                               v11 = icmp ugt v10, v5
+;; @003d                               trapnz v11, heap_oob
+;; @003d                               v12 = load.i64 notrap aligned readonly can_move v0+56
+;; @003d                               v13 = uextend.i64 v2
+;; @003d                               v14 = iconst.i64 1
+;; @003d                               v15 = imul v13, v14  ; v14 = 1
+;; @003d                               v16 = iadd v12, v15
+;; @003d                               v17 = load.i32 notrap aligned region1 v0+152
+;; @003d                               v18 = uextend.i64 v17
+;; @003d                               v19 = uextend.i64 v3
+;; @003d                               v20 = uextend.i64 v4
+;; @003d                               v21 = iconst.i64 1
+;; @003d                               v22 = imul v20, v21  ; v21 = 1
+;; @003d                               v23 = iadd v19, v22
+;; @003d                               v24 = icmp ugt v23, v18
+;; @003d                               trapnz v24, heap_oob
+;; @003d                               v25 = load.i64 notrap aligned region2 v0+144
+;; @003d                               v26 = uextend.i64 v3
+;; @003d                               v27 = iadd v25, v26
+;; @003d                               v28 = uextend.i64 v4
+;; @003d                               call fn0(v0, v16, v27, v28)
 ;; @0041                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/startup-data-active.wat
+++ b/tests/disas/startup-data-active.wat
@@ -38,7 +38,6 @@
 ;; function u2415919104:0(i64 vmctx, i64) tail {
 ;;     region0 = 112 "VMContext+0x70"
 ;;     region1 = 120 "VMContext+0x78"
-;;     gv0 = vmctx
 ;;     sig0 = (i64 vmctx, i64, i64, i64) tail
 ;;     fn0 = colocated u805306368:1 sig0
 ;;
@@ -50,12 +49,12 @@
 ;;
 ;; block1:
 ;;     v6 = load.i32 notrap aligned region1 v0+120
-;;     v9 = load.i64 notrap aligned v0+64
-;;     v11 = uextend.i64 v6
-;;     v15 = icmp ugt v11, v9
-;;     trapnz v15, heap_oob
-;;     v16 = load.i64 notrap aligned readonly can_move v0+56
-;;     call fn0(v0, v16, v2, v11)
+;;     v8 = load.i64 notrap aligned v0+64
+;;     v10 = uextend.i64 v6
+;;     v14 = icmp ugt v10, v8
+;;     trapnz v14, heap_oob
+;;     v15 = load.i64 notrap aligned readonly can_move v0+56
+;;     call fn0(v0, v15, v2, v10)
 ;;     jump block2
 ;;
 ;; block2:


### PR DESCRIPTION
The `FuncEnvironment::vmctx_val` method is preferred, which returns an `ir::Value`.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
