### PR TITLE
Clean up GC heap `VmctxLoadChain` construction

### DIFF
--- a/crates/cranelift/src/alias_region.rs
+++ b/crates/cranelift/src/alias_region.rs
@@ -296,19 +296,6 @@ where
         )
     }
 
-    /// Get the region for loading from a `*mut VMContext` at the given offset.
-    ///
-    /// XXX: This is ONLY for use with `ir::GlobalValue`s, all other uses should
-    /// instead use a helper method that actually emits the full load
-    /// instruction instead (e.g. `AliasRegions::vmctx_store_context`).
-    pub fn vmctx_region_for_use_in_ir_global(
-        &mut self,
-        func: &mut ir::Function,
-        offset: u32,
-    ) -> ir::AliasRegion {
-        self.vmctx_region(func, offset)
-    }
-
     fn vmctx_load(
         &mut self,
         cursor: &mut FuncCursor<'_>,
@@ -854,20 +841,6 @@ where
         )
     }
 
-    /// Get the alias region for the `VMStoreContext` field at `offset`, for use
-    /// in an `ir::GlobalValue`'s memory flags.
-    ///
-    /// XXX: This is ONLY for use with `ir::GlobalValue`s; all other uses should
-    /// instead use a helper method that actually emits the full load/store
-    /// instruction.
-    pub fn vmstore_context_region_for_use_in_ir_global(
-        &mut self,
-        func: &mut ir::Function,
-        offset: u32,
-    ) -> ir::AliasRegion {
-        self.vmstore_context_region(func, offset)
-    }
-
     /// Load the `VMStoreContext::fuel_consumed` field.
     pub fn vmstore_context_fuel_consumed(
         &mut self,
@@ -967,6 +940,28 @@ where
         )
     }
 
+    /// Get a `Load` of the GC heap base pointer (`VMStoreContext::gc_heap.base`).
+    ///
+    /// The caller supplies the base flags because whether the base pointer is
+    /// `readonly`/`can_move` depends on the GC heap's tunables.
+    pub fn vmstore_context_gc_heap_base_load(
+        &mut self,
+        func: &mut ir::Function,
+        base_flags: ir::MemFlagsData,
+    ) -> Load {
+        let offset = self
+            .offsets
+            .get_ptr_size()
+            .vmstore_context_gc_heap_base()
+            .into();
+        let region = self.vmstore_context_region(func, offset);
+        Load {
+            offset,
+            flags: base_flags.with_alias_region(Some(region)),
+            ty: self.pointer_type,
+        }
+    }
+
     /// Load the GC heap base pointer (`VMStoreContext::gc_heap.base`).
     ///
     /// The caller supplies the base flags because whether the base pointer is
@@ -977,16 +972,23 @@ where
         base_flags: ir::MemFlagsData,
         vmstore_ctx: ir::Value,
     ) -> ir::Value {
-        self.vmstore_context_load(
-            cursor,
-            self.pointer_type,
-            base_flags,
-            vmstore_ctx,
-            self.offsets
-                .get_ptr_size()
-                .vmstore_context_gc_heap_base()
-                .into(),
-        )
+        self.vmstore_context_gc_heap_base_load(cursor.func, base_flags)
+            .emit(cursor, vmstore_ctx)
+    }
+
+    /// Get a `Load` of the GC heap bound (`VMStoreContext::gc_heap.current_length`).
+    pub fn vmstore_context_gc_heap_current_length_load(&mut self, func: &mut ir::Function) -> Load {
+        let offset = self
+            .offsets
+            .get_ptr_size()
+            .vmstore_context_gc_heap_current_length()
+            .into();
+        let region = self.vmstore_context_region(func, offset);
+        Load {
+            offset,
+            flags: ir::MemFlagsData::trusted().with_alias_region(Some(region)),
+            ty: self.pointer_type,
+        }
     }
 
     /// Load the GC heap bound (`VMStoreContext::gc_heap.current_length`).
@@ -995,16 +997,8 @@ where
         cursor: &mut FuncCursor<'_>,
         vmstore_ctx: ir::Value,
     ) -> ir::Value {
-        self.vmstore_context_load(
-            cursor,
-            self.pointer_type,
-            ir::MemFlagsData::trusted(),
-            vmstore_ctx,
-            self.offsets
-                .get_ptr_size()
-                .vmstore_context_gc_heap_current_length()
-                .into(),
-        )
+        self.vmstore_context_gc_heap_current_length_load(cursor.func)
+            .emit(cursor, vmstore_ctx)
     }
 
     /// Load the `VMStoreContext::last_wasm_entry_fp` field.

