### PR TITLE
Tag `VMComponentContext` fields with alias regions

### DIFF
--- a/crates/cranelift/src/alias_region.rs
+++ b/crates/cranelift/src/alias_region.rs
@@ -8,6 +8,10 @@ use wasmtime_environ::{
     DefinedGlobalIndex, DefinedMemoryIndex, DefinedTableIndex, FuncIndex, GetPtrSize, GlobalIndex,
     MemoryIndex, OwnedMemoryIndex, PtrSize as _, RuntimeDataIndex, StaticModuleIndex, TableIndex,
     TagIndex, VMOffsets,
+    component::{
+        LoweredIndex, ResourceIndex, RuntimeCallbackIndex, RuntimeComponentInstanceIndex,
+        RuntimeMemoryIndex, RuntimePostReturnIndex, VMComponentOffsets,
+    },
 };
 
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
@@ -16,6 +20,7 @@ enum VmType {
     VMStoreContext,
     VMMemoryDefinition,
     VMTableDefinition,
+    VMComponentContext,
 }
 
 /// A key that uniquely identifies an alias region across an entire compilation.
@@ -105,6 +110,7 @@ impl AliasRegionKey {
     const GC_HEAP_KIND: u32 = Self::new_kind(0b1000);
     const VM_MEMORY_DEFINITION_KIND: u32 = Self::new_kind(0b1001);
     const VM_TABLE_DEFINITION_KIND: u32 = Self::new_kind(0b1010);
+    const VM_COMPONENT_CONTEXT_KIND: u32 = Self::new_kind(0b1011);
 
     /// Encode this key into a raw `u32` suitable for use as an
     /// `AliasRegionData::user_id`.
@@ -117,6 +123,7 @@ impl AliasRegionKey {
                     VmType::VMStoreContext => Self::VM_STORE_CONTEXT_KIND,
                     VmType::VMMemoryDefinition => Self::VM_MEMORY_DEFINITION_KIND,
                     VmType::VMTableDefinition => Self::VM_TABLE_DEFINITION_KIND,
+                    VmType::VMComponentContext => Self::VM_COMPONENT_CONTEXT_KIND,
                 };
                 kind | (offset & Self::OFFSET_MASK)
             }
@@ -1427,6 +1434,216 @@ where
             self.pointer_type,
             ir::MemFlagsData::trusted().with_alias_region(Some(region)),
             ptr,
