### PR TITLE
Tag `VMMemoryDefinition` fields with alias regions

### DIFF
--- a/crates/cranelift/src/alias_region.rs
+++ b/crates/cranelift/src/alias_region.rs
@@ -6,19 +6,14 @@ use cranelift_codegen::{
 };
 use wasmtime_environ::{
     DefinedGlobalIndex, DefinedMemoryIndex, DefinedTableIndex, FuncIndex, GetPtrSize, GlobalIndex,
-    MemoryIndex, PtrSize as _, RuntimeDataIndex, StaticModuleIndex, TableIndex, TagIndex,
-    VMOffsets,
+    MemoryIndex, OwnedMemoryIndex, PtrSize as _, RuntimeDataIndex, StaticModuleIndex, TableIndex,
+    TagIndex, VMOffsets,
 };
 
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
 enum VmType {
     VMContext,
     VMStoreContext,
-
-    #[allow(
-        dead_code,
-        reason = "used when tagging `VMMemoryDefinition` fields in upcoming commits"
-    )]
     VMMemoryDefinition,
 }
 
@@ -735,6 +730,64 @@ impl AliasRegions<VMOffsets<u8>> {
             new_length,
         )
     }
+
+    /// Get a `Load` for an inlined-in-the-`vmctx` `VMMemoryDefinition`'s `base`
+    /// field.
+    pub fn vmctx_vmmemory_definition_base_load(
+        &mut self,
+        func: &mut ir::Function,
+        memory: OwnedMemoryIndex,
+        base_flags: ir::MemFlagsData,
+    ) -> Load {
+        let field = self.offsets.ptr.vmmemory_definition_base();
+        let region = self.vmmemory_definition_region(func, field.into());
+        Load {
+            offset: self.offsets.vmctx_vmmemory_definition_base(memory),
+            flags: base_flags.with_alias_region(Some(region)),
+            ty: self.pointer_type,
+        }
+    }
+
+    /// Load an inlined-in-the-`vmctx` `VMMemoryDefinition`'s `base` field.
+    pub fn vmctx_vmmemory_definition_base(
+        &mut self,
+        cursor: &mut FuncCursor<'_>,
+        memory: OwnedMemoryIndex,
+        base_flags: ir::MemFlagsData,
+        vmctx: ir::Value,
+    ) -> ir::Value {
+        self.vmctx_vmmemory_definition_base_load(cursor.func, memory, base_flags)
+            .emit(cursor, vmctx)
+    }
+
+    /// Get a `Load` for an inlined-in-the-`vmctx` `VMMemoryDefinition`'s `current_length`
+    /// field.
+    pub fn vmctx_vmmemory_definition_current_length_load(
+        &mut self,
+        func: &mut ir::Function,
+        memory: OwnedMemoryIndex,
+    ) -> Load {
+        let field = self.offsets.ptr.vmmemory_definition_current_length();
+        let region = self.vmmemory_definition_region(func, field.into());
+        Load {
+            offset: self
+                .offsets
+                .vmctx_vmmemory_definition_current_length(memory),
+            flags: ir::MemFlagsData::trusted().with_alias_region(Some(region)),
+            ty: self.pointer_type,
+        }
+    }
+
+    /// Load an inlined-in-the-`vmctx` `VMMemoryDefinition`'s `current_length` field.
+    pub fn vmctx_vmmemory_definition_current_length(
+        &mut self,
+        cursor: &mut FuncCursor<'_>,
+        memory: OwnedMemoryIndex,
+        vmctx: ir::Value,
+    ) -> ir::Value {
+        self.vmctx_vmmemory_definition_current_length_load(cursor.func, memory)
+            .emit(cursor, vmctx)
+    }
 }
 
 /// `VMStoreContext`-related methods.
@@ -1170,6 +1223,111 @@ where
                 .vmstore_context_component_context_slot(slot)
                 .into(),
             val,
+        )
+    }
+}
+
+/// `VMMemoryDefinition`-related methods.
+///
+/// The `base` and `current_length` fields are reached either directly through
+/// the `vmctx` (for an owned, inline memory) or through a `*mut
+/// VMMemoryDefinition` (for a shared/imported memory). Both cases must share
+/// one region per field, so the region is keyed on the field's offset *within*
+/// the `VMMemoryDefinition` regardless of how the field is addressed; this is
+/// required for soundness under inlining (cf. `memory_alias_region`).
+impl<Offsets> AliasRegions<Offsets>
+where
+    Offsets: GetPtrSize,
+{
+    fn vmmemory_definition_region(
+        &mut self,
+        func: &mut ir::Function,
+        offset: u32,
+    ) -> ir::AliasRegion {
+        self.region(
+            func,
+            AliasRegionKey::Vm {
+                ty: VmType::VMMemoryDefinition,
+                offset,
+            },
+        )
+    }
+
+    /// Create a `Load` for the `VMMemoryDefinition::base` field, for use in a
+    /// `VmctxLoadChain`.
+    pub fn vmmemory_definition_base_load(
+        &mut self,
+        func: &mut ir::Function,
+        base_flags: ir::MemFlagsData,
+    ) -> Load {
+        let offset = self
+            .offsets
+            .get_ptr_size()
+            .vmmemory_definition_base()
+            .into();
+        let region = self.vmmemory_definition_region(func, offset);
+        Load {
+            offset,
+            flags: base_flags.with_alias_region(Some(region)),
+            ty: self.pointer_type,
+        }
+    }
+
+    /// Create a `Load` for the `VMMemoryDefinition::current_length` field, for
+    /// use in a `VmctxLoadChain`.
+    pub fn vmmemory_definition_current_length_load(&mut self, func: &mut ir::Function) -> Load {
+        let offset = self
+            .offsets
+            .get_ptr_size()
+            .vmmemory_definition_current_length()
+            .into();
+        let region = self.vmmemory_definition_region(func, offset);
+        Load {
+            offset,
+            flags: ir::MemFlagsData::trusted().with_alias_region(Some(region)),
+            ty: self.pointer_type,
+        }
+    }
+
+    /// Emit a load of the `VMMemoryDefinition::base` field from the given `vmmemory_definition`.
+    pub fn vmmemory_definition_base(
+        &mut self,
+        cursor: &mut FuncCursor<'_>,
+        vmmemory_definition: ir::Value,
+    ) -> ir::Value {
+        self.vmmemory_definition_base_load(cursor.func, ir::MemFlagsData::trusted())
+            .emit(cursor, vmmemory_definition)
+    }
+
+    /// Emit a (non-atomic) load of the `VMMemoryDefinition::current_length`
+    /// field from the given `vmmemory_definition`.
+    pub fn vmmemory_definition_current_length(
+        &mut self,
+        cursor: &mut FuncCursor<'_>,
+        vmmemory_definition: ir::Value,
+    ) -> ir::Value {
+        self.vmmemory_definition_current_length_load(cursor.func)
+            .emit(cursor, vmmemory_definition)
+    }
+
+    /// Emit an atomic load of the `VMMemoryDefinition::current_length` field out
+    /// of a `*mut VMMemoryDefinition`.
+    pub fn vmmemory_definition_current_length_atomic(
+        &mut self,
+        cursor: &mut FuncCursor<'_>,
+        vmmemory_definition: ir::Value,
+    ) -> ir::Value {
+        let offset = self
+            .offsets
+            .get_ptr_size()
+            .vmmemory_definition_current_length();
+        let region = self.vmmemory_definition_region(cursor.func, offset.into());
+        let offset = cursor.ins().iconst(self.pointer_type, i64::from(offset));
+        let ptr = cursor.ins().iadd(vmmemory_definition, offset);
+        cursor.ins().atomic_load(
+            self.pointer_type,
+            ir::MemFlagsData::trusted().with_alias_region(Some(region)),
+            ptr,
         )
     }
 }

--- a/crates/cranelift/src/compiler/component.rs
+++ b/crates/cranelift/src/compiler/component.rs
@@ -2052,14 +2052,9 @@ impl TrampolineCompiler<'_> {
     }
 
     fn load_runtime_memory_base(&mut self, vmctx: ir::Value, mem: RuntimeMemoryIndex) -> ir::Value {
-        let pointer_type = self.isa.pointer_type();
         let from_vmmemory_definition = self.load_memory(vmctx, mem);
-        self.builder.ins().load(
-            pointer_type,
-            MemFlagsData::trusted(),
-            from_vmmemory_definition,
-            i32::from(self.offsets.ptr.vmmemory_definition_base()),
-        )
+        self.alias_regions
+            .vmmemory_definition_base(&mut self.builder.cursor(), from_vmmemory_definition)
     }
 }
 

--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -1565,25 +1565,16 @@ impl FuncEnvironment<'_> {
         func: &mut ir::Function,
         index: MemoryIndex,
     ) -> (VmctxLoadChain, VmctxLoadChain) {
-        let pointer_type = self.pointer_type();
         let memory = self.module.memories[index];
         let is_shared = memory.shared;
 
         // The base pointer load is `can_move`, and additionally `readonly` when
         // this memory's base can never move.
         let memory_tunables = MemoryTunables::new(self.tunables, MemoryKind::LinearMemory);
-        let mut flags = ir::MemFlagsData::trusted().with_can_move();
+        let mut base_flags = ir::MemFlagsData::trusted().with_can_move();
         if !memory.memory_may_move(&memory_tunables) {
-            flags.set_readonly();
+            base_flags.set_readonly();
         }
-
-        let load = |offset, flags| Load {
-            offset,
-            flags,
-            ty: pointer_type,
-        };
-        let base_load = |offset: u32| load(offset, flags);
-        let bound_load = |offset: u32| load(offset, ir::MemFlagsData::trusted());
 
         if let Some(def_index) = self.module.defined_memory_index(index) {
             if is_shared {
@@ -1597,23 +1588,29 @@ impl FuncEnvironment<'_> {
                 (
                     VmctxLoadChain::new(smallvec![
                         mem,
-                        base_load(self.offsets.ptr.vmmemory_definition_base().into()),
+                        self.alias_regions
+                            .vmmemory_definition_base_load(func, base_flags),
                     ]),
                     VmctxLoadChain::new(smallvec![
                         mem,
-                        bound_load(self.offsets.ptr.vmmemory_definition_current_length().into()),
+                        self.alias_regions
+                            .vmmemory_definition_current_length_load(func),
                     ]),
                 )
             } else {
                 let owned_index = self.module.owned_memory_index(def_index);
                 (
-                    VmctxLoadChain::new(smallvec![base_load(
-                        self.offsets.vmctx_vmmemory_definition_base(owned_index)
-                    )]),
-                    VmctxLoadChain::new(smallvec![bound_load(
-                        self.offsets
-                            .vmctx_vmmemory_definition_current_length(owned_index)
-                    )]),
+                    VmctxLoadChain::new(smallvec![
+                        self.alias_regions.vmctx_vmmemory_definition_base_load(
+                            func,
+                            owned_index,
+                            base_flags
+                        )
+                    ]),
+                    VmctxLoadChain::new(smallvec![
+                        self.alias_regions
+                            .vmctx_vmmemory_definition_current_length_load(func, owned_index)
+                    ]),
                 )
             }
         } else {
@@ -1623,11 +1620,13 @@ impl FuncEnvironment<'_> {
             (
                 VmctxLoadChain::new(smallvec![
                     mem,
-                    base_load(self.offsets.ptr.vmmemory_definition_base().into()),
+                    self.alias_regions
+                        .vmmemory_definition_base_load(func, base_flags),
                 ]),
                 VmctxLoadChain::new(smallvec![
                     mem,
-                    bound_load(self.offsets.ptr.vmmemory_definition_current_length().into()),
+                    self.alias_regions
+                        .vmmemory_definition_current_length_load(func),
                 ]),
             )
         }
@@ -3316,65 +3315,30 @@ impl FuncEnvironment<'_> {
     /// Returns the `ir::Value`, typed as a pointer-width integer, that is the
     /// size in bytes.
     fn memory_size_in_bytes(&mut self, pos: &mut FuncCursor<'_>, index: MemoryIndex) -> ir::Value {
-        let pointer_type = self.pointer_type();
         let vmctx = self.vmctx_val(pos);
         let is_shared = self.module.memories[index].shared;
-        match self.module.defined_memory_index(index) {
-            Some(def_index) => {
-                if is_shared {
-                    let vmmemory_ptr = self
-                        .alias_regions
-                        .vmctx_vmmemory_pointer(pos, vmctx, def_index);
-                    let vmmemory_definition_offset =
-                        i64::from(self.offsets.ptr.vmmemory_definition_current_length());
-                    let vmmemory_definition_ptr = pos
-                        .ins()
-                        .iadd_imm_s(vmmemory_ptr, vmmemory_definition_offset);
-                    // This atomic access of the
-                    // `VMMemoryDefinition::current_length` is direct; no bounds
-                    // check is needed. This is possible because shared memory
-                    // has a static size (the maximum is always known). Shared
-                    // memory is thus built with a static memory plan and no
-                    // bounds-checked version of this is implemented.
-                    pos.ins().atomic_load(
-                        pointer_type,
-                        ir::MemFlagsData::trusted(),
-                        vmmemory_definition_ptr,
-                    )
-                } else {
-                    let owned_index = self.module.owned_memory_index(def_index);
-                    let offset = i32::try_from(
-                        self.offsets
-                            .vmctx_vmmemory_definition_current_length(owned_index),
-                    )
-                    .unwrap();
-                    pos.ins()
-                        .load(pointer_type, ir::MemFlagsData::trusted(), vmctx, offset)
-                }
-            }
-            None => {
-                let vmmemory_ptr = self
+        if let Some(def_index) = self.module.defined_memory_index(index) {
+            if is_shared {
+                let mem_ptr = self
                     .alias_regions
-                    .vmctx_vmmemory_import_from(pos, vmctx, index);
-                if is_shared {
-                    let vmmemory_definition_offset =
-                        i64::from(self.offsets.ptr.vmmemory_definition_current_length());
-                    let vmmemory_definition_ptr = pos
-                        .ins()
-                        .iadd_imm_s(vmmemory_ptr, vmmemory_definition_offset);
-                    pos.ins().atomic_load(
-                        pointer_type,
-                        ir::MemFlagsData::trusted(),
-                        vmmemory_definition_ptr,
-                    )
-                } else {
-                    pos.ins().load(
-                        pointer_type,
-                        ir::MemFlagsData::trusted(),
-                        vmmemory_ptr,
-                        i32::from(self.offsets.ptr.vmmemory_definition_current_length()),
-                    )
-                }
+                    .vmctx_vmmemory_pointer(pos, vmctx, def_index);
+                self.alias_regions
+                    .vmmemory_definition_current_length_atomic(pos, mem_ptr)
+            } else {
+                let owned_index = self.module.owned_memory_index(def_index);
+                self.alias_regions
+                    .vmctx_vmmemory_definition_current_length(pos, owned_index, vmctx)
+            }
+        } else {
+            let mem_ptr = self
+                .alias_regions
+                .vmctx_vmmemory_import_from(pos, vmctx, index);
+            if is_shared {
+                self.alias_regions
+                    .vmmemory_definition_current_length_atomic(pos, mem_ptr)
+            } else {
+                self.alias_regions
+                    .vmmemory_definition_current_length(pos, mem_ptr)
             }
         }
     }

--- a/tests/disas/alias-region-memories.wat
+++ b/tests/disas/alias-region-memories.wat
@@ -18,8 +18,10 @@
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     region2 = 48 "VMContext+0x30"
-;;     region3 = 536870912 "PublicMemory"
-;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region3 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region4 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region5 = 536870912 "PublicMemory"
+;;     region6 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -27,13 +29,13 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @003b                               v6 = load.i64 notrap aligned readonly can_move region2 v0+48
-;; @003b                               v7 = load.i64 notrap aligned readonly can_move v6
+;; @003b                               v7 = load.i64 notrap aligned readonly can_move region3 v6
 ;; @003b                               v5 = uextend.i64 v2
 ;; @003b                               v8 = iadd v7, v5
-;; @003b                               store little region3 v3, v8
-;; @0042                               v10 = load.i64 notrap aligned readonly can_move v0+80
+;; @003b                               store little region5 v3, v8
+;; @0042                               v10 = load.i64 notrap aligned readonly can_move region3 v0+80
 ;; @0042                               v11 = iadd v10, v5
-;; @0042                               store little region4 v3, v11
+;; @0042                               store little region6 v3, v11
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/basic-wat-test.wat
+++ b/tests/disas/basic-wat-test.wat
@@ -12,7 +12,9 @@
 ;; function u0:0(i64 vmctx, i64, i32, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -20,13 +22,13 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0021                               v5 = uextend.i64 v2
-;; @0021                               v6 = load.i64 notrap aligned readonly can_move v0+56
+;; @0021                               v6 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0021                               v7 = iadd v6, v5
-;; @0021                               v8 = load.i32 little region2 v7
+;; @0021                               v8 = load.i32 little region4 v7
 ;; @0026                               v9 = uextend.i64 v3
-;; @0026                               v10 = load.i64 notrap aligned readonly can_move v0+56
+;; @0026                               v10 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0026                               v11 = iadd v10, v9
-;; @0026                               v12 = load.i32 little region2 v11
+;; @0026                               v12 = load.i32 little region4 v11
 ;; @0029                               v13 = iadd v8, v12
 ;; @002a                               jump block1
 ;;

--- a/tests/disas/bounds-check.wat
+++ b/tests/disas/bounds-check.wat
@@ -27,7 +27,9 @@
 ;; function u0:0(i64 vmctx, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -35,20 +37,20 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @002a                               v3 = iconst.i32 0
-;; @002c                               v5 = load.i64 notrap aligned readonly can_move v0+56
+;; @002c                               v5 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @002c                               v4 = uextend.i64 v2
 ;; @002c                               v6 = iadd v5, v4
-;; @002c                               istore8 little region2 v3, v6  ; v3 = 0
+;; @002c                               istore8 little region4 v3, v6  ; v3 = 0
 ;; @0033                               v11 = iconst.i64 0x07ff_ffff
 ;; @0033                               v12 = iadd v6, v11  ; v11 = 0x07ff_ffff
-;; @0033                               istore8 little region2 v3, v12  ; v3 = 0
-;; @003d                               v15 = load.i64 notrap aligned v0+64
+;; @0033                               istore8 little region4 v3, v12  ; v3 = 0
+;; @003d                               v15 = load.i64 notrap aligned region3 v0+64
 ;; @003d                               v16 = icmp ugt v4, v15
 ;; @003d                               v21 = iconst.i64 0
 ;; @003d                               v19 = iconst.i64 0xffff_ffff
 ;; @003d                               v20 = iadd v6, v19  ; v19 = 0xffff_ffff
 ;; @003d                               v22 = select_spectre_guard v16, v21, v20  ; v21 = 0
-;; @003d                               istore8 little region2 v3, v22  ; v3 = 0
+;; @003d                               istore8 little region4 v3, v22  ; v3 = 0
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/duplicate-loads-dynamic-memory.wat
+++ b/tests/disas/duplicate-loads-dynamic-memory.wat
@@ -25,21 +25,23 @@
 ;; function u0:0(i64 vmctx, i64, i32) -> i32, i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 536870912 "PublicMemory"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 536870912 "PublicMemory"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0057                               v6 = load.i64 notrap aligned v0+64
-;; @0057                               v8 = load.i64 notrap aligned can_move v0+56
+;; @0057                               v6 = load.i64 notrap aligned region3 v0+64
+;; @0057                               v8 = load.i64 notrap aligned can_move region2 v0+56
 ;; @0057                               v5 = uextend.i64 v2
 ;; @0057                               v7 = icmp ugt v5, v6
 ;; @0057                               v10 = iconst.i64 0
 ;; @0057                               v9 = iadd v8, v5
 ;; @0057                               v11 = select_spectre_guard v7, v10, v9  ; v10 = 0
-;; @0057                               v12 = load.i32 little region2 v11
+;; @0057                               v12 = load.i32 little region4 v11
 ;; @005f                               jump block1
 ;;
 ;;                                 block1:
@@ -49,15 +51,17 @@
 ;; function u0:1(i64 vmctx, i64, i32) -> i32, i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 536870912 "PublicMemory"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 536870912 "PublicMemory"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0064                               v6 = load.i64 notrap aligned v0+64
-;; @0064                               v8 = load.i64 notrap aligned can_move v0+56
+;; @0064                               v6 = load.i64 notrap aligned region3 v0+64
+;; @0064                               v8 = load.i64 notrap aligned can_move region2 v0+56
 ;; @0064                               v5 = uextend.i64 v2
 ;; @0064                               v7 = icmp ugt v5, v6
 ;; @0064                               v12 = iconst.i64 0
@@ -65,7 +69,7 @@
 ;; @0064                               v10 = iconst.i64 1234
 ;; @0064                               v11 = iadd v9, v10  ; v10 = 1234
 ;; @0064                               v13 = select_spectre_guard v7, v12, v11  ; v12 = 0
-;; @0064                               v14 = load.i32 little region2 v13
+;; @0064                               v14 = load.i32 little region4 v13
 ;; @006e                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/duplicate-loads-static-memory.wat
+++ b/tests/disas/duplicate-loads-static-memory.wat
@@ -20,17 +20,19 @@
 ;; function u0:0(i64 vmctx, i64, i32) -> i32, i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 536870912 "PublicMemory"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 536870912 "PublicMemory"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0057                               v6 = load.i64 notrap aligned readonly can_move v0+56
+;; @0057                               v6 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0057                               v5 = uextend.i64 v2
 ;; @0057                               v7 = iadd v6, v5
-;; @0057                               v8 = load.i32 little region2 v7
+;; @0057                               v8 = load.i32 little region4 v7
 ;; @005f                               jump block1
 ;;
 ;;                                 block1:
@@ -40,19 +42,21 @@
 ;; function u0:1(i64 vmctx, i64, i32) -> i32, i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 536870912 "PublicMemory"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 536870912 "PublicMemory"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0064                               v6 = load.i64 notrap aligned readonly can_move v0+56
+;; @0064                               v6 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0064                               v5 = uextend.i64 v2
 ;; @0064                               v7 = iadd v6, v5
 ;; @0064                               v8 = iconst.i64 1234
 ;; @0064                               v9 = iadd v7, v8  ; v8 = 1234
-;; @0064                               v10 = load.i32 little region2 v9
+;; @0064                               v10 = load.i32 little region4 v9
 ;; @006e                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/dynamic-memory-no-spectre-access-same-index-different-offsets.wat
+++ b/tests/disas/dynamic-memory-no-spectre-access-same-index-different-offsets.wat
@@ -38,30 +38,32 @@
 ;; function u0:0(i64 vmctx, i64, i32) -> i32, i32, i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 536870912 "PublicMemory"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 536870912 "PublicMemory"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0047                               v7 = load.i64 notrap aligned v0+64
+;; @0047                               v7 = load.i64 notrap aligned region3 v0+64
 ;; @0047                               v6 = uextend.i64 v2
 ;; @0047                               v8 = icmp ugt v6, v7
 ;; @0047                               trapnz v8, heap_oob
-;; @0047                               v9 = load.i64 notrap aligned can_move v0+56
+;; @0047                               v9 = load.i64 notrap aligned can_move region2 v0+56
 ;; @0047                               v10 = iadd v9, v6
-;; @0047                               v11 = load.i32 little region2 v10
+;; @0047                               v11 = load.i32 little region4 v10
 ;; @004c                               v17 = iconst.i64 4
 ;; @004c                               v18 = iadd v10, v17  ; v17 = 4
-;; @004c                               v19 = load.i32 little region2 v18
+;; @004c                               v19 = load.i32 little region4 v18
 ;; @0051                               v21 = iconst.i64 0x0010_0003
 ;; @0051                               v22 = uadd_overflow_trap v6, v21, heap_oob  ; v21 = 0x0010_0003
 ;; @0051                               v24 = icmp ugt v22, v7
 ;; @0051                               trapnz v24, heap_oob
 ;; @0051                               v27 = iconst.i64 0x000f_ffff
 ;; @0051                               v28 = iadd v10, v27  ; v27 = 0x000f_ffff
-;; @0051                               v29 = load.i32 little region2 v28
+;; @0051                               v29 = load.i32 little region4 v28
 ;; @0056                               jump block1
 ;;
 ;;                                 block1:
@@ -71,30 +73,32 @@
 ;; function u0:1(i64 vmctx, i64, i32, i32, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 536870912 "PublicMemory"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 536870912 "PublicMemory"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):
-;; @005d                               v7 = load.i64 notrap aligned v0+64
+;; @005d                               v7 = load.i64 notrap aligned region3 v0+64
 ;; @005d                               v6 = uextend.i64 v2
 ;; @005d                               v8 = icmp ugt v6, v7
 ;; @005d                               trapnz v8, heap_oob
-;; @005d                               v9 = load.i64 notrap aligned can_move v0+56
+;; @005d                               v9 = load.i64 notrap aligned can_move region2 v0+56
 ;; @005d                               v10 = iadd v9, v6
-;; @005d                               store little region2 v3, v10
+;; @005d                               store little region4 v3, v10
 ;; @0064                               v16 = iconst.i64 4
 ;; @0064                               v17 = iadd v10, v16  ; v16 = 4
-;; @0064                               store little region2 v4, v17
+;; @0064                               store little region4 v4, v17
 ;; @006b                               v19 = iconst.i64 0x0010_0003
 ;; @006b                               v20 = uadd_overflow_trap v6, v19, heap_oob  ; v19 = 0x0010_0003
 ;; @006b                               v22 = icmp ugt v20, v7
 ;; @006b                               trapnz v22, heap_oob
 ;; @006b                               v25 = iconst.i64 0x000f_ffff
 ;; @006b                               v26 = iadd v10, v25  ; v25 = 0x000f_ffff
-;; @006b                               store little region2 v5, v26
+;; @006b                               store little region4 v5, v26
 ;; @0070                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/dynamic-memory-yes-spectre-access-same-index-different-offsets.wat
+++ b/tests/disas/dynamic-memory-yes-spectre-access-same-index-different-offsets.wat
@@ -34,32 +34,34 @@
 ;; function u0:0(i64 vmctx, i64, i32) -> i32, i32, i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 536870912 "PublicMemory"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 536870912 "PublicMemory"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0047                               v7 = load.i64 notrap aligned v0+64
-;; @0047                               v9 = load.i64 notrap aligned can_move v0+56
+;; @0047                               v7 = load.i64 notrap aligned region3 v0+64
+;; @0047                               v9 = load.i64 notrap aligned can_move region2 v0+56
 ;; @0047                               v6 = uextend.i64 v2
 ;; @0047                               v8 = icmp ugt v6, v7
 ;; @0047                               v11 = iconst.i64 0
 ;; @0047                               v10 = iadd v9, v6
 ;; @0047                               v12 = select_spectre_guard v8, v11, v10  ; v11 = 0
-;; @0047                               v13 = load.i32 little region2 v12
+;; @0047                               v13 = load.i32 little region4 v12
 ;; @004c                               v19 = iconst.i64 4
 ;; @004c                               v20 = iadd v10, v19  ; v19 = 4
 ;; @004c                               v22 = select_spectre_guard v8, v11, v20  ; v11 = 0
-;; @004c                               v23 = load.i32 little region2 v22
+;; @004c                               v23 = load.i32 little region4 v22
 ;; @0051                               v25 = iconst.i64 0x0010_0003
 ;; @0051                               v26 = uadd_overflow_trap v6, v25, heap_oob  ; v25 = 0x0010_0003
 ;; @0051                               v28 = icmp ugt v26, v7
 ;; @0051                               v31 = iconst.i64 0x000f_ffff
 ;; @0051                               v32 = iadd v10, v31  ; v31 = 0x000f_ffff
 ;; @0051                               v34 = select_spectre_guard v28, v11, v32  ; v11 = 0
-;; @0051                               v35 = load.i32 little region2 v34
+;; @0051                               v35 = load.i32 little region4 v34
 ;; @0056                               jump block1
 ;;
 ;;                                 block1:
@@ -69,32 +71,34 @@
 ;; function u0:1(i64 vmctx, i64, i32, i32, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 536870912 "PublicMemory"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 536870912 "PublicMemory"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):
-;; @005d                               v7 = load.i64 notrap aligned v0+64
-;; @005d                               v9 = load.i64 notrap aligned can_move v0+56
+;; @005d                               v7 = load.i64 notrap aligned region3 v0+64
+;; @005d                               v9 = load.i64 notrap aligned can_move region2 v0+56
 ;; @005d                               v6 = uextend.i64 v2
 ;; @005d                               v8 = icmp ugt v6, v7
 ;; @005d                               v11 = iconst.i64 0
 ;; @005d                               v10 = iadd v9, v6
 ;; @005d                               v12 = select_spectre_guard v8, v11, v10  ; v11 = 0
-;; @005d                               store little region2 v3, v12
+;; @005d                               store little region4 v3, v12
 ;; @0064                               v18 = iconst.i64 4
 ;; @0064                               v19 = iadd v10, v18  ; v18 = 4
 ;; @0064                               v21 = select_spectre_guard v8, v11, v19  ; v11 = 0
-;; @0064                               store little region2 v4, v21
+;; @0064                               store little region4 v4, v21
 ;; @006b                               v23 = iconst.i64 0x0010_0003
 ;; @006b                               v24 = uadd_overflow_trap v6, v23, heap_oob  ; v23 = 0x0010_0003
 ;; @006b                               v26 = icmp ugt v24, v7
 ;; @006b                               v29 = iconst.i64 0x000f_ffff
 ;; @006b                               v30 = iadd v10, v29  ; v29 = 0x000f_ffff
 ;; @006b                               v32 = select_spectre_guard v26, v11, v30  ; v11 = 0
-;; @006b                               store little region2 v5, v32
+;; @006b                               store little region4 v5, v32
 ;; @0070                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/f32-load.wat
+++ b/tests/disas/f32-load.wat
@@ -9,7 +9,9 @@
 ;; function u0:0(i64 vmctx, i64, i32) -> f32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -17,9 +19,9 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @002e                               v4 = uextend.i64 v2
-;; @002e                               v5 = load.i64 notrap aligned readonly can_move v0+56
+;; @002e                               v5 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @002e                               v6 = iadd v5, v4
-;; @002e                               v7 = load.f32 little region2 v6
+;; @002e                               v7 = load.f32 little region4 v6
 ;; @0031                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/f32-store.wat
+++ b/tests/disas/f32-store.wat
@@ -12,7 +12,9 @@
 ;; function u0:0(i64 vmctx, i64, i32, f32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -20,9 +22,9 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: f32):
 ;; @0031                               v4 = uextend.i64 v2
-;; @0031                               v5 = load.i64 notrap aligned readonly can_move v0+56
+;; @0031                               v5 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0031                               v6 = iadd v5, v4
-;; @0031                               store little region2 v3, v6
+;; @0031                               store little region4 v3, v6
 ;; @0034                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/f64-load.wat
+++ b/tests/disas/f64-load.wat
@@ -11,7 +11,9 @@
 ;; function u0:0(i64 vmctx, i64, i32) -> f64 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -19,9 +21,9 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @002e                               v4 = uextend.i64 v2
-;; @002e                               v5 = load.i64 notrap aligned readonly can_move v0+56
+;; @002e                               v5 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @002e                               v6 = iadd v5, v4
-;; @002e                               v7 = load.f64 little region2 v6
+;; @002e                               v7 = load.f64 little region4 v6
 ;; @0031                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/f64-store.wat
+++ b/tests/disas/f64-store.wat
@@ -12,7 +12,9 @@
 ;; function u0:0(i64 vmctx, i64, i32, f64) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -20,9 +22,9 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: f64):
 ;; @0031                               v4 = uextend.i64 v2
-;; @0031                               v5 = load.i64 notrap aligned readonly can_move v0+56
+;; @0031                               v5 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0031                               v6 = iadd v5, v4
-;; @0031                               store little region2 v3, v6
+;; @0031                               store little region4 v3, v6
 ;; @0034                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/fibonacci.wat
+++ b/tests/disas/fibonacci.wat
@@ -26,7 +26,9 @@
 ;; function u0:0(i64 vmctx, i64) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -55,9 +57,9 @@
 ;;                                 block2:
 ;; @0056                               v16 = iconst.i32 0
 ;; @005a                               v17 = uextend.i64 v16  ; v16 = 0
-;; @005a                               v18 = load.i64 notrap aligned readonly can_move v0+56
+;; @005a                               v18 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @005a                               v19 = iadd v18, v17
-;; @005a                               store.i32 little region2 v11, v19
+;; @005a                               store.i32 little region4 v11, v19
 ;; @005d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/fixed-size-memory.wat
+++ b/tests/disas/fixed-size-memory.wat
@@ -23,7 +23,9 @@
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -34,9 +36,9 @@
 ;; @0041                               v5 = iconst.i64 0x0001_0000
 ;; @0041                               v6 = icmp uge v4, v5  ; v5 = 0x0001_0000
 ;; @0041                               trapnz v6, heap_oob
-;; @0041                               v7 = load.i64 notrap aligned readonly can_move v0+56
+;; @0041                               v7 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0041                               v8 = iadd v7, v4
-;; @0041                               istore8 little region2 v3, v8
+;; @0041                               istore8 little region4 v3, v8
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -46,7 +48,9 @@
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -57,9 +61,9 @@
 ;; @0049                               v5 = iconst.i64 0x0001_0000
 ;; @0049                               v6 = icmp uge v4, v5  ; v5 = 0x0001_0000
 ;; @0049                               trapnz v6, heap_oob
-;; @0049                               v7 = load.i64 notrap aligned readonly can_move v0+56
+;; @0049                               v7 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0049                               v8 = iadd v7, v4
-;; @0049                               v9 = uload8.i32 little region2 v8
+;; @0049                               v9 = uload8.i32 little region4 v8
 ;; @004c                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/foo.wat
+++ b/tests/disas/foo.wat
@@ -17,10 +17,12 @@
 ;; function u0:0(i64 vmctx, i64, i32, i32) -> i32, i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
-;;     region3 = 72 "VMContext+0x48"
-;;     region4 = 1073741824 "PublicTable"
-;;     region5 = 40 "VMContext+0x28"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region5 = 72 "VMContext+0x48"
+;;     region6 = 1073741824 "PublicTable"
+;;     region7 = 40 "VMContext+0x28"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -30,11 +32,11 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
-;; @0040                               v7 = load.i64 notrap aligned readonly can_move v0+56
+;; @0040                               v7 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0040                               v6 = uextend.i64 v3
 ;; @0040                               v8 = iadd v7, v6
-;; @0040                               v9 = load.i32 little region2 v8
-;; @0043                               v10 = load.i64 notrap aligned readonly can_move region3 v0+72
+;; @0040                               v9 = load.i32 little region4 v8
+;; @0043                               v10 = load.i64 notrap aligned readonly can_move region5 v0+72
 ;; @0043                               v11 = load.i64 notrap aligned v10+8
 ;; @0043                               v16 = load.i64 notrap aligned v10
 ;; @0043                               v12 = ireduce.i32 v11
@@ -45,7 +47,7 @@
 ;; @0043                               v18 = ishl v14, v17  ; v17 = 3
 ;; @0043                               v19 = iadd v16, v18
 ;; @0043                               v21 = select_spectre_guard v13, v20, v19  ; v20 = 0
-;; @0043                               v22 = load.i64 user6 aligned region4 v21
+;; @0043                               v22 = load.i64 user6 aligned region6 v21
 ;; @0043                               v23 = iconst.i64 -2
 ;; @0043                               v24 = band v22, v23  ; v23 = -2
 ;; @0043                               brif v22, block3(v24), block2
@@ -57,14 +59,14 @@
 ;;
 ;;                                 block3(v25: i64):
 ;; @0043                               v31 = load.i32 user7 aligned readonly v25+16
-;; @0043                               v29 = load.i64 notrap aligned readonly can_move region5 v0+40
+;; @0043                               v29 = load.i64 notrap aligned readonly can_move region7 v0+40
 ;; @0043                               v30 = load.i32 notrap aligned readonly can_move v29+4
 ;; @0043                               v32 = icmp eq v31, v30
 ;; @0043                               trapz v32, user8
 ;; @0043                               v34 = load.i64 notrap aligned readonly v25+8
 ;; @0043                               v35 = load.i64 notrap aligned readonly v25+24
 ;; @0043                               v36 = call_indirect sig0, v34(v35, v0, v2)
-;; @004a                               v42 = load.i32 little region2 v8
+;; @004a                               v42 = load.i32 little region4 v8
 ;; @004d                               v44 = load.i64 notrap aligned v10+8
 ;; @004d                               v49 = load.i64 notrap aligned v10
 ;; @004d                               v45 = ireduce.i32 v44
@@ -75,7 +77,7 @@
 ;; @004d                               v52 = iadd v49, v71
 ;;                                     v72 = iconst.i64 0
 ;;                                     v73 = select_spectre_guard v46, v72, v52  ; v72 = 0
-;; @004d                               v55 = load.i64 user6 aligned region4 v73
+;; @004d                               v55 = load.i64 user6 aligned region6 v73
 ;;                                     v74 = iconst.i64 -2
 ;;                                     v75 = band v55, v74  ; v74 = -2
 ;; @004d                               brif v55, block5(v75), block4

--- a/tests/disas/globals.wat
+++ b/tests/disas/globals.wat
@@ -13,7 +13,9 @@
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     region2 = 1879048192 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(0))"
-;;     region3 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region3 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region4 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region5 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -24,9 +26,9 @@
 ;; @0029                               v3 = iconst.i32 0
 ;; @002b                               v4 = load.i32 notrap aligned region2 v0+80
 ;; @002d                               v5 = uextend.i64 v3  ; v3 = 0
-;; @002d                               v6 = load.i64 notrap aligned readonly can_move v0+56
+;; @002d                               v6 = load.i64 notrap aligned readonly can_move region3 v0+56
 ;; @002d                               v7 = iadd v6, v5
-;; @002d                               store little region3 v4, v7
+;; @002d                               store little region5 v4, v7
 ;; @0030                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/i32-load.wat
+++ b/tests/disas/i32-load.wat
@@ -11,7 +11,9 @@
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -19,9 +21,9 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @002e                               v4 = uextend.i64 v2
-;; @002e                               v5 = load.i64 notrap aligned readonly can_move v0+56
+;; @002e                               v5 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @002e                               v6 = iadd v5, v4
-;; @002e                               v7 = load.i32 little region2 v6
+;; @002e                               v7 = load.i32 little region4 v6
 ;; @0031                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/i32-load16-s.wat
+++ b/tests/disas/i32-load16-s.wat
@@ -11,7 +11,9 @@
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -19,9 +21,9 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0032                               v4 = uextend.i64 v2
-;; @0032                               v5 = load.i64 notrap aligned readonly can_move v0+56
+;; @0032                               v5 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0032                               v6 = iadd v5, v4
-;; @0032                               v7 = sload16.i32 little region2 v6
+;; @0032                               v7 = sload16.i32 little region4 v6
 ;; @0035                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/i32-load16-u.wat
+++ b/tests/disas/i32-load16-u.wat
@@ -11,7 +11,9 @@
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -19,9 +21,9 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0032                               v4 = uextend.i64 v2
-;; @0032                               v5 = load.i64 notrap aligned readonly can_move v0+56
+;; @0032                               v5 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0032                               v6 = iadd v5, v4
-;; @0032                               v7 = uload16.i32 little region2 v6
+;; @0032                               v7 = uload16.i32 little region4 v6
 ;; @0035                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/i32-load8-s.wat
+++ b/tests/disas/i32-load8-s.wat
@@ -11,7 +11,9 @@
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -19,9 +21,9 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0031                               v4 = uextend.i64 v2
-;; @0031                               v5 = load.i64 notrap aligned readonly can_move v0+56
+;; @0031                               v5 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0031                               v6 = iadd v5, v4
-;; @0031                               v7 = sload8.i32 little region2 v6
+;; @0031                               v7 = sload8.i32 little region4 v6
 ;; @0034                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/i32-load8-u.wat
+++ b/tests/disas/i32-load8-u.wat
@@ -11,7 +11,9 @@
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -19,9 +21,9 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0031                               v4 = uextend.i64 v2
-;; @0031                               v5 = load.i64 notrap aligned readonly can_move v0+56
+;; @0031                               v5 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0031                               v6 = iadd v5, v4
-;; @0031                               v7 = uload8.i32 little region2 v6
+;; @0031                               v7 = uload8.i32 little region4 v6
 ;; @0034                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/i32-store.wat
+++ b/tests/disas/i32-store.wat
@@ -12,7 +12,9 @@
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -20,9 +22,9 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0031                               v4 = uextend.i64 v2
-;; @0031                               v5 = load.i64 notrap aligned readonly can_move v0+56
+;; @0031                               v5 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0031                               v6 = iadd v5, v4
-;; @0031                               store little region2 v3, v6
+;; @0031                               store little region4 v3, v6
 ;; @0034                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/i32-store16.wat
+++ b/tests/disas/i32-store16.wat
@@ -12,7 +12,9 @@
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -20,9 +22,9 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0033                               v4 = uextend.i64 v2
-;; @0033                               v5 = load.i64 notrap aligned readonly can_move v0+56
+;; @0033                               v5 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0033                               v6 = iadd v5, v4
-;; @0033                               istore16 little region2 v3, v6
+;; @0033                               istore16 little region4 v3, v6
 ;; @0036                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/i32-store8.wat
+++ b/tests/disas/i32-store8.wat
@@ -12,7 +12,9 @@
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -20,9 +22,9 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0032                               v4 = uextend.i64 v2
-;; @0032                               v5 = load.i64 notrap aligned readonly can_move v0+56
+;; @0032                               v5 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0032                               v6 = iadd v5, v4
-;; @0032                               istore8 little region2 v3, v6
+;; @0032                               istore8 little region4 v3, v6
 ;; @0035                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/i64-load.wat
+++ b/tests/disas/i64-load.wat
@@ -11,7 +11,9 @@
 ;; function u0:0(i64 vmctx, i64, i32) -> i64 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -19,9 +21,9 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @002e                               v4 = uextend.i64 v2
-;; @002e                               v5 = load.i64 notrap aligned readonly can_move v0+56
+;; @002e                               v5 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @002e                               v6 = iadd v5, v4
-;; @002e                               v7 = load.i64 little region2 v6
+;; @002e                               v7 = load.i64 little region4 v6
 ;; @0031                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/i64-load16-s.wat
+++ b/tests/disas/i64-load16-s.wat
@@ -11,7 +11,9 @@
 ;; function u0:0(i64 vmctx, i64, i32) -> i64 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -19,9 +21,9 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0032                               v4 = uextend.i64 v2
-;; @0032                               v5 = load.i64 notrap aligned readonly can_move v0+56
+;; @0032                               v5 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0032                               v6 = iadd v5, v4
-;; @0032                               v7 = sload16.i64 little region2 v6
+;; @0032                               v7 = sload16.i64 little region4 v6
 ;; @0035                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/i64-load16-u.wat
+++ b/tests/disas/i64-load16-u.wat
@@ -11,7 +11,9 @@
 ;; function u0:0(i64 vmctx, i64, i32) -> i64 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -19,9 +21,9 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0032                               v4 = uextend.i64 v2
-;; @0032                               v5 = load.i64 notrap aligned readonly can_move v0+56
+;; @0032                               v5 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0032                               v6 = iadd v5, v4
-;; @0032                               v7 = uload16.i64 little region2 v6
+;; @0032                               v7 = uload16.i64 little region4 v6
 ;; @0035                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/i64-load8-s.wat
+++ b/tests/disas/i64-load8-s.wat
@@ -11,7 +11,9 @@
 ;; function u0:0(i64 vmctx, i64, i32) -> i64 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -19,9 +21,9 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0031                               v4 = uextend.i64 v2
-;; @0031                               v5 = load.i64 notrap aligned readonly can_move v0+56
+;; @0031                               v5 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0031                               v6 = iadd v5, v4
-;; @0031                               v7 = sload8.i64 little region2 v6
+;; @0031                               v7 = sload8.i64 little region4 v6
 ;; @0034                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/i64-load8-u.wat
+++ b/tests/disas/i64-load8-u.wat
@@ -11,7 +11,9 @@
 ;; function u0:0(i64 vmctx, i64, i32) -> i64 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -19,9 +21,9 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0031                               v4 = uextend.i64 v2
-;; @0031                               v5 = load.i64 notrap aligned readonly can_move v0+56
+;; @0031                               v5 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0031                               v6 = iadd v5, v4
-;; @0031                               v7 = uload8.i64 little region2 v6
+;; @0031                               v7 = uload8.i64 little region4 v6
 ;; @0034                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/i64-store.wat
+++ b/tests/disas/i64-store.wat
@@ -12,7 +12,9 @@
 ;; function u0:0(i64 vmctx, i64, i32, i64) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -20,9 +22,9 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i64):
 ;; @0031                               v4 = uextend.i64 v2
-;; @0031                               v5 = load.i64 notrap aligned readonly can_move v0+56
+;; @0031                               v5 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0031                               v6 = iadd v5, v4
-;; @0031                               store little region2 v3, v6
+;; @0031                               store little region4 v3, v6
 ;; @0034                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/i64-store16.wat
+++ b/tests/disas/i64-store16.wat
@@ -12,7 +12,9 @@
 ;; function u0:0(i64 vmctx, i64, i32, i64) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -20,9 +22,9 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i64):
 ;; @0033                               v4 = uextend.i64 v2
-;; @0033                               v5 = load.i64 notrap aligned readonly can_move v0+56
+;; @0033                               v5 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0033                               v6 = iadd v5, v4
-;; @0033                               istore16 little region2 v3, v6
+;; @0033                               istore16 little region4 v3, v6
 ;; @0036                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/i64-store32.wat
+++ b/tests/disas/i64-store32.wat
@@ -12,7 +12,9 @@
 ;; function u0:0(i64 vmctx, i64, i32, i64) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -20,9 +22,9 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i64):
 ;; @0033                               v4 = uextend.i64 v2
