### PR TITLE
Deduplicate wasmtime-bench-api component/core code

### DIFF
--- a/crates/bench-api/src/lib.rs
+++ b/crates/bench-api/src/lib.rs
@@ -140,10 +140,8 @@ use clap::Parser;
 use std::os::raw::{c_int, c_void};
 use std::slice;
 use std::{env, path::PathBuf};
-use wasmtime::component::ResourceTable;
 use wasmtime::{
-    CodeBuilder, CodeHint, Engine, Instance, Linker, Module, Result, Store, error::Context as _,
-    format_err,
+    CodeBuilder, CodeHint, Engine, Linker, Module, Result, Store, error::Context as _, format_err,
 };
 use wasmtime_cli_flags::CommonOptions;
 use wasmtime_wasi::cli::{InputFile, OutputFile};
@@ -282,12 +280,6 @@ pub extern "C" fn wasm_bench_create(
         let stdin_path = config.stdin_path()?;
         let options = config.execution_flags()?;
 
-        // Clone paths for the component WASI closure.
-        let working_dir2 = working_dir.clone();
-        let stdout_path2 = stdout_path.clone();
-        let stderr_path2 = stderr_path.clone();
-        let stdin_path2 = stdin_path.clone();
-
         let state = Box::new(BenchState::new(
             options,
             config.compilation_timer,
@@ -327,34 +319,6 @@ pub extern "C" fn wasm_bench_create(
                 }
 
                 Ok(cx.build_p1())
-            },
-            move || {
-                let mut cx = WasiCtx::builder();
-
-                let stdout = std::fs::File::create(&stdout_path2)
-                    .with_context(|| format!("failed to create {}", stdout_path2.display()))?;
-                cx.stdout(OutputFile::new(stdout));
-
-                let stderr = std::fs::File::create(&stderr_path2)
-                    .with_context(|| format!("failed to create {}", stderr_path2.display()))?;
-                cx.stderr(OutputFile::new(stderr));
-
-                if let Some(stdin_path) = &stdin_path2 {
-                    let stdin = std::fs::File::open(stdin_path)
-                        .with_context(|| format!("failed to open {}", stdin_path.display()))?;
-                    cx.stdin(InputFile::new(stdin));
-                }
-
-                cx.preopened_dir(working_dir2.clone(), ".", DirPerms::READ, FilePerms::READ)?;
-
-                if let Ok(val) = env::var("WASM_BENCH_USE_SMALL_WORKLOAD") {
-                    cx.env("WASM_BENCH_USE_SMALL_WORKLOAD", &val);
-                }
-
-                Ok(ComponentHostState {
-                    wasi: cx.build(),
-                    table: ResourceTable::new(),
-                })
             },
         )?);
         Ok(Box::into_raw(state) as _)