+        )
+    }
+}
+
+/// `VMComponentContext`-related methods, used when compiling component
+/// trampolines.
+impl AliasRegions<VMComponentOffsets<u8>> {
+    fn vmcomponent_region(&mut self, func: &mut ir::Function, offset: u32) -> ir::AliasRegion {
+        self.region(
+            func,
+            AliasRegionKey::Vm {
+                ty: VmType::VMComponentContext,
+                offset,
+            },
+        )
+    }
+
+    fn vmcomponent_load(
+        &mut self,
+        cursor: &mut FuncCursor<'_>,
+        ty: ir::Type,
+        base_flags: ir::MemFlagsData,
+        vmctx: ir::Value,
+        offset: u32,
+    ) -> ir::Value {
+        let region = self.vmcomponent_region(cursor.func, offset);
+        cursor.ins().load(
+            ty,
+            base_flags.with_alias_region(Some(region)),
+            vmctx,
+            i32::try_from(offset).unwrap(),
+        )
+    }
+
+    fn vmcomponent_store(
+        &mut self,
+        cursor: &mut FuncCursor<'_>,
+        base_flags: ir::MemFlagsData,
+        vmctx: ir::Value,
+        offset: u32,
+        val: ir::Value,
+    ) {
+        let region = self.vmcomponent_region(cursor.func, offset);
+        cursor.ins().store(
+            base_flags.with_alias_region(Some(region)),
+            val,
+            vmctx,
+            i32::try_from(offset).unwrap(),
+        );
+    }
+
+    /// Load a lowering's host-data pointer from the `VMComponentContext`.
+    pub fn vmcomponent_lowering_data(
+        &mut self,
+        cursor: &mut FuncCursor<'_>,
+        vmctx: ir::Value,
+        index: LoweredIndex,
+    ) -> ir::Value {
+        self.vmcomponent_load(
+            cursor,
+            self.pointer_type,
+            ir::MemFlagsData::trusted(),
+            vmctx,
+            self.offsets.lowering_data(index),
+        )
+    }
+
+    /// Load a lowering's host callee pointer from the `VMComponentContext`.
+    pub fn vmcomponent_lowering_callee(
+        &mut self,
+        cursor: &mut FuncCursor<'_>,
+        vmctx: ir::Value,
+        index: LoweredIndex,
+    ) -> ir::Value {
+        self.vmcomponent_load(
+            cursor,
+            self.pointer_type,
+            ir::MemFlagsData::trusted(),
+            vmctx,
+            self.offsets.lowering_callee(index),
+        )
+    }
+
+    /// Load the current task's `may_block` flag from the `VMComponentContext`.
+    pub fn vmcomponent_task_may_block(
+        &mut self,
+        cursor: &mut FuncCursor<'_>,
+        vmctx: ir::Value,
+    ) -> ir::Value {
+        self.vmcomponent_load(
+            cursor,
+            ir::types::I32,
+            ir::MemFlagsData::trusted().with_readonly(),
+            vmctx,
+            self.offsets.task_may_block(),
+        )
+    }
+
+    /// Store the current task's `may_block` flag into the `VMComponentContext`.
+    pub fn store_vmcomponent_task_may_block(
+        &mut self,
+        cursor: &mut FuncCursor<'_>,
+        vmctx: ir::Value,
+        val: ir::Value,
+    ) {
+        self.vmcomponent_store(
+            cursor,
+            ir::MemFlagsData::trusted(),
+            vmctx,
+            self.offsets.task_may_block(),
+            val,
+        )
+    }
+
+    /// Load a resource's destructor function pointer from the
+    /// `VMComponentContext`.
+    pub fn vmcomponent_resource_destructor(
+        &mut self,
+        cursor: &mut FuncCursor<'_>,
+        vmctx: ir::Value,
+        index: ResourceIndex,
+    ) -> ir::Value {
+        self.vmcomponent_load(
+            cursor,
+            self.pointer_type,
+            ir::MemFlagsData::trusted().with_readonly(),
+            vmctx,
+            self.offsets.resource_destructor(index),
+        )
+    }
+
+    /// Load a runtime memory's `*mut VMMemoryDefinition` from the
+    /// `VMComponentContext`.
+    pub fn vmcomponent_runtime_memory(
+        &mut self,
+        cursor: &mut FuncCursor<'_>,
+        vmctx: ir::Value,
+        index: RuntimeMemoryIndex,
+    ) -> ir::Value {
+        self.vmcomponent_load(
+            cursor,
+            self.pointer_type,
+            ir::MemFlagsData::trusted(),
+            vmctx,
+            self.offsets.runtime_memory(index),
+        )
+    }
+
+    /// Load a runtime callback function pointer from the `VMComponentContext`.
+    pub fn vmcomponent_runtime_callback(
+        &mut self,
+        cursor: &mut FuncCursor<'_>,
+        vmctx: ir::Value,
+        index: RuntimeCallbackIndex,
+    ) -> ir::Value {
+        self.vmcomponent_load(
+            cursor,
+            self.pointer_type,
+            ir::MemFlagsData::trusted(),
+            vmctx,
+            self.offsets.runtime_callback(index),
+        )
+    }
+
+    /// Load a runtime post-return function pointer from the
+    /// `VMComponentContext`.
+    pub fn vmcomponent_runtime_post_return(
+        &mut self,
+        cursor: &mut FuncCursor<'_>,
+        vmctx: ir::Value,
+        index: RuntimePostReturnIndex,
+    ) -> ir::Value {
+        self.vmcomponent_load(
+            cursor,
+            self.pointer_type,
+            ir::MemFlagsData::trusted(),
+            vmctx,
+            self.offsets.runtime_post_return(index),
+        )
+    }
+
+    /// Load the base pointer of the component builtins array from the
+    /// `VMComponentContext`.
+    pub fn vmcomponent_builtins(
+        &mut self,
+        cursor: &mut FuncCursor<'_>,
+        vmctx: ir::Value,
+    ) -> ir::Value {
+        self.vmcomponent_load(
+            cursor,
+            self.pointer_type,
+            ir::MemFlagsData::trusted().with_readonly(),
+            vmctx,
+            self.offsets.builtins(),
+        )
+    }
+
+    /// Load a component instance's flags from the `VMComponentContext`.
+    pub fn vmcomponent_instance_flags(
+        &mut self,
+        cursor: &mut FuncCursor<'_>,
+        vmctx: ir::Value,
+        instance: RuntimeComponentInstanceIndex,
+    ) -> ir::Value {
+        self.vmcomponent_load(
+            cursor,
+            ir::types::I32,
+            ir::MemFlagsData::trusted(),
+            vmctx,
+            self.offsets.instance_flags(instance),
         )
     }
 }

