### PR TITLE
Remove use of the `global_value` instruction from explicit stack limit checks

### DIFF
--- a/crates/cranelift/src/alias_region.rs
+++ b/crates/cranelift/src/alias_region.rs
@@ -923,22 +923,29 @@ where
         )
     }
 
+    /// Get a `Load` for the `VmStoreContext::stack_limits` field.
+    pub fn vmstore_context_stack_limit_load(&mut self, func: &mut ir::Function) -> Load {
+        let offset = self
+            .offsets
+            .get_ptr_size()
+            .vmstore_context_stack_limit()
+            .into();
+        let region = self.vmstore_context_region(func, offset);
+        Load {
+            offset,
+            flags: ir::MemFlagsData::trusted().with_alias_region(Some(region)),
+            ty: self.pointer_type,
+        }
+    }
+
     /// Load the `VMStoreContext::stack_limit` field.
     pub fn vmstore_context_stack_limit(
         &mut self,
         cursor: &mut FuncCursor<'_>,
         vmstore_ctx: ir::Value,
     ) -> ir::Value {
-        self.vmstore_context_load(
-            cursor,
-            self.pointer_type,
-            ir::MemFlagsData::trusted(),
-            vmstore_ctx,
-            self.offsets
-                .get_ptr_size()
-                .vmstore_context_stack_limit()
-                .into(),
-        )
+        self.vmstore_context_stack_limit_load(cursor.func)
+            .emit(cursor, vmstore_ctx)
     }
 
     /// Store the `VMStoreContext::stack_limit` field.

--- a/crates/cranelift/src/compiler.rs
+++ b/crates/cranelift/src/compiler.rs
@@ -2,7 +2,7 @@ use crate::TRAP_INTERNAL_ASSERT;
 use crate::alias_region::AliasRegions;
 use crate::debug::DwarfSectionRelocTarget;
 use crate::func_environ::FuncEnvironment;
-use crate::translate::FuncTranslator;
+use crate::translate::{FuncTranslator, VmctxLoadChain};
 use crate::{BuiltinFunctionSignatures, builder::LinkOptions, wasm_call_signature};
 use crate::{CompiledFunction, ModuleTextBuilder, array_call_signature};
 use cranelift_codegen::binemit::CodeOffset;
