### PR TITLE
Tag GC-ref global accesses with alias regions

### DIFF
--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -3035,12 +3035,14 @@ impl FuncEnvironment<'_> {
                         unreachable!()
                     };
                     let src = builder.ins().iadd_imm_s(base, i64::from(offset));
-                    let flags =
+                    let region = self.global_alias_region(builder.func, global_index);
+                    let mut flags =
                         if global_ty.mutability || gc::gc_compiler(self)?.is_moving_collector() {
                             ir::MemFlagsData::trusted()
                         } else {
                             ir::MemFlagsData::trusted().with_readonly().with_can_move()
                         };
+                    flags.set_alias_region(Some(region));
                     gc::gc_compiler(self)?
                         .translate_read_gc_reference(self, builder, ref_ty, src, flags)
                 } else {
@@ -3095,25 +3097,13 @@ impl FuncEnvironment<'_> {
             };
             let offset = builder.ins().iconst(self.pointer_type(), i64::from(offset));
             let src = builder.ins().iadd(base, offset);
+            let region = self.global_alias_region(builder.func, global_index);
+            let flags = ir::MemFlagsData::trusted().with_alias_region(Some(region));
             let mut gc = gc::gc_compiler(self)?;
             if initialized {
-                gc.translate_write_gc_reference(
-                    self,
-                    builder,
-                    ty,
-                    src,
-                    val,
-                    ir::MemFlagsData::trusted(),
-                )?;
+                gc.translate_write_gc_reference(self, builder, ty, src, val, flags)?;
             } else {
-                gc.translate_init_gc_reference(
-                    self,
-                    builder,
-                    ty,
-                    src,
-                    val,
-                    ir::MemFlagsData::trusted(),
-                )?;
+                gc.translate_init_gc_reference(self, builder, ty, src, val, flags)?;
             }
         } else {
             let ty = super::value_type(self.isa, wasm_ty);

--- a/tests/disas/gc/copying/externref-globals.wat
+++ b/tests/disas/gc/copying/externref-globals.wat
@@ -13,6 +13,7 @@
 ;; function u0:0(i64 vmctx, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 1879048192 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -21,7 +22,7 @@
 ;;                                 block0(v0: i64, v1: i64):
 ;; @0034                               v3 = iconst.i64 48
 ;; @0034                               v4 = iadd v0, v3  ; v3 = 48
-;; @0034                               v5 = load.i32 notrap aligned v4
+;; @0034                               v5 = load.i32 notrap aligned region2 v4
 ;; @0036                               jump block1
 ;;
 ;;                                 block1:
@@ -31,6 +32,7 @@
 ;; function u0:1(i64 vmctx, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 1879048192 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -39,7 +41,7 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @003b                               v3 = iconst.i64 48
 ;; @003b                               v4 = iadd v0, v3  ; v3 = 48
-;; @003b                               store notrap aligned v2, v4
+;; @003b                               store notrap aligned region2 v2, v4
 ;; @003d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/copying/i31ref-globals.wat
+++ b/tests/disas/gc/copying/i31ref-globals.wat
@@ -13,6 +13,7 @@
 ;; function u0:0(i64 vmctx, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 1879048192 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -21,7 +22,7 @@
 ;;                                 block0(v0: i64, v1: i64):
 ;; @0036                               v3 = iconst.i64 48
 ;; @0036                               v4 = iadd v0, v3  ; v3 = 48
-;; @0036                               v5 = load.i32 notrap aligned v4
+;; @0036                               v5 = load.i32 notrap aligned region2 v4
 ;; @0038                               jump block1
 ;;
 ;;                                 block1:
@@ -31,6 +32,7 @@
 ;; function u0:1(i64 vmctx, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 1879048192 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -39,7 +41,7 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @003d                               v3 = iconst.i64 48
 ;; @003d                               v4 = iadd v0, v3  ; v3 = 48
-;; @003d                               store notrap aligned v2, v4
+;; @003d                               store notrap aligned region2 v2, v4
 ;; @003f                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/drc/externref-globals.wat
+++ b/tests/disas/gc/drc/externref-globals.wat
@@ -16,10 +16,11 @@
 ;;     ss0 = explicit_slot 4, align = 4
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 268435488 "VMStoreContext+0x20"
-;;     region3 = 268435496 "VMStoreContext+0x28"
-;;     region4 = 2147483648 "GcHeap"
-;;     region5 = 32 "VMContext+0x20"
+;;     region2 = 1879048192 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(0))"
+;;     region3 = 268435488 "VMStoreContext+0x20"
+;;     region4 = 268435496 "VMStoreContext+0x28"
+;;     region5 = 2147483648 "GcHeap"
+;;     region6 = 32 "VMContext+0x20"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -30,7 +31,7 @@
 ;;                                 block0(v0: i64, v1: i64):
 ;; @0034                               v3 = iconst.i64 48
 ;; @0034                               v4 = iadd v0, v3  ; v3 = 48
-;; @0034                               v5 = load.i32 notrap aligned v4
+;; @0034                               v5 = load.i32 notrap aligned region2 v4
 ;;                                     v80 = stack_addr.i64 ss0
 ;;                                     store notrap v5, v80
 ;; @0034                               v6 = iconst.i32 1
@@ -43,30 +44,30 @@
 ;;
 ;;                                 block2:
 ;; @0034                               v13 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0034                               v14 = load.i64 notrap aligned readonly can_move region2 v13+32
+;; @0034                               v14 = load.i64 notrap aligned readonly can_move region3 v13+32
 ;; @0034                               v12 = uextend.i64 v5
 ;; @0034                               v15 = iadd v14, v12
-;; @0034                               v16 = load.i32 user2 region4 v15
+;; @0034                               v16 = load.i32 user2 region5 v15
 ;; @0034                               v17 = iconst.i32 2
 ;; @0034                               v18 = band v16, v17  ; v17 = 2
 ;; @0034                               brif v18, block4, block3
 ;;
 ;;                                 block3:
-;; @0034                               v19 = load.i64 notrap aligned readonly can_move region5 v0+32
-;; @0034                               v20 = load.i32 user2 region4 v19
+;; @0034                               v19 = load.i64 notrap aligned readonly can_move region6 v0+32
+;; @0034                               v20 = load.i32 user2 region5 v19
 ;; @0034                               v25 = iconst.i64 16
 ;; @0034                               v26 = iadd.i64 v15, v25  ; v25 = 16
-;; @0034                               store user2 region4 v20, v26
+;; @0034                               store user2 region5 v20, v26
 ;;                                     v81 = iconst.i32 2
 ;;                                     v82 = bor.i32 v16, v81  ; v81 = 2
-;; @0034                               store user2 region4 v82, v15
+;; @0034                               store user2 region5 v82, v15
 ;; @0034                               v37 = iconst.i64 8
 ;; @0034                               v38 = iadd.i64 v15, v37  ; v37 = 8
-;; @0034                               v39 = load.i64 user2 region4 v38
+;; @0034                               v39 = load.i64 user2 region5 v38
 ;; @0034                               v40 = iconst.i64 1
 ;; @0034                               v41 = iadd v39, v40  ; v40 = 1
-;; @0034                               store user2 region4 v41, v38
-;; @0034                               store.i32 user2 region4 v5, v19
+;; @0034                               store user2 region5 v41, v38
+;; @0034                               store.i32 user2 region5 v5, v19
 ;; @0034                               v49 = load.i32 notrap aligned v19+4
 ;;                                     v83 = iconst.i32 1
 ;;                                     v84 = iadd v49, v83  ; v83 = 1
@@ -96,9 +97,10 @@
 ;; function u0:1(i64 vmctx, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
-;;     region2 = 268435488 "VMStoreContext+0x20"
-;;     region3 = 268435496 "VMStoreContext+0x28"
-;;     region4 = 2147483648 "GcHeap"
+;;     region2 = 1879048192 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(0))"
+;;     region3 = 268435488 "VMStoreContext+0x20"
+;;     region4 = 268435496 "VMStoreContext+0x28"
+;;     region5 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -109,7 +111,7 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @003b                               v3 = iconst.i64 48
 ;; @003b                               v4 = iadd v0, v3  ; v3 = 48
-;; @003b                               v5 = load.i32 notrap aligned v4
+;; @003b                               v5 = load.i32 notrap aligned region2 v4
 ;; @003b                               v6 = iconst.i32 1
 ;; @003b                               v7 = band v2, v6  ; v6 = 1
 ;; @003b                               v8 = iconst.i32 0
@@ -120,20 +122,20 @@
 ;;
 ;;                                 block2:
 ;; @003b                               v13 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @003b                               v14 = load.i64 notrap aligned readonly can_move region2 v13+32
+;; @003b                               v14 = load.i64 notrap aligned readonly can_move region3 v13+32
 ;; @003b                               v12 = uextend.i64 v2
 ;; @003b                               v15 = iadd v14, v12
 ;; @003b                               v16 = iconst.i64 8
 ;; @003b                               v17 = iadd v15, v16  ; v16 = 8
-;; @003b                               v18 = load.i64 user2 region4 v17
+;; @003b                               v18 = load.i64 user2 region5 v17
 ;; @003b                               v19 = iconst.i64 1
 ;; @003b                               v20 = iadd v18, v19  ; v19 = 1
-;; @003b                               store user2 region4 v20, v17
+;; @003b                               store user2 region5 v20, v17
 ;; @003b                               jump block3
 ;;
 ;;                                 block3:
 ;;                                     v62 = iadd.i64 v0, v3  ; v3 = 48
-;; @003b                               store.i32 notrap aligned v2, v62
+;; @003b                               store.i32 notrap aligned region2 v2, v62
 ;;                                     v63 = iconst.i32 1
 ;;                                     v64 = band.i32 v5, v63  ; v63 = 1
 ;;                                     v65 = iconst.i32 0
@@ -144,12 +146,12 @@
 ;;
 ;;                                 block4:
 ;;                                     v67 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v68 = load.i64 notrap aligned readonly can_move region2 v67+32
+;;                                     v68 = load.i64 notrap aligned readonly can_move region3 v67+32
 ;; @003b                               v33 = uextend.i64 v5
 ;; @003b                               v36 = iadd v68, v33
 ;;                                     v69 = iconst.i64 8
 ;; @003b                               v38 = iadd v36, v69  ; v69 = 8
-;; @003b                               v39 = load.i64 user2 region4 v38
+;; @003b                               v39 = load.i64 user2 region5 v38
 ;;                                     v70 = iconst.i64 1
 ;;                                     v60 = icmp eq v39, v70  ; v70 = 1
 ;; @003b                               brif v60, block5, block6
@@ -162,7 +164,7 @@
 ;; @003b                               v40 = iconst.i64 -1
 ;; @003b                               v41 = iadd.i64 v39, v40  ; v40 = -1
 ;;                                     v71 = iadd.i64 v36, v69  ; v69 = 8
-;; @003b                               store user2 region4 v41, v71
+;; @003b                               store user2 region5 v41, v71
 ;; @003b                               jump block7
 ;;
 ;;                                 block7:

--- a/tests/disas/gc/drc/i31ref-globals.wat
+++ b/tests/disas/gc/drc/i31ref-globals.wat
@@ -15,6 +15,7 @@
 ;; function u0:0(i64 vmctx, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 1879048192 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -23,7 +24,7 @@
 ;;                                 block0(v0: i64, v1: i64):
 ;; @0036                               v3 = iconst.i64 48
 ;; @0036                               v4 = iadd v0, v3  ; v3 = 48
-;; @0036                               v5 = load.i32 notrap aligned v4
+;; @0036                               v5 = load.i32 notrap aligned region2 v4
 ;; @0038                               jump block1
 ;;
 ;;                                 block1:
@@ -33,6 +34,7 @@
 ;; function u0:1(i64 vmctx, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 1879048192 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -41,7 +43,7 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @003d                               v3 = iconst.i64 48
 ;; @003d                               v4 = iadd v0, v3  ; v3 = 48
-;; @003d                               store notrap aligned v2, v4
+;; @003d                               store notrap aligned region2 v2, v4
 ;; @003f                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/null/externref-globals.wat
+++ b/tests/disas/gc/null/externref-globals.wat
@@ -15,6 +15,7 @@
 ;; function u0:0(i64 vmctx, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 1879048192 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -23,7 +24,7 @@
 ;;                                 block0(v0: i64, v1: i64):
 ;; @0034                               v3 = iconst.i64 48
 ;; @0034                               v4 = iadd v0, v3  ; v3 = 48
-;; @0034                               v5 = load.i32 notrap aligned v4
+;; @0034                               v5 = load.i32 notrap aligned region2 v4
 ;; @0036                               jump block1
 ;;
 ;;                                 block1:
@@ -33,6 +34,7 @@
 ;; function u0:1(i64 vmctx, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 1879048192 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -41,7 +43,7 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @003b                               v3 = iconst.i64 48
 ;; @003b                               v4 = iadd v0, v3  ; v3 = 48
-;; @003b                               store notrap aligned v2, v4
+;; @003b                               store notrap aligned region2 v2, v4
 ;; @003d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/null/i31ref-globals.wat
+++ b/tests/disas/gc/null/i31ref-globals.wat
@@ -15,6 +15,7 @@
 ;; function u0:0(i64 vmctx, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 1879048192 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -23,7 +24,7 @@
 ;;                                 block0(v0: i64, v1: i64):
 ;; @0036                               v3 = iconst.i64 48
 ;; @0036                               v4 = iadd v0, v3  ; v3 = 48
-;; @0036                               v5 = load.i32 notrap aligned v4
+;; @0036                               v5 = load.i32 notrap aligned region2 v4
 ;; @0038                               jump block1
 ;;
 ;;                                 block1:
@@ -33,6 +34,7 @@
 ;; function u0:1(i64 vmctx, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 1879048192 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -41,7 +43,7 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @003d                               v3 = iconst.i64 48
 ;; @003d                               v4 = iadd v0, v3  ; v3 = 48
-;; @003d                               store notrap aligned v2, v4
+;; @003d                               store notrap aligned region2 v2, v4
 ;; @003f                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/ref-func-0.wat
+++ b/tests/disas/ref-func-0.wat
@@ -25,10 +25,10 @@
 ;;                                 block0(v0: i64, v1: i64):
 ;; @008f                               v6 = iconst.i64 80
 ;; @008f                               v7 = iadd v0, v6  ; v6 = 80
-;; @008f                               v8 = load.i32 notrap aligned v7
+;; @008f                               v8 = load.i32 notrap aligned region2 v7
 ;; @0091                               v9 = iconst.i64 96
 ;; @0091                               v10 = iadd v0, v9  ; v9 = 96
-;; @0091                               v11 = load.i32 notrap aligned v10
+;; @0091                               v11 = load.i32 notrap aligned region2 v10
 ;; @0093                               v12 = load.i64 notrap aligned region2 v0+112
 ;; @0095                               v13 = load.i64 notrap aligned region2 v0+128
 ;; @0097                               jump block1


### PR DESCRIPTION
These were previously skipped because they used to go through a different code path from regular globals. (They still do to some degree, but less than before.)

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
