### PR TITLE
Trap on sync stream/future cancel and subtask.cancel when in a waitable set

### DIFF
--- a/crates/test-programs/src/bin/async_cancel_callee.rs
+++ b/crates/test-programs/src/bin/async_cancel_callee.rs
@@ -181,14 +181,14 @@ unsafe extern "C" fn callback_yield_with_options_yield_times(
 
                 assert_eq!(result, STATUS_RETURN_CANCELLED);
 
+                waitable_join(*waitable, 0);
+
                 if params.mode == MODE_TRAP_CANCEL_HOST_AFTER_RETURN_CANCELLED {
                     // This should trap, since `waitable` has already been
                     // cancelled:
                     subtask_cancel(*waitable);
                     unreachable!()
                 }
-
-                waitable_join(*waitable, 0);
 
                 if params.mode != MODE_LEAK_TASK_AFTER_CANCEL {
                     subtask_drop(*waitable);
@@ -243,13 +243,14 @@ unsafe extern "C" fn callback_yield_with_options_yield_times(
                 assert_eq!(event1, *waitable);
                 assert_eq!(event2, STATUS_RETURNED);
 
+                waitable_join(*waitable, 0);
+
                 if params.mode == MODE_TRAP_CANCEL_HOST_AFTER_RETURN {
                     // This should trap, since `waitable` has already returned:
                     subtask_cancel(*waitable);
                     unreachable!()
                 }
 
-                waitable_join(*waitable, 0);
                 subtask_drop(*waitable);
                 waitable_set_drop(*set);
 

--- a/crates/wasmtime/src/runtime/component/concurrent.rs
+++ b/crates/wasmtime/src/runtime/component/concurrent.rs
@@ -2193,9 +2193,7 @@ impl StoreOpaque {
         let caller = self.current_guest_thread()?;
         let state = self.concurrent_state_mut()?;
 
-        if waitable.common(state)?.set.is_some() {
-            bail!(Trap::WaitableSyncAndAsync);
-        }
+        waitable.trap_if_in_waitable_set(state)?;
 
         let set = state.get_mut(caller.thread)?.sync_call_set;
         waitable.join(state, Some(set))?;
@@ -3970,6 +3968,10 @@ impl Instance {
 
         log::trace!("subtask_cancel {waitable:?} (handle {task_id})");
 
+        if !async_ {
+            waitable.trap_if_in_waitable_set(concurrent_state)?;
+        }
+
         let needs_block;
         if let Waitable::Host(host_task) = waitable {
             let state = &mut concurrent_state.get_mut(host_task)?.state;
@@ -5058,6 +5060,18 @@ impl Waitable {
             Self::Guest(id) => &mut state.get_mut(*id)?.common,
             Self::Transmit(id) => &mut state.get_mut(*id)?.common,
         })
+    }
+
+    /// Trap if this waitable is currently a member of a waitable set.
+    ///
+    /// A synchronous stream/future/subtask operation may end up blocking on
+    /// this waitable, so it is not allowed to run while the waitable is also
+    /// being watched by a waitable set.
+    fn trap_if_in_waitable_set(&self, state: &mut ConcurrentState) -> Result<()> {
+        if self.common(state)?.set.is_some() {
+            bail!(Trap::WaitableSyncAndAsync);
+        }
+        Ok(())
     }
 
     /// Set or clear the pending event for this waitable and either deliver it

--- a/crates/wasmtime/src/runtime/component/concurrent/futures_and_streams.rs
+++ b/crates/wasmtime/src/runtime/component/concurrent/futures_and_streams.rs
@@ -3997,6 +3997,10 @@ impl Instance {
         );
         let waitable = Waitable::Transmit(transmit.write_handle);
 
+        if !async_ {
+            waitable.trap_if_in_waitable_set(state)?;
+        }
+
         let code = if let Some(event) = waitable.take_event(state)? {
             let (Event::FutureWrite { code, .. } | Event::StreamWrite { code, .. }) = event else {
                 bail_bug!("expected either a stream or future write event")
@@ -4084,6 +4088,11 @@ impl Instance {
         );
 
         let waitable = Waitable::Transmit(transmit.read_handle);
+
+        if !async_ {
+            waitable.trap_if_in_waitable_set(state)?;
+        }
+
         let code = if let Some(event) = waitable.take_event(state)? {
             let (Event::FutureRead { code, .. } | Event::StreamRead { code, .. }) = event else {
                 bail_bug!("expected either a stream or future read event")

--- a/tests/misc_testsuite/component-model/async/cancel-sync-and-waitable.wast
+++ b/tests/misc_testsuite/component-model/async/cancel-sync-and-waitable.wast
@@ -1,0 +1,301 @@
+;;! component_model_async = true
+;;! component_model_more_async_builtins = true
+;;! reference_types = true
+
+;; Regression test for https://github.com/bytecodealliance/wasmtime/issues/13690.
+;;
+;; Per https://github.com/WebAssembly/component-model/pull/647, a *synchronous*
+;; `{stream,future}.cancel-{read,write}` and `subtask.cancel` must trap when the
+;; waitable being cancelled has already been added to a waitable set, for the
+;; same reason the synchronous read/write operations do: the synchronous cancel
+;; may need to block on the very waitable the set is concurrently watching.
+;;
+;; Each exported entry point is lifted `async` so that the synchronous operation
+;; is permitted to reach the waitable-set check rather than tripping the
+;; may-not-block check.
+
+;; future.cancel-write
+(component
+  (type $f (future))
+
+  (core module $libc (memory (export "mem") 1))
+  (core instance $libc (instantiate $libc))
+
+  (core func $new (canon future.new $f))
+  (core func $write (canon future.write $f async (memory $libc "mem")))
+  (core func $cancel (canon future.cancel-write $f))
+  (core func $ws-new (canon waitable-set.new))
+  (core func $join (canon waitable.join))
+
+  (core module $m
+    (import "" "new" (func $new (result i64)))
+    (import "" "write" (func $write (param i32 i32) (result i32)))
+    (import "" "cancel" (func $cancel (param i32) (result i32)))
+    (import "" "ws-new" (func $ws-new (result i32)))
+    (import "" "join" (func $join (param i32 i32)))
+
+    (func (export "f") (result i32)
+      (local $write i32)
+      (local $new i64)
+
+      (local.set $new (call $new))
+      (local.set $write (i32.wrap_i64 (i64.shr_u (local.get $new) (i64.const 32))))
+
+      ;; start a write; with no reader present it blocks (BLOCKED == -1)
+      (if (i32.ne (i32.const -1) (call $write (local.get $write) (i32.const 0)))
+        (then unreachable))
+
+      ;; add the writable end to a freshly created waitable set
+      (call $join (local.get $write) (call $ws-new))
+
+      ;; a synchronous cancel-write must now trap
+      (call $cancel (local.get $write))
+    )
+  )
+
+  (core instance $i (instantiate $m
+    (with "" (instance
+      (export "new" (func $new))
+      (export "write" (func $write))
+      (export "cancel" (func $cancel))
+      (export "ws-new" (func $ws-new))
+      (export "join" (func $join))
+    ))
+  ))
+
+  (func (export "f") async (result u32) (canon lift (core func $i "f")))
+)
+(assert_trap (invoke "f") "waitable cannot be used synchronously while added to a waitable set")
+
+;; future.cancel-read
+(component
+  (type $f (future))
+
+  (core module $libc (memory (export "mem") 1))
+  (core instance $libc (instantiate $libc))
+
+  (core func $new (canon future.new $f))
+  (core func $read (canon future.read $f async (memory $libc "mem")))
+  (core func $cancel (canon future.cancel-read $f))
+  (core func $ws-new (canon waitable-set.new))
+  (core func $join (canon waitable.join))
+
+  (core module $m
+    (import "" "new" (func $new (result i64)))
+    (import "" "read" (func $read (param i32 i32) (result i32)))
+    (import "" "cancel" (func $cancel (param i32) (result i32)))
+    (import "" "ws-new" (func $ws-new (result i32)))
+    (import "" "join" (func $join (param i32 i32)))
+
+    (func (export "f") (result i32)
+      (local $read i32)
+      (local $new i64)
+
+      (local.set $new (call $new))
+      (local.set $read (i32.wrap_i64 (local.get $new)))
+
+      ;; start a read; with no writer present it blocks (BLOCKED == -1)
+      (if (i32.ne (i32.const -1) (call $read (local.get $read) (i32.const 0)))
+        (then unreachable))
+
+      ;; add the readable end to a freshly created waitable set
+      (call $join (local.get $read) (call $ws-new))
+
+      ;; a synchronous cancel-read must now trap
+      (call $cancel (local.get $read))
+    )
+  )
+
+  (core instance $i (instantiate $m
+    (with "" (instance
+      (export "new" (func $new))
+      (export "read" (func $read))
+      (export "cancel" (func $cancel))
+      (export "ws-new" (func $ws-new))
+      (export "join" (func $join))
+    ))
+  ))
+
+  (func (export "f") async (result u32) (canon lift (core func $i "f")))
+)
+(assert_trap (invoke "f") "waitable cannot be used synchronously while added to a waitable set")
+
+;; stream.cancel-write
+(component
+  (type $s (stream u8))
+
+  (core module $libc (memory (export "mem") 1))
+  (core instance $libc (instantiate $libc))
+
+  (core func $new (canon stream.new $s))
+  (core func $write (canon stream.write $s async (memory $libc "mem")))
+  (core func $cancel (canon stream.cancel-write $s))
+  (core func $ws-new (canon waitable-set.new))
+  (core func $join (canon waitable.join))
+
+  (core module $m
+    (import "" "new" (func $new (result i64)))
+    (import "" "write" (func $write (param i32 i32 i32) (result i32)))
+    (import "" "cancel" (func $cancel (param i32) (result i32)))
+    (import "" "ws-new" (func $ws-new (result i32)))
+    (import "" "join" (func $join (param i32 i32)))
+
+    (func (export "f") (result i32)
+      (local $write i32)
+      (local $new i64)
+
+      (local.set $new (call $new))
+      (local.set $write (i32.wrap_i64 (i64.shr_u (local.get $new) (i64.const 32))))
+
+      ;; start a write; with no reader present it blocks (BLOCKED == -1)
+      (if (i32.ne (i32.const -1) (call $write (local.get $write) (i32.const 0) (i32.const 4)))
+        (then unreachable))
+
+      ;; add the writable end to a freshly created waitable set
+      (call $join (local.get $write) (call $ws-new))
+
+      ;; a synchronous cancel-write must now trap
+      (call $cancel (local.get $write))
+    )
+  )
+
+  (core instance $i (instantiate $m
+    (with "" (instance
+      (export "new" (func $new))
+      (export "write" (func $write))
+      (export "cancel" (func $cancel))
+      (export "ws-new" (func $ws-new))
+      (export "join" (func $join))
+    ))
+  ))
+
+  (func (export "f") async (result u32) (canon lift (core func $i "f")))
+)
+(assert_trap (invoke "f") "waitable cannot be used synchronously while added to a waitable set")
+
+;; stream.cancel-read
+(component
+  (type $s (stream u8))
+
+  (core module $libc (memory (export "mem") 1))
+  (core instance $libc (instantiate $libc))
+
+  (core func $new (canon stream.new $s))
+  (core func $read (canon stream.read $s async (memory $libc "mem")))
+  (core func $cancel (canon stream.cancel-read $s))
+  (core func $ws-new (canon waitable-set.new))
+  (core func $join (canon waitable.join))
+
+  (core module $m
+    (import "" "new" (func $new (result i64)))
+    (import "" "read" (func $read (param i32 i32 i32) (result i32)))
+    (import "" "cancel" (func $cancel (param i32) (result i32)))
+    (import "" "ws-new" (func $ws-new (result i32)))
+    (import "" "join" (func $join (param i32 i32)))
+
+    (func (export "f") (result i32)
+      (local $read i32)
+      (local $new i64)
+
+      (local.set $new (call $new))
+      (local.set $read (i32.wrap_i64 (local.get $new)))
+
+      ;; start a read; with no writer present it blocks (BLOCKED == -1)
+      (if (i32.ne (i32.const -1) (call $read (local.get $read) (i32.const 0) (i32.const 4)))
+        (then unreachable))
+
+      ;; add the readable end to a freshly created waitable set
+      (call $join (local.get $read) (call $ws-new))
+
+      ;; a synchronous cancel-read must now trap
+      (call $cancel (local.get $read))
+    )
+  )
+
+  (core instance $i (instantiate $m
+    (with "" (instance
+      (export "new" (func $new))
+      (export "read" (func $read))
+      (export "cancel" (func $cancel))
+      (export "ws-new" (func $ws-new))
+      (export "join" (func $join))
+    ))
+  ))
+
+  (func (export "f") async (result u32) (canon lift (core func $i "f")))
+)
+(assert_trap (invoke "f") "waitable cannot be used synchronously while added to a waitable set")
+
+;; subtask.cancel
+(component
+  ;; A callee whose async export applies backpressure so the caller's subtask
+  ;; stays pending (and is therefore a live waitable that can join a set).
+  (component $callee
+    (core module $m
+      (import "" "backpressure.inc" (func $backpressure.inc))
+      (func (export "set-backpressure") (call $backpressure.inc))
+      (func (export "block"))
+    )
+    (core func $backpressure.inc (canon backpressure.inc))
+    (core instance $i (instantiate $m
+      (with "" (instance (export "backpressure.inc" (func $backpressure.inc))))
+    ))
+    (func (export "set-backpressure") (canon lift (core func $i "set-backpressure")))
+    (func (export "block") async (canon lift (core func $i "block")))
+  )
+  (instance $callee (instantiate $callee))
+
+  (component $caller
+    (import "callee" (instance $callee
+      (export "set-backpressure" (func))
+      (export "block" (func async))
+    ))
+
+    (core func $set-backpressure (canon lower (func $callee "set-backpressure")))
+    (core func $block (canon lower (func $callee "block") async))
+    (core func $cancel (canon subtask.cancel))
+    (core func $ws-new (canon waitable-set.new))
+    (core func $join (canon waitable.join))
+
+    (core module $m
+      (import "" "set-backpressure" (func $set-backpressure))
+      (import "" "block" (func $block (result i32)))
+      (import "" "cancel" (func $cancel (param i32) (result i32)))
+      (import "" "ws-new" (func $ws-new (result i32)))
+      (import "" "join" (func $join (param i32 i32)))
+
+      (func (export "f")
+        (local $rc i32)
+        (local $task i32)
+
+        ;; ensure the callee can't complete eagerly
+        (call $set-backpressure)
+
+        ;; start the subtask; it stays pending under backpressure
+        (local.set $rc (call $block))
+        (local.set $task (i32.shr_u (local.get $rc) (i32.const 4)))
+
+        ;; add the subtask to a freshly created waitable set
+        (call $join (local.get $task) (call $ws-new))
+
+        ;; a synchronous subtask.cancel must now trap
+        (drop (call $cancel (local.get $task)))
+      )
+    )
+
+    (core instance $i (instantiate $m
+      (with "" (instance
+        (export "set-backpressure" (func $set-backpressure))
+        (export "block" (func $block))
+        (export "cancel" (func $cancel))
+        (export "ws-new" (func $ws-new))
+        (export "join" (func $join))
+      ))
+    ))
+
+    (func (export "f") async (canon lift (core func $i "f")))
+  )
+  (instance $caller (instantiate $caller (with "callee" (instance $callee))))
+  (func (export "f") (alias export $caller "f"))
+)
+(assert_trap (invoke "f") "waitable cannot be used synchronously while added to a waitable set")


### PR DESCRIPTION
Fixes #13690.

[component-model#647] tightened the trap rules for synchronous stream/future
operations: a synchronous `read`/`write` must trap if the waitable it operates
on has already been added to a waitable set. That PR extended the same rule to
`{stream,future}.cancel-{read,write}` and `subtask.cancel`, but Wasmtime only
implemented it for `read`/`write`. As a result the upstream
`trap-if-sync-and-waitable-set.wast` test hits an `unreachable` on the cancel
cases today instead of trapping.

### Why it was missing

The check lives in `wait_for_event`, the single point every blocking
synchronous read/write funnels through before suspending:

```rust
if waitable.common(state)?.set.is_some() {
    bail!(Trap::WaitableSyncAndAsync);
}
```

The cancel paths don't reliably reach it. When there is nothing pending to wait
on, `cancel_read`/`cancel_write` take an early return with a `Cancelled` code,
and `subtask.cancel` can resolve a starting/finished subtask without ever
suspending. In those cases the waitable-set check was never run, so the cancel
succeeded where the spec requires a trap.

### Fix

Pull the check into a small helper on `Waitable`:

```rust
fn trap_if_in_waitable_set(&self, state: &mut ConcurrentState) -> Result<()> {
    if self.common(state)?.set.is_some() {
        bail!(Trap::WaitableSyncAndAsync);
    }
    Ok(())
}
```

`wait_for_event` now calls it (no behavior change), and the three synchronous
cancel entry points — `cancel_read`, `cancel_write`, and `subtask_cancel` —
call it up front, guarded by `!async_` to match the neighbouring
`check_blocking` guards. The async variants are deliberately untouched: being a
member of a waitable set is the whole point of an asynchronous cancel.

### Testing

Added `tests/misc_testsuite/component-model/async/cancel-sync-and-waitable.wast`
covering all five operations (`future.cancel-{read,write}`,
`stream.cancel-{read,write}`, and `subtask.cancel`). Each starts a pending
operation, joins the waitable to a fresh set, and asserts the synchronous
cancel traps; this mirrors the upstream `trap-if-sync-and-waitable-set.wast`. I
verified each case regresses (returns a cancel code / completes normally rather
than trapping) when its individual guard is removed.

### Depends on bytecodealliance/wit-bindgen#1638

Enforcing this trap surfaces a latent bug in wit-bindgen's async runtime:
`cancel_inter_task_stream_read` issues a synchronous `stream.cancel-read` on its
inter-task wakeup stream while that stream is still in the task's waitable set
(it calls `remove_waitable` only afterwards). That is exactly the pattern this
trap now (correctly) rejects, so every `wasi:http@0.3.0` (p3) program built with
the current `wit-bindgen` traps during ordinary operation — which is what the
red p3 CI jobs here are.

bytecodealliance/wit-bindgen#1638 reorders that to leave the set before
cancelling, matching the unregister-then-cancel ordering the general
`WaitableOperation::cancel` path already uses. With that change applied locally
(via `[patch.crates-io]`), the full p3 suites pass again:

- `wasmtime-wasi-http` p3: 25 passed
- `wasmtime-wasi` p3: 27 passed
- `component-model/async` wast (incl. the new test): 192 passed

So this PR needs a `wit-bindgen` release containing #1638 and a corresponding
version bump before its p3 jobs go green. Happy to fold the bump in here once
that's available, or sequence it however you prefer.

[component-model#647]: https://github.com/WebAssembly/component-model/pull/647