-;; @0033                               v5 = load.i64 notrap aligned readonly can_move v0+56
+;; @0033                               v5 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0033                               v6 = iadd v5, v4
-;; @0033                               istore32 little region2 v3, v6
+;; @0033                               istore32 little region4 v3, v6
 ;; @0036                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/i64-store8.wat
+++ b/tests/disas/i64-store8.wat
@@ -12,7 +12,9 @@
 ;; function u0:0(i64 vmctx, i64, i32, i64) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -20,9 +22,9 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i64):
 ;; @0032                               v4 = uextend.i64 v2
-;; @0032                               v5 = load.i64 notrap aligned readonly can_move v0+56
+;; @0032                               v5 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0032                               v6 = iadd v5, v4
-;; @0032                               istore8 little region2 v3, v6
+;; @0032                               istore8 little region4 v3, v6
 ;; @0035                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/idempotent-store.wat
+++ b/tests/disas/idempotent-store.wat
@@ -17,17 +17,19 @@
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
-;; @0029                               v5 = load.i64 notrap aligned readonly can_move v0+56
+;; @0029                               v5 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0029                               v4 = uextend.i64 v2
 ;; @0029                               v6 = iadd v5, v4
-;; @0029                               store little region2 v3, v6
+;; @0029                               store little region4 v3, v6
 ;; @0033                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/if-unreachable-else-params-2.wat
+++ b/tests/disas/if-unreachable-else-params-2.wat
@@ -22,7 +22,9 @@
 ;; function u0:0(i64 vmctx, i64, i32, i32) -> f64 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 536870912 "PublicMemory"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 536870912 "PublicMemory"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -35,9 +37,9 @@
 ;;
 ;;                                 block2:
 ;; @0058                               v7 = uextend.i64 v2
-;; @0058                               v8 = load.i64 notrap aligned readonly can_move v0+56
+;; @0058                               v8 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0058                               v9 = iadd v8, v7
-;; @0058                               v10 = sload16.i64 little region2 v9
+;; @0058                               v10 = sload16.i64 little region4 v9
 ;; @005c                               jump block3
 ;;
 ;;                                 block3:

--- a/tests/disas/if-unreachable-else-params.wat
+++ b/tests/disas/if-unreachable-else-params.wat
@@ -45,7 +45,9 @@
 ;; function u0:0(i64 vmctx, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 536870912 "PublicMemory"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 536870912 "PublicMemory"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -60,9 +62,9 @@
 ;;
 ;;                                 block4:
 ;; @004b                               v7 = uextend.i64 v3  ; v3 = 35
-;; @004b                               v8 = load.i64 notrap aligned readonly can_move v0+56
+;; @004b                               v8 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @004b                               v9 = iadd v8, v7
-;; @004b                               v10 = sload16.i64 little region2 v9
+;; @004b                               v10 = sload16.i64 little region4 v9
 ;; @004e                               trap user12
 ;;
 ;;                                 block6:

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0_offset.wat
@@ -21,7 +21,9 @@
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -29,14 +31,14 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
-;; @0040                               v5 = load.i64 notrap aligned v0+64
+;; @0040                               v5 = load.i64 notrap aligned region3 v0+64
 ;; @0040                               v6 = iconst.i64 4
 ;; @0040                               v7 = isub v5, v6  ; v6 = 4
 ;; @0040                               v8 = icmp ugt v4, v7
 ;; @0040                               trapnz v8, heap_oob
-;; @0040                               v9 = load.i64 notrap aligned can_move v0+56
+;; @0040                               v9 = load.i64 notrap aligned can_move region2 v0+56
 ;; @0040                               v10 = iadd v9, v4
-;; @0040                               store little region2 v3, v10
+;; @0040                               store little region4 v3, v10
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -46,7 +48,9 @@
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -54,14 +58,14 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0048                               v4 = uextend.i64 v2
-;; @0048                               v5 = load.i64 notrap aligned v0+64
+;; @0048                               v5 = load.i64 notrap aligned region3 v0+64
 ;; @0048                               v6 = iconst.i64 4
 ;; @0048                               v7 = isub v5, v6  ; v6 = 4
 ;; @0048                               v8 = icmp ugt v4, v7
 ;; @0048                               trapnz v8, heap_oob
-;; @0048                               v9 = load.i64 notrap aligned can_move v0+56
+;; @0048                               v9 = load.i64 notrap aligned can_move region2 v0+56
 ;; @0048                               v10 = iadd v9, v4
-;; @0048                               v11 = load.i32 little region2 v10
+;; @0048                               v11 = load.i32 little region4 v10
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -21,7 +21,9 @@
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -29,16 +31,16 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
-;; @0040                               v5 = load.i64 notrap aligned v0+64
+;; @0040                               v5 = load.i64 notrap aligned region3 v0+64
 ;; @0040                               v6 = iconst.i64 4100
 ;; @0040                               v7 = isub v5, v6  ; v6 = 4100
 ;; @0040                               v8 = icmp ugt v4, v7
 ;; @0040                               trapnz v8, heap_oob
-;; @0040                               v9 = load.i64 notrap aligned can_move v0+56
+;; @0040                               v9 = load.i64 notrap aligned can_move region2 v0+56
 ;; @0040                               v10 = iadd v9, v4
 ;; @0040                               v11 = iconst.i64 4096
 ;; @0040                               v12 = iadd v10, v11  ; v11 = 4096
-;; @0040                               store little region2 v3, v12
+;; @0040                               store little region4 v3, v12
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -48,7 +50,9 @@
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -56,16 +60,16 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0049                               v4 = uextend.i64 v2
-;; @0049                               v5 = load.i64 notrap aligned v0+64
+;; @0049                               v5 = load.i64 notrap aligned region3 v0+64
 ;; @0049                               v6 = iconst.i64 4100
 ;; @0049                               v7 = isub v5, v6  ; v6 = 4100
 ;; @0049                               v8 = icmp ugt v4, v7
 ;; @0049                               trapnz v8, heap_oob
-;; @0049                               v9 = load.i64 notrap aligned can_move v0+56
+;; @0049                               v9 = load.i64 notrap aligned can_move region2 v0+56
 ;; @0049                               v10 = iadd v9, v4
 ;; @0049                               v11 = iconst.i64 4096
 ;; @0049                               v12 = iadd v10, v11  ; v11 = 4096
-;; @0049                               v13 = load.i32 little region2 v12
+;; @0049                               v13 = load.i32 little region4 v12
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -21,7 +21,9 @@
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -31,14 +33,14 @@
 ;; @0040                               v4 = uextend.i64 v2
 ;; @0040                               v5 = iconst.i64 0xffff_0004
 ;; @0040                               v6 = uadd_overflow_trap v4, v5, heap_oob  ; v5 = 0xffff_0004
-;; @0040                               v7 = load.i64 notrap aligned v0+64
+;; @0040                               v7 = load.i64 notrap aligned region3 v0+64
 ;; @0040                               v8 = icmp ugt v6, v7
 ;; @0040                               trapnz v8, heap_oob
-;; @0040                               v9 = load.i64 notrap aligned can_move v0+56
+;; @0040                               v9 = load.i64 notrap aligned can_move region2 v0+56
 ;; @0040                               v10 = iadd v9, v4
 ;; @0040                               v11 = iconst.i64 0xffff_0000
 ;; @0040                               v12 = iadd v10, v11  ; v11 = 0xffff_0000
-;; @0040                               store little region2 v3, v12
+;; @0040                               store little region4 v3, v12
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -48,7 +50,9 @@
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -58,14 +62,14 @@
 ;; @004c                               v4 = uextend.i64 v2
 ;; @004c                               v5 = iconst.i64 0xffff_0004
 ;; @004c                               v6 = uadd_overflow_trap v4, v5, heap_oob  ; v5 = 0xffff_0004
-;; @004c                               v7 = load.i64 notrap aligned v0+64
+;; @004c                               v7 = load.i64 notrap aligned region3 v0+64
 ;; @004c                               v8 = icmp ugt v6, v7
 ;; @004c                               trapnz v8, heap_oob
-;; @004c                               v9 = load.i64 notrap aligned can_move v0+56
+;; @004c                               v9 = load.i64 notrap aligned can_move region2 v0+56
 ;; @004c                               v10 = iadd v9, v4
 ;; @004c                               v11 = iconst.i64 0xffff_0000
 ;; @004c                               v12 = iadd v10, v11  ; v11 = 0xffff_0000
-;; @004c                               v13 = load.i32 little region2 v12
+;; @004c                               v13 = load.i32 little region4 v12
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0_offset.wat
@@ -21,7 +21,9 @@
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -29,12 +31,12 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
-;; @0040                               v5 = load.i64 notrap aligned v0+64
+;; @0040                               v5 = load.i64 notrap aligned region3 v0+64
 ;; @0040                               v6 = icmp uge v4, v5
 ;; @0040                               trapnz v6, heap_oob
-;; @0040                               v7 = load.i64 notrap aligned can_move v0+56
+;; @0040                               v7 = load.i64 notrap aligned can_move region2 v0+56
 ;; @0040                               v8 = iadd v7, v4
-;; @0040                               istore8 little region2 v3, v8
+;; @0040                               istore8 little region4 v3, v8
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -44,7 +46,9 @@
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -52,12 +56,12 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0048                               v4 = uextend.i64 v2
-;; @0048                               v5 = load.i64 notrap aligned v0+64
+;; @0048                               v5 = load.i64 notrap aligned region3 v0+64
 ;; @0048                               v6 = icmp uge v4, v5
 ;; @0048                               trapnz v6, heap_oob
-;; @0048                               v7 = load.i64 notrap aligned can_move v0+56
+;; @0048                               v7 = load.i64 notrap aligned can_move region2 v0+56
 ;; @0048                               v8 = iadd v7, v4
-;; @0048                               v9 = uload8.i32 little region2 v8
+;; @0048                               v9 = uload8.i32 little region4 v8
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -21,7 +21,9 @@
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -29,16 +31,16 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
-;; @0040                               v5 = load.i64 notrap aligned v0+64
+;; @0040                               v5 = load.i64 notrap aligned region3 v0+64
 ;; @0040                               v6 = iconst.i64 4097
 ;; @0040                               v7 = isub v5, v6  ; v6 = 4097
 ;; @0040                               v8 = icmp ugt v4, v7
 ;; @0040                               trapnz v8, heap_oob
-;; @0040                               v9 = load.i64 notrap aligned can_move v0+56
+;; @0040                               v9 = load.i64 notrap aligned can_move region2 v0+56
 ;; @0040                               v10 = iadd v9, v4
 ;; @0040                               v11 = iconst.i64 4096
 ;; @0040                               v12 = iadd v10, v11  ; v11 = 4096
-;; @0040                               istore8 little region2 v3, v12
+;; @0040                               istore8 little region4 v3, v12
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -48,7 +50,9 @@
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -56,16 +60,16 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0049                               v4 = uextend.i64 v2
-;; @0049                               v5 = load.i64 notrap aligned v0+64
+;; @0049                               v5 = load.i64 notrap aligned region3 v0+64
 ;; @0049                               v6 = iconst.i64 4097
 ;; @0049                               v7 = isub v5, v6  ; v6 = 4097
 ;; @0049                               v8 = icmp ugt v4, v7
 ;; @0049                               trapnz v8, heap_oob
-;; @0049                               v9 = load.i64 notrap aligned can_move v0+56
+;; @0049                               v9 = load.i64 notrap aligned can_move region2 v0+56
 ;; @0049                               v10 = iadd v9, v4
 ;; @0049                               v11 = iconst.i64 4096
 ;; @0049                               v12 = iadd v10, v11  ; v11 = 4096
-;; @0049                               v13 = uload8.i32 little region2 v12
+;; @0049                               v13 = uload8.i32 little region4 v12
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -21,7 +21,9 @@
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -31,14 +33,14 @@
 ;; @0040                               v4 = uextend.i64 v2
 ;; @0040                               v5 = iconst.i64 0xffff_0001
 ;; @0040                               v6 = uadd_overflow_trap v4, v5, heap_oob  ; v5 = 0xffff_0001
-;; @0040                               v7 = load.i64 notrap aligned v0+64
+;; @0040                               v7 = load.i64 notrap aligned region3 v0+64
 ;; @0040                               v8 = icmp ugt v6, v7
 ;; @0040                               trapnz v8, heap_oob
-;; @0040                               v9 = load.i64 notrap aligned can_move v0+56
+;; @0040                               v9 = load.i64 notrap aligned can_move region2 v0+56
 ;; @0040                               v10 = iadd v9, v4
 ;; @0040                               v11 = iconst.i64 0xffff_0000
 ;; @0040                               v12 = iadd v10, v11  ; v11 = 0xffff_0000
-;; @0040                               istore8 little region2 v3, v12
+;; @0040                               istore8 little region4 v3, v12
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -48,7 +50,9 @@
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -58,14 +62,14 @@
 ;; @004c                               v4 = uextend.i64 v2
 ;; @004c                               v5 = iconst.i64 0xffff_0001
 ;; @004c                               v6 = uadd_overflow_trap v4, v5, heap_oob  ; v5 = 0xffff_0001
-;; @004c                               v7 = load.i64 notrap aligned v0+64
+;; @004c                               v7 = load.i64 notrap aligned region3 v0+64
 ;; @004c                               v8 = icmp ugt v6, v7
 ;; @004c                               trapnz v8, heap_oob
-;; @004c                               v9 = load.i64 notrap aligned can_move v0+56
+;; @004c                               v9 = load.i64 notrap aligned can_move region2 v0+56
 ;; @004c                               v10 = iadd v9, v4
 ;; @004c                               v11 = iconst.i64 0xffff_0000
 ;; @004c                               v12 = iadd v10, v11  ; v11 = 0xffff_0000
-;; @004c                               v13 = uload8.i32 little region2 v12
+;; @004c                               v13 = uload8.i32 little region4 v12
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0_offset.wat
@@ -21,7 +21,9 @@
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -29,15 +31,15 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
-;; @0040                               v5 = load.i64 notrap aligned v0+64
+;; @0040                               v5 = load.i64 notrap aligned region3 v0+64
 ;; @0040                               v6 = iconst.i64 4
 ;; @0040                               v7 = isub v5, v6  ; v6 = 4
 ;; @0040                               v8 = icmp ugt v4, v7
-;; @0040                               v9 = load.i64 notrap aligned can_move v0+56
+;; @0040                               v9 = load.i64 notrap aligned can_move region2 v0+56
 ;; @0040                               v10 = iadd v9, v4
 ;; @0040                               v11 = iconst.i64 0
 ;; @0040                               v12 = select_spectre_guard v8, v11, v10  ; v11 = 0
-;; @0040                               store little region2 v3, v12
+;; @0040                               store little region4 v3, v12
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -47,7 +49,9 @@
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -55,15 +59,15 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0048                               v4 = uextend.i64 v2
-;; @0048                               v5 = load.i64 notrap aligned v0+64
+;; @0048                               v5 = load.i64 notrap aligned region3 v0+64
 ;; @0048                               v6 = iconst.i64 4
 ;; @0048                               v7 = isub v5, v6  ; v6 = 4
 ;; @0048                               v8 = icmp ugt v4, v7
-;; @0048                               v9 = load.i64 notrap aligned can_move v0+56
+;; @0048                               v9 = load.i64 notrap aligned can_move region2 v0+56
 ;; @0048                               v10 = iadd v9, v4
 ;; @0048                               v11 = iconst.i64 0
 ;; @0048                               v12 = select_spectre_guard v8, v11, v10  ; v11 = 0
-;; @0048                               v13 = load.i32 little region2 v12
+;; @0048                               v13 = load.i32 little region4 v12
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -21,7 +21,9 @@
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -29,17 +31,17 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
-;; @0040                               v5 = load.i64 notrap aligned v0+64
+;; @0040                               v5 = load.i64 notrap aligned region3 v0+64
 ;; @0040                               v6 = iconst.i64 4100
 ;; @0040                               v7 = isub v5, v6  ; v6 = 4100
 ;; @0040                               v8 = icmp ugt v4, v7
-;; @0040                               v9 = load.i64 notrap aligned can_move v0+56
+;; @0040                               v9 = load.i64 notrap aligned can_move region2 v0+56
 ;; @0040                               v10 = iadd v9, v4
 ;; @0040                               v11 = iconst.i64 4096
 ;; @0040                               v12 = iadd v10, v11  ; v11 = 4096
 ;; @0040                               v13 = iconst.i64 0
 ;; @0040                               v14 = select_spectre_guard v8, v13, v12  ; v13 = 0
-;; @0040                               store little region2 v3, v14
+;; @0040                               store little region4 v3, v14
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -49,7 +51,9 @@
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -57,17 +61,17 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0049                               v4 = uextend.i64 v2
-;; @0049                               v5 = load.i64 notrap aligned v0+64
+;; @0049                               v5 = load.i64 notrap aligned region3 v0+64
 ;; @0049                               v6 = iconst.i64 4100
 ;; @0049                               v7 = isub v5, v6  ; v6 = 4100
 ;; @0049                               v8 = icmp ugt v4, v7
-;; @0049                               v9 = load.i64 notrap aligned can_move v0+56
+;; @0049                               v9 = load.i64 notrap aligned can_move region2 v0+56
 ;; @0049                               v10 = iadd v9, v4
 ;; @0049                               v11 = iconst.i64 4096
 ;; @0049                               v12 = iadd v10, v11  ; v11 = 4096
 ;; @0049                               v13 = iconst.i64 0
 ;; @0049                               v14 = select_spectre_guard v8, v13, v12  ; v13 = 0
-;; @0049                               v15 = load.i32 little region2 v14
+;; @0049                               v15 = load.i32 little region4 v14
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -21,7 +21,9 @@
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -31,15 +33,15 @@
 ;; @0040                               v4 = uextend.i64 v2
 ;; @0040                               v5 = iconst.i64 0xffff_0004
 ;; @0040                               v6 = uadd_overflow_trap v4, v5, heap_oob  ; v5 = 0xffff_0004
-;; @0040                               v7 = load.i64 notrap aligned v0+64
+;; @0040                               v7 = load.i64 notrap aligned region3 v0+64
 ;; @0040                               v8 = icmp ugt v6, v7
-;; @0040                               v9 = load.i64 notrap aligned can_move v0+56
+;; @0040                               v9 = load.i64 notrap aligned can_move region2 v0+56
 ;; @0040                               v10 = iadd v9, v4
 ;; @0040                               v11 = iconst.i64 0xffff_0000
 ;; @0040                               v12 = iadd v10, v11  ; v11 = 0xffff_0000
 ;; @0040                               v13 = iconst.i64 0
 ;; @0040                               v14 = select_spectre_guard v8, v13, v12  ; v13 = 0
-;; @0040                               store little region2 v3, v14
+;; @0040                               store little region4 v3, v14
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -49,7 +51,9 @@
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -59,15 +63,15 @@
 ;; @004c                               v4 = uextend.i64 v2
 ;; @004c                               v5 = iconst.i64 0xffff_0004
 ;; @004c                               v6 = uadd_overflow_trap v4, v5, heap_oob  ; v5 = 0xffff_0004
-;; @004c                               v7 = load.i64 notrap aligned v0+64
+;; @004c                               v7 = load.i64 notrap aligned region3 v0+64
 ;; @004c                               v8 = icmp ugt v6, v7
-;; @004c                               v9 = load.i64 notrap aligned can_move v0+56
+;; @004c                               v9 = load.i64 notrap aligned can_move region2 v0+56
 ;; @004c                               v10 = iadd v9, v4
 ;; @004c                               v11 = iconst.i64 0xffff_0000
 ;; @004c                               v12 = iadd v10, v11  ; v11 = 0xffff_0000
 ;; @004c                               v13 = iconst.i64 0
 ;; @004c                               v14 = select_spectre_guard v8, v13, v12  ; v13 = 0
-;; @004c                               v15 = load.i32 little region2 v14
+;; @004c                               v15 = load.i32 little region4 v14
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0_offset.wat
@@ -21,7 +21,9 @@
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -29,13 +31,13 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
-;; @0040                               v5 = load.i64 notrap aligned v0+64
+;; @0040                               v5 = load.i64 notrap aligned region3 v0+64
 ;; @0040                               v6 = icmp uge v4, v5
-;; @0040                               v7 = load.i64 notrap aligned can_move v0+56
+;; @0040                               v7 = load.i64 notrap aligned can_move region2 v0+56
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               v9 = iconst.i64 0
 ;; @0040                               v10 = select_spectre_guard v6, v9, v8  ; v9 = 0
-;; @0040                               istore8 little region2 v3, v10
+;; @0040                               istore8 little region4 v3, v10
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -45,7 +47,9 @@
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -53,13 +57,13 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0048                               v4 = uextend.i64 v2
-;; @0048                               v5 = load.i64 notrap aligned v0+64
+;; @0048                               v5 = load.i64 notrap aligned region3 v0+64
 ;; @0048                               v6 = icmp uge v4, v5
-;; @0048                               v7 = load.i64 notrap aligned can_move v0+56
+;; @0048                               v7 = load.i64 notrap aligned can_move region2 v0+56
 ;; @0048                               v8 = iadd v7, v4
 ;; @0048                               v9 = iconst.i64 0
 ;; @0048                               v10 = select_spectre_guard v6, v9, v8  ; v9 = 0
-;; @0048                               v11 = uload8.i32 little region2 v10
+;; @0048                               v11 = uload8.i32 little region4 v10
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -21,7 +21,9 @@
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -29,17 +31,17 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
-;; @0040                               v5 = load.i64 notrap aligned v0+64
+;; @0040                               v5 = load.i64 notrap aligned region3 v0+64
 ;; @0040                               v6 = iconst.i64 4097
 ;; @0040                               v7 = isub v5, v6  ; v6 = 4097
 ;; @0040                               v8 = icmp ugt v4, v7
-;; @0040                               v9 = load.i64 notrap aligned can_move v0+56
+;; @0040                               v9 = load.i64 notrap aligned can_move region2 v0+56
 ;; @0040                               v10 = iadd v9, v4
 ;; @0040                               v11 = iconst.i64 4096
 ;; @0040                               v12 = iadd v10, v11  ; v11 = 4096
 ;; @0040                               v13 = iconst.i64 0
 ;; @0040                               v14 = select_spectre_guard v8, v13, v12  ; v13 = 0
-;; @0040                               istore8 little region2 v3, v14
+;; @0040                               istore8 little region4 v3, v14
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -49,7 +51,9 @@
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -57,17 +61,17 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0049                               v4 = uextend.i64 v2
-;; @0049                               v5 = load.i64 notrap aligned v0+64
+;; @0049                               v5 = load.i64 notrap aligned region3 v0+64
 ;; @0049                               v6 = iconst.i64 4097
 ;; @0049                               v7 = isub v5, v6  ; v6 = 4097
 ;; @0049                               v8 = icmp ugt v4, v7
-;; @0049                               v9 = load.i64 notrap aligned can_move v0+56
+;; @0049                               v9 = load.i64 notrap aligned can_move region2 v0+56
 ;; @0049                               v10 = iadd v9, v4
 ;; @0049                               v11 = iconst.i64 4096
 ;; @0049                               v12 = iadd v10, v11  ; v11 = 4096
 ;; @0049                               v13 = iconst.i64 0
 ;; @0049                               v14 = select_spectre_guard v8, v13, v12  ; v13 = 0
-;; @0049                               v15 = uload8.i32 little region2 v14
+;; @0049                               v15 = uload8.i32 little region4 v14
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -21,7 +21,9 @@
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -31,15 +33,15 @@
 ;; @0040                               v4 = uextend.i64 v2
 ;; @0040                               v5 = iconst.i64 0xffff_0001
 ;; @0040                               v6 = uadd_overflow_trap v4, v5, heap_oob  ; v5 = 0xffff_0001
-;; @0040                               v7 = load.i64 notrap aligned v0+64
+;; @0040                               v7 = load.i64 notrap aligned region3 v0+64
 ;; @0040                               v8 = icmp ugt v6, v7
-;; @0040                               v9 = load.i64 notrap aligned can_move v0+56
+;; @0040                               v9 = load.i64 notrap aligned can_move region2 v0+56
 ;; @0040                               v10 = iadd v9, v4
 ;; @0040                               v11 = iconst.i64 0xffff_0000
 ;; @0040                               v12 = iadd v10, v11  ; v11 = 0xffff_0000
 ;; @0040                               v13 = iconst.i64 0
 ;; @0040                               v14 = select_spectre_guard v8, v13, v12  ; v13 = 0
-;; @0040                               istore8 little region2 v3, v14
+;; @0040                               istore8 little region4 v3, v14
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -49,7 +51,9 @@
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -59,15 +63,15 @@
 ;; @004c                               v4 = uextend.i64 v2
 ;; @004c                               v5 = iconst.i64 0xffff_0001
 ;; @004c                               v6 = uadd_overflow_trap v4, v5, heap_oob  ; v5 = 0xffff_0001
-;; @004c                               v7 = load.i64 notrap aligned v0+64
+;; @004c                               v7 = load.i64 notrap aligned region3 v0+64
 ;; @004c                               v8 = icmp ugt v6, v7
-;; @004c                               v9 = load.i64 notrap aligned can_move v0+56
+;; @004c                               v9 = load.i64 notrap aligned can_move region2 v0+56
 ;; @004c                               v10 = iadd v9, v4
 ;; @004c                               v11 = iconst.i64 0xffff_0000
 ;; @004c                               v12 = iadd v10, v11  ; v11 = 0xffff_0000
 ;; @004c                               v13 = iconst.i64 0
 ;; @004c                               v14 = select_spectre_guard v8, v13, v12  ; v13 = 0
-;; @004c                               v15 = uload8.i32 little region2 v14
+;; @004c                               v15 = uload8.i32 little region4 v14
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
@@ -21,7 +21,9 @@
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -29,12 +31,12 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
-;; @0040                               v5 = load.i64 notrap aligned v0+64
+;; @0040                               v5 = load.i64 notrap aligned region3 v0+64
 ;; @0040                               v6 = icmp ugt v4, v5
 ;; @0040                               trapnz v6, heap_oob
-;; @0040                               v7 = load.i64 notrap aligned can_move v0+56
+;; @0040                               v7 = load.i64 notrap aligned can_move region2 v0+56
 ;; @0040                               v8 = iadd v7, v4
-;; @0040                               store little region2 v3, v8
+;; @0040                               store little region4 v3, v8
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -44,7 +46,9 @@
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -52,12 +56,12 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0048                               v4 = uextend.i64 v2
-;; @0048                               v5 = load.i64 notrap aligned v0+64
+;; @0048                               v5 = load.i64 notrap aligned region3 v0+64
 ;; @0048                               v6 = icmp ugt v4, v5
 ;; @0048                               trapnz v6, heap_oob
-;; @0048                               v7 = load.i64 notrap aligned can_move v0+56
+;; @0048                               v7 = load.i64 notrap aligned can_move region2 v0+56
 ;; @0048                               v8 = iadd v7, v4
-;; @0048                               v9 = load.i32 little region2 v8
+;; @0048                               v9 = load.i32 little region4 v8
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -21,7 +21,9 @@
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -29,14 +31,14 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
-;; @0040                               v5 = load.i64 notrap aligned v0+64
+;; @0040                               v5 = load.i64 notrap aligned region3 v0+64
 ;; @0040                               v6 = icmp ugt v4, v5
 ;; @0040                               trapnz v6, heap_oob
-;; @0040                               v7 = load.i64 notrap aligned can_move v0+56
+;; @0040                               v7 = load.i64 notrap aligned can_move region2 v0+56
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               v9 = iconst.i64 4096
 ;; @0040                               v10 = iadd v8, v9  ; v9 = 4096
-;; @0040                               store little region2 v3, v10
+;; @0040                               store little region4 v3, v10
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -46,7 +48,9 @@
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -54,14 +58,14 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0049                               v4 = uextend.i64 v2
-;; @0049                               v5 = load.i64 notrap aligned v0+64
+;; @0049                               v5 = load.i64 notrap aligned region3 v0+64
 ;; @0049                               v6 = icmp ugt v4, v5
 ;; @0049                               trapnz v6, heap_oob
-;; @0049                               v7 = load.i64 notrap aligned can_move v0+56
+;; @0049                               v7 = load.i64 notrap aligned can_move region2 v0+56
 ;; @0049                               v8 = iadd v7, v4
 ;; @0049                               v9 = iconst.i64 4096
 ;; @0049                               v10 = iadd v8, v9  ; v9 = 4096
-;; @0049                               v11 = load.i32 little region2 v10
+;; @0049                               v11 = load.i32 little region4 v10
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -21,7 +21,9 @@
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -29,14 +31,14 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
-;; @0040                               v5 = load.i64 notrap aligned v0+64
+;; @0040                               v5 = load.i64 notrap aligned region3 v0+64
 ;; @0040                               v6 = icmp ugt v4, v5
 ;; @0040                               trapnz v6, heap_oob
-;; @0040                               v7 = load.i64 notrap aligned can_move v0+56
+;; @0040                               v7 = load.i64 notrap aligned can_move region2 v0+56
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               v9 = iconst.i64 0xffff_0000
 ;; @0040                               v10 = iadd v8, v9  ; v9 = 0xffff_0000
-;; @0040                               store little region2 v3, v10
+;; @0040                               store little region4 v3, v10
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -46,7 +48,9 @@
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -54,14 +58,14 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @004c                               v4 = uextend.i64 v2
-;; @004c                               v5 = load.i64 notrap aligned v0+64
+;; @004c                               v5 = load.i64 notrap aligned region3 v0+64
 ;; @004c                               v6 = icmp ugt v4, v5
 ;; @004c                               trapnz v6, heap_oob
-;; @004c                               v7 = load.i64 notrap aligned can_move v0+56
+;; @004c                               v7 = load.i64 notrap aligned can_move region2 v0+56
 ;; @004c                               v8 = iadd v7, v4
 ;; @004c                               v9 = iconst.i64 0xffff_0000
 ;; @004c                               v10 = iadd v8, v9  ; v9 = 0xffff_0000
-;; @004c                               v11 = load.i32 little region2 v10
+;; @004c                               v11 = load.i32 little region4 v10
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
@@ -21,7 +21,9 @@
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -29,12 +31,12 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
-;; @0040                               v5 = load.i64 notrap aligned v0+64
+;; @0040                               v5 = load.i64 notrap aligned region3 v0+64
 ;; @0040                               v6 = icmp uge v4, v5
 ;; @0040                               trapnz v6, heap_oob
-;; @0040                               v7 = load.i64 notrap aligned can_move v0+56
+;; @0040                               v7 = load.i64 notrap aligned can_move region2 v0+56
 ;; @0040                               v8 = iadd v7, v4
-;; @0040                               istore8 little region2 v3, v8
+;; @0040                               istore8 little region4 v3, v8
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -44,7 +46,9 @@
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -52,12 +56,12 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0048                               v4 = uextend.i64 v2
-;; @0048                               v5 = load.i64 notrap aligned v0+64
+;; @0048                               v5 = load.i64 notrap aligned region3 v0+64
 ;; @0048                               v6 = icmp uge v4, v5
 ;; @0048                               trapnz v6, heap_oob
-;; @0048                               v7 = load.i64 notrap aligned can_move v0+56
+;; @0048                               v7 = load.i64 notrap aligned can_move region2 v0+56
 ;; @0048                               v8 = iadd v7, v4
-;; @0048                               v9 = uload8.i32 little region2 v8
+;; @0048                               v9 = uload8.i32 little region4 v8
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -21,7 +21,9 @@
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -29,14 +31,14 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
-;; @0040                               v5 = load.i64 notrap aligned v0+64
+;; @0040                               v5 = load.i64 notrap aligned region3 v0+64
 ;; @0040                               v6 = icmp ugt v4, v5
 ;; @0040                               trapnz v6, heap_oob
-;; @0040                               v7 = load.i64 notrap aligned can_move v0+56
+;; @0040                               v7 = load.i64 notrap aligned can_move region2 v0+56
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               v9 = iconst.i64 4096
 ;; @0040                               v10 = iadd v8, v9  ; v9 = 4096
-;; @0040                               istore8 little region2 v3, v10
+;; @0040                               istore8 little region4 v3, v10
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -46,7 +48,9 @@
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -54,14 +58,14 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0049                               v4 = uextend.i64 v2
-;; @0049                               v5 = load.i64 notrap aligned v0+64
+;; @0049                               v5 = load.i64 notrap aligned region3 v0+64
 ;; @0049                               v6 = icmp ugt v4, v5
 ;; @0049                               trapnz v6, heap_oob
-;; @0049                               v7 = load.i64 notrap aligned can_move v0+56
+;; @0049                               v7 = load.i64 notrap aligned can_move region2 v0+56
 ;; @0049                               v8 = iadd v7, v4
 ;; @0049                               v9 = iconst.i64 4096
 ;; @0049                               v10 = iadd v8, v9  ; v9 = 4096
-;; @0049                               v11 = uload8.i32 little region2 v10
+;; @0049                               v11 = uload8.i32 little region4 v10
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -21,7 +21,9 @@
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -29,14 +31,14 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
-;; @0040                               v5 = load.i64 notrap aligned v0+64
+;; @0040                               v5 = load.i64 notrap aligned region3 v0+64
 ;; @0040                               v6 = icmp ugt v4, v5
 ;; @0040                               trapnz v6, heap_oob
-;; @0040                               v7 = load.i64 notrap aligned can_move v0+56
+;; @0040                               v7 = load.i64 notrap aligned can_move region2 v0+56
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               v9 = iconst.i64 0xffff_0000
 ;; @0040                               v10 = iadd v8, v9  ; v9 = 0xffff_0000
-;; @0040                               istore8 little region2 v3, v10
+;; @0040                               istore8 little region4 v3, v10
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -46,7 +48,9 @@
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -54,14 +58,14 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @004c                               v4 = uextend.i64 v2
-;; @004c                               v5 = load.i64 notrap aligned v0+64
+;; @004c                               v5 = load.i64 notrap aligned region3 v0+64
 ;; @004c                               v6 = icmp ugt v4, v5
 ;; @004c                               trapnz v6, heap_oob
-;; @004c                               v7 = load.i64 notrap aligned can_move v0+56
+;; @004c                               v7 = load.i64 notrap aligned can_move region2 v0+56
 ;; @004c                               v8 = iadd v7, v4
 ;; @004c                               v9 = iconst.i64 0xffff_0000
 ;; @004c                               v10 = iadd v8, v9  ; v9 = 0xffff_0000
-;; @004c                               v11 = uload8.i32 little region2 v10
+;; @004c                               v11 = uload8.i32 little region4 v10
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
@@ -21,7 +21,9 @@
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -29,13 +31,13 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
-;; @0040                               v5 = load.i64 notrap aligned v0+64
+;; @0040                               v5 = load.i64 notrap aligned region3 v0+64
 ;; @0040                               v6 = icmp ugt v4, v5
-;; @0040                               v7 = load.i64 notrap aligned can_move v0+56
+;; @0040                               v7 = load.i64 notrap aligned can_move region2 v0+56
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               v9 = iconst.i64 0
 ;; @0040                               v10 = select_spectre_guard v6, v9, v8  ; v9 = 0
-;; @0040                               store little region2 v3, v10
+;; @0040                               store little region4 v3, v10
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -45,7 +47,9 @@
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -53,13 +57,13 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0048                               v4 = uextend.i64 v2
-;; @0048                               v5 = load.i64 notrap aligned v0+64
+;; @0048                               v5 = load.i64 notrap aligned region3 v0+64
 ;; @0048                               v6 = icmp ugt v4, v5
-;; @0048                               v7 = load.i64 notrap aligned can_move v0+56
+;; @0048                               v7 = load.i64 notrap aligned can_move region2 v0+56
 ;; @0048                               v8 = iadd v7, v4
 ;; @0048                               v9 = iconst.i64 0
 ;; @0048                               v10 = select_spectre_guard v6, v9, v8  ; v9 = 0
-;; @0048                               v11 = load.i32 little region2 v10
+;; @0048                               v11 = load.i32 little region4 v10
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -21,7 +21,9 @@
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -29,15 +31,15 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
-;; @0040                               v5 = load.i64 notrap aligned v0+64
+;; @0040                               v5 = load.i64 notrap aligned region3 v0+64
 ;; @0040                               v6 = icmp ugt v4, v5
-;; @0040                               v7 = load.i64 notrap aligned can_move v0+56
+;; @0040                               v7 = load.i64 notrap aligned can_move region2 v0+56
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               v9 = iconst.i64 4096
 ;; @0040                               v10 = iadd v8, v9  ; v9 = 4096
 ;; @0040                               v11 = iconst.i64 0
 ;; @0040                               v12 = select_spectre_guard v6, v11, v10  ; v11 = 0
-;; @0040                               store little region2 v3, v12
+;; @0040                               store little region4 v3, v12
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -47,7 +49,9 @@
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -55,15 +59,15 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0049                               v4 = uextend.i64 v2
-;; @0049                               v5 = load.i64 notrap aligned v0+64
+;; @0049                               v5 = load.i64 notrap aligned region3 v0+64
 ;; @0049                               v6 = icmp ugt v4, v5
-;; @0049                               v7 = load.i64 notrap aligned can_move v0+56
+;; @0049                               v7 = load.i64 notrap aligned can_move region2 v0+56
 ;; @0049                               v8 = iadd v7, v4
 ;; @0049                               v9 = iconst.i64 4096
 ;; @0049                               v10 = iadd v8, v9  ; v9 = 4096
 ;; @0049                               v11 = iconst.i64 0
 ;; @0049                               v12 = select_spectre_guard v6, v11, v10  ; v11 = 0
-;; @0049                               v13 = load.i32 little region2 v12
+;; @0049                               v13 = load.i32 little region4 v12
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -21,7 +21,9 @@
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -29,15 +31,15 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
-;; @0040                               v5 = load.i64 notrap aligned v0+64
+;; @0040                               v5 = load.i64 notrap aligned region3 v0+64
 ;; @0040                               v6 = icmp ugt v4, v5
-;; @0040                               v7 = load.i64 notrap aligned can_move v0+56
+;; @0040                               v7 = load.i64 notrap aligned can_move region2 v0+56
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               v9 = iconst.i64 0xffff_0000
 ;; @0040                               v10 = iadd v8, v9  ; v9 = 0xffff_0000
 ;; @0040                               v11 = iconst.i64 0
 ;; @0040                               v12 = select_spectre_guard v6, v11, v10  ; v11 = 0
-;; @0040                               store little region2 v3, v12
+;; @0040                               store little region4 v3, v12
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -47,7 +49,9 @@
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -55,15 +59,15 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @004c                               v4 = uextend.i64 v2
-;; @004c                               v5 = load.i64 notrap aligned v0+64
+;; @004c                               v5 = load.i64 notrap aligned region3 v0+64
 ;; @004c                               v6 = icmp ugt v4, v5
-;; @004c                               v7 = load.i64 notrap aligned can_move v0+56
+;; @004c                               v7 = load.i64 notrap aligned can_move region2 v0+56
 ;; @004c                               v8 = iadd v7, v4
 ;; @004c                               v9 = iconst.i64 0xffff_0000
 ;; @004c                               v10 = iadd v8, v9  ; v9 = 0xffff_0000
 ;; @004c                               v11 = iconst.i64 0
 ;; @004c                               v12 = select_spectre_guard v6, v11, v10  ; v11 = 0
-;; @004c                               v13 = load.i32 little region2 v12
+;; @004c                               v13 = load.i32 little region4 v12
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
@@ -21,7 +21,9 @@
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -29,13 +31,13 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
-;; @0040                               v5 = load.i64 notrap aligned v0+64
+;; @0040                               v5 = load.i64 notrap aligned region3 v0+64
 ;; @0040                               v6 = icmp uge v4, v5
-;; @0040                               v7 = load.i64 notrap aligned can_move v0+56
+;; @0040                               v7 = load.i64 notrap aligned can_move region2 v0+56
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               v9 = iconst.i64 0
 ;; @0040                               v10 = select_spectre_guard v6, v9, v8  ; v9 = 0
-;; @0040                               istore8 little region2 v3, v10
+;; @0040                               istore8 little region4 v3, v10
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -45,7 +47,9 @@
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -53,13 +57,13 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0048                               v4 = uextend.i64 v2
-;; @0048                               v5 = load.i64 notrap aligned v0+64
+;; @0048                               v5 = load.i64 notrap aligned region3 v0+64
 ;; @0048                               v6 = icmp uge v4, v5
-;; @0048                               v7 = load.i64 notrap aligned can_move v0+56
+;; @0048                               v7 = load.i64 notrap aligned can_move region2 v0+56
 ;; @0048                               v8 = iadd v7, v4
 ;; @0048                               v9 = iconst.i64 0
 ;; @0048                               v10 = select_spectre_guard v6, v9, v8  ; v9 = 0
-;; @0048                               v11 = uload8.i32 little region2 v10
+;; @0048                               v11 = uload8.i32 little region4 v10
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -21,7 +21,9 @@
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -29,15 +31,15 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
-;; @0040                               v5 = load.i64 notrap aligned v0+64
+;; @0040                               v5 = load.i64 notrap aligned region3 v0+64
 ;; @0040                               v6 = icmp ugt v4, v5
-;; @0040                               v7 = load.i64 notrap aligned can_move v0+56
+;; @0040                               v7 = load.i64 notrap aligned can_move region2 v0+56
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               v9 = iconst.i64 4096
 ;; @0040                               v10 = iadd v8, v9  ; v9 = 4096
 ;; @0040                               v11 = iconst.i64 0
 ;; @0040                               v12 = select_spectre_guard v6, v11, v10  ; v11 = 0
-;; @0040                               istore8 little region2 v3, v12
+;; @0040                               istore8 little region4 v3, v12
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -47,7 +49,9 @@
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -55,15 +59,15 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0049                               v4 = uextend.i64 v2
-;; @0049                               v5 = load.i64 notrap aligned v0+64
+;; @0049                               v5 = load.i64 notrap aligned region3 v0+64
 ;; @0049                               v6 = icmp ugt v4, v5
-;; @0049                               v7 = load.i64 notrap aligned can_move v0+56
+;; @0049                               v7 = load.i64 notrap aligned can_move region2 v0+56
 ;; @0049                               v8 = iadd v7, v4
 ;; @0049                               v9 = iconst.i64 4096
 ;; @0049                               v10 = iadd v8, v9  ; v9 = 4096
 ;; @0049                               v11 = iconst.i64 0
 ;; @0049                               v12 = select_spectre_guard v6, v11, v10  ; v11 = 0
-;; @0049                               v13 = uload8.i32 little region2 v12
+;; @0049                               v13 = uload8.i32 little region4 v12
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -21,7 +21,9 @@
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -29,15 +31,15 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
-;; @0040                               v5 = load.i64 notrap aligned v0+64
+;; @0040                               v5 = load.i64 notrap aligned region3 v0+64
 ;; @0040                               v6 = icmp ugt v4, v5
-;; @0040                               v7 = load.i64 notrap aligned can_move v0+56
+;; @0040                               v7 = load.i64 notrap aligned can_move region2 v0+56
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               v9 = iconst.i64 0xffff_0000
 ;; @0040                               v10 = iadd v8, v9  ; v9 = 0xffff_0000
 ;; @0040                               v11 = iconst.i64 0
 ;; @0040                               v12 = select_spectre_guard v6, v11, v10  ; v11 = 0
-;; @0040                               istore8 little region2 v3, v12
+;; @0040                               istore8 little region4 v3, v12
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -47,7 +49,9 @@
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -55,15 +59,15 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @004c                               v4 = uextend.i64 v2
-;; @004c                               v5 = load.i64 notrap aligned v0+64
+;; @004c                               v5 = load.i64 notrap aligned region3 v0+64
 ;; @004c                               v6 = icmp ugt v4, v5
-;; @004c                               v7 = load.i64 notrap aligned can_move v0+56
+;; @004c                               v7 = load.i64 notrap aligned can_move region2 v0+56
 ;; @004c                               v8 = iadd v7, v4
 ;; @004c                               v9 = iconst.i64 0xffff_0000
 ;; @004c                               v10 = iadd v8, v9  ; v9 = 0xffff_0000
 ;; @004c                               v11 = iconst.i64 0
 ;; @004c                               v12 = select_spectre_guard v6, v11, v10  ; v11 = 0
-;; @004c                               v13 = uload8.i32 little region2 v12
+;; @004c                               v13 = uload8.i32 little region4 v12
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0_offset.wat
@@ -21,21 +21,23 @@
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
-;; @0040                               v4 = load.i64 notrap aligned v0+64
+;; @0040                               v4 = load.i64 notrap aligned region3 v0+64
 ;; @0040                               v5 = iconst.i64 4
 ;; @0040                               v6 = isub v4, v5  ; v5 = 4
 ;; @0040                               v7 = icmp ugt v2, v6
 ;; @0040                               trapnz v7, heap_oob
-;; @0040                               v8 = load.i64 notrap aligned can_move v0+56
+;; @0040                               v8 = load.i64 notrap aligned can_move region2 v0+56
 ;; @0040                               v9 = iadd v8, v2
-;; @0040                               store little region2 v3, v9
+;; @0040                               store little region4 v3, v9
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -45,21 +47,23 @@
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0048                               v4 = load.i64 notrap aligned v0+64
+;; @0048                               v4 = load.i64 notrap aligned region3 v0+64
 ;; @0048                               v5 = iconst.i64 4
 ;; @0048                               v6 = isub v4, v5  ; v5 = 4
 ;; @0048                               v7 = icmp ugt v2, v6
 ;; @0048                               trapnz v7, heap_oob
-;; @0048                               v8 = load.i64 notrap aligned can_move v0+56
+;; @0048                               v8 = load.i64 notrap aligned can_move region2 v0+56
 ;; @0048                               v9 = iadd v8, v2
-;; @0048                               v10 = load.i32 little region2 v9
+;; @0048                               v10 = load.i32 little region4 v9
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -21,23 +21,25 @@
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
-;; @0040                               v4 = load.i64 notrap aligned v0+64
+;; @0040                               v4 = load.i64 notrap aligned region3 v0+64
 ;; @0040                               v5 = iconst.i64 4100
 ;; @0040                               v6 = isub v4, v5  ; v5 = 4100
 ;; @0040                               v7 = icmp ugt v2, v6
 ;; @0040                               trapnz v7, heap_oob
-;; @0040                               v8 = load.i64 notrap aligned can_move v0+56
+;; @0040                               v8 = load.i64 notrap aligned can_move region2 v0+56
 ;; @0040                               v9 = iadd v8, v2
 ;; @0040                               v10 = iconst.i64 4096
 ;; @0040                               v11 = iadd v9, v10  ; v10 = 4096
-;; @0040                               store little region2 v3, v11
+;; @0040                               store little region4 v3, v11
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -47,23 +49,25 @@
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0049                               v4 = load.i64 notrap aligned v0+64
+;; @0049                               v4 = load.i64 notrap aligned region3 v0+64
 ;; @0049                               v5 = iconst.i64 4100
 ;; @0049                               v6 = isub v4, v5  ; v5 = 4100
 ;; @0049                               v7 = icmp ugt v2, v6
 ;; @0049                               trapnz v7, heap_oob
-;; @0049                               v8 = load.i64 notrap aligned can_move v0+56
+;; @0049                               v8 = load.i64 notrap aligned can_move region2 v0+56
 ;; @0049                               v9 = iadd v8, v2
 ;; @0049                               v10 = iconst.i64 4096
 ;; @0049                               v11 = iadd v9, v10  ; v10 = 4096
-;; @0049                               v12 = load.i32 little region2 v11
+;; @0049                               v12 = load.i32 little region4 v11
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -21,7 +21,9 @@
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -30,14 +32,14 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = iconst.i64 0xffff_0004
 ;; @0040                               v5 = uadd_overflow_trap v2, v4, heap_oob  ; v4 = 0xffff_0004
-;; @0040                               v6 = load.i64 notrap aligned v0+64
+;; @0040                               v6 = load.i64 notrap aligned region3 v0+64
 ;; @0040                               v7 = icmp ugt v5, v6
 ;; @0040                               trapnz v7, heap_oob
-;; @0040                               v8 = load.i64 notrap aligned can_move v0+56
+;; @0040                               v8 = load.i64 notrap aligned can_move region2 v0+56
 ;; @0040                               v9 = iadd v8, v2
 ;; @0040                               v10 = iconst.i64 0xffff_0000
 ;; @0040                               v11 = iadd v9, v10  ; v10 = 0xffff_0000
-;; @0040                               store little region2 v3, v11
+;; @0040                               store little region4 v3, v11
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -47,7 +49,9 @@
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -56,14 +60,14 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @004c                               v4 = iconst.i64 0xffff_0004
 ;; @004c                               v5 = uadd_overflow_trap v2, v4, heap_oob  ; v4 = 0xffff_0004
-;; @004c                               v6 = load.i64 notrap aligned v0+64
+;; @004c                               v6 = load.i64 notrap aligned region3 v0+64
 ;; @004c                               v7 = icmp ugt v5, v6
 ;; @004c                               trapnz v7, heap_oob
-;; @004c                               v8 = load.i64 notrap aligned can_move v0+56
+;; @004c                               v8 = load.i64 notrap aligned can_move region2 v0+56
 ;; @004c                               v9 = iadd v8, v2
 ;; @004c                               v10 = iconst.i64 0xffff_0000
 ;; @004c                               v11 = iadd v9, v10  ; v10 = 0xffff_0000
-;; @004c                               v12 = load.i32 little region2 v11
+;; @004c                               v12 = load.i32 little region4 v11
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0_offset.wat
@@ -21,19 +21,21 @@
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
-;; @0040                               v4 = load.i64 notrap aligned v0+64
+;; @0040                               v4 = load.i64 notrap aligned region3 v0+64
 ;; @0040                               v5 = icmp uge v2, v4
 ;; @0040                               trapnz v5, heap_oob
-;; @0040                               v6 = load.i64 notrap aligned can_move v0+56
+;; @0040                               v6 = load.i64 notrap aligned can_move region2 v0+56
 ;; @0040                               v7 = iadd v6, v2
-;; @0040                               istore8 little region2 v3, v7
+;; @0040                               istore8 little region4 v3, v7
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -43,19 +45,21 @@
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0048                               v4 = load.i64 notrap aligned v0+64
+;; @0048                               v4 = load.i64 notrap aligned region3 v0+64
 ;; @0048                               v5 = icmp uge v2, v4
 ;; @0048                               trapnz v5, heap_oob
-;; @0048                               v6 = load.i64 notrap aligned can_move v0+56
+;; @0048                               v6 = load.i64 notrap aligned can_move region2 v0+56
 ;; @0048                               v7 = iadd v6, v2
-;; @0048                               v8 = uload8.i32 little region2 v7
+;; @0048                               v8 = uload8.i32 little region4 v7
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -21,23 +21,25 @@
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
-;; @0040                               v4 = load.i64 notrap aligned v0+64
+;; @0040                               v4 = load.i64 notrap aligned region3 v0+64
 ;; @0040                               v5 = iconst.i64 4097
 ;; @0040                               v6 = isub v4, v5  ; v5 = 4097
 ;; @0040                               v7 = icmp ugt v2, v6
 ;; @0040                               trapnz v7, heap_oob
-;; @0040                               v8 = load.i64 notrap aligned can_move v0+56
+;; @0040                               v8 = load.i64 notrap aligned can_move region2 v0+56
 ;; @0040                               v9 = iadd v8, v2
 ;; @0040                               v10 = iconst.i64 4096
 ;; @0040                               v11 = iadd v9, v10  ; v10 = 4096
-;; @0040                               istore8 little region2 v3, v11
+;; @0040                               istore8 little region4 v3, v11
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -47,23 +49,25 @@
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0049                               v4 = load.i64 notrap aligned v0+64
+;; @0049                               v4 = load.i64 notrap aligned region3 v0+64
 ;; @0049                               v5 = iconst.i64 4097
 ;; @0049                               v6 = isub v4, v5  ; v5 = 4097
 ;; @0049                               v7 = icmp ugt v2, v6
 ;; @0049                               trapnz v7, heap_oob
-;; @0049                               v8 = load.i64 notrap aligned can_move v0+56
+;; @0049                               v8 = load.i64 notrap aligned can_move region2 v0+56
 ;; @0049                               v9 = iadd v8, v2
 ;; @0049                               v10 = iconst.i64 4096
 ;; @0049                               v11 = iadd v9, v10  ; v10 = 4096
-;; @0049                               v12 = uload8.i32 little region2 v11
+;; @0049                               v12 = uload8.i32 little region4 v11
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -21,7 +21,9 @@
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -30,14 +32,14 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = iconst.i64 0xffff_0001
 ;; @0040                               v5 = uadd_overflow_trap v2, v4, heap_oob  ; v4 = 0xffff_0001
-;; @0040                               v6 = load.i64 notrap aligned v0+64
+;; @0040                               v6 = load.i64 notrap aligned region3 v0+64
 ;; @0040                               v7 = icmp ugt v5, v6
 ;; @0040                               trapnz v7, heap_oob
-;; @0040                               v8 = load.i64 notrap aligned can_move v0+56
+;; @0040                               v8 = load.i64 notrap aligned can_move region2 v0+56
 ;; @0040                               v9 = iadd v8, v2
 ;; @0040                               v10 = iconst.i64 0xffff_0000
 ;; @0040                               v11 = iadd v9, v10  ; v10 = 0xffff_0000
-;; @0040                               istore8 little region2 v3, v11
+;; @0040                               istore8 little region4 v3, v11
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -47,7 +49,9 @@
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -56,14 +60,14 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @004c                               v4 = iconst.i64 0xffff_0001
 ;; @004c                               v5 = uadd_overflow_trap v2, v4, heap_oob  ; v4 = 0xffff_0001
-;; @004c                               v6 = load.i64 notrap aligned v0+64
+;; @004c                               v6 = load.i64 notrap aligned region3 v0+64
 ;; @004c                               v7 = icmp ugt v5, v6
 ;; @004c                               trapnz v7, heap_oob
-;; @004c                               v8 = load.i64 notrap aligned can_move v0+56
+;; @004c                               v8 = load.i64 notrap aligned can_move region2 v0+56
 ;; @004c                               v9 = iadd v8, v2
 ;; @004c                               v10 = iconst.i64 0xffff_0000
 ;; @004c                               v11 = iadd v9, v10  ; v10 = 0xffff_0000
-;; @004c                               v12 = uload8.i32 little region2 v11
+;; @004c                               v12 = uload8.i32 little region4 v11
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0_offset.wat
@@ -21,22 +21,24 @@
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
-;; @0040                               v4 = load.i64 notrap aligned v0+64
+;; @0040                               v4 = load.i64 notrap aligned region3 v0+64
 ;; @0040                               v5 = iconst.i64 4
 ;; @0040                               v6 = isub v4, v5  ; v5 = 4
 ;; @0040                               v7 = icmp ugt v2, v6
-;; @0040                               v8 = load.i64 notrap aligned can_move v0+56
+;; @0040                               v8 = load.i64 notrap aligned can_move region2 v0+56
 ;; @0040                               v9 = iadd v8, v2
 ;; @0040                               v10 = iconst.i64 0
 ;; @0040                               v11 = select_spectre_guard v7, v10, v9  ; v10 = 0
-;; @0040                               store little region2 v3, v11
+;; @0040                               store little region4 v3, v11
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -46,22 +48,24 @@
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0048                               v4 = load.i64 notrap aligned v0+64
+;; @0048                               v4 = load.i64 notrap aligned region3 v0+64
 ;; @0048                               v5 = iconst.i64 4
 ;; @0048                               v6 = isub v4, v5  ; v5 = 4
 ;; @0048                               v7 = icmp ugt v2, v6
-;; @0048                               v8 = load.i64 notrap aligned can_move v0+56
+;; @0048                               v8 = load.i64 notrap aligned can_move region2 v0+56
 ;; @0048                               v9 = iadd v8, v2
 ;; @0048                               v10 = iconst.i64 0
 ;; @0048                               v11 = select_spectre_guard v7, v10, v9  ; v10 = 0
-;; @0048                               v12 = load.i32 little region2 v11
+;; @0048                               v12 = load.i32 little region4 v11
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -21,24 +21,26 @@
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
-;; @0040                               v4 = load.i64 notrap aligned v0+64
+;; @0040                               v4 = load.i64 notrap aligned region3 v0+64
 ;; @0040                               v5 = iconst.i64 4100
 ;; @0040                               v6 = isub v4, v5  ; v5 = 4100
 ;; @0040                               v7 = icmp ugt v2, v6
-;; @0040                               v8 = load.i64 notrap aligned can_move v0+56
+;; @0040                               v8 = load.i64 notrap aligned can_move region2 v0+56
 ;; @0040                               v9 = iadd v8, v2
 ;; @0040                               v10 = iconst.i64 4096
 ;; @0040                               v11 = iadd v9, v10  ; v10 = 4096
 ;; @0040                               v12 = iconst.i64 0
 ;; @0040                               v13 = select_spectre_guard v7, v12, v11  ; v12 = 0
-;; @0040                               store little region2 v3, v13
+;; @0040                               store little region4 v3, v13
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -48,24 +50,26 @@
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0049                               v4 = load.i64 notrap aligned v0+64
+;; @0049                               v4 = load.i64 notrap aligned region3 v0+64
 ;; @0049                               v5 = iconst.i64 4100
 ;; @0049                               v6 = isub v4, v5  ; v5 = 4100
 ;; @0049                               v7 = icmp ugt v2, v6
-;; @0049                               v8 = load.i64 notrap aligned can_move v0+56
+;; @0049                               v8 = load.i64 notrap aligned can_move region2 v0+56
 ;; @0049                               v9 = iadd v8, v2
 ;; @0049                               v10 = iconst.i64 4096
 ;; @0049                               v11 = iadd v9, v10  ; v10 = 4096
 ;; @0049                               v12 = iconst.i64 0
 ;; @0049                               v13 = select_spectre_guard v7, v12, v11  ; v12 = 0
-;; @0049                               v14 = load.i32 little region2 v13
+;; @0049                               v14 = load.i32 little region4 v13
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -21,7 +21,9 @@
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -30,15 +32,15 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = iconst.i64 0xffff_0004
 ;; @0040                               v5 = uadd_overflow_trap v2, v4, heap_oob  ; v4 = 0xffff_0004
-;; @0040                               v6 = load.i64 notrap aligned v0+64
+;; @0040                               v6 = load.i64 notrap aligned region3 v0+64
 ;; @0040                               v7 = icmp ugt v5, v6
-;; @0040                               v8 = load.i64 notrap aligned can_move v0+56
+;; @0040                               v8 = load.i64 notrap aligned can_move region2 v0+56
 ;; @0040                               v9 = iadd v8, v2
 ;; @0040                               v10 = iconst.i64 0xffff_0000
 ;; @0040                               v11 = iadd v9, v10  ; v10 = 0xffff_0000
 ;; @0040                               v12 = iconst.i64 0
 ;; @0040                               v13 = select_spectre_guard v7, v12, v11  ; v12 = 0
-;; @0040                               store little region2 v3, v13
+;; @0040                               store little region4 v3, v13
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -48,7 +50,9 @@
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -57,15 +61,15 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @004c                               v4 = iconst.i64 0xffff_0004
 ;; @004c                               v5 = uadd_overflow_trap v2, v4, heap_oob  ; v4 = 0xffff_0004
-;; @004c                               v6 = load.i64 notrap aligned v0+64
+;; @004c                               v6 = load.i64 notrap aligned region3 v0+64
 ;; @004c                               v7 = icmp ugt v5, v6
-;; @004c                               v8 = load.i64 notrap aligned can_move v0+56
+;; @004c                               v8 = load.i64 notrap aligned can_move region2 v0+56
 ;; @004c                               v9 = iadd v8, v2
 ;; @004c                               v10 = iconst.i64 0xffff_0000
 ;; @004c                               v11 = iadd v9, v10  ; v10 = 0xffff_0000
 ;; @004c                               v12 = iconst.i64 0
 ;; @004c                               v13 = select_spectre_guard v7, v12, v11  ; v12 = 0
-;; @004c                               v14 = load.i32 little region2 v13
+;; @004c                               v14 = load.i32 little region4 v13
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0_offset.wat
@@ -21,20 +21,22 @@
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
-;; @0040                               v4 = load.i64 notrap aligned v0+64
+;; @0040                               v4 = load.i64 notrap aligned region3 v0+64
 ;; @0040                               v5 = icmp uge v2, v4
-;; @0040                               v6 = load.i64 notrap aligned can_move v0+56
+;; @0040                               v6 = load.i64 notrap aligned can_move region2 v0+56
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 0
 ;; @0040                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0
-;; @0040                               istore8 little region2 v3, v9
+;; @0040                               istore8 little region4 v3, v9
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -44,20 +46,22 @@
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0048                               v4 = load.i64 notrap aligned v0+64
+;; @0048                               v4 = load.i64 notrap aligned region3 v0+64
 ;; @0048                               v5 = icmp uge v2, v4
-;; @0048                               v6 = load.i64 notrap aligned can_move v0+56
+;; @0048                               v6 = load.i64 notrap aligned can_move region2 v0+56
 ;; @0048                               v7 = iadd v6, v2
 ;; @0048                               v8 = iconst.i64 0
 ;; @0048                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0
-;; @0048                               v10 = uload8.i32 little region2 v9
+;; @0048                               v10 = uload8.i32 little region4 v9
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -21,24 +21,26 @@
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
-;; @0040                               v4 = load.i64 notrap aligned v0+64
+;; @0040                               v4 = load.i64 notrap aligned region3 v0+64
 ;; @0040                               v5 = iconst.i64 4097
 ;; @0040                               v6 = isub v4, v5  ; v5 = 4097
 ;; @0040                               v7 = icmp ugt v2, v6
-;; @0040                               v8 = load.i64 notrap aligned can_move v0+56
+;; @0040                               v8 = load.i64 notrap aligned can_move region2 v0+56
 ;; @0040                               v9 = iadd v8, v2
 ;; @0040                               v10 = iconst.i64 4096
 ;; @0040                               v11 = iadd v9, v10  ; v10 = 4096
 ;; @0040                               v12 = iconst.i64 0
 ;; @0040                               v13 = select_spectre_guard v7, v12, v11  ; v12 = 0
-;; @0040                               istore8 little region2 v3, v13
+;; @0040                               istore8 little region4 v3, v13
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -48,24 +50,26 @@
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0049                               v4 = load.i64 notrap aligned v0+64
+;; @0049                               v4 = load.i64 notrap aligned region3 v0+64
 ;; @0049                               v5 = iconst.i64 4097
 ;; @0049                               v6 = isub v4, v5  ; v5 = 4097
 ;; @0049                               v7 = icmp ugt v2, v6
-;; @0049                               v8 = load.i64 notrap aligned can_move v0+56
+;; @0049                               v8 = load.i64 notrap aligned can_move region2 v0+56
 ;; @0049                               v9 = iadd v8, v2
 ;; @0049                               v10 = iconst.i64 4096
 ;; @0049                               v11 = iadd v9, v10  ; v10 = 4096
 ;; @0049                               v12 = iconst.i64 0
 ;; @0049                               v13 = select_spectre_guard v7, v12, v11  ; v12 = 0
-;; @0049                               v14 = uload8.i32 little region2 v13
+;; @0049                               v14 = uload8.i32 little region4 v13
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -21,7 +21,9 @@
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -30,15 +32,15 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = iconst.i64 0xffff_0001
 ;; @0040                               v5 = uadd_overflow_trap v2, v4, heap_oob  ; v4 = 0xffff_0001
-;; @0040                               v6 = load.i64 notrap aligned v0+64
+;; @0040                               v6 = load.i64 notrap aligned region3 v0+64
 ;; @0040                               v7 = icmp ugt v5, v6
-;; @0040                               v8 = load.i64 notrap aligned can_move v0+56
+;; @0040                               v8 = load.i64 notrap aligned can_move region2 v0+56
 ;; @0040                               v9 = iadd v8, v2
 ;; @0040                               v10 = iconst.i64 0xffff_0000
 ;; @0040                               v11 = iadd v9, v10  ; v10 = 0xffff_0000
 ;; @0040                               v12 = iconst.i64 0
 ;; @0040                               v13 = select_spectre_guard v7, v12, v11  ; v12 = 0
-;; @0040                               istore8 little region2 v3, v13
+;; @0040                               istore8 little region4 v3, v13
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -48,7 +50,9 @@
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -57,15 +61,15 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @004c                               v4 = iconst.i64 0xffff_0001
 ;; @004c                               v5 = uadd_overflow_trap v2, v4, heap_oob  ; v4 = 0xffff_0001
-;; @004c                               v6 = load.i64 notrap aligned v0+64
+;; @004c                               v6 = load.i64 notrap aligned region3 v0+64
 ;; @004c                               v7 = icmp ugt v5, v6
-;; @004c                               v8 = load.i64 notrap aligned can_move v0+56
+;; @004c                               v8 = load.i64 notrap aligned can_move region2 v0+56
 ;; @004c                               v9 = iadd v8, v2
 ;; @004c                               v10 = iconst.i64 0xffff_0000
 ;; @004c                               v11 = iadd v9, v10  ; v10 = 0xffff_0000
 ;; @004c                               v12 = iconst.i64 0
 ;; @004c                               v13 = select_spectre_guard v7, v12, v11  ; v12 = 0
-;; @004c                               v14 = uload8.i32 little region2 v13
+;; @004c                               v14 = uload8.i32 little region4 v13
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
@@ -21,19 +21,21 @@
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
-;; @0040                               v4 = load.i64 notrap aligned v0+64
+;; @0040                               v4 = load.i64 notrap aligned region3 v0+64
 ;; @0040                               v5 = icmp ugt v2, v4
 ;; @0040                               trapnz v5, heap_oob
-;; @0040                               v6 = load.i64 notrap aligned can_move v0+56
+;; @0040                               v6 = load.i64 notrap aligned can_move region2 v0+56
 ;; @0040                               v7 = iadd v6, v2
-;; @0040                               store little region2 v3, v7
+;; @0040                               store little region4 v3, v7
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -43,19 +45,21 @@
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0048                               v4 = load.i64 notrap aligned v0+64
+;; @0048                               v4 = load.i64 notrap aligned region3 v0+64
 ;; @0048                               v5 = icmp ugt v2, v4
 ;; @0048                               trapnz v5, heap_oob
-;; @0048                               v6 = load.i64 notrap aligned can_move v0+56
+;; @0048                               v6 = load.i64 notrap aligned can_move region2 v0+56
 ;; @0048                               v7 = iadd v6, v2
-;; @0048                               v8 = load.i32 little region2 v7
+;; @0048                               v8 = load.i32 little region4 v7
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -21,21 +21,23 @@
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
-;; @0040                               v4 = load.i64 notrap aligned v0+64
+;; @0040                               v4 = load.i64 notrap aligned region3 v0+64
 ;; @0040                               v5 = icmp ugt v2, v4
 ;; @0040                               trapnz v5, heap_oob
-;; @0040                               v6 = load.i64 notrap aligned can_move v0+56
+;; @0040                               v6 = load.i64 notrap aligned can_move region2 v0+56
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 4096
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 4096
-;; @0040                               store little region2 v3, v9
+;; @0040                               store little region4 v3, v9
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -45,21 +47,23 @@
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0049                               v4 = load.i64 notrap aligned v0+64
+;; @0049                               v4 = load.i64 notrap aligned region3 v0+64
 ;; @0049                               v5 = icmp ugt v2, v4
 ;; @0049                               trapnz v5, heap_oob
-;; @0049                               v6 = load.i64 notrap aligned can_move v0+56
+;; @0049                               v6 = load.i64 notrap aligned can_move region2 v0+56
 ;; @0049                               v7 = iadd v6, v2
 ;; @0049                               v8 = iconst.i64 4096
 ;; @0049                               v9 = iadd v7, v8  ; v8 = 4096
-;; @0049                               v10 = load.i32 little region2 v9
+;; @0049                               v10 = load.i32 little region4 v9
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -21,21 +21,23 @@
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
-;; @0040                               v4 = load.i64 notrap aligned v0+64
+;; @0040                               v4 = load.i64 notrap aligned region3 v0+64
 ;; @0040                               v5 = icmp ugt v2, v4
 ;; @0040                               trapnz v5, heap_oob
-;; @0040                               v6 = load.i64 notrap aligned can_move v0+56
+;; @0040                               v6 = load.i64 notrap aligned can_move region2 v0+56
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 0xffff_0000
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
-;; @0040                               store little region2 v3, v9
+;; @0040                               store little region4 v3, v9
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -45,21 +47,23 @@
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @004c                               v4 = load.i64 notrap aligned v0+64
+;; @004c                               v4 = load.i64 notrap aligned region3 v0+64
 ;; @004c                               v5 = icmp ugt v2, v4
 ;; @004c                               trapnz v5, heap_oob
-;; @004c                               v6 = load.i64 notrap aligned can_move v0+56
+;; @004c                               v6 = load.i64 notrap aligned can_move region2 v0+56
 ;; @004c                               v7 = iadd v6, v2
 ;; @004c                               v8 = iconst.i64 0xffff_0000
 ;; @004c                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
-;; @004c                               v10 = load.i32 little region2 v9
+;; @004c                               v10 = load.i32 little region4 v9
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
@@ -21,19 +21,21 @@
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
-;; @0040                               v4 = load.i64 notrap aligned v0+64
+;; @0040                               v4 = load.i64 notrap aligned region3 v0+64
 ;; @0040                               v5 = icmp uge v2, v4
 ;; @0040                               trapnz v5, heap_oob
-;; @0040                               v6 = load.i64 notrap aligned can_move v0+56
+;; @0040                               v6 = load.i64 notrap aligned can_move region2 v0+56
 ;; @0040                               v7 = iadd v6, v2
-;; @0040                               istore8 little region2 v3, v7
+;; @0040                               istore8 little region4 v3, v7
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -43,19 +45,21 @@
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0048                               v4 = load.i64 notrap aligned v0+64
+;; @0048                               v4 = load.i64 notrap aligned region3 v0+64
 ;; @0048                               v5 = icmp uge v2, v4
 ;; @0048                               trapnz v5, heap_oob
-;; @0048                               v6 = load.i64 notrap aligned can_move v0+56
+;; @0048                               v6 = load.i64 notrap aligned can_move region2 v0+56
 ;; @0048                               v7 = iadd v6, v2
-;; @0048                               v8 = uload8.i32 little region2 v7
+;; @0048                               v8 = uload8.i32 little region4 v7
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -21,21 +21,23 @@
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
-;; @0040                               v4 = load.i64 notrap aligned v0+64
+;; @0040                               v4 = load.i64 notrap aligned region3 v0+64
 ;; @0040                               v5 = icmp ugt v2, v4
 ;; @0040                               trapnz v5, heap_oob
-;; @0040                               v6 = load.i64 notrap aligned can_move v0+56
+;; @0040                               v6 = load.i64 notrap aligned can_move region2 v0+56
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 4096
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 4096
-;; @0040                               istore8 little region2 v3, v9
+;; @0040                               istore8 little region4 v3, v9
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -45,21 +47,23 @@
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0049                               v4 = load.i64 notrap aligned v0+64
+;; @0049                               v4 = load.i64 notrap aligned region3 v0+64
 ;; @0049                               v5 = icmp ugt v2, v4
 ;; @0049                               trapnz v5, heap_oob
-;; @0049                               v6 = load.i64 notrap aligned can_move v0+56
+;; @0049                               v6 = load.i64 notrap aligned can_move region2 v0+56
 ;; @0049                               v7 = iadd v6, v2
 ;; @0049                               v8 = iconst.i64 4096
 ;; @0049                               v9 = iadd v7, v8  ; v8 = 4096
-;; @0049                               v10 = uload8.i32 little region2 v9
+;; @0049                               v10 = uload8.i32 little region4 v9
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -21,21 +21,23 @@
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
-;; @0040                               v4 = load.i64 notrap aligned v0+64
+;; @0040                               v4 = load.i64 notrap aligned region3 v0+64
 ;; @0040                               v5 = icmp ugt v2, v4
 ;; @0040                               trapnz v5, heap_oob
-;; @0040                               v6 = load.i64 notrap aligned can_move v0+56
+;; @0040                               v6 = load.i64 notrap aligned can_move region2 v0+56
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 0xffff_0000
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
-;; @0040                               istore8 little region2 v3, v9
+;; @0040                               istore8 little region4 v3, v9
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -45,21 +47,23 @@
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @004c                               v4 = load.i64 notrap aligned v0+64
+;; @004c                               v4 = load.i64 notrap aligned region3 v0+64
 ;; @004c                               v5 = icmp ugt v2, v4
 ;; @004c                               trapnz v5, heap_oob
-;; @004c                               v6 = load.i64 notrap aligned can_move v0+56
+;; @004c                               v6 = load.i64 notrap aligned can_move region2 v0+56
 ;; @004c                               v7 = iadd v6, v2
 ;; @004c                               v8 = iconst.i64 0xffff_0000
 ;; @004c                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
-;; @004c                               v10 = uload8.i32 little region2 v9
+;; @004c                               v10 = uload8.i32 little region4 v9
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
@@ -21,20 +21,22 @@
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
-;; @0040                               v4 = load.i64 notrap aligned v0+64
+;; @0040                               v4 = load.i64 notrap aligned region3 v0+64
 ;; @0040                               v5 = icmp ugt v2, v4
-;; @0040                               v6 = load.i64 notrap aligned can_move v0+56
+;; @0040                               v6 = load.i64 notrap aligned can_move region2 v0+56
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 0
 ;; @0040                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0
-;; @0040                               store little region2 v3, v9
+;; @0040                               store little region4 v3, v9
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -44,20 +46,22 @@
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0048                               v4 = load.i64 notrap aligned v0+64
+;; @0048                               v4 = load.i64 notrap aligned region3 v0+64
 ;; @0048                               v5 = icmp ugt v2, v4
-;; @0048                               v6 = load.i64 notrap aligned can_move v0+56
+;; @0048                               v6 = load.i64 notrap aligned can_move region2 v0+56
 ;; @0048                               v7 = iadd v6, v2
 ;; @0048                               v8 = iconst.i64 0
 ;; @0048                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0
-;; @0048                               v10 = load.i32 little region2 v9
+;; @0048                               v10 = load.i32 little region4 v9
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -21,22 +21,24 @@
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
-;; @0040                               v4 = load.i64 notrap aligned v0+64
+;; @0040                               v4 = load.i64 notrap aligned region3 v0+64
 ;; @0040                               v5 = icmp ugt v2, v4
-;; @0040                               v6 = load.i64 notrap aligned can_move v0+56
+;; @0040                               v6 = load.i64 notrap aligned can_move region2 v0+56
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 4096
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 4096
 ;; @0040                               v10 = iconst.i64 0
 ;; @0040                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
-;; @0040                               store little region2 v3, v11
+;; @0040                               store little region4 v3, v11
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -46,22 +48,24 @@
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0049                               v4 = load.i64 notrap aligned v0+64
+;; @0049                               v4 = load.i64 notrap aligned region3 v0+64
 ;; @0049                               v5 = icmp ugt v2, v4
-;; @0049                               v6 = load.i64 notrap aligned can_move v0+56
+;; @0049                               v6 = load.i64 notrap aligned can_move region2 v0+56
 ;; @0049                               v7 = iadd v6, v2
 ;; @0049                               v8 = iconst.i64 4096
 ;; @0049                               v9 = iadd v7, v8  ; v8 = 4096
 ;; @0049                               v10 = iconst.i64 0
 ;; @0049                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
-;; @0049                               v12 = load.i32 little region2 v11
+;; @0049                               v12 = load.i32 little region4 v11
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -21,22 +21,24 @@
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
-;; @0040                               v4 = load.i64 notrap aligned v0+64
+;; @0040                               v4 = load.i64 notrap aligned region3 v0+64
 ;; @0040                               v5 = icmp ugt v2, v4
-;; @0040                               v6 = load.i64 notrap aligned can_move v0+56
+;; @0040                               v6 = load.i64 notrap aligned can_move region2 v0+56
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 0xffff_0000
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
 ;; @0040                               v10 = iconst.i64 0
 ;; @0040                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
-;; @0040                               store little region2 v3, v11
+;; @0040                               store little region4 v3, v11
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -46,22 +48,24 @@
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @004c                               v4 = load.i64 notrap aligned v0+64
+;; @004c                               v4 = load.i64 notrap aligned region3 v0+64
 ;; @004c                               v5 = icmp ugt v2, v4
-;; @004c                               v6 = load.i64 notrap aligned can_move v0+56
+;; @004c                               v6 = load.i64 notrap aligned can_move region2 v0+56
 ;; @004c                               v7 = iadd v6, v2
 ;; @004c                               v8 = iconst.i64 0xffff_0000
 ;; @004c                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
 ;; @004c                               v10 = iconst.i64 0
 ;; @004c                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
-;; @004c                               v12 = load.i32 little region2 v11
+;; @004c                               v12 = load.i32 little region4 v11
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
@@ -21,20 +21,22 @@
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
-;; @0040                               v4 = load.i64 notrap aligned v0+64
+;; @0040                               v4 = load.i64 notrap aligned region3 v0+64
 ;; @0040                               v5 = icmp uge v2, v4
-;; @0040                               v6 = load.i64 notrap aligned can_move v0+56
+;; @0040                               v6 = load.i64 notrap aligned can_move region2 v0+56
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 0
 ;; @0040                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0
-;; @0040                               istore8 little region2 v3, v9
+;; @0040                               istore8 little region4 v3, v9
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -44,20 +46,22 @@
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0048                               v4 = load.i64 notrap aligned v0+64
+;; @0048                               v4 = load.i64 notrap aligned region3 v0+64
 ;; @0048                               v5 = icmp uge v2, v4
-;; @0048                               v6 = load.i64 notrap aligned can_move v0+56
+;; @0048                               v6 = load.i64 notrap aligned can_move region2 v0+56
 ;; @0048                               v7 = iadd v6, v2
 ;; @0048                               v8 = iconst.i64 0
 ;; @0048                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0
-;; @0048                               v10 = uload8.i32 little region2 v9
+;; @0048                               v10 = uload8.i32 little region4 v9
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -21,22 +21,24 @@
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
-;; @0040                               v4 = load.i64 notrap aligned v0+64
+;; @0040                               v4 = load.i64 notrap aligned region3 v0+64
 ;; @0040                               v5 = icmp ugt v2, v4
-;; @0040                               v6 = load.i64 notrap aligned can_move v0+56
+;; @0040                               v6 = load.i64 notrap aligned can_move region2 v0+56
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 4096
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 4096
 ;; @0040                               v10 = iconst.i64 0
 ;; @0040                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
-;; @0040                               istore8 little region2 v3, v11
+;; @0040                               istore8 little region4 v3, v11
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -46,22 +48,24 @@
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0049                               v4 = load.i64 notrap aligned v0+64
+;; @0049                               v4 = load.i64 notrap aligned region3 v0+64
 ;; @0049                               v5 = icmp ugt v2, v4
-;; @0049                               v6 = load.i64 notrap aligned can_move v0+56
+;; @0049                               v6 = load.i64 notrap aligned can_move region2 v0+56
 ;; @0049                               v7 = iadd v6, v2
 ;; @0049                               v8 = iconst.i64 4096
 ;; @0049                               v9 = iadd v7, v8  ; v8 = 4096
 ;; @0049                               v10 = iconst.i64 0
 ;; @0049                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
-;; @0049                               v12 = uload8.i32 little region2 v11
+;; @0049                               v12 = uload8.i32 little region4 v11
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -21,22 +21,24 @@
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
-;; @0040                               v4 = load.i64 notrap aligned v0+64
+;; @0040                               v4 = load.i64 notrap aligned region3 v0+64
 ;; @0040                               v5 = icmp ugt v2, v4
-;; @0040                               v6 = load.i64 notrap aligned can_move v0+56
+;; @0040                               v6 = load.i64 notrap aligned can_move region2 v0+56
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 0xffff_0000
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
 ;; @0040                               v10 = iconst.i64 0
 ;; @0040                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
-;; @0040                               istore8 little region2 v3, v11
+;; @0040                               istore8 little region4 v3, v11
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -46,22 +48,24 @@
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @004c                               v4 = load.i64 notrap aligned v0+64
+;; @004c                               v4 = load.i64 notrap aligned region3 v0+64
 ;; @004c                               v5 = icmp ugt v2, v4
-;; @004c                               v6 = load.i64 notrap aligned can_move v0+56
+;; @004c                               v6 = load.i64 notrap aligned can_move region2 v0+56
 ;; @004c                               v7 = iadd v6, v2
 ;; @004c                               v8 = iconst.i64 0xffff_0000
 ;; @004c                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
 ;; @004c                               v10 = iconst.i64 0
 ;; @004c                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
-;; @004c                               v12 = uload8.i32 little region2 v11
+;; @004c                               v12 = uload8.i32 little region4 v11
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0_offset.wat
@@ -21,7 +21,9 @@
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -32,9 +34,9 @@
 ;; @0040                               v5 = iconst.i64 0xffff_fffc
 ;; @0040                               v6 = icmp ugt v4, v5  ; v5 = 0xffff_fffc
 ;; @0040                               trapnz v6, heap_oob
-;; @0040                               v7 = load.i64 notrap aligned readonly can_move v0+56
+;; @0040                               v7 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0040                               v8 = iadd v7, v4
-;; @0040                               store little region2 v3, v8
+;; @0040                               store little region4 v3, v8
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -44,7 +46,9 @@
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -55,9 +59,9 @@
 ;; @0048                               v5 = iconst.i64 0xffff_fffc
 ;; @0048                               v6 = icmp ugt v4, v5  ; v5 = 0xffff_fffc
 ;; @0048                               trapnz v6, heap_oob
-;; @0048                               v7 = load.i64 notrap aligned readonly can_move v0+56
+;; @0048                               v7 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0048                               v8 = iadd v7, v4
-;; @0048                               v9 = load.i32 little region2 v8
+;; @0048                               v9 = load.i32 little region4 v8
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -21,7 +21,9 @@
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -32,11 +34,11 @@
 ;; @0040                               v5 = iconst.i64 0xffff_effc
 ;; @0040                               v6 = icmp ugt v4, v5  ; v5 = 0xffff_effc
 ;; @0040                               trapnz v6, heap_oob
-;; @0040                               v7 = load.i64 notrap aligned readonly can_move v0+56
+;; @0040                               v7 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               v9 = iconst.i64 4096
 ;; @0040                               v10 = iadd v8, v9  ; v9 = 4096
-;; @0040                               store little region2 v3, v10
+;; @0040                               store little region4 v3, v10
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -46,7 +48,9 @@
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -57,11 +61,11 @@
 ;; @0049                               v5 = iconst.i64 0xffff_effc
 ;; @0049                               v6 = icmp ugt v4, v5  ; v5 = 0xffff_effc
 ;; @0049                               trapnz v6, heap_oob
-;; @0049                               v7 = load.i64 notrap aligned readonly can_move v0+56
+;; @0049                               v7 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0049                               v8 = iadd v7, v4
 ;; @0049                               v9 = iconst.i64 4096
 ;; @0049                               v10 = iadd v8, v9  ; v9 = 4096
-;; @0049                               v11 = load.i32 little region2 v10
+;; @0049                               v11 = load.i32 little region4 v10
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -21,7 +21,9 @@
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -32,11 +34,11 @@
 ;; @0040                               v5 = iconst.i64 0xfffc
 ;; @0040                               v6 = icmp ugt v4, v5  ; v5 = 0xfffc
 ;; @0040                               trapnz v6, heap_oob
-;; @0040                               v7 = load.i64 notrap aligned readonly can_move v0+56
+;; @0040                               v7 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               v9 = iconst.i64 0xffff_0000
 ;; @0040                               v10 = iadd v8, v9  ; v9 = 0xffff_0000
-;; @0040                               store little region2 v3, v10
+;; @0040                               store little region4 v3, v10
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -46,7 +48,9 @@
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -57,11 +61,11 @@
 ;; @004c                               v5 = iconst.i64 0xfffc
 ;; @004c                               v6 = icmp ugt v4, v5  ; v5 = 0xfffc
 ;; @004c                               trapnz v6, heap_oob
-;; @004c                               v7 = load.i64 notrap aligned readonly can_move v0+56
+;; @004c                               v7 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @004c                               v8 = iadd v7, v4
 ;; @004c                               v9 = iconst.i64 0xffff_0000
 ;; @004c                               v10 = iadd v8, v9  ; v9 = 0xffff_0000
-;; @004c                               v11 = load.i32 little region2 v10
+;; @004c                               v11 = load.i32 little region4 v10
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0_offset.wat
@@ -21,7 +21,9 @@
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -29,9 +31,9 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
-;; @0040                               v5 = load.i64 notrap aligned readonly can_move v0+56
+;; @0040                               v5 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0040                               v6 = iadd v5, v4
-;; @0040                               istore8 little region2 v3, v6
+;; @0040                               istore8 little region4 v3, v6
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -41,7 +43,9 @@
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -49,9 +53,9 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0048                               v4 = uextend.i64 v2
-;; @0048                               v5 = load.i64 notrap aligned readonly can_move v0+56
+;; @0048                               v5 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0048                               v6 = iadd v5, v4
-;; @0048                               v7 = uload8.i32 little region2 v6
+;; @0048                               v7 = uload8.i32 little region4 v6
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -21,7 +21,9 @@
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -32,11 +34,11 @@
 ;; @0040                               v5 = iconst.i64 0xffff_efff
 ;; @0040                               v6 = icmp ugt v4, v5  ; v5 = 0xffff_efff
 ;; @0040                               trapnz v6, heap_oob
-;; @0040                               v7 = load.i64 notrap aligned readonly can_move v0+56
+;; @0040                               v7 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               v9 = iconst.i64 4096
 ;; @0040                               v10 = iadd v8, v9  ; v9 = 4096
-;; @0040                               istore8 little region2 v3, v10
+;; @0040                               istore8 little region4 v3, v10
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -46,7 +48,9 @@
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -57,11 +61,11 @@
 ;; @0049                               v5 = iconst.i64 0xffff_efff
 ;; @0049                               v6 = icmp ugt v4, v5  ; v5 = 0xffff_efff
 ;; @0049                               trapnz v6, heap_oob
-;; @0049                               v7 = load.i64 notrap aligned readonly can_move v0+56
+;; @0049                               v7 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0049                               v8 = iadd v7, v4
 ;; @0049                               v9 = iconst.i64 4096
 ;; @0049                               v10 = iadd v8, v9  ; v9 = 4096
-;; @0049                               v11 = uload8.i32 little region2 v10
+;; @0049                               v11 = uload8.i32 little region4 v10
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -21,7 +21,9 @@
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -32,11 +34,11 @@
 ;; @0040                               v5 = iconst.i64 0xffff
 ;; @0040                               v6 = icmp ugt v4, v5  ; v5 = 0xffff
 ;; @0040                               trapnz v6, heap_oob
-;; @0040                               v7 = load.i64 notrap aligned readonly can_move v0+56
+;; @0040                               v7 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               v9 = iconst.i64 0xffff_0000
 ;; @0040                               v10 = iadd v8, v9  ; v9 = 0xffff_0000
-;; @0040                               istore8 little region2 v3, v10
+;; @0040                               istore8 little region4 v3, v10
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -46,7 +48,9 @@
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -57,11 +61,11 @@
 ;; @004c                               v5 = iconst.i64 0xffff
 ;; @004c                               v6 = icmp ugt v4, v5  ; v5 = 0xffff
 ;; @004c                               trapnz v6, heap_oob
-;; @004c                               v7 = load.i64 notrap aligned readonly can_move v0+56
+;; @004c                               v7 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @004c                               v8 = iadd v7, v4
 ;; @004c                               v9 = iconst.i64 0xffff_0000
 ;; @004c                               v10 = iadd v8, v9  ; v9 = 0xffff_0000
-;; @004c                               v11 = uload8.i32 little region2 v10
+;; @004c                               v11 = uload8.i32 little region4 v10
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0_offset.wat
@@ -21,7 +21,9 @@
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -31,11 +33,11 @@
 ;; @0040                               v4 = uextend.i64 v2
 ;; @0040                               v5 = iconst.i64 0xffff_fffc
 ;; @0040                               v6 = icmp ugt v4, v5  ; v5 = 0xffff_fffc
-;; @0040                               v7 = load.i64 notrap aligned readonly can_move v0+56
+;; @0040                               v7 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               v9 = iconst.i64 0
 ;; @0040                               v10 = select_spectre_guard v6, v9, v8  ; v9 = 0
-;; @0040                               store little region2 v3, v10
+;; @0040                               store little region4 v3, v10
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -45,7 +47,9 @@
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -55,11 +59,11 @@
 ;; @0048                               v4 = uextend.i64 v2
 ;; @0048                               v5 = iconst.i64 0xffff_fffc
 ;; @0048                               v6 = icmp ugt v4, v5  ; v5 = 0xffff_fffc
-;; @0048                               v7 = load.i64 notrap aligned readonly can_move v0+56
+;; @0048                               v7 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0048                               v8 = iadd v7, v4
 ;; @0048                               v9 = iconst.i64 0
 ;; @0048                               v10 = select_spectre_guard v6, v9, v8  ; v9 = 0
-;; @0048                               v11 = load.i32 little region2 v10
+;; @0048                               v11 = load.i32 little region4 v10
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -21,7 +21,9 @@
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -31,13 +33,13 @@
 ;; @0040                               v4 = uextend.i64 v2
 ;; @0040                               v5 = iconst.i64 0xffff_effc
 ;; @0040                               v6 = icmp ugt v4, v5  ; v5 = 0xffff_effc
-;; @0040                               v7 = load.i64 notrap aligned readonly can_move v0+56
+;; @0040                               v7 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               v9 = iconst.i64 4096
 ;; @0040                               v10 = iadd v8, v9  ; v9 = 4096
 ;; @0040                               v11 = iconst.i64 0
 ;; @0040                               v12 = select_spectre_guard v6, v11, v10  ; v11 = 0
-;; @0040                               store little region2 v3, v12
+;; @0040                               store little region4 v3, v12
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -47,7 +49,9 @@
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -57,13 +61,13 @@
 ;; @0049                               v4 = uextend.i64 v2
 ;; @0049                               v5 = iconst.i64 0xffff_effc
 ;; @0049                               v6 = icmp ugt v4, v5  ; v5 = 0xffff_effc
-;; @0049                               v7 = load.i64 notrap aligned readonly can_move v0+56
+;; @0049                               v7 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0049                               v8 = iadd v7, v4
 ;; @0049                               v9 = iconst.i64 4096
 ;; @0049                               v10 = iadd v8, v9  ; v9 = 4096
 ;; @0049                               v11 = iconst.i64 0
 ;; @0049                               v12 = select_spectre_guard v6, v11, v10  ; v11 = 0
-;; @0049                               v13 = load.i32 little region2 v12
+;; @0049                               v13 = load.i32 little region4 v12
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -21,7 +21,9 @@
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -31,13 +33,13 @@
 ;; @0040                               v4 = uextend.i64 v2
 ;; @0040                               v5 = iconst.i64 0xfffc
 ;; @0040                               v6 = icmp ugt v4, v5  ; v5 = 0xfffc
-;; @0040                               v7 = load.i64 notrap aligned readonly can_move v0+56
+;; @0040                               v7 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               v9 = iconst.i64 0xffff_0000
 ;; @0040                               v10 = iadd v8, v9  ; v9 = 0xffff_0000
 ;; @0040                               v11 = iconst.i64 0
 ;; @0040                               v12 = select_spectre_guard v6, v11, v10  ; v11 = 0
-;; @0040                               store little region2 v3, v12
+;; @0040                               store little region4 v3, v12
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -47,7 +49,9 @@
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -57,13 +61,13 @@
 ;; @004c                               v4 = uextend.i64 v2
 ;; @004c                               v5 = iconst.i64 0xfffc
 ;; @004c                               v6 = icmp ugt v4, v5  ; v5 = 0xfffc
-;; @004c                               v7 = load.i64 notrap aligned readonly can_move v0+56
+;; @004c                               v7 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @004c                               v8 = iadd v7, v4
 ;; @004c                               v9 = iconst.i64 0xffff_0000
 ;; @004c                               v10 = iadd v8, v9  ; v9 = 0xffff_0000
 ;; @004c                               v11 = iconst.i64 0
 ;; @004c                               v12 = select_spectre_guard v6, v11, v10  ; v11 = 0
-;; @004c                               v13 = load.i32 little region2 v12
+;; @004c                               v13 = load.i32 little region4 v12
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i8_access_0_offset.wat
@@ -21,7 +21,9 @@
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -29,9 +31,9 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
-;; @0040                               v5 = load.i64 notrap aligned readonly can_move v0+56
+;; @0040                               v5 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0040                               v6 = iadd v5, v4
-;; @0040                               istore8 little region2 v3, v6
+;; @0040                               istore8 little region4 v3, v6
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -41,7 +43,9 @@
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -49,9 +53,9 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0048                               v4 = uextend.i64 v2
-;; @0048                               v5 = load.i64 notrap aligned readonly can_move v0+56
+;; @0048                               v5 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0048                               v6 = iadd v5, v4
-;; @0048                               v7 = uload8.i32 little region2 v6
+;; @0048                               v7 = uload8.i32 little region4 v6
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -21,7 +21,9 @@
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -31,13 +33,13 @@
 ;; @0040                               v4 = uextend.i64 v2
 ;; @0040                               v5 = iconst.i64 0xffff_efff
 ;; @0040                               v6 = icmp ugt v4, v5  ; v5 = 0xffff_efff
-;; @0040                               v7 = load.i64 notrap aligned readonly can_move v0+56
+;; @0040                               v7 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               v9 = iconst.i64 4096
 ;; @0040                               v10 = iadd v8, v9  ; v9 = 4096
 ;; @0040                               v11 = iconst.i64 0
 ;; @0040                               v12 = select_spectre_guard v6, v11, v10  ; v11 = 0
-;; @0040                               istore8 little region2 v3, v12
+;; @0040                               istore8 little region4 v3, v12
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -47,7 +49,9 @@
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -57,13 +61,13 @@
 ;; @0049                               v4 = uextend.i64 v2
 ;; @0049                               v5 = iconst.i64 0xffff_efff
 ;; @0049                               v6 = icmp ugt v4, v5  ; v5 = 0xffff_efff
-;; @0049                               v7 = load.i64 notrap aligned readonly can_move v0+56
+;; @0049                               v7 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0049                               v8 = iadd v7, v4
 ;; @0049                               v9 = iconst.i64 4096
 ;; @0049                               v10 = iadd v8, v9  ; v9 = 4096
 ;; @0049                               v11 = iconst.i64 0
 ;; @0049                               v12 = select_spectre_guard v6, v11, v10  ; v11 = 0
-;; @0049                               v13 = uload8.i32 little region2 v12
+;; @0049                               v13 = uload8.i32 little region4 v12
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -21,7 +21,9 @@
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -31,13 +33,13 @@
 ;; @0040                               v4 = uextend.i64 v2
 ;; @0040                               v5 = iconst.i64 0xffff
 ;; @0040                               v6 = icmp ugt v4, v5  ; v5 = 0xffff
-;; @0040                               v7 = load.i64 notrap aligned readonly can_move v0+56
+;; @0040                               v7 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               v9 = iconst.i64 0xffff_0000
 ;; @0040                               v10 = iadd v8, v9  ; v9 = 0xffff_0000
 ;; @0040                               v11 = iconst.i64 0
 ;; @0040                               v12 = select_spectre_guard v6, v11, v10  ; v11 = 0
-;; @0040                               istore8 little region2 v3, v12
+;; @0040                               istore8 little region4 v3, v12
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -47,7 +49,9 @@
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -57,13 +61,13 @@
 ;; @004c                               v4 = uextend.i64 v2
 ;; @004c                               v5 = iconst.i64 0xffff
 ;; @004c                               v6 = icmp ugt v4, v5  ; v5 = 0xffff
-;; @004c                               v7 = load.i64 notrap aligned readonly can_move v0+56
+;; @004c                               v7 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @004c                               v8 = iadd v7, v4
 ;; @004c                               v9 = iconst.i64 0xffff_0000
 ;; @004c                               v10 = iadd v8, v9  ; v9 = 0xffff_0000
 ;; @004c                               v11 = iconst.i64 0
 ;; @004c                               v12 = select_spectre_guard v6, v11, v10  ; v11 = 0
-;; @004c                               v13 = uload8.i32 little region2 v12
+;; @004c                               v13 = uload8.i32 little region4 v12
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
@@ -21,7 +21,9 @@
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -29,9 +31,9 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
-;; @0040                               v5 = load.i64 notrap aligned readonly can_move v0+56
+;; @0040                               v5 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0040                               v6 = iadd v5, v4
-;; @0040                               store little region2 v3, v6
+;; @0040                               store little region4 v3, v6
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -41,7 +43,9 @@
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -49,9 +53,9 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0048                               v4 = uextend.i64 v2
-;; @0048                               v5 = load.i64 notrap aligned readonly can_move v0+56
+;; @0048                               v5 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0048                               v6 = iadd v5, v4
-;; @0048                               v7 = load.i32 little region2 v6
+;; @0048                               v7 = load.i32 little region4 v6
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -21,7 +21,9 @@
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -29,11 +31,11 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
-;; @0040                               v5 = load.i64 notrap aligned readonly can_move v0+56
+;; @0040                               v5 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0040                               v6 = iadd v5, v4
 ;; @0040                               v7 = iconst.i64 4096
 ;; @0040                               v8 = iadd v6, v7  ; v7 = 4096
-;; @0040                               store little region2 v3, v8
+;; @0040                               store little region4 v3, v8
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -43,7 +45,9 @@
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -51,11 +55,11 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0049                               v4 = uextend.i64 v2
-;; @0049                               v5 = load.i64 notrap aligned readonly can_move v0+56
+;; @0049                               v5 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0049                               v6 = iadd v5, v4
 ;; @0049                               v7 = iconst.i64 4096
 ;; @0049                               v8 = iadd v6, v7  ; v7 = 4096
-;; @0049                               v9 = load.i32 little region2 v8
+;; @0049                               v9 = load.i32 little region4 v8
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -21,7 +21,9 @@
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -29,11 +31,11 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
-;; @0040                               v5 = load.i64 notrap aligned readonly can_move v0+56
+;; @0040                               v5 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0040                               v6 = iadd v5, v4
 ;; @0040                               v7 = iconst.i64 0xffff_0000
 ;; @0040                               v8 = iadd v6, v7  ; v7 = 0xffff_0000
-;; @0040                               store little region2 v3, v8
+;; @0040                               store little region4 v3, v8
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -43,7 +45,9 @@
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -51,11 +55,11 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @004c                               v4 = uextend.i64 v2
-;; @004c                               v5 = load.i64 notrap aligned readonly can_move v0+56
+;; @004c                               v5 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @004c                               v6 = iadd v5, v4
 ;; @004c                               v7 = iconst.i64 0xffff_0000
 ;; @004c                               v8 = iadd v6, v7  ; v7 = 0xffff_0000
-;; @004c                               v9 = load.i32 little region2 v8
+;; @004c                               v9 = load.i32 little region4 v8
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
@@ -21,7 +21,9 @@
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -29,9 +31,9 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
-;; @0040                               v5 = load.i64 notrap aligned readonly can_move v0+56
+;; @0040                               v5 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0040                               v6 = iadd v5, v4
-;; @0040                               istore8 little region2 v3, v6
+;; @0040                               istore8 little region4 v3, v6
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -41,7 +43,9 @@
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -49,9 +53,9 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0048                               v4 = uextend.i64 v2
-;; @0048                               v5 = load.i64 notrap aligned readonly can_move v0+56
+;; @0048                               v5 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0048                               v6 = iadd v5, v4
-;; @0048                               v7 = uload8.i32 little region2 v6
+;; @0048                               v7 = uload8.i32 little region4 v6
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -21,7 +21,9 @@
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -29,11 +31,11 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
-;; @0040                               v5 = load.i64 notrap aligned readonly can_move v0+56
+;; @0040                               v5 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0040                               v6 = iadd v5, v4
 ;; @0040                               v7 = iconst.i64 4096
 ;; @0040                               v8 = iadd v6, v7  ; v7 = 4096
-;; @0040                               istore8 little region2 v3, v8
+;; @0040                               istore8 little region4 v3, v8
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -43,7 +45,9 @@
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -51,11 +55,11 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0049                               v4 = uextend.i64 v2
-;; @0049                               v5 = load.i64 notrap aligned readonly can_move v0+56
+;; @0049                               v5 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0049                               v6 = iadd v5, v4
 ;; @0049                               v7 = iconst.i64 4096
 ;; @0049                               v8 = iadd v6, v7  ; v7 = 4096
-;; @0049                               v9 = uload8.i32 little region2 v8
+;; @0049                               v9 = uload8.i32 little region4 v8
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -21,7 +21,9 @@
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -29,11 +31,11 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
-;; @0040                               v5 = load.i64 notrap aligned readonly can_move v0+56
+;; @0040                               v5 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0040                               v6 = iadd v5, v4
 ;; @0040                               v7 = iconst.i64 0xffff_0000
 ;; @0040                               v8 = iadd v6, v7  ; v7 = 0xffff_0000
-;; @0040                               istore8 little region2 v3, v8
+;; @0040                               istore8 little region4 v3, v8
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -43,7 +45,9 @@
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -51,11 +55,11 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @004c                               v4 = uextend.i64 v2
-;; @004c                               v5 = load.i64 notrap aligned readonly can_move v0+56
+;; @004c                               v5 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @004c                               v6 = iadd v5, v4
 ;; @004c                               v7 = iconst.i64 0xffff_0000
 ;; @004c                               v8 = iadd v6, v7  ; v7 = 0xffff_0000
-;; @004c                               v9 = uload8.i32 little region2 v8
+;; @004c                               v9 = uload8.i32 little region4 v8
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
@@ -21,7 +21,9 @@
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -29,9 +31,9 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
-;; @0040                               v5 = load.i64 notrap aligned readonly can_move v0+56
+;; @0040                               v5 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0040                               v6 = iadd v5, v4
-;; @0040                               store little region2 v3, v6
+;; @0040                               store little region4 v3, v6
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -41,7 +43,9 @@
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -49,9 +53,9 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0048                               v4 = uextend.i64 v2
-;; @0048                               v5 = load.i64 notrap aligned readonly can_move v0+56
+;; @0048                               v5 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0048                               v6 = iadd v5, v4
-;; @0048                               v7 = load.i32 little region2 v6
+;; @0048                               v7 = load.i32 little region4 v6
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -21,7 +21,9 @@
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -29,11 +31,11 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
-;; @0040                               v5 = load.i64 notrap aligned readonly can_move v0+56
+;; @0040                               v5 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0040                               v6 = iadd v5, v4
 ;; @0040                               v7 = iconst.i64 4096
 ;; @0040                               v8 = iadd v6, v7  ; v7 = 4096
-;; @0040                               store little region2 v3, v8
+;; @0040                               store little region4 v3, v8
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -43,7 +45,9 @@
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -51,11 +55,11 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0049                               v4 = uextend.i64 v2
-;; @0049                               v5 = load.i64 notrap aligned readonly can_move v0+56
+;; @0049                               v5 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0049                               v6 = iadd v5, v4
 ;; @0049                               v7 = iconst.i64 4096
 ;; @0049                               v8 = iadd v6, v7  ; v7 = 4096
-;; @0049                               v9 = load.i32 little region2 v8
+;; @0049                               v9 = load.i32 little region4 v8
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -21,7 +21,9 @@
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -29,11 +31,11 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
-;; @0040                               v5 = load.i64 notrap aligned readonly can_move v0+56
+;; @0040                               v5 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0040                               v6 = iadd v5, v4
 ;; @0040                               v7 = iconst.i64 0xffff_0000
 ;; @0040                               v8 = iadd v6, v7  ; v7 = 0xffff_0000
-;; @0040                               store little region2 v3, v8
+;; @0040                               store little region4 v3, v8
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -43,7 +45,9 @@
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -51,11 +55,11 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @004c                               v4 = uextend.i64 v2
-;; @004c                               v5 = load.i64 notrap aligned readonly can_move v0+56
+;; @004c                               v5 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @004c                               v6 = iadd v5, v4
 ;; @004c                               v7 = iconst.i64 0xffff_0000
 ;; @004c                               v8 = iadd v6, v7  ; v7 = 0xffff_0000
-;; @004c                               v9 = load.i32 little region2 v8
+;; @004c                               v9 = load.i32 little region4 v8
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
@@ -21,7 +21,9 @@
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -29,9 +31,9 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
-;; @0040                               v5 = load.i64 notrap aligned readonly can_move v0+56
+;; @0040                               v5 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0040                               v6 = iadd v5, v4
-;; @0040                               istore8 little region2 v3, v6
+;; @0040                               istore8 little region4 v3, v6
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -41,7 +43,9 @@
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -49,9 +53,9 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0048                               v4 = uextend.i64 v2
-;; @0048                               v5 = load.i64 notrap aligned readonly can_move v0+56
+;; @0048                               v5 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0048                               v6 = iadd v5, v4
-;; @0048                               v7 = uload8.i32 little region2 v6
+;; @0048                               v7 = uload8.i32 little region4 v6
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -21,7 +21,9 @@
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -29,11 +31,11 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
-;; @0040                               v5 = load.i64 notrap aligned readonly can_move v0+56
+;; @0040                               v5 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0040                               v6 = iadd v5, v4
 ;; @0040                               v7 = iconst.i64 4096
 ;; @0040                               v8 = iadd v6, v7  ; v7 = 4096
-;; @0040                               istore8 little region2 v3, v8
+;; @0040                               istore8 little region4 v3, v8
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -43,7 +45,9 @@
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -51,11 +55,11 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0049                               v4 = uextend.i64 v2
-;; @0049                               v5 = load.i64 notrap aligned readonly can_move v0+56
+;; @0049                               v5 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0049                               v6 = iadd v5, v4
 ;; @0049                               v7 = iconst.i64 4096
 ;; @0049                               v8 = iadd v6, v7  ; v7 = 4096
-;; @0049                               v9 = uload8.i32 little region2 v8
+;; @0049                               v9 = uload8.i32 little region4 v8
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -21,7 +21,9 @@
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -29,11 +31,11 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
-;; @0040                               v5 = load.i64 notrap aligned readonly can_move v0+56
+;; @0040                               v5 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0040                               v6 = iadd v5, v4
 ;; @0040                               v7 = iconst.i64 0xffff_0000
 ;; @0040                               v8 = iadd v6, v7  ; v7 = 0xffff_0000
-;; @0040                               istore8 little region2 v3, v8
+;; @0040                               istore8 little region4 v3, v8
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -43,7 +45,9 @@
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -51,11 +55,11 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @004c                               v4 = uextend.i64 v2
-;; @004c                               v5 = load.i64 notrap aligned readonly can_move v0+56
+;; @004c                               v5 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @004c                               v6 = iadd v5, v4
 ;; @004c                               v7 = iconst.i64 0xffff_0000
 ;; @004c                               v8 = iadd v6, v7  ; v7 = 0xffff_0000
-;; @004c                               v9 = uload8.i32 little region2 v8
+;; @004c                               v9 = uload8.i32 little region4 v8
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0_offset.wat
@@ -21,7 +21,9 @@
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -31,9 +33,9 @@
 ;; @0040                               v4 = iconst.i64 0xffff_fffc
 ;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_fffc
 ;; @0040                               trapnz v5, heap_oob
-;; @0040                               v6 = load.i64 notrap aligned readonly can_move v0+56
+;; @0040                               v6 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0040                               v7 = iadd v6, v2
-;; @0040                               store little region2 v3, v7
+;; @0040                               store little region4 v3, v7
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -43,7 +45,9 @@
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -53,9 +57,9 @@
 ;; @0048                               v4 = iconst.i64 0xffff_fffc
 ;; @0048                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_fffc
 ;; @0048                               trapnz v5, heap_oob
-;; @0048                               v6 = load.i64 notrap aligned readonly can_move v0+56
+;; @0048                               v6 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0048                               v7 = iadd v6, v2
-;; @0048                               v8 = load.i32 little region2 v7
+;; @0048                               v8 = load.i32 little region4 v7
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -21,7 +21,9 @@
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -31,11 +33,11 @@
 ;; @0040                               v4 = iconst.i64 0xffff_effc
 ;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_effc
 ;; @0040                               trapnz v5, heap_oob
-;; @0040                               v6 = load.i64 notrap aligned readonly can_move v0+56
+;; @0040                               v6 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 4096
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 4096
-;; @0040                               store little region2 v3, v9
+;; @0040                               store little region4 v3, v9
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -45,7 +47,9 @@
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -55,11 +59,11 @@
 ;; @0049                               v4 = iconst.i64 0xffff_effc
 ;; @0049                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_effc
 ;; @0049                               trapnz v5, heap_oob
-;; @0049                               v6 = load.i64 notrap aligned readonly can_move v0+56
+;; @0049                               v6 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0049                               v7 = iadd v6, v2
 ;; @0049                               v8 = iconst.i64 4096
 ;; @0049                               v9 = iadd v7, v8  ; v8 = 4096
-;; @0049                               v10 = load.i32 little region2 v9
+;; @0049                               v10 = load.i32 little region4 v9
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -21,7 +21,9 @@
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -31,11 +33,11 @@
 ;; @0040                               v4 = iconst.i64 0xfffc
 ;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xfffc
 ;; @0040                               trapnz v5, heap_oob
-;; @0040                               v6 = load.i64 notrap aligned readonly can_move v0+56
+;; @0040                               v6 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 0xffff_0000
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
-;; @0040                               store little region2 v3, v9
+;; @0040                               store little region4 v3, v9
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -45,7 +47,9 @@
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -55,11 +59,11 @@
 ;; @004c                               v4 = iconst.i64 0xfffc
 ;; @004c                               v5 = icmp ugt v2, v4  ; v4 = 0xfffc
 ;; @004c                               trapnz v5, heap_oob
-;; @004c                               v6 = load.i64 notrap aligned readonly can_move v0+56
+;; @004c                               v6 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @004c                               v7 = iadd v6, v2
 ;; @004c                               v8 = iconst.i64 0xffff_0000
 ;; @004c                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
-;; @004c                               v10 = load.i32 little region2 v9
+;; @004c                               v10 = load.i32 little region4 v9
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0_offset.wat
@@ -21,7 +21,9 @@
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -31,9 +33,9 @@
 ;; @0040                               v4 = iconst.i64 0xffff_ffff
 ;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_ffff
 ;; @0040                               trapnz v5, heap_oob
-;; @0040                               v6 = load.i64 notrap aligned readonly can_move v0+56
+;; @0040                               v6 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0040                               v7 = iadd v6, v2
-;; @0040                               istore8 little region2 v3, v7
+;; @0040                               istore8 little region4 v3, v7
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -43,7 +45,9 @@
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -53,9 +57,9 @@
 ;; @0048                               v4 = iconst.i64 0xffff_ffff
 ;; @0048                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_ffff
 ;; @0048                               trapnz v5, heap_oob
-;; @0048                               v6 = load.i64 notrap aligned readonly can_move v0+56
+;; @0048                               v6 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0048                               v7 = iadd v6, v2
-;; @0048                               v8 = uload8.i32 little region2 v7
+;; @0048                               v8 = uload8.i32 little region4 v7
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -21,7 +21,9 @@
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -31,11 +33,11 @@
 ;; @0040                               v4 = iconst.i64 0xffff_efff
 ;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_efff
 ;; @0040                               trapnz v5, heap_oob
-;; @0040                               v6 = load.i64 notrap aligned readonly can_move v0+56
+;; @0040                               v6 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 4096
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 4096
-;; @0040                               istore8 little region2 v3, v9
+;; @0040                               istore8 little region4 v3, v9
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -45,7 +47,9 @@
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -55,11 +59,11 @@
 ;; @0049                               v4 = iconst.i64 0xffff_efff
 ;; @0049                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_efff
 ;; @0049                               trapnz v5, heap_oob
-;; @0049                               v6 = load.i64 notrap aligned readonly can_move v0+56
+;; @0049                               v6 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0049                               v7 = iadd v6, v2
 ;; @0049                               v8 = iconst.i64 4096
 ;; @0049                               v9 = iadd v7, v8  ; v8 = 4096
-;; @0049                               v10 = uload8.i32 little region2 v9
+;; @0049                               v10 = uload8.i32 little region4 v9
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -21,7 +21,9 @@
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -31,11 +33,11 @@
 ;; @0040                               v4 = iconst.i64 0xffff
 ;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xffff
 ;; @0040                               trapnz v5, heap_oob
-;; @0040                               v6 = load.i64 notrap aligned readonly can_move v0+56
+;; @0040                               v6 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 0xffff_0000
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
-;; @0040                               istore8 little region2 v3, v9
+;; @0040                               istore8 little region4 v3, v9
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -45,7 +47,9 @@
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -55,11 +59,11 @@
 ;; @004c                               v4 = iconst.i64 0xffff
 ;; @004c                               v5 = icmp ugt v2, v4  ; v4 = 0xffff
 ;; @004c                               trapnz v5, heap_oob
-;; @004c                               v6 = load.i64 notrap aligned readonly can_move v0+56
+;; @004c                               v6 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @004c                               v7 = iadd v6, v2
 ;; @004c                               v8 = iconst.i64 0xffff_0000
 ;; @004c                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
-;; @004c                               v10 = uload8.i32 little region2 v9
+;; @004c                               v10 = uload8.i32 little region4 v9
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0_offset.wat
@@ -21,7 +21,9 @@
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -30,11 +32,11 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = iconst.i64 0xffff_fffc
 ;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_fffc
-;; @0040                               v6 = load.i64 notrap aligned readonly can_move v0+56
+;; @0040                               v6 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 0
 ;; @0040                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0
-;; @0040                               store little region2 v3, v9
+;; @0040                               store little region4 v3, v9
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -44,7 +46,9 @@
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -53,11 +57,11 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @0048                               v4 = iconst.i64 0xffff_fffc
 ;; @0048                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_fffc
-;; @0048                               v6 = load.i64 notrap aligned readonly can_move v0+56
+;; @0048                               v6 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0048                               v7 = iadd v6, v2
 ;; @0048                               v8 = iconst.i64 0
 ;; @0048                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0
-;; @0048                               v10 = load.i32 little region2 v9
+;; @0048                               v10 = load.i32 little region4 v9
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -21,7 +21,9 @@
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -30,13 +32,13 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = iconst.i64 0xffff_effc
 ;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_effc
-;; @0040                               v6 = load.i64 notrap aligned readonly can_move v0+56
+;; @0040                               v6 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 4096
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 4096
 ;; @0040                               v10 = iconst.i64 0
 ;; @0040                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
-;; @0040                               store little region2 v3, v11
+;; @0040                               store little region4 v3, v11
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -46,7 +48,9 @@
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -55,13 +59,13 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @0049                               v4 = iconst.i64 0xffff_effc
 ;; @0049                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_effc
-;; @0049                               v6 = load.i64 notrap aligned readonly can_move v0+56
+;; @0049                               v6 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0049                               v7 = iadd v6, v2
 ;; @0049                               v8 = iconst.i64 4096
 ;; @0049                               v9 = iadd v7, v8  ; v8 = 4096
 ;; @0049                               v10 = iconst.i64 0
 ;; @0049                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
-;; @0049                               v12 = load.i32 little region2 v11
+;; @0049                               v12 = load.i32 little region4 v11
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -21,7 +21,9 @@
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -30,13 +32,13 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = iconst.i64 0xfffc
 ;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xfffc
-;; @0040                               v6 = load.i64 notrap aligned readonly can_move v0+56
+;; @0040                               v6 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 0xffff_0000
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
 ;; @0040                               v10 = iconst.i64 0
 ;; @0040                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
-;; @0040                               store little region2 v3, v11
+;; @0040                               store little region4 v3, v11
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -46,7 +48,9 @@
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -55,13 +59,13 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @004c                               v4 = iconst.i64 0xfffc
 ;; @004c                               v5 = icmp ugt v2, v4  ; v4 = 0xfffc
-;; @004c                               v6 = load.i64 notrap aligned readonly can_move v0+56
+;; @004c                               v6 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @004c                               v7 = iadd v6, v2
 ;; @004c                               v8 = iconst.i64 0xffff_0000
 ;; @004c                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
 ;; @004c                               v10 = iconst.i64 0
 ;; @004c                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
-;; @004c                               v12 = load.i32 little region2 v11
+;; @004c                               v12 = load.i32 little region4 v11
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0_offset.wat
@@ -21,7 +21,9 @@
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -30,11 +32,11 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = iconst.i64 0xffff_ffff
 ;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_ffff
-;; @0040                               v6 = load.i64 notrap aligned readonly can_move v0+56
+;; @0040                               v6 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 0
 ;; @0040                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0
-;; @0040                               istore8 little region2 v3, v9
+;; @0040                               istore8 little region4 v3, v9
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -44,7 +46,9 @@
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -53,11 +57,11 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @0048                               v4 = iconst.i64 0xffff_ffff
 ;; @0048                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_ffff
-;; @0048                               v6 = load.i64 notrap aligned readonly can_move v0+56
+;; @0048                               v6 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0048                               v7 = iadd v6, v2
 ;; @0048                               v8 = iconst.i64 0
 ;; @0048                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0
-;; @0048                               v10 = uload8.i32 little region2 v9
+;; @0048                               v10 = uload8.i32 little region4 v9
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -21,7 +21,9 @@
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -30,13 +32,13 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = iconst.i64 0xffff_efff
 ;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_efff
-;; @0040                               v6 = load.i64 notrap aligned readonly can_move v0+56
+;; @0040                               v6 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 4096
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 4096
 ;; @0040                               v10 = iconst.i64 0
 ;; @0040                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
-;; @0040                               istore8 little region2 v3, v11
+;; @0040                               istore8 little region4 v3, v11
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -46,7 +48,9 @@
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -55,13 +59,13 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @0049                               v4 = iconst.i64 0xffff_efff
 ;; @0049                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_efff
-;; @0049                               v6 = load.i64 notrap aligned readonly can_move v0+56
+;; @0049                               v6 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0049                               v7 = iadd v6, v2
 ;; @0049                               v8 = iconst.i64 4096
 ;; @0049                               v9 = iadd v7, v8  ; v8 = 4096
 ;; @0049                               v10 = iconst.i64 0
 ;; @0049                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
-;; @0049                               v12 = uload8.i32 little region2 v11
+;; @0049                               v12 = uload8.i32 little region4 v11
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -21,7 +21,9 @@
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -30,13 +32,13 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = iconst.i64 0xffff
 ;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xffff
-;; @0040                               v6 = load.i64 notrap aligned readonly can_move v0+56
+;; @0040                               v6 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 0xffff_0000
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
 ;; @0040                               v10 = iconst.i64 0
 ;; @0040                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
-;; @0040                               istore8 little region2 v3, v11
+;; @0040                               istore8 little region4 v3, v11
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -46,7 +48,9 @@
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -55,13 +59,13 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @004c                               v4 = iconst.i64 0xffff
 ;; @004c                               v5 = icmp ugt v2, v4  ; v4 = 0xffff
-;; @004c                               v6 = load.i64 notrap aligned readonly can_move v0+56
+;; @004c                               v6 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @004c                               v7 = iadd v6, v2
 ;; @004c                               v8 = iconst.i64 0xffff_0000
 ;; @004c                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
 ;; @004c                               v10 = iconst.i64 0
 ;; @004c                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
-;; @004c                               v12 = uload8.i32 little region2 v11
+;; @004c                               v12 = uload8.i32 little region4 v11
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
@@ -21,7 +21,9 @@
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -31,9 +33,9 @@
 ;; @0040                               v4 = iconst.i64 0xffff_fffc
 ;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_fffc
 ;; @0040                               trapnz v5, heap_oob
-;; @0040                               v6 = load.i64 notrap aligned readonly can_move v0+56
+;; @0040                               v6 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0040                               v7 = iadd v6, v2
-;; @0040                               store little region2 v3, v7
+;; @0040                               store little region4 v3, v7
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -43,7 +45,9 @@
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -53,9 +57,9 @@
 ;; @0048                               v4 = iconst.i64 0xffff_fffc
 ;; @0048                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_fffc
 ;; @0048                               trapnz v5, heap_oob
-;; @0048                               v6 = load.i64 notrap aligned readonly can_move v0+56
+;; @0048                               v6 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0048                               v7 = iadd v6, v2
-;; @0048                               v8 = load.i32 little region2 v7
+;; @0048                               v8 = load.i32 little region4 v7
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -21,7 +21,9 @@
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -31,11 +33,11 @@
 ;; @0040                               v4 = iconst.i64 0xffff_effc
 ;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_effc
 ;; @0040                               trapnz v5, heap_oob
-;; @0040                               v6 = load.i64 notrap aligned readonly can_move v0+56
+;; @0040                               v6 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 4096
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 4096
-;; @0040                               store little region2 v3, v9
+;; @0040                               store little region4 v3, v9
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -45,7 +47,9 @@
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -55,11 +59,11 @@
 ;; @0049                               v4 = iconst.i64 0xffff_effc
 ;; @0049                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_effc
 ;; @0049                               trapnz v5, heap_oob
-;; @0049                               v6 = load.i64 notrap aligned readonly can_move v0+56
+;; @0049                               v6 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0049                               v7 = iadd v6, v2
 ;; @0049                               v8 = iconst.i64 4096
 ;; @0049                               v9 = iadd v7, v8  ; v8 = 4096
-;; @0049                               v10 = load.i32 little region2 v9
+;; @0049                               v10 = load.i32 little region4 v9
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -21,7 +21,9 @@
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -31,11 +33,11 @@
 ;; @0040                               v4 = iconst.i64 0xfffc
 ;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xfffc
 ;; @0040                               trapnz v5, heap_oob
-;; @0040                               v6 = load.i64 notrap aligned readonly can_move v0+56
+;; @0040                               v6 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 0xffff_0000
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
-;; @0040                               store little region2 v3, v9
+;; @0040                               store little region4 v3, v9
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -45,7 +47,9 @@
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -55,11 +59,11 @@
 ;; @004c                               v4 = iconst.i64 0xfffc
 ;; @004c                               v5 = icmp ugt v2, v4  ; v4 = 0xfffc
 ;; @004c                               trapnz v5, heap_oob
-;; @004c                               v6 = load.i64 notrap aligned readonly can_move v0+56
+;; @004c                               v6 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @004c                               v7 = iadd v6, v2
 ;; @004c                               v8 = iconst.i64 0xffff_0000
 ;; @004c                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
-;; @004c                               v10 = load.i32 little region2 v9
+;; @004c                               v10 = load.i32 little region4 v9
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
@@ -21,7 +21,9 @@
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -31,9 +33,9 @@
 ;; @0040                               v4 = iconst.i64 0xffff_ffff
 ;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_ffff
 ;; @0040                               trapnz v5, heap_oob
-;; @0040                               v6 = load.i64 notrap aligned readonly can_move v0+56
+;; @0040                               v6 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0040                               v7 = iadd v6, v2
-;; @0040                               istore8 little region2 v3, v7
+;; @0040                               istore8 little region4 v3, v7
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -43,7 +45,9 @@
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -53,9 +57,9 @@
 ;; @0048                               v4 = iconst.i64 0xffff_ffff
 ;; @0048                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_ffff
 ;; @0048                               trapnz v5, heap_oob
-;; @0048                               v6 = load.i64 notrap aligned readonly can_move v0+56
+;; @0048                               v6 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0048                               v7 = iadd v6, v2
-;; @0048                               v8 = uload8.i32 little region2 v7
+;; @0048                               v8 = uload8.i32 little region4 v7
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -21,7 +21,9 @@
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -31,11 +33,11 @@
 ;; @0040                               v4 = iconst.i64 0xffff_efff
 ;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_efff
 ;; @0040                               trapnz v5, heap_oob
-;; @0040                               v6 = load.i64 notrap aligned readonly can_move v0+56
+;; @0040                               v6 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 4096
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 4096
-;; @0040                               istore8 little region2 v3, v9
+;; @0040                               istore8 little region4 v3, v9
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -45,7 +47,9 @@
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -55,11 +59,11 @@
 ;; @0049                               v4 = iconst.i64 0xffff_efff
 ;; @0049                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_efff
 ;; @0049                               trapnz v5, heap_oob
-;; @0049                               v6 = load.i64 notrap aligned readonly can_move v0+56
+;; @0049                               v6 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0049                               v7 = iadd v6, v2
 ;; @0049                               v8 = iconst.i64 4096
 ;; @0049                               v9 = iadd v7, v8  ; v8 = 4096
-;; @0049                               v10 = uload8.i32 little region2 v9
+;; @0049                               v10 = uload8.i32 little region4 v9
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -21,7 +21,9 @@
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -31,11 +33,11 @@
 ;; @0040                               v4 = iconst.i64 0xffff
 ;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xffff
 ;; @0040                               trapnz v5, heap_oob
-;; @0040                               v6 = load.i64 notrap aligned readonly can_move v0+56
+;; @0040                               v6 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 0xffff_0000
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
-;; @0040                               istore8 little region2 v3, v9
+;; @0040                               istore8 little region4 v3, v9
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -45,7 +47,9 @@
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -55,11 +59,11 @@
 ;; @004c                               v4 = iconst.i64 0xffff
 ;; @004c                               v5 = icmp ugt v2, v4  ; v4 = 0xffff
 ;; @004c                               trapnz v5, heap_oob
-;; @004c                               v6 = load.i64 notrap aligned readonly can_move v0+56
+;; @004c                               v6 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @004c                               v7 = iadd v6, v2
 ;; @004c                               v8 = iconst.i64 0xffff_0000
 ;; @004c                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
-;; @004c                               v10 = uload8.i32 little region2 v9
+;; @004c                               v10 = uload8.i32 little region4 v9
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
@@ -21,7 +21,9 @@
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -30,11 +32,11 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = iconst.i64 0xffff_fffc
 ;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_fffc
-;; @0040                               v6 = load.i64 notrap aligned readonly can_move v0+56
+;; @0040                               v6 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 0
 ;; @0040                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0
-;; @0040                               store little region2 v3, v9
+;; @0040                               store little region4 v3, v9
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -44,7 +46,9 @@
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -53,11 +57,11 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @0048                               v4 = iconst.i64 0xffff_fffc
 ;; @0048                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_fffc
-;; @0048                               v6 = load.i64 notrap aligned readonly can_move v0+56
+;; @0048                               v6 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0048                               v7 = iadd v6, v2
 ;; @0048                               v8 = iconst.i64 0
 ;; @0048                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0
-;; @0048                               v10 = load.i32 little region2 v9
+;; @0048                               v10 = load.i32 little region4 v9
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -21,7 +21,9 @@
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -30,13 +32,13 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = iconst.i64 0xffff_effc
 ;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_effc
-;; @0040                               v6 = load.i64 notrap aligned readonly can_move v0+56
+;; @0040                               v6 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 4096
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 4096
 ;; @0040                               v10 = iconst.i64 0
 ;; @0040                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
-;; @0040                               store little region2 v3, v11
+;; @0040                               store little region4 v3, v11
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -46,7 +48,9 @@
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -55,13 +59,13 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @0049                               v4 = iconst.i64 0xffff_effc
 ;; @0049                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_effc
-;; @0049                               v6 = load.i64 notrap aligned readonly can_move v0+56
+;; @0049                               v6 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0049                               v7 = iadd v6, v2
 ;; @0049                               v8 = iconst.i64 4096
 ;; @0049                               v9 = iadd v7, v8  ; v8 = 4096
 ;; @0049                               v10 = iconst.i64 0
 ;; @0049                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
-;; @0049                               v12 = load.i32 little region2 v11
+;; @0049                               v12 = load.i32 little region4 v11
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -21,7 +21,9 @@
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -30,13 +32,13 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = iconst.i64 0xfffc
 ;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xfffc
-;; @0040                               v6 = load.i64 notrap aligned readonly can_move v0+56
+;; @0040                               v6 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 0xffff_0000
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
 ;; @0040                               v10 = iconst.i64 0
 ;; @0040                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
-;; @0040                               store little region2 v3, v11
+;; @0040                               store little region4 v3, v11
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -46,7 +48,9 @@
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -55,13 +59,13 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @004c                               v4 = iconst.i64 0xfffc
 ;; @004c                               v5 = icmp ugt v2, v4  ; v4 = 0xfffc
-;; @004c                               v6 = load.i64 notrap aligned readonly can_move v0+56
+;; @004c                               v6 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @004c                               v7 = iadd v6, v2
 ;; @004c                               v8 = iconst.i64 0xffff_0000
 ;; @004c                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
 ;; @004c                               v10 = iconst.i64 0
 ;; @004c                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
-;; @004c                               v12 = load.i32 little region2 v11
+;; @004c                               v12 = load.i32 little region4 v11
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
@@ -21,7 +21,9 @@
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -30,11 +32,11 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = iconst.i64 0xffff_ffff
 ;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_ffff
-;; @0040                               v6 = load.i64 notrap aligned readonly can_move v0+56
+;; @0040                               v6 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 0
 ;; @0040                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0
-;; @0040                               istore8 little region2 v3, v9
+;; @0040                               istore8 little region4 v3, v9
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -44,7 +46,9 @@
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -53,11 +57,11 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @0048                               v4 = iconst.i64 0xffff_ffff
 ;; @0048                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_ffff
-;; @0048                               v6 = load.i64 notrap aligned readonly can_move v0+56
+;; @0048                               v6 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0048                               v7 = iadd v6, v2
 ;; @0048                               v8 = iconst.i64 0
 ;; @0048                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0
-;; @0048                               v10 = uload8.i32 little region2 v9
+;; @0048                               v10 = uload8.i32 little region4 v9
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -21,7 +21,9 @@
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -30,13 +32,13 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = iconst.i64 0xffff_efff
 ;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_efff
-;; @0040                               v6 = load.i64 notrap aligned readonly can_move v0+56
+;; @0040                               v6 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 4096
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 4096
 ;; @0040                               v10 = iconst.i64 0
 ;; @0040                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
-;; @0040                               istore8 little region2 v3, v11
+;; @0040                               istore8 little region4 v3, v11
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -46,7 +48,9 @@
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -55,13 +59,13 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @0049                               v4 = iconst.i64 0xffff_efff
 ;; @0049                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_efff
-;; @0049                               v6 = load.i64 notrap aligned readonly can_move v0+56
+;; @0049                               v6 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0049                               v7 = iadd v6, v2
 ;; @0049                               v8 = iconst.i64 4096
 ;; @0049                               v9 = iadd v7, v8  ; v8 = 4096
 ;; @0049                               v10 = iconst.i64 0
 ;; @0049                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
-;; @0049                               v12 = uload8.i32 little region2 v11
+;; @0049                               v12 = uload8.i32 little region4 v11
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -21,7 +21,9 @@
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -30,13 +32,13 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = iconst.i64 0xffff
 ;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xffff
-;; @0040                               v6 = load.i64 notrap aligned readonly can_move v0+56
+;; @0040                               v6 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 0xffff_0000
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
 ;; @0040                               v10 = iconst.i64 0
 ;; @0040                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
-;; @0040                               istore8 little region2 v3, v11
+;; @0040                               istore8 little region4 v3, v11
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -46,7 +48,9 @@
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -55,13 +59,13 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @004c                               v4 = iconst.i64 0xffff
 ;; @004c                               v5 = icmp ugt v2, v4  ; v4 = 0xffff
-;; @004c                               v6 = load.i64 notrap aligned readonly can_move v0+56
+;; @004c                               v6 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @004c                               v7 = iadd v6, v2
 ;; @004c                               v8 = iconst.i64 0xffff_0000
 ;; @004c                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
 ;; @004c                               v10 = iconst.i64 0
 ;; @004c                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
-;; @004c                               v12 = uload8.i32 little region2 v11
+;; @004c                               v12 = uload8.i32 little region4 v11
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/memory-copy-epochs.wat
+++ b/tests/disas/memory-copy-epochs.wat
@@ -13,6 +13,8 @@
 ;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     region2 = 24 "VMContext+0x18"
 ;;     region3 = 268435464 "VMStoreContext+0x8"
+;;     region4 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region5 = 2415919112 "VMMemoryDefinition+0x8"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -35,7 +37,7 @@
 ;; @001e                               jump block2(v10)
 ;;
 ;;                                 block2(v59: i64):
-;; @0025                               v14 = load.i64 notrap aligned v0+64
+;; @0025                               v14 = load.i64 notrap aligned region5 v0+64
 ;; @0025                               v15 = uextend.i64 v2
 ;; @0025                               v16 = uextend.i64 v4
 ;; @0025                               v19 = iadd v15, v16
@@ -45,7 +47,7 @@
 ;; @0025                               v31 = iadd v27, v16
 ;; @0025                               v32 = icmp ugt v31, v14
 ;; @0025                               trapnz v32, heap_oob
-;; @0025                               v21 = load.i64 notrap aligned readonly can_move v0+56
+;; @0025                               v21 = load.i64 notrap aligned readonly can_move region4 v0+56
 ;; @0025                               v37 = iadd v21, v27
 ;; @0025                               v25 = iadd v21, v15
 ;; @0025                               v40 = icmp ugt v37, v25

--- a/tests/disas/memory-copy-fuel.wat
+++ b/tests/disas/memory-copy-fuel.wat
@@ -12,6 +12,8 @@
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     region2 = 268435456 "VMStoreContext+0x0"
+;;     region3 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region4 = 2415919112 "VMMemoryDefinition+0x8"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -38,7 +40,7 @@
 ;; @001e                               jump block3(v14)
 ;;
 ;;                                 block3(v43: i64):
-;; @0025                               v18 = load.i64 notrap aligned v0+64
+;; @0025                               v18 = load.i64 notrap aligned region4 v0+64
 ;; @0025                               v19 = uextend.i64 v2
 ;; @0025                               v20 = uextend.i64 v4
 ;; @0025                               v23 = iadd v19, v20
@@ -48,7 +50,7 @@
 ;; @0025                               v35 = iadd v31, v20
 ;; @0025                               v36 = icmp ugt v35, v18
 ;; @0025                               trapnz v36, heap_oob
-;; @0025                               v25 = load.i64 notrap aligned readonly can_move v0+56
+;; @0025                               v25 = load.i64 notrap aligned readonly can_move region3 v0+56
 ;; @0025                               v41 = iadd v25, v31
 ;; @0025                               v29 = iadd v25, v19
 ;; @0025                               v47 = icmp ugt v41, v29

--- a/tests/disas/memory-copy-inline.wat
+++ b/tests/disas/memory-copy-inline.wat
@@ -14,14 +14,16 @@
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
-;; @0024                               v5 = load.i64 notrap aligned v0+64
+;; @0024                               v5 = load.i64 notrap aligned region3 v0+64
 ;; @0024                               v6 = uextend.i64 v2
 ;;                                     v31 = iconst.i64 16
 ;; @0024                               v10 = iadd v6, v31  ; v31 = 16
@@ -31,11 +33,11 @@
 ;; @0024                               v22 = iadd v18, v31  ; v31 = 16
 ;; @0024                               v23 = icmp ugt v22, v5
 ;; @0024                               trapnz v23, heap_oob
-;; @0024                               v12 = load.i64 notrap aligned readonly can_move v0+56
+;; @0024                               v12 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0024                               v28 = iadd v12, v18
-;; @0024                               v30 = load.i8x16 notrap aligned little region2 v28
+;; @0024                               v30 = load.i8x16 notrap aligned little region4 v28
 ;; @0024                               v16 = iadd v12, v6
-;; @0024                               store notrap aligned little region2 v30, v16
+;; @0024                               store notrap aligned little region4 v30, v16
 ;; @0028                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/memory-min-max-same.wat
+++ b/tests/disas/memory-min-max-same.wat
@@ -38,7 +38,9 @@
 ;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     region2 = 96 "VMContext+0x60"
 ;;     region3 = 80 "VMContext+0x50"
-;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region4 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region5 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region6 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -51,7 +53,7 @@
 ;; @0030                               v5 = load.i64 notrap aligned readonly can_move region2 v0+96
 ;; @0039                               v12 = iconst.i64 0x0001_0000
 ;; @0039                               v16 = iconst.i64 0
-;; @0039                               v14 = load.i64 notrap aligned readonly can_move v0+56
+;; @0039                               v14 = load.i64 notrap aligned readonly can_move region4 v0+56
 ;; @003e                               v18 = iconst.i32 1
 ;; @002e                               jump block2(v3)  ; v3 = 0
 ;;
@@ -65,7 +67,7 @@
 ;; @0039                               v15 = iadd.i64 v14, v11
 ;;                                     v23 = iconst.i64 0
 ;;                                     v24 = select_spectre_guard v22, v23, v15  ; v23 = 0
-;; @0039                               store little region4 v20, v24  ; v20 = 0
+;; @0039                               store little region6 v20, v24  ; v20 = 0
 ;;                                     v25 = iconst.i32 1
 ;;                                     v26 = iadd v8, v25  ; v25 = 1
 ;; @0043                               jump block2(v26)

--- a/tests/disas/memory.wat
+++ b/tests/disas/memory.wat
@@ -15,7 +15,9 @@
 ;; function u0:0(i64 vmctx, i64) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -26,32 +28,32 @@
 ;; @0021                               v3 = iconst.i32 0
 ;; @0023                               v4 = iconst.i32 0
 ;; @0025                               v5 = uextend.i64 v3  ; v3 = 0
-;; @0025                               v6 = load.i64 notrap aligned readonly can_move v0+56
+;; @0025                               v6 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0025                               v7 = iadd v6, v5
-;; @0025                               store little region2 v4, v7  ; v4 = 0
+;; @0025                               store little region4 v4, v7  ; v4 = 0
 ;; @0028                               v8 = iconst.i32 0
 ;; @002a                               v9 = uextend.i64 v8  ; v8 = 0
-;; @002a                               v10 = load.i64 notrap aligned readonly can_move v0+56
+;; @002a                               v10 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @002a                               v11 = iadd v10, v9
-;; @002a                               v12 = load.i32 little region2 v11
+;; @002a                               v12 = load.i32 little region4 v11
 ;; @002d                               brif v12, block2, block4
 ;;
 ;;                                 block2:
 ;; @002f                               v13 = iconst.i32 0
 ;; @0031                               v14 = iconst.i32 10
 ;; @0033                               v15 = uextend.i64 v13  ; v13 = 0
-;; @0033                               v16 = load.i64 notrap aligned readonly can_move v0+56
+;; @0033                               v16 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0033                               v17 = iadd v16, v15
-;; @0033                               store little region2 v14, v17  ; v14 = 10
+;; @0033                               store little region4 v14, v17  ; v14 = 10
 ;; @0036                               jump block3
 ;;
 ;;                                 block4:
 ;; @0037                               v18 = iconst.i32 0
 ;; @0039                               v19 = iconst.i32 11
 ;; @003b                               v20 = uextend.i64 v18  ; v18 = 0
-;; @003b                               v21 = load.i64 notrap aligned readonly can_move v0+56
+;; @003b                               v21 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @003b                               v22 = iadd v21, v20
-;; @003b                               store little region2 v19, v22  ; v19 = 11
+;; @003b                               store little region4 v19, v22  ; v19 = 11
 ;; @003e                               jump block3
 ;;
 ;;                                 block3:

--- a/tests/disas/memory_copy_host32.wat
+++ b/tests/disas/memory_copy_host32.wat
@@ -50,18 +50,20 @@
   )
 )
 ;; function u0:0(i32 vmctx, i32, i32, i32, i32) tail {
+;;     region0 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region1 = 2415919108 "VMMemoryDefinition+0x4"
 ;;     sig0 = (i32 vmctx, i32, i32, i32) tail
 ;;     fn0 = colocated u805306368:1 sig0
 ;;
 ;;                                 block0(v0: i32, v1: i32, v2: i32, v3: i32, v4: i32):
-;; @0042                               v5 = load.i32 notrap aligned v0+44
+;; @0042                               v5 = load.i32 notrap aligned region1 v0+44
 ;; @0042                               v6 = uextend.i64 v2
 ;; @0042                               v7 = uextend.i64 v4
 ;; @0042                               v10 = iadd v6, v7
 ;; @0042                               v11 = uextend.i64 v5
 ;; @0042                               v12 = icmp ugt v10, v11
 ;; @0042                               trapnz v12, heap_oob
-;; @0042                               v13 = load.i32 notrap aligned can_move v0+40
+;; @0042                               v13 = load.i32 notrap aligned can_move region0 v0+40
 ;; @0042                               v18 = uextend.i64 v3
 ;; @0042                               v22 = iadd v18, v7
 ;; @0042                               v24 = icmp ugt v22, v11
@@ -76,25 +78,27 @@
 ;; }
 ;;
 ;; function u0:1(i32 vmctx, i32, i32, i32, i32) tail {
+;;     region0 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region1 = 2415919108 "VMMemoryDefinition+0x4"
 ;;     sig0 = (i32 vmctx, i32, i32, i32) tail
 ;;     fn0 = colocated u805306368:1 sig0
 ;;
 ;;                                 block0(v0: i32, v1: i32, v2: i32, v3: i32, v4: i32):
-;; @004f                               v5 = load.i32 notrap aligned v0+52
+;; @004f                               v5 = load.i32 notrap aligned region1 v0+52
 ;; @004f                               v6 = uextend.i64 v2
 ;; @004f                               v7 = uextend.i64 v4
 ;; @004f                               v10 = iadd v6, v7
 ;; @004f                               v11 = uextend.i64 v5
 ;; @004f                               v12 = icmp ugt v10, v11
 ;; @004f                               trapnz v12, heap_oob
-;; @004f                               v13 = load.i32 notrap aligned can_move v0+48
-;; @004f                               v17 = load.i32 notrap aligned v0+44
+;; @004f                               v13 = load.i32 notrap aligned can_move region0 v0+48
+;; @004f                               v17 = load.i32 notrap aligned region1 v0+44
 ;; @004f                               v18 = uextend.i64 v3
 ;; @004f                               v22 = iadd v18, v7
 ;; @004f                               v23 = uextend.i64 v17
 ;; @004f                               v24 = icmp ugt v22, v23
 ;; @004f                               trapnz v24, heap_oob
-;; @004f                               v25 = load.i32 notrap aligned can_move v0+40
+;; @004f                               v25 = load.i32 notrap aligned can_move region0 v0+40
 ;; @004f                               v16 = iadd v13, v2
 ;; @004f                               v28 = iadd v25, v3
 ;; @004f                               call fn0(v0, v16, v28, v4)
@@ -105,24 +109,26 @@
 ;; }
 ;;
 ;; function u0:2(i32 vmctx, i32, i64, i32, i32) tail {
+;;     region0 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region1 = 2415919108 "VMMemoryDefinition+0x4"
 ;;     sig0 = (i32 vmctx, i32, i32, i32) tail
 ;;     fn0 = colocated u805306368:1 sig0
 ;;
 ;;                                 block0(v0: i32, v1: i32, v2: i64, v3: i32, v4: i32):
-;; @005c                               v6 = load.i32 notrap aligned v0+60
+;; @005c                               v6 = load.i32 notrap aligned region1 v0+60
 ;; @005c                               v5 = uextend.i64 v4
 ;; @005c                               v7 = uadd_overflow_trap v2, v5, heap_oob
 ;; @005c                               v8 = uextend.i64 v6
 ;; @005c                               v9 = icmp ugt v7, v8
 ;; @005c                               trapnz v9, heap_oob
-;; @005c                               v10 = load.i32 notrap aligned can_move v0+56
-;; @005c                               v15 = load.i32 notrap aligned v0+44
+;; @005c                               v10 = load.i32 notrap aligned can_move region0 v0+56
+;; @005c                               v15 = load.i32 notrap aligned region1 v0+44
 ;; @005c                               v16 = uextend.i64 v3
 ;; @005c                               v20 = iadd v16, v5
 ;; @005c                               v21 = uextend.i64 v15
 ;; @005c                               v22 = icmp ugt v20, v21
 ;; @005c                               trapnz v22, heap_oob
-;; @005c                               v23 = load.i32 notrap aligned can_move v0+40
+;; @005c                               v23 = load.i32 notrap aligned can_move region0 v0+40
 ;; @005c                               v11 = ireduce.i32 v2
 ;; @005c                               v14 = iadd v10, v11
 ;; @005c                               v26 = iadd v23, v3
@@ -134,16 +140,18 @@
 ;; }
 ;;
 ;; function u0:3(i32 vmctx, i32, i64, i64, i64) tail {
+;;     region0 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region1 = 2415919108 "VMMemoryDefinition+0x4"
 ;;     sig0 = (i32 vmctx, i32, i32, i32) tail
 ;;     fn0 = colocated u805306368:1 sig0
 ;;
 ;;                                 block0(v0: i32, v1: i32, v2: i64, v3: i64, v4: i64):
-;; @0069                               v5 = load.i32 notrap aligned v0+60
+;; @0069                               v5 = load.i32 notrap aligned region1 v0+60
 ;; @0069                               v6 = uadd_overflow_trap v2, v4, heap_oob
 ;; @0069                               v7 = uextend.i64 v5
 ;; @0069                               v8 = icmp ugt v6, v7
 ;; @0069                               trapnz v8, heap_oob
-;; @0069                               v9 = load.i32 notrap aligned can_move v0+56
+;; @0069                               v9 = load.i32 notrap aligned can_move region0 v0+56
 ;; @0069                               v15 = uadd_overflow_trap v3, v4, heap_oob
 ;; @0069                               v17 = icmp ugt v15, v7
 ;; @0069                               trapnz v17, heap_oob
@@ -160,22 +168,24 @@
 ;; }
 ;;
 ;; function u0:4(i32 vmctx, i32, i64, i64, i64) tail {
+;;     region0 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region1 = 2415919108 "VMMemoryDefinition+0x4"
 ;;     sig0 = (i32 vmctx, i32, i32, i32) tail
 ;;     fn0 = colocated u805306368:1 sig0
 ;;
 ;;                                 block0(v0: i32, v1: i32, v2: i64, v3: i64, v4: i64):
-;; @0076                               v5 = load.i32 notrap aligned v0+68
+;; @0076                               v5 = load.i32 notrap aligned region1 v0+68
 ;; @0076                               v6 = uadd_overflow_trap v2, v4, heap_oob
 ;; @0076                               v7 = uextend.i64 v5
 ;; @0076                               v8 = icmp ugt v6, v7
 ;; @0076                               trapnz v8, heap_oob
-;; @0076                               v9 = load.i32 notrap aligned can_move v0+64
-;; @0076                               v14 = load.i32 notrap aligned v0+60
+;; @0076                               v9 = load.i32 notrap aligned can_move region0 v0+64
+;; @0076                               v14 = load.i32 notrap aligned region1 v0+60
 ;; @0076                               v15 = uadd_overflow_trap v3, v4, heap_oob
 ;; @0076                               v16 = uextend.i64 v14
 ;; @0076                               v17 = icmp ugt v15, v16
 ;; @0076                               trapnz v17, heap_oob
-;; @0076                               v18 = load.i32 notrap aligned can_move v0+56
+;; @0076                               v18 = load.i32 notrap aligned can_move region0 v0+56
 ;; @0076                               v10 = ireduce.i32 v2
 ;; @0076                               v13 = iadd v9, v10
 ;; @0076                               v19 = ireduce.i32 v3
@@ -189,24 +199,26 @@
 ;; }
 ;;
 ;; function u0:5(i32 vmctx, i32, i32, i64, i32) tail {
+;;     region0 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region1 = 2415919108 "VMMemoryDefinition+0x4"
 ;;     sig0 = (i32 vmctx, i32, i32, i32) tail
 ;;     fn0 = colocated u805306368:1 sig0
 ;;
 ;;                                 block0(v0: i32, v1: i32, v2: i32, v3: i64, v4: i32):
-;; @0083                               v6 = load.i32 notrap aligned v0+44
+;; @0083                               v6 = load.i32 notrap aligned region1 v0+44
 ;; @0083                               v7 = uextend.i64 v2
 ;; @0083                               v5 = uextend.i64 v4
 ;; @0083                               v11 = iadd v7, v5
 ;; @0083                               v12 = uextend.i64 v6
 ;; @0083                               v13 = icmp ugt v11, v12
 ;; @0083                               trapnz v13, heap_oob
-;; @0083                               v14 = load.i32 notrap aligned can_move v0+40
-;; @0083                               v18 = load.i32 notrap aligned v0+60
+;; @0083                               v14 = load.i32 notrap aligned can_move region0 v0+40
+;; @0083                               v18 = load.i32 notrap aligned region1 v0+60
 ;; @0083                               v19 = uadd_overflow_trap v3, v5, heap_oob
 ;; @0083                               v20 = uextend.i64 v18
 ;; @0083                               v21 = icmp ugt v19, v20
 ;; @0083                               trapnz v21, heap_oob
-;; @0083                               v22 = load.i32 notrap aligned can_move v0+56
+;; @0083                               v22 = load.i32 notrap aligned can_move region0 v0+56
 ;; @0083                               v17 = iadd v14, v2
 ;; @0083                               v23 = ireduce.i32 v3
 ;; @0083                               v26 = iadd v22, v23

--- a/tests/disas/memory_copy_host64.wat
+++ b/tests/disas/memory_copy_host64.wat
@@ -52,6 +52,8 @@
 ;; function u0:0(i64 vmctx, i64, i32, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -60,7 +62,7 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
-;; @0042                               v5 = load.i64 notrap aligned v0+88
+;; @0042                               v5 = load.i64 notrap aligned region3 v0+88
 ;; @0042                               v6 = uextend.i64 v2
 ;; @0042                               v7 = uextend.i64 v4
 ;; @0042                               v10 = iadd v6, v7
@@ -70,7 +72,7 @@
 ;; @0042                               v22 = iadd v18, v7
 ;; @0042                               v23 = icmp ugt v22, v5
 ;; @0042                               trapnz v23, heap_oob
-;; @0042                               v12 = load.i64 notrap aligned readonly can_move v0+80
+;; @0042                               v12 = load.i64 notrap aligned readonly can_move region2 v0+80
 ;; @0042                               v16 = iadd v12, v6
 ;; @0042                               v28 = iadd v12, v18
 ;; @0042                               call fn0(v0, v16, v28, v7)
@@ -83,6 +85,8 @@
 ;; function u0:1(i64 vmctx, i64, i32, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -91,20 +95,20 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
-;; @004f                               v5 = load.i64 notrap aligned v0+104
+;; @004f                               v5 = load.i64 notrap aligned region3 v0+104
 ;; @004f                               v6 = uextend.i64 v2
 ;; @004f                               v7 = uextend.i64 v4
 ;; @004f                               v10 = iadd v6, v7
 ;; @004f                               v11 = icmp ugt v10, v5
 ;; @004f                               trapnz v11, heap_oob
-;; @004f                               v17 = load.i64 notrap aligned v0+88
+;; @004f                               v17 = load.i64 notrap aligned region3 v0+88
 ;; @004f                               v18 = uextend.i64 v3
 ;; @004f                               v22 = iadd v18, v7
 ;; @004f                               v23 = icmp ugt v22, v17
 ;; @004f                               trapnz v23, heap_oob
-;; @004f                               v12 = load.i64 notrap aligned readonly can_move v0+96
+;; @004f                               v12 = load.i64 notrap aligned readonly can_move region2 v0+96
 ;; @004f                               v16 = iadd v12, v6
-;; @004f                               v24 = load.i64 notrap aligned readonly can_move v0+80
+;; @004f                               v24 = load.i64 notrap aligned readonly can_move region2 v0+80
 ;; @004f                               v28 = iadd v24, v18
 ;; @004f                               call fn0(v0, v16, v28, v7)
 ;; @0053                               jump block1
@@ -116,6 +120,8 @@
 ;; function u0:2(i64 vmctx, i64, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -124,19 +130,19 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32, v4: i32):
-;; @005c                               v6 = load.i64 notrap aligned v0+120
+;; @005c                               v6 = load.i64 notrap aligned region3 v0+120
 ;; @005c                               v5 = uextend.i64 v4
 ;; @005c                               v7 = uadd_overflow_trap v2, v5, heap_oob
 ;; @005c                               v8 = icmp ugt v7, v6
 ;; @005c                               trapnz v8, heap_oob
-;; @005c                               v9 = load.i64 notrap aligned can_move v0+112
-;; @005c                               v13 = load.i64 notrap aligned v0+88
+;; @005c                               v9 = load.i64 notrap aligned can_move region2 v0+112
+;; @005c                               v13 = load.i64 notrap aligned region3 v0+88
 ;; @005c                               v14 = uextend.i64 v3
 ;; @005c                               v18 = iadd v14, v5
 ;; @005c                               v19 = icmp ugt v18, v13
 ;; @005c                               trapnz v19, heap_oob
 ;; @005c                               v12 = iadd v9, v2
-;; @005c                               v20 = load.i64 notrap aligned readonly can_move v0+80
+;; @005c                               v20 = load.i64 notrap aligned readonly can_move region2 v0+80
 ;; @005c                               v24 = iadd v20, v14
 ;; @005c                               call fn0(v0, v12, v24, v5)
 ;; @0060                               jump block1
@@ -148,6 +154,8 @@
 ;; function u0:3(i64 vmctx, i64, i64, i64, i64) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -156,11 +164,11 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i64, v4: i64):
-;; @0069                               v5 = load.i64 notrap aligned v0+120
+;; @0069                               v5 = load.i64 notrap aligned region3 v0+120
 ;; @0069                               v6 = uadd_overflow_trap v2, v4, heap_oob
 ;; @0069                               v7 = icmp ugt v6, v5
 ;; @0069                               trapnz v7, heap_oob
-;; @0069                               v8 = load.i64 notrap aligned can_move v0+112
+;; @0069                               v8 = load.i64 notrap aligned can_move region2 v0+112
 ;; @0069                               v13 = uadd_overflow_trap v3, v4, heap_oob
 ;; @0069                               v14 = icmp ugt v13, v5
 ;; @0069                               trapnz v14, heap_oob
@@ -176,6 +184,8 @@
 ;; function u0:4(i64 vmctx, i64, i64, i64, i64) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -184,16 +194,16 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i64, v4: i64):
-;; @0076                               v5 = load.i64 notrap aligned v0+136
+;; @0076                               v5 = load.i64 notrap aligned region3 v0+136
 ;; @0076                               v6 = uadd_overflow_trap v2, v4, heap_oob
 ;; @0076                               v7 = icmp ugt v6, v5
 ;; @0076                               trapnz v7, heap_oob
-;; @0076                               v8 = load.i64 notrap aligned can_move v0+128
-;; @0076                               v12 = load.i64 notrap aligned v0+120
+;; @0076                               v8 = load.i64 notrap aligned can_move region2 v0+128
+;; @0076                               v12 = load.i64 notrap aligned region3 v0+120
 ;; @0076                               v13 = uadd_overflow_trap v3, v4, heap_oob
 ;; @0076                               v14 = icmp ugt v13, v12
 ;; @0076                               trapnz v14, heap_oob
-;; @0076                               v15 = load.i64 notrap aligned can_move v0+112
+;; @0076                               v15 = load.i64 notrap aligned can_move region2 v0+112
 ;; @0076                               v11 = iadd v8, v2
 ;; @0076                               v18 = iadd v15, v3
 ;; @0076                               call fn0(v0, v11, v18, v4)
@@ -206,6 +216,8 @@
 ;; function u0:5(i64 vmctx, i64, i32, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -214,18 +226,18 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i64, v4: i32):
-;; @0083                               v6 = load.i64 notrap aligned v0+88
+;; @0083                               v6 = load.i64 notrap aligned region3 v0+88
 ;; @0083                               v7 = uextend.i64 v2
 ;; @0083                               v5 = uextend.i64 v4
 ;; @0083                               v11 = iadd v7, v5
 ;; @0083                               v12 = icmp ugt v11, v6
 ;; @0083                               trapnz v12, heap_oob
-;; @0083                               v18 = load.i64 notrap aligned v0+120
+;; @0083                               v18 = load.i64 notrap aligned region3 v0+120
 ;; @0083                               v19 = uadd_overflow_trap v3, v5, heap_oob
 ;; @0083                               v20 = icmp ugt v19, v18
 ;; @0083                               trapnz v20, heap_oob
-;; @0083                               v21 = load.i64 notrap aligned can_move v0+112
-;; @0083                               v13 = load.i64 notrap aligned readonly can_move v0+80
+;; @0083                               v21 = load.i64 notrap aligned can_move region2 v0+112
+;; @0083                               v13 = load.i64 notrap aligned readonly can_move region2 v0+80
 ;; @0083                               v17 = iadd v13, v7
 ;; @0083                               v24 = iadd v21, v3
 ;; @0083                               call fn0(v0, v17, v24, v5)

--- a/tests/disas/memory_fill_host32.wat
+++ b/tests/disas/memory_fill_host32.wat
@@ -47,18 +47,20 @@
   )
 )
 ;; function u0:0(i32 vmctx, i32, i32, i32) tail {
+;;     region0 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region1 = 2415919108 "VMMemoryDefinition+0x4"
 ;;     sig0 = (i32 vmctx, i32, i32, i32) tail
 ;;     fn0 = colocated u805306368:2 sig0
 ;;
 ;;                                 block0(v0: i32, v1: i32, v2: i32, v3: i32):
-;; @003c                               v5 = load.i32 notrap aligned v0+48
+;; @003c                               v5 = load.i32 notrap aligned region1 v0+48
 ;; @003c                               v6 = uextend.i64 v2
 ;; @003c                               v7 = uextend.i64 v3
 ;; @003c                               v10 = iadd v6, v7
 ;; @003c                               v11 = uextend.i64 v5
 ;; @003c                               v12 = icmp ugt v10, v11
 ;; @003c                               trapnz v12, heap_oob
-;; @003c                               v13 = load.i32 notrap aligned can_move v0+44
+;; @003c                               v13 = load.i32 notrap aligned can_move region0 v0+44
 ;; @003c                               v16 = iadd v13, v2
 ;; @0038                               v4 = iconst.i32 0
 ;; @003c                               call fn0(v0, v16, v4, v3)  ; v4 = 0
@@ -69,16 +71,18 @@
 ;; }
 ;;
 ;; function u0:1(i32 vmctx, i32, i64, i64) tail {
+;;     region0 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region1 = 2415919108 "VMMemoryDefinition+0x4"
 ;;     sig0 = (i32 vmctx, i32, i32, i32) tail
 ;;     fn0 = colocated u805306368:2 sig0
 ;;
 ;;                                 block0(v0: i32, v1: i32, v2: i64, v3: i64):
-;; @0048                               v5 = load.i32 notrap aligned v0+56
+;; @0048                               v5 = load.i32 notrap aligned region1 v0+56
 ;; @0048                               v6 = uadd_overflow_trap v2, v3, heap_oob
 ;; @0048                               v7 = uextend.i64 v5
 ;; @0048                               v8 = icmp ugt v6, v7
 ;; @0048                               trapnz v8, heap_oob
-;; @0048                               v9 = load.i32 notrap aligned can_move v0+52
+;; @0048                               v9 = load.i32 notrap aligned can_move region0 v0+52
 ;; @0048                               v10 = ireduce.i32 v2
 ;; @0048                               v13 = iadd v9, v10
 ;; @0044                               v4 = iconst.i32 0
@@ -91,18 +95,20 @@
 ;; }
 ;;
 ;; function u0:2(i32 vmctx, i32, i32, i32) tail {
+;;     region0 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region1 = 2415919108 "VMMemoryDefinition+0x4"
 ;;     sig0 = (i32 vmctx, i32, i32, i32) tail
 ;;     fn0 = colocated u805306368:2 sig0
 ;;
 ;;                                 block0(v0: i32, v1: i32, v2: i32, v3: i32):
-;; @0054                               v5 = load.i32 notrap aligned v0+64
+;; @0054                               v5 = load.i32 notrap aligned region1 v0+64
 ;; @0054                               v6 = uextend.i64 v2
 ;; @0054                               v7 = uextend.i64 v3
 ;; @0054                               v10 = iadd v6, v7
 ;; @0054                               v11 = uextend.i64 v5
 ;; @0054                               v12 = icmp ugt v10, v11
 ;; @0054                               trapnz v12, heap_oob
-;; @0054                               v13 = load.i32 notrap aligned can_move v0+60
+;; @0054                               v13 = load.i32 notrap aligned can_move region0 v0+60
 ;; @0054                               v16 = iadd v13, v2
 ;; @0050                               v4 = iconst.i32 0
 ;; @0054                               call fn0(v0, v16, v4, v3)  ; v4 = 0
@@ -113,16 +119,18 @@
 ;; }
 ;;
 ;; function u0:3(i32 vmctx, i32, i64, i64) tail {
+;;     region0 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region1 = 2415919108 "VMMemoryDefinition+0x4"
 ;;     sig0 = (i32 vmctx, i32, i32, i32) tail
 ;;     fn0 = colocated u805306368:2 sig0
 ;;
 ;;                                 block0(v0: i32, v1: i32, v2: i64, v3: i64):
-;; @0060                               v5 = load.i32 notrap aligned v0+72
+;; @0060                               v5 = load.i32 notrap aligned region1 v0+72
 ;; @0060                               v6 = uadd_overflow_trap v2, v3, heap_oob
 ;; @0060                               v7 = uextend.i64 v5
 ;; @0060                               v8 = icmp ugt v6, v7
 ;; @0060                               trapnz v8, heap_oob
-;; @0060                               v9 = load.i32 notrap aligned can_move v0+68
+;; @0060                               v9 = load.i32 notrap aligned can_move region0 v0+68
 ;; @0060                               v10 = ireduce.i32 v2
 ;; @0060                               v13 = iadd v9, v10
 ;; @005c                               v4 = iconst.i32 0
@@ -135,18 +143,20 @@
 ;; }
 ;;
 ;; function u0:4(i32 vmctx, i32, i32, i32) tail {
+;;     region0 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region1 = 2415919108 "VMMemoryDefinition+0x4"
 ;;     sig0 = (i32 vmctx, i32, i32, i32) tail
 ;;     fn0 = colocated u805306368:2 sig0
 ;;
 ;;                                 block0(v0: i32, v1: i32, v2: i32, v3: i32):
-;; @006c                               v5 = load.i32 notrap aligned v0+80
+;; @006c                               v5 = load.i32 notrap aligned region1 v0+80
 ;; @006c                               v6 = uextend.i64 v2
 ;; @006c                               v7 = uextend.i64 v3
 ;; @006c                               v10 = iadd v6, v7
 ;; @006c                               v11 = uextend.i64 v5
 ;; @006c                               v12 = icmp ugt v10, v11
 ;; @006c                               trapnz v12, heap_oob
-;; @006c                               v13 = load.i32 notrap aligned readonly can_move v0+76
+;; @006c                               v13 = load.i32 notrap aligned readonly can_move region0 v0+76
 ;; @006c                               v16 = iadd v13, v2
 ;; @0068                               v4 = iconst.i32 0
 ;; @006c                               call fn0(v0, v16, v4, v3)  ; v4 = 0

--- a/tests/disas/memory_fill_host64.wat
+++ b/tests/disas/memory_fill_host64.wat
@@ -46,6 +46,8 @@
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -54,13 +56,13 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
-;; @003c                               v5 = load.i64 notrap aligned v0+96
+;; @003c                               v5 = load.i64 notrap aligned region3 v0+96
 ;; @003c                               v6 = uextend.i64 v2
 ;; @003c                               v7 = uextend.i64 v3
 ;; @003c                               v10 = iadd v6, v7
 ;; @003c                               v11 = icmp ugt v10, v5
 ;; @003c                               trapnz v11, heap_oob
-;; @003c                               v12 = load.i64 notrap aligned readonly can_move v0+88
+;; @003c                               v12 = load.i64 notrap aligned readonly can_move region2 v0+88
 ;; @003c                               v16 = iadd v12, v6
 ;; @0038                               v4 = iconst.i32 0
 ;; @003c                               call fn0(v0, v16, v4, v7)  ; v4 = 0
@@ -73,6 +75,8 @@
 ;; function u0:1(i64 vmctx, i64, i64, i64) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -81,11 +85,11 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i64):