@@ -538,55 +538,15 @@ impl wasmtime_environ::Compiler for Compiler {
         // the embedder should cause wasm to trap before it reaches that
         // (ensuring the host has enough space as well for its functionality).
         if !isa.triple().is_pulley() {
-            let vmctx = context
-                .func
-                .create_global_value(ir::GlobalValueData::VMContext);
-
-            let vmctx_store_context_region =
-                func_env.alias_regions.vmctx_region_for_use_in_ir_global(
-                    &mut context.func,
-                    func_env.offsets.ptr.vmctx_store_context().into(),
-                );
-
-            let flags = context
-                .func
-                .dfg
-                .mem_flags
-                .insert(
-                    MemFlagsData::trusted()
-                        .with_readonly()
-                        .with_can_move()
-                        .with_alias_region(Some(vmctx_store_context_region)),
-                )
-                .unwrap();
-
-            let vmstore_ctx_ptr = context.func.create_global_value(ir::GlobalValueData::Load {
-                base: vmctx,
-                offset: i32::from(func_env.offsets.ptr.vmctx_store_context()).into(),
-                global_type: isa.pointer_type(),
-                flags,
-            });
-
-            let stack_limit_region = func_env
+            let store_ctx = func_env
                 .alias_regions
-                .vmstore_context_region_for_use_in_ir_global(
-                    &mut context.func,
-                    func_env.offsets.ptr.vmstore_context_stack_limit().into(),
-                );
-            let flags = context
-                .func
-                .dfg
-                .mem_flags
-                .insert(MemFlagsData::trusted().with_alias_region(Some(stack_limit_region)))
-                .unwrap();
-
-            let stack_limit = context.func.create_global_value(ir::GlobalValueData::Load {
-                base: vmstore_ctx_ptr,
-                offset: i32::from(func_env.offsets.ptr.vmstore_context_stack_limit()).into(),
-                global_type: isa.pointer_type(),
-                flags,
-            });
+                .vmctx_store_context_load(&mut context.func);
+            let stack_limit = func_env
+                .alias_regions
+                .vmstore_context_stack_limit_load(&mut context.func);
+            let stack_limit = VmctxLoadChain::new([store_ctx, stack_limit].into());
             if self.tunables.signals_based_traps {
+                let stack_limit = stack_limit.emit_global(&mut context.func);
                 context.func.stack_limit = Some(stack_limit);
             } else {
                 func_env.stack_limit_at_function_entry = Some(stack_limit);

--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -195,14 +195,14 @@ pub struct FuncEnvironment<'module_environment> {
 
     fuel_consumed: i64,
 
-    /// A `GlobalValue` in CLIF which represents the stack limit.
+    /// A stack limit for when signals-based traps are disabled.
     ///
     /// Typically this resides in the `stack_limit` value of `ir::Function` but
     /// that requires signal handlers on the host and when that's disabled this
     /// is here with an explicit check instead. Note that the explicit check is
     /// always present even if this is a "leaf" function, as we have to call
     /// into the host to trap when signal handlers are disabled.
-    pub(crate) stack_limit_at_function_entry: Option<ir::GlobalValue>,
+    pub(crate) stack_limit_at_function_entry: Option<VmctxLoadChain>,
 
     /// Used by the stack switching feature. If set, we have a allocated a
     /// slot on this function's stack to be used for the
@@ -5045,8 +5045,9 @@ impl FuncEnvironment<'_> {
     pub fn before_translate_function(&mut self, builder: &mut FunctionBuilder) -> WasmResult<()> {
         // If an explicit stack limit is requested, emit one here at the start
         // of the function.
-        if let Some(gv) = self.stack_limit_at_function_entry {
-            let limit = builder.ins().global_value(self.pointer_type(), gv);
+        if let Some(limit) = self.stack_limit_at_function_entry.take() {
+            let vmctx = self.vmctx_val(&mut builder.cursor());
+            let limit = limit.emit(&mut builder.cursor(), vmctx);
             let sp = builder.ins().get_stack_pointer(self.pointer_type());
             let overflow = builder.ins().icmp(IntCC::UnsignedLessThan, sp, limit);
             self.conditionally_trap(builder, overflow, ir::TrapCode::STACK_OVERFLOW);

--- a/crates/cranelift/src/translate/heap.rs
+++ b/crates/cranelift/src/translate/heap.rs
@@ -29,6 +29,21 @@ impl Load {
             i32::try_from(self.offset).unwrap(),
         )
     }
+
+    /// Emit this load, relative to the given `base`, as an `ir::GlobalValue`.
+    ///
+    /// Prefer plain `emit`; this is only for cases where a global value is
+    /// required (like the stack limit checks that Cranelift emits inline in the
+    /// compiled function's prologue).
+    pub fn emit_global(&self, func: &mut ir::Function, base: ir::GlobalValue) -> ir::GlobalValue {
+        let flags = func.dfg.mem_flags.insert(self.flags).unwrap();
+        func.global_values.push(ir::GlobalValueData::Load {
+            base,
+            offset: i32::try_from(self.offset).unwrap().into(),
+            global_type: self.ty,
+            flags,
+        })
+    }
 }
 
 /// A chain of loads, rooted at the `vmctx`.
@@ -52,6 +67,20 @@ impl VmctxLoadChain {
         let mut val = vmctx;
         for load in &self.0 {
             val = load.emit(cursor, val);
+        }
+        val
+    }
+
+    /// Emit the load chain, starting from `vmctx`, as a sequence of CLIF global
+    /// values.
+    ///
+    /// Prefer plain `emit`; this is only for cases where a global value is
+    /// required (like the stack limit checks that Cranelift emits inline in the
+    /// compiled function's prologue).
+    pub fn emit_global(&self, func: &mut ir::Function) -> ir::GlobalValue {
+        let mut val = func.global_values.push(ir::GlobalValueData::VMContext);
+        for load in &self.0 {
+            val = load.emit_global(func, val);
         }
         val
     }


### PR DESCRIPTION


<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
