### PR TITLE
Allow bracketed IPv6 authorities without ports in wasi-http p3

### DIFF
--- a/crates/test-programs/src/bin/p3_http_outbound_request_response_build.rs
+++ b/crates/test-programs/src/bin/p3_http_outbound_request_response_build.rs
@@ -54,6 +54,9 @@ impl test_programs::p3::exports::wasi::cli::run::Guest for Component {
             assert!(req.set_authority(Some("bad-port:99999")).is_err());
             assert!(req.set_authority(Some("bad-\nhost")).is_err());
             assert!(req.set_authority(Some("too-many-ports:80:80:80")).is_err());
+            // IPv6 addresses with and without a port should be allowed.
+            assert!(req.set_authority(Some("[::]:443")).is_ok());
+            assert!(req.set_authority(Some("[::]")).is_ok());
 
             assert!(
                 req.set_scheme(Some(&Scheme::Other("bad\nscheme".to_string())))


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->

This updates the wasi-http p3 `set_authority` validation to allow bracketed IPv6 authorities without an explicit port, such as `[::]`.

Previously p3 treated any `:` in the authority string as indicating a port. That incorrectly rejected bracketed IPv6 literals without ports because their colons are part of the host. This keeps the existing validation for invalid ports, such as `bad-port:99999`, while only treating a bracketed IPv6 authority as having a port when the suffix after `]` starts with `:`.

A test case was added to align p3 behavior with the existing p2 coverage for `[::]:443` and `[::]`.

Testing:
- `cargo fmt --check`
- `cargo test -p wasmtime-wasi-http --features p3,default-send-request p3_http_outbound_request_response_build`