-;; @0048                               v5 = load.i64 notrap aligned v0+112
+;; @0048                               v5 = load.i64 notrap aligned region3 v0+112
 ;; @0048                               v6 = uadd_overflow_trap v2, v3, heap_oob
 ;; @0048                               v7 = icmp ugt v6, v5
 ;; @0048                               trapnz v7, heap_oob
-;; @0048                               v8 = load.i64 notrap aligned can_move v0+104
+;; @0048                               v8 = load.i64 notrap aligned can_move region2 v0+104
 ;; @0048                               v11 = iadd v8, v2
 ;; @0044                               v4 = iconst.i32 0
 ;; @0048                               call fn0(v0, v11, v4, v3)  ; v4 = 0
@@ -98,6 +102,8 @@
 ;; function u0:2(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -106,13 +112,13 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
-;; @0054                               v5 = load.i64 notrap aligned v0+128
+;; @0054                               v5 = load.i64 notrap aligned region3 v0+128
 ;; @0054                               v6 = uextend.i64 v2
 ;; @0054                               v7 = uextend.i64 v3
 ;; @0054                               v10 = iadd v6, v7
 ;; @0054                               v11 = icmp ugt v10, v5
 ;; @0054                               trapnz v11, heap_oob
-;; @0054                               v12 = load.i64 notrap aligned readonly can_move v0+120
+;; @0054                               v12 = load.i64 notrap aligned readonly can_move region2 v0+120
 ;; @0054                               v16 = iadd v12, v6
 ;; @0050                               v4 = iconst.i32 0
 ;; @0054                               call fn0(v0, v16, v4, v7)  ; v4 = 0
@@ -125,6 +131,8 @@
 ;; function u0:3(i64 vmctx, i64, i64, i64) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -133,11 +141,11 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i64):