@@ -425,7 +389,7 @@ fn to_exit_code<T>(result: impl Into<Result<T>>) -> ExitCode {
 /// to manage the Wasmtime engine between calls.
 struct BenchState {
     linker: Linker<HostState>,
-    component_linker: wasmtime::component::Linker<ComponentHostState>,
+    component_linker: wasmtime::component::Linker<HostState>,
     compilation_timer: *mut u8,
     compilation_start: extern "C" fn(*mut u8),
     compilation_end: extern "C" fn(*mut u8),
@@ -433,14 +397,16 @@ struct BenchState {
     instantiation_start: extern "C" fn(*mut u8),
     instantiation_end: extern "C" fn(*mut u8),
     make_wasi_cx: Box<dyn FnMut() -> Result<WasiP1Ctx>>,
-    make_component_wasi_cx: Box<dyn FnMut() -> Result<ComponentHostState>>,
     module: Option<Module>,
     component: Option<wasmtime::component::Component>,
     store_and_instance: Option<(Store<HostState>, Instance)>,
-    component_store_and_instance:
-        Option<(Store<ComponentHostState>, wasmtime::component::Instance)>,
     epoch_interruption: bool,
     fuel: Option<u64>,
+}
+
+enum Instance {
+    Core(wasmtime::Instance),
+    Component(wasmtime::component::Instance),
 }
 
 struct HostState {
@@ -449,17 +415,9 @@ struct HostState {
     wasi_nn: wasmtime_wasi_nn::witx::WasiNnCtx,
 }
 
-struct ComponentHostState {
-    wasi: WasiCtx,
-    table: ResourceTable,
-}
-
-impl WasiView for ComponentHostState {
+impl WasiView for HostState {
     fn ctx(&mut self) -> WasiCtxView<'_> {
-        WasiCtxView {
-            ctx: &mut self.wasi,
-            table: &mut self.table,
-        }
+        self.wasi.ctx()
     }
 }
 
@@ -476,14 +434,13 @@ impl BenchState {
         execution_start: extern "C" fn(*mut u8),
         execution_end: extern "C" fn(*mut u8),
         make_wasi_cx: impl FnMut() -> Result<WasiP1Ctx> + 'static,
-        make_component_wasi_cx: impl FnMut() -> Result<ComponentHostState> + 'static,
     ) -> Result<Self> {
         let mut config = options.config(None)?;
         // NB: always disable the compilation cache.
         config.cache(None);
         let engine = Engine::new(&config)?;
         let mut linker = Linker::<HostState>::new(&engine);
-        let mut component_linker = wasmtime::component::Linker::<ComponentHostState>::new(&engine);
+        let mut component_linker = wasmtime::component::Linker::<HostState>::new(&engine);
 
         // Define the benchmarking start/end functions.
         let execution_timer = unsafe {
@@ -504,18 +461,15 @@ impl BenchState {
         let mut bench_instance = component_linker.instance("bench")?;
         bench_instance.func_wrap(
             "start",
-            move |_: wasmtime::StoreContextMut<'_, ComponentHostState>, (): ()| {
+            move |_: wasmtime::StoreContextMut<'_, _>, (): ()| {
                 execution_start(*execution_timer.get());
                 Ok(())
             },
         )?;
-        bench_instance.func_wrap(
-            "end",
-            move |_: wasmtime::StoreContextMut<'_, ComponentHostState>, (): ()| {
-                execution_end(*execution_timer.get());
-                Ok(())
-            },
-        )?;
+        bench_instance.func_wrap("end", move |_: wasmtime::StoreContextMut<'_, _>, (): ()| {
+            execution_end(*execution_timer.get());
+            Ok(())
+        })?;
 
         let epoch_interruption = options.wasm.epoch_interruption.unwrap_or(false);
         let fuel = options.wasm.fuel;
@@ -540,11 +494,9 @@ impl BenchState {
             instantiation_start,
             instantiation_end,
             make_wasi_cx: Box::new(make_wasi_cx) as _,
-            make_component_wasi_cx: Box::new(make_component_wasi_cx) as _,
             module: None,
             component: None,
             store_and_instance: None,
-            component_store_and_instance: None,
             epoch_interruption,
             fuel,
         })
@@ -577,94 +529,77 @@ impl BenchState {
 
     fn instantiate(&mut self) -> Result<()> {
         self.store_and_instance = None;
-        self.component_store_and_instance = None;
 
-        if let Some(component) = &self.component {
-            let host = (self.make_component_wasi_cx)()
-                .context("failed to create a WASI context for component")?;
+        let host = HostState {
+            wasi: (self.make_wasi_cx)().context("failed to create a WASI context")?,
+            #[cfg(feature = "wasi-nn")]
+            wasi_nn: {
+                let (backends, registry) = wasmtime_wasi_nn::preload(&[])?;
+                wasmtime_wasi_nn::witx::WasiNnCtx::new(backends, registry)
+            },
+        };
 
-            // NB: Start measuring instantiation time *after* we've created the
-            // WASI context, since that needs to do file I/O to setup
-            // stdin/stdout/stderr.
-            (self.instantiation_start)(self.instantiation_timer);
+        // NB: Start measuring instantiation time *after* we've created the
+        // WASI context, since that needs to do file I/O to setup
+        // stdin/stdout/stderr.
+        (self.instantiation_start)(self.instantiation_timer);
 
-            let mut store = Store::new(self.component_linker.engine(), host);
-            if self.epoch_interruption {
-                store.set_epoch_deadline(1);
-            }
-            if let Some(fuel) = self.fuel {
-                store.set_fuel(fuel).unwrap();
-            }
-
-            let instance = self.component_linker.instantiate(&mut store, component)?;
-
-            (self.instantiation_end)(self.instantiation_timer);
-
-            self.component_store_and_instance = Some((store, instance));
-        } else {
-            let module = self
-                .module
-                .as_ref()
-                .expect("compile the module before instantiating it");
-
-            let host = HostState {
-                wasi: (self.make_wasi_cx)().context("failed to create a WASI context")?,
-                #[cfg(feature = "wasi-nn")]
-                wasi_nn: {
-                    let (backends, registry) = wasmtime_wasi_nn::preload(&[])?;
-                    wasmtime_wasi_nn::witx::WasiNnCtx::new(backends, registry)
-                },
-            };
-
-            // NB: Start measuring instantiation time *after* we've created the
-            // WASI context, since that needs to do file I/O to setup
-            // stdin/stdout/stderr.
-            (self.instantiation_start)(self.instantiation_timer);
-
-            let mut store = Store::new(self.linker.engine(), host);
-            if self.epoch_interruption {
-                store.set_epoch_deadline(1);
-            }
-            if let Some(fuel) = self.fuel {
-                store.set_fuel(fuel).unwrap();
-            }
-
-            let instance = self.linker.instantiate(&mut store, &module)?;
-
-            (self.instantiation_end)(self.instantiation_timer);
-
-            self.store_and_instance = Some((store, instance));
+        let mut store = Store::new(self.linker.engine(), host);
+        if self.epoch_interruption {
+            store.set_epoch_deadline(1);
         }
+        if let Some(fuel) = self.fuel {
+            store.set_fuel(fuel).unwrap();
+        }
+
+        let instance = match &self.component {
+            Some(component) => {
+                Instance::Component(self.component_linker.instantiate(&mut store, component)?)
+            }
+            None => {
+                let module = self
+                    .module
+                    .as_ref()
+                    .expect("compile the module before instantiating it");
+                Instance::Core(self.linker.instantiate(&mut store, &module)?)
+            }
+        };
+
+        (self.instantiation_end)(self.instantiation_timer);
+
+        self.store_and_instance = Some((store, instance));
         Ok(())
     }
 
     fn execute(&mut self) -> Result<()> {
-        if let Some((mut store, instance)) = self.component_store_and_instance.take() {
-            let command = wasmtime_wasi::p2::bindings::sync::Command::new(&mut store, &instance)?;
-            match command.wasi_cli_run().call_run(&mut store)? {
-                Ok(()) => Ok(()),
-                Err(()) => Err(format_err!("calling `run` failed")),
-            }
-        } else {
-            let (mut store, instance) = self
-                .store_and_instance
-                .take()
-                .expect("instantiate the module before executing it");
-
-            let start_func = instance.get_typed_func::<(), ()>(&mut store, "_start")?;
-            match start_func.call(&mut store, ()) {
-                Ok(_) => Ok(()),
-                Err(trap) => {
-                    // Since _start will likely return by using the system `exit` call, we must
-                    // check the trap code to see if it actually represents a successful exit.
-                    if let Some(exit) = trap.downcast_ref::<I32Exit>() {
-                        if exit.0 == 0 {
-                            return Ok(());
-                        }
-                    }
-
-                    Err(trap)
+        match self.store_and_instance.take() {
+            Some((mut store, Instance::Component(instance))) => {
+                let command =
+                    wasmtime_wasi::p2::bindings::sync::Command::new(&mut store, &instance)?;
+                match command.wasi_cli_run().call_run(&mut store)? {
+                    Ok(()) => Ok(()),
+                    Err(()) => Err(format_err!("calling `run` failed")),
                 }
+            }
+            Some((mut store, Instance::Core(instance))) => {
+                let start_func = instance.get_typed_func::<(), ()>(&mut store, "_start")?;
+                match start_func.call(&mut store, ()) {
+                    Ok(_) => Ok(()),
+                    Err(trap) => {
+                        // Since _start will likely return by using the system `exit` call, we must
+                        // check the trap code to see if it actually represents a successful exit.
+                        if let Some(exit) = trap.downcast_ref::<I32Exit>() {
+                            if exit.0 == 0 {
+                                return Ok(());
+                            }
+                        }
+
+                        Err(trap)
+                    }
+                }
+            }
+            None => {
+                panic!("instantiate before execution")
             }
         }
     }


### PR DESCRIPTION
No need to 2x the execution/instantiation/wasi/etc paths for components/core wasm, it can all use the same store and the same state and such.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