--- a/crates/cranelift/src/func_environ/gc.rs
+++ b/crates/cranelift/src/func_environ/gc.rs
@@ -4,7 +4,7 @@ use crate::TRAP_ARRAY_OUT_OF_BOUNDS;
 use crate::bounds_checks::BoundsCheck;
 use crate::func_environ::{CheckedEntity, Extension, FuncEnvironment};
 use crate::translate::{
-    Heap, HeapData, Load, MemoryKind, StructFieldsVec, TargetEnvironment, VmctxLoadChain,
+    Heap, HeapData, MemoryKind, StructFieldsVec, TargetEnvironment, VmctxLoadChain,
 };
 use crate::trap::TranslateTrap;
 use crate::{Reachability, TRAP_GC_HEAP_CORRUPT, TRAP_INTERNAL_ASSERT};
@@ -18,7 +18,7 @@ use cranelift_frontend::FunctionBuilder;
 use smallvec::{SmallVec, smallvec};
 use wasmtime_environ::{
     Collector, GcArrayLayout, GcLayout, GcStructLayout, GcTypeLayouts, I31_DISCRIMINANT,
-    ModuleInternedTypeIndex, PtrSize, TagIndex, TypeIndex, VMGcKind, WasmCompositeInnerType,
+    ModuleInternedTypeIndex, TagIndex, TypeIndex, VMGcKind, WasmCompositeInnerType,
     WasmHeapTopType, WasmHeapType, WasmRefType, WasmResult, WasmStorageType, WasmValType,
     wasm_unsupported,
 };
@@ -1484,50 +1484,31 @@ impl FuncEnvironment<'_> {
 
         let store_ctx = self.alias_regions.vmctx_store_context_load(func);
 
-        // The GC heap base/bound live in the `VMStoreContext`, so the second
-        // load in each chain (off the `*mut VMStoreContext`) is tagged with the
-        // `VMStoreContext` region for that field.
-        let base_offset = u32::from(self.offsets.ptr.vmstore_context_gc_heap_base());
-        let bound_offset = u32::from(self.offsets.ptr.vmstore_context_gc_heap_current_length());
-        let base_region = self
-            .alias_regions
-            .vmstore_context_region_for_use_in_ir_global(func, base_offset);
-        let bound_region = self
-            .alias_regions
-            .vmstore_context_region_for_use_in_ir_global(func, bound_offset);
-
         // The base pointer's load is `can_move` and `readonly` when the GC
         // heap's base can never move.
         let memory_tunables =
             wasmtime_environ::MemoryTunables::new(self.tunables, MemoryKind::GcHeap);
-        let mut flags = ir::MemFlagsData::trusted().with_alias_region(Some(base_region));
+        let mut base_flags = ir::MemFlagsData::trusted();
         if !self
             .tunables
             .gc_heap_memory_type()
             .memory_may_move(&memory_tunables)
         {
-            flags.set_readonly();
-            flags.set_can_move();
+            base_flags.set_readonly();
+            base_flags.set_can_move();
         }
+        let base = self
+            .alias_regions
+            .vmstore_context_gc_heap_base_load(func, base_flags);
+
+        let bound = self
+            .alias_regions
+            .vmstore_context_gc_heap_current_length_load(func);
 
         let memory = self.tunables.gc_heap_memory_type();
         let heap = self.heaps.push(HeapData {
-            base: VmctxLoadChain::new(smallvec![
-                store_ctx,
-                Load {
-                    offset: base_offset,
-                    flags,
-                    ty: self.pointer_type(),
-                }
-            ]),
-            bound: VmctxLoadChain::new(smallvec![
-                store_ctx,
-                Load {
-                    offset: bound_offset,
-                    flags: ir::MemFlagsData::trusted().with_alias_region(Some(bound_region)),
-                    ty: self.pointer_type(),
-                }
-            ]),
+            base: VmctxLoadChain::new(smallvec![store_ctx, base]),
+            bound: VmctxLoadChain::new(smallvec![store_ctx, bound]),
             memory,
             kind: MemoryKind::GcHeap,
         });


### PR DESCRIPTION
Have the `Load` constructors as `AliasRegions` helper methods to avoid exposing raw `ir::AliasRegion`s for the `VMStoreContext`.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
