### PR TITLE
require write-before-drop for futures unconditionally

### DIFF
--- a/crates/wasmtime/src/runtime/component/concurrent/futures_and_streams.rs
+++ b/crates/wasmtime/src/runtime/component/concurrent/futures_and_streams.rs
@@ -2488,10 +2488,7 @@ impl StoreOpaque {
             }
             WriteState::HostReady { .. } => {}
             v @ WriteState::Open => {
-                if let (Some(on_drop_open), false) = (
-                    on_drop_open,
-                    transmit.done || matches!(transmit.read, ReadState::Dropped),
-                ) {
+                if let (Some(on_drop_open), false) = (on_drop_open, transmit.done) {
                     on_drop_open()?;
                 } else {
                     *v = WriteState::Dropped;

--- a/tests/misc_testsuite/component-model/async/futures-must-write2.wast
+++ b/tests/misc_testsuite/component-model/async/futures-must-write2.wast
@@ -1,0 +1,39 @@
+;;! component_model_async = true
+
+;; The writable end of a future must be written to before it is dropped
+;; regardless of whether the readable end is dropped first.
+(component
+  (core module $libc (memory (export "m") 1))
+  (core instance $libc (instantiate $libc))
+
+  (type $f (future u8))
+  (core func $future.new (canon future.new $f))
+  (core func $future.drop-readable (canon future.drop-readable $f))
+  (core func $future.drop-writable (canon future.drop-writable $f))
+
+  (core module $m
+    (import "" "m" (memory 1))
+    (import "" "future.new" (func $future.new (result i64)))
+    (import "" "future.drop-readable" (func $future.drop-readable (param i32)))
+    (import "" "future.drop-writable" (func $future.drop-writable (param i32)))
+
+    (func (export "run")
+      (local $tmp i64) (local $r i32) (local $w i32)
+      (local.set $tmp (call $future.new))
+      (local.set $r (i32.wrap_i64 (local.get $tmp)))
+      (local.set $w (i32.wrap_i64 (i64.shr_u (local.get $tmp) (i64.const 32))))
+      (call $future.drop-readable (local.get $r))
+      (call $future.drop-writable (local.get $w))
+    )
+  )
+  (core instance $i (instantiate $m
+    (with "" (instance
+      (export "m" (memory $libc "m"))
+      (export "future.new" (func $future.new))
+      (export "future.drop-readable" (func $future.drop-readable))
+      (export "future.drop-writable" (func $future.drop-writable))
+    ))
+  ))
+  (func (export "run") async (canon lift (core func $i "run")))
+)
+(assert_trap (invoke "run") "cannot drop future write end without first writing a value")


### PR DESCRIPTION
Previously, we only trapped if the writable end of a future was dropped without having writen a value _and_ the readable end had not yet been dropped, but the spec says we need to trap regardless of whether the readable end has been dropped.

Test case courtesy of Alex.

Fixes #13661

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