--- a/crates/cranelift/src/compiler/component.rs
+++ b/crates/cranelift/src/compiler/component.rs
@@ -148,7 +148,6 @@ impl<'a> TrampolineCompiler<'a> {
                 options,
                 lower_ty,
             } => {
-                let pointer_type = self.isa.pointer_type();
                 self.translate_hostcall(
                     HostCallee::Lowering(*index),
                     HostResult::MultiValue {
@@ -158,13 +157,13 @@ impl<'a> TrampolineCompiler<'a> {
                     WasmArgs::ValRawList,
                     |me, params| {
                         let vmctx = params[0];
+                        let lowering_data = me.alias_regions.vmcomponent_lowering_data(
+                            &mut me.builder.cursor(),
+                            vmctx,
+                            *index,
+                        );
                         params.extend([
-                            me.builder.ins().load(
-                                pointer_type,
-                                MemFlagsData::trusted(),
-                                vmctx,
-                                i32::try_from(me.offsets.lowering_data(*index)).unwrap(),
-                            ),
+                            lowering_data,
                             me.index_value(*lower_ty),
                             me.index_value(*options),
                         ]);
@@ -975,11 +974,10 @@ impl<'a> TrampolineCompiler<'a> {
             HostCallee::Lowering(index) => {
                 // Load host function pointer from the vmcontext and then call that
                 // indirect function pointer with the list of arguments.
-                let host_fn = self.builder.ins().load(
-                    pointer_type,
-                    MemFlagsData::trusted(),
+                let host_fn = self.alias_regions.vmcomponent_lowering_callee(
+                    &mut self.builder.cursor(),
                     vmctx,
-                    i32::try_from(self.offsets.lowering_callee(index)).unwrap(),
+                    index,
                 );
                 let host_sig = {
                     let mut sig = ir::Signature::new(CallConv::triple_default(self.isa.triple()));
@@ -1191,18 +1189,14 @@ impl<'a> TrampolineCompiler<'a> {
 
                 if self.compiler.tunables.concurrency_support {
                     // Stash the old value of `may_block` and then set it to false.
-                    let old_may_block = self.builder.ins().load(
-                        ir::types::I32,
-                        trusted,
-                        vmctx,
-                        i32::try_from(self.offsets.task_may_block()).unwrap(),
-                    );
+                    let old_may_block = self
+                        .alias_regions
+                        .vmcomponent_task_may_block(&mut self.builder.cursor(), vmctx);
                     let zero = self.builder.ins().iconst(ir::types::I32, i64::from(0));
-                    self.builder.ins().store(
-                        ir::MemFlagsData::trusted(),
-                        zero,
+                    self.alias_regions.store_vmcomponent_task_may_block(
+                        &mut self.builder.cursor(),
                         vmctx,
-                        i32::try_from(self.offsets.task_may_block()).unwrap(),
+                        zero,
                     );
 
                     // Call `enter_sync_call`
@@ -1242,11 +1236,10 @@ impl<'a> TrampolineCompiler<'a> {
             // NB: despite the vmcontext storing nullable funcrefs for function
             // pointers we know this is statically never null due to the
             // `has_destructor` check above.
-            let dtor_func_ref = self.builder.ins().load(
-                pointer_type,
-                trusted,
+            let dtor_func_ref = self.alias_regions.vmcomponent_resource_destructor(
+                &mut self.builder.cursor(),
                 vmctx,
-                i32::try_from(self.offsets.resource_destructor(index)).unwrap(),
+                index,
             );
             if self.compiler.emit_debug_checks {
                 self.builder
@@ -1317,11 +1310,10 @@ impl<'a> TrampolineCompiler<'a> {
             self.raise_if_host_trapped(result.unwrap());
 
             // Restore the old value of `may_block`
-            self.builder.ins().store(
-                ir::MemFlagsData::trusted(),
-                old_may_block,
+            self.alias_regions.store_vmcomponent_task_may_block(
+                &mut self.builder.cursor(),
                 vmctx,
-                i32::try_from(self.offsets.task_may_block()).unwrap(),
+                old_may_block,
             );
         }
 
@@ -1345,12 +1337,8 @@ impl<'a> TrampolineCompiler<'a> {
     }
 
     fn load_memory(&mut self, vmctx: ir::Value, memory: RuntimeMemoryIndex) -> ir::Value {
-        self.builder.ins().load(
-            self.isa.pointer_type(),
-            MemFlagsData::trusted(),
-            vmctx,
-            i32::try_from(self.offsets.runtime_memory(memory)).unwrap(),
-        )
+        self.alias_regions
+            .vmcomponent_runtime_memory(&mut self.builder.cursor(), vmctx, memory)
     }
 
     fn load_callback(
@@ -1360,11 +1348,10 @@ impl<'a> TrampolineCompiler<'a> {
     ) -> ir::Value {
         let pointer_type = self.isa.pointer_type();
         match callback {
-            Some(idx) => self.builder.ins().load(
-                pointer_type,
-                MemFlagsData::trusted(),
+            Some(idx) => self.alias_regions.vmcomponent_runtime_callback(
+                &mut self.builder.cursor(),
                 vmctx,
-                i32::try_from(self.offsets.runtime_callback(idx)).unwrap(),
+                idx,
             ),
             None => self.builder.ins().iconst(pointer_type, 0),
         }
@@ -1377,11 +1364,10 @@ impl<'a> TrampolineCompiler<'a> {
     ) -> ir::Value {
         let pointer_type = self.isa.pointer_type();
         match post_return {
-            Some(idx) => self.builder.ins().load(
-                pointer_type,
-                MemFlagsData::trusted(),
+            Some(idx) => self.alias_regions.vmcomponent_runtime_post_return(
+                &mut self.builder.cursor(),
                 vmctx,
-                i32::try_from(self.offsets.runtime_post_return(idx)).unwrap(),
+                idx,
             ),
             None => self.builder.ins().iconst(pointer_type, 0),
         }
@@ -1399,12 +1385,9 @@ impl<'a> TrampolineCompiler<'a> {
         let pointer_type = self.isa.pointer_type();
         // First load the pointer to the builtins structure which is static
         // per-process.
-        let builtins_array = self.builder.ins().load(
-            pointer_type,
-            MemFlagsData::trusted().with_readonly(),
-            vmctx,
-            i32::try_from(self.offsets.builtins()).unwrap(),
-        );
+        let builtins_array = self
+            .alias_regions
+            .vmcomponent_builtins(&mut self.builder.cursor(), vmctx);
         // Next load the function pointer at `offset` and return that.
         self.builder.ins().load(
             pointer_type,
@@ -1544,11 +1527,10 @@ impl<'a> TrampolineCompiler<'a> {
     fn check_may_leave_instance(&mut self, instance: RuntimeComponentInstanceIndex) {
         let vmctx = self.builder.func.dfg.block_params(self.block0)[0];
 
-        let flags = self.builder.ins().load(
-            ir::types::I32,
-            ir::MemFlagsData::trusted(),
+        let flags = self.alias_regions.vmcomponent_instance_flags(
+            &mut self.builder.cursor(),
             vmctx,
-            i32::try_from(self.offsets.instance_flags(instance)).unwrap(),
+            instance,
         );
         let may_leave_bit = self
             .builder

--- a/tests/disas/riscv64-component-builtins.wat
+++ b/tests/disas/riscv64-component-builtins.wat
@@ -14,7 +14,9 @@
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435504 "VMStoreContext+0x30"
 ;;     region2 = 268435512 "VMStoreContext+0x38"
-;;     region3 = 16 "VMContext+0x10"
+;;     region3 = 2952790048 "VMComponentContext+0x20"
+;;     region4 = 2952790024 "VMComponentContext+0x8"
+;;     region5 = 16 "VMContext+0x10"
 ;;     sig0 = (i64 sext, i32 sext, i32 sext, i32 sext) -> i64 sext system_v
 ;;     sig1 = (i64 sext vmctx) system_v
 ;;
@@ -24,11 +26,11 @@
 ;;     store notrap aligned region1 v4, v3+48
 ;;     v5 = get_return_address.i64 
 ;;     store notrap aligned region2 v5, v3+56
-;;     v6 = load.i32 notrap aligned v0+32
+;;     v6 = load.i32 notrap aligned region3 v0+32
 ;;     v7 = iconst.i32 1
 ;;     v8 = band v6, v7  ; v7 = 1
 ;;     trapz v8, user26
-;;     v11 = load.i64 notrap aligned readonly v0+8
+;;     v11 = load.i64 notrap aligned readonly region4 v0+8
 ;;     v12 = load.i64 notrap aligned readonly v11+16
 ;;     v9 = iconst.i32 0
 ;;     v13 = call_indirect sig0, v12(v0, v9, v9, v2)  ; v9 = 0, v9 = 0
@@ -37,7 +39,7 @@
 ;;     brif v15, block2, block1
 ;;
 ;; block1 cold:
-;;     v16 = load.i64 notrap aligned readonly can_move region3 v1+16
+;;     v16 = load.i64 notrap aligned readonly can_move region5 v1+16
 ;;     v17 = load.i64 notrap aligned readonly can_move v16+328
 ;;     call_indirect sig1, v17(v1)
 ;;     trap user1


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