-;; @0060                               v5 = load.i64 notrap aligned v0+144
+;; @0060                               v5 = load.i64 notrap aligned region3 v0+144
 ;; @0060                               v6 = uadd_overflow_trap v2, v3, heap_oob
 ;; @0060                               v7 = icmp ugt v6, v5
 ;; @0060                               trapnz v7, heap_oob
-;; @0060                               v8 = load.i64 notrap aligned can_move v0+136
+;; @0060                               v8 = load.i64 notrap aligned can_move region2 v0+136
 ;; @0060                               v11 = iadd v8, v2
 ;; @005c                               v4 = iconst.i32 0
 ;; @0060                               call fn0(v0, v11, v4, v3)  ; v4 = 0
@@ -150,6 +158,8 @@
 ;; function u0:4(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -158,13 +168,13 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
-;; @006c                               v5 = load.i64 notrap aligned v0+160
+;; @006c                               v5 = load.i64 notrap aligned region3 v0+160
 ;; @006c                               v6 = uextend.i64 v2
 ;; @006c                               v7 = uextend.i64 v3
 ;; @006c                               v10 = iadd v6, v7
 ;; @006c                               v11 = icmp ugt v10, v5
 ;; @006c                               trapnz v11, heap_oob
-;; @006c                               v12 = load.i64 notrap aligned readonly can_move v0+152
+;; @006c                               v12 = load.i64 notrap aligned readonly can_move region2 v0+152
 ;; @006c                               v16 = iadd v12, v6
 ;; @0068                               v4 = iconst.i32 0
 ;; @006c                               call fn0(v0, v16, v4, v7)  ; v4 = 0

--- a/tests/disas/non-fixed-size-memory.wat
+++ b/tests/disas/non-fixed-size-memory.wat
@@ -23,7 +23,9 @@
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -31,12 +33,12 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0041                               v4 = uextend.i64 v2
-;; @0041                               v5 = load.i64 notrap aligned v0+64
+;; @0041                               v5 = load.i64 notrap aligned region3 v0+64
 ;; @0041                               v6 = icmp uge v4, v5
 ;; @0041                               trapnz v6, heap_oob
-;; @0041                               v7 = load.i64 notrap aligned can_move v0+56
+;; @0041                               v7 = load.i64 notrap aligned can_move region2 v0+56
 ;; @0041                               v8 = iadd v7, v4
-;; @0041                               istore8 little region2 v3, v8
+;; @0041                               istore8 little region4 v3, v8
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -46,7 +48,9 @@
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -54,12 +58,12 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0049                               v4 = uextend.i64 v2
-;; @0049                               v5 = load.i64 notrap aligned v0+64
+;; @0049                               v5 = load.i64 notrap aligned region3 v0+64
 ;; @0049                               v6 = icmp uge v4, v5
 ;; @0049                               trapnz v6, heap_oob
-;; @0049                               v7 = load.i64 notrap aligned can_move v0+56
+;; @0049                               v7 = load.i64 notrap aligned can_move region2 v0+56
 ;; @0049                               v8 = iadd v7, v4
-;; @0049                               v9 = uload8.i32 little region2 v8
+;; @0049                               v9 = uload8.i32 little region4 v8
 ;; @004c                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/passive-data.wat
+++ b/tests/disas/passive-data.wat
@@ -16,8 +16,10 @@
 ;; function u0:0(i64 vmctx, i64, i32, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 152 "VMContext+0x98"
-;;     region3 = 144 "VMContext+0x90"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 152 "VMContext+0x98"
+;;     region5 = 144 "VMContext+0x90"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -26,7 +28,7 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
-;; @003d                               v5 = load.i64 notrap aligned v0+64
+;; @003d                               v5 = load.i64 notrap aligned region3 v0+64
 ;; @003d                               v6 = uextend.i64 v2
 ;; @003d                               v7 = uextend.i64 v4
 ;; @003d                               v8 = iconst.i64 1
@@ -34,12 +36,12 @@
 ;; @003d                               v10 = iadd v6, v9
 ;; @003d                               v11 = icmp ugt v10, v5
 ;; @003d                               trapnz v11, heap_oob
-;; @003d                               v12 = load.i64 notrap aligned readonly can_move v0+56
+;; @003d                               v12 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @003d                               v13 = uextend.i64 v2
 ;; @003d                               v14 = iconst.i64 1
 ;; @003d                               v15 = imul v13, v14  ; v14 = 1
 ;; @003d                               v16 = iadd v12, v15
-;; @003d                               v17 = load.i32 notrap aligned region2 v0+152
+;; @003d                               v17 = load.i32 notrap aligned region4 v0+152
 ;; @003d                               v18 = uextend.i64 v17
 ;; @003d                               v19 = uextend.i64 v3
 ;; @003d                               v20 = uextend.i64 v4
@@ -48,7 +50,7 @@
 ;; @003d                               v23 = iadd v19, v22
 ;; @003d                               v24 = icmp ugt v23, v18
 ;; @003d                               trapnz v24, heap_oob
-;; @003d                               v25 = load.i64 notrap aligned region3 v0+144
+;; @003d                               v25 = load.i64 notrap aligned region5 v0+144
 ;; @003d                               v26 = uextend.i64 v3
 ;; @003d                               v27 = iadd v25, v26
 ;; @003d                               v28 = uextend.i64 v4

--- a/tests/disas/pic.wat
+++ b/tests/disas/pic.wat
@@ -50,17 +50,19 @@
 ;; function u0:0(i64 vmctx, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @005e                               v7 = load.i64 notrap aligned readonly can_move v0+56
+;; @005e                               v7 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;;                                     v15 = iconst.i64 0x0010_0000
 ;; @005e                               v8 = iadd v7, v15  ; v15 = 0x0010_0000
-;; @005e                               v9 = load.i32 little region2 v8
+;; @005e                               v9 = load.i32 little region4 v8
 ;; @0061                               jump block1
 ;;
 ;;                                 block1:
@@ -71,9 +73,11 @@
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     region2 = 1879048192 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(0))"
-;;     region3 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
-;;     region4 = 96 "VMContext+0x60"
-;;     region5 = 80 "VMContext+0x50"
+;;     region3 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region4 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region5 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region6 = 96 "VMContext+0x60"
+;;     region7 = 80 "VMContext+0x50"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -85,23 +89,23 @@
 ;; @0068                               v6 = iconst.i32 16
 ;; @006a                               v7 = isub v5, v6  ; v6 = 16
 ;; @006d                               store notrap aligned region2 v7, v0+128
-;; @0073                               v9 = load.i64 notrap aligned readonly can_move v0+56
+;; @0073                               v9 = load.i64 notrap aligned readonly can_move region3 v0+56
 ;; @0073                               v8 = uextend.i64 v2
 ;; @0073                               v10 = iadd v9, v8
-;; @0073                               v11 = load.i32 little region3 v10
+;; @0073                               v11 = load.i32 little region5 v10
 ;; @0078                               v12 = uextend.i64 v7
 ;; @0078                               v14 = iadd v9, v12
 ;; @0078                               v15 = iconst.i64 12
 ;; @0078                               v16 = iadd v14, v15  ; v15 = 12
-;; @0078                               store little region3 v11, v16
-;; @0084                               v21 = load.i64 notrap aligned readonly can_move region5 v0+80
-;; @0084                               v20 = load.i64 notrap aligned readonly can_move region4 v0+96
+;; @0078                               store little region5 v11, v16
+;; @0084                               v21 = load.i64 notrap aligned readonly can_move region7 v0+80
+;; @0084                               v20 = load.i64 notrap aligned readonly can_move region6 v0+96
 ;;                                     v29 = iconst.i32 -4
 ;;                                     v30 = iadd v5, v29  ; v29 = -4
 ;; @0084                               call_indirect sig0, v21(v20, v0, v30)
 ;;                                     v37 = iconst.i64 0x0010_0000
 ;; @0090                               v26 = iadd v9, v37  ; v37 = 0x0010_0000
-;; @0090                               store little region3 v11, v26
+;; @0090                               store little region5 v11, v26
 ;; @0098                               store notrap aligned region2 v5, v0+128
 ;; @009c                               jump block1
 ;;

--- a/tests/disas/pr2303.wat
+++ b/tests/disas/pr2303.wat
@@ -19,7 +19,9 @@
 ;; function u0:0(i64 vmctx, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 536870912 "PublicMemory"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 536870912 "PublicMemory"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -29,14 +31,14 @@
 ;; @0036                               v3 = iconst.i32 48
 ;; @0038                               v4 = iconst.i32 0
 ;; @003a                               v5 = uextend.i64 v4  ; v4 = 0
-;; @003a                               v6 = load.i64 notrap aligned readonly can_move v0+56
+;; @003a                               v6 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @003a                               v7 = iadd v6, v5
-;; @003a                               v8 = load.i8x16 little region2 v7
+;; @003a                               v8 = load.i8x16 little region4 v7
 ;; @003e                               v9 = iconst.i32 16
 ;; @0040                               v10 = uextend.i64 v9  ; v9 = 16
-;; @0040                               v11 = load.i64 notrap aligned readonly can_move v0+56
+;; @0040                               v11 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0040                               v12 = iadd v11, v10
-;; @0040                               v13 = load.i8x16 little region2 v12
+;; @0040                               v13 = load.i8x16 little region4 v12
 ;; @0046                               brif v2, block2, block4
 ;;
 ;;                                 block2:
@@ -45,9 +47,9 @@
 ;; @0048                               v18 = iadd v16, v17
 ;; @004b                               v19 = iconst.i32 32
 ;; @004d                               v20 = uextend.i64 v19  ; v19 = 32
-;; @004d                               v21 = load.i64 notrap aligned readonly can_move v0+56
+;; @004d                               v21 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @004d                               v22 = iadd v21, v20
-;; @004d                               v23 = load.i8x16 little region2 v22
+;; @004d                               v23 = load.i8x16 little region4 v22
 ;; @0051                               v26 = bitcast.i8x16 little v18
 ;; @0051                               jump block3(v26, v23)
 ;;
@@ -57,9 +59,9 @@
 ;; @0052                               v29 = isub v27, v28
 ;; @0055                               v30 = iconst.i32 0
 ;; @0057                               v31 = uextend.i64 v30  ; v30 = 0
-;; @0057                               v32 = load.i64 notrap aligned readonly can_move v0+56
+;; @0057                               v32 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0057                               v33 = iadd v32, v31
-;; @0057                               v34 = load.i8x16 little region2 v33
+;; @0057                               v34 = load.i8x16 little region4 v33
 ;; @005b                               v35 = bitcast.i8x16 little v29
 ;; @005b                               jump block3(v35, v34)
 ;;
@@ -68,9 +70,9 @@
 ;; @005c                               v37 = bitcast.i16x8 little v15
 ;; @005c                               v38 = imul v36, v37
 ;; @005f                               v39 = uextend.i64 v3  ; v3 = 48
-;; @005f                               v40 = load.i64 notrap aligned readonly can_move v0+56
+;; @005f                               v40 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @005f                               v41 = iadd v40, v39
-;; @005f                               store little region2 v38, v41
+;; @005f                               store little region4 v38, v41
 ;; @0063                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/readonly-heap-base-pointer1.wat
+++ b/tests/disas/readonly-heap-base-pointer1.wat
@@ -10,7 +10,9 @@
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -21,10 +23,10 @@
 ;; @0020                               v5 = iconst.i64 0x0001_fffc
 ;; @0020                               v6 = icmp ugt v4, v5  ; v5 = 0x0001_fffc
 ;; @0020                               v9 = iconst.i64 0
-;; @0020                               v7 = load.i64 notrap aligned readonly can_move v0+56
+;; @0020                               v7 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0020                               v8 = iadd v7, v4
 ;; @0020                               v10 = select_spectre_guard v6, v9, v8  ; v9 = 0
-;; @0020                               v11 = load.i32 little region2 v10
+;; @0020                               v11 = load.i32 little region4 v10
 ;; @0023                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/readonly-heap-base-pointer2.wat
+++ b/tests/disas/readonly-heap-base-pointer2.wat
@@ -11,7 +11,9 @@
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     region2 = 48 "VMContext+0x30"
-;;     region3 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region3 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region4 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region5 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -23,10 +25,10 @@
 ;; @0022                               v6 = icmp ugt v4, v5  ; v5 = 0x0001_fffc
 ;; @0022                               v10 = iconst.i64 0
 ;; @0022                               v7 = load.i64 notrap aligned readonly can_move region2 v0+48
-;; @0022                               v8 = load.i64 notrap aligned readonly can_move v7
+;; @0022                               v8 = load.i64 notrap aligned readonly can_move region3 v7
 ;; @0022                               v9 = iadd v8, v4
 ;; @0022                               v11 = select_spectre_guard v6, v10, v9  ; v10 = 0
-;; @0022                               v12 = load.i32 little region3 v11
+;; @0022                               v12 = load.i32 little region5 v11
 ;; @0025                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/readonly-heap-base-pointer3.wat
+++ b/tests/disas/readonly-heap-base-pointer3.wat
@@ -10,7 +10,9 @@
 ;; function u0:0(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -20,10 +22,10 @@
 ;; @0020                               v4 = iconst.i64 0xffff_fffc
 ;; @0020                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_fffc
 ;; @0020                               v8 = iconst.i64 0
-;; @0020                               v6 = load.i64 notrap aligned readonly can_move v0+56
+;; @0020                               v6 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0020                               v7 = iadd v6, v2
 ;; @0020                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0
-;; @0020                               v10 = load.i32 little region2 v9
+;; @0020                               v10 = load.i32 little region4 v9
 ;; @0023                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/simd-store.wat
+++ b/tests/disas/simd-store.wat
@@ -87,7 +87,9 @@
 ;; function u0:0(i64 vmctx, i64, i8x16) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -97,9 +99,9 @@
 ;; @003f                               v3 = iconst.i32 0
 ;; @0045                               v4 = icmp eq v2, v2
 ;; @0047                               v5 = uextend.i64 v3  ; v3 = 0
-;; @0047                               v6 = load.i64 notrap aligned readonly can_move v0+56
+;; @0047                               v6 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0047                               v7 = iadd v6, v5
-;; @0047                               store little region2 v4, v7
+;; @0047                               store little region4 v4, v7
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:
@@ -109,7 +111,9 @@
 ;; function u0:10(i64 vmctx, i64, i8x16) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -121,9 +125,9 @@
 ;; @00dd                               v5 = bitcast.i32x4 little v2
 ;; @00dd                               v6 = icmp slt v4, v5
 ;; @00df                               v7 = uextend.i64 v3  ; v3 = 0
-;; @00df                               v8 = load.i64 notrap aligned readonly can_move v0+56
+;; @00df                               v8 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @00df                               v9 = iadd v8, v7
-;; @00df                               store little region2 v6, v9
+;; @00df                               store little region4 v6, v9
 ;; @00e3                               jump block1
 ;;
 ;;                                 block1:
@@ -133,7 +137,9 @@
 ;; function u0:11(i64 vmctx, i64, i8x16) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -145,9 +151,9 @@
 ;; @00ec                               v5 = bitcast.i64x2 little v2
 ;; @00ec                               v6 = icmp slt v4, v5
 ;; @00ef                               v7 = uextend.i64 v3  ; v3 = 0
-;; @00ef                               v8 = load.i64 notrap aligned readonly can_move v0+56
+;; @00ef                               v8 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @00ef                               v9 = iadd v8, v7
-;; @00ef                               store little region2 v6, v9
+;; @00ef                               store little region4 v6, v9
 ;; @00f3                               jump block1
 ;;
 ;;                                 block1:
@@ -157,7 +163,9 @@
 ;; function u0:12(i64 vmctx, i64, i8x16) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -167,9 +175,9 @@
 ;; @00f6                               v3 = iconst.i32 0
 ;; @00fc                               v4 = icmp ult v2, v2
 ;; @00fe                               v5 = uextend.i64 v3  ; v3 = 0
-;; @00fe                               v6 = load.i64 notrap aligned readonly can_move v0+56
+;; @00fe                               v6 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @00fe                               v7 = iadd v6, v5
-;; @00fe                               store little region2 v4, v7
+;; @00fe                               store little region4 v4, v7
 ;; @0102                               jump block1
 ;;
 ;;                                 block1:
@@ -179,7 +187,9 @@
 ;; function u0:13(i64 vmctx, i64, i8x16) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -191,9 +201,9 @@
 ;; @010b                               v5 = bitcast.i16x8 little v2
 ;; @010b                               v6 = icmp ult v4, v5
 ;; @010d                               v7 = uextend.i64 v3  ; v3 = 0
-;; @010d                               v8 = load.i64 notrap aligned readonly can_move v0+56
+;; @010d                               v8 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @010d                               v9 = iadd v8, v7
-;; @010d                               store little region2 v6, v9
+;; @010d                               store little region4 v6, v9
 ;; @0111                               jump block1
 ;;
 ;;                                 block1:
@@ -203,7 +213,9 @@
 ;; function u0:14(i64 vmctx, i64, i8x16) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -215,9 +227,9 @@
 ;; @011a                               v5 = bitcast.i32x4 little v2
 ;; @011a                               v6 = icmp ult v4, v5
 ;; @011c                               v7 = uextend.i64 v3  ; v3 = 0
-;; @011c                               v8 = load.i64 notrap aligned readonly can_move v0+56
+;; @011c                               v8 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @011c                               v9 = iadd v8, v7
-;; @011c                               store little region2 v6, v9
+;; @011c                               store little region4 v6, v9
 ;; @0120                               jump block1
 ;;
 ;;                                 block1:
@@ -227,7 +239,9 @@
 ;; function u0:15(i64 vmctx, i64, i8x16) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -237,9 +251,9 @@
 ;; @0123                               v3 = iconst.i32 0
 ;; @0129                               v4 = icmp sgt v2, v2
 ;; @012b                               v5 = uextend.i64 v3  ; v3 = 0
-;; @012b                               v6 = load.i64 notrap aligned readonly can_move v0+56
+;; @012b                               v6 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @012b                               v7 = iadd v6, v5
-;; @012b                               store little region2 v4, v7
+;; @012b                               store little region4 v4, v7
 ;; @012f                               jump block1
 ;;
 ;;                                 block1:
@@ -249,7 +263,9 @@
 ;; function u0:16(i64 vmctx, i64, i8x16) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -261,9 +277,9 @@
 ;; @0138                               v5 = bitcast.i16x8 little v2
 ;; @0138                               v6 = icmp sgt v4, v5
 ;; @013a                               v7 = uextend.i64 v3  ; v3 = 0
-;; @013a                               v8 = load.i64 notrap aligned readonly can_move v0+56
+;; @013a                               v8 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @013a                               v9 = iadd v8, v7
-;; @013a                               store little region2 v6, v9
+;; @013a                               store little region4 v6, v9
 ;; @013e                               jump block1
 ;;
 ;;                                 block1:
@@ -273,7 +289,9 @@
 ;; function u0:17(i64 vmctx, i64, i8x16) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -285,9 +303,9 @@
 ;; @0147                               v5 = bitcast.i32x4 little v2
 ;; @0147                               v6 = icmp sgt v4, v5
 ;; @0149                               v7 = uextend.i64 v3  ; v3 = 0
-;; @0149                               v8 = load.i64 notrap aligned readonly can_move v0+56
+;; @0149                               v8 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0149                               v9 = iadd v8, v7
-;; @0149                               store little region2 v6, v9
+;; @0149                               store little region4 v6, v9
 ;; @014d                               jump block1
 ;;
 ;;                                 block1:
@@ -297,7 +315,9 @@
 ;; function u0:18(i64 vmctx, i64, i8x16) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -309,9 +329,9 @@
 ;; @0156                               v5 = bitcast.i64x2 little v2
 ;; @0156                               v6 = icmp sgt v4, v5
 ;; @0159                               v7 = uextend.i64 v3  ; v3 = 0
-;; @0159                               v8 = load.i64 notrap aligned readonly can_move v0+56
+;; @0159                               v8 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0159                               v9 = iadd v8, v7
-;; @0159                               store little region2 v6, v9
+;; @0159                               store little region4 v6, v9
 ;; @015d                               jump block1
 ;;
 ;;                                 block1:
@@ -321,7 +341,9 @@
 ;; function u0:19(i64 vmctx, i64, i8x16) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -331,9 +353,9 @@
 ;; @0160                               v3 = iconst.i32 0
 ;; @0166                               v4 = icmp ugt v2, v2
 ;; @0168                               v5 = uextend.i64 v3  ; v3 = 0
-;; @0168                               v6 = load.i64 notrap aligned readonly can_move v0+56
+;; @0168                               v6 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0168                               v7 = iadd v6, v5
-;; @0168                               store little region2 v4, v7
+;; @0168                               store little region4 v4, v7
 ;; @016c                               jump block1
 ;;
 ;;                                 block1:
@@ -343,7 +365,9 @@
 ;; function u0:1(i64 vmctx, i64, i8x16) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -355,9 +379,9 @@
 ;; @0054                               v5 = bitcast.i16x8 little v2
 ;; @0054                               v6 = icmp eq v4, v5
 ;; @0056                               v7 = uextend.i64 v3  ; v3 = 0
-;; @0056                               v8 = load.i64 notrap aligned readonly can_move v0+56
+;; @0056                               v8 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0056                               v9 = iadd v8, v7
-;; @0056                               store little region2 v6, v9
+;; @0056                               store little region4 v6, v9
 ;; @005a                               jump block1
 ;;
 ;;                                 block1:
@@ -367,7 +391,9 @@
 ;; function u0:20(i64 vmctx, i64, i8x16) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -379,9 +405,9 @@
 ;; @0175                               v5 = bitcast.i16x8 little v2
 ;; @0175                               v6 = icmp ugt v4, v5
 ;; @0177                               v7 = uextend.i64 v3  ; v3 = 0
-;; @0177                               v8 = load.i64 notrap aligned readonly can_move v0+56
+;; @0177                               v8 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0177                               v9 = iadd v8, v7
-;; @0177                               store little region2 v6, v9
+;; @0177                               store little region4 v6, v9
 ;; @017b                               jump block1
 ;;
 ;;                                 block1:
@@ -391,7 +417,9 @@
 ;; function u0:21(i64 vmctx, i64, i8x16) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -403,9 +431,9 @@
 ;; @0184                               v5 = bitcast.i32x4 little v2
 ;; @0184                               v6 = icmp ugt v4, v5
 ;; @0186                               v7 = uextend.i64 v3  ; v3 = 0
-;; @0186                               v8 = load.i64 notrap aligned readonly can_move v0+56
+;; @0186                               v8 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0186                               v9 = iadd v8, v7
-;; @0186                               store little region2 v6, v9
+;; @0186                               store little region4 v6, v9
 ;; @018a                               jump block1
 ;;
 ;;                                 block1:
@@ -415,7 +443,9 @@
 ;; function u0:22(i64 vmctx, i64, i8x16) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -427,9 +457,9 @@
 ;; @0193                               v5 = bitcast.f32x4 little v2
 ;; @0193                               v6 = fcmp eq v4, v5
 ;; @0195                               v7 = uextend.i64 v3  ; v3 = 0
-;; @0195                               v8 = load.i64 notrap aligned readonly can_move v0+56
+;; @0195                               v8 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0195                               v9 = iadd v8, v7
-;; @0195                               store little region2 v6, v9
+;; @0195                               store little region4 v6, v9
 ;; @0199                               jump block1
 ;;
 ;;                                 block1:
@@ -439,7 +469,9 @@
 ;; function u0:23(i64 vmctx, i64, i8x16) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -451,9 +483,9 @@
 ;; @01a2                               v5 = bitcast.f64x2 little v2
 ;; @01a2                               v6 = fcmp eq v4, v5
 ;; @01a4                               v7 = uextend.i64 v3  ; v3 = 0
-;; @01a4                               v8 = load.i64 notrap aligned readonly can_move v0+56
+;; @01a4                               v8 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @01a4                               v9 = iadd v8, v7
-;; @01a4                               store little region2 v6, v9
+;; @01a4                               store little region4 v6, v9
 ;; @01a8                               jump block1
 ;;
 ;;                                 block1:
@@ -463,7 +495,9 @@
 ;; function u0:24(i64 vmctx, i64, i8x16) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -475,9 +509,9 @@
 ;; @01b1                               v5 = bitcast.f32x4 little v2
 ;; @01b1                               v6 = fcmp ne v4, v5
 ;; @01b3                               v7 = uextend.i64 v3  ; v3 = 0
-;; @01b3                               v8 = load.i64 notrap aligned readonly can_move v0+56
+;; @01b3                               v8 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @01b3                               v9 = iadd v8, v7
-;; @01b3                               store little region2 v6, v9
+;; @01b3                               store little region4 v6, v9
 ;; @01b7                               jump block1
 ;;
 ;;                                 block1:
@@ -487,7 +521,9 @@
 ;; function u0:25(i64 vmctx, i64, i8x16) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -499,9 +535,9 @@
 ;; @01c0                               v5 = bitcast.f64x2 little v2
 ;; @01c0                               v6 = fcmp ne v4, v5
 ;; @01c2                               v7 = uextend.i64 v3  ; v3 = 0
-;; @01c2                               v8 = load.i64 notrap aligned readonly can_move v0+56
+;; @01c2                               v8 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @01c2                               v9 = iadd v8, v7
-;; @01c2                               store little region2 v6, v9
+;; @01c2                               store little region4 v6, v9
 ;; @01c6                               jump block1
 ;;
 ;;                                 block1:
@@ -511,7 +547,9 @@
 ;; function u0:26(i64 vmctx, i64, i8x16) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -523,9 +561,9 @@
 ;; @01cf                               v5 = bitcast.f32x4 little v2
 ;; @01cf                               v6 = fcmp lt v4, v5
 ;; @01d1                               v7 = uextend.i64 v3  ; v3 = 0
-;; @01d1                               v8 = load.i64 notrap aligned readonly can_move v0+56
+;; @01d1                               v8 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @01d1                               v9 = iadd v8, v7
-;; @01d1                               store little region2 v6, v9
+;; @01d1                               store little region4 v6, v9
 ;; @01d5                               jump block1
 ;;
 ;;                                 block1:
@@ -535,7 +573,9 @@
 ;; function u0:27(i64 vmctx, i64, i8x16) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -547,9 +587,9 @@
 ;; @01de                               v5 = bitcast.f64x2 little v2
 ;; @01de                               v6 = fcmp lt v4, v5
 ;; @01e0                               v7 = uextend.i64 v3  ; v3 = 0
-;; @01e0                               v8 = load.i64 notrap aligned readonly can_move v0+56
+;; @01e0                               v8 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @01e0                               v9 = iadd v8, v7
-;; @01e0                               store little region2 v6, v9
+;; @01e0                               store little region4 v6, v9
 ;; @01e4                               jump block1
 ;;
 ;;                                 block1:
@@ -559,7 +599,9 @@
 ;; function u0:28(i64 vmctx, i64, i8x16) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -571,9 +613,9 @@
 ;; @01ed                               v5 = bitcast.f32x4 little v2
 ;; @01ed                               v6 = fcmp le v4, v5
 ;; @01ef                               v7 = uextend.i64 v3  ; v3 = 0
-;; @01ef                               v8 = load.i64 notrap aligned readonly can_move v0+56
+;; @01ef                               v8 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @01ef                               v9 = iadd v8, v7
-;; @01ef                               store little region2 v6, v9
+;; @01ef                               store little region4 v6, v9
 ;; @01f3                               jump block1
 ;;
 ;;                                 block1:
@@ -583,7 +625,9 @@
 ;; function u0:29(i64 vmctx, i64, i8x16) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -595,9 +639,9 @@
 ;; @01fc                               v5 = bitcast.f64x2 little v2
 ;; @01fc                               v6 = fcmp le v4, v5
 ;; @01fe                               v7 = uextend.i64 v3  ; v3 = 0
-;; @01fe                               v8 = load.i64 notrap aligned readonly can_move v0+56
+;; @01fe                               v8 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @01fe                               v9 = iadd v8, v7
-;; @01fe                               store little region2 v6, v9
+;; @01fe                               store little region4 v6, v9
 ;; @0202                               jump block1
 ;;
 ;;                                 block1:
@@ -607,7 +651,9 @@
 ;; function u0:2(i64 vmctx, i64, i8x16) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -619,9 +665,9 @@
 ;; @0063                               v5 = bitcast.i32x4 little v2
 ;; @0063                               v6 = icmp eq v4, v5
 ;; @0065                               v7 = uextend.i64 v3  ; v3 = 0
-;; @0065                               v8 = load.i64 notrap aligned readonly can_move v0+56
+;; @0065                               v8 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0065                               v9 = iadd v8, v7
-;; @0065                               store little region2 v6, v9
+;; @0065                               store little region4 v6, v9
 ;; @0069                               jump block1
 ;;
 ;;                                 block1:
@@ -631,7 +677,9 @@
 ;; function u0:30(i64 vmctx, i64, i8x16) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -643,9 +691,9 @@
 ;; @020b                               v5 = bitcast.f32x4 little v2
 ;; @020b                               v6 = fcmp gt v4, v5
 ;; @020d                               v7 = uextend.i64 v3  ; v3 = 0
-;; @020d                               v8 = load.i64 notrap aligned readonly can_move v0+56
+;; @020d                               v8 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @020d                               v9 = iadd v8, v7
-;; @020d                               store little region2 v6, v9
+;; @020d                               store little region4 v6, v9
 ;; @0211                               jump block1
 ;;
 ;;                                 block1:
@@ -655,7 +703,9 @@
 ;; function u0:31(i64 vmctx, i64, i8x16) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -667,9 +717,9 @@
 ;; @021a                               v5 = bitcast.f64x2 little v2
 ;; @021a                               v6 = fcmp gt v4, v5
 ;; @021c                               v7 = uextend.i64 v3  ; v3 = 0
-;; @021c                               v8 = load.i64 notrap aligned readonly can_move v0+56
+;; @021c                               v8 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @021c                               v9 = iadd v8, v7
-;; @021c                               store little region2 v6, v9
+;; @021c                               store little region4 v6, v9
 ;; @0220                               jump block1
 ;;
 ;;                                 block1:
@@ -679,7 +729,9 @@
 ;; function u0:32(i64 vmctx, i64, i8x16) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -691,9 +743,9 @@
 ;; @0229                               v5 = bitcast.f32x4 little v2
 ;; @0229                               v6 = fcmp ge v4, v5
 ;; @022b                               v7 = uextend.i64 v3  ; v3 = 0
-;; @022b                               v8 = load.i64 notrap aligned readonly can_move v0+56
+;; @022b                               v8 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @022b                               v9 = iadd v8, v7
-;; @022b                               store little region2 v6, v9
+;; @022b                               store little region4 v6, v9
 ;; @022f                               jump block1
 ;;
 ;;                                 block1:
@@ -703,7 +755,9 @@
 ;; function u0:33(i64 vmctx, i64, i8x16) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -715,9 +769,9 @@
 ;; @0238                               v5 = bitcast.f64x2 little v2
 ;; @0238                               v6 = fcmp ge v4, v5
 ;; @023a                               v7 = uextend.i64 v3  ; v3 = 0
-;; @023a                               v8 = load.i64 notrap aligned readonly can_move v0+56
+;; @023a                               v8 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @023a                               v9 = iadd v8, v7
-;; @023a                               store little region2 v6, v9
+;; @023a                               store little region4 v6, v9
 ;; @023e                               jump block1
 ;;
 ;;                                 block1:
@@ -727,7 +781,9 @@
 ;; function u0:3(i64 vmctx, i64, i8x16) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -739,9 +795,9 @@
 ;; @0072                               v5 = bitcast.i64x2 little v2
 ;; @0072                               v6 = icmp eq v4, v5
 ;; @0075                               v7 = uextend.i64 v3  ; v3 = 0
-;; @0075                               v8 = load.i64 notrap aligned readonly can_move v0+56
+;; @0075                               v8 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0075                               v9 = iadd v8, v7
-;; @0075                               store little region2 v6, v9
+;; @0075                               store little region4 v6, v9
 ;; @0079                               jump block1
 ;;
 ;;                                 block1:
@@ -751,7 +807,9 @@
 ;; function u0:4(i64 vmctx, i64, i8x16) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -761,9 +819,9 @@
 ;; @007c                               v3 = iconst.i32 0
 ;; @0082                               v4 = icmp ne v2, v2
 ;; @0084                               v5 = uextend.i64 v3  ; v3 = 0
-;; @0084                               v6 = load.i64 notrap aligned readonly can_move v0+56
+;; @0084                               v6 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0084                               v7 = iadd v6, v5
-;; @0084                               store little region2 v4, v7
+;; @0084                               store little region4 v4, v7
 ;; @0088                               jump block1
 ;;
 ;;                                 block1:
@@ -773,7 +831,9 @@
 ;; function u0:5(i64 vmctx, i64, i8x16) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -785,9 +845,9 @@
 ;; @0091                               v5 = bitcast.i16x8 little v2
 ;; @0091                               v6 = icmp ne v4, v5
 ;; @0093                               v7 = uextend.i64 v3  ; v3 = 0
-;; @0093                               v8 = load.i64 notrap aligned readonly can_move v0+56
+;; @0093                               v8 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0093                               v9 = iadd v8, v7
-;; @0093                               store little region2 v6, v9
+;; @0093                               store little region4 v6, v9
 ;; @0097                               jump block1
 ;;
 ;;                                 block1:
@@ -797,7 +857,9 @@
 ;; function u0:6(i64 vmctx, i64, i8x16) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -809,9 +871,9 @@
 ;; @00a0                               v5 = bitcast.i32x4 little v2
 ;; @00a0                               v6 = icmp ne v4, v5
 ;; @00a2                               v7 = uextend.i64 v3  ; v3 = 0
-;; @00a2                               v8 = load.i64 notrap aligned readonly can_move v0+56
+;; @00a2                               v8 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @00a2                               v9 = iadd v8, v7
-;; @00a2                               store little region2 v6, v9
+;; @00a2                               store little region4 v6, v9
 ;; @00a6                               jump block1
 ;;
 ;;                                 block1:
@@ -821,7 +883,9 @@
 ;; function u0:7(i64 vmctx, i64, i8x16) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -833,9 +897,9 @@
 ;; @00af                               v5 = bitcast.i64x2 little v2
 ;; @00af                               v6 = icmp ne v4, v5
 ;; @00b2                               v7 = uextend.i64 v3  ; v3 = 0
-;; @00b2                               v8 = load.i64 notrap aligned readonly can_move v0+56
+;; @00b2                               v8 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @00b2                               v9 = iadd v8, v7
-;; @00b2                               store little region2 v6, v9
+;; @00b2                               store little region4 v6, v9
 ;; @00b6                               jump block1
 ;;
 ;;                                 block1:
@@ -845,7 +909,9 @@
 ;; function u0:8(i64 vmctx, i64, i8x16) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -855,9 +921,9 @@
 ;; @00b9                               v3 = iconst.i32 0
 ;; @00bf                               v4 = icmp slt v2, v2
 ;; @00c1                               v5 = uextend.i64 v3  ; v3 = 0
-;; @00c1                               v6 = load.i64 notrap aligned readonly can_move v0+56
+;; @00c1                               v6 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @00c1                               v7 = iadd v6, v5
-;; @00c1                               store little region2 v4, v7
+;; @00c1                               store little region4 v4, v7
 ;; @00c5                               jump block1
 ;;
 ;;                                 block1:
@@ -867,7 +933,9 @@
 ;; function u0:9(i64 vmctx, i64, i8x16) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region2 = 2415919104 "VMMemoryDefinition+0x0"
+;;     region3 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region4 = 805306368 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -879,9 +947,9 @@
 ;; @00ce                               v5 = bitcast.i16x8 little v2
 ;; @00ce                               v6 = icmp slt v4, v5
 ;; @00d0                               v7 = uextend.i64 v3  ; v3 = 0
-;; @00d0                               v8 = load.i64 notrap aligned readonly can_move v0+56
+;; @00d0                               v8 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @00d0                               v9 = iadd v8, v7
-;; @00d0                               store little region2 v6, v9
+;; @00d0                               store little region4 v6, v9
 ;; @00d4                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/startup-data-active.wat
+++ b/tests/disas/startup-data-active.wat
@@ -41,6 +41,8 @@
 ;; function u2415919104:0(i64 vmctx, i64) tail {
 ;;     region0 = 112 "VMContext+0x70"
 ;;     region1 = 120 "VMContext+0x78"
+;;     region2 = 2415919112 "VMMemoryDefinition+0x8"
+;;     region3 = 2415919104 "VMMemoryDefinition+0x0"
 ;;     sig0 = (i64 vmctx, i64, i64, i64) tail
 ;;     fn0 = colocated u805306368:1 sig0
 ;;
@@ -52,11 +54,11 @@
 ;;
 ;; block1:
 ;;     v6 = load.i32 notrap aligned region1 v0+120
-;;     v8 = load.i64 notrap aligned v0+64
+;;     v8 = load.i64 notrap aligned region2 v0+64
 ;;     v10 = uextend.i64 v6
 ;;     v14 = icmp ugt v10, v8
 ;;     trapnz v14, heap_oob
-;;     v15 = load.i64 notrap aligned readonly can_move v0+56
+;;     v15 = load.i64 notrap aligned readonly can_move region3 v0+56
 ;;     call fn0(v0, v15, v2, v10)
 ;;     jump block2
 ;;


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
