### PR TITLE
Translate Wasm block params into `Variable`s instead of CLIF block params

### DIFF
--- a/crates/cranelift/src/func_environ/stack_switching/instructions.rs
+++ b/crates/cranelift/src/func_environ/stack_switching/instructions.rs
@@ -7,7 +7,6 @@ use cranelift_codegen::ir::{self, MemFlagsData};
 use cranelift_codegen::ir::{Block, BlockCall, InstBuilder, JumpTableData};
 use cranelift_frontend::FunctionBuilder;
 use itertools::{Either, Itertools};
-use smallvec::SmallVec;
 use wasmtime_environ::{PtrSize, TagIndex, TypeIndex, WasmResult, WasmValType, wasm_unsupported};
 
 fn control_context_size(triple: &target_lexicon::Triple) -> WasmResult<u8> {
@@ -1536,9 +1535,8 @@ pub(crate) fn translate_resume<'a>(
 
             values.clear(env, builder, false);
 
-            let mut tmp = SmallVec::new();
-            let args = set_block_params(env, builder, &mut tmp, target_block, &suspend_args);
-            builder.ins().jump(target_block, args);
+            set_block_params(env, builder, target_block, &suspend_args);
+            builder.ins().jump(target_block, &[]);
         }
 
         preamble_blocks

--- a/crates/cranelift/src/func_environ/stack_switching/instructions.rs
+++ b/crates/cranelift/src/func_environ/stack_switching/instructions.rs
@@ -1,12 +1,13 @@
-use cranelift_codegen::ir::BlockArg;
-use itertools::{Either, Itertools};
-
+use crate::translate::set_block_params;
 use crate::trap::TranslateTrap;
+use cranelift_codegen::ir::BlockArg;
 use cranelift_codegen::ir::condcodes::*;
 use cranelift_codegen::ir::types::*;
 use cranelift_codegen::ir::{self, MemFlagsData};
 use cranelift_codegen::ir::{Block, BlockCall, InstBuilder, JumpTableData};
 use cranelift_frontend::FunctionBuilder;
+use itertools::{Either, Itertools};
+use smallvec::SmallVec;
 use wasmtime_environ::{PtrSize, TagIndex, TypeIndex, WasmResult, WasmValType, wasm_unsupported};
 
 fn control_context_size(triple: &target_lexicon::Triple) -> WasmResult<u8> {
@@ -1522,23 +1523,22 @@ pub(crate) fn translate_resume<'a>(
                 .collect();
 
             let values = suspended_contref.values(env, builder);
-            let mut suspend_args: Vec<BlockArg> = values
-                .load_data_entries(env, builder, &param_types)
-                .into_iter()
-                .map(|v| BlockArg::Value(v))
-                .collect();
+            let mut suspend_args: Vec<ir::Value> =
+                values.load_data_entries(env, builder, &param_types);
 
             // At the suspend site, we store the suspend args in the the
             // `values` buffer of the VMContRef that was active at the time that
             // the suspend instruction was performed.
-            suspend_args.push(BlockArg::Value(suspended_contobj));
+            suspend_args.push(suspended_contobj);
 
             // We clear the suspend args. This is mostly for consistency. Note
             // that we don't zero out the data buffer, we still need it for the
 
             values.clear(env, builder, false);
 
-            builder.ins().jump(target_block, &suspend_args);
+            let mut tmp = SmallVec::new();
+            let args = set_block_params(env, builder, &mut tmp, target_block, &suspend_args);
+            builder.ins().jump(target_block, args);
         }
 
         preamble_blocks

--- a/crates/cranelift/src/translate/code_translator.rs
+++ b/crates/cranelift/src/translate/code_translator.rs
@@ -78,15 +78,15 @@ use crate::translate::TargetEnvironment;
 use crate::translate::environ::StructFieldsVec;
 use crate::translate::stack::{ControlStackFrame, ElseData};
 use crate::translate::translation_utils::{
-    block_with_params, blocktype_params_results, f32_translation, f64_translation,
+    block_with_params, blocktype_params_results, f32_translation, f64_translation, set_block_params,
 };
 use crate::trap::TranslateTrap;
 use cranelift_codegen::ir::condcodes::{FloatCC, IntCC};
 use cranelift_codegen::ir::immediates::Offset32;
 use cranelift_codegen::ir::{
     self, AtomicRmwOp, ExceptionTag, InstBuilder, JumpTableData, MemFlagsData, Value, ValueLabel,
+    types::*,
 };
-use cranelift_codegen::ir::{BlockArg, types::*};
 use cranelift_codegen::packed_option::ReservedValue;
 use cranelift_frontend::{FunctionBuilder, Variable};
 use itertools::Itertools;
@@ -128,7 +128,7 @@ pub fn translate_operator(
     log::trace!("Translating Wasm opcode: {op:?}");
 
     if !environ.is_reachable() {
-        translate_unreachable_operator(validator, &op, builder, environ)?;
+        translate_unreachable_operator(&op, builder, environ)?;
         return Ok(());
     }
 
@@ -269,20 +269,22 @@ pub fn translate_operator(
             let (params, results) = blocktype_params_results(validator, *blockty)?;
             let loop_body = block_with_params(builder, params.clone(), environ)?;
             let next = block_with_params(builder, results.clone(), environ)?;
-            canonicalise_then_jump(builder, loop_body, environ.stacks.peekn(params.len()));
+            canonicalise_then_jump(
+                environ,
+                builder,
+                loop_body,
+                environ.stacks.peekn(params.len()),
+            );
             environ
                 .stacks
                 .push_loop(loop_body, next, params.len(), results.len());
 
-            // Pop the initial `Block` actuals and replace them with the `Block`'s
-            // params since control flow joins at the top of the loop.
+            // Pop the initial `Block` actuals and replace them with the loop
+            // header's parameters since control flow joins at the top of the
+            // loop.
             environ.stacks.popn(params.len());
-            environ
-                .stacks
-                .stack
-                .extend_from_slice(builder.block_params(loop_body));
-
             builder.switch_to_block(loop_body);
+            push_block_params(environ, builder, loop_body);
             environ.translate_loop_header(builder)?;
         }
         Operator::If { blockty } => {
@@ -302,6 +304,7 @@ pub fn translate_operator(
                 // and go back and patch the jump.
                 let destination = block_with_params(builder, results.clone(), environ)?;
                 let branch_inst = canonicalise_brif(
+                    environ,
                     builder,
                     val,
                     next_block,
@@ -320,15 +323,8 @@ pub fn translate_operator(
                 // The `if` type signature is not valid without an `else` block,
                 // so we eagerly allocate the `else` block here.
                 let destination = block_with_params(builder, results.clone(), environ)?;
-                let else_block = block_with_params(builder, params.clone(), environ)?;
-                canonicalise_brif(
-                    builder,
-                    val,
-                    next_block,
-                    &[],
-                    else_block,
-                    environ.stacks.peekn(params.len()),
-                );
+                let else_block = builder.create_block();
+                canonicalise_brif(environ, builder, val, next_block, &[], else_block, &[]);
                 builder.seal_block(else_block);
                 (destination, ElseData::WithElse { else_block })
             };
@@ -402,9 +398,9 @@ pub fn translate_operator(
                                 let (params, _results) =
                                     blocktype_params_results(validator, blocktype)?;
                                 debug_assert_eq!(params.len(), num_return_values);
-                                let else_block =
-                                    block_with_params(builder, params.clone(), environ)?;
+                                let else_block = builder.create_block();
                                 canonicalise_then_jump(
+                                    environ,
                                     builder,
                                     destination,
                                     environ.stacks.peekn(params.len()),
@@ -421,6 +417,7 @@ pub fn translate_operator(
                             }
                             ElseData::WithElse { else_block } => {
                                 canonicalise_then_jump(
+                                    environ,
                                     builder,
                                     destination,
                                     environ.stacks.peekn(num_return_values),
@@ -459,9 +456,13 @@ pub fn translate_operator(
             let frame = environ.stacks.control_stack.pop().unwrap();
             let next_block = frame.following_code();
             let return_count = frame.num_return_values();
-            let return_args = environ.stacks.peekn_mut(return_count);
 
-            canonicalise_then_jump(builder, next_block, return_args);
+            canonicalise_then_jump(
+                environ,
+                builder,
+                next_block,
+                environ.stacks.peekn(return_count),
+            );
             // You might expect that if we just finished an `if` block that
             // didn't have a corresponding `else` block, then we would clean
             // up our duplicate set of parameters that we pushed earlier
@@ -483,10 +484,7 @@ pub fn translate_operator(
                 &mut environ.stacks.stack,
                 &mut environ.stacks.stack_shape,
             );
-            environ
-                .stacks
-                .stack
-                .extend_from_slice(builder.block_params(next_block));
+            push_block_params(environ, builder, next_block);
         }
         /**************************** Branch instructions *********************************
          * The branch instructions all have as arguments a target nesting level, which
@@ -522,8 +520,12 @@ pub fn translate_operator(
                 };
                 (return_count, frame.br_destination())
             };
-            let destination_args = environ.stacks.peekn_mut(return_count);
-            canonicalise_then_jump(builder, br_destination, destination_args);
+            canonicalise_then_jump(
+                environ,
+                builder,
+                br_destination,
+                environ.stacks.peekn(return_count),
+            );
             environ.stacks.popn(return_count);
             environ.stacks.reachable = false;
         }
@@ -607,8 +609,12 @@ pub fn translate_operator(
                         frame.set_branched_to_exit();
                         frame.br_destination()
                     };
-                    let destination_args = environ.stacks.peekn_mut(return_count);
-                    canonicalise_then_jump(builder, real_dest_block, destination_args);
+                    canonicalise_then_jump(
+                        environ,
+                        builder,
+                        real_dest_block,
+                        environ.stacks.peekn(return_count),
+                    );
                 }
                 environ.stacks.popn(return_count);
             }
@@ -2641,7 +2647,15 @@ pub fn translate_operator(
             let is_null = environ.translate_ref_is_null(builder.cursor(), r, r_ty)?;
             let (br_destination, inputs) = translate_br_if_args(*relative_depth, environ);
             let else_block = builder.create_block();
-            canonicalise_brif(builder, is_null, br_destination, inputs, else_block, &[]);
+            canonicalise_brif(
+                environ,
+                builder,
+                is_null,
+                br_destination,
+                &inputs,
+                else_block,
+                &[],
+            );
 
             builder.seal_block(else_block); // The only predecessor is the current block.
             builder.switch_to_block(else_block);
@@ -2660,10 +2674,17 @@ pub fn translate_operator(
             };
             let r_ty = *r_ty;
             let (br_destination, inputs) = translate_br_if_args(*relative_depth, environ);
-            let inputs = inputs.to_vec();
             let is_null = environ.translate_ref_is_null(builder.cursor(), r, r_ty)?;
             let else_block = builder.create_block();
-            canonicalise_brif(builder, is_null, else_block, &[], br_destination, &inputs);
+            canonicalise_brif(
+                environ,
+                builder,
+                is_null,
+                else_block,
+                &[],
+                br_destination,
+                &inputs,
+            );
 
             // In the null case, pop the ref
             environ.stacks.pop1();
@@ -3048,10 +3069,11 @@ pub fn translate_operator(
             let (cast_succeeds_block, inputs) = translate_br_if_args(*relative_depth, environ);
             let cast_fails_block = builder.create_block();
             canonicalise_brif(
+                environ,
                 builder,
                 cast_is_okay,
                 cast_succeeds_block,
-                inputs,
+                &inputs,
                 cast_fails_block,
                 &[
                     // NB: the `cast_fails_block` is dominated by the current
@@ -3082,6 +3104,7 @@ pub fn translate_operator(
             let (cast_fails_block, inputs) = translate_br_if_args(*relative_depth, environ);
             let cast_succeeds_block = builder.create_block();
             canonicalise_brif(
+                environ,
                 builder,
                 cast_is_okay,
                 cast_succeeds_block,
@@ -3090,7 +3113,7 @@ pub fn translate_operator(
                     // block, and therefore doesn't need any block params.
                 ],
                 cast_fails_block,
-                inputs,
+                &inputs,
             );
 
             // The only predecessor is the current block.
@@ -3355,7 +3378,6 @@ pub fn translate_operator(
 /// are dropped but special ones like `End` or `Else` signal the potential end of the unreachable
 /// portion so the translation state must be updated accordingly.
 fn translate_unreachable_operator(
-    validator: &FuncValidator<impl WasmModuleResources>,
     op: &Operator,
     builder: &mut FunctionBuilder,
     environ: &mut FuncEnvironment<'_>,
@@ -3390,7 +3412,6 @@ fn translate_unreachable_operator(
                     ref else_data,
                     head_is_reachable,
                     ref mut consequent_ends_reachable,
-                    blocktype,
                     ..
                 } => {
                     debug_assert!(consequent_ends_reachable.is_none());
@@ -3405,9 +3426,7 @@ fn translate_unreachable_operator(
                                 branch_inst,
                                 placeholder,
                             } => {
-                                let (params, _results) =
-                                    blocktype_params_results(validator, blocktype)?;
-                                let else_block = block_with_params(builder, params, environ)?;
+                                let else_block = builder.create_block();
                                 let frame = environ.stacks.control_stack.last().unwrap();
                                 frame.truncate_value_stack_to_else_params(
                                     &mut environ.stacks.stack,
@@ -3445,15 +3464,15 @@ fn translate_unreachable_operator(
             }
         }
         Operator::End => {
-            let value_stack = &mut environ.stacks.stack;
-            let stack_shape = &mut environ.stacks.stack_shape;
-            let control_stack = &mut environ.stacks.control_stack;
-            let frame = control_stack.pop().unwrap();
+            let frame = environ.stacks.control_stack.pop().unwrap();
 
             frame.restore_catch_handlers(&mut environ.stacks.handlers, builder);
 
             // Pop unused parameters from stack.
-            frame.truncate_value_stack_to_original_size(value_stack, stack_shape);
+            frame.truncate_value_stack_to_original_size(
+                &mut environ.stacks.stack,
+                &mut environ.stacks.stack_shape,
+            );
 
             let reachable_anyway = match frame {
                 // If it is a loop we also have to seal the body loop block
@@ -3485,12 +3504,13 @@ fn translate_unreachable_operator(
             };
 
             if frame.exit_is_branched_to() || reachable_anyway {
-                builder.switch_to_block(frame.following_code());
-                builder.seal_block(frame.following_code());
+                let next_block = frame.following_code();
+                builder.switch_to_block(next_block);
+                builder.seal_block(next_block);
 
                 // And add the return values of the block but only if the next block is reachable
                 // (which corresponds to testing if the stack depth is 1)
-                value_stack.extend_from_slice(builder.block_params(frame.following_code()));
+                push_block_params(environ, builder, next_block);
                 environ.stacks.reachable = true;
             }
         }
@@ -4036,16 +4056,16 @@ fn translate_br_if(
         });
     }
 
-    canonicalise_brif(builder, val, br_destination, inputs, next_block, &[]);
+    canonicalise_brif(env, builder, val, br_destination, &inputs, next_block, &[]);
 
     builder.seal_block(next_block); // The only predecessor is the current block.
     builder.switch_to_block(next_block);
 }
 
-fn translate_br_if_args<'a>(
+fn translate_br_if_args(
     relative_depth: u32,
-    env: &'a mut FuncEnvironment<'_>,
-) -> (ir::Block, &'a mut [ir::Value]) {
+    env: &mut FuncEnvironment<'_>,
+) -> (ir::Block, SmallVec<[ir::Value; 8]>) {
     let i = env.stacks.control_stack.len() - 1 - (relative_depth as usize);
     let (return_count, br_destination) = {
         let frame = &mut env.stacks.control_stack[i];
@@ -4059,7 +4079,10 @@ fn translate_br_if_args<'a>(
         };
         (return_count, frame.br_destination())
     };
-    let inputs = env.stacks.peekn_mut(return_count);
+    // Copy the branch arguments off the operand stack into an owned buffer so
+    // that callers can subsequently borrow `env` (e.g. to look up the
+    // destination's parameter variables) without conflicting with this borrow.
+    let inputs = env.stacks.peekn(return_count).to_smallvec();
     (br_destination, inputs)
 }
 
@@ -4311,12 +4334,20 @@ fn is_non_canonical_v128(ty: ir::Type) -> bool {
 /// actually necessary, and if not, the original slice is returned.  Otherwise the cast values
 /// are returned in a slice that belongs to the caller-supplied `SmallVec`.
 fn canonicalise_v128_values<'a>(
-    tmp_canonicalised: &'a mut SmallVec<[BlockArg; 16]>,
+    tmp_canonicalised: &'a mut SmallVec<[ir::Value; 16]>,
     builder: &mut FunctionBuilder,
     values: &'a [ir::Value],
-) -> &'a [BlockArg] {
+) -> &'a [ir::Value] {
     debug_assert!(tmp_canonicalised.is_empty());
-    // Cast, and push the resulting `Value`s into `canonicalised`.
+    // If no value needs canonicalising, we can avoid any work and return the
+    // original slice unchanged.
+    if values
+        .iter()
+        .all(|v| !is_non_canonical_v128(builder.func.dfg.value_type(*v)))
+    {
+        return values;
+    }
+    // Otherwise cast as necessary, and push the resulting `Value`s into `canonicalised`.
     for v in values {
         let value = if is_non_canonical_v128(builder.func.dfg.value_type(*v)) {
             let mut flags = MemFlagsData::new();
@@ -4325,26 +4356,62 @@ fn canonicalise_v128_values<'a>(
         } else {
             *v
         };
-        tmp_canonicalised.push(BlockArg::from(value));
+        tmp_canonicalised.push(value);
     }
     tmp_canonicalised.as_slice()
+}
+
+/// Recover the Wasm stack parameters of `block` and push them onto the operand
+/// stack as we begin translating that block.
+///
+/// The caller must have already switched to `block`.
+///
+/// For a Wasm control-flow target (i.e. a block with associated parameter
+/// `Variable`s) we `use_var` each of those variables. For a block with real
+/// CLIF block parameters (the function's exit block) we read those parameters
+/// directly.
+fn push_block_params(
+    environ: &mut FuncEnvironment<'_>,
+    builder: &mut FunctionBuilder,
+    block: ir::Block,
+) {
+    debug_assert_eq!(builder.current_block(), Some(block));
+    match environ.stacks.block_param_vars.get(&block) {
+        Some(vars) => {
+            let vars: SmallVec<[Variable; 6]> = vars.clone();
+            for var in vars {
+                let val = builder.use_var(var);
+                environ.stacks.stack.push(val);
+            }
+        }
+        None => {
+            environ
+                .stacks
+                .stack
+                .extend_from_slice(builder.block_params(block));
+        }
+    }
 }
 
 /// Generate a `jump` instruction, but first cast all 128-bit vector values to I8X16 if they
 /// don't have that type.  This is done in somewhat roundabout way so as to ensure that we
 /// almost never have to do any heap allocation.
 fn canonicalise_then_jump(
+    environ: &FuncEnvironment<'_>,
     builder: &mut FunctionBuilder,
     destination: ir::Block,
     params: &[ir::Value],
 ) -> ir::Inst {
-    let mut tmp_canonicalised = SmallVec::<[_; 16]>::new();
-    let canonicalised = canonicalise_v128_values(&mut tmp_canonicalised, builder, params);
-    builder.ins().jump(destination, canonicalised)
+    let mut canonicalised = SmallVec::<[_; 16]>::new();
+    let canonicalised = canonicalise_v128_values(&mut canonicalised, builder, params);
+    let mut args = SmallVec::<[_; 16]>::new();
+    let args = set_block_params(environ, builder, &mut args, destination, canonicalised);
+    builder.ins().jump(destination, args)
 }
 
-/// The same but for a `brif` instruction.
+/// The same as `canonicalise_then_jump` but for a `brif` instruction.
 fn canonicalise_brif(
+    environ: &FuncEnvironment<'_>,
     builder: &mut FunctionBuilder,
     cond: ir::Value,
     block_then: ir::Block,
@@ -4352,19 +4419,33 @@ fn canonicalise_brif(
     block_else: ir::Block,
     params_else: &[ir::Value],
 ) -> ir::Inst {
-    let mut tmp_canonicalised_then = SmallVec::<[_; 16]>::new();
+    let mut canonicalised_then = SmallVec::<[_; 16]>::new();
     let canonicalised_then =
-        canonicalise_v128_values(&mut tmp_canonicalised_then, builder, params_then);
-    let mut tmp_canonicalised_else = SmallVec::<[_; 16]>::new();
-    let canonicalised_else =
-        canonicalise_v128_values(&mut tmp_canonicalised_else, builder, params_else);
-    builder.ins().brif(
-        cond,
+        canonicalise_v128_values(&mut canonicalised_then, builder, params_then);
+    let mut args_then = SmallVec::<[_; 16]>::new();
+    let args_then = set_block_params(
+        environ,
+        builder,
+        &mut args_then,
         block_then,
         canonicalised_then,
+    );
+
+    let mut canonicalised_else = SmallVec::<[_; 16]>::new();
+    let canonicalised_else =
+        canonicalise_v128_values(&mut canonicalised_else, builder, params_else);
+    let mut args_else = SmallVec::<[_; 16]>::new();
+    let args_else = set_block_params(
+        environ,
+        builder,
+        &mut args_else,
         block_else,
         canonicalised_else,
-    )
+    );
+
+    builder
+        .ins()
+        .brif(cond, block_then, args_then, block_else, args_else)
 }
 
 /// A helper for popping and bitcasting a single value; since SIMD values can lose their type by
@@ -4501,14 +4582,18 @@ fn create_catch_block(
     // are compiling a `*Ref` variant.
 
     let (exn_ref_ty, needs_stack_map) = environ.reference_type(WasmHeapType::Exn);
-    let (exn_payload_wasm_ty, exn_payload_ty) = match environ.pointer_type().bits() {
-        32 => (wasmparser::ValType::I32, I32),
-        64 => (wasmparser::ValType::I64, I64),
+    let exn_payload_ty = match environ.pointer_type().bits() {
+        32 => I32,
+        64 => I64,
         _ => panic!("Unsupported pointer width"),
     };
-    let block = block_with_params(builder, [exn_payload_wasm_ty], environ)?;
+    // Unlike Wasm control-flow targets, a catch block's single parameter is a
+    // real CLIF block parameter: it is filled in by the exception ABI (the
+    // `try_call`'s exception table), not by an ordinary branch. So create it
+    // directly rather than going through `block_with_params`.
+    let block = builder.create_block();
+    let exn_ref = builder.append_block_param(block, exn_payload_ty);
     builder.switch_to_block(block);
-    let exn_ref = builder.func.dfg.block_params(block)[0];
     debug_assert!(exn_ref_ty.bits() <= exn_payload_ty.bits());
     let exn_ref = if exn_ref_ty.bits() < exn_payload_ty.bits() {
         builder.ins().ireduce(exn_ref_ty, exn_ref)
@@ -4543,7 +4628,8 @@ fn create_catch_block(
     let i = environ.stacks.control_stack.len() - 1 - (label as usize);
     let frame = &mut environ.stacks.control_stack[i];
     frame.set_branched_to_exit();
-    canonicalise_then_jump(builder, frame.br_destination(), &params);
+    let br_destination = frame.br_destination();
+    canonicalise_then_jump(environ, builder, br_destination, &params);
 
     Ok(block)
 }

--- a/crates/cranelift/src/translate/code_translator.rs
+++ b/crates/cranelift/src/translate/code_translator.rs
@@ -4366,30 +4366,19 @@ fn canonicalise_v128_values<'a>(
 ///
 /// The caller must have already switched to `block`.
 ///
-/// For a Wasm control-flow target (i.e. a block with associated parameter
-/// `Variable`s) we `use_var` each of those variables. For a block with real
-/// CLIF block parameters (the function's exit block) we read those parameters
-/// directly.
+/// Every block whose Wasm parameters we recover this way (a Wasm control-flow
+/// target or the function exit block) has associated parameter `Variable`s, so
+/// we `use_var` each of them.
 fn push_block_params(
     environ: &mut FuncEnvironment<'_>,
     builder: &mut FunctionBuilder,
     block: ir::Block,
 ) {
     debug_assert_eq!(builder.current_block(), Some(block));
-    match environ.stacks.block_param_vars.get(&block) {
-        Some(vars) => {
-            let vars: SmallVec<[Variable; 6]> = vars.clone();
-            for var in vars {
-                let val = builder.use_var(var);
-                environ.stacks.stack.push(val);
-            }
-        }
-        None => {
-            environ
-                .stacks
-                .stack
-                .extend_from_slice(builder.block_params(block));
-        }
+    let vars = &environ.stacks.block_param_vars[block];
+    for var in vars {
+        let val = builder.use_var(*var);
+        environ.stacks.stack.push(val);
     }
 }
 
@@ -4404,9 +4393,8 @@ fn canonicalise_then_jump(
 ) -> ir::Inst {
     let mut canonicalised = SmallVec::<[_; 16]>::new();
     let canonicalised = canonicalise_v128_values(&mut canonicalised, builder, params);
-    let mut args = SmallVec::<[_; 16]>::new();
-    let args = set_block_params(environ, builder, &mut args, destination, canonicalised);
-    builder.ins().jump(destination, args)
+    set_block_params(environ, builder, destination, canonicalised);
+    builder.ins().jump(destination, &[])
 }
 
 /// The same as `canonicalise_then_jump` but for a `brif` instruction.
@@ -4422,30 +4410,14 @@ fn canonicalise_brif(
     let mut canonicalised_then = SmallVec::<[_; 16]>::new();
     let canonicalised_then =
         canonicalise_v128_values(&mut canonicalised_then, builder, params_then);
-    let mut args_then = SmallVec::<[_; 16]>::new();
-    let args_then = set_block_params(
-        environ,
-        builder,
-        &mut args_then,
-        block_then,
-        canonicalised_then,
-    );
+    set_block_params(environ, builder, block_then, canonicalised_then);
 
     let mut canonicalised_else = SmallVec::<[_; 16]>::new();
     let canonicalised_else =
         canonicalise_v128_values(&mut canonicalised_else, builder, params_else);
-    let mut args_else = SmallVec::<[_; 16]>::new();
-    let args_else = set_block_params(
-        environ,
-        builder,
-        &mut args_else,
-        block_else,
-        canonicalised_else,
-    );
+    set_block_params(environ, builder, block_else, canonicalised_else);
 
-    builder
-        .ins()
-        .brif(cond, block_then, args_then, block_else, args_else)
+    builder.ins().brif(cond, block_then, &[], block_else, &[])
 }
 
 /// A helper for popping and bitcasting a single value; since SIMD values can lose their type by

--- a/crates/cranelift/src/translate/func_translator.rs
+++ b/crates/cranelift/src/translate/func_translator.rs
@@ -11,7 +11,8 @@ use crate::translate::translation_utils::get_vmctx_value_label;
 use cranelift_codegen::entity::EntityRef;
 use cranelift_codegen::ir::{self, Block, InstBuilder, ValueLabel};
 use cranelift_codegen::timing;
-use cranelift_frontend::{FunctionBuilder, FunctionBuilderContext};
+use cranelift_frontend::{FunctionBuilder, FunctionBuilderContext, Variable};
+use smallvec::SmallVec;
 use wasmparser::{BinaryReader, FuncValidator, FunctionBody, OperatorsReader, WasmModuleResources};
 use wasmtime_environ::{TypeConvert, WasmResult};
 
@@ -84,12 +85,34 @@ impl FuncTranslator {
         // Set up the translation state with a single pushed control block representing the whole
         // function and its return values.
         let exit_block = builder.create_block();
-        builder.append_block_params_for_function_returns(exit_block);
         environ
             .stacks
             .initialize(&builder.func.signature, exit_block);
 
         parse_local_decls(&mut reader, &mut builder, num_params, environ, validator)?;
+
+        // Represent the function's return values as `Variable`s, exactly like
+        // Wasm block parameters, rather than as real CLIF block parameters.
+        //
+        // Note this must happen *after* `parse_local_decls`: the Wasm locals'
+        // `Variable`s must be indexed contiguously after the parameters, so we
+        // can only declare these additional variables once all locals exist.
+        let return_types: SmallVec<[ir::Type; 6]> = builder
+            .func
+            .signature
+            .returns
+            .iter()
+            .map(|ret| ret.value_type)
+            .collect();
+        let return_vars: SmallVec<[Variable; 6]> = return_types
+            .iter()
+            .map(|ty| builder.declare_var(*ty))
+            .collect();
+        environ
+            .stacks
+            .block_param_vars
+            .insert(exit_block, return_vars);
+
         parse_function_body(validator, reader, &mut builder, environ)?;
 
         builder.finalize(environ.target_config());

--- a/crates/cranelift/src/translate/stack.rs
+++ b/crates/cranelift/src/translate/stack.rs
@@ -5,9 +5,9 @@
 //! a single function.
 
 use cranelift_codegen::ir::{self, Block, ExceptionTag, Inst, Value};
+use cranelift_entity::SecondaryMap;
 use cranelift_frontend::{FunctionBuilder, Variable};
 use smallvec::SmallVec;
-use std::collections::HashMap;
 use std::vec::Vec;
 use wasmtime_environ::FrameStackShape;
 
@@ -283,11 +283,10 @@ pub struct FuncTranslationStacks {
     /// differing values) instead of pessimistically creating one for every
     /// Wasm block.
     ///
-    /// Note that not every CLIF block is present in this map: the function's
-    /// exit block keeps real CLIF block parameters (for the function returns),
-    /// and various internal blocks (e.g. an `if`'s consequent, or the
-    /// fall-through after a `br_if`) have no parameters at all.
-    pub(crate) block_param_vars: HashMap<Block, SmallVec<[Variable; 6]>>,
+    /// The only blocks with real CLIF block parameters are the entry block
+    /// (function parameters) and `try_table` catch blocks (the exception
+    /// payload, filled in by the exception ABI).
+    pub(crate) block_param_vars: SecondaryMap<Block, SmallVec<[Variable; 6]>>,
     /// Exception handler state, updated as we enter and exit
     /// `try_table` scopes and attached to each call that we make.
     pub(crate) handlers: HandlerState,
@@ -312,7 +311,7 @@ impl FuncTranslationStacks {
             stack: Vec::new(),
             stack_shape: Vec::new(),
             control_stack: Vec::new(),
-            block_param_vars: HashMap::new(),
+            block_param_vars: SecondaryMap::new(),
             handlers: HandlerState::default(),
             reachable: true,
         }

--- a/crates/cranelift/src/translate/stack.rs
+++ b/crates/cranelift/src/translate/stack.rs
@@ -5,7 +5,9 @@
 //! a single function.
 
 use cranelift_codegen::ir::{self, Block, ExceptionTag, Inst, Value};
-use cranelift_frontend::FunctionBuilder;
+use cranelift_frontend::{FunctionBuilder, Variable};
+use smallvec::SmallVec;
+use std::collections::HashMap;
 use std::vec::Vec;
 use wasmtime_environ::FrameStackShape;
 
@@ -267,6 +269,25 @@ pub struct FuncTranslationStacks {
     pub(crate) stack_shape: Vec<FrameStackShape>,
     /// A stack of active control flow operations at this point in the input wasm function.
     pub(crate) control_stack: Vec<ControlStackFrame>,
+    /// Maps a CLIF block representing a Wasm control-flow target to the
+    /// `Variable`s that hold its Wasm stack parameters.
+    ///
+    /// Rather than giving these blocks CLIF block parameters and passing the
+    /// Wasm operand stack values as block arguments when branching to them, we
+    /// represent each Wasm stack parameter as a `Variable`. When branching to
+    /// such a block we `def_var` the variables and emit an argument-less
+    /// branch; when we begin translating the block we `use_var` each variable
+    /// and push the results onto the operand stack. This lets
+    /// `cranelift-frontend`'s SSA construction decide whether a real block
+    /// parameter is actually needed (i.e. only when multiple predecessors pass
+    /// differing values) instead of pessimistically creating one for every
+    /// Wasm block.
+    ///
+    /// Note that not every CLIF block is present in this map: the function's
+    /// exit block keeps real CLIF block parameters (for the function returns),
+    /// and various internal blocks (e.g. an `if`'s consequent, or the
+    /// fall-through after a `br_if`) have no parameters at all.
+    pub(crate) block_param_vars: HashMap<Block, SmallVec<[Variable; 6]>>,
     /// Exception handler state, updated as we enter and exit
     /// `try_table` scopes and attached to each call that we make.
     pub(crate) handlers: HandlerState,
@@ -291,6 +312,7 @@ impl FuncTranslationStacks {
             stack: Vec::new(),
             stack_shape: Vec::new(),
             control_stack: Vec::new(),
+            block_param_vars: HashMap::new(),
             handlers: HandlerState::default(),
             reachable: true,
         }
@@ -301,6 +323,7 @@ impl FuncTranslationStacks {
         debug_assert!(self.stack_shape.is_empty());
         debug_assert!(self.control_stack.is_empty());
         debug_assert!(self.handlers.is_empty());
+        self.block_param_vars.clear();
         self.reachable = true;
     }
 
@@ -430,13 +453,6 @@ impl FuncTranslationStacks {
     pub(crate) fn peekn(&self, n: usize) -> &[Value] {
         self.ensure_length_is_at_least(n);
         &self.stack[self.stack.len() - n..]
-    }
-
-    /// Peek at the top `n` values on the stack in the order they were pushed.
-    pub(crate) fn peekn_mut(&mut self, n: usize) -> &mut [Value] {
-        self.ensure_length_is_at_least(n);
-        let len = self.stack.len();
-        &mut self.stack[len - n..]
     }
 
     fn push_block_impl(

--- a/crates/cranelift/src/translate/translation_utils.rs
+++ b/crates/cranelift/src/translate/translation_utils.rs
@@ -43,34 +43,18 @@ where
     });
 }
 
-/// Set up the Wasm stack parameters of `destination` to `values` ahead of an
+/// Set the parameter `Variable`s of `destination` to `values` ahead of an
 /// argument-less branch to that block.
-///
-/// If `destination` is a Wasm control-flow target (i.e. it has associated
-/// parameter `Variable`s) then we `def_var` each of those variables and the
-/// branch carries no block arguments. Otherwise `destination` has real CLIF
-/// block parameters (e.g. the function exit block), so we return the values as
-/// block arguments to pass directly.
-pub fn set_block_params<'a>(
+pub fn set_block_params(
     environ: &FuncEnvironment<'_>,
     builder: &mut FunctionBuilder,
-    tmp: &'a mut SmallVec<[ir::BlockArg; 16]>,
     destination: ir::Block,
     values: &[ir::Value],
-) -> &'a [ir::BlockArg] {
-    debug_assert!(tmp.is_empty());
-    match environ.stacks.block_param_vars.get(&destination) {
-        Some(vars) => {
-            debug_assert_eq!(vars.len(), values.len());
-            for (var, val) in vars.iter().zip(values) {
-                builder.def_var(*var, *val);
-            }
-            &[]
-        }
-        None => {
-            tmp.extend(values.iter().map(|v| ir::BlockArg::from(*v)));
-            tmp.as_slice()
-        }
+) {
+    let vars = &environ.stacks.block_param_vars[destination];
+    debug_assert_eq!(vars.len(), values.len());
+    for (var, val) in vars.iter().zip(values) {
+        builder.def_var(*var, *val);
     }
 }
 
@@ -106,7 +90,8 @@ pub fn block_with_params(
         }
         vars.push(var);
     }
-    environ.stacks.block_param_vars.insert(block, vars);
+    let old = environ.stacks.block_param_vars.insert(block, vars);
+    debug_assert!(old.is_none());
     Ok(block)
 }
 

--- a/crates/cranelift/src/translate/translation_utils.rs
+++ b/crates/cranelift/src/translate/translation_utils.rs
@@ -1,10 +1,12 @@
 //! Helper functions and structures for the translation.
+use crate::func_environ::FuncEnvironment;
 use crate::translate::environ::TargetEnvironment;
 use core::u32;
 use cranelift_codegen::ir;
 use cranelift_frontend::FunctionBuilder;
+use smallvec::SmallVec;
 use wasmparser::{FuncValidator, WasmModuleResources};
-use wasmtime_environ::WasmResult;
+use wasmtime_environ::{TypeConvert, WasmResult};
 
 /// Get the parameter and result types for the given Wasm blocktype.
 pub fn blocktype_params_results<'a, T>(
@@ -41,40 +43,70 @@ where
     });
 }
 
-/// Create a `Block` with the given Wasm parameters.
-pub fn block_with_params<PE: TargetEnvironment + ?Sized>(
+/// Set up the Wasm stack parameters of `destination` to `values` ahead of an
+/// argument-less branch to that block.
+///
+/// If `destination` is a Wasm control-flow target (i.e. it has associated
+/// parameter `Variable`s) then we `def_var` each of those variables and the
+/// branch carries no block arguments. Otherwise `destination` has real CLIF
+/// block parameters (e.g. the function exit block), so we return the values as
+/// block arguments to pass directly.
+pub fn set_block_params<'a>(
+    environ: &FuncEnvironment<'_>,
     builder: &mut FunctionBuilder,
-    params: impl IntoIterator<Item = wasmparser::ValType>,
-    environ: &PE,
-) -> WasmResult<ir::Block> {
-    let block = builder.create_block();
-    for ty in params {
-        match ty {
-            wasmparser::ValType::I32 => {
-                builder.append_block_param(block, ir::types::I32);
+    tmp: &'a mut SmallVec<[ir::BlockArg; 16]>,
+    destination: ir::Block,
+    values: &[ir::Value],
+) -> &'a [ir::BlockArg] {
+    debug_assert!(tmp.is_empty());
+    match environ.stacks.block_param_vars.get(&destination) {
+        Some(vars) => {
+            debug_assert_eq!(vars.len(), values.len());
+            for (var, val) in vars.iter().zip(values) {
+                builder.def_var(*var, *val);
             }
-            wasmparser::ValType::I64 => {
-                builder.append_block_param(block, ir::types::I64);
-            }
-            wasmparser::ValType::F32 => {
-                builder.append_block_param(block, ir::types::F32);
-            }
-            wasmparser::ValType::F64 => {
-                builder.append_block_param(block, ir::types::F64);
-            }
-            wasmparser::ValType::Ref(rt) => {
-                let hty = environ.convert_heap_type(rt.heap_type())?;
-                let (ty, needs_stack_map) = environ.reference_type(hty);
-                let val = builder.append_block_param(block, ty);
-                if needs_stack_map {
-                    builder.declare_value_needs_stack_map(val);
-                }
-            }
-            wasmparser::ValType::V128 => {
-                builder.append_block_param(block, ir::types::I8X16);
-            }
+            &[]
+        }
+        None => {
+            tmp.extend(values.iter().map(|v| ir::BlockArg::from(*v)));
+            tmp.as_slice()
         }
     }
+}
+
+/// Create a `Block` representing a Wasm control-flow target with the given Wasm
+/// stack parameters.
+///
+/// Rather than giving the block CLIF block parameters, we create a
+/// `cranelift_frontend::Variable` for each Wasm stack parameter and record the
+/// block-to-variables mapping in `environ.stacks.block_param_vars`. See the
+/// `block_param_vars` docs for more details.
+pub fn block_with_params(
+    builder: &mut FunctionBuilder,
+    params: impl IntoIterator<Item = wasmparser::ValType>,
+    environ: &mut FuncEnvironment<'_>,
+) -> WasmResult<ir::Block> {
+    let block = builder.create_block();
+    let mut vars = SmallVec::<[_; 6]>::new();
+    for ty in params {
+        let (clif_ty, needs_stack_map) = match ty {
+            wasmparser::ValType::I32 => (ir::types::I32, false),
+            wasmparser::ValType::I64 => (ir::types::I64, false),
+            wasmparser::ValType::F32 => (ir::types::F32, false),
+            wasmparser::ValType::F64 => (ir::types::F64, false),
+            wasmparser::ValType::Ref(rt) => {
+                let hty = environ.convert_heap_type(rt.heap_type())?;
+                environ.reference_type(hty)
+            }
+            wasmparser::ValType::V128 => (ir::types::I8X16, false),
+        };
+        let var = builder.declare_var(clif_ty);
+        if needs_stack_map {
+            builder.declare_var_needs_stack_map(var);
+        }
+        vars.push(var);
+    }
+    environ.stacks.block_param_vars.insert(block, vars);
     Ok(block)
 }
 

--- a/tests/disas/alias-region-globals.wat
+++ b/tests/disas/alias-region-globals.wat
@@ -26,8 +26,8 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0039                               v4 = load.i64 notrap aligned readonly can_move region2 v0+48
-;; @0039                               store notrap aligned region3 v2, v4
+;; @0039                               v3 = load.i64 notrap aligned readonly can_move region2 v0+48
+;; @0039                               store notrap aligned region3 v2, v3
 ;; @003d                               store notrap aligned region4 v2, v0+80
 ;; @0041                               jump block1
 ;;

--- a/tests/disas/alias-region-memories.wat
+++ b/tests/disas/alias-region-memories.wat
@@ -28,14 +28,14 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
-;; @003b                               v6 = load.i64 notrap aligned readonly can_move region2 v0+48
-;; @003b                               v7 = load.i64 notrap aligned readonly can_move region3 v6
-;; @003b                               v5 = uextend.i64 v2
-;; @003b                               v8 = iadd v7, v5
-;; @003b                               store little region5 v3, v8
-;; @0042                               v10 = load.i64 notrap aligned readonly can_move region3 v0+80
-;; @0042                               v11 = iadd v10, v5
-;; @0042                               store little region6 v3, v11
+;; @003b                               v5 = load.i64 notrap aligned readonly can_move region2 v0+48
+;; @003b                               v6 = load.i64 notrap aligned readonly can_move region3 v5
+;; @003b                               v4 = uextend.i64 v2
+;; @003b                               v7 = iadd v6, v4
+;; @003b                               store little region5 v3, v7
+;; @0042                               v9 = load.i64 notrap aligned readonly can_move region3 v0+80
+;; @0042                               v10 = iadd v9, v4
+;; @0042                               store little region6 v3, v10
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/alias-region-tables.wat
+++ b/tests/disas/alias-region-tables.wat
@@ -33,47 +33,47 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i64):
-;; @0043                               v5 = load.i64 notrap aligned readonly can_move region2 v0+48
-;; @0043                               v6 = load.i64 notrap aligned region4 v5+8
-;; @0043                               v11 = load.i64 notrap aligned region3 v5
-;; @0043                               v17 = iconst.i64 1
-;; @0043                               v18 = bor v3, v17  ; v17 = 1
-;; @0043                               v7 = ireduce.i32 v6
-;; @0043                               v8 = icmp uge v2, v7
-;; @0043                               v15 = iconst.i64 0
-;; @0043                               v9 = uextend.i64 v2
-;; @0043                               v12 = iconst.i64 3
-;; @0043                               v13 = ishl v9, v12  ; v12 = 3
-;; @0043                               v14 = iadd v11, v13
-;; @0043                               v16 = select_spectre_guard v8, v15, v14  ; v15 = 0
-;; @0043                               store user6 aligned region5 v18, v16
-;; @0049                               v19 = load.i64 notrap aligned region4 v0+80
-;; @0049                               v23 = load.i64 notrap aligned region3 v0+72
-;; @0049                               v20 = ireduce.i32 v19
-;; @0049                               v21 = icmp uge v2, v20
-;; @0049                               v26 = iadd v23, v13
-;; @0049                               v28 = select_spectre_guard v21, v15, v26  ; v15 = 0
-;; @0049                               store user6 aligned region6 v18, v28
-;; @004d                               v44 = iconst.i64 -2
-;; @004d                               v45 = band v18, v44  ; v44 = -2
-;; @004d                               brif v18, block3(v45), block2
+;; @0043                               v4 = load.i64 notrap aligned readonly can_move region2 v0+48
+;; @0043                               v5 = load.i64 notrap aligned region4 v4+8
+;; @0043                               v10 = load.i64 notrap aligned region3 v4
+;; @0043                               v16 = iconst.i64 1
+;; @0043                               v17 = bor v3, v16  ; v16 = 1
+;; @0043                               v6 = ireduce.i32 v5
+;; @0043                               v7 = icmp uge v2, v6
+;; @0043                               v14 = iconst.i64 0
+;; @0043                               v8 = uextend.i64 v2
+;; @0043                               v11 = iconst.i64 3
+;; @0043                               v12 = ishl v8, v11  ; v11 = 3
+;; @0043                               v13 = iadd v10, v12
+;; @0043                               v15 = select_spectre_guard v7, v14, v13  ; v14 = 0
+;; @0043                               store user6 aligned region5 v17, v15
+;; @0049                               v18 = load.i64 notrap aligned region4 v0+80
+;; @0049                               v22 = load.i64 notrap aligned region3 v0+72
+;; @0049                               v19 = ireduce.i32 v18
+;; @0049                               v20 = icmp uge v2, v19
+;; @0049                               v25 = iadd v22, v12
+;; @0049                               v27 = select_spectre_guard v20, v14, v25  ; v14 = 0
+;; @0049                               store user6 aligned region6 v17, v27
+;; @004d                               v43 = iconst.i64 -2
+;; @004d                               v44 = band v17, v43  ; v43 = -2
+;; @004d                               brif v17, block3(v44), block2
 ;;
 ;;                                 block2 cold:
-;; @004d                               v47 = iconst.i32 0
-;; @004d                               v49 = call fn0(v0, v47, v9)  ; v47 = 0
-;; @004d                               jump block3(v49)
+;; @004d                               v46 = iconst.i32 0
+;; @004d                               v48 = call fn0(v0, v46, v8)  ; v46 = 0
+;; @004d                               jump block3(v48)
 ;;
-;;                                 block3(v46: i64):
-;; @004d                               v52 = load.i32 user7 aligned readonly v46+16
-;; @004d                               v50 = load.i64 notrap aligned readonly can_move region7 v0+40
-;; @004d                               v51 = load.i32 notrap aligned readonly can_move v50
-;; @004d                               v53 = icmp eq v52, v51
-;; @004d                               trapz v53, user8
-;; @004d                               v55 = load.i64 notrap aligned readonly v46+8
-;; @004d                               v56 = load.i64 notrap aligned readonly v46+24
-;; @004d                               v57 = call_indirect sig0, v55(v56, v0)
+;;                                 block3(v45: i64):
+;; @004d                               v51 = load.i32 user7 aligned readonly v45+16
+;; @004d                               v49 = load.i64 notrap aligned readonly can_move region7 v0+40
+;; @004d                               v50 = load.i32 notrap aligned readonly can_move v49
+;; @004d                               v52 = icmp eq v51, v50
+;; @004d                               trapz v52, user8
+;; @004d                               v54 = load.i64 notrap aligned readonly v45+8
+;; @004d                               v55 = load.i64 notrap aligned readonly v45+24
+;; @004d                               v56 = call_indirect sig0, v54(v55, v0)
 ;; @0050                               jump block1
 ;;
 ;;                                 block1:
-;; @0050                               return v57
+;; @0050                               return v56
 ;; }

--- a/tests/disas/basic-wat-test.wat
+++ b/tests/disas/basic-wat-test.wat
@@ -21,17 +21,17 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
-;; @0021                               v5 = uextend.i64 v2
-;; @0021                               v6 = load.i64 notrap aligned readonly can_move region2 v0+56
-;; @0021                               v7 = iadd v6, v5
-;; @0021                               v8 = load.i32 little region4 v7
-;; @0026                               v9 = uextend.i64 v3
-;; @0026                               v10 = load.i64 notrap aligned readonly can_move region2 v0+56
-;; @0026                               v11 = iadd v10, v9
-;; @0026                               v12 = load.i32 little region4 v11
-;; @0029                               v13 = iadd v8, v12
+;; @0021                               v4 = uextend.i64 v2
+;; @0021                               v5 = load.i64 notrap aligned readonly can_move region2 v0+56
+;; @0021                               v6 = iadd v5, v4
+;; @0021                               v7 = load.i32 little region4 v6
+;; @0026                               v8 = uextend.i64 v3
+;; @0026                               v9 = load.i64 notrap aligned readonly can_move region2 v0+56
+;; @0026                               v10 = iadd v9, v8
+;; @0026                               v11 = load.i32 little region4 v10
+;; @0029                               v12 = iadd v7, v11
 ;; @002a                               jump block1
 ;;
 ;;                                 block1:
-;; @002a                               return v13
+;; @002a                               return v12
 ;; }

--- a/tests/disas/block-params-br_if-single-pred.wat
+++ b/tests/disas/block-params-br_if-single-pred.wat
@@ -1,0 +1,61 @@
+;;! target = "x86_64"
+
+;; A `br_if` to a block whose only reachable predecessor is that `br_if` (the
+;; fall-through path ends in `unreachable`) does not need block parameters for
+;; the branched-with values.
+
+(module
+  (import "" "f" (func $f (result i32)))
+  (import "" "g" (func $g (param i32 i32)))
+  (import "" "h" (func $h (param i32 i32)))
+  (func
+    block (result i32 i32)
+      i32.const 1
+      i32.const 2
+      call $f
+      br_if 0
+      call $g
+      unreachable
+    end
+    call $h
+  )
+)
+;; function u0:0(i64 vmctx, i64) tail {
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 72 "VMContext+0x48"
+;;     region3 = 56 "VMContext+0x38"
+;;     region4 = 104 "VMContext+0x68"
+;;     region5 = 88 "VMContext+0x58"
+;;     region6 = 136 "VMContext+0x88"
+;;     region7 = 120 "VMContext+0x78"
+;;     gv0 = vmctx
+;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
+;;     sig0 = (i64 vmctx, i64) -> i32 tail
+;;     sig1 = (i64 vmctx, i64, i32, i32) tail
+;;     stack_limit = gv2
+;;
+;;                                 block0(v0: i64, v1: i64):
+;; @0039                               v2 = iconst.i32 1
+;; @003b                               v3 = iconst.i32 2
+;; @003d                               v4 = load.i64 notrap aligned readonly can_move region2 v0+72
+;; @003d                               v5 = load.i64 notrap aligned readonly can_move region3 v0+56
+;; @003d                               v6 = call_indirect sig0, v5(v4, v0)
+;; @003f                               brif v6, block2, block3
+;;
+;;                                 block3:
+;; @0041                               v7 = load.i64 notrap aligned readonly can_move region4 v0+104
+;; @0041                               v8 = load.i64 notrap aligned readonly can_move region5 v0+88
+;; @0041                               call_indirect sig1, v8(v7, v0, v2, v3)  ; v2 = 1, v3 = 2
+;; @0043                               trap user12
+;;
+;;                                 block2:
+;; @0045                               v9 = load.i64 notrap aligned readonly can_move region6 v0+136
+;; @0045                               v10 = load.i64 notrap aligned readonly can_move region7 v0+120
+;; @0045                               call_indirect sig1, v10(v9, v0, v2, v3)  ; v2 = 1, v3 = 2
+;; @0047                               jump block1
+;;
+;;                                 block1:
+;; @0047                               return
+;; }

--- a/tests/disas/block-params-if-else-same-values.wat
+++ b/tests/disas/block-params-if-else-same-values.wat
@@ -37,15 +37,15 @@
 ;; @0033                               brif v2, block2, block4
 ;;
 ;;                                 block2:
-;; @0035                               v7 = load.i64 notrap aligned readonly can_move region2 v0+72
-;; @0035                               v8 = load.i64 notrap aligned readonly can_move region3 v0+56
-;; @0035                               call_indirect sig0, v8(v7, v0)
+;; @0035                               v5 = load.i64 notrap aligned readonly can_move region2 v0+72
+;; @0035                               v6 = load.i64 notrap aligned readonly can_move region3 v0+56
+;; @0035                               call_indirect sig0, v6(v5, v0)
 ;; @003b                               jump block3
 ;;
 ;;                                 block4:
-;; @003c                               v9 = load.i64 notrap aligned readonly can_move region4 v0+104
-;; @003c                               v10 = load.i64 notrap aligned readonly can_move region5 v0+88
-;; @003c                               call_indirect sig0, v10(v9, v0)
+;; @003c                               v7 = load.i64 notrap aligned readonly can_move region4 v0+104
+;; @003c                               v8 = load.i64 notrap aligned readonly can_move region5 v0+88
+;; @003c                               call_indirect sig0, v8(v7, v0)
 ;; @0042                               jump block3
 ;;
 ;;                                 block3:

--- a/tests/disas/block-params-if-else-same-values.wat
+++ b/tests/disas/block-params-if-else-same-values.wat
@@ -1,0 +1,56 @@
+;;! target = "x86_64"
+
+;; The control-flow join after an if/else diamond has two predecessors, but when
+;; both the consequent and the alternative pass the same values, no block
+;; parameter is needed.
+
+(module
+  (import "" "f" (func $f))
+  (import "" "g" (func $g))
+  (func (param i32 i32 i32) (result i32 i32)
+    local.get 0
+    if (result i32 i32)
+      call $f
+      local.get 1
+      local.get 2
+    else
+      call $g
+      local.get 1
+      local.get 2
+    end
+  )
+)
+;; function u0:0(i64 vmctx, i64, i32, i32, i32) -> i32, i32 tail {
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     region2 = 72 "VMContext+0x48"
+;;     region3 = 56 "VMContext+0x38"
+;;     region4 = 104 "VMContext+0x68"
+;;     region5 = 88 "VMContext+0x58"
+;;     gv0 = vmctx
+;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
+;;     sig0 = (i64 vmctx, i64) tail
+;;     stack_limit = gv2
+;;
+;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
+;; @0033                               brif v2, block2, block4
+;;
+;;                                 block2:
+;; @0035                               v7 = load.i64 notrap aligned readonly can_move region2 v0+72
+;; @0035                               v8 = load.i64 notrap aligned readonly can_move region3 v0+56
+;; @0035                               call_indirect sig0, v8(v7, v0)
+;; @003b                               jump block3
+;;
+;;                                 block4:
+;; @003c                               v9 = load.i64 notrap aligned readonly can_move region4 v0+104
+;; @003c                               v10 = load.i64 notrap aligned readonly can_move region5 v0+88
+;; @003c                               call_indirect sig0, v10(v9, v0)
+;; @0042                               jump block3
+;;
+;;                                 block3:
+;; @0043                               jump block1
+;;
+;;                                 block1:
+;; @0043                               return v3, v4
+;; }

--- a/tests/disas/block-params-loop-single-iteration.wat
+++ b/tests/disas/block-params-loop-single-iteration.wat
@@ -1,0 +1,37 @@
+;;! target = "x86_64"
+
+;; A `loop` that never branches back to the loop header only ever runs a single
+;; iteration, so its header block has just one predecessor and should have no
+;; block parameters.
+
+(module
+  (func (param i32) (result i32)
+    local.get 0
+    (loop (param i32) (result i32)
+      i32.const 1
+      i32.add
+    )
+  )
+)
+;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 268435480 "VMStoreContext+0x18"
+;;     gv0 = vmctx
+;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
+;;     stack_limit = gv2
+;;
+;;                                 block0(v0: i64, v1: i64, v2: i32):
+;; @001b                               jump block2
+;;
+;;                                 block2:
+;; @001d                               v5 = iconst.i32 1
+;; @001f                               v6 = iadd.i32 v2, v5  ; v5 = 1
+;; @0020                               jump block3
+;;
+;;                                 block3:
+;; @0021                               jump block1
+;;
+;;                                 block1:
+;; @0021                               return v6
+;; }

--- a/tests/disas/block-params-loop-single-iteration.wat
+++ b/tests/disas/block-params-loop-single-iteration.wat
@@ -25,13 +25,13 @@
 ;; @001b                               jump block2
 ;;
 ;;                                 block2:
-;; @001d                               v5 = iconst.i32 1
-;; @001f                               v6 = iadd.i32 v2, v5  ; v5 = 1
+;; @001d                               v4 = iconst.i32 1
+;; @001f                               v5 = iadd.i32 v2, v4  ; v4 = 1
 ;; @0020                               jump block3
 ;;
 ;;                                 block3:
 ;; @0021                               jump block1
 ;;
 ;;                                 block1:
-;; @0021                               return v6
+;; @0021                               return v5
 ;; }

--- a/tests/disas/br_table.wat
+++ b/tests/disas/br_table.wat
@@ -40,9 +40,9 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @0021                               v6 = iconst.i32 42
-;; @0023                               v7 = iconst.i32 0
-;; @0025                               br_table v7, block8, [block5, block6, block7]  ; v7 = 0
+;; @0021                               v3 = iconst.i32 42
+;; @0023                               v4 = iconst.i32 0
+;; @0025                               br_table v4, block8, [block5, block6, block7]  ; v4 = 0
 ;;
 ;;                                 block5:
 ;; @0025                               jump block4
@@ -66,7 +66,7 @@
 ;; @002e                               jump block1
 ;;
 ;;                                 block1:
-;; @002e                               return v6  ; v6 = 42
+;; @002e                               return v3  ; v3 = 42
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64) -> i32 tail {
@@ -78,9 +78,9 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @0037                               v6 = iconst.i32 42
-;; @0039                               v7 = iconst.i32 0
-;; @003b                               br_table v7, block8, [block5, block6, block7]  ; v7 = 0
+;; @0037                               v3 = iconst.i32 42
+;; @0039                               v4 = iconst.i32 0
+;; @003b                               br_table v4, block8, [block5, block6, block7]  ; v4 = 0
 ;;
 ;;                                 block5:
 ;; @003b                               jump block1
@@ -104,7 +104,7 @@
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
-;; @0044                               return v6  ; v6 = 42
+;; @0044                               return v3  ; v3 = 42
 ;; }
 ;;
 ;; function u0:2(i64 vmctx, i64) -> i32 tail {
@@ -116,9 +116,9 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @0049                               v4 = iconst.i32 42
-;; @004b                               v5 = iconst.i32 0
-;; @004d                               br_table v5, block4, [block3, block3, block4]  ; v5 = 0
+;; @0049                               v3 = iconst.i32 42
+;; @004b                               v4 = iconst.i32 0
+;; @004d                               br_table v4, block4, [block3, block3, block4]  ; v4 = 0
 ;;
 ;;                                 block3:
 ;; @004d                               jump block2
@@ -130,7 +130,7 @@
 ;; @0054                               jump block1
 ;;
 ;;                                 block1:
-;; @0054                               return v4  ; v4 = 42
+;; @0054                               return v3  ; v3 = 42
 ;; }
 ;;
 ;; function u0:3(i64 vmctx, i64) -> i32 tail {
@@ -142,9 +142,9 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @0059                               v4 = iconst.i32 42
-;; @005b                               v5 = iconst.i32 0
-;; @005d                               br_table v5, block4, [block3, block3, block4]  ; v5 = 0
+;; @0059                               v3 = iconst.i32 42
+;; @005b                               v4 = iconst.i32 0
+;; @005d                               br_table v4, block4, [block3, block3, block4]  ; v4 = 0
 ;;
 ;;                                 block3:
 ;; @005d                               jump block1
@@ -156,5 +156,5 @@
 ;; @0064                               jump block1
 ;;
 ;;                                 block1:
-;; @0064                               return v4  ; v4 = 42
+;; @0064                               return v3  ; v3 = 42
 ;; }

--- a/tests/disas/br_table.wat
+++ b/tests/disas/br_table.wat
@@ -40,9 +40,9 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @0021                               v3 = iconst.i32 42
-;; @0023                               v4 = iconst.i32 0
-;; @0025                               br_table v4, block8, [block5, block6, block7]  ; v4 = 0
+;; @0021                               v2 = iconst.i32 42
+;; @0023                               v3 = iconst.i32 0
+;; @0025                               br_table v3, block8, [block5, block6, block7]  ; v3 = 0
 ;;
 ;;                                 block5:
 ;; @0025                               jump block4
@@ -66,7 +66,7 @@
 ;; @002e                               jump block1
 ;;
 ;;                                 block1:
-;; @002e                               return v3  ; v3 = 42
+;; @002e                               return v2  ; v2 = 42
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64) -> i32 tail {
@@ -78,9 +78,9 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @0037                               v3 = iconst.i32 42
-;; @0039                               v4 = iconst.i32 0
-;; @003b                               br_table v4, block8, [block5, block6, block7]  ; v4 = 0
+;; @0037                               v2 = iconst.i32 42
+;; @0039                               v3 = iconst.i32 0
+;; @003b                               br_table v3, block8, [block5, block6, block7]  ; v3 = 0
 ;;
 ;;                                 block5:
 ;; @003b                               jump block1
@@ -104,7 +104,7 @@
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
-;; @0044                               return v3  ; v3 = 42
+;; @0044                               return v2  ; v2 = 42
 ;; }
 ;;
 ;; function u0:2(i64 vmctx, i64) -> i32 tail {
@@ -116,9 +116,9 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @0049                               v3 = iconst.i32 42
-;; @004b                               v4 = iconst.i32 0
-;; @004d                               br_table v4, block4, [block3, block3, block4]  ; v4 = 0
+;; @0049                               v2 = iconst.i32 42
+;; @004b                               v3 = iconst.i32 0
+;; @004d                               br_table v3, block4, [block3, block3, block4]  ; v3 = 0
 ;;
 ;;                                 block3:
 ;; @004d                               jump block2
@@ -130,7 +130,7 @@
 ;; @0054                               jump block1
 ;;
 ;;                                 block1:
-;; @0054                               return v3  ; v3 = 42
+;; @0054                               return v2  ; v2 = 42
 ;; }
 ;;
 ;; function u0:3(i64 vmctx, i64) -> i32 tail {
@@ -142,9 +142,9 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @0059                               v3 = iconst.i32 42
-;; @005b                               v4 = iconst.i32 0
-;; @005d                               br_table v4, block4, [block3, block3, block4]  ; v4 = 0
+;; @0059                               v2 = iconst.i32 42
+;; @005b                               v3 = iconst.i32 0
+;; @005d                               br_table v3, block4, [block3, block3, block4]  ; v3 = 0
 ;;
 ;;                                 block3:
 ;; @005d                               jump block1
@@ -156,5 +156,5 @@
 ;; @0064                               jump block1
 ;;
 ;;                                 block1:
-;; @0064                               return v3  ; v3 = 42
+;; @0064                               return v2  ; v2 = 42
 ;; }

--- a/tests/disas/branch-hinting-disabled.wat
+++ b/tests/disas/branch-hinting-disabled.wat
@@ -39,15 +39,15 @@
 ;; @0043                               brif v2, block2, block4
 ;;
 ;;                                 block2:
-;; @0045                               v5 = iconst.i32 1
-;; @0047                               jump block3(v5)  ; v5 = 1
+;; @0045                               v4 = iconst.i32 1
+;; @0047                               jump block3(v4)  ; v4 = 1
 ;;
 ;;                                 block4:
-;; @0048                               v6 = iconst.i32 2
-;; @004a                               jump block3(v6)  ; v6 = 2
+;; @0048                               v5 = iconst.i32 2
+;; @004a                               jump block3(v5)  ; v5 = 2
 ;;
-;;                                 block3(v4: i32):
-;; @004b                               jump block1(v4)
+;;                                 block3(v6: i32):
+;; @004b                               jump block1(v6)
 ;;
 ;;                                 block1(v3: i32):
 ;; @004b                               return v3

--- a/tests/disas/branch-hinting-disabled.wat
+++ b/tests/disas/branch-hinting-disabled.wat
@@ -39,18 +39,18 @@
 ;; @0043                               brif v2, block2, block4
 ;;
 ;;                                 block2:
-;; @0045                               v4 = iconst.i32 1
-;; @0047                               jump block3(v4)  ; v4 = 1
+;; @0045                               v3 = iconst.i32 1
+;; @0047                               jump block3(v3)  ; v3 = 1
 ;;
 ;;                                 block4:
-;; @0048                               v5 = iconst.i32 2
-;; @004a                               jump block3(v5)  ; v5 = 2
+;; @0048                               v4 = iconst.i32 2
+;; @004a                               jump block3(v4)  ; v4 = 2
 ;;
-;;                                 block3(v6: i32):
-;; @004b                               jump block1(v6)
+;;                                 block3(v5: i32):
+;; @004b                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @004b                               return v3
+;;                                 block1:
+;; @004b                               return v5
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
@@ -65,13 +65,13 @@
 ;; @0052                               brif v2, block2, block3
 ;;
 ;;                                 block3:
-;; @0054                               v4 = iconst.i32 1
-;; @0056                               return v4  ; v4 = 1
+;; @0054                               v3 = iconst.i32 1
+;; @0056                               return v3  ; v3 = 1
 ;;
 ;;                                 block2:
 ;; @005a                               jump block1
 ;;
 ;;                                 block1:
-;; @0058                               v5 = iconst.i32 2
-;; @005a                               return v5  ; v5 = 2
+;; @0058                               v4 = iconst.i32 2
+;; @005a                               return v4  ; v4 = 2
 ;; }

--- a/tests/disas/branch-hinting.wat
+++ b/tests/disas/branch-hinting.wat
@@ -130,15 +130,15 @@
 ;; @007f                               brif v2, block2, block4
 ;;
 ;;                                 block2 cold:
-;; @0081                               v5 = iconst.i32 1
-;; @0083                               jump block3(v5)  ; v5 = 1
+;; @0081                               v4 = iconst.i32 1
+;; @0083                               jump block3(v4)  ; v4 = 1
 ;;
 ;;                                 block4:
-;; @0084                               v6 = iconst.i32 2
-;; @0086                               jump block3(v6)  ; v6 = 2
+;; @0084                               v5 = iconst.i32 2
+;; @0086                               jump block3(v5)  ; v5 = 2
 ;;
-;;                                 block3(v4: i32):
-;; @0087                               jump block1(v4)
+;;                                 block3(v6: i32):
+;; @0087                               jump block1(v6)
 ;;
 ;;                                 block1(v3: i32):
 ;; @0087                               return v3
@@ -156,15 +156,15 @@
 ;; @008c                               brif v2, block2, block4
 ;;
 ;;                                 block2:
-;; @008e                               v5 = iconst.i32 1
-;; @0090                               jump block3(v5)  ; v5 = 1
+;; @008e                               v4 = iconst.i32 1
+;; @0090                               jump block3(v4)  ; v4 = 1
 ;;
 ;;                                 block4 cold:
-;; @0091                               v6 = iconst.i32 2
-;; @0093                               jump block3(v6)  ; v6 = 2
+;; @0091                               v5 = iconst.i32 2
+;; @0093                               jump block3(v5)  ; v5 = 2
 ;;
-;;                                 block3(v4: i32):
-;; @0094                               jump block1(v4)
+;;                                 block3(v6: i32):
+;; @0094                               jump block1(v6)
 ;;
 ;;                                 block1(v3: i32):
 ;; @0094                               return v3

--- a/tests/disas/branch-hinting.wat
+++ b/tests/disas/branch-hinting.wat
@@ -84,15 +84,15 @@
 ;; @0063                               brif v2, block2, block3
 ;;
 ;;                                 block3:
-;; @0065                               v4 = iconst.i32 1
-;; @0067                               return v4  ; v4 = 1
+;; @0065                               v3 = iconst.i32 1
+;; @0067                               return v3  ; v3 = 1
 ;;
 ;;                                 block2 cold:
 ;; @006b                               jump block1
 ;;
 ;;                                 block1:
-;; @0069                               v5 = iconst.i32 2
-;; @006b                               return v5  ; v5 = 2
+;; @0069                               v4 = iconst.i32 2
+;; @006b                               return v4  ; v4 = 2
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
@@ -107,15 +107,15 @@
 ;; @0072                               brif v2, block2, block3
 ;;
 ;;                                 block3 cold:
-;; @0074                               v4 = iconst.i32 1
-;; @0076                               return v4  ; v4 = 1
+;; @0074                               v3 = iconst.i32 1
+;; @0076                               return v3  ; v3 = 1
 ;;
 ;;                                 block2:
 ;; @007a                               jump block1
 ;;
 ;;                                 block1:
-;; @0078                               v5 = iconst.i32 2
-;; @007a                               return v5  ; v5 = 2
+;; @0078                               v4 = iconst.i32 2
+;; @007a                               return v4  ; v4 = 2
 ;; }
 ;;
 ;; function u0:2(i64 vmctx, i64, i32) -> i32 tail {
@@ -130,18 +130,18 @@
 ;; @007f                               brif v2, block2, block4
 ;;
 ;;                                 block2 cold:
-;; @0081                               v4 = iconst.i32 1
-;; @0083                               jump block3(v4)  ; v4 = 1
+;; @0081                               v3 = iconst.i32 1
+;; @0083                               jump block3(v3)  ; v3 = 1
 ;;
 ;;                                 block4:
-;; @0084                               v5 = iconst.i32 2
-;; @0086                               jump block3(v5)  ; v5 = 2
+;; @0084                               v4 = iconst.i32 2
+;; @0086                               jump block3(v4)  ; v4 = 2
 ;;
-;;                                 block3(v6: i32):
-;; @0087                               jump block1(v6)
+;;                                 block3(v5: i32):
+;; @0087                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @0087                               return v3
+;;                                 block1:
+;; @0087                               return v5
 ;; }
 ;;
 ;; function u0:3(i64 vmctx, i64, i32) -> i32 tail {
@@ -156,18 +156,18 @@
 ;; @008c                               brif v2, block2, block4
 ;;
 ;;                                 block2:
-;; @008e                               v4 = iconst.i32 1
-;; @0090                               jump block3(v4)  ; v4 = 1
+;; @008e                               v3 = iconst.i32 1
+;; @0090                               jump block3(v3)  ; v3 = 1
 ;;
 ;;                                 block4 cold:
-;; @0091                               v5 = iconst.i32 2
-;; @0093                               jump block3(v5)  ; v5 = 2
+;; @0091                               v4 = iconst.i32 2
+;; @0093                               jump block3(v4)  ; v4 = 2
 ;;
-;;                                 block3(v6: i32):
-;; @0094                               jump block1(v6)
+;;                                 block3(v5: i32):
+;; @0094                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @0094                               return v3
+;;                                 block1:
+;; @0094                               return v5
 ;; }
 ;;
 ;; function u0:4(i64 vmctx, i64, i32) tail {

--- a/tests/disas/byteswap.wat
+++ b/tests/disas/byteswap.wat
@@ -83,8 +83,8 @@
 ;; @0057                               jump block1
 ;;
 ;;                                 block1:
-;;                                     v19 = bswap.i32 v2
-;; @0057                               return v19
+;;                                     v18 = bswap.i32 v2
+;; @0057                               return v18
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i64 tail {
@@ -99,6 +99,6 @@
 ;; @00ad                               jump block1
 ;;
 ;;                                 block1:
-;;                                     v39 = bswap.i64 v2
-;; @00ad                               return v39
+;;                                     v38 = bswap.i64 v2
+;; @00ad                               return v38
 ;; }

--- a/tests/disas/call-indirect-with-gc.wat
+++ b/tests/disas/call-indirect-with-gc.wat
@@ -25,37 +25,37 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
-;; @0035                               v5 = load.i64 notrap aligned region3 v0+56
-;; @0035                               v9 = load.i64 notrap aligned region2 v0+48
-;; @0035                               v6 = ireduce.i32 v5
-;; @0035                               v7 = icmp uge v3, v6
-;; @0035                               v13 = iconst.i64 0
-;; @0035                               v8 = uextend.i64 v3
-;; @0035                               v10 = iconst.i64 3
-;; @0035                               v11 = ishl v8, v10  ; v10 = 3
-;; @0035                               v12 = iadd v9, v11
-;; @0035                               v14 = select_spectre_guard v7, v13, v12  ; v13 = 0
-;; @0035                               v15 = load.i64 user6 aligned region4 v14
-;; @0035                               v16 = iconst.i64 -2
-;; @0035                               v17 = band v15, v16  ; v16 = -2
-;; @0035                               brif v15, block3(v17), block2
+;; @0035                               v4 = load.i64 notrap aligned region3 v0+56
+;; @0035                               v8 = load.i64 notrap aligned region2 v0+48
+;; @0035                               v5 = ireduce.i32 v4
+;; @0035                               v6 = icmp uge v3, v5
+;; @0035                               v12 = iconst.i64 0
+;; @0035                               v7 = uextend.i64 v3
+;; @0035                               v9 = iconst.i64 3
+;; @0035                               v10 = ishl v7, v9  ; v9 = 3
+;; @0035                               v11 = iadd v8, v10
+;; @0035                               v13 = select_spectre_guard v6, v12, v11  ; v12 = 0
+;; @0035                               v14 = load.i64 user6 aligned region4 v13
+;; @0035                               v15 = iconst.i64 -2
+;; @0035                               v16 = band v14, v15  ; v15 = -2
+;; @0035                               brif v14, block3(v16), block2
 ;;
 ;;                                 block2 cold:
-;; @0035                               v19 = iconst.i32 0
-;; @0035                               v21 = call fn0(v0, v19, v8)  ; v19 = 0
-;; @0035                               jump block3(v21)
+;; @0035                               v18 = iconst.i32 0
+;; @0035                               v20 = call fn0(v0, v18, v7)  ; v18 = 0
+;; @0035                               jump block3(v20)
 ;;
-;;                                 block3(v18: i64):
-;; @0035                               v24 = load.i32 user7 aligned readonly v18+16
-;; @0035                               v22 = load.i64 notrap aligned readonly can_move region5 v0+40
-;; @0035                               v23 = load.i32 notrap aligned readonly can_move v22+4
-;; @0035                               v25 = icmp eq v24, v23
-;; @0035                               trapz v25, user8
-;; @0035                               v27 = load.i64 notrap aligned readonly v18+8
-;; @0035                               v28 = load.i64 notrap aligned readonly v18+24
-;; @0035                               v29 = call_indirect sig0, v27(v28, v0, v2)
+;;                                 block3(v17: i64):
+;; @0035                               v23 = load.i32 user7 aligned readonly v17+16
+;; @0035                               v21 = load.i64 notrap aligned readonly can_move region5 v0+40
+;; @0035                               v22 = load.i32 notrap aligned readonly can_move v21+4
+;; @0035                               v24 = icmp eq v23, v22
+;; @0035                               trapz v24, user8
+;; @0035                               v26 = load.i64 notrap aligned readonly v17+8
+;; @0035                               v27 = load.i64 notrap aligned readonly v17+24
+;; @0035                               v28 = call_indirect sig0, v26(v27, v0, v2)
 ;; @0038                               jump block1
 ;;
 ;;                                 block1:
-;; @0038                               return v29
+;; @0038                               return v28
 ;; }

--- a/tests/disas/call-indirect-without-gc.wat
+++ b/tests/disas/call-indirect-without-gc.wat
@@ -25,37 +25,37 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
-;; @0035                               v5 = load.i64 notrap aligned region3 v0+56
-;; @0035                               v9 = load.i64 notrap aligned region2 v0+48
-;; @0035                               v6 = ireduce.i32 v5
-;; @0035                               v7 = icmp uge v3, v6
-;; @0035                               v13 = iconst.i64 0
-;; @0035                               v8 = uextend.i64 v3
-;; @0035                               v10 = iconst.i64 3
-;; @0035                               v11 = ishl v8, v10  ; v10 = 3
-;; @0035                               v12 = iadd v9, v11
-;; @0035                               v14 = select_spectre_guard v7, v13, v12  ; v13 = 0
-;; @0035                               v15 = load.i64 user6 aligned region4 v14
-;; @0035                               v16 = iconst.i64 -2
-;; @0035                               v17 = band v15, v16  ; v16 = -2
-;; @0035                               brif v15, block3(v17), block2
+;; @0035                               v4 = load.i64 notrap aligned region3 v0+56
+;; @0035                               v8 = load.i64 notrap aligned region2 v0+48
+;; @0035                               v5 = ireduce.i32 v4
+;; @0035                               v6 = icmp uge v3, v5
+;; @0035                               v12 = iconst.i64 0
+;; @0035                               v7 = uextend.i64 v3
+;; @0035                               v9 = iconst.i64 3
+;; @0035                               v10 = ishl v7, v9  ; v9 = 3
+;; @0035                               v11 = iadd v8, v10
+;; @0035                               v13 = select_spectre_guard v6, v12, v11  ; v12 = 0
+;; @0035                               v14 = load.i64 user6 aligned region4 v13
+;; @0035                               v15 = iconst.i64 -2
+;; @0035                               v16 = band v14, v15  ; v15 = -2
+;; @0035                               brif v14, block3(v16), block2
 ;;
 ;;                                 block2 cold:
-;; @0035                               v19 = iconst.i32 0
-;; @0035                               v21 = call fn0(v0, v19, v8)  ; v19 = 0
-;; @0035                               jump block3(v21)
+;; @0035                               v18 = iconst.i32 0
+;; @0035                               v20 = call fn0(v0, v18, v7)  ; v18 = 0
+;; @0035                               jump block3(v20)
 ;;
-;;                                 block3(v18: i64):
-;; @0035                               v24 = load.i32 user7 aligned readonly v18+16
-;; @0035                               v22 = load.i64 notrap aligned readonly can_move region5 v0+40
-;; @0035                               v23 = load.i32 notrap aligned readonly can_move v22+4
-;; @0035                               v25 = icmp eq v24, v23
-;; @0035                               trapz v25, user8
-;; @0035                               v27 = load.i64 notrap aligned readonly v18+8
-;; @0035                               v28 = load.i64 notrap aligned readonly v18+24
-;; @0035                               v29 = call_indirect sig0, v27(v28, v0, v2)
+;;                                 block3(v17: i64):
+;; @0035                               v23 = load.i32 user7 aligned readonly v17+16
+;; @0035                               v21 = load.i64 notrap aligned readonly can_move region5 v0+40
+;; @0035                               v22 = load.i32 notrap aligned readonly can_move v21+4
+;; @0035                               v24 = icmp eq v23, v22
+;; @0035                               trapz v24, user8
+;; @0035                               v26 = load.i64 notrap aligned readonly v17+8
+;; @0035                               v27 = load.i64 notrap aligned readonly v17+24
+;; @0035                               v28 = call_indirect sig0, v26(v27, v0, v2)
 ;; @0038                               jump block1
 ;;
 ;;                                 block1:
-;; @0038                               return v29
+;; @0038                               return v28
 ;; }

--- a/tests/disas/call-indirect.wat
+++ b/tests/disas/call-indirect.wat
@@ -23,39 +23,39 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
-;; @0035                               v5 = load.i64 notrap aligned region3 v0+56
-;; @0035                               v6 = ireduce.i32 v5
-;; @0035                               v7 = icmp uge v3, v6
-;; @0035                               v8 = uextend.i64 v3
-;; @0035                               v9 = load.i64 notrap aligned region2 v0+48
-;; @0035                               v10 = iconst.i64 3
-;; @0035                               v11 = ishl v8, v10  ; v10 = 3
-;; @0035                               v12 = iadd v9, v11
-;; @0035                               v13 = iconst.i64 0
-;; @0035                               v14 = select_spectre_guard v7, v13, v12  ; v13 = 0
-;; @0035                               v15 = load.i64 user6 aligned region4 v14
-;; @0035                               v16 = iconst.i64 -2
-;; @0035                               v17 = band v15, v16  ; v16 = -2
-;; @0035                               brif v15, block3(v17), block2
+;; @0035                               v4 = load.i64 notrap aligned region3 v0+56
+;; @0035                               v5 = ireduce.i32 v4
+;; @0035                               v6 = icmp uge v3, v5
+;; @0035                               v7 = uextend.i64 v3
+;; @0035                               v8 = load.i64 notrap aligned region2 v0+48
+;; @0035                               v9 = iconst.i64 3
+;; @0035                               v10 = ishl v7, v9  ; v9 = 3
+;; @0035                               v11 = iadd v8, v10
+;; @0035                               v12 = iconst.i64 0
+;; @0035                               v13 = select_spectre_guard v6, v12, v11  ; v12 = 0
+;; @0035                               v14 = load.i64 user6 aligned region4 v13
+;; @0035                               v15 = iconst.i64 -2
+;; @0035                               v16 = band v14, v15  ; v15 = -2
+;; @0035                               brif v14, block3(v16), block2
 ;;
 ;;                                 block2 cold:
-;; @0035                               v19 = iconst.i32 0
-;; @0035                               v20 = uextend.i64 v3
-;; @0035                               v21 = call fn0(v0, v19, v20)  ; v19 = 0
-;; @0035                               jump block3(v21)
+;; @0035                               v18 = iconst.i32 0
+;; @0035                               v19 = uextend.i64 v3
+;; @0035                               v20 = call fn0(v0, v18, v19)  ; v18 = 0
+;; @0035                               jump block3(v20)
 ;;
-;;                                 block3(v18: i64):
-;; @0035                               v22 = load.i64 notrap aligned readonly can_move region5 v0+40
-;; @0035                               v23 = load.i32 notrap aligned readonly can_move v22+4
-;; @0035                               v24 = load.i32 user7 aligned readonly v18+16
-;; @0035                               v25 = icmp eq v24, v23
-;; @0035                               v26 = uextend.i32 v25
-;; @0035                               trapz v26, user8
-;; @0035                               v27 = load.i64 notrap aligned readonly v18+8
-;; @0035                               v28 = load.i64 notrap aligned readonly v18+24
-;; @0035                               v29 = call_indirect sig0, v27(v28, v0, v2)
+;;                                 block3(v17: i64):
+;; @0035                               v21 = load.i64 notrap aligned readonly can_move region5 v0+40
+;; @0035                               v22 = load.i32 notrap aligned readonly can_move v21+4
+;; @0035                               v23 = load.i32 user7 aligned readonly v17+16
+;; @0035                               v24 = icmp eq v23, v22
+;; @0035                               v25 = uextend.i32 v24
+;; @0035                               trapz v25, user8
+;; @0035                               v26 = load.i64 notrap aligned readonly v17+8
+;; @0035                               v27 = load.i64 notrap aligned readonly v17+24
+;; @0035                               v28 = call_indirect sig0, v26(v27, v0, v2)
 ;; @0038                               jump block1
 ;;
 ;;                                 block1:
-;; @0038                               return v29
+;; @0038                               return v28
 ;; }

--- a/tests/disas/call-simd.wat
+++ b/tests/disas/call-simd.wat
@@ -45,12 +45,12 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16, v3: i8x16):
-;; @004f                               v5 = bitcast.i32x4 little v2
-;; @004f                               v6 = bitcast.i32x4 little v3
-;; @004f                               v7 = iadd v5, v6
-;; @0052                               v8 = bitcast.i8x16 little v7
+;; @004f                               v4 = bitcast.i32x4 little v2
+;; @004f                               v5 = bitcast.i32x4 little v3
+;; @004f                               v6 = iadd v4, v5
+;; @0052                               v7 = bitcast.i8x16 little v6
 ;; @0052                               jump block1
 ;;
 ;;                                 block1:
-;; @0052                               return v8
+;; @0052                               return v7
 ;; }

--- a/tests/disas/call.wat
+++ b/tests/disas/call.wat
@@ -40,9 +40,9 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @002b                               v3 = iconst.i32 1
+;; @002b                               v2 = iconst.i32 1
 ;; @002d                               jump block1
 ;;
 ;;                                 block1:
-;; @002d                               return v3  ; v3 = 1
+;; @002d                               return v2  ; v2 = 1
 ;; }

--- a/tests/disas/component-model/direct-adapter-calls-inlining.wat
+++ b/tests/disas/component-model/direct-adapter-calls-inlining.wat
@@ -85,15 +85,17 @@
 ;;                                 block2:
 ;;                                     jump block6
 ;;
-;;                                 block8(v9: i64):
+;;                                 block8(v7: i64):
 ;;                                     jump block5
 ;;
 ;;                                 block6:
 ;; @00ee                               v4 = load.i64 notrap aligned readonly can_move region2 v0+72
-;;                                     v14 = load.i64 notrap aligned readonly can_move region3 v4+136
-;;                                     v15 = load.i32 notrap aligned region4 v14
-;;                                     v13 = iconst.i32 0
-;;                                     v17 = icmp eq v15, v13  ; v13 = 0
+;;                                     v12 = load.i64 notrap aligned readonly can_move region3 v4+136
+;;                                     v13 = load.i32 notrap aligned region4 v12
+;;                                     v14 = iconst.i32 1
+;;                                     v15 = band v13, v14  ; v14 = 1
+;;                                     v11 = iconst.i32 0
+;;                                     v17 = icmp eq v15, v11  ; v11 = 0
 ;;                                     brif v17, block9, block10
 ;;
 ;;                                 block9:
@@ -108,9 +110,12 @@
 ;;                                 block10:
 ;;                                     v26 = load.i64 notrap aligned readonly can_move region7 v4+112
 ;;                                     v27 = load.i32 notrap aligned region4 v26
-;;                                     v43 = iconst.i32 0
-;;                                     store notrap aligned region4 v43, v26  ; v43 = 0
-;;                                     store notrap aligned region4 v27, v26
+;;                                     v28 = iconst.i32 -2
+;;                                     v29 = band v27, v28  ; v28 = -2
+;;                                     store notrap aligned region4 v29, v26
+;;                                     v59 = iconst.i32 1
+;;                                     v60 = bor v27, v59  ; v59 = 1
+;;                                     store notrap aligned region4 v60, v26
 ;;                                     jump block13
 ;;
 ;;                                 block13:
@@ -120,9 +125,13 @@
 ;;                                     jump block12
 ;;
 ;;                                 block12:
-;;                                     v44 = iconst.i32 0
-;;                                     store notrap aligned region4 v44, v14  ; v44 = 0
-;;                                     store.i32 notrap aligned region4 v15, v14
+;;                                     v40 = load.i32 notrap aligned region4 v12
+;;                                     v61 = iconst.i32 -2
+;;                                     v62 = band v40, v61  ; v61 = -2
+;;                                     store notrap aligned region4 v62, v12
+;;                                     v63 = iconst.i32 1
+;;                                     v64 = bor v40, v63  ; v63 = 1
+;;                                     store notrap aligned region4 v64, v12
 ;;                                     jump block7
 ;;
 ;;                                 block7:
@@ -143,6 +152,6 @@
 ;; @00f0                               jump block1
 ;;
 ;;                                 block1:
-;;                                     v37 = iconst.i32 1276
-;; @00f0                               return v37  ; v37 = 1276
+;;                                     v51 = iconst.i32 1276
+;; @00f0                               return v51  ; v51 = 1276
 ;; }

--- a/tests/disas/component-model/direct-adapter-calls-inlining.wat
+++ b/tests/disas/component-model/direct-adapter-calls-inlining.wat
@@ -92,30 +92,25 @@
 ;; @00ee                               v3 = load.i64 notrap aligned readonly can_move region2 v0+72
 ;;                                     v9 = load.i64 notrap aligned readonly can_move region3 v3+136
 ;;                                     v10 = load.i32 notrap aligned region4 v9
-;;                                     v11 = iconst.i32 1
-;;                                     v12 = band v10, v11  ; v11 = 1
 ;;                                     v8 = iconst.i32 0
-;;                                     v14 = icmp eq v12, v8  ; v8 = 0
-;;                                     brif v14, block9, block10
+;;                                     v12 = icmp eq v10, v8  ; v8 = 0
+;;                                     brif v12, block9, block10
 ;;
 ;;                                 block9:
-;;                                     v18 = load.i64 notrap aligned readonly can_move region6 v3+88
-;;                                     v17 = load.i64 notrap aligned readonly can_move region5 v3+104
-;;                                     v16 = iconst.i32 23
-;;                                     try_call_indirect v18(v17, v3, v16), sig1, block11, [ context v3, default: block8(exn0) ]  ; v16 = 23
+;;                                     v16 = load.i64 notrap aligned readonly can_move region6 v3+88
+;;                                     v15 = load.i64 notrap aligned readonly can_move region5 v3+104
+;;                                     v14 = iconst.i32 23
+;;                                     try_call_indirect v16(v15, v3, v14), sig1, block11, [ context v3, default: block8(exn0) ]  ; v14 = 23
 ;;
 ;;                                 block11:
 ;;                                     trap user12
 ;;
 ;;                                 block10:
-;;                                     v23 = load.i64 notrap aligned readonly can_move region7 v3+112
-;;                                     v24 = load.i32 notrap aligned region4 v23
-;;                                     v25 = iconst.i32 -2
-;;                                     v26 = band v24, v25  ; v25 = -2
-;;                                     store notrap aligned region4 v26, v23
-;;                                     v56 = iconst.i32 1
-;;                                     v57 = bor v24, v56  ; v56 = 1
-;;                                     store notrap aligned region4 v57, v23
+;;                                     v21 = load.i64 notrap aligned readonly can_move region7 v3+112
+;;                                     v22 = load.i32 notrap aligned region4 v21
+;;                                     v38 = iconst.i32 0
+;;                                     store notrap aligned region4 v38, v21  ; v38 = 0
+;;                                     store notrap aligned region4 v22, v21
 ;;                                     jump block13
 ;;
 ;;                                 block13:
@@ -125,21 +120,17 @@
 ;;                                     jump block12
 ;;
 ;;                                 block12:
-;;                                     v37 = load.i32 notrap aligned region4 v9
-;;                                     v58 = iconst.i32 -2
-;;                                     v59 = band v37, v58  ; v58 = -2
-;;                                     store notrap aligned region4 v59, v9
-;;                                     v60 = iconst.i32 1
-;;                                     v61 = bor v37, v60  ; v60 = 1
-;;                                     store notrap aligned region4 v61, v9
+;;                                     v39 = iconst.i32 0
+;;                                     store notrap aligned region4 v39, v9  ; v39 = 0
+;;                                     store.i32 notrap aligned region4 v10, v9
 ;;                                     jump block7
 ;;
 ;;                                 block7:
 ;;                                     jump block4
 ;;
 ;;                                 block5:
-;;                                     v20 = iconst.i32 49
-;;                                     call_indirect.i64 sig1, v18(v17, v3, v20)  ; v20 = 49
+;;                                     v18 = iconst.i32 49
+;;                                     call_indirect.i64 sig1, v16(v15, v3, v18)  ; v18 = 49
 ;;                                     trap user12
 ;;
 ;;                                 block4:
@@ -152,6 +143,6 @@
 ;; @00f0                               jump block1
 ;;
 ;;                                 block1:
-;;                                     v48 = iconst.i32 1276
-;; @00f0                               return v48  ; v48 = 1276
+;;                                     v32 = iconst.i32 1276
+;; @00f0                               return v32  ; v32 = 1276
 ;; }

--- a/tests/disas/component-model/direct-adapter-calls-inlining.wat
+++ b/tests/disas/component-model/direct-adapter-calls-inlining.wat
@@ -85,37 +85,37 @@
 ;;                                 block2:
 ;;                                     jump block6
 ;;
-;;                                 block8(v7: i64):
+;;                                 block8(v5: i64):
 ;;                                     jump block5
 ;;
 ;;                                 block6:
-;; @00ee                               v4 = load.i64 notrap aligned readonly can_move region2 v0+72
-;;                                     v12 = load.i64 notrap aligned readonly can_move region3 v4+136
-;;                                     v13 = load.i32 notrap aligned region4 v12
-;;                                     v14 = iconst.i32 1
-;;                                     v15 = band v13, v14  ; v14 = 1
-;;                                     v11 = iconst.i32 0
-;;                                     v17 = icmp eq v15, v11  ; v11 = 0
-;;                                     brif v17, block9, block10
+;; @00ee                               v3 = load.i64 notrap aligned readonly can_move region2 v0+72
+;;                                     v9 = load.i64 notrap aligned readonly can_move region3 v3+136
+;;                                     v10 = load.i32 notrap aligned region4 v9
+;;                                     v11 = iconst.i32 1
+;;                                     v12 = band v10, v11  ; v11 = 1
+;;                                     v8 = iconst.i32 0
+;;                                     v14 = icmp eq v12, v8  ; v8 = 0
+;;                                     brif v14, block9, block10
 ;;
 ;;                                 block9:
-;;                                     v21 = load.i64 notrap aligned readonly can_move region6 v4+88
-;;                                     v20 = load.i64 notrap aligned readonly can_move region5 v4+104
-;;                                     v19 = iconst.i32 23
-;;                                     try_call_indirect v21(v20, v4, v19), sig1, block11, [ context v4, default: block8(exn0) ]  ; v19 = 23
+;;                                     v18 = load.i64 notrap aligned readonly can_move region6 v3+88
+;;                                     v17 = load.i64 notrap aligned readonly can_move region5 v3+104
+;;                                     v16 = iconst.i32 23
+;;                                     try_call_indirect v18(v17, v3, v16), sig1, block11, [ context v3, default: block8(exn0) ]  ; v16 = 23
 ;;
 ;;                                 block11:
 ;;                                     trap user12
 ;;
 ;;                                 block10:
-;;                                     v26 = load.i64 notrap aligned readonly can_move region7 v4+112
-;;                                     v27 = load.i32 notrap aligned region4 v26
-;;                                     v28 = iconst.i32 -2
-;;                                     v29 = band v27, v28  ; v28 = -2
-;;                                     store notrap aligned region4 v29, v26
-;;                                     v59 = iconst.i32 1
-;;                                     v60 = bor v27, v59  ; v59 = 1
-;;                                     store notrap aligned region4 v60, v26
+;;                                     v23 = load.i64 notrap aligned readonly can_move region7 v3+112
+;;                                     v24 = load.i32 notrap aligned region4 v23
+;;                                     v25 = iconst.i32 -2
+;;                                     v26 = band v24, v25  ; v25 = -2
+;;                                     store notrap aligned region4 v26, v23
+;;                                     v56 = iconst.i32 1
+;;                                     v57 = bor v24, v56  ; v56 = 1
+;;                                     store notrap aligned region4 v57, v23
 ;;                                     jump block13
 ;;
 ;;                                 block13:
@@ -125,21 +125,21 @@
 ;;                                     jump block12
 ;;
 ;;                                 block12:
-;;                                     v40 = load.i32 notrap aligned region4 v12
-;;                                     v61 = iconst.i32 -2
-;;                                     v62 = band v40, v61  ; v61 = -2
-;;                                     store notrap aligned region4 v62, v12
-;;                                     v63 = iconst.i32 1
-;;                                     v64 = bor v40, v63  ; v63 = 1
-;;                                     store notrap aligned region4 v64, v12
+;;                                     v37 = load.i32 notrap aligned region4 v9
+;;                                     v58 = iconst.i32 -2
+;;                                     v59 = band v37, v58  ; v58 = -2
+;;                                     store notrap aligned region4 v59, v9
+;;                                     v60 = iconst.i32 1
+;;                                     v61 = bor v37, v60  ; v60 = 1
+;;                                     store notrap aligned region4 v61, v9
 ;;                                     jump block7
 ;;
 ;;                                 block7:
 ;;                                     jump block4
 ;;
 ;;                                 block5:
-;;                                     v23 = iconst.i32 49
-;;                                     call_indirect.i64 sig1, v21(v20, v4, v23)  ; v23 = 49
+;;                                     v20 = iconst.i32 49
+;;                                     call_indirect.i64 sig1, v18(v17, v3, v20)  ; v20 = 49
 ;;                                     trap user12
 ;;
 ;;                                 block4:
@@ -152,6 +152,6 @@
 ;; @00f0                               jump block1
 ;;
 ;;                                 block1:
-;;                                     v51 = iconst.i32 1276
-;; @00f0                               return v51  ; v51 = 1276
+;;                                     v48 = iconst.i32 1276
+;; @00f0                               return v48  ; v48 = 1276
 ;; }

--- a/tests/disas/component-model/direct-adapter-calls.wat
+++ b/tests/disas/component-model/direct-adapter-calls.wat
@@ -121,56 +121,47 @@
 ;;                                 block4:
 ;; @0080                               v6 = load.i64 notrap aligned readonly can_move region2 v0+136
 ;; @0080                               v7 = load.i32 notrap aligned region3 v6
-;; @0082                               v8 = iconst.i32 1
-;; @0084                               v9 = band v7, v8  ; v8 = 1
 ;; @0075                               v3 = iconst.i32 0
-;; @0085                               v11 = icmp eq v9, v3  ; v3 = 0
-;; @0086                               brif v11, block7, block8
+;; @0084                               v9 = icmp eq v7, v3  ; v3 = 0
+;; @0085                               brif v9, block7, block8
 ;;
 ;;                                 block7:
-;; @008a                               v15 = load.i64 notrap aligned readonly can_move region5 v0+88
-;; @008a                               v14 = load.i64 notrap aligned readonly can_move region4 v0+104
-;; @0088                               v13 = iconst.i32 23
-;; @008a                               try_call_indirect v15(v14, v0, v13), sig0, block9, [ context v0, default: block6(exn0) ]  ; v13 = 23
+;; @0089                               v13 = load.i64 notrap aligned readonly can_move region5 v0+88
+;; @0089                               v12 = load.i64 notrap aligned readonly can_move region4 v0+104
+;; @0087                               v11 = iconst.i32 23
+;; @0089                               try_call_indirect v13(v12, v0, v11), sig0, block9, [ context v0, default: block6(exn0) ]  ; v11 = 23
 ;;
 ;;                                 block9:
-;; @008c                               trap user12
+;; @008b                               trap user12
 ;;
 ;;                                 block8:
-;; @008e                               v16 = load.i64 notrap aligned readonly can_move region6 v0+112
-;; @008e                               v17 = load.i32 notrap aligned region3 v16
-;; @0090                               v18 = iconst.i32 -2
-;; @0092                               v19 = band v17, v18  ; v18 = -2
-;; @0093                               store notrap aligned region3 v19, v16
-;;                                     v45 = iconst.i32 1
-;;                                     v46 = bor v17, v45  ; v45 = 1
-;; @009c                               store notrap aligned region3 v46, v16
-;; @009e                               v26 = load.i64 notrap aligned readonly can_move region7 v0+72
-;; @009e                               try_call fn0(v26, v0, v2), sig1, block10(ret0), [ context v0, default: block6(exn0) ]
+;; @008d                               v14 = load.i64 notrap aligned readonly can_move region6 v0+112
+;; @008d                               v15 = load.i32 notrap aligned region3 v14
+;;                                     v27 = iconst.i32 0
+;; @0093                               store notrap aligned region3 v27, v14  ; v27 = 0
+;; @0099                               store notrap aligned region3 v15, v14
+;; @009b                               v19 = load.i64 notrap aligned readonly can_move region7 v0+72
+;; @009b                               try_call fn0(v19, v0, v2), sig1, block10(ret0), [ context v0, default: block6(exn0) ]
 ;;
-;;                                 block10(v27: i32):
-;; @00a2                               v29 = load.i32 notrap aligned region3 v6
-;;                                     v47 = iconst.i32 -2
-;;                                     v48 = band v29, v47  ; v47 = -2
-;; @00a7                               store notrap aligned region3 v48, v6
-;;                                     v49 = iconst.i32 1
-;;                                     v50 = bor v29, v49  ; v49 = 1
-;; @00b0                               store notrap aligned region3 v50, v6
-;; @00b2                               jump block5
+;;                                 block10(v20: i32):
+;;                                     v28 = iconst.i32 0
+;; @00a1                               store notrap aligned region3 v28, v6  ; v28 = 0
+;; @00a7                               store.i32 notrap aligned region3 v7, v6
+;; @00a9                               jump block5
 ;;
 ;;                                 block5:
-;; @00b3                               jump block2
+;; @00aa                               jump block2
 ;;
 ;;                                 block3:
-;;                                     v51 = load.i64 notrap aligned readonly can_move region5 v0+88
-;;                                     v52 = load.i64 notrap aligned readonly can_move region4 v0+104
-;; @00b6                               v38 = iconst.i32 49
-;; @00b8                               call_indirect sig0, v51(v52, v0, v38)  ; v38 = 49
-;; @00ba                               trap user12
+;;                                     v29 = load.i64 notrap aligned readonly can_move region5 v0+88
+;;                                     v30 = load.i64 notrap aligned readonly can_move region4 v0+104
+;; @00ad                               v24 = iconst.i32 49
+;; @00af                               call_indirect sig0, v29(v30, v0, v24)  ; v24 = 49
+;; @00b1                               trap user12
 ;;
 ;;                                 block2:
-;; @00bc                               jump block1
+;; @00b3                               jump block1
 ;;
 ;;                                 block1:
-;; @00bc                               return v27
+;; @00b3                               return v20
 ;; }

--- a/tests/disas/component-model/direct-adapter-calls.wat
+++ b/tests/disas/component-model/direct-adapter-calls.wat
@@ -115,53 +115,62 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @007b                               jump block4
 ;;
-;;                                 block6(v7: i64):
+;;                                 block6(v5: i64):
 ;; @007b                               jump block3
 ;;
 ;;                                 block4:
-;; @0080                               v9 = load.i64 notrap aligned readonly can_move region2 v0+136
-;; @0080                               v10 = load.i32 notrap aligned region3 v9
+;; @0080                               v7 = load.i64 notrap aligned readonly can_move region2 v0+136
+;; @0080                               v8 = load.i32 notrap aligned region3 v7
+;; @0082                               v9 = iconst.i32 1
+;; @0084                               v10 = band v8, v9  ; v9 = 1
 ;; @0075                               v4 = iconst.i32 0
-;; @0084                               v12 = icmp eq v10, v4  ; v4 = 0
-;; @0085                               brif v12, block7, block8
+;; @0085                               v12 = icmp eq v10, v4  ; v4 = 0
+;; @0086                               brif v12, block7, block8
 ;;
 ;;                                 block7:
-;; @0089                               v16 = load.i64 notrap aligned readonly can_move region5 v0+88
-;; @0089                               v15 = load.i64 notrap aligned readonly can_move region4 v0+104
-;; @0087                               v14 = iconst.i32 23
-;; @0089                               try_call_indirect v16(v15, v0, v14), sig0, block9, [ context v0, default: block6(exn0) ]  ; v14 = 23
+;; @008a                               v16 = load.i64 notrap aligned readonly can_move region5 v0+88
+;; @008a                               v15 = load.i64 notrap aligned readonly can_move region4 v0+104
+;; @0088                               v14 = iconst.i32 23
+;; @008a                               try_call_indirect v16(v15, v0, v14), sig0, block9, [ context v0, default: block6(exn0) ]  ; v14 = 23
 ;;
 ;;                                 block9:
-;; @008b                               trap user12
+;; @008c                               trap user12
 ;;
 ;;                                 block8:
-;; @008d                               v17 = load.i64 notrap aligned readonly can_move region6 v0+112
-;; @008d                               v18 = load.i32 notrap aligned region3 v17
-;;                                     v30 = iconst.i32 0
-;; @0093                               store notrap aligned region3 v30, v17  ; v30 = 0
-;; @0099                               store notrap aligned region3 v18, v17
-;; @009b                               v22 = load.i64 notrap aligned readonly can_move region7 v0+72
-;; @009b                               try_call fn0(v22, v0, v2), sig1, block10(ret0), [ context v0, default: block6(exn0) ]
+;; @008e                               v17 = load.i64 notrap aligned readonly can_move region6 v0+112
+;; @008e                               v18 = load.i32 notrap aligned region3 v17
+;; @0090                               v19 = iconst.i32 -2
+;; @0092                               v20 = band v18, v19  ; v19 = -2
+;; @0093                               store notrap aligned region3 v20, v17
+;;                                     v46 = iconst.i32 1
+;;                                     v47 = bor v18, v46  ; v46 = 1
+;; @009c                               store notrap aligned region3 v47, v17
+;; @009e                               v27 = load.i64 notrap aligned readonly can_move region7 v0+72
+;; @009e                               try_call fn0(v27, v0, v2), sig1, block10(ret0), [ context v0, default: block6(exn0) ]
 ;;
-;;                                 block10(v23: i32):
-;;                                     v31 = iconst.i32 0
-;; @00a1                               store notrap aligned region3 v31, v9  ; v31 = 0
-;; @00a7                               store.i32 notrap aligned region3 v10, v9
-;; @00a9                               jump block5(v23)
+;;                                 block10(v28: i32):
+;; @00a2                               v30 = load.i32 notrap aligned region3 v7
+;;                                     v48 = iconst.i32 -2
+;;                                     v49 = band v30, v48  ; v48 = -2
+;; @00a7                               store notrap aligned region3 v49, v7
+;;                                     v50 = iconst.i32 1
+;;                                     v51 = bor v30, v50  ; v50 = 1
+;; @00b0                               store notrap aligned region3 v51, v7
+;; @00b2                               jump block5
 ;;
-;;                                 block5(v6: i32):
-;; @00aa                               jump block2(v6)
+;;                                 block5:
+;; @00b3                               jump block2
 ;;
 ;;                                 block3:
-;;                                     v32 = load.i64 notrap aligned readonly can_move region5 v0+88
-;;                                     v33 = load.i64 notrap aligned readonly can_move region4 v0+104
-;; @00ad                               v27 = iconst.i32 49
-;; @00af                               call_indirect sig0, v32(v33, v0, v27)  ; v27 = 49
-;; @00b1                               trap user12
+;;                                     v52 = load.i64 notrap aligned readonly can_move region5 v0+88
+;;                                     v53 = load.i64 notrap aligned readonly can_move region4 v0+104
+;; @00b6                               v39 = iconst.i32 49
+;; @00b8                               call_indirect sig0, v52(v53, v0, v39)  ; v39 = 49
+;; @00ba                               trap user12
 ;;
-;;                                 block2(v5: i32):
-;; @00b3                               jump block1(v5)
+;;                                 block2:
+;; @00bc                               jump block1(v28)
 ;;
 ;;                                 block1(v3: i32):
-;; @00b3                               return v3
+;; @00bc                               return v3
 ;; }

--- a/tests/disas/component-model/direct-adapter-calls.wat
+++ b/tests/disas/component-model/direct-adapter-calls.wat
@@ -69,9 +69,9 @@
 ;; @003b                               jump block1
 ;;
 ;;                                 block1:
-;; @0038                               v4 = iconst.i32 42
-;;                                     v5 = iadd.i32 v2, v4  ; v4 = 42
-;; @003b                               return v5
+;; @0038                               v3 = iconst.i32 42
+;;                                     v4 = iadd.i32 v2, v3  ; v3 = 42
+;; @003b                               return v4
 ;; }
 ;;
 ;; function u1:0(i64 vmctx, i64) -> i32 tail {
@@ -86,13 +86,13 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @00ee                               v4 = load.i64 notrap aligned readonly can_move region2 v0+72
-;; @00eb                               v3 = iconst.i32 1234
-;; @00ee                               v5 = call fn0(v4, v0, v3)  ; v3 = 1234
+;; @00ee                               v3 = load.i64 notrap aligned readonly can_move region2 v0+72
+;; @00eb                               v2 = iconst.i32 1234
+;; @00ee                               v4 = call fn0(v3, v0, v2)  ; v2 = 1234
 ;; @00f0                               jump block1
 ;;
 ;;                                 block1:
-;; @00f0                               return v5
+;; @00f0                               return v4
 ;; }
 ;;
 ;; function u2:0(i64 vmctx, i64, i32) -> i32 tail {
@@ -115,62 +115,62 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @007b                               jump block4
 ;;
-;;                                 block6(v5: i64):
+;;                                 block6(v4: i64):
 ;; @007b                               jump block3
 ;;
 ;;                                 block4:
-;; @0080                               v7 = load.i64 notrap aligned readonly can_move region2 v0+136
-;; @0080                               v8 = load.i32 notrap aligned region3 v7
-;; @0082                               v9 = iconst.i32 1
-;; @0084                               v10 = band v8, v9  ; v9 = 1
-;; @0075                               v4 = iconst.i32 0
-;; @0085                               v12 = icmp eq v10, v4  ; v4 = 0
-;; @0086                               brif v12, block7, block8
+;; @0080                               v6 = load.i64 notrap aligned readonly can_move region2 v0+136
+;; @0080                               v7 = load.i32 notrap aligned region3 v6
+;; @0082                               v8 = iconst.i32 1
+;; @0084                               v9 = band v7, v8  ; v8 = 1
+;; @0075                               v3 = iconst.i32 0
+;; @0085                               v11 = icmp eq v9, v3  ; v3 = 0
+;; @0086                               brif v11, block7, block8
 ;;
 ;;                                 block7:
-;; @008a                               v16 = load.i64 notrap aligned readonly can_move region5 v0+88
-;; @008a                               v15 = load.i64 notrap aligned readonly can_move region4 v0+104
-;; @0088                               v14 = iconst.i32 23
-;; @008a                               try_call_indirect v16(v15, v0, v14), sig0, block9, [ context v0, default: block6(exn0) ]  ; v14 = 23
+;; @008a                               v15 = load.i64 notrap aligned readonly can_move region5 v0+88
+;; @008a                               v14 = load.i64 notrap aligned readonly can_move region4 v0+104
+;; @0088                               v13 = iconst.i32 23
+;; @008a                               try_call_indirect v15(v14, v0, v13), sig0, block9, [ context v0, default: block6(exn0) ]  ; v13 = 23
 ;;
 ;;                                 block9:
 ;; @008c                               trap user12
 ;;
 ;;                                 block8:
-;; @008e                               v17 = load.i64 notrap aligned readonly can_move region6 v0+112
-;; @008e                               v18 = load.i32 notrap aligned region3 v17
-;; @0090                               v19 = iconst.i32 -2
-;; @0092                               v20 = band v18, v19  ; v19 = -2
-;; @0093                               store notrap aligned region3 v20, v17
-;;                                     v46 = iconst.i32 1
-;;                                     v47 = bor v18, v46  ; v46 = 1
-;; @009c                               store notrap aligned region3 v47, v17
-;; @009e                               v27 = load.i64 notrap aligned readonly can_move region7 v0+72
-;; @009e                               try_call fn0(v27, v0, v2), sig1, block10(ret0), [ context v0, default: block6(exn0) ]
+;; @008e                               v16 = load.i64 notrap aligned readonly can_move region6 v0+112
+;; @008e                               v17 = load.i32 notrap aligned region3 v16
+;; @0090                               v18 = iconst.i32 -2
+;; @0092                               v19 = band v17, v18  ; v18 = -2
+;; @0093                               store notrap aligned region3 v19, v16
+;;                                     v45 = iconst.i32 1
+;;                                     v46 = bor v17, v45  ; v45 = 1
+;; @009c                               store notrap aligned region3 v46, v16
+;; @009e                               v26 = load.i64 notrap aligned readonly can_move region7 v0+72
+;; @009e                               try_call fn0(v26, v0, v2), sig1, block10(ret0), [ context v0, default: block6(exn0) ]
 ;;
-;;                                 block10(v28: i32):
-;; @00a2                               v30 = load.i32 notrap aligned region3 v7
-;;                                     v48 = iconst.i32 -2
-;;                                     v49 = band v30, v48  ; v48 = -2
-;; @00a7                               store notrap aligned region3 v49, v7
-;;                                     v50 = iconst.i32 1
-;;                                     v51 = bor v30, v50  ; v50 = 1
-;; @00b0                               store notrap aligned region3 v51, v7
+;;                                 block10(v27: i32):
+;; @00a2                               v29 = load.i32 notrap aligned region3 v6
+;;                                     v47 = iconst.i32 -2
+;;                                     v48 = band v29, v47  ; v47 = -2
+;; @00a7                               store notrap aligned region3 v48, v6
+;;                                     v49 = iconst.i32 1
+;;                                     v50 = bor v29, v49  ; v49 = 1
+;; @00b0                               store notrap aligned region3 v50, v6
 ;; @00b2                               jump block5
 ;;
 ;;                                 block5:
 ;; @00b3                               jump block2
 ;;
 ;;                                 block3:
-;;                                     v52 = load.i64 notrap aligned readonly can_move region5 v0+88
-;;                                     v53 = load.i64 notrap aligned readonly can_move region4 v0+104
-;; @00b6                               v39 = iconst.i32 49
-;; @00b8                               call_indirect sig0, v52(v53, v0, v39)  ; v39 = 49
+;;                                     v51 = load.i64 notrap aligned readonly can_move region5 v0+88
+;;                                     v52 = load.i64 notrap aligned readonly can_move region4 v0+104
+;; @00b6                               v38 = iconst.i32 49
+;; @00b8                               call_indirect sig0, v51(v52, v0, v38)  ; v38 = 49
 ;; @00ba                               trap user12
 ;;
 ;;                                 block2:
-;; @00bc                               jump block1(v28)
+;; @00bc                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @00bc                               return v3
+;;                                 block1:
+;; @00bc                               return v27
 ;; }

--- a/tests/disas/component-model/exported-module-makes-adapters-indirect.wat
+++ b/tests/disas/component-model/exported-module-makes-adapters-indirect.wat
@@ -70,12 +70,12 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @00ee                               v5 = load.i64 notrap aligned readonly can_move region3 v0+56
-;; @00ee                               v4 = load.i64 notrap aligned readonly can_move region2 v0+72
-;; @00eb                               v3 = iconst.i32 1234
-;; @00ee                               v6 = call_indirect sig0, v5(v4, v0, v3)  ; v3 = 1234
+;; @00ee                               v4 = load.i64 notrap aligned readonly can_move region3 v0+56
+;; @00ee                               v3 = load.i64 notrap aligned readonly can_move region2 v0+72
+;; @00eb                               v2 = iconst.i32 1234
+;; @00ee                               v5 = call_indirect sig0, v4(v3, v0, v2)  ; v2 = 1234
 ;; @00f0                               jump block1
 ;;
 ;;                                 block1:
-;; @00f0                               return v6
+;; @00f0                               return v5
 ;; }

--- a/tests/disas/component-model/inlining-bug.wat
+++ b/tests/disas/component-model/inlining-bug.wat
@@ -63,9 +63,9 @@
 ;;                                     jump block4
 ;;
 ;;                                 block4:
-;; @00d4                               v3 = load.i64 notrap aligned readonly can_move region2 v0+72
-;;                                     v9 = load.i64 notrap aligned readonly can_move region3 v3+104
-;;                                     call fn2(v9, v9)
+;; @00d4                               v2 = load.i64 notrap aligned readonly can_move region2 v0+72
+;;                                     v6 = load.i64 notrap aligned readonly can_move region3 v2+104
+;;                                     call fn2(v6, v6)
 ;;                                     jump block5
 ;;
 ;;                                 block5:
@@ -81,6 +81,6 @@
 ;; @00d6                               jump block1
 ;;
 ;;                                 block1:
-;;                                     v10 = iconst.i32 1
-;; @00d6                               return v10  ; v10 = 1
+;;                                     v7 = iconst.i32 1
+;; @00d6                               return v7  ; v7 = 1
 ;; }

--- a/tests/disas/component-model/inlining-fuzz-bug.wat
+++ b/tests/disas/component-model/inlining-fuzz-bug.wat
@@ -92,6 +92,6 @@
 ;; @00c6                               jump block1
 ;;
 ;;                                 block1:
-;;                                     v24 = iconst.i32 301
-;; @00c6                               return v24  ; v24 = 301
+;;                                     v20 = iconst.i32 301
+;; @00c6                               return v20  ; v20 = 301
 ;; }

--- a/tests/disas/component-model/issue-11458.wat
+++ b/tests/disas/component-model/issue-11458.wat
@@ -39,14 +39,14 @@
 ;; @006f                               jump block2
 ;;
 ;;                                 block2:
-;; @006f                               v5 = load.i64 notrap aligned readonly can_move region2 v0+72
-;;                                     v9 = iconst.i32 1
-;;                                     v11 = call fn1(v5, v5, v9)  ; v9 = 1
+;; @006f                               v4 = load.i64 notrap aligned readonly can_move region2 v0+72
+;;                                     v7 = iconst.i32 1
+;;                                     v9 = call fn1(v4, v4, v7)  ; v7 = 1
 ;;                                     jump block4
 ;;
 ;;                                 block4:
 ;; @0071                               jump block1
 ;;
 ;;                                 block1:
-;; @0071                               return v11
+;; @0071                               return v9
 ;; }

--- a/tests/disas/component-model/multiple-instantiations-makes-adapters-indirect.wat
+++ b/tests/disas/component-model/multiple-instantiations-makes-adapters-indirect.wat
@@ -76,12 +76,12 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @00ee                               v5 = load.i64 notrap aligned readonly can_move region3 v0+56
-;; @00ee                               v4 = load.i64 notrap aligned readonly can_move region2 v0+72
-;; @00eb                               v3 = iconst.i32 1234
-;; @00ee                               v6 = call_indirect sig0, v5(v4, v0, v3)  ; v3 = 1234
+;; @00ee                               v4 = load.i64 notrap aligned readonly can_move region3 v0+56
+;; @00ee                               v3 = load.i64 notrap aligned readonly can_move region2 v0+72
+;; @00eb                               v2 = iconst.i32 1234
+;; @00ee                               v5 = call_indirect sig0, v4(v3, v0, v2)  ; v2 = 1234
 ;; @00f0                               jump block1
 ;;
 ;;                                 block1:
-;; @00f0                               return v6
+;; @00f0                               return v5
 ;; }

--- a/tests/disas/ctz-clz-bool-condition.wat
+++ b/tests/disas/ctz-clz-bool-condition.wat
@@ -272,9 +272,9 @@
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       movl    $0x20, %esi
-;;       bsfl    %edx, %r9d
-;;       cmovel  %esi, %r9d
-;;       cmpl    $4, %r9d
+;;       bsfl    %edx, %r8d
+;;       cmovel  %esi, %r8d
+;;       cmpl    $4, %r8d
 ;;       je      0x345
 ;;  33b: movl    $0xc8, %eax
 ;;       jmp     0x34a

--- a/tests/disas/dead-code.wat
+++ b/tests/disas/dead-code.wat
@@ -87,6 +87,6 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0042                               v4 = iconst.i32 1
-;; @0044                               return v4  ; v4 = 1
+;; @0042                               v3 = iconst.i32 1
+;; @0044                               return v3  ; v3 = 1
 ;; }

--- a/tests/disas/duplicate-function-types.wat
+++ b/tests/disas/duplicate-function-types.wat
@@ -33,74 +33,74 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @002d                               v5 = load.i64 notrap aligned readonly can_move region2 v0+48
-;; @002d                               v6 = load.i64 notrap aligned region4 v5+8
-;; @002d                               v7 = ireduce.i32 v6
-;; @002d                               v8 = icmp uge v2, v7
-;; @002d                               v9 = uextend.i64 v2
-;; @002d                               v10 = load.i64 notrap aligned readonly can_move region2 v0+48
-;; @002d                               v11 = load.i64 notrap aligned region3 v10
-;; @002d                               v12 = iconst.i64 3
-;; @002d                               v13 = ishl v9, v12  ; v12 = 3
-;; @002d                               v14 = iadd v11, v13
-;; @002d                               v15 = iconst.i64 0
-;; @002d                               v16 = select_spectre_guard v8, v15, v14  ; v15 = 0
-;; @002d                               v17 = load.i64 user6 aligned region5 v16
-;; @002d                               v18 = iconst.i64 -2
-;; @002d                               v19 = band v17, v18  ; v18 = -2
-;; @002d                               brif v17, block3(v19), block2
+;; @002d                               v3 = load.i64 notrap aligned readonly can_move region2 v0+48
+;; @002d                               v4 = load.i64 notrap aligned region4 v3+8
+;; @002d                               v5 = ireduce.i32 v4
+;; @002d                               v6 = icmp uge v2, v5
+;; @002d                               v7 = uextend.i64 v2
+;; @002d                               v8 = load.i64 notrap aligned readonly can_move region2 v0+48
+;; @002d                               v9 = load.i64 notrap aligned region3 v8
+;; @002d                               v10 = iconst.i64 3
+;; @002d                               v11 = ishl v7, v10  ; v10 = 3
+;; @002d                               v12 = iadd v9, v11
+;; @002d                               v13 = iconst.i64 0
+;; @002d                               v14 = select_spectre_guard v6, v13, v12  ; v13 = 0
+;; @002d                               v15 = load.i64 user6 aligned region5 v14
+;; @002d                               v16 = iconst.i64 -2
+;; @002d                               v17 = band v15, v16  ; v16 = -2
+;; @002d                               brif v15, block3(v17), block2
 ;;
 ;;                                 block2 cold:
-;; @002d                               v21 = iconst.i32 0
-;; @002d                               v22 = uextend.i64 v2
-;; @002d                               v23 = call fn0(v0, v21, v22)  ; v21 = 0
-;; @002d                               jump block3(v23)
+;; @002d                               v19 = iconst.i32 0
+;; @002d                               v20 = uextend.i64 v2
+;; @002d                               v21 = call fn0(v0, v19, v20)  ; v19 = 0
+;; @002d                               jump block3(v21)
 ;;
-;;                                 block3(v20: i64):
-;; @002d                               v24 = load.i64 notrap aligned readonly can_move region6 v0+40
-;; @002d                               v25 = load.i32 notrap aligned readonly can_move v24
-;; @002d                               v26 = load.i32 user7 aligned readonly v20+16
-;; @002d                               v27 = icmp eq v26, v25
-;; @002d                               v28 = uextend.i32 v27
-;; @002d                               trapz v28, user8
-;; @002d                               v29 = load.i64 notrap aligned readonly v20+8
-;; @002d                               v30 = load.i64 notrap aligned readonly v20+24
-;; @002d                               v31 = call_indirect sig0, v29(v30, v0)
-;; @0032                               v33 = load.i64 notrap aligned readonly can_move region2 v0+48
-;; @0032                               v34 = load.i64 notrap aligned region4 v33+8
-;; @0032                               v35 = ireduce.i32 v34
-;; @0032                               v36 = icmp.i32 uge v2, v35
-;; @0032                               v37 = uextend.i64 v2
-;; @0032                               v38 = load.i64 notrap aligned readonly can_move region2 v0+48
-;; @0032                               v39 = load.i64 notrap aligned region3 v38
-;; @0032                               v40 = iconst.i64 3
-;; @0032                               v41 = ishl v37, v40  ; v40 = 3
-;; @0032                               v42 = iadd v39, v41
-;; @0032                               v43 = iconst.i64 0
-;; @0032                               v44 = select_spectre_guard v36, v43, v42  ; v43 = 0
-;; @0032                               v45 = load.i64 user6 aligned region5 v44
-;; @0032                               v46 = iconst.i64 -2
-;; @0032                               v47 = band v45, v46  ; v46 = -2
-;; @0032                               brif v45, block5(v47), block4
+;;                                 block3(v18: i64):
+;; @002d                               v22 = load.i64 notrap aligned readonly can_move region6 v0+40
+;; @002d                               v23 = load.i32 notrap aligned readonly can_move v22
+;; @002d                               v24 = load.i32 user7 aligned readonly v18+16
+;; @002d                               v25 = icmp eq v24, v23
+;; @002d                               v26 = uextend.i32 v25
+;; @002d                               trapz v26, user8
+;; @002d                               v27 = load.i64 notrap aligned readonly v18+8
+;; @002d                               v28 = load.i64 notrap aligned readonly v18+24
+;; @002d                               v29 = call_indirect sig0, v27(v28, v0)
+;; @0032                               v31 = load.i64 notrap aligned readonly can_move region2 v0+48
+;; @0032                               v32 = load.i64 notrap aligned region4 v31+8
+;; @0032                               v33 = ireduce.i32 v32
+;; @0032                               v34 = icmp.i32 uge v2, v33
+;; @0032                               v35 = uextend.i64 v2
+;; @0032                               v36 = load.i64 notrap aligned readonly can_move region2 v0+48
+;; @0032                               v37 = load.i64 notrap aligned region3 v36
+;; @0032                               v38 = iconst.i64 3
+;; @0032                               v39 = ishl v35, v38  ; v38 = 3
+;; @0032                               v40 = iadd v37, v39
+;; @0032                               v41 = iconst.i64 0
+;; @0032                               v42 = select_spectre_guard v34, v41, v40  ; v41 = 0
+;; @0032                               v43 = load.i64 user6 aligned region5 v42
+;; @0032                               v44 = iconst.i64 -2
+;; @0032                               v45 = band v43, v44  ; v44 = -2
+;; @0032                               brif v43, block5(v45), block4
 ;;
 ;;                                 block4 cold:
-;; @0032                               v49 = iconst.i32 0
-;; @0032                               v50 = uextend.i64 v2
-;; @0032                               v51 = call fn0(v0, v49, v50)  ; v49 = 0
-;; @0032                               jump block5(v51)
+;; @0032                               v47 = iconst.i32 0
+;; @0032                               v48 = uextend.i64 v2
+;; @0032                               v49 = call fn0(v0, v47, v48)  ; v47 = 0
+;; @0032                               jump block5(v49)
 ;;
-;;                                 block5(v48: i64):
-;; @0032                               v52 = load.i64 notrap aligned readonly can_move region6 v0+40
-;; @0032                               v53 = load.i32 notrap aligned readonly can_move v52
-;; @0032                               v54 = load.i32 user7 aligned readonly v48+16
-;; @0032                               v55 = icmp eq v54, v53
-;; @0032                               v56 = uextend.i32 v55
-;; @0032                               trapz v56, user8
-;; @0032                               v57 = load.i64 notrap aligned readonly v48+8
-;; @0032                               v58 = load.i64 notrap aligned readonly v48+24
-;; @0032                               v59 = call_indirect sig0, v57(v58, v0)
+;;                                 block5(v46: i64):
+;; @0032                               v50 = load.i64 notrap aligned readonly can_move region6 v0+40
+;; @0032                               v51 = load.i32 notrap aligned readonly can_move v50
+;; @0032                               v52 = load.i32 user7 aligned readonly v46+16
+;; @0032                               v53 = icmp eq v52, v51
+;; @0032                               v54 = uextend.i32 v53
+;; @0032                               trapz v54, user8
+;; @0032                               v55 = load.i64 notrap aligned readonly v46+8
+;; @0032                               v56 = load.i64 notrap aligned readonly v46+24
+;; @0032                               v57 = call_indirect sig0, v55(v56, v0)
 ;; @0035                               jump block1
 ;;
 ;;                                 block1:
-;; @0035                               return v31, v59
+;; @0035                               return v29, v57
 ;; }

--- a/tests/disas/duplicate-loads-dynamic-memory.wat
+++ b/tests/disas/duplicate-loads-dynamic-memory.wat
@@ -34,18 +34,18 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0057                               v6 = load.i64 notrap aligned region3 v0+64
-;; @0057                               v8 = load.i64 notrap aligned can_move region2 v0+56
-;; @0057                               v5 = uextend.i64 v2
-;; @0057                               v7 = icmp ugt v5, v6
-;; @0057                               v10 = iconst.i64 0
-;; @0057                               v9 = iadd v8, v5
-;; @0057                               v11 = select_spectre_guard v7, v10, v9  ; v10 = 0
-;; @0057                               v12 = load.i32 little region4 v11
+;; @0057                               v4 = load.i64 notrap aligned region3 v0+64
+;; @0057                               v6 = load.i64 notrap aligned can_move region2 v0+56
+;; @0057                               v3 = uextend.i64 v2
+;; @0057                               v5 = icmp ugt v3, v4
+;; @0057                               v8 = iconst.i64 0
+;; @0057                               v7 = iadd v6, v3
+;; @0057                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0
+;; @0057                               v10 = load.i32 little region4 v9
 ;; @005f                               jump block1
 ;;
 ;;                                 block1:
-;; @005f                               return v12, v12
+;; @005f                               return v10, v10
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32, i32 tail {
@@ -60,18 +60,18 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0064                               v6 = load.i64 notrap aligned region3 v0+64
-;; @0064                               v8 = load.i64 notrap aligned can_move region2 v0+56
-;; @0064                               v5 = uextend.i64 v2
-;; @0064                               v7 = icmp ugt v5, v6
-;; @0064                               v12 = iconst.i64 0
-;; @0064                               v9 = iadd v8, v5
-;; @0064                               v10 = iconst.i64 1234
-;; @0064                               v11 = iadd v9, v10  ; v10 = 1234
-;; @0064                               v13 = select_spectre_guard v7, v12, v11  ; v12 = 0
-;; @0064                               v14 = load.i32 little region4 v13
+;; @0064                               v4 = load.i64 notrap aligned region3 v0+64
+;; @0064                               v6 = load.i64 notrap aligned can_move region2 v0+56
+;; @0064                               v3 = uextend.i64 v2
+;; @0064                               v5 = icmp ugt v3, v4
+;; @0064                               v10 = iconst.i64 0
+;; @0064                               v7 = iadd v6, v3
+;; @0064                               v8 = iconst.i64 1234
+;; @0064                               v9 = iadd v7, v8  ; v8 = 1234
+;; @0064                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
+;; @0064                               v12 = load.i32 little region4 v11
 ;; @006e                               jump block1
 ;;
 ;;                                 block1:
-;; @006e                               return v14, v14
+;; @006e                               return v12, v12
 ;; }

--- a/tests/disas/duplicate-loads-static-memory.wat
+++ b/tests/disas/duplicate-loads-static-memory.wat
@@ -29,14 +29,14 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0057                               v6 = load.i64 notrap aligned readonly can_move region2 v0+56
-;; @0057                               v5 = uextend.i64 v2
-;; @0057                               v7 = iadd v6, v5
-;; @0057                               v8 = load.i32 little region4 v7
+;; @0057                               v4 = load.i64 notrap aligned readonly can_move region2 v0+56
+;; @0057                               v3 = uextend.i64 v2
+;; @0057                               v5 = iadd v4, v3
+;; @0057                               v6 = load.i32 little region4 v5
 ;; @005f                               jump block1
 ;;
 ;;                                 block1:
-;; @005f                               return v8, v8
+;; @005f                               return v6, v6
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32, i32 tail {
@@ -51,14 +51,14 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0064                               v6 = load.i64 notrap aligned readonly can_move region2 v0+56
-;; @0064                               v5 = uextend.i64 v2
-;; @0064                               v7 = iadd v6, v5
-;; @0064                               v8 = iconst.i64 1234
-;; @0064                               v9 = iadd v7, v8  ; v8 = 1234
-;; @0064                               v10 = load.i32 little region4 v9
+;; @0064                               v4 = load.i64 notrap aligned readonly can_move region2 v0+56
+;; @0064                               v3 = uextend.i64 v2
+;; @0064                               v5 = iadd v4, v3
+;; @0064                               v6 = iconst.i64 1234
+;; @0064                               v7 = iadd v5, v6  ; v6 = 1234
+;; @0064                               v8 = load.i32 little region4 v7
 ;; @006e                               jump block1
 ;;
 ;;                                 block1:
-;; @006e                               return v10, v10
+;; @006e                               return v8, v8
 ;; }

--- a/tests/disas/dynamic-memory-no-spectre-access-same-index-different-offsets.wat
+++ b/tests/disas/dynamic-memory-no-spectre-access-same-index-different-offsets.wat
@@ -47,27 +47,27 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0047                               v7 = load.i64 notrap aligned region3 v0+64
-;; @0047                               v6 = uextend.i64 v2
-;; @0047                               v8 = icmp ugt v6, v7
-;; @0047                               trapnz v8, heap_oob
-;; @0047                               v9 = load.i64 notrap aligned can_move region2 v0+56
-;; @0047                               v10 = iadd v9, v6
-;; @0047                               v11 = load.i32 little region4 v10
-;; @004c                               v17 = iconst.i64 4
-;; @004c                               v18 = iadd v10, v17  ; v17 = 4
-;; @004c                               v19 = load.i32 little region4 v18
-;; @0051                               v21 = iconst.i64 0x0010_0003
-;; @0051                               v22 = uadd_overflow_trap v6, v21, heap_oob  ; v21 = 0x0010_0003
-;; @0051                               v24 = icmp ugt v22, v7
-;; @0051                               trapnz v24, heap_oob
-;; @0051                               v27 = iconst.i64 0x000f_ffff
-;; @0051                               v28 = iadd v10, v27  ; v27 = 0x000f_ffff
-;; @0051                               v29 = load.i32 little region4 v28
+;; @0047                               v4 = load.i64 notrap aligned region3 v0+64
+;; @0047                               v3 = uextend.i64 v2
+;; @0047                               v5 = icmp ugt v3, v4
+;; @0047                               trapnz v5, heap_oob
+;; @0047                               v6 = load.i64 notrap aligned can_move region2 v0+56
+;; @0047                               v7 = iadd v6, v3
+;; @0047                               v8 = load.i32 little region4 v7
+;; @004c                               v14 = iconst.i64 4
+;; @004c                               v15 = iadd v7, v14  ; v14 = 4
+;; @004c                               v16 = load.i32 little region4 v15
+;; @0051                               v18 = iconst.i64 0x0010_0003
+;; @0051                               v19 = uadd_overflow_trap v3, v18, heap_oob  ; v18 = 0x0010_0003
+;; @0051                               v21 = icmp ugt v19, v4
+;; @0051                               trapnz v21, heap_oob
+;; @0051                               v24 = iconst.i64 0x000f_ffff
+;; @0051                               v25 = iadd v7, v24  ; v24 = 0x000f_ffff
+;; @0051                               v26 = load.i32 little region4 v25
 ;; @0056                               jump block1
 ;;
 ;;                                 block1:
-;; @0056                               return v11, v19, v29
+;; @0056                               return v8, v16, v26
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32, i32, i32, i32) tail {

--- a/tests/disas/dynamic-memory-yes-spectre-access-same-index-different-offsets.wat
+++ b/tests/disas/dynamic-memory-yes-spectre-access-same-index-different-offsets.wat
@@ -43,29 +43,29 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0047                               v7 = load.i64 notrap aligned region3 v0+64
-;; @0047                               v9 = load.i64 notrap aligned can_move region2 v0+56
-;; @0047                               v6 = uextend.i64 v2
-;; @0047                               v8 = icmp ugt v6, v7
-;; @0047                               v11 = iconst.i64 0
-;; @0047                               v10 = iadd v9, v6
-;; @0047                               v12 = select_spectre_guard v8, v11, v10  ; v11 = 0
-;; @0047                               v13 = load.i32 little region4 v12
-;; @004c                               v19 = iconst.i64 4
-;; @004c                               v20 = iadd v10, v19  ; v19 = 4
-;; @004c                               v22 = select_spectre_guard v8, v11, v20  ; v11 = 0
-;; @004c                               v23 = load.i32 little region4 v22
-;; @0051                               v25 = iconst.i64 0x0010_0003
-;; @0051                               v26 = uadd_overflow_trap v6, v25, heap_oob  ; v25 = 0x0010_0003
-;; @0051                               v28 = icmp ugt v26, v7
-;; @0051                               v31 = iconst.i64 0x000f_ffff
-;; @0051                               v32 = iadd v10, v31  ; v31 = 0x000f_ffff
-;; @0051                               v34 = select_spectre_guard v28, v11, v32  ; v11 = 0
-;; @0051                               v35 = load.i32 little region4 v34
+;; @0047                               v4 = load.i64 notrap aligned region3 v0+64
+;; @0047                               v6 = load.i64 notrap aligned can_move region2 v0+56
+;; @0047                               v3 = uextend.i64 v2
+;; @0047                               v5 = icmp ugt v3, v4
+;; @0047                               v8 = iconst.i64 0
+;; @0047                               v7 = iadd v6, v3
+;; @0047                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0
+;; @0047                               v10 = load.i32 little region4 v9
+;; @004c                               v16 = iconst.i64 4
+;; @004c                               v17 = iadd v7, v16  ; v16 = 4
+;; @004c                               v19 = select_spectre_guard v5, v8, v17  ; v8 = 0
+;; @004c                               v20 = load.i32 little region4 v19
+;; @0051                               v22 = iconst.i64 0x0010_0003
+;; @0051                               v23 = uadd_overflow_trap v3, v22, heap_oob  ; v22 = 0x0010_0003
+;; @0051                               v25 = icmp ugt v23, v4
+;; @0051                               v28 = iconst.i64 0x000f_ffff
+;; @0051                               v29 = iadd v7, v28  ; v28 = 0x000f_ffff
+;; @0051                               v31 = select_spectre_guard v25, v8, v29  ; v8 = 0
+;; @0051                               v32 = load.i32 little region4 v31
 ;; @0056                               jump block1
 ;;
 ;;                                 block1:
-;; @0056                               return v13, v23, v35
+;; @0056                               return v10, v20, v32
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32, i32, i32, i32) tail {

--- a/tests/disas/f32-load.wat
+++ b/tests/disas/f32-load.wat
@@ -18,12 +18,12 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @002e                               v4 = uextend.i64 v2
-;; @002e                               v5 = load.i64 notrap aligned readonly can_move region2 v0+56
-;; @002e                               v6 = iadd v5, v4
-;; @002e                               v7 = load.f32 little region4 v6
+;; @002e                               v3 = uextend.i64 v2
+;; @002e                               v4 = load.i64 notrap aligned readonly can_move region2 v0+56
+;; @002e                               v5 = iadd v4, v3
+;; @002e                               v6 = load.f32 little region4 v5
 ;; @0031                               jump block1
 ;;
 ;;                                 block1:
-;; @0031                               return v7
+;; @0031                               return v6
 ;; }

--- a/tests/disas/f64-load.wat
+++ b/tests/disas/f64-load.wat
@@ -20,12 +20,12 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @002e                               v4 = uextend.i64 v2
-;; @002e                               v5 = load.i64 notrap aligned readonly can_move region2 v0+56
-;; @002e                               v6 = iadd v5, v4
-;; @002e                               v7 = load.f64 little region4 v6
+;; @002e                               v3 = uextend.i64 v2
+;; @002e                               v4 = load.i64 notrap aligned readonly can_move region2 v0+56
+;; @002e                               v5 = iadd v4, v3
+;; @002e                               v6 = load.f64 little region4 v5
 ;; @0031                               jump block1
 ;;
 ;;                                 block1:
-;; @0031                               return v7
+;; @0031                               return v6
 ;; }

--- a/tests/disas/fac-multi-value.wat
+++ b/tests/disas/fac-multi-value.wat
@@ -67,18 +67,18 @@
 ;; @0050                               jump block2(v4, v2)  ; v4 = 1
 ;;
 ;;                                 block2(v5: i64, v6: i64):
-;; @0052                               v8, v9, v10 = call fn0(v0, v0, v5, v6)
-;; @0054                               v11, v12, v13 = call fn0(v0, v0, v9, v10)
-;; @0056                               v14 = imul v12, v13
-;; @0057                               v15, v16, v17 = call fn0(v0, v0, v11, v14)
-;; @0059                               v18 = iconst.i64 1
-;; @005b                               v19 = isub v17, v18  ; v18 = 1
-;; @005c                               v20, v21 = call fn1(v0, v0, v19)
-;; @005e                               v22 = iconst.i64 0
-;; @0060                               v23 = icmp ugt v21, v22  ; v22 = 0
-;; @0060                               v24 = uextend.i32 v23
-;; @0061                               brif v24, block2(v16, v20), block4
+;; @0052                               v7, v8, v9 = call fn0(v0, v0, v5, v6)
+;; @0054                               v10, v11, v12 = call fn0(v0, v0, v8, v9)
+;; @0056                               v13 = imul v11, v12
+;; @0057                               v14, v15, v16 = call fn0(v0, v0, v10, v13)
+;; @0059                               v17 = iconst.i64 1
+;; @005b                               v18 = isub v16, v17  ; v17 = 1
+;; @005c                               v19, v20 = call fn1(v0, v0, v18)
+;; @005e                               v21 = iconst.i64 0
+;; @0060                               v22 = icmp ugt v20, v21  ; v21 = 0
+;; @0060                               v23 = uextend.i32 v22
+;; @0061                               brif v23, block2(v15, v19), block4
 ;;
 ;;                                 block4:
-;; @0064                               return v16
+;; @0064                               return v15
 ;; }

--- a/tests/disas/fac-multi-value.wat
+++ b/tests/disas/fac-multi-value.wat
@@ -63,22 +63,22 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @004c                               v4 = iconst.i64 1
-;; @0050                               jump block2(v4, v2)  ; v4 = 1
+;; @004c                               v3 = iconst.i64 1
+;; @0050                               jump block2(v3, v2)  ; v3 = 1
 ;;
-;;                                 block2(v5: i64, v6: i64):
-;; @0052                               v7, v8, v9 = call fn0(v0, v0, v5, v6)
-;; @0054                               v10, v11, v12 = call fn0(v0, v0, v8, v9)
-;; @0056                               v13 = imul v11, v12
-;; @0057                               v14, v15, v16 = call fn0(v0, v0, v10, v13)
-;; @0059                               v17 = iconst.i64 1
-;; @005b                               v18 = isub v16, v17  ; v17 = 1
-;; @005c                               v19, v20 = call fn1(v0, v0, v18)
-;; @005e                               v21 = iconst.i64 0
-;; @0060                               v22 = icmp ugt v20, v21  ; v21 = 0
-;; @0060                               v23 = uextend.i32 v22
-;; @0061                               brif v23, block2(v15, v19), block4
+;;                                 block2(v4: i64, v5: i64):
+;; @0052                               v6, v7, v8 = call fn0(v0, v0, v4, v5)
+;; @0054                               v9, v10, v11 = call fn0(v0, v0, v7, v8)
+;; @0056                               v12 = imul v10, v11
+;; @0057                               v13, v14, v15 = call fn0(v0, v0, v9, v12)
+;; @0059                               v16 = iconst.i64 1
+;; @005b                               v17 = isub v15, v16  ; v16 = 1
+;; @005c                               v18, v19 = call fn1(v0, v0, v17)
+;; @005e                               v20 = iconst.i64 0
+;; @0060                               v21 = icmp ugt v19, v20  ; v20 = 0
+;; @0060                               v22 = uextend.i32 v21
+;; @0061                               brif v22, block2(v14, v18), block4
 ;;
 ;;                                 block4:
-;; @0064                               return v15
+;; @0064                               return v14
 ;; }

--- a/tests/disas/fixed-size-memory.wat
+++ b/tests/disas/fixed-size-memory.wat
@@ -57,15 +57,15 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0049                               v4 = uextend.i64 v2
-;; @0049                               v5 = iconst.i64 0x0001_0000
-;; @0049                               v6 = icmp uge v4, v5  ; v5 = 0x0001_0000
-;; @0049                               trapnz v6, heap_oob
-;; @0049                               v7 = load.i64 notrap aligned readonly can_move region2 v0+56
-;; @0049                               v8 = iadd v7, v4
-;; @0049                               v9 = uload8.i32 little region4 v8
+;; @0049                               v3 = uextend.i64 v2
+;; @0049                               v4 = iconst.i64 0x0001_0000
+;; @0049                               v5 = icmp uge v3, v4  ; v4 = 0x0001_0000
+;; @0049                               trapnz v5, heap_oob
+;; @0049                               v6 = load.i64 notrap aligned readonly can_move region2 v0+56
+;; @0049                               v7 = iadd v6, v3
+;; @0049                               v8 = uload8.i32 little region4 v7
 ;; @004c                               jump block1
 ;;
 ;;                                 block1:
-;; @004c                               return v9
+;; @004c                               return v8
 ;; }

--- a/tests/disas/foo.wat
+++ b/tests/disas/foo.wat
@@ -34,70 +34,70 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
-;; @0040                               v7 = load.i64 notrap aligned readonly can_move region2 v0+56
-;; @0040                               v6 = uextend.i64 v3
-;; @0040                               v8 = iadd v7, v6
-;; @0040                               v9 = load.i32 little region4 v8
-;; @0043                               v10 = load.i64 notrap aligned readonly can_move region5 v0+72
-;; @0043                               v11 = load.i64 notrap aligned region7 v10+8
-;; @0043                               v16 = load.i64 notrap aligned region6 v10
-;; @0043                               v12 = ireduce.i32 v11
-;; @0043                               v13 = icmp uge v9, v12
-;; @0043                               v20 = iconst.i64 0
-;; @0043                               v14 = uextend.i64 v9
-;; @0043                               v17 = iconst.i64 3
-;; @0043                               v18 = ishl v14, v17  ; v17 = 3
-;; @0043                               v19 = iadd v16, v18
-;; @0043                               v21 = select_spectre_guard v13, v20, v19  ; v20 = 0
-;; @0043                               v22 = load.i64 user6 aligned region8 v21
-;; @0043                               v23 = iconst.i64 -2
-;; @0043                               v24 = band v22, v23  ; v23 = -2
-;; @0043                               brif v22, block3(v24), block2
+;; @0040                               v5 = load.i64 notrap aligned readonly can_move region2 v0+56
+;; @0040                               v4 = uextend.i64 v3
+;; @0040                               v6 = iadd v5, v4
+;; @0040                               v7 = load.i32 little region4 v6
+;; @0043                               v8 = load.i64 notrap aligned readonly can_move region5 v0+72
+;; @0043                               v9 = load.i64 notrap aligned region7 v8+8
+;; @0043                               v14 = load.i64 notrap aligned region6 v8
+;; @0043                               v10 = ireduce.i32 v9
+;; @0043                               v11 = icmp uge v7, v10
+;; @0043                               v18 = iconst.i64 0
+;; @0043                               v12 = uextend.i64 v7
+;; @0043                               v15 = iconst.i64 3
+;; @0043                               v16 = ishl v12, v15  ; v15 = 3
+;; @0043                               v17 = iadd v14, v16
+;; @0043                               v19 = select_spectre_guard v11, v18, v17  ; v18 = 0
+;; @0043                               v20 = load.i64 user6 aligned region8 v19
+;; @0043                               v21 = iconst.i64 -2
+;; @0043                               v22 = band v20, v21  ; v21 = -2
+;; @0043                               brif v20, block3(v22), block2
 ;;
 ;;                                 block2 cold:
-;; @0043                               v26 = iconst.i32 0
-;; @0043                               v28 = call fn0(v0, v26, v14)  ; v26 = 0
-;; @0043                               jump block3(v28)
+;; @0043                               v24 = iconst.i32 0
+;; @0043                               v26 = call fn0(v0, v24, v12)  ; v24 = 0
+;; @0043                               jump block3(v26)
 ;;
-;;                                 block3(v25: i64):
-;; @0043                               v31 = load.i32 user7 aligned readonly v25+16
-;; @0043                               v29 = load.i64 notrap aligned readonly can_move region9 v0+40
-;; @0043                               v30 = load.i32 notrap aligned readonly can_move v29+4
-;; @0043                               v32 = icmp eq v31, v30
-;; @0043                               trapz v32, user8
-;; @0043                               v34 = load.i64 notrap aligned readonly v25+8
-;; @0043                               v35 = load.i64 notrap aligned readonly v25+24
-;; @0043                               v36 = call_indirect sig0, v34(v35, v0, v2)
-;; @004a                               v42 = load.i32 little region4 v8
-;; @004d                               v44 = load.i64 notrap aligned region7 v10+8
-;; @004d                               v49 = load.i64 notrap aligned region6 v10
-;; @004d                               v45 = ireduce.i32 v44
-;; @004d                               v46 = icmp uge v42, v45
-;; @004d                               v47 = uextend.i64 v42
-;;                                     v70 = iconst.i64 3
-;;                                     v71 = ishl v47, v70  ; v70 = 3
-;; @004d                               v52 = iadd v49, v71
-;;                                     v72 = iconst.i64 0
-;;                                     v73 = select_spectre_guard v46, v72, v52  ; v72 = 0
-;; @004d                               v55 = load.i64 user6 aligned region8 v73
-;;                                     v74 = iconst.i64 -2
-;;                                     v75 = band v55, v74  ; v74 = -2
-;; @004d                               brif v55, block5(v75), block4
+;;                                 block3(v23: i64):
+;; @0043                               v29 = load.i32 user7 aligned readonly v23+16
+;; @0043                               v27 = load.i64 notrap aligned readonly can_move region9 v0+40
+;; @0043                               v28 = load.i32 notrap aligned readonly can_move v27+4
+;; @0043                               v30 = icmp eq v29, v28
+;; @0043                               trapz v30, user8
+;; @0043                               v32 = load.i64 notrap aligned readonly v23+8
+;; @0043                               v33 = load.i64 notrap aligned readonly v23+24
+;; @0043                               v34 = call_indirect sig0, v32(v33, v0, v2)
+;; @004a                               v40 = load.i32 little region4 v6
+;; @004d                               v42 = load.i64 notrap aligned region7 v8+8
+;; @004d                               v47 = load.i64 notrap aligned region6 v8
+;; @004d                               v43 = ireduce.i32 v42
+;; @004d                               v44 = icmp uge v40, v43
+;; @004d                               v45 = uextend.i64 v40
+;;                                     v68 = iconst.i64 3
+;;                                     v69 = ishl v45, v68  ; v68 = 3
+;; @004d                               v50 = iadd v47, v69
+;;                                     v70 = iconst.i64 0
+;;                                     v71 = select_spectre_guard v44, v70, v50  ; v70 = 0
+;; @004d                               v53 = load.i64 user6 aligned region8 v71
+;;                                     v72 = iconst.i64 -2
+;;                                     v73 = band v53, v72  ; v72 = -2
+;; @004d                               brif v53, block5(v73), block4
 ;;
 ;;                                 block4 cold:
-;;                                     v76 = iconst.i32 0
-;; @004d                               v61 = call fn0(v0, v76, v47)  ; v76 = 0
-;; @004d                               jump block5(v61)
+;;                                     v74 = iconst.i32 0
+;; @004d                               v59 = call fn0(v0, v74, v45)  ; v74 = 0
+;; @004d                               jump block5(v59)
 ;;
-;;                                 block5(v58: i64):
-;; @004d                               v64 = load.i32 user7 aligned readonly v58+16
-;; @004d                               v65 = icmp eq v64, v30
-;; @004d                               trapz v65, user8
-;; @004d                               v67 = load.i64 notrap aligned readonly v58+8
-;; @004d                               v68 = load.i64 notrap aligned readonly v58+24
-;; @004d                               v69 = call_indirect sig0, v67(v68, v0, v2)
+;;                                 block5(v56: i64):
+;; @004d                               v62 = load.i32 user7 aligned readonly v56+16
+;; @004d                               v63 = icmp eq v62, v28
+;; @004d                               trapz v63, user8
+;; @004d                               v65 = load.i64 notrap aligned readonly v56+8
+;; @004d                               v66 = load.i64 notrap aligned readonly v56+24
+;; @004d                               v67 = call_indirect sig0, v65(v66, v0, v2)
 ;; @0050                               jump block1
 ;;
 ;;                                 block1:
-;; @0050                               return v36, v69
+;; @0050                               return v34, v67
 ;; }

--- a/tests/disas/gc/array-new-data.wat
+++ b/tests/disas/gc/array-new-data.wat
@@ -96,97 +96,97 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
-;; @0025                               v5 = load.i32 notrap aligned region2 v0+56
-;; @0025                               v7 = uextend.i64 v2
-;; @0025                               v8 = uextend.i64 v3
-;; @0025                               v11 = iadd v7, v8
-;; @0025                               v6 = uextend.i64 v5
-;; @0025                               v12 = icmp ugt v11, v6
-;; @0025                               trapnz v12, heap_oob
-;; @0025                               v13 = load.i64 notrap aligned region3 v0+48
-;; @0025                               v20 = iconst.i64 32
-;; @0025                               v21 = ushr v8, v20  ; v20 = 32
-;; @0025                               trapnz v21, user18
-;; @0025                               v16 = iconst.i32 20
-;; @0025                               v23 = uadd_overflow_trap v16, v3, user18  ; v16 = 20
-;; @0025                               v24 = load.i64 notrap aligned readonly can_move region4 v0+32
-;; @0025                               v25 = load.i32 notrap aligned v24
-;; @0025                               v26 = load.i32 notrap aligned v24+4
-;; @0025                               v32 = uextend.i64 v25
-;; @0025                               v27 = uextend.i64 v23
-;; @0025                               v28 = iconst.i64 15
-;; @0025                               v30 = iadd v27, v28  ; v28 = 15
-;; @0025                               v29 = iconst.i64 -16
-;; @0025                               v31 = band v30, v29  ; v29 = -16
-;; @0025                               v33 = iadd v32, v31
-;; @0025                               v34 = uextend.i64 v26
-;; @0025                               v35 = icmp ule v33, v34
-;; @0025                               brif v35, block2, block3
+;; @0025                               v4 = load.i32 notrap aligned region2 v0+56
+;; @0025                               v6 = uextend.i64 v2
+;; @0025                               v7 = uextend.i64 v3
+;; @0025                               v10 = iadd v6, v7
+;; @0025                               v5 = uextend.i64 v4
+;; @0025                               v11 = icmp ugt v10, v5
+;; @0025                               trapnz v11, heap_oob
+;; @0025                               v12 = load.i64 notrap aligned region3 v0+48
+;; @0025                               v19 = iconst.i64 32
+;; @0025                               v20 = ushr v7, v19  ; v19 = 32
+;; @0025                               trapnz v20, user18
+;; @0025                               v15 = iconst.i32 20
+;; @0025                               v22 = uadd_overflow_trap v15, v3, user18  ; v15 = 20
+;; @0025                               v23 = load.i64 notrap aligned readonly can_move region4 v0+32
+;; @0025                               v24 = load.i32 notrap aligned v23
+;; @0025                               v25 = load.i32 notrap aligned v23+4
+;; @0025                               v31 = uextend.i64 v24
+;; @0025                               v26 = uextend.i64 v22
+;; @0025                               v27 = iconst.i64 15
+;; @0025                               v29 = iadd v26, v27  ; v27 = 15
+;; @0025                               v28 = iconst.i64 -16
+;; @0025                               v30 = band v29, v28  ; v28 = -16
+;; @0025                               v32 = iadd v31, v30
+;; @0025                               v33 = uextend.i64 v25
+;; @0025                               v34 = icmp ule v32, v33
+;; @0025                               brif v34, block2, block3
 ;;
 ;;                                 block2:
-;;                                     v121 = iconst.i32 15
-;;                                     v122 = iadd.i32 v23, v121  ; v121 = 15
-;;                                     v125 = iconst.i32 -16
-;;                                     v126 = band v122, v125  ; v125 = -16
-;;                                     v128 = iadd.i32 v25, v126
-;; @0025                               store notrap aligned v128, v24
-;;                                     v142 = iconst.i32 -1476395002
-;;                                     v143 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v144 = load.i64 notrap aligned readonly can_move region6 v143+32
-;; @0025                               v49 = iadd v144, v32
-;; @0025                               store notrap aligned v142, v49  ; v142 = -1476395002
-;;                                     v145 = load.i64 notrap aligned readonly can_move region5 v0+40
-;;                                     v146 = load.i32 notrap aligned readonly can_move v145
-;; @0025                               store notrap aligned v146, v49+4
-;;                                     v147 = band.i64 v30, v29  ; v29 = -16
-;; @0025                               istore32 notrap aligned v147, v49+8
-;; @0025                               jump block4(v25, v49)
+;;                                     v120 = iconst.i32 15
+;;                                     v121 = iadd.i32 v22, v120  ; v120 = 15
+;;                                     v124 = iconst.i32 -16
+;;                                     v125 = band v121, v124  ; v124 = -16
+;;                                     v127 = iadd.i32 v24, v125
+;; @0025                               store notrap aligned v127, v23
+;;                                     v141 = iconst.i32 -1476395002
+;;                                     v142 = load.i64 notrap aligned readonly can_move region0 v0+8
+;;                                     v143 = load.i64 notrap aligned readonly can_move region6 v142+32
+;; @0025                               v48 = iadd v143, v31
+;; @0025                               store notrap aligned v141, v48  ; v141 = -1476395002
+;;                                     v144 = load.i64 notrap aligned readonly can_move region5 v0+40
+;;                                     v145 = load.i32 notrap aligned readonly can_move v144
+;; @0025                               store notrap aligned v145, v48+4
+;;                                     v146 = band.i64 v29, v28  ; v28 = -16
+;; @0025                               istore32 notrap aligned v146, v48+8
+;; @0025                               jump block4(v24, v48)
 ;;
 ;;                                 block3 cold:
-;; @0025                               v36 = iconst.i32 -1476395002
-;; @0025                               v37 = load.i64 notrap aligned readonly can_move region5 v0+40
-;; @0025                               v38 = load.i32 notrap aligned readonly can_move v37
-;; @0025                               v39 = iconst.i32 16
-;; @0025                               v40 = call fn0(v0, v36, v38, v23, v39)  ; v36 = -1476395002, v39 = 16
-;; @0025                               v41 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0025                               v42 = load.i64 notrap aligned readonly can_move region6 v41+32
-;; @0025                               v43 = uextend.i64 v40
-;; @0025                               v44 = iadd v42, v43
-;; @0025                               jump block4(v40, v44)
+;; @0025                               v35 = iconst.i32 -1476395002
+;; @0025                               v36 = load.i64 notrap aligned readonly can_move region5 v0+40
+;; @0025                               v37 = load.i32 notrap aligned readonly can_move v36
+;; @0025                               v38 = iconst.i32 16
+;; @0025                               v39 = call fn0(v0, v35, v37, v22, v38)  ; v35 = -1476395002, v38 = 16
+;; @0025                               v40 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @0025                               v41 = load.i64 notrap aligned readonly can_move region6 v40+32
+;; @0025                               v42 = uextend.i64 v39
+;; @0025                               v43 = iadd v41, v42
+;; @0025                               jump block4(v39, v43)
 ;;
-;;                                 block4(v53: i32, v54: i64):
-;;                                     v113 = stack_addr.i64 ss0
-;;                                     store notrap v53, v113
-;; @0025                               v55 = iconst.i64 16
-;; @0025                               v56 = iadd v54, v55  ; v55 = 16
-;; @0025                               store.i32 user2 region7 v3, v56
-;; @0025                               trapz v53, user16
-;;                                     v148 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v149 = load.i64 notrap aligned readonly can_move region6 v148+32
-;; @0025                               v58 = uextend.i64 v53
-;; @0025                               v61 = iadd v149, v58
-;; @0025                               v63 = iadd v61, v55  ; v55 = 16
-;; @0025                               v64 = load.i32 user2 readonly region7 v63
-;; @0025                               v65 = uextend.i64 v64
-;; @0025                               v71 = icmp.i64 ugt v8, v65
-;; @0025                               trapnz v71, user17
-;; @0025                               v82 = load.i32 notrap aligned region2 v0+56
-;; @0025                               v83 = uextend.i64 v82
-;; @0025                               v89 = icmp.i64 ugt v11, v83
-;; @0025                               trapnz v89, heap_oob
-;; @0025                               v90 = load.i64 notrap aligned region3 v0+48
-;; @0025                               v101 = load.i64 notrap aligned region8 v148+40
-;; @0025                               v76 = iconst.i64 20
-;; @0025                               v77 = iadd v61, v76  ; v76 = 20
-;; @0025                               v103 = uadd_overflow_trap v77, v8, user2
-;; @0025                               v102 = iadd v149, v101
-;; @0025                               v104 = icmp ugt v103, v102
-;; @0025                               trapnz v104, user2
-;; @0025                               v92 = iadd v90, v7
-;; @0025                               call fn1(v0, v77, v92, v8), stack_map=[i32 @ ss0+0]
-;;                                     v106 = load.i32 notrap v113
+;;                                 block4(v52: i32, v53: i64):
+;;                                     v112 = stack_addr.i64 ss0
+;;                                     store notrap v52, v112
+;; @0025                               v54 = iconst.i64 16
+;; @0025                               v55 = iadd v53, v54  ; v54 = 16
+;; @0025                               store.i32 user2 region7 v3, v55
+;; @0025                               trapz v52, user16
+;;                                     v147 = load.i64 notrap aligned readonly can_move region0 v0+8
+;;                                     v148 = load.i64 notrap aligned readonly can_move region6 v147+32
+;; @0025                               v57 = uextend.i64 v52
+;; @0025                               v60 = iadd v148, v57
+;; @0025                               v62 = iadd v60, v54  ; v54 = 16
+;; @0025                               v63 = load.i32 user2 readonly region7 v62
+;; @0025                               v64 = uextend.i64 v63
+;; @0025                               v70 = icmp.i64 ugt v7, v64
+;; @0025                               trapnz v70, user17
+;; @0025                               v81 = load.i32 notrap aligned region2 v0+56
+;; @0025                               v82 = uextend.i64 v81
+;; @0025                               v88 = icmp.i64 ugt v10, v82
+;; @0025                               trapnz v88, heap_oob
+;; @0025                               v89 = load.i64 notrap aligned region3 v0+48
+;; @0025                               v100 = load.i64 notrap aligned region8 v147+40
+;; @0025                               v75 = iconst.i64 20
+;; @0025                               v76 = iadd v60, v75  ; v75 = 20
+;; @0025                               v102 = uadd_overflow_trap v76, v7, user2
+;; @0025                               v101 = iadd v148, v100
+;; @0025                               v103 = icmp ugt v102, v101
+;; @0025                               trapnz v103, user2
+;; @0025                               v91 = iadd v89, v6
+;; @0025                               call fn1(v0, v76, v91, v7), stack_map=[i32 @ ss0+0]
 ;; @0029                               jump block1
 ;;
 ;;                                 block1:
-;; @0029                               return v106
+;;                                     v105 = load.i32 notrap v112
+;; @0029                               return v105
 ;; }

--- a/tests/disas/gc/array-new-default-anyref.wat
+++ b/tests/disas/gc/array-new-default-anyref.wat
@@ -25,100 +25,100 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @001f                               v5 = uextend.i64 v2
-;;                                     v88 = iconst.i64 2
-;;                                     v89 = ishl v5, v88  ; v88 = 2
-;; @001f                               v8 = iconst.i64 32
-;; @001f                               v9 = ushr v89, v8  ; v8 = 32
-;; @001f                               trapnz v9, user18
-;; @001f                               v4 = iconst.i32 20
-;;                                     v95 = iconst.i32 2
-;;                                     v96 = ishl v2, v95  ; v95 = 2
-;; @001f                               v11 = uadd_overflow_trap v4, v96, user18  ; v4 = 20
-;; @001f                               v12 = load.i64 notrap aligned readonly can_move region2 v0+32
-;; @001f                               v13 = load.i32 notrap aligned v12
-;; @001f                               v14 = load.i32 notrap aligned v12+4
-;; @001f                               v20 = uextend.i64 v13
-;; @001f                               v15 = uextend.i64 v11
-;; @001f                               v16 = iconst.i64 15
-;; @001f                               v18 = iadd v15, v16  ; v16 = 15
-;; @001f                               v17 = iconst.i64 -16
-;; @001f                               v19 = band v18, v17  ; v17 = -16
-;; @001f                               v21 = iadd v20, v19
-;; @001f                               v22 = uextend.i64 v14
-;; @001f                               v23 = icmp ule v21, v22
-;; @001f                               brif v23, block2, block3
+;; @001f                               v4 = uextend.i64 v2
+;;                                     v87 = iconst.i64 2
+;;                                     v88 = ishl v4, v87  ; v87 = 2
+;; @001f                               v7 = iconst.i64 32
+;; @001f                               v8 = ushr v88, v7  ; v7 = 32
+;; @001f                               trapnz v8, user18
+;; @001f                               v3 = iconst.i32 20
+;;                                     v94 = iconst.i32 2
+;;                                     v95 = ishl v2, v94  ; v94 = 2
+;; @001f                               v10 = uadd_overflow_trap v3, v95, user18  ; v3 = 20
+;; @001f                               v11 = load.i64 notrap aligned readonly can_move region2 v0+32
+;; @001f                               v12 = load.i32 notrap aligned v11
+;; @001f                               v13 = load.i32 notrap aligned v11+4
+;; @001f                               v19 = uextend.i64 v12
+;; @001f                               v14 = uextend.i64 v10
+;; @001f                               v15 = iconst.i64 15
+;; @001f                               v17 = iadd v14, v15  ; v15 = 15
+;; @001f                               v16 = iconst.i64 -16
+;; @001f                               v18 = band v17, v16  ; v16 = -16
+;; @001f                               v20 = iadd v19, v18
+;; @001f                               v21 = uextend.i64 v13
+;; @001f                               v22 = icmp ule v20, v21
+;; @001f                               brif v22, block2, block3
 ;;
 ;;                                 block2:
-;;                                     v104 = iconst.i32 15
-;;                                     v105 = iadd.i32 v11, v104  ; v104 = 15
-;;                                     v108 = iconst.i32 -16
-;;                                     v109 = band v105, v108  ; v108 = -16
-;;                                     v111 = iadd.i32 v13, v109
-;; @001f                               store notrap aligned v111, v12
-;;                                     v127 = iconst.i32 -1476394994
-;;                                     v128 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v129 = load.i64 notrap aligned readonly can_move region4 v128+32
-;; @001f                               v37 = iadd v129, v20
-;; @001f                               store notrap aligned v127, v37  ; v127 = -1476394994
-;;                                     v130 = load.i64 notrap aligned readonly can_move region3 v0+40
-;;                                     v131 = load.i32 notrap aligned readonly can_move v130
-;; @001f                               store notrap aligned v131, v37+4
-;;                                     v132 = band.i64 v18, v17  ; v17 = -16
-;; @001f                               istore32 notrap aligned v132, v37+8
-;; @001f                               jump block4(v13, v37)
+;;                                     v103 = iconst.i32 15
+;;                                     v104 = iadd.i32 v10, v103  ; v103 = 15
+;;                                     v107 = iconst.i32 -16
+;;                                     v108 = band v104, v107  ; v107 = -16
+;;                                     v110 = iadd.i32 v12, v108
+;; @001f                               store notrap aligned v110, v11
+;;                                     v126 = iconst.i32 -1476394994
+;;                                     v127 = load.i64 notrap aligned readonly can_move region0 v0+8
+;;                                     v128 = load.i64 notrap aligned readonly can_move region4 v127+32
+;; @001f                               v36 = iadd v128, v19
+;; @001f                               store notrap aligned v126, v36  ; v126 = -1476394994
+;;                                     v129 = load.i64 notrap aligned readonly can_move region3 v0+40
+;;                                     v130 = load.i32 notrap aligned readonly can_move v129
+;; @001f                               store notrap aligned v130, v36+4
+;;                                     v131 = band.i64 v17, v16  ; v16 = -16
+;; @001f                               istore32 notrap aligned v131, v36+8
+;; @001f                               jump block4(v12, v36)
 ;;
 ;;                                 block3 cold:
-;; @001f                               v24 = iconst.i32 -1476394994
-;; @001f                               v25 = load.i64 notrap aligned readonly can_move region3 v0+40
-;; @001f                               v26 = load.i32 notrap aligned readonly can_move v25
-;; @001f                               v27 = iconst.i32 16
-;; @001f                               v28 = call fn0(v0, v24, v26, v11, v27)  ; v24 = -1476394994, v27 = 16
-;; @001f                               v29 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @001f                               v30 = load.i64 notrap aligned readonly can_move region4 v29+32
-;; @001f                               v31 = uextend.i64 v28
-;; @001f                               v32 = iadd v30, v31
-;; @001f                               jump block4(v28, v32)
+;; @001f                               v23 = iconst.i32 -1476394994
+;; @001f                               v24 = load.i64 notrap aligned readonly can_move region3 v0+40
+;; @001f                               v25 = load.i32 notrap aligned readonly can_move v24
+;; @001f                               v26 = iconst.i32 16
+;; @001f                               v27 = call fn0(v0, v23, v25, v10, v26)  ; v23 = -1476394994, v26 = 16
+;; @001f                               v28 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @001f                               v29 = load.i64 notrap aligned readonly can_move region4 v28+32
+;; @001f                               v30 = uextend.i64 v27
+;; @001f                               v31 = iadd v29, v30
+;; @001f                               jump block4(v27, v31)
 ;;
-;;                                 block4(v41: i32, v42: i64):
-;; @001f                               v43 = iconst.i64 16
-;; @001f                               v44 = iadd v42, v43  ; v43 = 16
-;; @001f                               store.i32 user2 region5 v2, v44
-;; @001f                               trapz v41, user16
-;;                                     v133 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v134 = load.i64 notrap aligned readonly can_move region4 v133+32
-;; @001f                               v47 = uextend.i64 v41
-;; @001f                               v50 = iadd v134, v47
-;; @001f                               v52 = iadd v50, v43  ; v43 = 16
-;; @001f                               v53 = load.i32 user2 readonly region5 v52
-;; @001f                               v54 = uextend.i64 v53
-;; @001f                               v60 = icmp.i64 ugt v5, v54
-;; @001f                               trapnz v60, user17
-;; @001f                               v77 = load.i64 notrap aligned region6 v133+40
-;; @001f                               v65 = iconst.i64 20
-;; @001f                               v66 = iadd v50, v65  ; v65 = 20
-;; @001f                               v79 = uadd_overflow_trap v66, v89, user2
-;; @001f                               v78 = iadd v134, v77
-;; @001f                               v80 = icmp ugt v79, v78
-;; @001f                               trapnz v80, user2
-;;                                     v113 = iconst.i64 0
-;; @001f                               v83 = icmp.i64 eq v5, v113  ; v113 = 0
-;; @001f                               v45 = iconst.i32 0
-;; @001f                               v6 = iconst.i64 4
-;; @001f                               v81 = iadd v66, v89
-;; @001f                               brif v83, block6, block5(v66)
+;;                                 block4(v40: i32, v41: i64):
+;; @001f                               v42 = iconst.i64 16
+;; @001f                               v43 = iadd v41, v42  ; v42 = 16
+;; @001f                               store.i32 user2 region5 v2, v43
+;; @001f                               trapz v40, user16
+;;                                     v132 = load.i64 notrap aligned readonly can_move region0 v0+8
+;;                                     v133 = load.i64 notrap aligned readonly can_move region4 v132+32
+;; @001f                               v46 = uextend.i64 v40
+;; @001f                               v49 = iadd v133, v46
+;; @001f                               v51 = iadd v49, v42  ; v42 = 16
+;; @001f                               v52 = load.i32 user2 readonly region5 v51
+;; @001f                               v53 = uextend.i64 v52
+;; @001f                               v59 = icmp.i64 ugt v4, v53
+;; @001f                               trapnz v59, user17
+;; @001f                               v76 = load.i64 notrap aligned region6 v132+40
+;; @001f                               v64 = iconst.i64 20
+;; @001f                               v65 = iadd v49, v64  ; v64 = 20
+;; @001f                               v78 = uadd_overflow_trap v65, v88, user2
+;; @001f                               v77 = iadd v133, v76
+;; @001f                               v79 = icmp ugt v78, v77
+;; @001f                               trapnz v79, user2
+;;                                     v112 = iconst.i64 0
+;; @001f                               v82 = icmp.i64 eq v4, v112  ; v112 = 0
+;; @001f                               v44 = iconst.i32 0
+;; @001f                               v5 = iconst.i64 4
+;; @001f                               v80 = iadd v65, v88
+;; @001f                               brif v82, block6, block5(v65)
 ;;
-;;                                 block5(v84: i64):
-;;                                     v135 = iconst.i32 0
-;; @001f                               store user2 little region5 v135, v84  ; v135 = 0
-;;                                     v136 = iconst.i64 4
-;;                                     v137 = iadd v84, v136  ; v136 = 4
-;; @001f                               v87 = icmp eq v137, v81
-;; @001f                               brif v87, block6, block5(v137)
+;;                                 block5(v83: i64):
+;;                                     v134 = iconst.i32 0
+;; @001f                               store user2 little region5 v134, v83  ; v134 = 0
+;;                                     v135 = iconst.i64 4
+;;                                     v136 = iadd v83, v135  ; v135 = 4
+;; @001f                               v86 = icmp eq v136, v80
+;; @001f                               brif v86, block6, block5(v136)
 ;;
 ;;                                 block6:
-;; @0022                               jump block1(v41)
+;; @0022                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @0022                               return v3
+;;                                 block1:
+;; @0022                               return v40
 ;; }

--- a/tests/disas/gc/array-new-default-exnref.wat
+++ b/tests/disas/gc/array-new-default-exnref.wat
@@ -25,100 +25,100 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @001f                               v5 = uextend.i64 v2
-;;                                     v88 = iconst.i64 2
-;;                                     v89 = ishl v5, v88  ; v88 = 2
-;; @001f                               v8 = iconst.i64 32
-;; @001f                               v9 = ushr v89, v8  ; v8 = 32
-;; @001f                               trapnz v9, user18
-;; @001f                               v4 = iconst.i32 20
-;;                                     v95 = iconst.i32 2
-;;                                     v96 = ishl v2, v95  ; v95 = 2
-;; @001f                               v11 = uadd_overflow_trap v4, v96, user18  ; v4 = 20
-;; @001f                               v12 = load.i64 notrap aligned readonly can_move region2 v0+32
-;; @001f                               v13 = load.i32 notrap aligned v12
-;; @001f                               v14 = load.i32 notrap aligned v12+4
-;; @001f                               v20 = uextend.i64 v13
-;; @001f                               v15 = uextend.i64 v11
-;; @001f                               v16 = iconst.i64 15
-;; @001f                               v18 = iadd v15, v16  ; v16 = 15
-;; @001f                               v17 = iconst.i64 -16
-;; @001f                               v19 = band v18, v17  ; v17 = -16
-;; @001f                               v21 = iadd v20, v19
-;; @001f                               v22 = uextend.i64 v14
-;; @001f                               v23 = icmp ule v21, v22
-;; @001f                               brif v23, block2, block3
+;; @001f                               v4 = uextend.i64 v2
+;;                                     v87 = iconst.i64 2
+;;                                     v88 = ishl v4, v87  ; v87 = 2
+;; @001f                               v7 = iconst.i64 32
+;; @001f                               v8 = ushr v88, v7  ; v7 = 32
+;; @001f                               trapnz v8, user18
+;; @001f                               v3 = iconst.i32 20
+;;                                     v94 = iconst.i32 2
+;;                                     v95 = ishl v2, v94  ; v94 = 2
+;; @001f                               v10 = uadd_overflow_trap v3, v95, user18  ; v3 = 20
+;; @001f                               v11 = load.i64 notrap aligned readonly can_move region2 v0+32
+;; @001f                               v12 = load.i32 notrap aligned v11
+;; @001f                               v13 = load.i32 notrap aligned v11+4
+;; @001f                               v19 = uextend.i64 v12
+;; @001f                               v14 = uextend.i64 v10
+;; @001f                               v15 = iconst.i64 15
+;; @001f                               v17 = iadd v14, v15  ; v15 = 15
+;; @001f                               v16 = iconst.i64 -16
+;; @001f                               v18 = band v17, v16  ; v16 = -16
+;; @001f                               v20 = iadd v19, v18
+;; @001f                               v21 = uextend.i64 v13
+;; @001f                               v22 = icmp ule v20, v21
+;; @001f                               brif v22, block2, block3
 ;;
 ;;                                 block2:
-;;                                     v104 = iconst.i32 15
-;;                                     v105 = iadd.i32 v11, v104  ; v104 = 15
-;;                                     v108 = iconst.i32 -16
-;;                                     v109 = band v105, v108  ; v108 = -16
-;;                                     v111 = iadd.i32 v13, v109
-;; @001f                               store notrap aligned v111, v12
-;;                                     v127 = iconst.i32 -1476394994
-;;                                     v128 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v129 = load.i64 notrap aligned readonly can_move region4 v128+32
-;; @001f                               v37 = iadd v129, v20
-;; @001f                               store notrap aligned v127, v37  ; v127 = -1476394994
-;;                                     v130 = load.i64 notrap aligned readonly can_move region3 v0+40
-;;                                     v131 = load.i32 notrap aligned readonly can_move v130
-;; @001f                               store notrap aligned v131, v37+4
-;;                                     v132 = band.i64 v18, v17  ; v17 = -16
-;; @001f                               istore32 notrap aligned v132, v37+8
-;; @001f                               jump block4(v13, v37)
+;;                                     v103 = iconst.i32 15
+;;                                     v104 = iadd.i32 v10, v103  ; v103 = 15
+;;                                     v107 = iconst.i32 -16
+;;                                     v108 = band v104, v107  ; v107 = -16
+;;                                     v110 = iadd.i32 v12, v108
+;; @001f                               store notrap aligned v110, v11
+;;                                     v126 = iconst.i32 -1476394994
+;;                                     v127 = load.i64 notrap aligned readonly can_move region0 v0+8
+;;                                     v128 = load.i64 notrap aligned readonly can_move region4 v127+32
+;; @001f                               v36 = iadd v128, v19
+;; @001f                               store notrap aligned v126, v36  ; v126 = -1476394994
+;;                                     v129 = load.i64 notrap aligned readonly can_move region3 v0+40
+;;                                     v130 = load.i32 notrap aligned readonly can_move v129
+;; @001f                               store notrap aligned v130, v36+4
+;;                                     v131 = band.i64 v17, v16  ; v16 = -16
+;; @001f                               istore32 notrap aligned v131, v36+8
+;; @001f                               jump block4(v12, v36)
 ;;
 ;;                                 block3 cold:
-;; @001f                               v24 = iconst.i32 -1476394994
-;; @001f                               v25 = load.i64 notrap aligned readonly can_move region3 v0+40
-;; @001f                               v26 = load.i32 notrap aligned readonly can_move v25
-;; @001f                               v27 = iconst.i32 16
-;; @001f                               v28 = call fn0(v0, v24, v26, v11, v27)  ; v24 = -1476394994, v27 = 16
-;; @001f                               v29 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @001f                               v30 = load.i64 notrap aligned readonly can_move region4 v29+32
-;; @001f                               v31 = uextend.i64 v28
-;; @001f                               v32 = iadd v30, v31
-;; @001f                               jump block4(v28, v32)
+;; @001f                               v23 = iconst.i32 -1476394994
+;; @001f                               v24 = load.i64 notrap aligned readonly can_move region3 v0+40
+;; @001f                               v25 = load.i32 notrap aligned readonly can_move v24
+;; @001f                               v26 = iconst.i32 16
+;; @001f                               v27 = call fn0(v0, v23, v25, v10, v26)  ; v23 = -1476394994, v26 = 16
+;; @001f                               v28 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @001f                               v29 = load.i64 notrap aligned readonly can_move region4 v28+32
+;; @001f                               v30 = uextend.i64 v27
+;; @001f                               v31 = iadd v29, v30
+;; @001f                               jump block4(v27, v31)
 ;;
-;;                                 block4(v41: i32, v42: i64):
-;; @001f                               v43 = iconst.i64 16
-;; @001f                               v44 = iadd v42, v43  ; v43 = 16
-;; @001f                               store.i32 user2 region5 v2, v44
-;; @001f                               trapz v41, user16
-;;                                     v133 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v134 = load.i64 notrap aligned readonly can_move region4 v133+32
-;; @001f                               v47 = uextend.i64 v41
-;; @001f                               v50 = iadd v134, v47
-;; @001f                               v52 = iadd v50, v43  ; v43 = 16
-;; @001f                               v53 = load.i32 user2 readonly region5 v52
-;; @001f                               v54 = uextend.i64 v53
-;; @001f                               v60 = icmp.i64 ugt v5, v54
-;; @001f                               trapnz v60, user17
-;; @001f                               v77 = load.i64 notrap aligned region6 v133+40
-;; @001f                               v65 = iconst.i64 20
-;; @001f                               v66 = iadd v50, v65  ; v65 = 20
-;; @001f                               v79 = uadd_overflow_trap v66, v89, user2
-;; @001f                               v78 = iadd v134, v77
-;; @001f                               v80 = icmp ugt v79, v78
-;; @001f                               trapnz v80, user2
-;;                                     v113 = iconst.i64 0
-;; @001f                               v83 = icmp.i64 eq v5, v113  ; v113 = 0
-;; @001f                               v45 = iconst.i32 0
-;; @001f                               v6 = iconst.i64 4
-;; @001f                               v81 = iadd v66, v89
-;; @001f                               brif v83, block6, block5(v66)
+;;                                 block4(v40: i32, v41: i64):
+;; @001f                               v42 = iconst.i64 16
+;; @001f                               v43 = iadd v41, v42  ; v42 = 16
+;; @001f                               store.i32 user2 region5 v2, v43
+;; @001f                               trapz v40, user16
+;;                                     v132 = load.i64 notrap aligned readonly can_move region0 v0+8
+;;                                     v133 = load.i64 notrap aligned readonly can_move region4 v132+32
+;; @001f                               v46 = uextend.i64 v40
+;; @001f                               v49 = iadd v133, v46
+;; @001f                               v51 = iadd v49, v42  ; v42 = 16
+;; @001f                               v52 = load.i32 user2 readonly region5 v51
+;; @001f                               v53 = uextend.i64 v52
+;; @001f                               v59 = icmp.i64 ugt v4, v53
+;; @001f                               trapnz v59, user17
+;; @001f                               v76 = load.i64 notrap aligned region6 v132+40
+;; @001f                               v64 = iconst.i64 20
+;; @001f                               v65 = iadd v49, v64  ; v64 = 20
+;; @001f                               v78 = uadd_overflow_trap v65, v88, user2
+;; @001f                               v77 = iadd v133, v76
+;; @001f                               v79 = icmp ugt v78, v77
+;; @001f                               trapnz v79, user2
+;;                                     v112 = iconst.i64 0
+;; @001f                               v82 = icmp.i64 eq v4, v112  ; v112 = 0
+;; @001f                               v44 = iconst.i32 0
+;; @001f                               v5 = iconst.i64 4
+;; @001f                               v80 = iadd v65, v88
+;; @001f                               brif v82, block6, block5(v65)
 ;;
-;;                                 block5(v84: i64):
-;;                                     v135 = iconst.i32 0
-;; @001f                               store user2 little region5 v135, v84  ; v135 = 0
-;;                                     v136 = iconst.i64 4
-;;                                     v137 = iadd v84, v136  ; v136 = 4
-;; @001f                               v87 = icmp eq v137, v81
-;; @001f                               brif v87, block6, block5(v137)
+;;                                 block5(v83: i64):
+;;                                     v134 = iconst.i32 0
+;; @001f                               store user2 little region5 v134, v83  ; v134 = 0
+;;                                     v135 = iconst.i64 4
+;;                                     v136 = iadd v83, v135  ; v135 = 4
+;; @001f                               v86 = icmp eq v136, v80
+;; @001f                               brif v86, block6, block5(v136)
 ;;
 ;;                                 block6:
-;; @0022                               jump block1(v41)
+;; @0022                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @0022                               return v3
+;;                                 block1:
+;; @0022                               return v40
 ;; }

--- a/tests/disas/gc/array-new-default-externref.wat
+++ b/tests/disas/gc/array-new-default-externref.wat
@@ -25,100 +25,100 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @001f                               v5 = uextend.i64 v2
-;;                                     v88 = iconst.i64 2
-;;                                     v89 = ishl v5, v88  ; v88 = 2
-;; @001f                               v8 = iconst.i64 32
-;; @001f                               v9 = ushr v89, v8  ; v8 = 32
-;; @001f                               trapnz v9, user18
-;; @001f                               v4 = iconst.i32 20
-;;                                     v95 = iconst.i32 2
-;;                                     v96 = ishl v2, v95  ; v95 = 2
-;; @001f                               v11 = uadd_overflow_trap v4, v96, user18  ; v4 = 20
-;; @001f                               v12 = load.i64 notrap aligned readonly can_move region2 v0+32
-;; @001f                               v13 = load.i32 notrap aligned v12
-;; @001f                               v14 = load.i32 notrap aligned v12+4
-;; @001f                               v20 = uextend.i64 v13
-;; @001f                               v15 = uextend.i64 v11
-;; @001f                               v16 = iconst.i64 15
-;; @001f                               v18 = iadd v15, v16  ; v16 = 15
-;; @001f                               v17 = iconst.i64 -16
-;; @001f                               v19 = band v18, v17  ; v17 = -16
-;; @001f                               v21 = iadd v20, v19
-;; @001f                               v22 = uextend.i64 v14
-;; @001f                               v23 = icmp ule v21, v22
-;; @001f                               brif v23, block2, block3
+;; @001f                               v4 = uextend.i64 v2
+;;                                     v87 = iconst.i64 2
+;;                                     v88 = ishl v4, v87  ; v87 = 2
+;; @001f                               v7 = iconst.i64 32
+;; @001f                               v8 = ushr v88, v7  ; v7 = 32
+;; @001f                               trapnz v8, user18
+;; @001f                               v3 = iconst.i32 20
+;;                                     v94 = iconst.i32 2
+;;                                     v95 = ishl v2, v94  ; v94 = 2
+;; @001f                               v10 = uadd_overflow_trap v3, v95, user18  ; v3 = 20
+;; @001f                               v11 = load.i64 notrap aligned readonly can_move region2 v0+32
+;; @001f                               v12 = load.i32 notrap aligned v11
+;; @001f                               v13 = load.i32 notrap aligned v11+4
+;; @001f                               v19 = uextend.i64 v12
+;; @001f                               v14 = uextend.i64 v10
+;; @001f                               v15 = iconst.i64 15
+;; @001f                               v17 = iadd v14, v15  ; v15 = 15
+;; @001f                               v16 = iconst.i64 -16
+;; @001f                               v18 = band v17, v16  ; v16 = -16
+;; @001f                               v20 = iadd v19, v18
+;; @001f                               v21 = uextend.i64 v13
+;; @001f                               v22 = icmp ule v20, v21
+;; @001f                               brif v22, block2, block3
 ;;
 ;;                                 block2:
-;;                                     v104 = iconst.i32 15
-;;                                     v105 = iadd.i32 v11, v104  ; v104 = 15
-;;                                     v108 = iconst.i32 -16
-;;                                     v109 = band v105, v108  ; v108 = -16
-;;                                     v111 = iadd.i32 v13, v109
-;; @001f                               store notrap aligned v111, v12
-;;                                     v127 = iconst.i32 -1476394994
-;;                                     v128 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v129 = load.i64 notrap aligned readonly can_move region4 v128+32
-;; @001f                               v37 = iadd v129, v20
-;; @001f                               store notrap aligned v127, v37  ; v127 = -1476394994
-;;                                     v130 = load.i64 notrap aligned readonly can_move region3 v0+40
-;;                                     v131 = load.i32 notrap aligned readonly can_move v130
-;; @001f                               store notrap aligned v131, v37+4
-;;                                     v132 = band.i64 v18, v17  ; v17 = -16
-;; @001f                               istore32 notrap aligned v132, v37+8
-;; @001f                               jump block4(v13, v37)
+;;                                     v103 = iconst.i32 15
+;;                                     v104 = iadd.i32 v10, v103  ; v103 = 15
+;;                                     v107 = iconst.i32 -16
+;;                                     v108 = band v104, v107  ; v107 = -16
+;;                                     v110 = iadd.i32 v12, v108
+;; @001f                               store notrap aligned v110, v11
+;;                                     v126 = iconst.i32 -1476394994
+;;                                     v127 = load.i64 notrap aligned readonly can_move region0 v0+8
+;;                                     v128 = load.i64 notrap aligned readonly can_move region4 v127+32
+;; @001f                               v36 = iadd v128, v19
+;; @001f                               store notrap aligned v126, v36  ; v126 = -1476394994
+;;                                     v129 = load.i64 notrap aligned readonly can_move region3 v0+40
+;;                                     v130 = load.i32 notrap aligned readonly can_move v129
+;; @001f                               store notrap aligned v130, v36+4
+;;                                     v131 = band.i64 v17, v16  ; v16 = -16
+;; @001f                               istore32 notrap aligned v131, v36+8
+;; @001f                               jump block4(v12, v36)
 ;;
 ;;                                 block3 cold:
-;; @001f                               v24 = iconst.i32 -1476394994
-;; @001f                               v25 = load.i64 notrap aligned readonly can_move region3 v0+40
-;; @001f                               v26 = load.i32 notrap aligned readonly can_move v25
-;; @001f                               v27 = iconst.i32 16
-;; @001f                               v28 = call fn0(v0, v24, v26, v11, v27)  ; v24 = -1476394994, v27 = 16
-;; @001f                               v29 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @001f                               v30 = load.i64 notrap aligned readonly can_move region4 v29+32
-;; @001f                               v31 = uextend.i64 v28
-;; @001f                               v32 = iadd v30, v31
-;; @001f                               jump block4(v28, v32)
+;; @001f                               v23 = iconst.i32 -1476394994
+;; @001f                               v24 = load.i64 notrap aligned readonly can_move region3 v0+40
+;; @001f                               v25 = load.i32 notrap aligned readonly can_move v24
+;; @001f                               v26 = iconst.i32 16
+;; @001f                               v27 = call fn0(v0, v23, v25, v10, v26)  ; v23 = -1476394994, v26 = 16
+;; @001f                               v28 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @001f                               v29 = load.i64 notrap aligned readonly can_move region4 v28+32
+;; @001f                               v30 = uextend.i64 v27
+;; @001f                               v31 = iadd v29, v30
+;; @001f                               jump block4(v27, v31)
 ;;
-;;                                 block4(v41: i32, v42: i64):
-;; @001f                               v43 = iconst.i64 16
-;; @001f                               v44 = iadd v42, v43  ; v43 = 16
-;; @001f                               store.i32 user2 region5 v2, v44
-;; @001f                               trapz v41, user16
-;;                                     v133 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v134 = load.i64 notrap aligned readonly can_move region4 v133+32
-;; @001f                               v47 = uextend.i64 v41
-;; @001f                               v50 = iadd v134, v47
-;; @001f                               v52 = iadd v50, v43  ; v43 = 16
-;; @001f                               v53 = load.i32 user2 readonly region5 v52
-;; @001f                               v54 = uextend.i64 v53
-;; @001f                               v60 = icmp.i64 ugt v5, v54
-;; @001f                               trapnz v60, user17
-;; @001f                               v77 = load.i64 notrap aligned region6 v133+40
-;; @001f                               v65 = iconst.i64 20
-;; @001f                               v66 = iadd v50, v65  ; v65 = 20
-;; @001f                               v79 = uadd_overflow_trap v66, v89, user2
-;; @001f                               v78 = iadd v134, v77
-;; @001f                               v80 = icmp ugt v79, v78
-;; @001f                               trapnz v80, user2
-;;                                     v113 = iconst.i64 0
-;; @001f                               v83 = icmp.i64 eq v5, v113  ; v113 = 0
-;; @001f                               v45 = iconst.i32 0
-;; @001f                               v6 = iconst.i64 4
-;; @001f                               v81 = iadd v66, v89
-;; @001f                               brif v83, block6, block5(v66)
+;;                                 block4(v40: i32, v41: i64):
+;; @001f                               v42 = iconst.i64 16
+;; @001f                               v43 = iadd v41, v42  ; v42 = 16
+;; @001f                               store.i32 user2 region5 v2, v43
+;; @001f                               trapz v40, user16
+;;                                     v132 = load.i64 notrap aligned readonly can_move region0 v0+8
+;;                                     v133 = load.i64 notrap aligned readonly can_move region4 v132+32
+;; @001f                               v46 = uextend.i64 v40
+;; @001f                               v49 = iadd v133, v46
+;; @001f                               v51 = iadd v49, v42  ; v42 = 16
+;; @001f                               v52 = load.i32 user2 readonly region5 v51
+;; @001f                               v53 = uextend.i64 v52
+;; @001f                               v59 = icmp.i64 ugt v4, v53
+;; @001f                               trapnz v59, user17
+;; @001f                               v76 = load.i64 notrap aligned region6 v132+40
+;; @001f                               v64 = iconst.i64 20
+;; @001f                               v65 = iadd v49, v64  ; v64 = 20
+;; @001f                               v78 = uadd_overflow_trap v65, v88, user2
+;; @001f                               v77 = iadd v133, v76
+;; @001f                               v79 = icmp ugt v78, v77
+;; @001f                               trapnz v79, user2
+;;                                     v112 = iconst.i64 0
+;; @001f                               v82 = icmp.i64 eq v4, v112  ; v112 = 0
+;; @001f                               v44 = iconst.i32 0
+;; @001f                               v5 = iconst.i64 4
+;; @001f                               v80 = iadd v65, v88
+;; @001f                               brif v82, block6, block5(v65)
 ;;
-;;                                 block5(v84: i64):
-;;                                     v135 = iconst.i32 0
-;; @001f                               store user2 little region5 v135, v84  ; v135 = 0
-;;                                     v136 = iconst.i64 4
-;;                                     v137 = iadd v84, v136  ; v136 = 4
-;; @001f                               v87 = icmp eq v137, v81
-;; @001f                               brif v87, block6, block5(v137)
+;;                                 block5(v83: i64):
+;;                                     v134 = iconst.i32 0
+;; @001f                               store user2 little region5 v134, v83  ; v134 = 0
+;;                                     v135 = iconst.i64 4
+;;                                     v136 = iadd v83, v135  ; v135 = 4
+;; @001f                               v86 = icmp eq v136, v80
+;; @001f                               brif v86, block6, block5(v136)
 ;;
 ;;                                 block6:
-;; @0022                               jump block1(v41)
+;; @0022                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @0022                               return v3
+;;                                 block1:
+;; @0022                               return v40
 ;; }

--- a/tests/disas/gc/array-new-default-f32.wat
+++ b/tests/disas/gc/array-new-default-f32.wat
@@ -28,89 +28,89 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @001f                               v5 = uextend.i64 v2
-;;                                     v91 = iconst.i64 2
-;;                                     v92 = ishl v5, v91  ; v91 = 2
-;; @001f                               v8 = iconst.i64 32
-;; @001f                               v9 = ushr v92, v8  ; v8 = 32
-;; @001f                               trapnz v9, user18
-;; @001f                               v4 = iconst.i32 20
-;;                                     v98 = iconst.i32 2
-;;                                     v99 = ishl v2, v98  ; v98 = 2
-;; @001f                               v11 = uadd_overflow_trap v4, v99, user18  ; v4 = 20
-;; @001f                               v12 = load.i64 notrap aligned readonly can_move region2 v0+32
-;; @001f                               v13 = load.i32 notrap aligned v12
-;; @001f                               v14 = load.i32 notrap aligned v12+4
-;; @001f                               v20 = uextend.i64 v13
-;; @001f                               v15 = uextend.i64 v11
-;; @001f                               v16 = iconst.i64 15
-;; @001f                               v18 = iadd v15, v16  ; v16 = 15
-;; @001f                               v17 = iconst.i64 -16
-;; @001f                               v19 = band v18, v17  ; v17 = -16
-;; @001f                               v21 = iadd v20, v19
-;; @001f                               v22 = uextend.i64 v14
-;; @001f                               v23 = icmp ule v21, v22
-;; @001f                               brif v23, block2, block3
+;; @001f                               v4 = uextend.i64 v2
+;;                                     v90 = iconst.i64 2
+;;                                     v91 = ishl v4, v90  ; v90 = 2
+;; @001f                               v7 = iconst.i64 32
+;; @001f                               v8 = ushr v91, v7  ; v7 = 32
+;; @001f                               trapnz v8, user18
+;; @001f                               v3 = iconst.i32 20
+;;                                     v97 = iconst.i32 2
+;;                                     v98 = ishl v2, v97  ; v97 = 2
+;; @001f                               v10 = uadd_overflow_trap v3, v98, user18  ; v3 = 20
+;; @001f                               v11 = load.i64 notrap aligned readonly can_move region2 v0+32
+;; @001f                               v12 = load.i32 notrap aligned v11
+;; @001f                               v13 = load.i32 notrap aligned v11+4
+;; @001f                               v19 = uextend.i64 v12
+;; @001f                               v14 = uextend.i64 v10
+;; @001f                               v15 = iconst.i64 15
+;; @001f                               v17 = iadd v14, v15  ; v15 = 15
+;; @001f                               v16 = iconst.i64 -16
+;; @001f                               v18 = band v17, v16  ; v16 = -16
+;; @001f                               v20 = iadd v19, v18
+;; @001f                               v21 = uextend.i64 v13
+;; @001f                               v22 = icmp ule v20, v21
+;; @001f                               brif v22, block2, block3
 ;;
 ;;                                 block2:
-;;                                     v107 = iconst.i32 15
-;;                                     v108 = iadd.i32 v11, v107  ; v107 = 15
-;;                                     v111 = iconst.i32 -16
-;;                                     v112 = band v108, v111  ; v111 = -16
-;;                                     v114 = iadd.i32 v13, v112
-;; @001f                               store notrap aligned v114, v12
-;;                                     v130 = iconst.i32 -1476395002
-;;                                     v131 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v132 = load.i64 notrap aligned readonly can_move region4 v131+32
-;; @001f                               v37 = iadd v132, v20
-;; @001f                               store notrap aligned v130, v37  ; v130 = -1476395002
-;;                                     v133 = load.i64 notrap aligned readonly can_move region3 v0+40
-;;                                     v134 = load.i32 notrap aligned readonly can_move v133
-;; @001f                               store notrap aligned v134, v37+4
-;;                                     v135 = band.i64 v18, v17  ; v17 = -16
-;; @001f                               istore32 notrap aligned v135, v37+8
-;; @001f                               jump block4(v13, v37)
+;;                                     v106 = iconst.i32 15
+;;                                     v107 = iadd.i32 v10, v106  ; v106 = 15
+;;                                     v110 = iconst.i32 -16
+;;                                     v111 = band v107, v110  ; v110 = -16
+;;                                     v113 = iadd.i32 v12, v111
+;; @001f                               store notrap aligned v113, v11
+;;                                     v129 = iconst.i32 -1476395002
+;;                                     v130 = load.i64 notrap aligned readonly can_move region0 v0+8
+;;                                     v131 = load.i64 notrap aligned readonly can_move region4 v130+32
+;; @001f                               v36 = iadd v131, v19
+;; @001f                               store notrap aligned v129, v36  ; v129 = -1476395002
+;;                                     v132 = load.i64 notrap aligned readonly can_move region3 v0+40
+;;                                     v133 = load.i32 notrap aligned readonly can_move v132
+;; @001f                               store notrap aligned v133, v36+4
+;;                                     v134 = band.i64 v17, v16  ; v16 = -16
+;; @001f                               istore32 notrap aligned v134, v36+8
+;; @001f                               jump block4(v12, v36)
 ;;
 ;;                                 block3 cold:
-;; @001f                               v24 = iconst.i32 -1476395002
-;; @001f                               v25 = load.i64 notrap aligned readonly can_move region3 v0+40
-;; @001f                               v26 = load.i32 notrap aligned readonly can_move v25
-;; @001f                               v27 = iconst.i32 16
-;; @001f                               v28 = call fn0(v0, v24, v26, v11, v27)  ; v24 = -1476395002, v27 = 16
-;; @001f                               v29 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @001f                               v30 = load.i64 notrap aligned readonly can_move region4 v29+32
-;; @001f                               v31 = uextend.i64 v28
-;; @001f                               v32 = iadd v30, v31
-;; @001f                               jump block4(v28, v32)
+;; @001f                               v23 = iconst.i32 -1476395002
+;; @001f                               v24 = load.i64 notrap aligned readonly can_move region3 v0+40
+;; @001f                               v25 = load.i32 notrap aligned readonly can_move v24
+;; @001f                               v26 = iconst.i32 16
+;; @001f                               v27 = call fn0(v0, v23, v25, v10, v26)  ; v23 = -1476395002, v26 = 16
+;; @001f                               v28 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @001f                               v29 = load.i64 notrap aligned readonly can_move region4 v28+32
+;; @001f                               v30 = uextend.i64 v27
+;; @001f                               v31 = iadd v29, v30
+;; @001f                               jump block4(v27, v31)
 ;;
-;;                                 block4(v41: i32, v42: i64):
-;;                                     v90 = stack_addr.i64 ss0
-;;                                     store notrap v41, v90
-;; @001f                               v43 = iconst.i64 16
-;; @001f                               v44 = iadd v42, v43  ; v43 = 16
-;; @001f                               store.i32 user2 region5 v2, v44
-;; @001f                               trapz v41, user16
-;;                                     v136 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v137 = load.i64 notrap aligned readonly can_move region4 v136+32
-;; @001f                               v47 = uextend.i64 v41
-;; @001f                               v50 = iadd v137, v47
-;; @001f                               v52 = iadd v50, v43  ; v43 = 16
-;; @001f                               v53 = load.i32 user2 readonly region5 v52
-;; @001f                               v54 = uextend.i64 v53
-;; @001f                               v60 = icmp.i64 ugt v5, v54
-;; @001f                               trapnz v60, user17
-;; @001f                               v77 = load.i64 notrap aligned region6 v136+40
-;; @001f                               v65 = iconst.i64 20
-;; @001f                               v66 = iadd v50, v65  ; v65 = 20
-;; @001f                               v79 = uadd_overflow_trap v66, v92, user2
-;; @001f                               v78 = iadd v137, v77
-;; @001f                               v80 = icmp ugt v79, v78
-;; @001f                               trapnz v80, user2
-;; @001f                               v46 = iconst.i32 0
-;; @001f                               call fn1(v0, v66, v46, v92), stack_map=[i32 @ ss0+0]  ; v46 = 0
-;;                                     v83 = load.i32 notrap v90
+;;                                 block4(v40: i32, v41: i64):
+;;                                     v89 = stack_addr.i64 ss0
+;;                                     store notrap v40, v89
+;; @001f                               v42 = iconst.i64 16
+;; @001f                               v43 = iadd v41, v42  ; v42 = 16
+;; @001f                               store.i32 user2 region5 v2, v43
+;; @001f                               trapz v40, user16
+;;                                     v135 = load.i64 notrap aligned readonly can_move region0 v0+8
+;;                                     v136 = load.i64 notrap aligned readonly can_move region4 v135+32
+;; @001f                               v46 = uextend.i64 v40
+;; @001f                               v49 = iadd v136, v46
+;; @001f                               v51 = iadd v49, v42  ; v42 = 16
+;; @001f                               v52 = load.i32 user2 readonly region5 v51
+;; @001f                               v53 = uextend.i64 v52
+;; @001f                               v59 = icmp.i64 ugt v4, v53
+;; @001f                               trapnz v59, user17
+;; @001f                               v76 = load.i64 notrap aligned region6 v135+40
+;; @001f                               v64 = iconst.i64 20
+;; @001f                               v65 = iadd v49, v64  ; v64 = 20
+;; @001f                               v78 = uadd_overflow_trap v65, v91, user2
+;; @001f                               v77 = iadd v136, v76
+;; @001f                               v79 = icmp ugt v78, v77
+;; @001f                               trapnz v79, user2
+;; @001f                               v45 = iconst.i32 0
+;; @001f                               call fn1(v0, v65, v45, v91), stack_map=[i32 @ ss0+0]  ; v45 = 0
 ;; @0022                               jump block1
 ;;
 ;;                                 block1:
-;; @0022                               return v83
+;;                                     v82 = load.i32 notrap v89
+;; @0022                               return v82
 ;; }

--- a/tests/disas/gc/array-new-default-f64.wat
+++ b/tests/disas/gc/array-new-default-f64.wat
@@ -28,89 +28,89 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @001f                               v5 = uextend.i64 v2
-;;                                     v91 = iconst.i64 3
-;;                                     v92 = ishl v5, v91  ; v91 = 3
-;; @001f                               v8 = iconst.i64 32
-;; @001f                               v9 = ushr v92, v8  ; v8 = 32
-;; @001f                               trapnz v9, user18
-;; @001f                               v4 = iconst.i32 24
-;;                                     v98 = iconst.i32 3
-;;                                     v99 = ishl v2, v98  ; v98 = 3
-;; @001f                               v11 = uadd_overflow_trap v4, v99, user18  ; v4 = 24
-;; @001f                               v12 = load.i64 notrap aligned readonly can_move region2 v0+32
-;; @001f                               v13 = load.i32 notrap aligned v12
-;; @001f                               v14 = load.i32 notrap aligned v12+4
-;; @001f                               v20 = uextend.i64 v13
-;; @001f                               v15 = uextend.i64 v11
-;; @001f                               v16 = iconst.i64 15
-;; @001f                               v18 = iadd v15, v16  ; v16 = 15
-;; @001f                               v17 = iconst.i64 -16
-;; @001f                               v19 = band v18, v17  ; v17 = -16
-;; @001f                               v21 = iadd v20, v19
-;; @001f                               v22 = uextend.i64 v14
-;; @001f                               v23 = icmp ule v21, v22
-;; @001f                               brif v23, block2, block3
+;; @001f                               v4 = uextend.i64 v2
+;;                                     v90 = iconst.i64 3
+;;                                     v91 = ishl v4, v90  ; v90 = 3
+;; @001f                               v7 = iconst.i64 32
+;; @001f                               v8 = ushr v91, v7  ; v7 = 32
+;; @001f                               trapnz v8, user18
+;; @001f                               v3 = iconst.i32 24
+;;                                     v97 = iconst.i32 3
+;;                                     v98 = ishl v2, v97  ; v97 = 3
+;; @001f                               v10 = uadd_overflow_trap v3, v98, user18  ; v3 = 24
+;; @001f                               v11 = load.i64 notrap aligned readonly can_move region2 v0+32
+;; @001f                               v12 = load.i32 notrap aligned v11
+;; @001f                               v13 = load.i32 notrap aligned v11+4
+;; @001f                               v19 = uextend.i64 v12
+;; @001f                               v14 = uextend.i64 v10
+;; @001f                               v15 = iconst.i64 15
+;; @001f                               v17 = iadd v14, v15  ; v15 = 15
+;; @001f                               v16 = iconst.i64 -16
+;; @001f                               v18 = band v17, v16  ; v16 = -16
+;; @001f                               v20 = iadd v19, v18
+;; @001f                               v21 = uextend.i64 v13
+;; @001f                               v22 = icmp ule v20, v21
+;; @001f                               brif v22, block2, block3
 ;;
 ;;                                 block2:
-;;                                     v107 = iconst.i32 15
-;;                                     v108 = iadd.i32 v11, v107  ; v107 = 15
-;;                                     v111 = iconst.i32 -16
-;;                                     v112 = band v108, v111  ; v111 = -16
-;;                                     v114 = iadd.i32 v13, v112
-;; @001f                               store notrap aligned v114, v12
-;;                                     v130 = iconst.i32 -1476395002
-;;                                     v131 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v132 = load.i64 notrap aligned readonly can_move region4 v131+32
-;; @001f                               v37 = iadd v132, v20
-;; @001f                               store notrap aligned v130, v37  ; v130 = -1476395002
-;;                                     v133 = load.i64 notrap aligned readonly can_move region3 v0+40
-;;                                     v134 = load.i32 notrap aligned readonly can_move v133
-;; @001f                               store notrap aligned v134, v37+4
-;;                                     v135 = band.i64 v18, v17  ; v17 = -16
-;; @001f                               istore32 notrap aligned v135, v37+8
-;; @001f                               jump block4(v13, v37)
+;;                                     v106 = iconst.i32 15
+;;                                     v107 = iadd.i32 v10, v106  ; v106 = 15
+;;                                     v110 = iconst.i32 -16
+;;                                     v111 = band v107, v110  ; v110 = -16
+;;                                     v113 = iadd.i32 v12, v111
+;; @001f                               store notrap aligned v113, v11
+;;                                     v129 = iconst.i32 -1476395002
+;;                                     v130 = load.i64 notrap aligned readonly can_move region0 v0+8
+;;                                     v131 = load.i64 notrap aligned readonly can_move region4 v130+32
+;; @001f                               v36 = iadd v131, v19
+;; @001f                               store notrap aligned v129, v36  ; v129 = -1476395002
+;;                                     v132 = load.i64 notrap aligned readonly can_move region3 v0+40
+;;                                     v133 = load.i32 notrap aligned readonly can_move v132
+;; @001f                               store notrap aligned v133, v36+4
+;;                                     v134 = band.i64 v17, v16  ; v16 = -16
+;; @001f                               istore32 notrap aligned v134, v36+8
+;; @001f                               jump block4(v12, v36)
 ;;
 ;;                                 block3 cold:
-;; @001f                               v24 = iconst.i32 -1476395002
-;; @001f                               v25 = load.i64 notrap aligned readonly can_move region3 v0+40
-;; @001f                               v26 = load.i32 notrap aligned readonly can_move v25
-;; @001f                               v27 = iconst.i32 16
-;; @001f                               v28 = call fn0(v0, v24, v26, v11, v27)  ; v24 = -1476395002, v27 = 16
-;; @001f                               v29 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @001f                               v30 = load.i64 notrap aligned readonly can_move region4 v29+32
-;; @001f                               v31 = uextend.i64 v28
-;; @001f                               v32 = iadd v30, v31
-;; @001f                               jump block4(v28, v32)
+;; @001f                               v23 = iconst.i32 -1476395002
+;; @001f                               v24 = load.i64 notrap aligned readonly can_move region3 v0+40
+;; @001f                               v25 = load.i32 notrap aligned readonly can_move v24
+;; @001f                               v26 = iconst.i32 16
+;; @001f                               v27 = call fn0(v0, v23, v25, v10, v26)  ; v23 = -1476395002, v26 = 16
+;; @001f                               v28 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @001f                               v29 = load.i64 notrap aligned readonly can_move region4 v28+32
+;; @001f                               v30 = uextend.i64 v27
+;; @001f                               v31 = iadd v29, v30
+;; @001f                               jump block4(v27, v31)
 ;;
-;;                                 block4(v41: i32, v42: i64):
-;;                                     v90 = stack_addr.i64 ss0
-;;                                     store notrap v41, v90
-;; @001f                               v43 = iconst.i64 16
-;; @001f                               v44 = iadd v42, v43  ; v43 = 16
-;; @001f                               store.i32 user2 region5 v2, v44
-;; @001f                               trapz v41, user16
-;;                                     v136 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v137 = load.i64 notrap aligned readonly can_move region4 v136+32
-;; @001f                               v47 = uextend.i64 v41
-;; @001f                               v50 = iadd v137, v47
-;; @001f                               v52 = iadd v50, v43  ; v43 = 16
-;; @001f                               v53 = load.i32 user2 readonly region5 v52
-;; @001f                               v54 = uextend.i64 v53
-;; @001f                               v60 = icmp.i64 ugt v5, v54
-;; @001f                               trapnz v60, user17
-;; @001f                               v77 = load.i64 notrap aligned region6 v136+40
-;; @001f                               v65 = iconst.i64 24
-;; @001f                               v66 = iadd v50, v65  ; v65 = 24
-;; @001f                               v79 = uadd_overflow_trap v66, v92, user2
-;; @001f                               v78 = iadd v137, v77
-;; @001f                               v80 = icmp ugt v79, v78
-;; @001f                               trapnz v80, user2
-;; @001f                               v46 = iconst.i32 0
-;; @001f                               call fn1(v0, v66, v46, v92), stack_map=[i32 @ ss0+0]  ; v46 = 0
-;;                                     v83 = load.i32 notrap v90
+;;                                 block4(v40: i32, v41: i64):
+;;                                     v89 = stack_addr.i64 ss0
+;;                                     store notrap v40, v89
+;; @001f                               v42 = iconst.i64 16
+;; @001f                               v43 = iadd v41, v42  ; v42 = 16
+;; @001f                               store.i32 user2 region5 v2, v43
+;; @001f                               trapz v40, user16
+;;                                     v135 = load.i64 notrap aligned readonly can_move region0 v0+8
+;;                                     v136 = load.i64 notrap aligned readonly can_move region4 v135+32
+;; @001f                               v46 = uextend.i64 v40
+;; @001f                               v49 = iadd v136, v46
+;; @001f                               v51 = iadd v49, v42  ; v42 = 16
+;; @001f                               v52 = load.i32 user2 readonly region5 v51
+;; @001f                               v53 = uextend.i64 v52
+;; @001f                               v59 = icmp.i64 ugt v4, v53
+;; @001f                               trapnz v59, user17
+;; @001f                               v76 = load.i64 notrap aligned region6 v135+40
+;; @001f                               v64 = iconst.i64 24
+;; @001f                               v65 = iadd v49, v64  ; v64 = 24
+;; @001f                               v78 = uadd_overflow_trap v65, v91, user2
+;; @001f                               v77 = iadd v136, v76
+;; @001f                               v79 = icmp ugt v78, v77
+;; @001f                               trapnz v79, user2
+;; @001f                               v45 = iconst.i32 0
+;; @001f                               call fn1(v0, v65, v45, v91), stack_map=[i32 @ ss0+0]  ; v45 = 0
 ;; @0022                               jump block1
 ;;
 ;;                                 block1:
-;; @0022                               return v83
+;;                                     v82 = load.i32 notrap v89
+;; @0022                               return v82
 ;; }

--- a/tests/disas/gc/array-new-default-funcref.wat
+++ b/tests/disas/gc/array-new-default-funcref.wat
@@ -28,103 +28,103 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @001f                               v5 = uextend.i64 v2
-;;                                     v99 = iconst.i64 2
-;;                                     v100 = ishl v5, v99  ; v99 = 2
-;; @001f                               v8 = iconst.i64 32
-;; @001f                               v9 = ushr v100, v8  ; v8 = 32
-;; @001f                               trapnz v9, user18
-;; @001f                               v4 = iconst.i32 20
-;;                                     v106 = iconst.i32 2
-;;                                     v107 = ishl v2, v106  ; v106 = 2
-;; @001f                               v11 = uadd_overflow_trap v4, v107, user18  ; v4 = 20
-;; @001f                               v12 = load.i64 notrap aligned readonly can_move region2 v0+32
-;; @001f                               v13 = load.i32 notrap aligned v12
-;; @001f                               v14 = load.i32 notrap aligned v12+4
-;; @001f                               v20 = uextend.i64 v13
-;; @001f                               v15 = uextend.i64 v11
-;; @001f                               v16 = iconst.i64 15
-;; @001f                               v18 = iadd v15, v16  ; v16 = 15
-;; @001f                               v17 = iconst.i64 -16
-;; @001f                               v19 = band v18, v17  ; v17 = -16
-;; @001f                               v21 = iadd v20, v19
-;; @001f                               v22 = uextend.i64 v14
-;; @001f                               v23 = icmp ule v21, v22
-;; @001f                               brif v23, block2, block3
+;; @001f                               v4 = uextend.i64 v2
+;;                                     v98 = iconst.i64 2
+;;                                     v99 = ishl v4, v98  ; v98 = 2
+;; @001f                               v7 = iconst.i64 32
+;; @001f                               v8 = ushr v99, v7  ; v7 = 32
+;; @001f                               trapnz v8, user18
+;; @001f                               v3 = iconst.i32 20
+;;                                     v105 = iconst.i32 2
+;;                                     v106 = ishl v2, v105  ; v105 = 2
+;; @001f                               v10 = uadd_overflow_trap v3, v106, user18  ; v3 = 20
+;; @001f                               v11 = load.i64 notrap aligned readonly can_move region2 v0+32
+;; @001f                               v12 = load.i32 notrap aligned v11
+;; @001f                               v13 = load.i32 notrap aligned v11+4
+;; @001f                               v19 = uextend.i64 v12
+;; @001f                               v14 = uextend.i64 v10
+;; @001f                               v15 = iconst.i64 15
+;; @001f                               v17 = iadd v14, v15  ; v15 = 15
+;; @001f                               v16 = iconst.i64 -16
+;; @001f                               v18 = band v17, v16  ; v16 = -16
+;; @001f                               v20 = iadd v19, v18
+;; @001f                               v21 = uextend.i64 v13
+;; @001f                               v22 = icmp ule v20, v21
+;; @001f                               brif v22, block2, block3
 ;;
 ;;                                 block2:
-;;                                     v115 = iconst.i32 15
-;;                                     v116 = iadd.i32 v11, v115  ; v115 = 15
-;;                                     v119 = iconst.i32 -16
-;;                                     v120 = band v116, v119  ; v119 = -16
-;;                                     v122 = iadd.i32 v13, v120
-;; @001f                               store notrap aligned v122, v12
-;;                                     v137 = iconst.i32 -1476395002
-;;                                     v138 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v139 = load.i64 notrap aligned readonly can_move region4 v138+32
-;; @001f                               v37 = iadd v139, v20
-;; @001f                               store notrap aligned v137, v37  ; v137 = -1476395002
-;;                                     v140 = load.i64 notrap aligned readonly can_move region3 v0+40
-;;                                     v141 = load.i32 notrap aligned readonly can_move v140
-;; @001f                               store notrap aligned v141, v37+4
-;;                                     v142 = band.i64 v18, v17  ; v17 = -16
-;; @001f                               istore32 notrap aligned v142, v37+8
-;; @001f                               jump block4(v13, v37)
+;;                                     v114 = iconst.i32 15
+;;                                     v115 = iadd.i32 v10, v114  ; v114 = 15
+;;                                     v118 = iconst.i32 -16
+;;                                     v119 = band v115, v118  ; v118 = -16
+;;                                     v121 = iadd.i32 v12, v119
+;; @001f                               store notrap aligned v121, v11
+;;                                     v136 = iconst.i32 -1476395002
+;;                                     v137 = load.i64 notrap aligned readonly can_move region0 v0+8
+;;                                     v138 = load.i64 notrap aligned readonly can_move region4 v137+32
+;; @001f                               v36 = iadd v138, v19
+;; @001f                               store notrap aligned v136, v36  ; v136 = -1476395002
+;;                                     v139 = load.i64 notrap aligned readonly can_move region3 v0+40
+;;                                     v140 = load.i32 notrap aligned readonly can_move v139
+;; @001f                               store notrap aligned v140, v36+4
+;;                                     v141 = band.i64 v17, v16  ; v16 = -16
+;; @001f                               istore32 notrap aligned v141, v36+8
+;; @001f                               jump block4(v12, v36)
 ;;
 ;;                                 block3 cold:
-;; @001f                               v24 = iconst.i32 -1476395002
-;; @001f                               v25 = load.i64 notrap aligned readonly can_move region3 v0+40
-;; @001f                               v26 = load.i32 notrap aligned readonly can_move v25
-;; @001f                               v27 = iconst.i32 16
-;; @001f                               v28 = call fn0(v0, v24, v26, v11, v27)  ; v24 = -1476395002, v27 = 16
-;; @001f                               v29 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @001f                               v30 = load.i64 notrap aligned readonly can_move region4 v29+32
-;; @001f                               v31 = uextend.i64 v28
-;; @001f                               v32 = iadd v30, v31
-;; @001f                               jump block4(v28, v32)
+;; @001f                               v23 = iconst.i32 -1476395002
+;; @001f                               v24 = load.i64 notrap aligned readonly can_move region3 v0+40
+;; @001f                               v25 = load.i32 notrap aligned readonly can_move v24
+;; @001f                               v26 = iconst.i32 16
+;; @001f                               v27 = call fn0(v0, v23, v25, v10, v26)  ; v23 = -1476395002, v26 = 16
+;; @001f                               v28 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @001f                               v29 = load.i64 notrap aligned readonly can_move region4 v28+32
+;; @001f                               v30 = uextend.i64 v27
+;; @001f                               v31 = iadd v29, v30
+;; @001f                               jump block4(v27, v31)
 ;;
-;;                                 block4(v41: i32, v42: i64):
-;;                                     v98 = stack_addr.i64 ss0
-;;                                     store notrap v41, v98
-;; @001f                               v43 = iconst.i64 16
-;; @001f                               v44 = iadd v42, v43  ; v43 = 16
-;; @001f                               store.i32 user2 region5 v2, v44
-;; @001f                               trapz v41, user16
-;;                                     v143 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v144 = load.i64 notrap aligned readonly can_move region4 v143+32
-;; @001f                               v47 = uextend.i64 v41
-;; @001f                               v50 = iadd v144, v47
-;; @001f                               v52 = iadd v50, v43  ; v43 = 16
-;; @001f                               v53 = load.i32 user2 readonly region5 v52
-;; @001f                               v54 = uextend.i64 v53
-;; @001f                               v60 = icmp.i64 ugt v5, v54
-;; @001f                               trapnz v60, user17
-;; @001f                               v77 = load.i64 notrap aligned region6 v143+40
-;; @001f                               v65 = iconst.i64 20
-;; @001f                               v66 = iadd v50, v65  ; v65 = 20
-;; @001f                               v79 = uadd_overflow_trap v66, v100, user2
-;; @001f                               v78 = iadd v144, v77
-;; @001f                               v80 = icmp ugt v79, v78
-;; @001f                               trapnz v80, user2
-;; @001f                               v45 = iconst.i64 0
-;; @001f                               v81 = call fn1(v0, v45), stack_map=[i32 @ ss0+0]  ; v45 = 0
-;; @001f                               v85 = icmp.i64 eq v5, v45  ; v45 = 0
-;; @001f                               v82 = ireduce.i32 v81
-;; @001f                               v6 = iconst.i64 4
-;; @001f                               v83 = iadd v66, v100
-;; @001f                               brif v85, block6, block5(v66)
+;;                                 block4(v40: i32, v41: i64):
+;;                                     v97 = stack_addr.i64 ss0
+;;                                     store notrap v40, v97
+;; @001f                               v42 = iconst.i64 16
+;; @001f                               v43 = iadd v41, v42  ; v42 = 16
+;; @001f                               store.i32 user2 region5 v2, v43
+;; @001f                               trapz v40, user16
+;;                                     v142 = load.i64 notrap aligned readonly can_move region0 v0+8
+;;                                     v143 = load.i64 notrap aligned readonly can_move region4 v142+32
+;; @001f                               v46 = uextend.i64 v40
+;; @001f                               v49 = iadd v143, v46
+;; @001f                               v51 = iadd v49, v42  ; v42 = 16
+;; @001f                               v52 = load.i32 user2 readonly region5 v51
+;; @001f                               v53 = uextend.i64 v52
+;; @001f                               v59 = icmp.i64 ugt v4, v53
+;; @001f                               trapnz v59, user17
+;; @001f                               v76 = load.i64 notrap aligned region6 v142+40
+;; @001f                               v64 = iconst.i64 20
+;; @001f                               v65 = iadd v49, v64  ; v64 = 20
+;; @001f                               v78 = uadd_overflow_trap v65, v99, user2
+;; @001f                               v77 = iadd v143, v76
+;; @001f                               v79 = icmp ugt v78, v77
+;; @001f                               trapnz v79, user2
+;; @001f                               v44 = iconst.i64 0
+;; @001f                               v80 = call fn1(v0, v44), stack_map=[i32 @ ss0+0]  ; v44 = 0
+;; @001f                               v84 = icmp.i64 eq v4, v44  ; v44 = 0
+;; @001f                               v81 = ireduce.i32 v80
+;; @001f                               v5 = iconst.i64 4
+;; @001f                               v82 = iadd v65, v99
+;; @001f                               brif v84, block6, block5(v65)
 ;;
-;;                                 block5(v86: i64):
-;; @001f                               store.i32 notrap aligned little v82, v86
-;;                                     v145 = iconst.i64 4
-;;                                     v146 = iadd v86, v145  ; v145 = 4
-;; @001f                               v89 = icmp eq v146, v83
-;; @001f                               brif v89, block6, block5(v146)
+;;                                 block5(v85: i64):
+;; @001f                               store.i32 notrap aligned little v81, v85
+;;                                     v144 = iconst.i64 4
+;;                                     v145 = iadd v85, v144  ; v144 = 4
+;; @001f                               v88 = icmp eq v145, v82
+;; @001f                               brif v88, block6, block5(v145)
 ;;
 ;;                                 block6:
-;;                                     v91 = load.i32 notrap v98
 ;; @0022                               jump block1
 ;;
 ;;                                 block1:
-;; @0022                               return v91
+;;                                     v90 = load.i32 notrap v97
+;; @0022                               return v90
 ;; }

--- a/tests/disas/gc/array-new-default-i16.wat
+++ b/tests/disas/gc/array-new-default-i16.wat
@@ -28,88 +28,88 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @001f                               v5 = uextend.i64 v2
-;;                                     v92 = iconst.i64 1
-;;                                     v93 = ishl v5, v92  ; v92 = 1
-;; @001f                               v8 = iconst.i64 32
-;; @001f                               v9 = ushr v93, v8  ; v8 = 32
-;; @001f                               trapnz v9, user18
-;; @001f                               v4 = iconst.i32 20
-;;                                     v97 = iadd v2, v2
-;; @001f                               v11 = uadd_overflow_trap v4, v97, user18  ; v4 = 20
-;; @001f                               v12 = load.i64 notrap aligned readonly can_move region2 v0+32
-;; @001f                               v13 = load.i32 notrap aligned v12
-;; @001f                               v14 = load.i32 notrap aligned v12+4
-;; @001f                               v20 = uextend.i64 v13
-;; @001f                               v15 = uextend.i64 v11
-;; @001f                               v16 = iconst.i64 15
-;; @001f                               v18 = iadd v15, v16  ; v16 = 15
-;; @001f                               v17 = iconst.i64 -16
-;; @001f                               v19 = band v18, v17  ; v17 = -16
-;; @001f                               v21 = iadd v20, v19
-;; @001f                               v22 = uextend.i64 v14
-;; @001f                               v23 = icmp ule v21, v22
-;; @001f                               brif v23, block2, block3
+;; @001f                               v4 = uextend.i64 v2
+;;                                     v91 = iconst.i64 1
+;;                                     v92 = ishl v4, v91  ; v91 = 1
+;; @001f                               v7 = iconst.i64 32
+;; @001f                               v8 = ushr v92, v7  ; v7 = 32
+;; @001f                               trapnz v8, user18
+;; @001f                               v3 = iconst.i32 20
+;;                                     v96 = iadd v2, v2
+;; @001f                               v10 = uadd_overflow_trap v3, v96, user18  ; v3 = 20
+;; @001f                               v11 = load.i64 notrap aligned readonly can_move region2 v0+32
+;; @001f                               v12 = load.i32 notrap aligned v11
+;; @001f                               v13 = load.i32 notrap aligned v11+4
+;; @001f                               v19 = uextend.i64 v12
+;; @001f                               v14 = uextend.i64 v10
+;; @001f                               v15 = iconst.i64 15
+;; @001f                               v17 = iadd v14, v15  ; v15 = 15
+;; @001f                               v16 = iconst.i64 -16
+;; @001f                               v18 = band v17, v16  ; v16 = -16
+;; @001f                               v20 = iadd v19, v18
+;; @001f                               v21 = uextend.i64 v13
+;; @001f                               v22 = icmp ule v20, v21
+;; @001f                               brif v22, block2, block3
 ;;
 ;;                                 block2:
-;;                                     v112 = iconst.i32 15
-;;                                     v113 = iadd.i32 v11, v112  ; v112 = 15
-;;                                     v116 = iconst.i32 -16
-;;                                     v117 = band v113, v116  ; v116 = -16
-;;                                     v119 = iadd.i32 v13, v117
-;; @001f                               store notrap aligned v119, v12
-;;                                     v140 = iconst.i32 -1476395002
-;;                                     v141 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v142 = load.i64 notrap aligned readonly can_move region4 v141+32
-;; @001f                               v37 = iadd v142, v20
-;; @001f                               store notrap aligned v140, v37  ; v140 = -1476395002
-;;                                     v143 = load.i64 notrap aligned readonly can_move region3 v0+40
-;;                                     v144 = load.i32 notrap aligned readonly can_move v143
-;; @001f                               store notrap aligned v144, v37+4
-;;                                     v145 = band.i64 v18, v17  ; v17 = -16
-;; @001f                               istore32 notrap aligned v145, v37+8
-;; @001f                               jump block4(v13, v37)
+;;                                     v111 = iconst.i32 15
+;;                                     v112 = iadd.i32 v10, v111  ; v111 = 15
+;;                                     v115 = iconst.i32 -16
+;;                                     v116 = band v112, v115  ; v115 = -16
+;;                                     v118 = iadd.i32 v12, v116
+;; @001f                               store notrap aligned v118, v11
+;;                                     v139 = iconst.i32 -1476395002
+;;                                     v140 = load.i64 notrap aligned readonly can_move region0 v0+8
+;;                                     v141 = load.i64 notrap aligned readonly can_move region4 v140+32
+;; @001f                               v36 = iadd v141, v19
+;; @001f                               store notrap aligned v139, v36  ; v139 = -1476395002
+;;                                     v142 = load.i64 notrap aligned readonly can_move region3 v0+40
+;;                                     v143 = load.i32 notrap aligned readonly can_move v142
+;; @001f                               store notrap aligned v143, v36+4
+;;                                     v144 = band.i64 v17, v16  ; v16 = -16
+;; @001f                               istore32 notrap aligned v144, v36+8
+;; @001f                               jump block4(v12, v36)
 ;;
 ;;                                 block3 cold:
-;; @001f                               v24 = iconst.i32 -1476395002
-;; @001f                               v25 = load.i64 notrap aligned readonly can_move region3 v0+40
-;; @001f                               v26 = load.i32 notrap aligned readonly can_move v25
-;; @001f                               v27 = iconst.i32 16
-;; @001f                               v28 = call fn0(v0, v24, v26, v11, v27)  ; v24 = -1476395002, v27 = 16
-;; @001f                               v29 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @001f                               v30 = load.i64 notrap aligned readonly can_move region4 v29+32
-;; @001f                               v31 = uextend.i64 v28
-;; @001f                               v32 = iadd v30, v31
-;; @001f                               jump block4(v28, v32)
+;; @001f                               v23 = iconst.i32 -1476395002
+;; @001f                               v24 = load.i64 notrap aligned readonly can_move region3 v0+40
+;; @001f                               v25 = load.i32 notrap aligned readonly can_move v24
+;; @001f                               v26 = iconst.i32 16
+;; @001f                               v27 = call fn0(v0, v23, v25, v10, v26)  ; v23 = -1476395002, v26 = 16
+;; @001f                               v28 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @001f                               v29 = load.i64 notrap aligned readonly can_move region4 v28+32
+;; @001f                               v30 = uextend.i64 v27
+;; @001f                               v31 = iadd v29, v30
+;; @001f                               jump block4(v27, v31)
 ;;
-;;                                 block4(v41: i32, v42: i64):
-;;                                     v90 = stack_addr.i64 ss0
-;;                                     store notrap v41, v90
-;; @001f                               v43 = iconst.i64 16
-;; @001f                               v44 = iadd v42, v43  ; v43 = 16
-;; @001f                               store.i32 user2 region5 v2, v44
-;; @001f                               trapz v41, user16
-;;                                     v146 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v147 = load.i64 notrap aligned readonly can_move region4 v146+32
-;; @001f                               v47 = uextend.i64 v41
-;; @001f                               v50 = iadd v147, v47
-;; @001f                               v52 = iadd v50, v43  ; v43 = 16
-;; @001f                               v53 = load.i32 user2 readonly region5 v52
-;; @001f                               v54 = uextend.i64 v53
-;; @001f                               v60 = icmp.i64 ugt v5, v54
-;; @001f                               trapnz v60, user17
-;; @001f                               v77 = load.i64 notrap aligned region6 v146+40
-;; @001f                               v65 = iconst.i64 20
-;; @001f                               v66 = iadd v50, v65  ; v65 = 20
-;; @001f                               v79 = uadd_overflow_trap v66, v93, user2
-;; @001f                               v78 = iadd v147, v77
-;; @001f                               v80 = icmp ugt v79, v78
-;; @001f                               trapnz v80, user2
-;; @001f                               v45 = iconst.i32 0
-;; @001f                               call fn1(v0, v66, v45, v93), stack_map=[i32 @ ss0+0]  ; v45 = 0
-;;                                     v83 = load.i32 notrap v90
+;;                                 block4(v40: i32, v41: i64):
+;;                                     v89 = stack_addr.i64 ss0
+;;                                     store notrap v40, v89
+;; @001f                               v42 = iconst.i64 16
+;; @001f                               v43 = iadd v41, v42  ; v42 = 16
+;; @001f                               store.i32 user2 region5 v2, v43
+;; @001f                               trapz v40, user16
+;;                                     v145 = load.i64 notrap aligned readonly can_move region0 v0+8
+;;                                     v146 = load.i64 notrap aligned readonly can_move region4 v145+32
+;; @001f                               v46 = uextend.i64 v40
+;; @001f                               v49 = iadd v146, v46
+;; @001f                               v51 = iadd v49, v42  ; v42 = 16
+;; @001f                               v52 = load.i32 user2 readonly region5 v51
+;; @001f                               v53 = uextend.i64 v52
+;; @001f                               v59 = icmp.i64 ugt v4, v53
+;; @001f                               trapnz v59, user17
+;; @001f                               v76 = load.i64 notrap aligned region6 v145+40
+;; @001f                               v64 = iconst.i64 20
+;; @001f                               v65 = iadd v49, v64  ; v64 = 20
+;; @001f                               v78 = uadd_overflow_trap v65, v92, user2
+;; @001f                               v77 = iadd v146, v76
+;; @001f                               v79 = icmp ugt v78, v77
+;; @001f                               trapnz v79, user2
+;; @001f                               v44 = iconst.i32 0
+;; @001f                               call fn1(v0, v65, v44, v92), stack_map=[i32 @ ss0+0]  ; v44 = 0
 ;; @0022                               jump block1
 ;;
 ;;                                 block1:
-;; @0022                               return v83
+;;                                     v82 = load.i32 notrap v89
+;; @0022                               return v82
 ;; }

--- a/tests/disas/gc/array-new-default-i32.wat
+++ b/tests/disas/gc/array-new-default-i32.wat
@@ -28,89 +28,89 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @001f                               v5 = uextend.i64 v2
-;;                                     v91 = iconst.i64 2
-;;                                     v92 = ishl v5, v91  ; v91 = 2
-;; @001f                               v8 = iconst.i64 32
-;; @001f                               v9 = ushr v92, v8  ; v8 = 32
-;; @001f                               trapnz v9, user18
-;; @001f                               v4 = iconst.i32 20
-;;                                     v98 = iconst.i32 2
-;;                                     v99 = ishl v2, v98  ; v98 = 2
-;; @001f                               v11 = uadd_overflow_trap v4, v99, user18  ; v4 = 20
-;; @001f                               v12 = load.i64 notrap aligned readonly can_move region2 v0+32
-;; @001f                               v13 = load.i32 notrap aligned v12
-;; @001f                               v14 = load.i32 notrap aligned v12+4
-;; @001f                               v20 = uextend.i64 v13
-;; @001f                               v15 = uextend.i64 v11
-;; @001f                               v16 = iconst.i64 15
-;; @001f                               v18 = iadd v15, v16  ; v16 = 15
-;; @001f                               v17 = iconst.i64 -16
-;; @001f                               v19 = band v18, v17  ; v17 = -16
-;; @001f                               v21 = iadd v20, v19
-;; @001f                               v22 = uextend.i64 v14
-;; @001f                               v23 = icmp ule v21, v22
-;; @001f                               brif v23, block2, block3
+;; @001f                               v4 = uextend.i64 v2
+;;                                     v90 = iconst.i64 2
+;;                                     v91 = ishl v4, v90  ; v90 = 2
+;; @001f                               v7 = iconst.i64 32
+;; @001f                               v8 = ushr v91, v7  ; v7 = 32
+;; @001f                               trapnz v8, user18
+;; @001f                               v3 = iconst.i32 20
+;;                                     v97 = iconst.i32 2
+;;                                     v98 = ishl v2, v97  ; v97 = 2
+;; @001f                               v10 = uadd_overflow_trap v3, v98, user18  ; v3 = 20
+;; @001f                               v11 = load.i64 notrap aligned readonly can_move region2 v0+32
+;; @001f                               v12 = load.i32 notrap aligned v11
+;; @001f                               v13 = load.i32 notrap aligned v11+4
+;; @001f                               v19 = uextend.i64 v12
+;; @001f                               v14 = uextend.i64 v10
+;; @001f                               v15 = iconst.i64 15
+;; @001f                               v17 = iadd v14, v15  ; v15 = 15
+;; @001f                               v16 = iconst.i64 -16
+;; @001f                               v18 = band v17, v16  ; v16 = -16
+;; @001f                               v20 = iadd v19, v18
+;; @001f                               v21 = uextend.i64 v13
+;; @001f                               v22 = icmp ule v20, v21
+;; @001f                               brif v22, block2, block3
 ;;
 ;;                                 block2:
-;;                                     v107 = iconst.i32 15
-;;                                     v108 = iadd.i32 v11, v107  ; v107 = 15
-;;                                     v111 = iconst.i32 -16
-;;                                     v112 = band v108, v111  ; v111 = -16
-;;                                     v114 = iadd.i32 v13, v112
-;; @001f                               store notrap aligned v114, v12
-;;                                     v130 = iconst.i32 -1476395002
-;;                                     v131 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v132 = load.i64 notrap aligned readonly can_move region4 v131+32
-;; @001f                               v37 = iadd v132, v20
-;; @001f                               store notrap aligned v130, v37  ; v130 = -1476395002
-;;                                     v133 = load.i64 notrap aligned readonly can_move region3 v0+40
-;;                                     v134 = load.i32 notrap aligned readonly can_move v133
-;; @001f                               store notrap aligned v134, v37+4
-;;                                     v135 = band.i64 v18, v17  ; v17 = -16
-;; @001f                               istore32 notrap aligned v135, v37+8
-;; @001f                               jump block4(v13, v37)
+;;                                     v106 = iconst.i32 15
+;;                                     v107 = iadd.i32 v10, v106  ; v106 = 15
+;;                                     v110 = iconst.i32 -16
+;;                                     v111 = band v107, v110  ; v110 = -16
+;;                                     v113 = iadd.i32 v12, v111
+;; @001f                               store notrap aligned v113, v11
+;;                                     v129 = iconst.i32 -1476395002
+;;                                     v130 = load.i64 notrap aligned readonly can_move region0 v0+8
+;;                                     v131 = load.i64 notrap aligned readonly can_move region4 v130+32
+;; @001f                               v36 = iadd v131, v19
+;; @001f                               store notrap aligned v129, v36  ; v129 = -1476395002
+;;                                     v132 = load.i64 notrap aligned readonly can_move region3 v0+40
+;;                                     v133 = load.i32 notrap aligned readonly can_move v132
+;; @001f                               store notrap aligned v133, v36+4
+;;                                     v134 = band.i64 v17, v16  ; v16 = -16
+;; @001f                               istore32 notrap aligned v134, v36+8
+;; @001f                               jump block4(v12, v36)
 ;;
 ;;                                 block3 cold:
-;; @001f                               v24 = iconst.i32 -1476395002
-;; @001f                               v25 = load.i64 notrap aligned readonly can_move region3 v0+40
-;; @001f                               v26 = load.i32 notrap aligned readonly can_move v25
-;; @001f                               v27 = iconst.i32 16
-;; @001f                               v28 = call fn0(v0, v24, v26, v11, v27)  ; v24 = -1476395002, v27 = 16
-;; @001f                               v29 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @001f                               v30 = load.i64 notrap aligned readonly can_move region4 v29+32
-;; @001f                               v31 = uextend.i64 v28
-;; @001f                               v32 = iadd v30, v31
-;; @001f                               jump block4(v28, v32)
+;; @001f                               v23 = iconst.i32 -1476395002
+;; @001f                               v24 = load.i64 notrap aligned readonly can_move region3 v0+40
+;; @001f                               v25 = load.i32 notrap aligned readonly can_move v24
+;; @001f                               v26 = iconst.i32 16
+;; @001f                               v27 = call fn0(v0, v23, v25, v10, v26)  ; v23 = -1476395002, v26 = 16
+;; @001f                               v28 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @001f                               v29 = load.i64 notrap aligned readonly can_move region4 v28+32
+;; @001f                               v30 = uextend.i64 v27
+;; @001f                               v31 = iadd v29, v30
+;; @001f                               jump block4(v27, v31)
 ;;
-;;                                 block4(v41: i32, v42: i64):
-;;                                     v90 = stack_addr.i64 ss0
-;;                                     store notrap v41, v90
-;; @001f                               v43 = iconst.i64 16
-;; @001f                               v44 = iadd v42, v43  ; v43 = 16
-;; @001f                               store.i32 user2 region5 v2, v44
-;; @001f                               trapz v41, user16
-;;                                     v136 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v137 = load.i64 notrap aligned readonly can_move region4 v136+32
-;; @001f                               v47 = uextend.i64 v41
-;; @001f                               v50 = iadd v137, v47
-;; @001f                               v52 = iadd v50, v43  ; v43 = 16
-;; @001f                               v53 = load.i32 user2 readonly region5 v52
-;; @001f                               v54 = uextend.i64 v53
-;; @001f                               v60 = icmp.i64 ugt v5, v54
-;; @001f                               trapnz v60, user17
-;; @001f                               v77 = load.i64 notrap aligned region6 v136+40
-;; @001f                               v65 = iconst.i64 20
-;; @001f                               v66 = iadd v50, v65  ; v65 = 20
-;; @001f                               v79 = uadd_overflow_trap v66, v92, user2
-;; @001f                               v78 = iadd v137, v77
-;; @001f                               v80 = icmp ugt v79, v78
-;; @001f                               trapnz v80, user2
-;; @001f                               v45 = iconst.i32 0
-;; @001f                               call fn1(v0, v66, v45, v92), stack_map=[i32 @ ss0+0]  ; v45 = 0
-;;                                     v83 = load.i32 notrap v90
+;;                                 block4(v40: i32, v41: i64):
+;;                                     v89 = stack_addr.i64 ss0
+;;                                     store notrap v40, v89
+;; @001f                               v42 = iconst.i64 16
+;; @001f                               v43 = iadd v41, v42  ; v42 = 16
+;; @001f                               store.i32 user2 region5 v2, v43
+;; @001f                               trapz v40, user16
+;;                                     v135 = load.i64 notrap aligned readonly can_move region0 v0+8
+;;                                     v136 = load.i64 notrap aligned readonly can_move region4 v135+32
+;; @001f                               v46 = uextend.i64 v40
+;; @001f                               v49 = iadd v136, v46
+;; @001f                               v51 = iadd v49, v42  ; v42 = 16
+;; @001f                               v52 = load.i32 user2 readonly region5 v51
+;; @001f                               v53 = uextend.i64 v52
+;; @001f                               v59 = icmp.i64 ugt v4, v53
+;; @001f                               trapnz v59, user17
+;; @001f                               v76 = load.i64 notrap aligned region6 v135+40
+;; @001f                               v64 = iconst.i64 20
+;; @001f                               v65 = iadd v49, v64  ; v64 = 20
+;; @001f                               v78 = uadd_overflow_trap v65, v91, user2
+;; @001f                               v77 = iadd v136, v76
+;; @001f                               v79 = icmp ugt v78, v77
+;; @001f                               trapnz v79, user2
+;; @001f                               v44 = iconst.i32 0
+;; @001f                               call fn1(v0, v65, v44, v91), stack_map=[i32 @ ss0+0]  ; v44 = 0
 ;; @0022                               jump block1
 ;;
 ;;                                 block1:
-;; @0022                               return v83
+;;                                     v82 = load.i32 notrap v89
+;; @0022                               return v82
 ;; }

--- a/tests/disas/gc/array-new-default-i64.wat
+++ b/tests/disas/gc/array-new-default-i64.wat
@@ -28,89 +28,89 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @001f                               v5 = uextend.i64 v2
-;;                                     v91 = iconst.i64 3
-;;                                     v92 = ishl v5, v91  ; v91 = 3
-;; @001f                               v8 = iconst.i64 32
-;; @001f                               v9 = ushr v92, v8  ; v8 = 32
-;; @001f                               trapnz v9, user18
-;; @001f                               v4 = iconst.i32 24
-;;                                     v98 = iconst.i32 3
-;;                                     v99 = ishl v2, v98  ; v98 = 3
-;; @001f                               v11 = uadd_overflow_trap v4, v99, user18  ; v4 = 24
-;; @001f                               v12 = load.i64 notrap aligned readonly can_move region2 v0+32
-;; @001f                               v13 = load.i32 notrap aligned v12
-;; @001f                               v14 = load.i32 notrap aligned v12+4
-;; @001f                               v20 = uextend.i64 v13
-;; @001f                               v15 = uextend.i64 v11
-;; @001f                               v16 = iconst.i64 15
-;; @001f                               v18 = iadd v15, v16  ; v16 = 15
-;; @001f                               v17 = iconst.i64 -16
-;; @001f                               v19 = band v18, v17  ; v17 = -16
-;; @001f                               v21 = iadd v20, v19
-;; @001f                               v22 = uextend.i64 v14
-;; @001f                               v23 = icmp ule v21, v22
-;; @001f                               brif v23, block2, block3
+;; @001f                               v4 = uextend.i64 v2
+;;                                     v90 = iconst.i64 3
+;;                                     v91 = ishl v4, v90  ; v90 = 3
+;; @001f                               v7 = iconst.i64 32
+;; @001f                               v8 = ushr v91, v7  ; v7 = 32
+;; @001f                               trapnz v8, user18
+;; @001f                               v3 = iconst.i32 24
+;;                                     v97 = iconst.i32 3
+;;                                     v98 = ishl v2, v97  ; v97 = 3
+;; @001f                               v10 = uadd_overflow_trap v3, v98, user18  ; v3 = 24
+;; @001f                               v11 = load.i64 notrap aligned readonly can_move region2 v0+32
+;; @001f                               v12 = load.i32 notrap aligned v11
+;; @001f                               v13 = load.i32 notrap aligned v11+4
+;; @001f                               v19 = uextend.i64 v12
+;; @001f                               v14 = uextend.i64 v10
+;; @001f                               v15 = iconst.i64 15
+;; @001f                               v17 = iadd v14, v15  ; v15 = 15
+;; @001f                               v16 = iconst.i64 -16
+;; @001f                               v18 = band v17, v16  ; v16 = -16
+;; @001f                               v20 = iadd v19, v18
+;; @001f                               v21 = uextend.i64 v13
+;; @001f                               v22 = icmp ule v20, v21
+;; @001f                               brif v22, block2, block3
 ;;
 ;;                                 block2:
-;;                                     v107 = iconst.i32 15
-;;                                     v108 = iadd.i32 v11, v107  ; v107 = 15
-;;                                     v111 = iconst.i32 -16
-;;                                     v112 = band v108, v111  ; v111 = -16
-;;                                     v114 = iadd.i32 v13, v112
-;; @001f                               store notrap aligned v114, v12
-;;                                     v129 = iconst.i32 -1476395002
-;;                                     v130 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v131 = load.i64 notrap aligned readonly can_move region4 v130+32
-;; @001f                               v37 = iadd v131, v20
-;; @001f                               store notrap aligned v129, v37  ; v129 = -1476395002
-;;                                     v132 = load.i64 notrap aligned readonly can_move region3 v0+40
-;;                                     v133 = load.i32 notrap aligned readonly can_move v132
-;; @001f                               store notrap aligned v133, v37+4
-;;                                     v134 = band.i64 v18, v17  ; v17 = -16
-;; @001f                               istore32 notrap aligned v134, v37+8
-;; @001f                               jump block4(v13, v37)
+;;                                     v106 = iconst.i32 15
+;;                                     v107 = iadd.i32 v10, v106  ; v106 = 15
+;;                                     v110 = iconst.i32 -16
+;;                                     v111 = band v107, v110  ; v110 = -16
+;;                                     v113 = iadd.i32 v12, v111
+;; @001f                               store notrap aligned v113, v11
+;;                                     v128 = iconst.i32 -1476395002
+;;                                     v129 = load.i64 notrap aligned readonly can_move region0 v0+8
+;;                                     v130 = load.i64 notrap aligned readonly can_move region4 v129+32
+;; @001f                               v36 = iadd v130, v19
+;; @001f                               store notrap aligned v128, v36  ; v128 = -1476395002
+;;                                     v131 = load.i64 notrap aligned readonly can_move region3 v0+40
+;;                                     v132 = load.i32 notrap aligned readonly can_move v131
+;; @001f                               store notrap aligned v132, v36+4
+;;                                     v133 = band.i64 v17, v16  ; v16 = -16
+;; @001f                               istore32 notrap aligned v133, v36+8
+;; @001f                               jump block4(v12, v36)
 ;;
 ;;                                 block3 cold:
-;; @001f                               v24 = iconst.i32 -1476395002
-;; @001f                               v25 = load.i64 notrap aligned readonly can_move region3 v0+40
-;; @001f                               v26 = load.i32 notrap aligned readonly can_move v25
-;; @001f                               v27 = iconst.i32 16
-;; @001f                               v28 = call fn0(v0, v24, v26, v11, v27)  ; v24 = -1476395002, v27 = 16
-;; @001f                               v29 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @001f                               v30 = load.i64 notrap aligned readonly can_move region4 v29+32
-;; @001f                               v31 = uextend.i64 v28
-;; @001f                               v32 = iadd v30, v31
-;; @001f                               jump block4(v28, v32)
+;; @001f                               v23 = iconst.i32 -1476395002
+;; @001f                               v24 = load.i64 notrap aligned readonly can_move region3 v0+40
+;; @001f                               v25 = load.i32 notrap aligned readonly can_move v24
+;; @001f                               v26 = iconst.i32 16
+;; @001f                               v27 = call fn0(v0, v23, v25, v10, v26)  ; v23 = -1476395002, v26 = 16
+;; @001f                               v28 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @001f                               v29 = load.i64 notrap aligned readonly can_move region4 v28+32
+;; @001f                               v30 = uextend.i64 v27
+;; @001f                               v31 = iadd v29, v30
+;; @001f                               jump block4(v27, v31)
 ;;
-;;                                 block4(v41: i32, v42: i64):
-;;                                     v90 = stack_addr.i64 ss0
-;;                                     store notrap v41, v90
-;; @001f                               v43 = iconst.i64 16
-;; @001f                               v44 = iadd v42, v43  ; v43 = 16
-;; @001f                               store.i32 user2 region5 v2, v44
-;; @001f                               trapz v41, user16
-;;                                     v135 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v136 = load.i64 notrap aligned readonly can_move region4 v135+32
-;; @001f                               v47 = uextend.i64 v41
-;; @001f                               v50 = iadd v136, v47
-;; @001f                               v52 = iadd v50, v43  ; v43 = 16
-;; @001f                               v53 = load.i32 user2 readonly region5 v52
-;; @001f                               v54 = uextend.i64 v53
-;; @001f                               v60 = icmp.i64 ugt v5, v54
-;; @001f                               trapnz v60, user17
-;; @001f                               v77 = load.i64 notrap aligned region6 v135+40
-;; @001f                               v65 = iconst.i64 24
-;; @001f                               v66 = iadd v50, v65  ; v65 = 24
-;; @001f                               v79 = uadd_overflow_trap v66, v92, user2
-;; @001f                               v78 = iadd v136, v77
-;; @001f                               v80 = icmp ugt v79, v78
-;; @001f                               trapnz v80, user2
-;; @001f                               v46 = iconst.i32 0
-;; @001f                               call fn1(v0, v66, v46, v92), stack_map=[i32 @ ss0+0]  ; v46 = 0
-;;                                     v83 = load.i32 notrap v90
+;;                                 block4(v40: i32, v41: i64):
+;;                                     v89 = stack_addr.i64 ss0
+;;                                     store notrap v40, v89
+;; @001f                               v42 = iconst.i64 16
+;; @001f                               v43 = iadd v41, v42  ; v42 = 16
+;; @001f                               store.i32 user2 region5 v2, v43
+;; @001f                               trapz v40, user16
+;;                                     v134 = load.i64 notrap aligned readonly can_move region0 v0+8
+;;                                     v135 = load.i64 notrap aligned readonly can_move region4 v134+32
+;; @001f                               v46 = uextend.i64 v40
+;; @001f                               v49 = iadd v135, v46
+;; @001f                               v51 = iadd v49, v42  ; v42 = 16
+;; @001f                               v52 = load.i32 user2 readonly region5 v51
+;; @001f                               v53 = uextend.i64 v52
+;; @001f                               v59 = icmp.i64 ugt v4, v53
+;; @001f                               trapnz v59, user17
+;; @001f                               v76 = load.i64 notrap aligned region6 v134+40
+;; @001f                               v64 = iconst.i64 24
+;; @001f                               v65 = iadd v49, v64  ; v64 = 24
+;; @001f                               v78 = uadd_overflow_trap v65, v91, user2
+;; @001f                               v77 = iadd v135, v76
+;; @001f                               v79 = icmp ugt v78, v77
+;; @001f                               trapnz v79, user2
+;; @001f                               v45 = iconst.i32 0
+;; @001f                               call fn1(v0, v65, v45, v91), stack_map=[i32 @ ss0+0]  ; v45 = 0
 ;; @0022                               jump block1
 ;;
 ;;                                 block1:
-;; @0022                               return v83
+;;                                     v82 = load.i32 notrap v89
+;; @0022                               return v82
 ;; }

--- a/tests/disas/gc/array-new-default-i8.wat
+++ b/tests/disas/gc/array-new-default-i8.wat
@@ -28,85 +28,85 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @001f                               v5 = uextend.i64 v2
-;; @001f                               v8 = iconst.i64 32
-;; @001f                               v9 = ushr v5, v8  ; v8 = 32
-;; @001f                               trapnz v9, user18
-;; @001f                               v4 = iconst.i32 20
-;; @001f                               v11 = uadd_overflow_trap v4, v2, user18  ; v4 = 20
-;; @001f                               v12 = load.i64 notrap aligned readonly can_move region2 v0+32
-;; @001f                               v13 = load.i32 notrap aligned v12
-;; @001f                               v14 = load.i32 notrap aligned v12+4
-;; @001f                               v20 = uextend.i64 v13
-;; @001f                               v15 = uextend.i64 v11
-;; @001f                               v16 = iconst.i64 15
-;; @001f                               v18 = iadd v15, v16  ; v16 = 15
-;; @001f                               v17 = iconst.i64 -16
-;; @001f                               v19 = band v18, v17  ; v17 = -16
-;; @001f                               v21 = iadd v20, v19
-;; @001f                               v22 = uextend.i64 v14
-;; @001f                               v23 = icmp ule v21, v22
-;; @001f                               brif v23, block2, block3
+;; @001f                               v4 = uextend.i64 v2
+;; @001f                               v7 = iconst.i64 32
+;; @001f                               v8 = ushr v4, v7  ; v7 = 32
+;; @001f                               trapnz v8, user18
+;; @001f                               v3 = iconst.i32 20
+;; @001f                               v10 = uadd_overflow_trap v3, v2, user18  ; v3 = 20
+;; @001f                               v11 = load.i64 notrap aligned readonly can_move region2 v0+32
+;; @001f                               v12 = load.i32 notrap aligned v11
+;; @001f                               v13 = load.i32 notrap aligned v11+4
+;; @001f                               v19 = uextend.i64 v12
+;; @001f                               v14 = uextend.i64 v10
+;; @001f                               v15 = iconst.i64 15
+;; @001f                               v17 = iadd v14, v15  ; v15 = 15
+;; @001f                               v16 = iconst.i64 -16
+;; @001f                               v18 = band v17, v16  ; v16 = -16
+;; @001f                               v20 = iadd v19, v18
+;; @001f                               v21 = uextend.i64 v13
+;; @001f                               v22 = icmp ule v20, v21
+;; @001f                               brif v22, block2, block3
 ;;
 ;;                                 block2:
-;;                                     v97 = iconst.i32 15
-;;                                     v98 = iadd.i32 v11, v97  ; v97 = 15
-;;                                     v101 = iconst.i32 -16
-;;                                     v102 = band v98, v101  ; v101 = -16
-;;                                     v104 = iadd.i32 v13, v102
-;; @001f                               store notrap aligned v104, v12
-;;                                     v118 = iconst.i32 -1476395002
-;;                                     v119 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v120 = load.i64 notrap aligned readonly can_move region4 v119+32
-;; @001f                               v37 = iadd v120, v20
-;; @001f                               store notrap aligned v118, v37  ; v118 = -1476395002
-;;                                     v121 = load.i64 notrap aligned readonly can_move region3 v0+40
-;;                                     v122 = load.i32 notrap aligned readonly can_move v121
-;; @001f                               store notrap aligned v122, v37+4
-;;                                     v123 = band.i64 v18, v17  ; v17 = -16
-;; @001f                               istore32 notrap aligned v123, v37+8
-;; @001f                               jump block4(v13, v37)
+;;                                     v96 = iconst.i32 15
+;;                                     v97 = iadd.i32 v10, v96  ; v96 = 15
+;;                                     v100 = iconst.i32 -16
+;;                                     v101 = band v97, v100  ; v100 = -16
+;;                                     v103 = iadd.i32 v12, v101
+;; @001f                               store notrap aligned v103, v11
+;;                                     v117 = iconst.i32 -1476395002
+;;                                     v118 = load.i64 notrap aligned readonly can_move region0 v0+8
+;;                                     v119 = load.i64 notrap aligned readonly can_move region4 v118+32
+;; @001f                               v36 = iadd v119, v19
+;; @001f                               store notrap aligned v117, v36  ; v117 = -1476395002
+;;                                     v120 = load.i64 notrap aligned readonly can_move region3 v0+40
+;;                                     v121 = load.i32 notrap aligned readonly can_move v120
+;; @001f                               store notrap aligned v121, v36+4
+;;                                     v122 = band.i64 v17, v16  ; v16 = -16
+;; @001f                               istore32 notrap aligned v122, v36+8
+;; @001f                               jump block4(v12, v36)
 ;;
 ;;                                 block3 cold:
-;; @001f                               v24 = iconst.i32 -1476395002
-;; @001f                               v25 = load.i64 notrap aligned readonly can_move region3 v0+40
-;; @001f                               v26 = load.i32 notrap aligned readonly can_move v25
-;; @001f                               v27 = iconst.i32 16
-;; @001f                               v28 = call fn0(v0, v24, v26, v11, v27)  ; v24 = -1476395002, v27 = 16
-;; @001f                               v29 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @001f                               v30 = load.i64 notrap aligned readonly can_move region4 v29+32
-;; @001f                               v31 = uextend.i64 v28
-;; @001f                               v32 = iadd v30, v31
-;; @001f                               jump block4(v28, v32)
+;; @001f                               v23 = iconst.i32 -1476395002
+;; @001f                               v24 = load.i64 notrap aligned readonly can_move region3 v0+40
+;; @001f                               v25 = load.i32 notrap aligned readonly can_move v24
+;; @001f                               v26 = iconst.i32 16
+;; @001f                               v27 = call fn0(v0, v23, v25, v10, v26)  ; v23 = -1476395002, v26 = 16
+;; @001f                               v28 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @001f                               v29 = load.i64 notrap aligned readonly can_move region4 v28+32
+;; @001f                               v30 = uextend.i64 v27
+;; @001f                               v31 = iadd v29, v30
+;; @001f                               jump block4(v27, v31)
 ;;
-;;                                 block4(v41: i32, v42: i64):
-;;                                     v89 = stack_addr.i64 ss0
-;;                                     store notrap v41, v89
-;; @001f                               v43 = iconst.i64 16
-;; @001f                               v44 = iadd v42, v43  ; v43 = 16
-;; @001f                               store.i32 user2 region5 v2, v44
-;; @001f                               trapz v41, user16
-;;                                     v124 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v125 = load.i64 notrap aligned readonly can_move region4 v124+32
-;; @001f                               v47 = uextend.i64 v41
-;; @001f                               v50 = iadd v125, v47
-;; @001f                               v52 = iadd v50, v43  ; v43 = 16
-;; @001f                               v53 = load.i32 user2 readonly region5 v52
-;; @001f                               v54 = uextend.i64 v53
-;; @001f                               v60 = icmp.i64 ugt v5, v54
-;; @001f                               trapnz v60, user17
-;; @001f                               v77 = load.i64 notrap aligned region6 v124+40
-;; @001f                               v65 = iconst.i64 20
-;; @001f                               v66 = iadd v50, v65  ; v65 = 20
-;; @001f                               v79 = uadd_overflow_trap v66, v5, user2
-;; @001f                               v78 = iadd v125, v77
-;; @001f                               v80 = icmp ugt v79, v78
-;; @001f                               trapnz v80, user2
-;; @001f                               v45 = iconst.i32 0
-;; @001f                               call fn1(v0, v66, v45, v5), stack_map=[i32 @ ss0+0]  ; v45 = 0
-;;                                     v82 = load.i32 notrap v89
+;;                                 block4(v40: i32, v41: i64):
+;;                                     v88 = stack_addr.i64 ss0
+;;                                     store notrap v40, v88
+;; @001f                               v42 = iconst.i64 16
+;; @001f                               v43 = iadd v41, v42  ; v42 = 16
+;; @001f                               store.i32 user2 region5 v2, v43
+;; @001f                               trapz v40, user16
+;;                                     v123 = load.i64 notrap aligned readonly can_move region0 v0+8
+;;                                     v124 = load.i64 notrap aligned readonly can_move region4 v123+32
+;; @001f                               v46 = uextend.i64 v40
+;; @001f                               v49 = iadd v124, v46
+;; @001f                               v51 = iadd v49, v42  ; v42 = 16
+;; @001f                               v52 = load.i32 user2 readonly region5 v51
+;; @001f                               v53 = uextend.i64 v52
+;; @001f                               v59 = icmp.i64 ugt v4, v53
+;; @001f                               trapnz v59, user17
+;; @001f                               v76 = load.i64 notrap aligned region6 v123+40
+;; @001f                               v64 = iconst.i64 20
+;; @001f                               v65 = iadd v49, v64  ; v64 = 20
+;; @001f                               v78 = uadd_overflow_trap v65, v4, user2
+;; @001f                               v77 = iadd v124, v76
+;; @001f                               v79 = icmp ugt v78, v77
+;; @001f                               trapnz v79, user2
+;; @001f                               v44 = iconst.i32 0
+;; @001f                               call fn1(v0, v65, v44, v4), stack_map=[i32 @ ss0+0]  ; v44 = 0
 ;; @0022                               jump block1
 ;;
 ;;                                 block1:
-;; @0022                               return v82
+;;                                     v81 = load.i32 notrap v88
+;; @0022                               return v81
 ;; }

--- a/tests/disas/gc/call-indirect-final-type.wat
+++ b/tests/disas/gc/call-indirect-final-type.wat
@@ -31,39 +31,39 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
-;; @002b                               v5 = load.i64 notrap aligned region3 v0+56
-;; @002b                               v9 = load.i64 notrap aligned region2 v0+48
-;; @002b                               v6 = ireduce.i32 v5
-;; @002b                               v7 = icmp uge v3, v6
-;; @002b                               v13 = iconst.i64 0
-;; @002b                               v8 = uextend.i64 v3
-;; @002b                               v10 = iconst.i64 3
-;; @002b                               v11 = ishl v8, v10  ; v10 = 3
-;; @002b                               v12 = iadd v9, v11
-;; @002b                               v14 = select_spectre_guard v7, v13, v12  ; v13 = 0
-;; @002b                               v15 = load.i64 user6 aligned region4 v14
-;; @002b                               v16 = iconst.i64 -2
-;; @002b                               v17 = band v15, v16  ; v16 = -2
-;; @002b                               brif v15, block3(v17), block2
+;; @002b                               v4 = load.i64 notrap aligned region3 v0+56
+;; @002b                               v8 = load.i64 notrap aligned region2 v0+48
+;; @002b                               v5 = ireduce.i32 v4
+;; @002b                               v6 = icmp uge v3, v5
+;; @002b                               v12 = iconst.i64 0
+;; @002b                               v7 = uextend.i64 v3
+;; @002b                               v9 = iconst.i64 3
+;; @002b                               v10 = ishl v7, v9  ; v9 = 3
+;; @002b                               v11 = iadd v8, v10
+;; @002b                               v13 = select_spectre_guard v6, v12, v11  ; v12 = 0
+;; @002b                               v14 = load.i64 user6 aligned region4 v13
+;; @002b                               v15 = iconst.i64 -2
+;; @002b                               v16 = band v14, v15  ; v15 = -2
+;; @002b                               brif v14, block3(v16), block2
 ;;
 ;;                                 block2 cold:
-;; @002b                               v19 = iconst.i32 0
-;; @002b                               v21 = call fn0(v0, v19, v8)  ; v19 = 0
-;; @002b                               jump block3(v21)
+;; @002b                               v18 = iconst.i32 0
+;; @002b                               v20 = call fn0(v0, v18, v7)  ; v18 = 0
+;; @002b                               jump block3(v20)
 ;;
-;;                                 block3(v18: i64):
-;; @002b                               v24 = load.i32 user7 aligned readonly v18+16
-;; @002b                               v22 = load.i64 notrap aligned readonly can_move region5 v0+40
-;; @002b                               v23 = load.i32 notrap aligned readonly can_move v22
-;; @002b                               v25 = icmp eq v24, v23
-;; @002b                               trapz v25, user8
-;; @002b                               v27 = load.i64 notrap aligned readonly v18+8
-;; @002b                               v28 = load.i64 notrap aligned readonly v18+24
-;; @002b                               v29 = call_indirect sig0, v27(v28, v0, v2)
+;;                                 block3(v17: i64):
+;; @002b                               v23 = load.i32 user7 aligned readonly v17+16
+;; @002b                               v21 = load.i64 notrap aligned readonly can_move region5 v0+40
+;; @002b                               v22 = load.i32 notrap aligned readonly can_move v21
+;; @002b                               v24 = icmp eq v23, v22
+;; @002b                               trapz v24, user8
+;; @002b                               v26 = load.i64 notrap aligned readonly v17+8
+;; @002b                               v27 = load.i64 notrap aligned readonly v17+24
+;; @002b                               v28 = call_indirect sig0, v26(v27, v0, v2)
 ;; @002e                               jump block1
 ;;
 ;;                                 block1:
-;; @002e                               return v29
+;; @002e                               return v28
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32, i32) -> i32 tail {
@@ -82,33 +82,33 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
-;; @0035                               v5 = load.i64 notrap aligned region3 v0+56
-;; @0035                               v9 = load.i64 notrap aligned region2 v0+48
-;; @0035                               v6 = ireduce.i32 v5
-;; @0035                               v7 = icmp uge v3, v6
-;; @0035                               v13 = iconst.i64 0
-;; @0035                               v8 = uextend.i64 v3
-;; @0035                               v10 = iconst.i64 3
-;; @0035                               v11 = ishl v8, v10  ; v10 = 3
-;; @0035                               v12 = iadd v9, v11
-;; @0035                               v14 = select_spectre_guard v7, v13, v12  ; v13 = 0
-;; @0035                               v15 = load.i64 user6 aligned region4 v14
-;; @0035                               v16 = iconst.i64 -2
-;; @0035                               v17 = band v15, v16  ; v16 = -2
-;; @0035                               brif v15, block3(v17), block2
+;; @0035                               v4 = load.i64 notrap aligned region3 v0+56
+;; @0035                               v8 = load.i64 notrap aligned region2 v0+48
+;; @0035                               v5 = ireduce.i32 v4
+;; @0035                               v6 = icmp uge v3, v5
+;; @0035                               v12 = iconst.i64 0
+;; @0035                               v7 = uextend.i64 v3
+;; @0035                               v9 = iconst.i64 3
+;; @0035                               v10 = ishl v7, v9  ; v9 = 3
+;; @0035                               v11 = iadd v8, v10
+;; @0035                               v13 = select_spectre_guard v6, v12, v11  ; v12 = 0
+;; @0035                               v14 = load.i64 user6 aligned region4 v13
+;; @0035                               v15 = iconst.i64 -2
+;; @0035                               v16 = band v14, v15  ; v15 = -2
+;; @0035                               brif v14, block3(v16), block2
 ;;
 ;;                                 block2 cold:
-;; @0035                               v19 = iconst.i32 0
-;; @0035                               v21 = call fn0(v0, v19, v8)  ; v19 = 0
-;; @0035                               jump block3(v21)
+;; @0035                               v18 = iconst.i32 0
+;; @0035                               v20 = call fn0(v0, v18, v7)  ; v18 = 0
+;; @0035                               jump block3(v20)
 ;;
-;;                                 block3(v18: i64):
-;; @0035                               v24 = load.i32 user7 aligned readonly v18+16
-;; @0035                               v22 = load.i64 notrap aligned readonly can_move region5 v0+40
-;; @0035                               v23 = load.i32 notrap aligned readonly can_move v22
-;; @0035                               v25 = icmp eq v24, v23
-;; @0035                               trapz v25, user8
-;; @0035                               v27 = load.i64 notrap aligned readonly v18+8
-;; @0035                               v28 = load.i64 notrap aligned readonly v18+24
-;; @0035                               return_call_indirect sig0, v27(v28, v0, v2)
+;;                                 block3(v17: i64):
+;; @0035                               v23 = load.i32 user7 aligned readonly v17+16
+;; @0035                               v21 = load.i64 notrap aligned readonly can_move region5 v0+40
+;; @0035                               v22 = load.i32 notrap aligned readonly can_move v21
+;; @0035                               v24 = icmp eq v23, v22
+;; @0035                               trapz v24, user8
+;; @0035                               v26 = load.i64 notrap aligned readonly v17+8
+;; @0035                               v27 = load.i64 notrap aligned readonly v17+24
+;; @0035                               return_call_indirect sig0, v26(v27, v0, v2)
 ;; }

--- a/tests/disas/gc/copying/array-get-s.wat
+++ b/tests/disas/gc/copying/array-get-s.wat
@@ -21,32 +21,32 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0022                               trapz v2, user16
-;; @0022                               v6 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0022                               v7 = load.i64 notrap aligned readonly can_move region2 v6+32
-;; @0022                               v5 = uextend.i64 v2
-;; @0022                               v8 = iadd v7, v5
-;; @0022                               v9 = iconst.i64 16
-;; @0022                               v10 = iadd v8, v9  ; v9 = 16
-;; @0022                               v11 = load.i32 user2 readonly region4 v10
-;; @0022                               v12 = icmp ult v3, v11
-;; @0022                               trapz v12, user17
-;; @0022                               v14 = uextend.i64 v11
-;; @0022                               v16 = iconst.i64 32
-;; @0022                               v17 = ushr v14, v16  ; v16 = 32
-;; @0022                               trapnz v17, user2
-;; @0022                               v19 = iconst.i32 20
-;; @0022                               v20 = uadd_overflow_trap v11, v19, user2  ; v19 = 20
-;; @0022                               v24 = uadd_overflow_trap v2, v20, user2
-;; @0022                               v25 = uextend.i64 v24
-;; @0022                               v28 = iadd v7, v25
-;; @0022                               v23 = iadd v3, v19  ; v19 = 20
-;; @0022                               v29 = isub v20, v23
-;; @0022                               v30 = uextend.i64 v29
-;; @0022                               v31 = isub v28, v30
-;; @0022                               v32 = load.i8 user2 little region4 v31
+;; @0022                               v5 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @0022                               v6 = load.i64 notrap aligned readonly can_move region2 v5+32
+;; @0022                               v4 = uextend.i64 v2
+;; @0022                               v7 = iadd v6, v4
+;; @0022                               v8 = iconst.i64 16
+;; @0022                               v9 = iadd v7, v8  ; v8 = 16
+;; @0022                               v10 = load.i32 user2 readonly region4 v9
+;; @0022                               v11 = icmp ult v3, v10
+;; @0022                               trapz v11, user17
+;; @0022                               v13 = uextend.i64 v10
+;; @0022                               v15 = iconst.i64 32
+;; @0022                               v16 = ushr v13, v15  ; v15 = 32
+;; @0022                               trapnz v16, user2
+;; @0022                               v18 = iconst.i32 20
+;; @0022                               v19 = uadd_overflow_trap v10, v18, user2  ; v18 = 20
+;; @0022                               v23 = uadd_overflow_trap v2, v19, user2
+;; @0022                               v24 = uextend.i64 v23
+;; @0022                               v27 = iadd v6, v24
+;; @0022                               v22 = iadd v3, v18  ; v18 = 20
+;; @0022                               v28 = isub v19, v22
+;; @0022                               v29 = uextend.i64 v28
+;; @0022                               v30 = isub v27, v29
+;; @0022                               v31 = load.i8 user2 little region4 v30
 ;; @0025                               jump block1
 ;;
 ;;                                 block1:
-;; @0022                               v33 = sextend.i32 v32
-;; @0025                               return v33
+;; @0022                               v32 = sextend.i32 v31
+;; @0025                               return v32
 ;; }

--- a/tests/disas/gc/copying/array-get-u.wat
+++ b/tests/disas/gc/copying/array-get-u.wat
@@ -21,32 +21,32 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0022                               trapz v2, user16
-;; @0022                               v6 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0022                               v7 = load.i64 notrap aligned readonly can_move region2 v6+32
-;; @0022                               v5 = uextend.i64 v2
-;; @0022                               v8 = iadd v7, v5
-;; @0022                               v9 = iconst.i64 16
-;; @0022                               v10 = iadd v8, v9  ; v9 = 16
-;; @0022                               v11 = load.i32 user2 readonly region4 v10
-;; @0022                               v12 = icmp ult v3, v11
-;; @0022                               trapz v12, user17
-;; @0022                               v14 = uextend.i64 v11
-;; @0022                               v16 = iconst.i64 32
-;; @0022                               v17 = ushr v14, v16  ; v16 = 32
-;; @0022                               trapnz v17, user2
-;; @0022                               v19 = iconst.i32 20
-;; @0022                               v20 = uadd_overflow_trap v11, v19, user2  ; v19 = 20
-;; @0022                               v24 = uadd_overflow_trap v2, v20, user2
-;; @0022                               v25 = uextend.i64 v24
-;; @0022                               v28 = iadd v7, v25
-;; @0022                               v23 = iadd v3, v19  ; v19 = 20
-;; @0022                               v29 = isub v20, v23
-;; @0022                               v30 = uextend.i64 v29
-;; @0022                               v31 = isub v28, v30
-;; @0022                               v32 = load.i8 user2 little region4 v31
+;; @0022                               v5 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @0022                               v6 = load.i64 notrap aligned readonly can_move region2 v5+32
+;; @0022                               v4 = uextend.i64 v2
+;; @0022                               v7 = iadd v6, v4
+;; @0022                               v8 = iconst.i64 16
+;; @0022                               v9 = iadd v7, v8  ; v8 = 16
+;; @0022                               v10 = load.i32 user2 readonly region4 v9
+;; @0022                               v11 = icmp ult v3, v10
+;; @0022                               trapz v11, user17
+;; @0022                               v13 = uextend.i64 v10
+;; @0022                               v15 = iconst.i64 32
+;; @0022                               v16 = ushr v13, v15  ; v15 = 32
+;; @0022                               trapnz v16, user2
+;; @0022                               v18 = iconst.i32 20
+;; @0022                               v19 = uadd_overflow_trap v10, v18, user2  ; v18 = 20
+;; @0022                               v23 = uadd_overflow_trap v2, v19, user2
+;; @0022                               v24 = uextend.i64 v23
+;; @0022                               v27 = iadd v6, v24
+;; @0022                               v22 = iadd v3, v18  ; v18 = 20
+;; @0022                               v28 = isub v19, v22
+;; @0022                               v29 = uextend.i64 v28
+;; @0022                               v30 = isub v27, v29
+;; @0022                               v31 = load.i8 user2 little region4 v30
 ;; @0025                               jump block1
 ;;
 ;;                                 block1:
-;; @0022                               v33 = uextend.i32 v32
-;; @0025                               return v33
+;; @0022                               v32 = uextend.i32 v31
+;; @0025                               return v32
 ;; }

--- a/tests/disas/gc/copying/array-get.wat
+++ b/tests/disas/gc/copying/array-get.wat
@@ -21,36 +21,36 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0022                               trapz v2, user16
-;; @0022                               v6 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0022                               v7 = load.i64 notrap aligned readonly can_move region2 v6+32
-;; @0022                               v5 = uextend.i64 v2
-;; @0022                               v8 = iadd v7, v5
-;; @0022                               v9 = iconst.i64 16
-;; @0022                               v10 = iadd v8, v9  ; v9 = 16
-;; @0022                               v11 = load.i32 user2 readonly region4 v10
-;; @0022                               v12 = icmp ult v3, v11
-;; @0022                               trapz v12, user17
-;; @0022                               v14 = uextend.i64 v11
-;;                                     v33 = iconst.i64 3
-;;                                     v34 = ishl v14, v33  ; v33 = 3
-;; @0022                               v16 = iconst.i64 32
-;; @0022                               v17 = ushr v34, v16  ; v16 = 32
-;; @0022                               trapnz v17, user2
-;;                                     v43 = iconst.i32 3
-;;                                     v44 = ishl v11, v43  ; v43 = 3
-;; @0022                               v19 = iconst.i32 24
-;; @0022                               v20 = uadd_overflow_trap v44, v19, user2  ; v19 = 24
-;; @0022                               v24 = uadd_overflow_trap v2, v20, user2
-;; @0022                               v25 = uextend.i64 v24
-;; @0022                               v28 = iadd v7, v25
-;;                                     v50 = ishl v3, v43  ; v43 = 3
-;; @0022                               v23 = iadd v50, v19  ; v19 = 24
-;; @0022                               v29 = isub v20, v23
-;; @0022                               v30 = uextend.i64 v29
-;; @0022                               v31 = isub v28, v30
-;; @0022                               v32 = load.i64 user2 little region4 v31
+;; @0022                               v5 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @0022                               v6 = load.i64 notrap aligned readonly can_move region2 v5+32
+;; @0022                               v4 = uextend.i64 v2
+;; @0022                               v7 = iadd v6, v4
+;; @0022                               v8 = iconst.i64 16
+;; @0022                               v9 = iadd v7, v8  ; v8 = 16
+;; @0022                               v10 = load.i32 user2 readonly region4 v9
+;; @0022                               v11 = icmp ult v3, v10
+;; @0022                               trapz v11, user17
+;; @0022                               v13 = uextend.i64 v10
+;;                                     v32 = iconst.i64 3
+;;                                     v33 = ishl v13, v32  ; v32 = 3
+;; @0022                               v15 = iconst.i64 32
+;; @0022                               v16 = ushr v33, v15  ; v15 = 32
+;; @0022                               trapnz v16, user2
+;;                                     v42 = iconst.i32 3
+;;                                     v43 = ishl v10, v42  ; v42 = 3
+;; @0022                               v18 = iconst.i32 24
+;; @0022                               v19 = uadd_overflow_trap v43, v18, user2  ; v18 = 24
+;; @0022                               v23 = uadd_overflow_trap v2, v19, user2
+;; @0022                               v24 = uextend.i64 v23
+;; @0022                               v27 = iadd v6, v24
+;;                                     v49 = ishl v3, v42  ; v42 = 3
+;; @0022                               v22 = iadd v49, v18  ; v18 = 24
+;; @0022                               v28 = isub v19, v22
+;; @0022                               v29 = uextend.i64 v28
+;; @0022                               v30 = isub v27, v29
+;; @0022                               v31 = load.i64 user2 little region4 v30
 ;; @0025                               jump block1
 ;;
 ;;                                 block1:
-;; @0025                               return v32
+;; @0025                               return v31
 ;; }

--- a/tests/disas/gc/copying/array-len.wat
+++ b/tests/disas/gc/copying/array-len.wat
@@ -21,15 +21,15 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @001f                               trapz v2, user16
-;; @001f                               v5 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @001f                               v6 = load.i64 notrap aligned readonly can_move region2 v5+32
-;; @001f                               v4 = uextend.i64 v2
-;; @001f                               v7 = iadd v6, v4
-;; @001f                               v8 = iconst.i64 16
-;; @001f                               v9 = iadd v7, v8  ; v8 = 16
-;; @001f                               v10 = load.i32 user2 readonly region4 v9
+;; @001f                               v4 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @001f                               v5 = load.i64 notrap aligned readonly can_move region2 v4+32
+;; @001f                               v3 = uextend.i64 v2
+;; @001f                               v6 = iadd v5, v3
+;; @001f                               v7 = iconst.i64 16
+;; @001f                               v8 = iadd v6, v7  ; v7 = 16
+;; @001f                               v9 = load.i32 user2 readonly region4 v8
 ;; @0021                               jump block1
 ;;
 ;;                                 block1:
-;; @0021                               return v10
+;; @0021                               return v9
 ;; }

--- a/tests/disas/gc/copying/array-new-fixed-of-gc-refs.wat
+++ b/tests/disas/gc/copying/array-new-fixed-of-gc-refs.wat
@@ -27,121 +27,121 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
-;;                                     v138 = stack_addr.i64 ss2
-;;                                     store notrap v2, v138
-;;                                     v139 = stack_addr.i64 ss1
-;;                                     store notrap v3, v139
-;;                                     v140 = stack_addr.i64 ss0
-;;                                     store notrap v4, v140
-;; @0025                               v15 = load.i64 notrap aligned readonly can_move region2 v0+32
-;; @0025                               v16 = load.i32 notrap aligned v15
-;; @0025                               v17 = load.i32 notrap aligned v15+4
-;; @0025                               v23 = uextend.i64 v16
-;; @0025                               v11 = iconst.i64 32
-;; @0025                               v24 = iadd v23, v11  ; v11 = 32
-;; @0025                               v25 = uextend.i64 v17
-;; @0025                               v26 = icmp ule v24, v25
-;; @0025                               brif v26, block2, block3
+;;                                     v137 = stack_addr.i64 ss2
+;;                                     store notrap v2, v137
+;;                                     v138 = stack_addr.i64 ss1
+;;                                     store notrap v3, v138
+;;                                     v139 = stack_addr.i64 ss0
+;;                                     store notrap v4, v139
+;; @0025                               v14 = load.i64 notrap aligned readonly can_move region2 v0+32
+;; @0025                               v15 = load.i32 notrap aligned v14
+;; @0025                               v16 = load.i32 notrap aligned v14+4
+;; @0025                               v22 = uextend.i64 v15
+;; @0025                               v10 = iconst.i64 32
+;; @0025                               v23 = iadd v22, v10  ; v10 = 32
+;; @0025                               v24 = uextend.i64 v16
+;; @0025                               v25 = icmp ule v23, v24
+;; @0025                               brif v25, block2, block3
 ;;
 ;;                                 block2:
-;;                                     v260 = iconst.i32 32
-;;                                     v166 = iadd.i32 v16, v260  ; v260 = 32
-;; @0025                               store notrap aligned v166, v15
-;;                                     v261 = iconst.i32 -1476394994
-;;                                     v262 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v263 = load.i64 notrap aligned readonly can_move region4 v262+32
-;; @0025                               v40 = iadd v263, v23
-;; @0025                               store notrap aligned v261, v40  ; v261 = -1476394994
-;;                                     v264 = load.i64 notrap aligned readonly can_move region3 v0+40
-;;                                     v265 = load.i32 notrap aligned readonly can_move v264
-;; @0025                               store notrap aligned v265, v40+4
-;;                                     v266 = iconst.i64 32
-;; @0025                               istore32 notrap aligned v266, v40+8  ; v266 = 32
-;; @0025                               jump block4(v16, v40)
+;;                                     v259 = iconst.i32 32
+;;                                     v165 = iadd.i32 v15, v259  ; v259 = 32
+;; @0025                               store notrap aligned v165, v14
+;;                                     v260 = iconst.i32 -1476394994
+;;                                     v261 = load.i64 notrap aligned readonly can_move region0 v0+8
+;;                                     v262 = load.i64 notrap aligned readonly can_move region4 v261+32
+;; @0025                               v39 = iadd v262, v22
+;; @0025                               store notrap aligned v260, v39  ; v260 = -1476394994
+;;                                     v263 = load.i64 notrap aligned readonly can_move region3 v0+40
+;;                                     v264 = load.i32 notrap aligned readonly can_move v263
+;; @0025                               store notrap aligned v264, v39+4
+;;                                     v265 = iconst.i64 32
+;; @0025                               istore32 notrap aligned v265, v39+8  ; v265 = 32
+;; @0025                               jump block4(v15, v39)
 ;;
 ;;                                 block3 cold:
-;; @0025                               v27 = iconst.i32 -1476394994
-;; @0025                               v28 = load.i64 notrap aligned readonly can_move region3 v0+40
-;; @0025                               v29 = load.i32 notrap aligned readonly can_move v28
-;;                                     v152 = iconst.i32 32
-;; @0025                               v30 = iconst.i32 16
-;; @0025                               v31 = call fn0(v0, v27, v29, v152, v30), stack_map=[i32 @ ss2+0, i32 @ ss1+0, i32 @ ss0+0]  ; v27 = -1476394994, v152 = 32, v30 = 16
-;; @0025                               v32 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0025                               v33 = load.i64 notrap aligned readonly can_move region4 v32+32
-;; @0025                               v34 = uextend.i64 v31
-;; @0025                               v35 = iadd v33, v34
-;; @0025                               jump block4(v31, v35)
+;; @0025                               v26 = iconst.i32 -1476394994
+;; @0025                               v27 = load.i64 notrap aligned readonly can_move region3 v0+40
+;; @0025                               v28 = load.i32 notrap aligned readonly can_move v27
+;;                                     v151 = iconst.i32 32
+;; @0025                               v29 = iconst.i32 16
+;; @0025                               v30 = call fn0(v0, v26, v28, v151, v29), stack_map=[i32 @ ss2+0, i32 @ ss1+0, i32 @ ss0+0]  ; v26 = -1476394994, v151 = 32, v29 = 16
+;; @0025                               v31 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @0025                               v32 = load.i64 notrap aligned readonly can_move region4 v31+32
+;; @0025                               v33 = uextend.i64 v30
+;; @0025                               v34 = iadd v32, v33
+;; @0025                               jump block4(v30, v34)
 ;;
-;;                                 block4(v44: i32, v45: i64):
-;; @0025                               v6 = iconst.i32 3
-;; @0025                               v46 = iconst.i64 16
-;; @0025                               v47 = iadd v45, v46  ; v46 = 16
-;; @0025                               store user2 region5 v6, v47  ; v6 = 3
-;; @0025                               trapz v44, user16
-;;                                     v267 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v268 = load.i64 notrap aligned readonly can_move region4 v267+32
-;; @0025                               v49 = uextend.i64 v44
-;; @0025                               v52 = iadd v268, v49
-;; @0025                               v54 = iadd v52, v46  ; v46 = 16
-;; @0025                               v55 = load.i32 user2 readonly region5 v54
-;; @0025                               trapz v55, user17
-;; @0025                               v58 = uextend.i64 v55
-;;                                     v143 = iconst.i64 2
-;;                                     v172 = ishl v58, v143  ; v143 = 2
-;;                                     v269 = iconst.i64 32
-;;                                     v270 = ushr v172, v269  ; v269 = 32
+;;                                 block4(v43: i32, v44: i64):
+;; @0025                               v5 = iconst.i32 3
+;; @0025                               v45 = iconst.i64 16
+;; @0025                               v46 = iadd v44, v45  ; v45 = 16
+;; @0025                               store user2 region5 v5, v46  ; v5 = 3
+;; @0025                               trapz v43, user16
+;;                                     v266 = load.i64 notrap aligned readonly can_move region0 v0+8
+;;                                     v267 = load.i64 notrap aligned readonly can_move region4 v266+32
+;; @0025                               v48 = uextend.i64 v43
+;; @0025                               v51 = iadd v267, v48
+;; @0025                               v53 = iadd v51, v45  ; v45 = 16
+;; @0025                               v54 = load.i32 user2 readonly region5 v53
+;; @0025                               trapz v54, user17
+;; @0025                               v57 = uextend.i64 v54
+;;                                     v142 = iconst.i64 2
+;;                                     v171 = ishl v57, v142  ; v142 = 2
+;;                                     v268 = iconst.i64 32
+;;                                     v269 = ushr v171, v268  ; v268 = 32
+;; @0025                               trapnz v269, user2
+;;                                     v180 = iconst.i32 2
+;;                                     v181 = ishl v54, v180  ; v180 = 2
+;; @0025                               v6 = iconst.i32 20
+;; @0025                               v63 = uadd_overflow_trap v181, v6, user2  ; v6 = 20
+;; @0025                               v67 = uadd_overflow_trap v43, v63, user2
+;;                                     v136 = load.i32 notrap v137
+;; @0025                               v68 = uextend.i64 v67
+;; @0025                               v71 = iadd v267, v68
+;; @0025                               v72 = isub v63, v6  ; v6 = 20
+;; @0025                               v73 = uextend.i64 v72
+;; @0025                               v74 = isub v71, v73
+;; @0025                               store user2 little region5 v136, v74
+;; @0025                               v82 = load.i32 user2 readonly region5 v53
+;; @0025                               v75 = iconst.i32 1
+;;                                     v198 = icmp ugt v82, v75  ; v75 = 1
+;; @0025                               trapz v198, user17
+;; @0025                               v85 = uextend.i64 v82
+;;                                     v200 = ishl v85, v142  ; v142 = 2
+;;                                     v270 = ushr v200, v268  ; v268 = 32
 ;; @0025                               trapnz v270, user2
-;;                                     v181 = iconst.i32 2
-;;                                     v182 = ishl v55, v181  ; v181 = 2
-;; @0025                               v7 = iconst.i32 20
-;; @0025                               v64 = uadd_overflow_trap v182, v7, user2  ; v7 = 20
-;; @0025                               v68 = uadd_overflow_trap v44, v64, user2
-;;                                     v137 = load.i32 notrap v138
-;; @0025                               v69 = uextend.i64 v68
-;; @0025                               v72 = iadd v268, v69
-;; @0025                               v73 = isub v64, v7  ; v7 = 20
-;; @0025                               v74 = uextend.i64 v73
-;; @0025                               v75 = isub v72, v74
-;; @0025                               store user2 little region5 v137, v75
-;; @0025                               v83 = load.i32 user2 readonly region5 v54
-;; @0025                               v76 = iconst.i32 1
-;;                                     v199 = icmp ugt v83, v76  ; v76 = 1
-;; @0025                               trapz v199, user17
-;; @0025                               v86 = uextend.i64 v83
-;;                                     v201 = ishl v86, v143  ; v143 = 2
-;;                                     v271 = ushr v201, v269  ; v269 = 32
+;;                                     v207 = ishl v82, v180  ; v180 = 2
+;; @0025                               v91 = uadd_overflow_trap v207, v6, user2  ; v6 = 20
+;; @0025                               v95 = uadd_overflow_trap v43, v91, user2
+;;                                     v134 = load.i32 notrap v138
+;; @0025                               v96 = uextend.i64 v95
+;; @0025                               v99 = iadd v267, v96
+;;                                     v220 = iconst.i32 24
+;; @0025                               v100 = isub v91, v220  ; v220 = 24
+;; @0025                               v101 = uextend.i64 v100
+;; @0025                               v102 = isub v99, v101
+;; @0025                               store user2 little region5 v134, v102
+;; @0025                               v110 = load.i32 user2 readonly region5 v53
+;;                                     v226 = icmp ugt v110, v180  ; v180 = 2
+;; @0025                               trapz v226, user17
+;; @0025                               v113 = uextend.i64 v110
+;;                                     v228 = ishl v113, v142  ; v142 = 2
+;;                                     v271 = ushr v228, v268  ; v268 = 32
 ;; @0025                               trapnz v271, user2
-;;                                     v208 = ishl v83, v181  ; v181 = 2
-;; @0025                               v92 = uadd_overflow_trap v208, v7, user2  ; v7 = 20
-;; @0025                               v96 = uadd_overflow_trap v44, v92, user2
-;;                                     v135 = load.i32 notrap v139
-;; @0025                               v97 = uextend.i64 v96
-;; @0025                               v100 = iadd v268, v97
-;;                                     v221 = iconst.i32 24
-;; @0025                               v101 = isub v92, v221  ; v221 = 24
-;; @0025                               v102 = uextend.i64 v101
-;; @0025                               v103 = isub v100, v102
-;; @0025                               store user2 little region5 v135, v103
-;; @0025                               v111 = load.i32 user2 readonly region5 v54
-;;                                     v227 = icmp ugt v111, v181  ; v181 = 2
-;; @0025                               trapz v227, user17
-;; @0025                               v114 = uextend.i64 v111
-;;                                     v229 = ishl v114, v143  ; v143 = 2
-;;                                     v272 = ushr v229, v269  ; v269 = 32
-;; @0025                               trapnz v272, user2
-;;                                     v236 = ishl v111, v181  ; v181 = 2
-;; @0025                               v120 = uadd_overflow_trap v236, v7, user2  ; v7 = 20
-;; @0025                               v124 = uadd_overflow_trap v44, v120, user2
-;;                                     v133 = load.i32 notrap v140
-;; @0025                               v125 = uextend.i64 v124
-;; @0025                               v128 = iadd v268, v125
-;;                                     v254 = iconst.i32 28
-;; @0025                               v129 = isub v120, v254  ; v254 = 28
-;; @0025                               v130 = uextend.i64 v129
-;; @0025                               v131 = isub v128, v130
-;; @0025                               store user2 little region5 v133, v131
-;; @0029                               jump block1(v44)
+;;                                     v235 = ishl v110, v180  ; v180 = 2
+;; @0025                               v119 = uadd_overflow_trap v235, v6, user2  ; v6 = 20
+;; @0025                               v123 = uadd_overflow_trap v43, v119, user2
+;;                                     v132 = load.i32 notrap v139
+;; @0025                               v124 = uextend.i64 v123
+;; @0025                               v127 = iadd v267, v124
+;;                                     v253 = iconst.i32 28
+;; @0025                               v128 = isub v119, v253  ; v253 = 28
+;; @0025                               v129 = uextend.i64 v128
+;; @0025                               v130 = isub v127, v129
+;; @0025                               store user2 little region5 v132, v130
+;; @0029                               jump block1
 ;;
-;;                                 block1(v5: i32):
-;; @0029                               return v5
+;;                                 block1:
+;; @0029                               return v43
 ;; }

--- a/tests/disas/gc/copying/array-new-fixed.wat
+++ b/tests/disas/gc/copying/array-new-fixed.wat
@@ -24,112 +24,112 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i64, v4: i64):
-;; @0025                               v15 = load.i64 notrap aligned readonly can_move region2 v0+32
-;; @0025                               v16 = load.i32 notrap aligned v15
-;; @0025                               v17 = load.i32 notrap aligned v15+4
-;; @0025                               v23 = uextend.i64 v16
-;;                                     v142 = iconst.i64 48
-;; @0025                               v24 = iadd v23, v142  ; v142 = 48
-;; @0025                               v25 = uextend.i64 v17
-;; @0025                               v26 = icmp ule v24, v25
-;; @0025                               brif v26, block2, block3
+;; @0025                               v14 = load.i64 notrap aligned readonly can_move region2 v0+32
+;; @0025                               v15 = load.i32 notrap aligned v14
+;; @0025                               v16 = load.i32 notrap aligned v14+4
+;; @0025                               v22 = uextend.i64 v15
+;;                                     v141 = iconst.i64 48
+;; @0025                               v23 = iadd v22, v141  ; v141 = 48
+;; @0025                               v24 = uextend.i64 v16
+;; @0025                               v25 = icmp ule v23, v24
+;; @0025                               brif v25, block2, block3
 ;;
 ;;                                 block2:
-;;                                     v248 = iconst.i32 48
-;;                                     v156 = iadd.i32 v16, v248  ; v248 = 48
-;; @0025                               store notrap aligned v156, v15
-;;                                     v249 = iconst.i32 -1476395002
-;;                                     v250 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v251 = load.i64 notrap aligned readonly can_move region4 v250+32
-;; @0025                               v40 = iadd v251, v23
-;; @0025                               store notrap aligned v249, v40  ; v249 = -1476395002
-;;                                     v252 = load.i64 notrap aligned readonly can_move region3 v0+40
-;;                                     v253 = load.i32 notrap aligned readonly can_move v252
-;; @0025                               store notrap aligned v253, v40+4
-;;                                     v254 = iconst.i64 48
-;; @0025                               istore32 notrap aligned v254, v40+8  ; v254 = 48
-;; @0025                               jump block4(v16, v40)
+;;                                     v247 = iconst.i32 48
+;;                                     v155 = iadd.i32 v15, v247  ; v247 = 48
+;; @0025                               store notrap aligned v155, v14
+;;                                     v248 = iconst.i32 -1476395002
+;;                                     v249 = load.i64 notrap aligned readonly can_move region0 v0+8
+;;                                     v250 = load.i64 notrap aligned readonly can_move region4 v249+32
+;; @0025                               v39 = iadd v250, v22
+;; @0025                               store notrap aligned v248, v39  ; v248 = -1476395002
+;;                                     v251 = load.i64 notrap aligned readonly can_move region3 v0+40
+;;                                     v252 = load.i32 notrap aligned readonly can_move v251
+;; @0025                               store notrap aligned v252, v39+4
+;;                                     v253 = iconst.i64 48
+;; @0025                               istore32 notrap aligned v253, v39+8  ; v253 = 48
+;; @0025                               jump block4(v15, v39)
 ;;
 ;;                                 block3 cold:
-;; @0025                               v27 = iconst.i32 -1476395002
-;; @0025                               v28 = load.i64 notrap aligned readonly can_move region3 v0+40
-;; @0025                               v29 = load.i32 notrap aligned readonly can_move v28
-;;                                     v141 = iconst.i32 48
-;; @0025                               v30 = iconst.i32 16
-;; @0025                               v31 = call fn0(v0, v27, v29, v141, v30)  ; v27 = -1476395002, v141 = 48, v30 = 16
-;; @0025                               v32 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0025                               v33 = load.i64 notrap aligned readonly can_move region4 v32+32
-;; @0025                               v34 = uextend.i64 v31
-;; @0025                               v35 = iadd v33, v34
-;; @0025                               jump block4(v31, v35)
+;; @0025                               v26 = iconst.i32 -1476395002
+;; @0025                               v27 = load.i64 notrap aligned readonly can_move region3 v0+40
+;; @0025                               v28 = load.i32 notrap aligned readonly can_move v27
+;;                                     v140 = iconst.i32 48
+;; @0025                               v29 = iconst.i32 16
+;; @0025                               v30 = call fn0(v0, v26, v28, v140, v29)  ; v26 = -1476395002, v140 = 48, v29 = 16
+;; @0025                               v31 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @0025                               v32 = load.i64 notrap aligned readonly can_move region4 v31+32
+;; @0025                               v33 = uextend.i64 v30
+;; @0025                               v34 = iadd v32, v33
+;; @0025                               jump block4(v30, v34)
 ;;
-;;                                 block4(v44: i32, v45: i64):
-;; @0025                               v6 = iconst.i32 3
-;; @0025                               v46 = iconst.i64 16
-;; @0025                               v47 = iadd v45, v46  ; v46 = 16
-;; @0025                               store user2 region5 v6, v47  ; v6 = 3
-;; @0025                               trapz v44, user16
-;;                                     v255 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v256 = load.i64 notrap aligned readonly can_move region4 v255+32
-;; @0025                               v49 = uextend.i64 v44
-;; @0025                               v52 = iadd v256, v49
-;; @0025                               v54 = iadd v52, v46  ; v46 = 16
-;; @0025                               v55 = load.i32 user2 readonly region5 v54
-;; @0025                               trapz v55, user17
-;; @0025                               v58 = uextend.i64 v55
-;;                                     v132 = iconst.i64 3
-;;                                     v162 = ishl v58, v132  ; v132 = 3
-;; @0025                               v11 = iconst.i64 32
-;; @0025                               v61 = ushr v162, v11  ; v11 = 32
-;; @0025                               trapnz v61, user2
-;;                                     v171 = ishl v55, v6  ; v6 = 3
-;; @0025                               v7 = iconst.i32 24
-;; @0025                               v64 = uadd_overflow_trap v171, v7, user2  ; v7 = 24
-;; @0025                               v68 = uadd_overflow_trap v44, v64, user2
-;; @0025                               v69 = uextend.i64 v68
-;; @0025                               v72 = iadd v256, v69
-;; @0025                               v73 = isub v64, v7  ; v7 = 24
-;; @0025                               v74 = uextend.i64 v73
-;; @0025                               v75 = isub v72, v74
-;; @0025                               store.i64 user2 little region5 v2, v75
-;; @0025                               v83 = load.i32 user2 readonly region5 v54
-;; @0025                               v76 = iconst.i32 1
-;;                                     v188 = icmp ugt v83, v76  ; v76 = 1
-;; @0025                               trapz v188, user17
-;; @0025                               v86 = uextend.i64 v83
-;;                                     v190 = ishl v86, v132  ; v132 = 3
-;; @0025                               v89 = ushr v190, v11  ; v11 = 32
-;; @0025                               trapnz v89, user2
-;;                                     v197 = ishl v83, v6  ; v6 = 3
-;; @0025                               v92 = uadd_overflow_trap v197, v7, user2  ; v7 = 24
-;; @0025                               v96 = uadd_overflow_trap v44, v92, user2
-;; @0025                               v97 = uextend.i64 v96
-;; @0025                               v100 = iadd v256, v97
-;;                                     v210 = iconst.i32 32
-;; @0025                               v101 = isub v92, v210  ; v210 = 32
-;; @0025                               v102 = uextend.i64 v101
-;; @0025                               v103 = isub v100, v102
-;; @0025                               store.i64 user2 little region5 v3, v103
-;; @0025                               v111 = load.i32 user2 readonly region5 v54
-;; @0025                               v104 = iconst.i32 2
-;;                                     v216 = icmp ugt v111, v104  ; v104 = 2
-;; @0025                               trapz v216, user17
-;; @0025                               v114 = uextend.i64 v111
-;;                                     v218 = ishl v114, v132  ; v132 = 3
-;; @0025                               v117 = ushr v218, v11  ; v11 = 32
-;; @0025                               trapnz v117, user2
-;;                                     v225 = ishl v111, v6  ; v6 = 3
-;; @0025                               v120 = uadd_overflow_trap v225, v7, user2  ; v7 = 24
-;; @0025                               v124 = uadd_overflow_trap v44, v120, user2
-;; @0025                               v125 = uextend.i64 v124
-;; @0025                               v128 = iadd v256, v125
-;;                                     v242 = iconst.i32 40
-;; @0025                               v129 = isub v120, v242  ; v242 = 40
-;; @0025                               v130 = uextend.i64 v129
-;; @0025                               v131 = isub v128, v130
-;; @0025                               store.i64 user2 little region5 v4, v131
-;; @0029                               jump block1(v44)
+;;                                 block4(v43: i32, v44: i64):
+;; @0025                               v5 = iconst.i32 3
+;; @0025                               v45 = iconst.i64 16
+;; @0025                               v46 = iadd v44, v45  ; v45 = 16
+;; @0025                               store user2 region5 v5, v46  ; v5 = 3
+;; @0025                               trapz v43, user16
+;;                                     v254 = load.i64 notrap aligned readonly can_move region0 v0+8
+;;                                     v255 = load.i64 notrap aligned readonly can_move region4 v254+32
+;; @0025                               v48 = uextend.i64 v43
+;; @0025                               v51 = iadd v255, v48
+;; @0025                               v53 = iadd v51, v45  ; v45 = 16
+;; @0025                               v54 = load.i32 user2 readonly region5 v53
+;; @0025                               trapz v54, user17
+;; @0025                               v57 = uextend.i64 v54
+;;                                     v131 = iconst.i64 3
+;;                                     v161 = ishl v57, v131  ; v131 = 3
+;; @0025                               v10 = iconst.i64 32
+;; @0025                               v60 = ushr v161, v10  ; v10 = 32
+;; @0025                               trapnz v60, user2
+;;                                     v170 = ishl v54, v5  ; v5 = 3
+;; @0025                               v6 = iconst.i32 24
+;; @0025                               v63 = uadd_overflow_trap v170, v6, user2  ; v6 = 24
+;; @0025                               v67 = uadd_overflow_trap v43, v63, user2
+;; @0025                               v68 = uextend.i64 v67
+;; @0025                               v71 = iadd v255, v68
+;; @0025                               v72 = isub v63, v6  ; v6 = 24
+;; @0025                               v73 = uextend.i64 v72
+;; @0025                               v74 = isub v71, v73
+;; @0025                               store.i64 user2 little region5 v2, v74
+;; @0025                               v82 = load.i32 user2 readonly region5 v53
+;; @0025                               v75 = iconst.i32 1
+;;                                     v187 = icmp ugt v82, v75  ; v75 = 1
+;; @0025                               trapz v187, user17
+;; @0025                               v85 = uextend.i64 v82
+;;                                     v189 = ishl v85, v131  ; v131 = 3
+;; @0025                               v88 = ushr v189, v10  ; v10 = 32
+;; @0025                               trapnz v88, user2
+;;                                     v196 = ishl v82, v5  ; v5 = 3
+;; @0025                               v91 = uadd_overflow_trap v196, v6, user2  ; v6 = 24
+;; @0025                               v95 = uadd_overflow_trap v43, v91, user2
+;; @0025                               v96 = uextend.i64 v95
+;; @0025                               v99 = iadd v255, v96
+;;                                     v209 = iconst.i32 32
+;; @0025                               v100 = isub v91, v209  ; v209 = 32
+;; @0025                               v101 = uextend.i64 v100
+;; @0025                               v102 = isub v99, v101
+;; @0025                               store.i64 user2 little region5 v3, v102
+;; @0025                               v110 = load.i32 user2 readonly region5 v53
+;; @0025                               v103 = iconst.i32 2
+;;                                     v215 = icmp ugt v110, v103  ; v103 = 2
+;; @0025                               trapz v215, user17
+;; @0025                               v113 = uextend.i64 v110
+;;                                     v217 = ishl v113, v131  ; v131 = 3
+;; @0025                               v116 = ushr v217, v10  ; v10 = 32
+;; @0025                               trapnz v116, user2
+;;                                     v224 = ishl v110, v5  ; v5 = 3
+;; @0025                               v119 = uadd_overflow_trap v224, v6, user2  ; v6 = 24
+;; @0025                               v123 = uadd_overflow_trap v43, v119, user2
+;; @0025                               v124 = uextend.i64 v123
+;; @0025                               v127 = iadd v255, v124
+;;                                     v241 = iconst.i32 40
+;; @0025                               v128 = isub v119, v241  ; v241 = 40
+;; @0025                               v129 = uextend.i64 v128
+;; @0025                               v130 = isub v127, v129
+;; @0025                               store.i64 user2 little region5 v4, v130
+;; @0029                               jump block1
 ;;
-;;                                 block1(v5: i32):
-;; @0029                               return v5
+;;                                 block1:
+;; @0029                               return v43
 ;; }

--- a/tests/disas/gc/copying/array-new.wat
+++ b/tests/disas/gc/copying/array-new.wat
@@ -24,98 +24,98 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
-;; @0022                               v6 = uextend.i64 v3
-;;                                     v88 = iconst.i64 3
-;;                                     v89 = ishl v6, v88  ; v88 = 3
-;; @0022                               v9 = iconst.i64 32
-;; @0022                               v10 = ushr v89, v9  ; v9 = 32
-;; @0022                               trapnz v10, user18
-;; @0022                               v5 = iconst.i32 24
-;;                                     v95 = iconst.i32 3
-;;                                     v96 = ishl v3, v95  ; v95 = 3
-;; @0022                               v12 = uadd_overflow_trap v5, v96, user18  ; v5 = 24
-;; @0022                               v13 = load.i64 notrap aligned readonly can_move region2 v0+32
-;; @0022                               v14 = load.i32 notrap aligned v13
-;; @0022                               v15 = load.i32 notrap aligned v13+4
-;; @0022                               v21 = uextend.i64 v14
-;; @0022                               v16 = uextend.i64 v12
-;; @0022                               v17 = iconst.i64 15
-;; @0022                               v19 = iadd v16, v17  ; v17 = 15
-;; @0022                               v18 = iconst.i64 -16
-;; @0022                               v20 = band v19, v18  ; v18 = -16
-;; @0022                               v22 = iadd v21, v20
-;; @0022                               v23 = uextend.i64 v15
-;; @0022                               v24 = icmp ule v22, v23
-;; @0022                               brif v24, block2, block3
+;; @0022                               v5 = uextend.i64 v3
+;;                                     v87 = iconst.i64 3
+;;                                     v88 = ishl v5, v87  ; v87 = 3
+;; @0022                               v8 = iconst.i64 32
+;; @0022                               v9 = ushr v88, v8  ; v8 = 32
+;; @0022                               trapnz v9, user18
+;; @0022                               v4 = iconst.i32 24
+;;                                     v94 = iconst.i32 3
+;;                                     v95 = ishl v3, v94  ; v94 = 3
+;; @0022                               v11 = uadd_overflow_trap v4, v95, user18  ; v4 = 24
+;; @0022                               v12 = load.i64 notrap aligned readonly can_move region2 v0+32
+;; @0022                               v13 = load.i32 notrap aligned v12
+;; @0022                               v14 = load.i32 notrap aligned v12+4
+;; @0022                               v20 = uextend.i64 v13
+;; @0022                               v15 = uextend.i64 v11
+;; @0022                               v16 = iconst.i64 15
+;; @0022                               v18 = iadd v15, v16  ; v16 = 15
+;; @0022                               v17 = iconst.i64 -16
+;; @0022                               v19 = band v18, v17  ; v17 = -16
+;; @0022                               v21 = iadd v20, v19
+;; @0022                               v22 = uextend.i64 v14
+;; @0022                               v23 = icmp ule v21, v22
+;; @0022                               brif v23, block2, block3
 ;;
 ;;                                 block2:
-;;                                     v104 = iconst.i32 15
-;;                                     v105 = iadd.i32 v12, v104  ; v104 = 15
-;;                                     v108 = iconst.i32 -16
-;;                                     v109 = band v105, v108  ; v108 = -16
-;;                                     v111 = iadd.i32 v14, v109
-;; @0022                               store notrap aligned v111, v13
-;;                                     v127 = iconst.i32 -1476395002
-;;                                     v128 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v129 = load.i64 notrap aligned readonly can_move region4 v128+32
-;; @0022                               v38 = iadd v129, v21
-;; @0022                               store notrap aligned v127, v38  ; v127 = -1476395002
-;;                                     v130 = load.i64 notrap aligned readonly can_move region3 v0+40
-;;                                     v131 = load.i32 notrap aligned readonly can_move v130
-;; @0022                               store notrap aligned v131, v38+4
-;;                                     v132 = band.i64 v19, v18  ; v18 = -16
-;; @0022                               istore32 notrap aligned v132, v38+8
-;; @0022                               jump block4(v14, v38)
+;;                                     v103 = iconst.i32 15
+;;                                     v104 = iadd.i32 v11, v103  ; v103 = 15
+;;                                     v107 = iconst.i32 -16
+;;                                     v108 = band v104, v107  ; v107 = -16
+;;                                     v110 = iadd.i32 v13, v108
+;; @0022                               store notrap aligned v110, v12
+;;                                     v126 = iconst.i32 -1476395002
+;;                                     v127 = load.i64 notrap aligned readonly can_move region0 v0+8
+;;                                     v128 = load.i64 notrap aligned readonly can_move region4 v127+32
+;; @0022                               v37 = iadd v128, v20
+;; @0022                               store notrap aligned v126, v37  ; v126 = -1476395002
+;;                                     v129 = load.i64 notrap aligned readonly can_move region3 v0+40
+;;                                     v130 = load.i32 notrap aligned readonly can_move v129
+;; @0022                               store notrap aligned v130, v37+4
+;;                                     v131 = band.i64 v18, v17  ; v17 = -16
+;; @0022                               istore32 notrap aligned v131, v37+8
+;; @0022                               jump block4(v13, v37)
 ;;
 ;;                                 block3 cold:
-;; @0022                               v25 = iconst.i32 -1476395002
-;; @0022                               v26 = load.i64 notrap aligned readonly can_move region3 v0+40
-;; @0022                               v27 = load.i32 notrap aligned readonly can_move v26
-;; @0022                               v28 = iconst.i32 16
-;; @0022                               v29 = call fn0(v0, v25, v27, v12, v28)  ; v25 = -1476395002, v28 = 16
-;; @0022                               v30 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0022                               v31 = load.i64 notrap aligned readonly can_move region4 v30+32
-;; @0022                               v32 = uextend.i64 v29
-;; @0022                               v33 = iadd v31, v32
-;; @0022                               jump block4(v29, v33)
+;; @0022                               v24 = iconst.i32 -1476395002
+;; @0022                               v25 = load.i64 notrap aligned readonly can_move region3 v0+40
+;; @0022                               v26 = load.i32 notrap aligned readonly can_move v25
+;; @0022                               v27 = iconst.i32 16
+;; @0022                               v28 = call fn0(v0, v24, v26, v11, v27)  ; v24 = -1476395002, v27 = 16
+;; @0022                               v29 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @0022                               v30 = load.i64 notrap aligned readonly can_move region4 v29+32
+;; @0022                               v31 = uextend.i64 v28
+;; @0022                               v32 = iadd v30, v31
+;; @0022                               jump block4(v28, v32)
 ;;
-;;                                 block4(v42: i32, v43: i64):
-;; @0022                               v44 = iconst.i64 16
-;; @0022                               v45 = iadd v43, v44  ; v44 = 16
-;; @0022                               store.i32 user2 region5 v3, v45
-;; @0022                               trapz v42, user16
-;;                                     v133 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v134 = load.i64 notrap aligned readonly can_move region4 v133+32
-;; @0022                               v47 = uextend.i64 v42
-;; @0022                               v50 = iadd v134, v47
-;; @0022                               v52 = iadd v50, v44  ; v44 = 16
-;; @0022                               v53 = load.i32 user2 readonly region5 v52
-;; @0022                               v54 = uextend.i64 v53
-;; @0022                               v60 = icmp.i64 ugt v6, v54
-;; @0022                               trapnz v60, user17
-;; @0022                               v77 = load.i64 notrap aligned region6 v133+40
-;; @0022                               v65 = iconst.i64 24
-;; @0022                               v66 = iadd v50, v65  ; v65 = 24
-;; @0022                               v79 = uadd_overflow_trap v66, v89, user2
-;; @0022                               v78 = iadd v134, v77
-;; @0022                               v80 = icmp ugt v79, v78
-;; @0022                               trapnz v80, user2
-;;                                     v113 = iconst.i64 0
-;; @0022                               v83 = icmp.i64 eq v6, v113  ; v113 = 0
-;; @0022                               v7 = iconst.i64 8
-;; @0022                               v81 = iadd v66, v89
-;; @0022                               brif v83, block6, block5(v66)
+;;                                 block4(v41: i32, v42: i64):
+;; @0022                               v43 = iconst.i64 16
+;; @0022                               v44 = iadd v42, v43  ; v43 = 16
+;; @0022                               store.i32 user2 region5 v3, v44
+;; @0022                               trapz v41, user16
+;;                                     v132 = load.i64 notrap aligned readonly can_move region0 v0+8
+;;                                     v133 = load.i64 notrap aligned readonly can_move region4 v132+32
+;; @0022                               v46 = uextend.i64 v41
+;; @0022                               v49 = iadd v133, v46
+;; @0022                               v51 = iadd v49, v43  ; v43 = 16
+;; @0022                               v52 = load.i32 user2 readonly region5 v51
+;; @0022                               v53 = uextend.i64 v52
+;; @0022                               v59 = icmp.i64 ugt v5, v53
+;; @0022                               trapnz v59, user17
+;; @0022                               v76 = load.i64 notrap aligned region6 v132+40
+;; @0022                               v64 = iconst.i64 24
+;; @0022                               v65 = iadd v49, v64  ; v64 = 24
+;; @0022                               v78 = uadd_overflow_trap v65, v88, user2
+;; @0022                               v77 = iadd v133, v76
+;; @0022                               v79 = icmp ugt v78, v77
+;; @0022                               trapnz v79, user2
+;;                                     v112 = iconst.i64 0
+;; @0022                               v82 = icmp.i64 eq v5, v112  ; v112 = 0
+;; @0022                               v6 = iconst.i64 8
+;; @0022                               v80 = iadd v65, v88
+;; @0022                               brif v82, block6, block5(v65)
 ;;
-;;                                 block5(v84: i64):
-;; @0022                               store.i64 user2 little region5 v2, v84
-;;                                     v135 = iconst.i64 8
-;;                                     v136 = iadd v84, v135  ; v135 = 8
-;; @0022                               v87 = icmp eq v136, v81
-;; @0022                               brif v87, block6, block5(v136)
+;;                                 block5(v83: i64):
+;; @0022                               store.i64 user2 little region5 v2, v83
+;;                                     v134 = iconst.i64 8
+;;                                     v135 = iadd v83, v134  ; v134 = 8
+;; @0022                               v86 = icmp eq v135, v80
+;; @0022                               brif v86, block6, block5(v135)
 ;;
 ;;                                 block6:
-;; @0025                               jump block1(v42)
+;; @0025                               jump block1
 ;;
-;;                                 block1(v4: i32):
-;; @0025                               return v4
+;;                                 block1:
+;; @0025                               return v41
 ;; }

--- a/tests/disas/gc/copying/br-on-cast-fail.wat
+++ b/tests/disas/gc/copying/br-on-cast-fail.wat
@@ -33,42 +33,42 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @002e                               v4 = iconst.i32 0
-;; @002e                               v5 = icmp eq v2, v4  ; v4 = 0
-;; @002e                               brif v5, block5(v4), block3  ; v4 = 0
+;; @002e                               v3 = iconst.i32 0
+;; @002e                               v4 = icmp eq v2, v3  ; v3 = 0
+;; @002e                               brif v4, block5(v3), block3  ; v3 = 0
 ;;
 ;;                                 block3:
-;; @002e                               v8 = iconst.i32 1
-;; @002e                               v9 = band.i32 v2, v8  ; v8 = 1
-;;                                     v27 = iconst.i32 0
-;; @002e                               brif v9, block5(v27), block4  ; v27 = 0
+;; @002e                               v7 = iconst.i32 1
+;; @002e                               v8 = band.i32 v2, v7  ; v7 = 1
+;;                                     v26 = iconst.i32 0
+;; @002e                               brif v8, block5(v26), block4  ; v26 = 0
 ;;
 ;;                                 block4:
-;; @002e                               v14 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @002e                               v15 = load.i64 notrap aligned readonly can_move region3 v14+32
-;; @002e                               v13 = uextend.i64 v2
-;; @002e                               v16 = iadd v15, v13
-;; @002e                               v17 = iconst.i64 4
-;; @002e                               v18 = iadd v16, v17  ; v17 = 4
-;; @002e                               v19 = load.i32 user2 readonly region5 v18
-;; @002e                               v11 = load.i64 notrap aligned readonly can_move region2 v0+40
-;; @002e                               v12 = load.i32 notrap aligned readonly can_move v11
-;; @002e                               v20 = icmp eq v19, v12
-;; @002e                               v21 = uextend.i32 v20
-;; @002e                               jump block5(v21)
+;; @002e                               v13 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @002e                               v14 = load.i64 notrap aligned readonly can_move region3 v13+32
+;; @002e                               v12 = uextend.i64 v2
+;; @002e                               v15 = iadd v14, v12
+;; @002e                               v16 = iconst.i64 4
+;; @002e                               v17 = iadd v15, v16  ; v16 = 4
+;; @002e                               v18 = load.i32 user2 readonly region5 v17
+;; @002e                               v10 = load.i64 notrap aligned readonly can_move region2 v0+40
+;; @002e                               v11 = load.i32 notrap aligned readonly can_move v10
+;; @002e                               v19 = icmp eq v18, v11
+;; @002e                               v20 = uextend.i32 v19
+;; @002e                               jump block5(v20)
 ;;
-;;                                 block5(v22: i32):
-;; @002e                               brif v22, block6, block2
+;;                                 block5(v21: i32):
+;; @002e                               brif v21, block6, block2
 ;;
 ;;                                 block6:
-;; @0034                               v24 = load.i64 notrap aligned readonly can_move region7 v0+56
-;; @0034                               v23 = load.i64 notrap aligned readonly can_move region6 v0+72
-;; @0034                               call_indirect sig0, v24(v23, v0)
+;; @0034                               v23 = load.i64 notrap aligned readonly can_move region7 v0+56
+;; @0034                               v22 = load.i64 notrap aligned readonly can_move region6 v0+72
+;; @0034                               call_indirect sig0, v23(v22, v0)
 ;; @0036                               return
 ;;
 ;;                                 block2:
-;; @0038                               v26 = load.i64 notrap aligned readonly can_move region9 v0+88
-;; @0038                               v25 = load.i64 notrap aligned readonly can_move region8 v0+104
-;; @0038                               call_indirect sig0, v26(v25, v0)
+;; @0038                               v25 = load.i64 notrap aligned readonly can_move region9 v0+88
+;; @0038                               v24 = load.i64 notrap aligned readonly can_move region8 v0+104
+;; @0038                               call_indirect sig0, v25(v24, v0)
 ;; @003a                               return
 ;; }

--- a/tests/disas/gc/copying/br-on-cast.wat
+++ b/tests/disas/gc/copying/br-on-cast.wat
@@ -33,42 +33,42 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @002f                               v4 = iconst.i32 0
-;; @002f                               v5 = icmp eq v2, v4  ; v4 = 0
-;; @002f                               brif v5, block5(v4), block3  ; v4 = 0
+;; @002f                               v3 = iconst.i32 0
+;; @002f                               v4 = icmp eq v2, v3  ; v3 = 0
+;; @002f                               brif v4, block5(v3), block3  ; v3 = 0
 ;;
 ;;                                 block3:
-;; @002f                               v8 = iconst.i32 1
-;; @002f                               v9 = band.i32 v2, v8  ; v8 = 1
-;;                                     v27 = iconst.i32 0
-;; @002f                               brif v9, block5(v27), block4  ; v27 = 0
+;; @002f                               v7 = iconst.i32 1
+;; @002f                               v8 = band.i32 v2, v7  ; v7 = 1
+;;                                     v26 = iconst.i32 0
+;; @002f                               brif v8, block5(v26), block4  ; v26 = 0
 ;;
 ;;                                 block4:
-;; @002f                               v14 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @002f                               v15 = load.i64 notrap aligned readonly can_move region3 v14+32
-;; @002f                               v13 = uextend.i64 v2
-;; @002f                               v16 = iadd v15, v13
-;; @002f                               v17 = iconst.i64 4
-;; @002f                               v18 = iadd v16, v17  ; v17 = 4
-;; @002f                               v19 = load.i32 user2 readonly region5 v18
-;; @002f                               v11 = load.i64 notrap aligned readonly can_move region2 v0+40
-;; @002f                               v12 = load.i32 notrap aligned readonly can_move v11
-;; @002f                               v20 = icmp eq v19, v12
-;; @002f                               v21 = uextend.i32 v20
-;; @002f                               jump block5(v21)
+;; @002f                               v13 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @002f                               v14 = load.i64 notrap aligned readonly can_move region3 v13+32
+;; @002f                               v12 = uextend.i64 v2
+;; @002f                               v15 = iadd v14, v12
+;; @002f                               v16 = iconst.i64 4
+;; @002f                               v17 = iadd v15, v16  ; v16 = 4
+;; @002f                               v18 = load.i32 user2 readonly region5 v17
+;; @002f                               v10 = load.i64 notrap aligned readonly can_move region2 v0+40
+;; @002f                               v11 = load.i32 notrap aligned readonly can_move v10
+;; @002f                               v19 = icmp eq v18, v11
+;; @002f                               v20 = uextend.i32 v19
+;; @002f                               jump block5(v20)
 ;;
-;;                                 block5(v22: i32):
-;; @002f                               brif v22, block2, block6
+;;                                 block5(v21: i32):
+;; @002f                               brif v21, block2, block6
 ;;
 ;;                                 block6:
-;; @0035                               v24 = load.i64 notrap aligned readonly can_move region7 v0+56
-;; @0035                               v23 = load.i64 notrap aligned readonly can_move region6 v0+72
-;; @0035                               call_indirect sig0, v24(v23, v0)
+;; @0035                               v23 = load.i64 notrap aligned readonly can_move region7 v0+56
+;; @0035                               v22 = load.i64 notrap aligned readonly can_move region6 v0+72
+;; @0035                               call_indirect sig0, v23(v22, v0)
 ;; @0037                               return
 ;;
 ;;                                 block2:
-;; @0039                               v26 = load.i64 notrap aligned readonly can_move region9 v0+88
-;; @0039                               v25 = load.i64 notrap aligned readonly can_move region8 v0+104
-;; @0039                               call_indirect sig0, v26(v25, v0)
+;; @0039                               v25 = load.i64 notrap aligned readonly can_move region9 v0+88
+;; @0039                               v24 = load.i64 notrap aligned readonly can_move region8 v0+104
+;; @0039                               call_indirect sig0, v25(v24, v0)
 ;; @003b                               return
 ;; }

--- a/tests/disas/gc/copying/externref-globals.wat
+++ b/tests/disas/gc/copying/externref-globals.wat
@@ -20,13 +20,13 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @0034                               v3 = iconst.i64 48
-;; @0034                               v4 = iadd v0, v3  ; v3 = 48
-;; @0034                               v5 = load.i32 notrap aligned region2 v4
+;; @0034                               v2 = iconst.i64 48
+;; @0034                               v3 = iadd v0, v2  ; v2 = 48
+;; @0034                               v4 = load.i32 notrap aligned region2 v3
 ;; @0036                               jump block1
 ;;
 ;;                                 block1:
-;; @0036                               return v5
+;; @0036                               return v4
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) tail {

--- a/tests/disas/gc/copying/funcref-in-gc-heap-get.wat
+++ b/tests/disas/gc/copying/funcref-in-gc-heap-get.wat
@@ -23,17 +23,17 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0020                               trapz v2, user16
-;; @0020                               v5 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0020                               v6 = load.i64 notrap aligned readonly can_move region2 v5+32
-;; @0020                               v4 = uextend.i64 v2
-;; @0020                               v7 = iadd v6, v4
-;; @0020                               v8 = iconst.i64 16
-;; @0020                               v9 = iadd v7, v8  ; v8 = 16
-;; @0020                               v11 = load.i32 user2 little region4 v9
-;; @0020                               v10 = iconst.i32 -1
-;; @0020                               v12 = call fn0(v0, v11, v10)  ; v10 = -1
+;; @0020                               v4 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @0020                               v5 = load.i64 notrap aligned readonly can_move region2 v4+32
+;; @0020                               v3 = uextend.i64 v2
+;; @0020                               v6 = iadd v5, v3
+;; @0020                               v7 = iconst.i64 16
+;; @0020                               v8 = iadd v6, v7  ; v7 = 16
+;; @0020                               v10 = load.i32 user2 little region4 v8
+;; @0020                               v9 = iconst.i32 -1
+;; @0020                               v11 = call fn0(v0, v10, v9)  ; v9 = -1
 ;; @0024                               jump block1
 ;;
 ;;                                 block1:
-;; @0024                               return v12
+;; @0024                               return v11
 ;; }

--- a/tests/disas/gc/copying/funcref-in-gc-heap-new.wat
+++ b/tests/disas/gc/copying/funcref-in-gc-heap-new.wat
@@ -26,56 +26,56 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0020                               v5 = load.i64 notrap aligned readonly can_move region2 v0+32
-;; @0020                               v6 = load.i32 notrap aligned v5
-;; @0020                               v7 = load.i32 notrap aligned v5+4
-;; @0020                               v13 = uextend.i64 v6
-;;                                     v43 = iconst.i64 32
-;; @0020                               v14 = iadd v13, v43  ; v43 = 32
-;; @0020                               v15 = uextend.i64 v7
-;; @0020                               v16 = icmp ule v14, v15
-;; @0020                               brif v16, block2, block3
+;; @0020                               v4 = load.i64 notrap aligned readonly can_move region2 v0+32
+;; @0020                               v5 = load.i32 notrap aligned v4
+;; @0020                               v6 = load.i32 notrap aligned v4+4
+;; @0020                               v12 = uextend.i64 v5
+;;                                     v42 = iconst.i64 32
+;; @0020                               v13 = iadd v12, v42  ; v42 = 32
+;; @0020                               v14 = uextend.i64 v6
+;; @0020                               v15 = icmp ule v13, v14
+;; @0020                               brif v15, block2, block3
 ;;
 ;;                                 block2:
-;;                                     v59 = iconst.i32 32
-;;                                     v57 = iadd.i32 v6, v59  ; v59 = 32
-;; @0020                               store notrap aligned v57, v5
-;;                                     v60 = iconst.i32 -1342177278
-;;                                     v61 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v62 = load.i64 notrap aligned readonly can_move region4 v61+32
-;; @0020                               v30 = iadd v62, v13
-;; @0020                               store notrap aligned v60, v30  ; v60 = -1342177278
-;;                                     v63 = load.i64 notrap aligned readonly can_move region3 v0+40
-;;                                     v64 = load.i32 notrap aligned readonly can_move v63
-;; @0020                               store notrap aligned v64, v30+4
-;;                                     v65 = iconst.i64 32
-;; @0020                               istore32 notrap aligned v65, v30+8  ; v65 = 32
-;; @0020                               jump block4(v6, v30)
+;;                                     v58 = iconst.i32 32
+;;                                     v56 = iadd.i32 v5, v58  ; v58 = 32
+;; @0020                               store notrap aligned v56, v4
+;;                                     v59 = iconst.i32 -1342177278
+;;                                     v60 = load.i64 notrap aligned readonly can_move region0 v0+8
+;;                                     v61 = load.i64 notrap aligned readonly can_move region4 v60+32
+;; @0020                               v29 = iadd v61, v12
+;; @0020                               store notrap aligned v59, v29  ; v59 = -1342177278
+;;                                     v62 = load.i64 notrap aligned readonly can_move region3 v0+40
+;;                                     v63 = load.i32 notrap aligned readonly can_move v62
+;; @0020                               store notrap aligned v63, v29+4
+;;                                     v64 = iconst.i64 32
+;; @0020                               istore32 notrap aligned v64, v29+8  ; v64 = 32
+;; @0020                               jump block4(v5, v29)
 ;;
 ;;                                 block3 cold:
-;; @0020                               v17 = iconst.i32 -1342177278
-;; @0020                               v18 = load.i64 notrap aligned readonly can_move region3 v0+40
-;; @0020                               v19 = load.i32 notrap aligned readonly can_move v18
-;; @0020                               v4 = iconst.i32 32
-;; @0020                               v20 = iconst.i32 16
-;; @0020                               v21 = call fn0(v0, v17, v19, v4, v20)  ; v17 = -1342177278, v4 = 32, v20 = 16
-;; @0020                               v22 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0020                               v23 = load.i64 notrap aligned readonly can_move region4 v22+32
-;; @0020                               v24 = uextend.i64 v21
-;; @0020                               v25 = iadd v23, v24
-;; @0020                               jump block4(v21, v25)
+;; @0020                               v16 = iconst.i32 -1342177278
+;; @0020                               v17 = load.i64 notrap aligned readonly can_move region3 v0+40
+;; @0020                               v18 = load.i32 notrap aligned readonly can_move v17
+;; @0020                               v3 = iconst.i32 32
+;; @0020                               v19 = iconst.i32 16
+;; @0020                               v20 = call fn0(v0, v16, v18, v3, v19)  ; v16 = -1342177278, v3 = 32, v19 = 16
+;; @0020                               v21 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @0020                               v22 = load.i64 notrap aligned readonly can_move region4 v21+32
+;; @0020                               v23 = uextend.i64 v20
+;; @0020                               v24 = iadd v22, v23
+;; @0020                               jump block4(v20, v24)
 ;;
-;;                                 block4(v34: i32, v35: i64):
-;;                                     v42 = stack_addr.i64 ss0
-;;                                     store notrap v34, v42
-;; @0020                               v38 = call fn1(v0, v2), stack_map=[i32 @ ss0+0]
-;; @0020                               v39 = ireduce.i32 v38
-;; @0020                               v36 = iconst.i64 16
-;; @0020                               v37 = iadd v35, v36  ; v36 = 16
-;; @0020                               store user2 little region5 v39, v37
-;;                                     v41 = load.i32 notrap v42
+;;                                 block4(v33: i32, v34: i64):
+;;                                     v41 = stack_addr.i64 ss0
+;;                                     store notrap v33, v41
+;; @0020                               v37 = call fn1(v0, v2), stack_map=[i32 @ ss0+0]
+;; @0020                               v38 = ireduce.i32 v37
+;; @0020                               v35 = iconst.i64 16
+;; @0020                               v36 = iadd v34, v35  ; v35 = 16
+;; @0020                               store user2 little region5 v38, v36
 ;; @0023                               jump block1
 ;;
 ;;                                 block1:
-;; @0023                               return v41
+;;                                     v40 = load.i32 notrap v41
+;; @0023                               return v40
 ;; }

--- a/tests/disas/gc/copying/i31ref-globals.wat
+++ b/tests/disas/gc/copying/i31ref-globals.wat
@@ -20,13 +20,13 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @0036                               v3 = iconst.i64 48
-;; @0036                               v4 = iadd v0, v3  ; v3 = 48
-;; @0036                               v5 = load.i32 notrap aligned region2 v4
+;; @0036                               v2 = iconst.i64 48
+;; @0036                               v3 = iadd v0, v2  ; v2 = 48
+;; @0036                               v4 = load.i32 notrap aligned region2 v3
 ;; @0038                               jump block1
 ;;
 ;;                                 block1:
-;; @0038                               return v5
+;; @0038                               return v4
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) tail {

--- a/tests/disas/gc/copying/multiple-array-get.wat
+++ b/tests/disas/gc/copying/multiple-array-get.wat
@@ -22,44 +22,44 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
 ;; @0024                               trapz v2, user16
-;; @0024                               v8 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0024                               v9 = load.i64 notrap aligned readonly can_move region2 v8+32
-;; @0024                               v7 = uextend.i64 v2
-;; @0024                               v10 = iadd v9, v7
-;; @0024                               v11 = iconst.i64 16
-;; @0024                               v12 = iadd v10, v11  ; v11 = 16
-;; @0024                               v13 = load.i32 user2 readonly region4 v12
-;; @0024                               v14 = icmp ult v3, v13
-;; @0024                               trapz v14, user17
-;; @0024                               v16 = uextend.i64 v13
-;;                                     v63 = iconst.i64 3
-;;                                     v64 = ishl v16, v63  ; v63 = 3
-;; @0024                               v18 = iconst.i64 32
-;; @0024                               v19 = ushr v64, v18  ; v18 = 32
-;; @0024                               trapnz v19, user2
-;;                                     v73 = iconst.i32 3
-;;                                     v74 = ishl v13, v73  ; v73 = 3
-;; @0024                               v21 = iconst.i32 24
-;; @0024                               v22 = uadd_overflow_trap v74, v21, user2  ; v21 = 24
-;; @0024                               v26 = uadd_overflow_trap v2, v22, user2
-;; @0024                               v27 = uextend.i64 v26
-;; @0024                               v30 = iadd v9, v27
-;;                                     v80 = ishl v3, v73  ; v73 = 3
-;; @0024                               v25 = iadd v80, v21  ; v21 = 24
-;; @0024                               v31 = isub v22, v25
-;; @0024                               v32 = uextend.i64 v31
-;; @0024                               v33 = isub v30, v32
-;; @0024                               v34 = load.i64 user2 little region4 v33
-;; @002b                               v42 = icmp ult v4, v13
-;; @002b                               trapz v42, user17
-;;                                     v82 = ishl v4, v73  ; v73 = 3
-;; @002b                               v53 = iadd v82, v21  ; v21 = 24
-;; @002b                               v59 = isub v22, v53
-;; @002b                               v60 = uextend.i64 v59
-;; @002b                               v61 = isub v30, v60
-;; @002b                               v62 = load.i64 user2 little region4 v61
+;; @0024                               v6 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @0024                               v7 = load.i64 notrap aligned readonly can_move region2 v6+32
+;; @0024                               v5 = uextend.i64 v2
+;; @0024                               v8 = iadd v7, v5
+;; @0024                               v9 = iconst.i64 16
+;; @0024                               v10 = iadd v8, v9  ; v9 = 16
+;; @0024                               v11 = load.i32 user2 readonly region4 v10
+;; @0024                               v12 = icmp ult v3, v11
+;; @0024                               trapz v12, user17
+;; @0024                               v14 = uextend.i64 v11
+;;                                     v61 = iconst.i64 3
+;;                                     v62 = ishl v14, v61  ; v61 = 3
+;; @0024                               v16 = iconst.i64 32
+;; @0024                               v17 = ushr v62, v16  ; v16 = 32
+;; @0024                               trapnz v17, user2
+;;                                     v71 = iconst.i32 3
+;;                                     v72 = ishl v11, v71  ; v71 = 3
+;; @0024                               v19 = iconst.i32 24
+;; @0024                               v20 = uadd_overflow_trap v72, v19, user2  ; v19 = 24
+;; @0024                               v24 = uadd_overflow_trap v2, v20, user2
+;; @0024                               v25 = uextend.i64 v24
+;; @0024                               v28 = iadd v7, v25
+;;                                     v78 = ishl v3, v71  ; v71 = 3
+;; @0024                               v23 = iadd v78, v19  ; v19 = 24
+;; @0024                               v29 = isub v20, v23
+;; @0024                               v30 = uextend.i64 v29
+;; @0024                               v31 = isub v28, v30
+;; @0024                               v32 = load.i64 user2 little region4 v31
+;; @002b                               v40 = icmp ult v4, v11
+;; @002b                               trapz v40, user17
+;;                                     v80 = ishl v4, v71  ; v71 = 3
+;; @002b                               v51 = iadd v80, v19  ; v19 = 24
+;; @002b                               v57 = isub v20, v51
+;; @002b                               v58 = uextend.i64 v57
+;; @002b                               v59 = isub v28, v58
+;; @002b                               v60 = load.i64 user2 little region4 v59
 ;; @002e                               jump block1
 ;;
 ;;                                 block1:
-;; @002e                               return v34, v62
+;; @002e                               return v32, v60
 ;; }

--- a/tests/disas/gc/copying/multiple-struct-get.wat
+++ b/tests/disas/gc/copying/multiple-struct-get.wat
@@ -23,19 +23,19 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0023                               trapz v2, user16
-;; @0023                               v6 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0023                               v7 = load.i64 notrap aligned readonly can_move region2 v6+32
-;; @0023                               v5 = uextend.i64 v2
-;; @0023                               v8 = iadd v7, v5
-;; @0023                               v9 = iconst.i64 16
-;; @0023                               v10 = iadd v8, v9  ; v9 = 16
-;; @0023                               v11 = load.f32 user2 little region4 v10
-;; @0029                               v16 = iconst.i64 20
-;; @0029                               v17 = iadd v8, v16  ; v16 = 20
-;; @0029                               v18 = load.i8 user2 little region4 v17
+;; @0023                               v4 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @0023                               v5 = load.i64 notrap aligned readonly can_move region2 v4+32
+;; @0023                               v3 = uextend.i64 v2
+;; @0023                               v6 = iadd v5, v3
+;; @0023                               v7 = iconst.i64 16
+;; @0023                               v8 = iadd v6, v7  ; v7 = 16
+;; @0023                               v9 = load.f32 user2 little region4 v8
+;; @0029                               v14 = iconst.i64 20
+;; @0029                               v15 = iadd v6, v14  ; v14 = 20
+;; @0029                               v16 = load.i8 user2 little region4 v15
 ;; @002d                               jump block1
 ;;
 ;;                                 block1:
-;; @0029                               v19 = sextend.i32 v18
-;; @002d                               return v11, v19
+;; @0029                               v17 = sextend.i32 v16
+;; @002d                               return v9, v17
 ;; }

--- a/tests/disas/gc/copying/ref-cast.wat
+++ b/tests/disas/gc/copying/ref-cast.wat
@@ -20,32 +20,32 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @001e                               v4 = iconst.i32 0
-;; @001e                               v5 = icmp eq v2, v4  ; v4 = 0
-;; @001e                               brif v5, block4(v4), block2  ; v4 = 0
+;; @001e                               v3 = iconst.i32 0
+;; @001e                               v4 = icmp eq v2, v3  ; v3 = 0
+;; @001e                               brif v4, block4(v3), block2  ; v3 = 0
 ;;
 ;;                                 block2:
-;; @001e                               v8 = iconst.i32 1
-;; @001e                               v9 = band.i32 v2, v8  ; v8 = 1
-;;                                     v23 = iconst.i32 0
-;; @001e                               brif v9, block4(v23), block3  ; v23 = 0
+;; @001e                               v7 = iconst.i32 1
+;; @001e                               v8 = band.i32 v2, v7  ; v7 = 1
+;;                                     v22 = iconst.i32 0
+;; @001e                               brif v8, block4(v22), block3  ; v22 = 0
 ;;
 ;;                                 block3:
-;; @001e                               v14 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @001e                               v15 = load.i64 notrap aligned readonly can_move region3 v14+32
-;; @001e                               v13 = uextend.i64 v2
-;; @001e                               v16 = iadd v15, v13
-;; @001e                               v17 = iconst.i64 4
-;; @001e                               v18 = iadd v16, v17  ; v17 = 4
-;; @001e                               v19 = load.i32 user2 readonly region5 v18
-;; @001e                               v11 = load.i64 notrap aligned readonly can_move region2 v0+40
-;; @001e                               v12 = load.i32 notrap aligned readonly can_move v11
-;; @001e                               v20 = icmp eq v19, v12
-;; @001e                               v21 = uextend.i32 v20
-;; @001e                               jump block4(v21)
+;; @001e                               v13 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @001e                               v14 = load.i64 notrap aligned readonly can_move region3 v13+32
+;; @001e                               v12 = uextend.i64 v2
+;; @001e                               v15 = iadd v14, v12
+;; @001e                               v16 = iconst.i64 4
+;; @001e                               v17 = iadd v15, v16  ; v16 = 4
+;; @001e                               v18 = load.i32 user2 readonly region5 v17
+;; @001e                               v10 = load.i64 notrap aligned readonly can_move region2 v0+40
+;; @001e                               v11 = load.i32 notrap aligned readonly can_move v10
+;; @001e                               v19 = icmp eq v18, v11
+;; @001e                               v20 = uextend.i32 v19
+;; @001e                               jump block4(v20)
 ;;
-;;                                 block4(v22: i32):
-;; @001e                               trapz v22, user19
+;;                                 block4(v21: i32):
+;; @001e                               trapz v21, user19
 ;; @0021                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/copying/ref-is-null.wat
+++ b/tests/disas/gc/copying/ref-is-null.wat
@@ -21,10 +21,10 @@
 ;; @0023                               jump block1
 ;;
 ;;                                 block1:
-;;                                     v4 = iconst.i32 0
-;;                                     v5 = icmp.i32 eq v2, v4  ; v4 = 0
-;;                                     v6 = uextend.i32 v5
-;; @0023                               return v6
+;;                                     v3 = iconst.i32 0
+;;                                     v4 = icmp.i32 eq v2, v3  ; v3 = 0
+;;                                     v5 = uextend.i32 v4
+;; @0023                               return v5
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
@@ -39,6 +39,6 @@
 ;; @0029                               jump block1
 ;;
 ;;                                 block1:
-;;                                     v4 = iconst.i32 0
-;; @0029                               return v4  ; v4 = 0
+;;                                     v3 = iconst.i32 0
+;; @0029                               return v3  ; v3 = 0
 ;; }

--- a/tests/disas/gc/copying/ref-test-any.wat
+++ b/tests/disas/gc/copying/ref-test-any.wat
@@ -21,10 +21,10 @@
 ;; @0025                               jump block1
 ;;
 ;;                                 block1:
-;; @0022                               v8 = iconst.i32 1
-;; @0022                               v4 = iconst.i32 0
-;;                                     v14 = select v2, v8, v4  ; v8 = 1, v4 = 0
-;; @0025                               return v14
+;; @0022                               v7 = iconst.i32 1
+;; @0022                               v3 = iconst.i32 0
+;;                                     v13 = select v2, v7, v3  ; v7 = 1, v3 = 0
+;; @0025                               return v13
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
@@ -39,6 +39,6 @@
 ;; @002d                               jump block1
 ;;
 ;;                                 block1:
-;; @002a                               v6 = iconst.i32 1
-;; @002d                               return v6  ; v6 = 1
+;; @002a                               v5 = iconst.i32 1
+;; @002d                               return v5  ; v5 = 1
 ;; }

--- a/tests/disas/gc/copying/ref-test-array.wat
+++ b/tests/disas/gc/copying/ref-test-array.wat
@@ -18,31 +18,31 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @001b                               v4 = iconst.i32 0
-;; @001b                               v5 = icmp eq v2, v4  ; v4 = 0
-;; @001b                               brif v5, block4(v4), block2  ; v4 = 0
+;; @001b                               v3 = iconst.i32 0
+;; @001b                               v4 = icmp eq v2, v3  ; v3 = 0
+;; @001b                               brif v4, block4(v3), block2  ; v3 = 0
 ;;
 ;;                                 block2:
-;; @001b                               v8 = iconst.i32 1
-;; @001b                               v9 = band.i32 v2, v8  ; v8 = 1
-;;                                     v23 = iconst.i32 0
-;; @001b                               brif v9, block4(v23), block3  ; v23 = 0
+;; @001b                               v7 = iconst.i32 1
+;; @001b                               v8 = band.i32 v2, v7  ; v7 = 1
+;;                                     v22 = iconst.i32 0
+;; @001b                               brif v8, block4(v22), block3  ; v22 = 0
 ;;
 ;;                                 block3:
-;; @001b                               v12 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @001b                               v13 = load.i64 notrap aligned readonly can_move region2 v12+32
-;; @001b                               v11 = uextend.i64 v2
-;; @001b                               v14 = iadd v13, v11
-;; @001b                               v17 = load.i32 user2 readonly region4 v14
-;; @001b                               v18 = iconst.i32 -1476395008
-;; @001b                               v19 = band v17, v18  ; v18 = -1476395008
-;; @001b                               v20 = icmp eq v19, v18  ; v18 = -1476395008
-;; @001b                               v21 = uextend.i32 v20
-;; @001b                               jump block4(v21)
+;; @001b                               v11 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @001b                               v12 = load.i64 notrap aligned readonly can_move region2 v11+32
+;; @001b                               v10 = uextend.i64 v2
+;; @001b                               v13 = iadd v12, v10
+;; @001b                               v16 = load.i32 user2 readonly region4 v13
+;; @001b                               v17 = iconst.i32 -1476395008
+;; @001b                               v18 = band v16, v17  ; v17 = -1476395008
+;; @001b                               v19 = icmp eq v18, v17  ; v17 = -1476395008
+;; @001b                               v20 = uextend.i32 v19
+;; @001b                               jump block4(v20)
 ;;
-;;                                 block4(v22: i32):
-;; @001e                               jump block1(v22)
+;;                                 block4(v21: i32):
+;; @001e                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @001e                               return v3
+;;                                 block1:
+;; @001e                               return v21
 ;; }

--- a/tests/disas/gc/copying/ref-test-concrete-func-type.wat
+++ b/tests/disas/gc/copying/ref-test-concrete-func-type.wat
@@ -18,25 +18,25 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0020                               v4 = iconst.i64 0
-;; @0020                               v5 = icmp eq v2, v4  ; v4 = 0
-;; @0020                               v7 = iconst.i32 0
-;; @0020                               brif v5, block4(v7), block2  ; v7 = 0
+;; @0020                               v3 = iconst.i64 0
+;; @0020                               v4 = icmp eq v2, v3  ; v3 = 0
+;; @0020                               v6 = iconst.i32 0
+;; @0020                               brif v4, block4(v6), block2  ; v6 = 0
 ;;
 ;;                                 block2:
 ;; @0020                               jump block3
 ;;
 ;;                                 block3:
-;; @0020                               v10 = load.i32 user2 readonly region3 v2+16
-;; @0020                               v8 = load.i64 notrap aligned readonly can_move region2 v0+40
-;; @0020                               v9 = load.i32 notrap aligned readonly can_move v8
-;; @0020                               v11 = icmp eq v10, v9
-;; @0020                               v12 = uextend.i32 v11
-;; @0020                               jump block4(v12)
+;; @0020                               v9 = load.i32 user2 readonly region3 v2+16
+;; @0020                               v7 = load.i64 notrap aligned readonly can_move region2 v0+40
+;; @0020                               v8 = load.i32 notrap aligned readonly can_move v7
+;; @0020                               v10 = icmp eq v9, v8
+;; @0020                               v11 = uextend.i32 v10
+;; @0020                               jump block4(v11)
 ;;
-;;                                 block4(v13: i32):
-;; @0023                               jump block1(v13)
+;;                                 block4(v12: i32):
+;; @0023                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @0023                               return v3
+;;                                 block1:
+;; @0023                               return v12
 ;; }

--- a/tests/disas/gc/copying/ref-test-concrete-type.wat
+++ b/tests/disas/gc/copying/ref-test-concrete-type.wat
@@ -20,33 +20,33 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @001d                               v4 = iconst.i32 0
-;; @001d                               v5 = icmp eq v2, v4  ; v4 = 0
-;; @001d                               brif v5, block4(v4), block2  ; v4 = 0
+;; @001d                               v3 = iconst.i32 0
+;; @001d                               v4 = icmp eq v2, v3  ; v3 = 0
+;; @001d                               brif v4, block4(v3), block2  ; v3 = 0
 ;;
 ;;                                 block2:
-;; @001d                               v8 = iconst.i32 1
-;; @001d                               v9 = band.i32 v2, v8  ; v8 = 1
-;;                                     v23 = iconst.i32 0
-;; @001d                               brif v9, block4(v23), block3  ; v23 = 0
+;; @001d                               v7 = iconst.i32 1
+;; @001d                               v8 = band.i32 v2, v7  ; v7 = 1
+;;                                     v22 = iconst.i32 0
+;; @001d                               brif v8, block4(v22), block3  ; v22 = 0
 ;;
 ;;                                 block3:
-;; @001d                               v14 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @001d                               v15 = load.i64 notrap aligned readonly can_move region3 v14+32
-;; @001d                               v13 = uextend.i64 v2
-;; @001d                               v16 = iadd v15, v13
-;; @001d                               v17 = iconst.i64 4
-;; @001d                               v18 = iadd v16, v17  ; v17 = 4
-;; @001d                               v19 = load.i32 user2 readonly region5 v18
-;; @001d                               v11 = load.i64 notrap aligned readonly can_move region2 v0+40
-;; @001d                               v12 = load.i32 notrap aligned readonly can_move v11
-;; @001d                               v20 = icmp eq v19, v12
-;; @001d                               v21 = uextend.i32 v20
-;; @001d                               jump block4(v21)
+;; @001d                               v13 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @001d                               v14 = load.i64 notrap aligned readonly can_move region3 v13+32
+;; @001d                               v12 = uextend.i64 v2
+;; @001d                               v15 = iadd v14, v12
+;; @001d                               v16 = iconst.i64 4
+;; @001d                               v17 = iadd v15, v16  ; v16 = 4
+;; @001d                               v18 = load.i32 user2 readonly region5 v17
+;; @001d                               v10 = load.i64 notrap aligned readonly can_move region2 v0+40
+;; @001d                               v11 = load.i32 notrap aligned readonly can_move v10
+;; @001d                               v19 = icmp eq v18, v11
+;; @001d                               v20 = uextend.i32 v19
+;; @001d                               jump block4(v20)
 ;;
-;;                                 block4(v22: i32):
-;; @0020                               jump block1(v22)
+;;                                 block4(v21: i32):
+;; @0020                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @0020                               return v3
+;;                                 block1:
+;; @0020                               return v21
 ;; }

--- a/tests/disas/gc/copying/ref-test-eq.wat
+++ b/tests/disas/gc/copying/ref-test-eq.wat
@@ -18,30 +18,30 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @001b                               v4 = iconst.i32 0
-;; @001b                               v5 = icmp eq v2, v4  ; v4 = 0
-;; @001b                               brif v5, block4(v4), block2  ; v4 = 0
+;; @001b                               v3 = iconst.i32 0
+;; @001b                               v4 = icmp eq v2, v3  ; v3 = 0
+;; @001b                               brif v4, block4(v3), block2  ; v3 = 0
 ;;
 ;;                                 block2:
-;; @001b                               v8 = iconst.i32 1
-;; @001b                               v9 = band.i32 v2, v8  ; v8 = 1
-;; @001b                               brif v9, block4(v8), block3  ; v8 = 1
+;; @001b                               v7 = iconst.i32 1
+;; @001b                               v8 = band.i32 v2, v7  ; v7 = 1
+;; @001b                               brif v8, block4(v7), block3  ; v7 = 1
 ;;
 ;;                                 block3:
-;; @001b                               v12 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @001b                               v13 = load.i64 notrap aligned readonly can_move region2 v12+32
-;; @001b                               v11 = uextend.i64 v2
-;; @001b                               v14 = iadd v13, v11
-;; @001b                               v17 = load.i32 user2 readonly region4 v14
-;; @001b                               v18 = iconst.i32 -1610612736
-;; @001b                               v19 = band v17, v18  ; v18 = -1610612736
-;; @001b                               v20 = icmp eq v19, v18  ; v18 = -1610612736
-;; @001b                               v21 = uextend.i32 v20
-;; @001b                               jump block4(v21)
+;; @001b                               v11 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @001b                               v12 = load.i64 notrap aligned readonly can_move region2 v11+32
+;; @001b                               v10 = uextend.i64 v2
+;; @001b                               v13 = iadd v12, v10
+;; @001b                               v16 = load.i32 user2 readonly region4 v13
+;; @001b                               v17 = iconst.i32 -1610612736
+;; @001b                               v18 = band v16, v17  ; v17 = -1610612736
+;; @001b                               v19 = icmp eq v18, v17  ; v17 = -1610612736
+;; @001b                               v20 = uextend.i32 v19
+;; @001b                               jump block4(v20)
 ;;
-;;                                 block4(v22: i32):
-;; @001e                               jump block1(v22)
+;;                                 block4(v21: i32):
+;; @001e                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @001e                               return v3
+;;                                 block1:
+;; @001e                               return v21
 ;; }

--- a/tests/disas/gc/copying/ref-test-i31.wat
+++ b/tests/disas/gc/copying/ref-test-i31.wat
@@ -18,7 +18,7 @@
 ;; @001e                               jump block1
 ;;
 ;;                                 block1:
-;; @001b                               v4 = iconst.i32 1
-;; @001b                               v5 = band.i32 v2, v4  ; v4 = 1
-;; @001e                               return v5
+;; @001b                               v3 = iconst.i32 1
+;; @001b                               v4 = band.i32 v2, v3  ; v3 = 1
+;; @001e                               return v4
 ;; }

--- a/tests/disas/gc/copying/ref-test-none.wat
+++ b/tests/disas/gc/copying/ref-test-none.wat
@@ -21,8 +21,8 @@
 ;; @001f                               jump block1
 ;;
 ;;                                 block1:
-;; @001c                               v4 = iconst.i32 0
-;; @001f                               return v4  ; v4 = 0
+;; @001c                               v3 = iconst.i32 0
+;; @001f                               return v3  ; v3 = 0
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
@@ -37,8 +37,8 @@
 ;; @0027                               jump block1
 ;;
 ;;                                 block1:
-;; @0024                               v4 = iconst.i32 0
-;; @0024                               v5 = icmp.i32 eq v2, v4  ; v4 = 0
-;; @0024                               v6 = uextend.i32 v5
-;; @0027                               return v6
+;; @0024                               v3 = iconst.i32 0
+;; @0024                               v4 = icmp.i32 eq v2, v3  ; v3 = 0
+;; @0024                               v5 = uextend.i32 v4
+;; @0027                               return v5
 ;; }

--- a/tests/disas/gc/copying/ref-test-struct.wat
+++ b/tests/disas/gc/copying/ref-test-struct.wat
@@ -18,31 +18,31 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @001b                               v4 = iconst.i32 0
-;; @001b                               v5 = icmp eq v2, v4  ; v4 = 0
-;; @001b                               brif v5, block4(v4), block2  ; v4 = 0
+;; @001b                               v3 = iconst.i32 0
+;; @001b                               v4 = icmp eq v2, v3  ; v3 = 0
+;; @001b                               brif v4, block4(v3), block2  ; v3 = 0
 ;;
 ;;                                 block2:
-;; @001b                               v8 = iconst.i32 1
-;; @001b                               v9 = band.i32 v2, v8  ; v8 = 1
-;;                                     v23 = iconst.i32 0
-;; @001b                               brif v9, block4(v23), block3  ; v23 = 0
+;; @001b                               v7 = iconst.i32 1
+;; @001b                               v8 = band.i32 v2, v7  ; v7 = 1
+;;                                     v22 = iconst.i32 0
+;; @001b                               brif v8, block4(v22), block3  ; v22 = 0
 ;;
 ;;                                 block3:
-;; @001b                               v12 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @001b                               v13 = load.i64 notrap aligned readonly can_move region2 v12+32
-;; @001b                               v11 = uextend.i64 v2
-;; @001b                               v14 = iadd v13, v11
-;; @001b                               v17 = load.i32 user2 readonly region4 v14
-;; @001b                               v18 = iconst.i32 -1342177280
-;; @001b                               v19 = band v17, v18  ; v18 = -1342177280
-;; @001b                               v20 = icmp eq v19, v18  ; v18 = -1342177280
-;; @001b                               v21 = uextend.i32 v20
-;; @001b                               jump block4(v21)
+;; @001b                               v11 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @001b                               v12 = load.i64 notrap aligned readonly can_move region2 v11+32
+;; @001b                               v10 = uextend.i64 v2
+;; @001b                               v13 = iadd v12, v10
+;; @001b                               v16 = load.i32 user2 readonly region4 v13
+;; @001b                               v17 = iconst.i32 -1342177280
+;; @001b                               v18 = band v16, v17  ; v17 = -1342177280
+;; @001b                               v19 = icmp eq v18, v17  ; v17 = -1342177280
+;; @001b                               v20 = uextend.i32 v19
+;; @001b                               jump block4(v20)
 ;;
-;;                                 block4(v22: i32):
-;; @001e                               jump block1(v22)
+;;                                 block4(v21: i32):
+;; @001e                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @001e                               return v3
+;;                                 block1:
+;; @001e                               return v21
 ;; }

--- a/tests/disas/gc/copying/struct-get.wat
+++ b/tests/disas/gc/copying/struct-get.wat
@@ -35,17 +35,17 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0033                               trapz v2, user16
-;; @0033                               v5 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0033                               v6 = load.i64 notrap aligned readonly can_move region2 v5+32
-;; @0033                               v4 = uextend.i64 v2
-;; @0033                               v7 = iadd v6, v4
-;; @0033                               v8 = iconst.i64 16
-;; @0033                               v9 = iadd v7, v8  ; v8 = 16
-;; @0033                               v10 = load.f32 user2 little region4 v9
+;; @0033                               v4 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @0033                               v5 = load.i64 notrap aligned readonly can_move region2 v4+32
+;; @0033                               v3 = uextend.i64 v2
+;; @0033                               v6 = iadd v5, v3
+;; @0033                               v7 = iconst.i64 16
+;; @0033                               v8 = iadd v6, v7  ; v7 = 16
+;; @0033                               v9 = load.f32 user2 little region4 v8
 ;; @0037                               jump block1
 ;;
 ;;                                 block1:
-;; @0037                               return v10
+;; @0037                               return v9
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
@@ -61,18 +61,18 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @003c                               trapz v2, user16
-;; @003c                               v5 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @003c                               v6 = load.i64 notrap aligned readonly can_move region2 v5+32
-;; @003c                               v4 = uextend.i64 v2
-;; @003c                               v7 = iadd v6, v4
-;; @003c                               v8 = iconst.i64 20
-;; @003c                               v9 = iadd v7, v8  ; v8 = 20
-;; @003c                               v10 = load.i8 user2 little region4 v9
+;; @003c                               v4 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @003c                               v5 = load.i64 notrap aligned readonly can_move region2 v4+32
+;; @003c                               v3 = uextend.i64 v2
+;; @003c                               v6 = iadd v5, v3
+;; @003c                               v7 = iconst.i64 20
+;; @003c                               v8 = iadd v6, v7  ; v7 = 20
+;; @003c                               v9 = load.i8 user2 little region4 v8
 ;; @0040                               jump block1
 ;;
 ;;                                 block1:
-;; @003c                               v11 = sextend.i32 v10
-;; @0040                               return v11
+;; @003c                               v10 = sextend.i32 v9
+;; @0040                               return v10
 ;; }
 ;;
 ;; function u0:2(i64 vmctx, i64, i32) -> i32 tail {
@@ -88,18 +88,18 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0045                               trapz v2, user16
-;; @0045                               v5 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0045                               v6 = load.i64 notrap aligned readonly can_move region2 v5+32
-;; @0045                               v4 = uextend.i64 v2
-;; @0045                               v7 = iadd v6, v4
-;; @0045                               v8 = iconst.i64 20
-;; @0045                               v9 = iadd v7, v8  ; v8 = 20
-;; @0045                               v10 = load.i8 user2 little region4 v9
+;; @0045                               v4 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @0045                               v5 = load.i64 notrap aligned readonly can_move region2 v4+32
+;; @0045                               v3 = uextend.i64 v2
+;; @0045                               v6 = iadd v5, v3
+;; @0045                               v7 = iconst.i64 20
+;; @0045                               v8 = iadd v6, v7  ; v7 = 20
+;; @0045                               v9 = load.i8 user2 little region4 v8
 ;; @0049                               jump block1
 ;;
 ;;                                 block1:
-;; @0045                               v11 = uextend.i32 v10
-;; @0049                               return v11
+;; @0045                               v10 = uextend.i32 v9
+;; @0049                               return v10
 ;; }
 ;;
 ;; function u0:3(i64 vmctx, i64, i32) -> i32 tail {
@@ -115,15 +115,15 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @004e                               trapz v2, user16
-;; @004e                               v5 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @004e                               v6 = load.i64 notrap aligned readonly can_move region2 v5+32
-;; @004e                               v4 = uextend.i64 v2
-;; @004e                               v7 = iadd v6, v4
-;; @004e                               v8 = iconst.i64 24
-;; @004e                               v9 = iadd v7, v8  ; v8 = 24
-;; @004e                               v10 = load.i32 user2 little region4 v9
+;; @004e                               v4 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @004e                               v5 = load.i64 notrap aligned readonly can_move region2 v4+32
+;; @004e                               v3 = uextend.i64 v2
+;; @004e                               v6 = iadd v5, v3
+;; @004e                               v7 = iconst.i64 24
+;; @004e                               v8 = iadd v6, v7  ; v7 = 24
+;; @004e                               v9 = load.i32 user2 little region4 v8
 ;; @0052                               jump block1
 ;;
 ;;                                 block1:
-;; @0052                               return v10
+;; @0052                               return v9
 ;; }

--- a/tests/disas/gc/copying/struct-new-default.wat
+++ b/tests/disas/gc/copying/struct-new-default.wat
@@ -25,59 +25,59 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @0021                               v7 = load.i64 notrap aligned readonly can_move region2 v0+32
-;; @0021                               v8 = load.i32 notrap aligned v7
-;; @0021                               v9 = load.i32 notrap aligned v7+4
-;; @0021                               v15 = uextend.i64 v8
-;;                                     v44 = iconst.i64 32
-;; @0021                               v16 = iadd v15, v44  ; v44 = 32
-;; @0021                               v17 = uextend.i64 v9
-;; @0021                               v18 = icmp ule v16, v17
-;; @0021                               brif v18, block2, block3
+;; @0021                               v6 = load.i64 notrap aligned readonly can_move region2 v0+32
+;; @0021                               v7 = load.i32 notrap aligned v6
+;; @0021                               v8 = load.i32 notrap aligned v6+4
+;; @0021                               v14 = uextend.i64 v7
+;;                                     v43 = iconst.i64 32
+;; @0021                               v15 = iadd v14, v43  ; v43 = 32
+;; @0021                               v16 = uextend.i64 v8
+;; @0021                               v17 = icmp ule v15, v16
+;; @0021                               brif v17, block2, block3
 ;;
 ;;                                 block2:
-;;                                     v60 = iconst.i32 32
-;;                                     v58 = iadd.i32 v8, v60  ; v60 = 32
-;; @0021                               store notrap aligned v58, v7
-;;                                     v61 = iconst.i32 -1342177246
-;;                                     v62 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v63 = load.i64 notrap aligned readonly can_move region4 v62+32
-;; @0021                               v32 = iadd v63, v15
-;; @0021                               store notrap aligned v61, v32  ; v61 = -1342177246
-;;                                     v64 = load.i64 notrap aligned readonly can_move region3 v0+40
-;;                                     v65 = load.i32 notrap aligned readonly can_move v64
-;; @0021                               store notrap aligned v65, v32+4
-;;                                     v66 = iconst.i64 32
-;; @0021                               istore32 notrap aligned v66, v32+8  ; v66 = 32
-;; @0021                               jump block4(v8, v32)
+;;                                     v59 = iconst.i32 32
+;;                                     v57 = iadd.i32 v7, v59  ; v59 = 32
+;; @0021                               store notrap aligned v57, v6
+;;                                     v60 = iconst.i32 -1342177246
+;;                                     v61 = load.i64 notrap aligned readonly can_move region0 v0+8
+;;                                     v62 = load.i64 notrap aligned readonly can_move region4 v61+32
+;; @0021                               v31 = iadd v62, v14
+;; @0021                               store notrap aligned v60, v31  ; v60 = -1342177246
+;;                                     v63 = load.i64 notrap aligned readonly can_move region3 v0+40
+;;                                     v64 = load.i32 notrap aligned readonly can_move v63
+;; @0021                               store notrap aligned v64, v31+4
+;;                                     v65 = iconst.i64 32
+;; @0021                               istore32 notrap aligned v65, v31+8  ; v65 = 32
+;; @0021                               jump block4(v7, v31)
 ;;
 ;;                                 block3 cold:
-;; @0021                               v19 = iconst.i32 -1342177246
-;; @0021                               v20 = load.i64 notrap aligned readonly can_move region3 v0+40
-;; @0021                               v21 = load.i32 notrap aligned readonly can_move v20
-;; @0021                               v6 = iconst.i32 32
-;; @0021                               v22 = iconst.i32 16
-;; @0021                               v23 = call fn0(v0, v19, v21, v6, v22)  ; v19 = -1342177246, v6 = 32, v22 = 16
-;; @0021                               v24 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0021                               v25 = load.i64 notrap aligned readonly can_move region4 v24+32
-;; @0021                               v26 = uextend.i64 v23
-;; @0021                               v27 = iadd v25, v26
-;; @0021                               jump block4(v23, v27)
+;; @0021                               v18 = iconst.i32 -1342177246
+;; @0021                               v19 = load.i64 notrap aligned readonly can_move region3 v0+40
+;; @0021                               v20 = load.i32 notrap aligned readonly can_move v19
+;; @0021                               v5 = iconst.i32 32
+;; @0021                               v21 = iconst.i32 16
+;; @0021                               v22 = call fn0(v0, v18, v20, v5, v21)  ; v18 = -1342177246, v5 = 32, v21 = 16
+;; @0021                               v23 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @0021                               v24 = load.i64 notrap aligned readonly can_move region4 v23+32
+;; @0021                               v25 = uextend.i64 v22
+;; @0021                               v26 = iadd v24, v25
+;; @0021                               jump block4(v22, v26)
 ;;
-;;                                 block4(v36: i32, v37: i64):
-;; @0021                               v3 = f32const 0.0
-;; @0021                               v38 = iconst.i64 16
-;; @0021                               v39 = iadd v37, v38  ; v38 = 16
-;; @0021                               store user2 little region5 v3, v39  ; v3 = 0.0
-;; @0021                               v4 = iconst.i32 0
-;; @0021                               v40 = iconst.i64 20
-;; @0021                               v41 = iadd v37, v40  ; v40 = 20
-;; @0021                               istore8 user2 little region5 v4, v41  ; v4 = 0
-;; @0021                               v42 = iconst.i64 24
-;; @0021                               v43 = iadd v37, v42  ; v42 = 24
-;; @0021                               store user2 little region5 v4, v43  ; v4 = 0
-;; @0024                               jump block1(v36)
+;;                                 block4(v35: i32, v36: i64):
+;; @0021                               v2 = f32const 0.0
+;; @0021                               v37 = iconst.i64 16
+;; @0021                               v38 = iadd v36, v37  ; v37 = 16
+;; @0021                               store user2 little region5 v2, v38  ; v2 = 0.0
+;; @0021                               v3 = iconst.i32 0
+;; @0021                               v39 = iconst.i64 20
+;; @0021                               v40 = iadd v36, v39  ; v39 = 20
+;; @0021                               istore8 user2 little region5 v3, v40  ; v3 = 0
+;; @0021                               v41 = iconst.i64 24
+;; @0021                               v42 = iadd v36, v41  ; v41 = 24
+;; @0021                               store user2 little region5 v3, v42  ; v3 = 0
+;; @0024                               jump block1
 ;;
-;;                                 block1(v2: i32):
-;; @0024                               return v2
+;;                                 block1:
+;; @0024                               return v35
 ;; }

--- a/tests/disas/gc/copying/struct-new.wat
+++ b/tests/disas/gc/copying/struct-new.wat
@@ -26,60 +26,60 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: f32, v3: i32, v4: i32):
-;;                                     v46 = stack_addr.i64 ss0
-;;                                     store notrap v4, v46
-;; @002a                               v7 = load.i64 notrap aligned readonly can_move region2 v0+32
-;; @002a                               v8 = load.i32 notrap aligned v7
-;; @002a                               v9 = load.i32 notrap aligned v7+4
-;; @002a                               v15 = uextend.i64 v8
-;;                                     v47 = iconst.i64 32
-;; @002a                               v16 = iadd v15, v47  ; v47 = 32
-;; @002a                               v17 = uextend.i64 v9
-;; @002a                               v18 = icmp ule v16, v17
-;; @002a                               brif v18, block2, block3
+;;                                     v45 = stack_addr.i64 ss0
+;;                                     store notrap v4, v45
+;; @002a                               v6 = load.i64 notrap aligned readonly can_move region2 v0+32
+;; @002a                               v7 = load.i32 notrap aligned v6
+;; @002a                               v8 = load.i32 notrap aligned v6+4
+;; @002a                               v14 = uextend.i64 v7
+;;                                     v46 = iconst.i64 32
+;; @002a                               v15 = iadd v14, v46  ; v46 = 32
+;; @002a                               v16 = uextend.i64 v8
+;; @002a                               v17 = icmp ule v15, v16
+;; @002a                               brif v17, block2, block3
 ;;
 ;;                                 block2:
-;;                                     v63 = iconst.i32 32
-;;                                     v61 = iadd.i32 v8, v63  ; v63 = 32
-;; @002a                               store notrap aligned v61, v7
-;;                                     v64 = iconst.i32 -1342177246
-;;                                     v65 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v66 = load.i64 notrap aligned readonly can_move region4 v65+32
-;; @002a                               v32 = iadd v66, v15
-;; @002a                               store notrap aligned v64, v32  ; v64 = -1342177246
-;;                                     v67 = load.i64 notrap aligned readonly can_move region3 v0+40
-;;                                     v68 = load.i32 notrap aligned readonly can_move v67
-;; @002a                               store notrap aligned v68, v32+4
-;;                                     v69 = iconst.i64 32
-;; @002a                               istore32 notrap aligned v69, v32+8  ; v69 = 32
-;; @002a                               jump block4(v8, v32)
+;;                                     v62 = iconst.i32 32
+;;                                     v60 = iadd.i32 v7, v62  ; v62 = 32
+;; @002a                               store notrap aligned v60, v6
+;;                                     v63 = iconst.i32 -1342177246
+;;                                     v64 = load.i64 notrap aligned readonly can_move region0 v0+8
+;;                                     v65 = load.i64 notrap aligned readonly can_move region4 v64+32
+;; @002a                               v31 = iadd v65, v14
+;; @002a                               store notrap aligned v63, v31  ; v63 = -1342177246
+;;                                     v66 = load.i64 notrap aligned readonly can_move region3 v0+40
+;;                                     v67 = load.i32 notrap aligned readonly can_move v66
+;; @002a                               store notrap aligned v67, v31+4
+;;                                     v68 = iconst.i64 32
+;; @002a                               istore32 notrap aligned v68, v31+8  ; v68 = 32
+;; @002a                               jump block4(v7, v31)
 ;;
 ;;                                 block3 cold:
-;; @002a                               v19 = iconst.i32 -1342177246
-;; @002a                               v20 = load.i64 notrap aligned readonly can_move region3 v0+40
-;; @002a                               v21 = load.i32 notrap aligned readonly can_move v20
-;; @002a                               v6 = iconst.i32 32
-;; @002a                               v22 = iconst.i32 16
-;; @002a                               v23 = call fn0(v0, v19, v21, v6, v22), stack_map=[i32 @ ss0+0]  ; v19 = -1342177246, v6 = 32, v22 = 16
-;; @002a                               v24 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @002a                               v25 = load.i64 notrap aligned readonly can_move region4 v24+32
-;; @002a                               v26 = uextend.i64 v23
-;; @002a                               v27 = iadd v25, v26
-;; @002a                               jump block4(v23, v27)
+;; @002a                               v18 = iconst.i32 -1342177246
+;; @002a                               v19 = load.i64 notrap aligned readonly can_move region3 v0+40
+;; @002a                               v20 = load.i32 notrap aligned readonly can_move v19
+;; @002a                               v5 = iconst.i32 32
+;; @002a                               v21 = iconst.i32 16
+;; @002a                               v22 = call fn0(v0, v18, v20, v5, v21), stack_map=[i32 @ ss0+0]  ; v18 = -1342177246, v5 = 32, v21 = 16
+;; @002a                               v23 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @002a                               v24 = load.i64 notrap aligned readonly can_move region4 v23+32
+;; @002a                               v25 = uextend.i64 v22
+;; @002a                               v26 = iadd v24, v25
+;; @002a                               jump block4(v22, v26)
 ;;
-;;                                 block4(v36: i32, v37: i64):
-;; @002a                               v38 = iconst.i64 16
-;; @002a                               v39 = iadd v37, v38  ; v38 = 16
-;; @002a                               store.f32 user2 little region5 v2, v39
-;; @002a                               v40 = iconst.i64 20
-;; @002a                               v41 = iadd v37, v40  ; v40 = 20
-;; @002a                               istore8.i32 user2 little region5 v3, v41
-;;                                     v45 = load.i32 notrap v46
-;; @002a                               v42 = iconst.i64 24
-;; @002a                               v43 = iadd v37, v42  ; v42 = 24
-;; @002a                               store user2 little region5 v45, v43
-;; @002d                               jump block1(v36)
+;;                                 block4(v35: i32, v36: i64):
+;; @002a                               v37 = iconst.i64 16
+;; @002a                               v38 = iadd v36, v37  ; v37 = 16
+;; @002a                               store.f32 user2 little region5 v2, v38
+;; @002a                               v39 = iconst.i64 20
+;; @002a                               v40 = iadd v36, v39  ; v39 = 20
+;; @002a                               istore8.i32 user2 little region5 v3, v40
+;;                                     v44 = load.i32 notrap v45
+;; @002a                               v41 = iconst.i64 24
+;; @002a                               v42 = iadd v36, v41  ; v41 = 24
+;; @002a                               store user2 little region5 v44, v42
+;; @002d                               jump block1
 ;;
-;;                                 block1(v5: i32):
-;; @002d                               return v5
+;;                                 block1:
+;; @002d                               return v35
 ;; }

--- a/tests/disas/gc/copying/v128-fields.wat
+++ b/tests/disas/gc/copying/v128-fields.wat
@@ -23,16 +23,16 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0022                               trapz v2, user16
-;; @0022                               v5 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0022                               v6 = load.i64 notrap aligned readonly can_move region2 v5+32
-;; @0022                               v4 = uextend.i64 v2
-;; @0022                               v7 = iadd v6, v4
-;; @0022                               v8 = iconst.i64 16
-;; @0022                               v9 = iadd v7, v8  ; v8 = 16
-;; @0022                               v10 = load.i8x16 user2 little region4 v9
+;; @0022                               v4 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @0022                               v5 = load.i64 notrap aligned readonly can_move region2 v4+32
+;; @0022                               v3 = uextend.i64 v2
+;; @0022                               v6 = iadd v5, v3
+;; @0022                               v7 = iconst.i64 16
+;; @0022                               v8 = iadd v6, v7  ; v7 = 16
+;; @0022                               v9 = load.i8x16 user2 little region4 v8
 ;; @002e                               jump block1
 ;;
 ;;                                 block1:
-;; @002c                               v18 = bxor.i8x16 v10, v10
-;; @002e                               return v18
+;; @002c                               v17 = bxor.i8x16 v9, v9
+;; @002e                               return v17
 ;; }

--- a/tests/disas/gc/drc/array-get-s.wat
+++ b/tests/disas/gc/drc/array-get-s.wat
@@ -22,32 +22,32 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0022                               trapz v2, user16
-;; @0022                               v6 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0022                               v7 = load.i64 notrap aligned readonly can_move region2 v6+32
-;; @0022                               v5 = uextend.i64 v2
-;; @0022                               v8 = iadd v7, v5
-;; @0022                               v9 = iconst.i64 24
-;; @0022                               v10 = iadd v8, v9  ; v9 = 24
-;; @0022                               v11 = load.i32 user2 readonly region4 v10
-;; @0022                               v12 = icmp ult v3, v11
-;; @0022                               trapz v12, user17
-;; @0022                               v14 = uextend.i64 v11
-;; @0022                               v16 = iconst.i64 32
-;; @0022                               v17 = ushr v14, v16  ; v16 = 32
-;; @0022                               trapnz v17, user2
-;; @0022                               v19 = iconst.i32 28
-;; @0022                               v20 = uadd_overflow_trap v11, v19, user2  ; v19 = 28
-;; @0022                               v24 = uadd_overflow_trap v2, v20, user2
-;; @0022                               v25 = uextend.i64 v24
-;; @0022                               v28 = iadd v7, v25
-;; @0022                               v23 = iadd v3, v19  ; v19 = 28
-;; @0022                               v29 = isub v20, v23
-;; @0022                               v30 = uextend.i64 v29
-;; @0022                               v31 = isub v28, v30
-;; @0022                               v32 = load.i8 user2 little region4 v31
+;; @0022                               v5 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @0022                               v6 = load.i64 notrap aligned readonly can_move region2 v5+32
+;; @0022                               v4 = uextend.i64 v2
+;; @0022                               v7 = iadd v6, v4
+;; @0022                               v8 = iconst.i64 24
+;; @0022                               v9 = iadd v7, v8  ; v8 = 24
+;; @0022                               v10 = load.i32 user2 readonly region4 v9
+;; @0022                               v11 = icmp ult v3, v10
+;; @0022                               trapz v11, user17
+;; @0022                               v13 = uextend.i64 v10
+;; @0022                               v15 = iconst.i64 32
+;; @0022                               v16 = ushr v13, v15  ; v15 = 32
+;; @0022                               trapnz v16, user2
+;; @0022                               v18 = iconst.i32 28
+;; @0022                               v19 = uadd_overflow_trap v10, v18, user2  ; v18 = 28
+;; @0022                               v23 = uadd_overflow_trap v2, v19, user2
+;; @0022                               v24 = uextend.i64 v23
+;; @0022                               v27 = iadd v6, v24
+;; @0022                               v22 = iadd v3, v18  ; v18 = 28
+;; @0022                               v28 = isub v19, v22
+;; @0022                               v29 = uextend.i64 v28
+;; @0022                               v30 = isub v27, v29
+;; @0022                               v31 = load.i8 user2 little region4 v30
 ;; @0025                               jump block1
 ;;
 ;;                                 block1:
-;; @0022                               v33 = sextend.i32 v32
-;; @0025                               return v33
+;; @0022                               v32 = sextend.i32 v31
+;; @0025                               return v32
 ;; }

--- a/tests/disas/gc/drc/array-get-u.wat
+++ b/tests/disas/gc/drc/array-get-u.wat
@@ -22,32 +22,32 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0022                               trapz v2, user16
-;; @0022                               v6 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0022                               v7 = load.i64 notrap aligned readonly can_move region2 v6+32
-;; @0022                               v5 = uextend.i64 v2
-;; @0022                               v8 = iadd v7, v5
-;; @0022                               v9 = iconst.i64 24
-;; @0022                               v10 = iadd v8, v9  ; v9 = 24
-;; @0022                               v11 = load.i32 user2 readonly region4 v10
-;; @0022                               v12 = icmp ult v3, v11
-;; @0022                               trapz v12, user17
-;; @0022                               v14 = uextend.i64 v11
-;; @0022                               v16 = iconst.i64 32
-;; @0022                               v17 = ushr v14, v16  ; v16 = 32
-;; @0022                               trapnz v17, user2
-;; @0022                               v19 = iconst.i32 28
-;; @0022                               v20 = uadd_overflow_trap v11, v19, user2  ; v19 = 28
-;; @0022                               v24 = uadd_overflow_trap v2, v20, user2
-;; @0022                               v25 = uextend.i64 v24
-;; @0022                               v28 = iadd v7, v25
-;; @0022                               v23 = iadd v3, v19  ; v19 = 28
-;; @0022                               v29 = isub v20, v23
-;; @0022                               v30 = uextend.i64 v29
-;; @0022                               v31 = isub v28, v30
-;; @0022                               v32 = load.i8 user2 little region4 v31
+;; @0022                               v5 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @0022                               v6 = load.i64 notrap aligned readonly can_move region2 v5+32
+;; @0022                               v4 = uextend.i64 v2
+;; @0022                               v7 = iadd v6, v4
+;; @0022                               v8 = iconst.i64 24
+;; @0022                               v9 = iadd v7, v8  ; v8 = 24
+;; @0022                               v10 = load.i32 user2 readonly region4 v9
+;; @0022                               v11 = icmp ult v3, v10
+;; @0022                               trapz v11, user17
+;; @0022                               v13 = uextend.i64 v10
+;; @0022                               v15 = iconst.i64 32
+;; @0022                               v16 = ushr v13, v15  ; v15 = 32
+;; @0022                               trapnz v16, user2
+;; @0022                               v18 = iconst.i32 28
+;; @0022                               v19 = uadd_overflow_trap v10, v18, user2  ; v18 = 28
+;; @0022                               v23 = uadd_overflow_trap v2, v19, user2
+;; @0022                               v24 = uextend.i64 v23
+;; @0022                               v27 = iadd v6, v24
+;; @0022                               v22 = iadd v3, v18  ; v18 = 28
+;; @0022                               v28 = isub v19, v22
+;; @0022                               v29 = uextend.i64 v28
+;; @0022                               v30 = isub v27, v29
+;; @0022                               v31 = load.i8 user2 little region4 v30
 ;; @0025                               jump block1
 ;;
 ;;                                 block1:
-;; @0022                               v33 = uextend.i32 v32
-;; @0025                               return v33
+;; @0022                               v32 = uextend.i32 v31
+;; @0025                               return v32
 ;; }

--- a/tests/disas/gc/drc/array-get.wat
+++ b/tests/disas/gc/drc/array-get.wat
@@ -22,36 +22,36 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0022                               trapz v2, user16
-;; @0022                               v6 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0022                               v7 = load.i64 notrap aligned readonly can_move region2 v6+32
-;; @0022                               v5 = uextend.i64 v2
-;; @0022                               v8 = iadd v7, v5
-;; @0022                               v9 = iconst.i64 24
-;; @0022                               v10 = iadd v8, v9  ; v9 = 24
-;; @0022                               v11 = load.i32 user2 readonly region4 v10
-;; @0022                               v12 = icmp ult v3, v11
-;; @0022                               trapz v12, user17
-;; @0022                               v14 = uextend.i64 v11
-;;                                     v33 = iconst.i64 3
-;;                                     v34 = ishl v14, v33  ; v33 = 3
-;; @0022                               v16 = iconst.i64 32
-;; @0022                               v17 = ushr v34, v16  ; v16 = 32
-;; @0022                               trapnz v17, user2
-;;                                     v43 = iconst.i32 3
-;;                                     v44 = ishl v11, v43  ; v43 = 3
-;; @0022                               v19 = iconst.i32 32
-;; @0022                               v20 = uadd_overflow_trap v44, v19, user2  ; v19 = 32
-;; @0022                               v24 = uadd_overflow_trap v2, v20, user2
-;; @0022                               v25 = uextend.i64 v24
-;; @0022                               v28 = iadd v7, v25
-;;                                     v50 = ishl v3, v43  ; v43 = 3
-;; @0022                               v23 = iadd v50, v19  ; v19 = 32
-;; @0022                               v29 = isub v20, v23
-;; @0022                               v30 = uextend.i64 v29
-;; @0022                               v31 = isub v28, v30
-;; @0022                               v32 = load.i64 user2 little region4 v31
+;; @0022                               v5 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @0022                               v6 = load.i64 notrap aligned readonly can_move region2 v5+32
+;; @0022                               v4 = uextend.i64 v2
+;; @0022                               v7 = iadd v6, v4
+;; @0022                               v8 = iconst.i64 24
+;; @0022                               v9 = iadd v7, v8  ; v8 = 24
+;; @0022                               v10 = load.i32 user2 readonly region4 v9
+;; @0022                               v11 = icmp ult v3, v10
+;; @0022                               trapz v11, user17
+;; @0022                               v13 = uextend.i64 v10
+;;                                     v32 = iconst.i64 3
+;;                                     v33 = ishl v13, v32  ; v32 = 3
+;; @0022                               v15 = iconst.i64 32
+;; @0022                               v16 = ushr v33, v15  ; v15 = 32
+;; @0022                               trapnz v16, user2
+;;                                     v42 = iconst.i32 3
+;;                                     v43 = ishl v10, v42  ; v42 = 3
+;; @0022                               v18 = iconst.i32 32
+;; @0022                               v19 = uadd_overflow_trap v43, v18, user2  ; v18 = 32
+;; @0022                               v23 = uadd_overflow_trap v2, v19, user2
+;; @0022                               v24 = uextend.i64 v23
+;; @0022                               v27 = iadd v6, v24
+;;                                     v49 = ishl v3, v42  ; v42 = 3
+;; @0022                               v22 = iadd v49, v18  ; v18 = 32
+;; @0022                               v28 = isub v19, v22
+;; @0022                               v29 = uextend.i64 v28
+;; @0022                               v30 = isub v27, v29
+;; @0022                               v31 = load.i64 user2 little region4 v30
 ;; @0025                               jump block1
 ;;
 ;;                                 block1:
-;; @0025                               return v32
+;; @0025                               return v31
 ;; }

--- a/tests/disas/gc/drc/array-len.wat
+++ b/tests/disas/gc/drc/array-len.wat
@@ -22,15 +22,15 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @001f                               trapz v2, user16
-;; @001f                               v5 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @001f                               v6 = load.i64 notrap aligned readonly can_move region2 v5+32
-;; @001f                               v4 = uextend.i64 v2
-;; @001f                               v7 = iadd v6, v4
-;; @001f                               v8 = iconst.i64 24
-;; @001f                               v9 = iadd v7, v8  ; v8 = 24
-;; @001f                               v10 = load.i32 user2 readonly region4 v9
+;; @001f                               v4 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @001f                               v5 = load.i64 notrap aligned readonly can_move region2 v4+32
+;; @001f                               v3 = uextend.i64 v2
+;; @001f                               v6 = iadd v5, v3
+;; @001f                               v7 = iconst.i64 24
+;; @001f                               v8 = iadd v6, v7  ; v7 = 24
+;; @001f                               v9 = load.i32 user2 readonly region4 v8
 ;; @0021                               jump block1
 ;;
 ;;                                 block1:
-;; @0021                               return v10
+;; @0021                               return v9
 ;; }

--- a/tests/disas/gc/drc/array-new-fixed-of-gc-refs.wat
+++ b/tests/disas/gc/drc/array-new-fixed-of-gc-refs.wat
@@ -27,148 +27,148 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
-;;                                     v203 = stack_addr.i64 ss2
-;;                                     store notrap v2, v203
-;;                                     v204 = stack_addr.i64 ss1
-;;                                     store notrap v3, v204
-;;                                     v205 = stack_addr.i64 ss0
-;;                                     store notrap v4, v205
-;; @0025                               v15 = iconst.i32 -1476395008
-;; @0025                               v16 = load.i64 notrap aligned readonly can_move region2 v0+40
-;; @0025                               v17 = load.i32 notrap aligned readonly can_move v16
-;;                                     v217 = iconst.i32 40
-;; @0025                               v18 = iconst.i32 8
-;; @0025                               v19 = call fn0(v0, v15, v17, v217, v18), stack_map=[i32 @ ss2+0, i32 @ ss1+0, i32 @ ss0+0]  ; v15 = -1476395008, v217 = 40, v18 = 8
-;; @0025                               v6 = iconst.i32 3
-;; @0025                               v20 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0025                               v21 = load.i64 notrap aligned readonly can_move region3 v20+32
-;; @0025                               v22 = uextend.i64 v19
-;; @0025                               v23 = iadd v21, v22
-;; @0025                               v24 = iconst.i64 24
-;; @0025                               v25 = iadd v23, v24  ; v24 = 24
-;; @0025                               store user2 region4 v6, v25  ; v6 = 3
-;; @0025                               trapz v19, user16
-;; @0025                               v46 = uadd_overflow_trap v19, v217, user2  ; v217 = 40
-;;                                     v202 = load.i32 notrap v203
-;; @0025                               v54 = iconst.i32 1
-;; @0025                               v55 = band v202, v54  ; v54 = 1
-;; @0025                               v26 = iconst.i32 0
-;; @0025                               v57 = icmp eq v202, v26  ; v26 = 0
-;; @0025                               v58 = uextend.i32 v57
-;; @0025                               v59 = bor v55, v58
-;; @0025                               brif v59, block3, block2
+;;                                     v202 = stack_addr.i64 ss2
+;;                                     store notrap v2, v202
+;;                                     v203 = stack_addr.i64 ss1
+;;                                     store notrap v3, v203
+;;                                     v204 = stack_addr.i64 ss0
+;;                                     store notrap v4, v204
+;; @0025                               v14 = iconst.i32 -1476395008
+;; @0025                               v15 = load.i64 notrap aligned readonly can_move region2 v0+40
+;; @0025                               v16 = load.i32 notrap aligned readonly can_move v15
+;;                                     v216 = iconst.i32 40
+;; @0025                               v17 = iconst.i32 8
+;; @0025                               v18 = call fn0(v0, v14, v16, v216, v17), stack_map=[i32 @ ss2+0, i32 @ ss1+0, i32 @ ss0+0]  ; v14 = -1476395008, v216 = 40, v17 = 8
+;; @0025                               v5 = iconst.i32 3
+;; @0025                               v19 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @0025                               v20 = load.i64 notrap aligned readonly can_move region3 v19+32
+;; @0025                               v21 = uextend.i64 v18
+;; @0025                               v22 = iadd v20, v21
+;; @0025                               v23 = iconst.i64 24
+;; @0025                               v24 = iadd v22, v23  ; v23 = 24
+;; @0025                               store user2 region4 v5, v24  ; v5 = 3
+;; @0025                               trapz v18, user16
+;; @0025                               v45 = uadd_overflow_trap v18, v216, user2  ; v216 = 40
+;;                                     v201 = load.i32 notrap v202
+;; @0025                               v53 = iconst.i32 1
+;; @0025                               v54 = band v201, v53  ; v53 = 1
+;; @0025                               v25 = iconst.i32 0
+;; @0025                               v56 = icmp eq v201, v25  ; v25 = 0
+;; @0025                               v57 = uextend.i32 v56
+;; @0025                               v58 = bor v54, v57
+;; @0025                               brif v58, block3, block2
 ;;
 ;;                                 block2:
-;;                                     v198 = load.i32 notrap v203
-;; @0025                               v60 = uextend.i64 v198
-;; @0025                               v63 = iadd.i64 v21, v60
-;; @0025                               v64 = iconst.i64 8
-;; @0025                               v65 = iadd v63, v64  ; v64 = 8
-;; @0025                               v66 = load.i64 user2 region4 v65
-;; @0025                               v67 = iconst.i64 1
-;; @0025                               v68 = iadd v66, v67  ; v67 = 1
-;; @0025                               store user2 region4 v68, v65
+;;                                     v197 = load.i32 notrap v202
+;; @0025                               v59 = uextend.i64 v197
+;; @0025                               v62 = iadd.i64 v20, v59
+;; @0025                               v63 = iconst.i64 8
+;; @0025                               v64 = iadd v62, v63  ; v63 = 8
+;; @0025                               v65 = load.i64 user2 region4 v64
+;; @0025                               v66 = iconst.i64 1
+;; @0025                               v67 = iadd v65, v66  ; v66 = 1
+;; @0025                               store user2 region4 v67, v64
 ;; @0025                               jump block3
 ;;
 ;;                                 block3:
-;;                                     v194 = load.i32 notrap v203
-;; @0025                               v47 = uextend.i64 v46
-;; @0025                               v50 = iadd.i64 v21, v47
-;;                                     v207 = iconst.i64 12
-;; @0025                               v53 = isub v50, v207  ; v207 = 12
-;; @0025                               store user2 little region4 v194, v53
-;;                                     v310 = iadd.i64 v23, v24  ; v24 = 24
-;; @0025                               v82 = load.i32 user2 readonly region4 v310
-;;                                     v311 = iconst.i32 1
-;;                                     v312 = icmp ugt v82, v311  ; v311 = 1
-;; @0025                               trapz v312, user17
-;; @0025                               v85 = uextend.i64 v82
-;;                                     v208 = iconst.i64 2
-;;                                     v252 = ishl v85, v208  ; v208 = 2
-;; @0025                               v11 = iconst.i64 32
-;; @0025                               v88 = ushr v252, v11  ; v11 = 32
-;; @0025                               trapnz v88, user2
-;;                                     v229 = iconst.i32 2
-;;                                     v259 = ishl v82, v229  ; v229 = 2
-;; @0025                               v7 = iconst.i32 28
-;; @0025                               v91 = uadd_overflow_trap v259, v7, user2  ; v7 = 28
-;; @0025                               v95 = uadd_overflow_trap.i32 v19, v91, user2
-;;                                     v192 = load.i32 notrap v204
-;;                                     v313 = band v192, v311  ; v311 = 1
-;;                                     v314 = iconst.i32 0
-;;                                     v315 = icmp eq v192, v314  ; v314 = 0
-;; @0025                               v107 = uextend.i32 v315
-;; @0025                               v108 = bor v313, v107
-;; @0025                               brif v108, block5, block4
+;;                                     v193 = load.i32 notrap v202
+;; @0025                               v46 = uextend.i64 v45
+;; @0025                               v49 = iadd.i64 v20, v46
+;;                                     v206 = iconst.i64 12
+;; @0025                               v52 = isub v49, v206  ; v206 = 12
+;; @0025                               store user2 little region4 v193, v52
+;;                                     v309 = iadd.i64 v22, v23  ; v23 = 24
+;; @0025                               v81 = load.i32 user2 readonly region4 v309
+;;                                     v310 = iconst.i32 1
+;;                                     v311 = icmp ugt v81, v310  ; v310 = 1
+;; @0025                               trapz v311, user17
+;; @0025                               v84 = uextend.i64 v81
+;;                                     v207 = iconst.i64 2
+;;                                     v251 = ishl v84, v207  ; v207 = 2
+;; @0025                               v10 = iconst.i64 32
+;; @0025                               v87 = ushr v251, v10  ; v10 = 32
+;; @0025                               trapnz v87, user2
+;;                                     v228 = iconst.i32 2
+;;                                     v258 = ishl v81, v228  ; v228 = 2
+;; @0025                               v6 = iconst.i32 28
+;; @0025                               v90 = uadd_overflow_trap v258, v6, user2  ; v6 = 28
+;; @0025                               v94 = uadd_overflow_trap.i32 v18, v90, user2
+;;                                     v191 = load.i32 notrap v203
+;;                                     v312 = band v191, v310  ; v310 = 1
+;;                                     v313 = iconst.i32 0
+;;                                     v314 = icmp eq v191, v313  ; v313 = 0
+;; @0025                               v106 = uextend.i32 v314
+;; @0025                               v107 = bor v312, v106
+;; @0025                               brif v107, block5, block4
 ;;
 ;;                                 block4:
-;;                                     v188 = load.i32 notrap v204
-;; @0025                               v109 = uextend.i64 v188
-;; @0025                               v112 = iadd.i64 v21, v109
-;;                                     v316 = iconst.i64 8
-;; @0025                               v114 = iadd v112, v316  ; v316 = 8
-;; @0025                               v115 = load.i64 user2 region4 v114
-;;                                     v317 = iconst.i64 1
-;; @0025                               v117 = iadd v115, v317  ; v317 = 1
-;; @0025                               store user2 region4 v117, v114
+;;                                     v187 = load.i32 notrap v203
+;; @0025                               v108 = uextend.i64 v187
+;; @0025                               v111 = iadd.i64 v20, v108
+;;                                     v315 = iconst.i64 8
+;; @0025                               v113 = iadd v111, v315  ; v315 = 8
+;; @0025                               v114 = load.i64 user2 region4 v113
+;;                                     v316 = iconst.i64 1
+;; @0025                               v116 = iadd v114, v316  ; v316 = 1
+;; @0025                               store user2 region4 v116, v113
 ;; @0025                               jump block5
 ;;
 ;;                                 block5:
-;;                                     v184 = load.i32 notrap v204
-;; @0025                               v96 = uextend.i64 v95
-;; @0025                               v99 = iadd.i64 v21, v96
-;;                                     v272 = iconst.i32 32
-;; @0025                               v100 = isub.i32 v91, v272  ; v272 = 32
-;; @0025                               v101 = uextend.i64 v100
-;; @0025                               v102 = isub v99, v101
-;; @0025                               store user2 little region4 v184, v102
-;;                                     v318 = iadd.i64 v23, v24  ; v24 = 24
-;; @0025                               v131 = load.i32 user2 readonly region4 v318
-;;                                     v319 = iconst.i32 2
-;;                                     v320 = icmp ugt v131, v319  ; v319 = 2
-;; @0025                               trapz v320, user17
-;; @0025                               v134 = uextend.i64 v131
-;;                                     v321 = iconst.i64 2
-;;                                     v322 = ishl v134, v321  ; v321 = 2
-;;                                     v323 = iconst.i64 32
-;;                                     v324 = ushr v322, v323  ; v323 = 32
-;; @0025                               trapnz v324, user2
-;;                                     v325 = ishl v131, v319  ; v319 = 2
-;;                                     v326 = iconst.i32 28
-;; @0025                               v140 = uadd_overflow_trap v325, v326, user2  ; v326 = 28
-;; @0025                               v144 = uadd_overflow_trap.i32 v19, v140, user2
-;;                                     v182 = load.i32 notrap v205
-;;                                     v327 = iconst.i32 1
-;;                                     v328 = band v182, v327  ; v327 = 1
-;;                                     v329 = iconst.i32 0
-;;                                     v330 = icmp eq v182, v329  ; v329 = 0
-;; @0025                               v156 = uextend.i32 v330
-;; @0025                               v157 = bor v328, v156
-;; @0025                               brif v157, block7, block6
+;;                                     v183 = load.i32 notrap v203
+;; @0025                               v95 = uextend.i64 v94
+;; @0025                               v98 = iadd.i64 v20, v95
+;;                                     v271 = iconst.i32 32
+;; @0025                               v99 = isub.i32 v90, v271  ; v271 = 32
+;; @0025                               v100 = uextend.i64 v99
+;; @0025                               v101 = isub v98, v100
+;; @0025                               store user2 little region4 v183, v101
+;;                                     v317 = iadd.i64 v22, v23  ; v23 = 24
+;; @0025                               v130 = load.i32 user2 readonly region4 v317
+;;                                     v318 = iconst.i32 2
+;;                                     v319 = icmp ugt v130, v318  ; v318 = 2
+;; @0025                               trapz v319, user17
+;; @0025                               v133 = uextend.i64 v130
+;;                                     v320 = iconst.i64 2
+;;                                     v321 = ishl v133, v320  ; v320 = 2
+;;                                     v322 = iconst.i64 32
+;;                                     v323 = ushr v321, v322  ; v322 = 32
+;; @0025                               trapnz v323, user2
+;;                                     v324 = ishl v130, v318  ; v318 = 2
+;;                                     v325 = iconst.i32 28
+;; @0025                               v139 = uadd_overflow_trap v324, v325, user2  ; v325 = 28
+;; @0025                               v143 = uadd_overflow_trap.i32 v18, v139, user2
+;;                                     v181 = load.i32 notrap v204
+;;                                     v326 = iconst.i32 1
+;;                                     v327 = band v181, v326  ; v326 = 1
+;;                                     v328 = iconst.i32 0
+;;                                     v329 = icmp eq v181, v328  ; v328 = 0
+;; @0025                               v155 = uextend.i32 v329
+;; @0025                               v156 = bor v327, v155
+;; @0025                               brif v156, block7, block6
 ;;
 ;;                                 block6:
-;;                                     v178 = load.i32 notrap v205
-;; @0025                               v158 = uextend.i64 v178
-;; @0025                               v161 = iadd.i64 v21, v158
-;;                                     v331 = iconst.i64 8
-;; @0025                               v163 = iadd v161, v331  ; v331 = 8
-;; @0025                               v164 = load.i64 user2 region4 v163
-;;                                     v332 = iconst.i64 1
-;; @0025                               v166 = iadd v164, v332  ; v332 = 1
-;; @0025                               store user2 region4 v166, v163
+;;                                     v177 = load.i32 notrap v204
+;; @0025                               v157 = uextend.i64 v177
+;; @0025                               v160 = iadd.i64 v20, v157
+;;                                     v330 = iconst.i64 8
+;; @0025                               v162 = iadd v160, v330  ; v330 = 8
+;; @0025                               v163 = load.i64 user2 region4 v162
+;;                                     v331 = iconst.i64 1
+;; @0025                               v165 = iadd v163, v331  ; v331 = 1
+;; @0025                               store user2 region4 v165, v162
 ;; @0025                               jump block7
 ;;
 ;;                                 block7:
-;;                                     v174 = load.i32 notrap v205
-;; @0025                               v145 = uextend.i64 v144
-;; @0025                               v148 = iadd.i64 v21, v145
-;;                                     v304 = iconst.i32 36
-;; @0025                               v149 = isub.i32 v140, v304  ; v304 = 36
-;; @0025                               v150 = uextend.i64 v149
-;; @0025                               v151 = isub v148, v150
-;; @0025                               store user2 little region4 v174, v151
+;;                                     v173 = load.i32 notrap v204
+;; @0025                               v144 = uextend.i64 v143
+;; @0025                               v147 = iadd.i64 v20, v144
+;;                                     v303 = iconst.i32 36
+;; @0025                               v148 = isub.i32 v139, v303  ; v303 = 36
+;; @0025                               v149 = uextend.i64 v148
+;; @0025                               v150 = isub v147, v149
+;; @0025                               store user2 little region4 v173, v150
 ;; @0029                               jump block1
 ;;
 ;;                                 block1:
-;; @0029                               return v19
+;; @0029                               return v18
 ;; }

--- a/tests/disas/gc/drc/array-new-fixed.wat
+++ b/tests/disas/gc/drc/array-new-fixed.wat
@@ -24,67 +24,67 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i64, v4: i64):
-;; @0025                               v15 = iconst.i32 -1476395008
-;; @0025                               v16 = load.i64 notrap aligned readonly can_move region2 v0+40
-;; @0025                               v17 = load.i32 notrap aligned readonly can_move v16
-;;                                     v120 = iconst.i32 56
-;; @0025                               v18 = iconst.i32 8
-;; @0025                               v19 = call fn0(v0, v15, v17, v120, v18)  ; v15 = -1476395008, v120 = 56, v18 = 8
-;; @0025                               v6 = iconst.i32 3
-;; @0025                               v20 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0025                               v21 = load.i64 notrap aligned readonly can_move region3 v20+32
-;; @0025                               v22 = uextend.i64 v19
-;; @0025                               v23 = iadd v21, v22
-;;                                     v111 = iconst.i64 24
-;; @0025                               v25 = iadd v23, v111  ; v111 = 24
-;; @0025                               store user2 region4 v6, v25  ; v6 = 3
-;; @0025                               trapz v19, user16
-;; @0025                               v46 = uadd_overflow_trap v19, v120, user2  ; v120 = 56
-;; @0025                               v47 = uextend.i64 v46
-;; @0025                               v50 = iadd v21, v47
-;; @0025                               v53 = isub v50, v111  ; v111 = 24
-;; @0025                               store user2 little region4 v2, v53
-;; @0025                               v61 = load.i32 user2 readonly region4 v25
-;; @0025                               v54 = iconst.i32 1
-;;                                     v151 = icmp ugt v61, v54  ; v54 = 1
-;; @0025                               trapz v151, user17
-;; @0025                               v64 = uextend.i64 v61
-;;                                     v110 = iconst.i64 3
-;;                                     v153 = ishl v64, v110  ; v110 = 3
-;; @0025                               v11 = iconst.i64 32
-;; @0025                               v67 = ushr v153, v11  ; v11 = 32
-;; @0025                               trapnz v67, user2
-;;                                     v160 = ishl v61, v6  ; v6 = 3
-;; @0025                               v7 = iconst.i32 32
-;; @0025                               v70 = uadd_overflow_trap v160, v7, user2  ; v7 = 32
-;; @0025                               v74 = uadd_overflow_trap v19, v70, user2
-;; @0025                               v75 = uextend.i64 v74
-;; @0025                               v78 = iadd v21, v75
-;;                                     v173 = iconst.i32 40
-;; @0025                               v79 = isub v70, v173  ; v173 = 40
-;; @0025                               v80 = uextend.i64 v79
-;; @0025                               v81 = isub v78, v80
-;; @0025                               store user2 little region4 v3, v81
-;; @0025                               v89 = load.i32 user2 readonly region4 v25
-;; @0025                               v82 = iconst.i32 2
-;;                                     v179 = icmp ugt v89, v82  ; v82 = 2
-;; @0025                               trapz v179, user17
-;; @0025                               v92 = uextend.i64 v89
-;;                                     v181 = ishl v92, v110  ; v110 = 3
-;; @0025                               v95 = ushr v181, v11  ; v11 = 32
-;; @0025                               trapnz v95, user2
-;;                                     v188 = ishl v89, v6  ; v6 = 3
-;; @0025                               v98 = uadd_overflow_trap v188, v7, user2  ; v7 = 32
-;; @0025                               v102 = uadd_overflow_trap v19, v98, user2
-;; @0025                               v103 = uextend.i64 v102
-;; @0025                               v106 = iadd v21, v103
-;;                                     v206 = iconst.i32 48
-;; @0025                               v107 = isub v98, v206  ; v206 = 48
-;; @0025                               v108 = uextend.i64 v107
-;; @0025                               v109 = isub v106, v108
-;; @0025                               store user2 little region4 v4, v109
+;; @0025                               v14 = iconst.i32 -1476395008
+;; @0025                               v15 = load.i64 notrap aligned readonly can_move region2 v0+40
+;; @0025                               v16 = load.i32 notrap aligned readonly can_move v15
+;;                                     v119 = iconst.i32 56
+;; @0025                               v17 = iconst.i32 8
+;; @0025                               v18 = call fn0(v0, v14, v16, v119, v17)  ; v14 = -1476395008, v119 = 56, v17 = 8
+;; @0025                               v5 = iconst.i32 3
+;; @0025                               v19 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @0025                               v20 = load.i64 notrap aligned readonly can_move region3 v19+32
+;; @0025                               v21 = uextend.i64 v18
+;; @0025                               v22 = iadd v20, v21
+;;                                     v110 = iconst.i64 24
+;; @0025                               v24 = iadd v22, v110  ; v110 = 24
+;; @0025                               store user2 region4 v5, v24  ; v5 = 3
+;; @0025                               trapz v18, user16
+;; @0025                               v45 = uadd_overflow_trap v18, v119, user2  ; v119 = 56
+;; @0025                               v46 = uextend.i64 v45
+;; @0025                               v49 = iadd v20, v46
+;; @0025                               v52 = isub v49, v110  ; v110 = 24
+;; @0025                               store user2 little region4 v2, v52
+;; @0025                               v60 = load.i32 user2 readonly region4 v24
+;; @0025                               v53 = iconst.i32 1
+;;                                     v150 = icmp ugt v60, v53  ; v53 = 1
+;; @0025                               trapz v150, user17
+;; @0025                               v63 = uextend.i64 v60
+;;                                     v109 = iconst.i64 3
+;;                                     v152 = ishl v63, v109  ; v109 = 3
+;; @0025                               v10 = iconst.i64 32
+;; @0025                               v66 = ushr v152, v10  ; v10 = 32
+;; @0025                               trapnz v66, user2
+;;                                     v159 = ishl v60, v5  ; v5 = 3
+;; @0025                               v6 = iconst.i32 32
+;; @0025                               v69 = uadd_overflow_trap v159, v6, user2  ; v6 = 32
+;; @0025                               v73 = uadd_overflow_trap v18, v69, user2
+;; @0025                               v74 = uextend.i64 v73
+;; @0025                               v77 = iadd v20, v74
+;;                                     v172 = iconst.i32 40
+;; @0025                               v78 = isub v69, v172  ; v172 = 40
+;; @0025                               v79 = uextend.i64 v78
+;; @0025                               v80 = isub v77, v79
+;; @0025                               store user2 little region4 v3, v80
+;; @0025                               v88 = load.i32 user2 readonly region4 v24
+;; @0025                               v81 = iconst.i32 2
+;;                                     v178 = icmp ugt v88, v81  ; v81 = 2
+;; @0025                               trapz v178, user17
+;; @0025                               v91 = uextend.i64 v88
+;;                                     v180 = ishl v91, v109  ; v109 = 3
+;; @0025                               v94 = ushr v180, v10  ; v10 = 32
+;; @0025                               trapnz v94, user2
+;;                                     v187 = ishl v88, v5  ; v5 = 3
+;; @0025                               v97 = uadd_overflow_trap v187, v6, user2  ; v6 = 32
+;; @0025                               v101 = uadd_overflow_trap v18, v97, user2
+;; @0025                               v102 = uextend.i64 v101
+;; @0025                               v105 = iadd v20, v102
+;;                                     v205 = iconst.i32 48
+;; @0025                               v106 = isub v97, v205  ; v205 = 48
+;; @0025                               v107 = uextend.i64 v106
+;; @0025                               v108 = isub v105, v107
+;; @0025                               store user2 little region4 v4, v108
 ;; @0029                               jump block1
 ;;
 ;;                                 block1:
-;; @0029                               return v19
+;; @0029                               return v18
 ;; }

--- a/tests/disas/gc/drc/array-new.wat
+++ b/tests/disas/gc/drc/array-new.wat
@@ -24,51 +24,51 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
-;; @0022                               v6 = uextend.i64 v3
-;;                                     v66 = iconst.i64 3
-;;                                     v67 = ishl v6, v66  ; v66 = 3
-;; @0022                               v9 = iconst.i64 32
-;; @0022                               v10 = ushr v67, v9  ; v9 = 32
-;; @0022                               trapnz v10, user18
-;; @0022                               v5 = iconst.i32 32
-;;                                     v73 = iconst.i32 3
-;;                                     v74 = ishl v3, v73  ; v73 = 3
-;; @0022                               v12 = uadd_overflow_trap v5, v74, user18  ; v5 = 32
-;; @0022                               v13 = iconst.i32 -1476395008
-;; @0022                               v14 = load.i64 notrap aligned readonly can_move region2 v0+40
-;; @0022                               v15 = load.i32 notrap aligned readonly can_move v14
-;;                                     v71 = iconst.i32 8
-;; @0022                               v17 = call fn0(v0, v13, v15, v12, v71)  ; v13 = -1476395008, v71 = 8
-;; @0022                               v18 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0022                               v19 = load.i64 notrap aligned readonly can_move region3 v18+32
-;; @0022                               v20 = uextend.i64 v17
-;; @0022                               v21 = iadd v19, v20
-;; @0022                               v22 = iconst.i64 24
-;; @0022                               v23 = iadd v21, v22  ; v22 = 24
-;; @0022                               store user2 region4 v3, v23
-;; @0022                               trapz v17, user16
-;; @0022                               v55 = load.i64 notrap aligned region5 v18+40
-;; @0022                               v44 = iadd v21, v9  ; v9 = 32
-;; @0022                               v57 = uadd_overflow_trap v44, v67, user2
-;; @0022                               v56 = iadd v19, v55
-;; @0022                               v58 = icmp ugt v57, v56
-;; @0022                               trapnz v58, user2
-;;                                     v77 = iconst.i64 0
-;; @0022                               v61 = icmp eq v6, v77  ; v77 = 0
-;; @0022                               v7 = iconst.i64 8
-;; @0022                               v59 = iadd v44, v67
-;; @0022                               brif v61, block3, block2(v44)
+;; @0022                               v5 = uextend.i64 v3
+;;                                     v65 = iconst.i64 3
+;;                                     v66 = ishl v5, v65  ; v65 = 3
+;; @0022                               v8 = iconst.i64 32
+;; @0022                               v9 = ushr v66, v8  ; v8 = 32
+;; @0022                               trapnz v9, user18
+;; @0022                               v4 = iconst.i32 32
+;;                                     v72 = iconst.i32 3
+;;                                     v73 = ishl v3, v72  ; v72 = 3
+;; @0022                               v11 = uadd_overflow_trap v4, v73, user18  ; v4 = 32
+;; @0022                               v12 = iconst.i32 -1476395008
+;; @0022                               v13 = load.i64 notrap aligned readonly can_move region2 v0+40
+;; @0022                               v14 = load.i32 notrap aligned readonly can_move v13
+;;                                     v70 = iconst.i32 8
+;; @0022                               v16 = call fn0(v0, v12, v14, v11, v70)  ; v12 = -1476395008, v70 = 8
+;; @0022                               v17 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @0022                               v18 = load.i64 notrap aligned readonly can_move region3 v17+32
+;; @0022                               v19 = uextend.i64 v16
+;; @0022                               v20 = iadd v18, v19
+;; @0022                               v21 = iconst.i64 24
+;; @0022                               v22 = iadd v20, v21  ; v21 = 24
+;; @0022                               store user2 region4 v3, v22
+;; @0022                               trapz v16, user16
+;; @0022                               v54 = load.i64 notrap aligned region5 v17+40
+;; @0022                               v43 = iadd v20, v8  ; v8 = 32
+;; @0022                               v56 = uadd_overflow_trap v43, v66, user2
+;; @0022                               v55 = iadd v18, v54
+;; @0022                               v57 = icmp ugt v56, v55
+;; @0022                               trapnz v57, user2
+;;                                     v76 = iconst.i64 0
+;; @0022                               v60 = icmp eq v5, v76  ; v76 = 0
+;; @0022                               v6 = iconst.i64 8
+;; @0022                               v58 = iadd v43, v66
+;; @0022                               brif v60, block3, block2(v43)
 ;;
-;;                                 block2(v62: i64):
-;; @0022                               store.i64 user2 little region4 v2, v62
-;;                                     v92 = iconst.i64 8
-;;                                     v93 = iadd v62, v92  ; v92 = 8
-;; @0022                               v65 = icmp eq v93, v59
-;; @0022                               brif v65, block3, block2(v93)
+;;                                 block2(v61: i64):
+;; @0022                               store.i64 user2 little region4 v2, v61
+;;                                     v91 = iconst.i64 8
+;;                                     v92 = iadd v61, v91  ; v91 = 8
+;; @0022                               v64 = icmp eq v92, v58
+;; @0022                               brif v64, block3, block2(v92)
 ;;
 ;;                                 block3:
 ;; @0025                               jump block1
 ;;
 ;;                                 block1:
-;; @0025                               return v17
+;; @0025                               return v16
 ;; }

--- a/tests/disas/gc/drc/br-on-cast-fail.wat
+++ b/tests/disas/gc/drc/br-on-cast-fail.wat
@@ -34,42 +34,42 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @002e                               v4 = iconst.i32 0
-;; @002e                               v5 = icmp eq v2, v4  ; v4 = 0
-;; @002e                               brif v5, block5(v4), block3  ; v4 = 0
+;; @002e                               v3 = iconst.i32 0
+;; @002e                               v4 = icmp eq v2, v3  ; v3 = 0
+;; @002e                               brif v4, block5(v3), block3  ; v3 = 0
 ;;
 ;;                                 block3:
-;; @002e                               v8 = iconst.i32 1
-;; @002e                               v9 = band.i32 v2, v8  ; v8 = 1
-;;                                     v27 = iconst.i32 0
-;; @002e                               brif v9, block5(v27), block4  ; v27 = 0
+;; @002e                               v7 = iconst.i32 1
+;; @002e                               v8 = band.i32 v2, v7  ; v7 = 1
+;;                                     v26 = iconst.i32 0
+;; @002e                               brif v8, block5(v26), block4  ; v26 = 0
 ;;
 ;;                                 block4:
-;; @002e                               v14 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @002e                               v15 = load.i64 notrap aligned readonly can_move region3 v14+32
-;; @002e                               v13 = uextend.i64 v2
-;; @002e                               v16 = iadd v15, v13
-;; @002e                               v17 = iconst.i64 4
-;; @002e                               v18 = iadd v16, v17  ; v17 = 4
-;; @002e                               v19 = load.i32 user2 readonly region5 v18
-;; @002e                               v11 = load.i64 notrap aligned readonly can_move region2 v0+40
-;; @002e                               v12 = load.i32 notrap aligned readonly can_move v11
-;; @002e                               v20 = icmp eq v19, v12
-;; @002e                               v21 = uextend.i32 v20
-;; @002e                               jump block5(v21)
+;; @002e                               v13 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @002e                               v14 = load.i64 notrap aligned readonly can_move region3 v13+32
+;; @002e                               v12 = uextend.i64 v2
+;; @002e                               v15 = iadd v14, v12
+;; @002e                               v16 = iconst.i64 4
+;; @002e                               v17 = iadd v15, v16  ; v16 = 4
+;; @002e                               v18 = load.i32 user2 readonly region5 v17
+;; @002e                               v10 = load.i64 notrap aligned readonly can_move region2 v0+40
+;; @002e                               v11 = load.i32 notrap aligned readonly can_move v10
+;; @002e                               v19 = icmp eq v18, v11
+;; @002e                               v20 = uextend.i32 v19
+;; @002e                               jump block5(v20)
 ;;
-;;                                 block5(v22: i32):
-;; @002e                               brif v22, block6, block2
+;;                                 block5(v21: i32):
+;; @002e                               brif v21, block6, block2
 ;;
 ;;                                 block6:
-;; @0034                               v24 = load.i64 notrap aligned readonly can_move region7 v0+56
-;; @0034                               v23 = load.i64 notrap aligned readonly can_move region6 v0+72
-;; @0034                               call_indirect sig0, v24(v23, v0)
+;; @0034                               v23 = load.i64 notrap aligned readonly can_move region7 v0+56
+;; @0034                               v22 = load.i64 notrap aligned readonly can_move region6 v0+72
+;; @0034                               call_indirect sig0, v23(v22, v0)
 ;; @0036                               return
 ;;
 ;;                                 block2:
-;; @0038                               v26 = load.i64 notrap aligned readonly can_move region9 v0+88
-;; @0038                               v25 = load.i64 notrap aligned readonly can_move region8 v0+104
-;; @0038                               call_indirect sig0, v26(v25, v0)
+;; @0038                               v25 = load.i64 notrap aligned readonly can_move region9 v0+88
+;; @0038                               v24 = load.i64 notrap aligned readonly can_move region8 v0+104
+;; @0038                               call_indirect sig0, v25(v24, v0)
 ;; @003a                               return
 ;; }

--- a/tests/disas/gc/drc/br-on-cast.wat
+++ b/tests/disas/gc/drc/br-on-cast.wat
@@ -34,42 +34,42 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @002f                               v4 = iconst.i32 0
-;; @002f                               v5 = icmp eq v2, v4  ; v4 = 0
-;; @002f                               brif v5, block5(v4), block3  ; v4 = 0
+;; @002f                               v3 = iconst.i32 0
+;; @002f                               v4 = icmp eq v2, v3  ; v3 = 0
+;; @002f                               brif v4, block5(v3), block3  ; v3 = 0
 ;;
 ;;                                 block3:
-;; @002f                               v8 = iconst.i32 1
-;; @002f                               v9 = band.i32 v2, v8  ; v8 = 1
-;;                                     v27 = iconst.i32 0
-;; @002f                               brif v9, block5(v27), block4  ; v27 = 0
+;; @002f                               v7 = iconst.i32 1
+;; @002f                               v8 = band.i32 v2, v7  ; v7 = 1
+;;                                     v26 = iconst.i32 0
+;; @002f                               brif v8, block5(v26), block4  ; v26 = 0
 ;;
 ;;                                 block4:
-;; @002f                               v14 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @002f                               v15 = load.i64 notrap aligned readonly can_move region3 v14+32
-;; @002f                               v13 = uextend.i64 v2
-;; @002f                               v16 = iadd v15, v13
-;; @002f                               v17 = iconst.i64 4
-;; @002f                               v18 = iadd v16, v17  ; v17 = 4
-;; @002f                               v19 = load.i32 user2 readonly region5 v18
-;; @002f                               v11 = load.i64 notrap aligned readonly can_move region2 v0+40
-;; @002f                               v12 = load.i32 notrap aligned readonly can_move v11
-;; @002f                               v20 = icmp eq v19, v12
-;; @002f                               v21 = uextend.i32 v20
-;; @002f                               jump block5(v21)
+;; @002f                               v13 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @002f                               v14 = load.i64 notrap aligned readonly can_move region3 v13+32
+;; @002f                               v12 = uextend.i64 v2
+;; @002f                               v15 = iadd v14, v12
+;; @002f                               v16 = iconst.i64 4
+;; @002f                               v17 = iadd v15, v16  ; v16 = 4
+;; @002f                               v18 = load.i32 user2 readonly region5 v17
+;; @002f                               v10 = load.i64 notrap aligned readonly can_move region2 v0+40
+;; @002f                               v11 = load.i32 notrap aligned readonly can_move v10
+;; @002f                               v19 = icmp eq v18, v11
+;; @002f                               v20 = uextend.i32 v19
+;; @002f                               jump block5(v20)
 ;;
-;;                                 block5(v22: i32):
-;; @002f                               brif v22, block2, block6
+;;                                 block5(v21: i32):
+;; @002f                               brif v21, block2, block6
 ;;
 ;;                                 block6:
-;; @0035                               v24 = load.i64 notrap aligned readonly can_move region7 v0+56
-;; @0035                               v23 = load.i64 notrap aligned readonly can_move region6 v0+72
-;; @0035                               call_indirect sig0, v24(v23, v0)
+;; @0035                               v23 = load.i64 notrap aligned readonly can_move region7 v0+56
+;; @0035                               v22 = load.i64 notrap aligned readonly can_move region6 v0+72
+;; @0035                               call_indirect sig0, v23(v22, v0)
 ;; @0037                               return
 ;;
 ;;                                 block2:
-;; @0039                               v26 = load.i64 notrap aligned readonly can_move region9 v0+88
-;; @0039                               v25 = load.i64 notrap aligned readonly can_move region8 v0+104
-;; @0039                               call_indirect sig0, v26(v25, v0)
+;; @0039                               v25 = load.i64 notrap aligned readonly can_move region9 v0+88
+;; @0039                               v24 = load.i64 notrap aligned readonly can_move region8 v0+104
+;; @0039                               call_indirect sig0, v25(v24, v0)
 ;; @003b                               return
 ;; }

--- a/tests/disas/gc/drc/externref-globals.wat
+++ b/tests/disas/gc/drc/externref-globals.wat
@@ -29,69 +29,69 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @0034                               v3 = iconst.i64 48
-;; @0034                               v4 = iadd v0, v3  ; v3 = 48
-;; @0034                               v5 = load.i32 notrap aligned region2 v4
-;;                                     v80 = stack_addr.i64 ss0
-;;                                     store notrap v5, v80
-;; @0034                               v6 = iconst.i32 1
-;; @0034                               v7 = band v5, v6  ; v6 = 1
-;; @0034                               v8 = iconst.i32 0
-;; @0034                               v9 = icmp eq v5, v8  ; v8 = 0
-;; @0034                               v10 = uextend.i32 v9
-;; @0034                               v11 = bor v7, v10
-;; @0034                               brif v11, block4, block2
+;; @0034                               v2 = iconst.i64 48
+;; @0034                               v3 = iadd v0, v2  ; v2 = 48
+;; @0034                               v4 = load.i32 notrap aligned region2 v3
+;;                                     v79 = stack_addr.i64 ss0
+;;                                     store notrap v4, v79
+;; @0034                               v5 = iconst.i32 1
+;; @0034                               v6 = band v4, v5  ; v5 = 1
+;; @0034                               v7 = iconst.i32 0
+;; @0034                               v8 = icmp eq v4, v7  ; v7 = 0
+;; @0034                               v9 = uextend.i32 v8
+;; @0034                               v10 = bor v6, v9
+;; @0034                               brif v10, block4, block2
 ;;
 ;;                                 block2:
-;; @0034                               v13 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0034                               v14 = load.i64 notrap aligned readonly can_move region3 v13+32
-;; @0034                               v12 = uextend.i64 v5
-;; @0034                               v15 = iadd v14, v12
-;; @0034                               v16 = load.i32 user2 region5 v15
-;; @0034                               v17 = iconst.i32 2
-;; @0034                               v18 = band v16, v17  ; v17 = 2
-;; @0034                               brif v18, block4, block3
+;; @0034                               v12 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @0034                               v13 = load.i64 notrap aligned readonly can_move region3 v12+32
+;; @0034                               v11 = uextend.i64 v4
+;; @0034                               v14 = iadd v13, v11
+;; @0034                               v15 = load.i32 user2 region5 v14
+;; @0034                               v16 = iconst.i32 2
+;; @0034                               v17 = band v15, v16  ; v16 = 2
+;; @0034                               brif v17, block4, block3
 ;;
 ;;                                 block3:
-;; @0034                               v19 = load.i64 notrap aligned readonly can_move region6 v0+32
-;; @0034                               v20 = load.i32 user2 region5 v19
-;; @0034                               v25 = iconst.i64 16
-;; @0034                               v26 = iadd.i64 v15, v25  ; v25 = 16
-;; @0034                               store user2 region5 v20, v26
-;;                                     v81 = iconst.i32 2
-;;                                     v82 = bor.i32 v16, v81  ; v81 = 2
-;; @0034                               store user2 region5 v82, v15
-;; @0034                               v37 = iconst.i64 8
-;; @0034                               v38 = iadd.i64 v15, v37  ; v37 = 8
-;; @0034                               v39 = load.i64 user2 region5 v38
-;; @0034                               v40 = iconst.i64 1
-;; @0034                               v41 = iadd v39, v40  ; v40 = 1
-;; @0034                               store user2 region5 v41, v38
-;; @0034                               store.i32 user2 region5 v5, v19
-;; @0034                               v49 = load.i32 notrap aligned v19+4
-;;                                     v83 = iconst.i32 1
-;;                                     v84 = iadd v49, v83  ; v83 = 1
-;; @0034                               store notrap aligned v84, v19+4
-;; @0034                               v56 = load.i32 notrap aligned v19+8
-;; @0034                               v57 = iadd v56, v56
-;; @0034                               v58 = iconst.i32 1024
-;; @0034                               v59 = umax v57, v58  ; v58 = 1024
-;; @0034                               v60 = icmp uge v84, v59
-;; @0034                               brif v60, block5, block6
+;; @0034                               v18 = load.i64 notrap aligned readonly can_move region6 v0+32
+;; @0034                               v19 = load.i32 user2 region5 v18
+;; @0034                               v24 = iconst.i64 16
+;; @0034                               v25 = iadd.i64 v14, v24  ; v24 = 16
+;; @0034                               store user2 region5 v19, v25
+;;                                     v80 = iconst.i32 2
+;;                                     v81 = bor.i32 v15, v80  ; v80 = 2
+;; @0034                               store user2 region5 v81, v14
+;; @0034                               v36 = iconst.i64 8
+;; @0034                               v37 = iadd.i64 v14, v36  ; v36 = 8
+;; @0034                               v38 = load.i64 user2 region5 v37
+;; @0034                               v39 = iconst.i64 1
+;; @0034                               v40 = iadd v38, v39  ; v39 = 1
+;; @0034                               store user2 region5 v40, v37
+;; @0034                               store.i32 user2 region5 v4, v18
+;; @0034                               v48 = load.i32 notrap aligned v18+4
+;;                                     v82 = iconst.i32 1
+;;                                     v83 = iadd v48, v82  ; v82 = 1
+;; @0034                               store notrap aligned v83, v18+4
+;; @0034                               v55 = load.i32 notrap aligned v18+8
+;; @0034                               v56 = iadd v55, v55
+;; @0034                               v57 = iconst.i32 1024
+;; @0034                               v58 = umax v56, v57  ; v57 = 1024
+;; @0034                               v59 = icmp uge v83, v58
+;; @0034                               brif v59, block5, block6
 ;;
 ;;                                 block5 cold:
-;; @0034                               v61 = call fn0(v0), stack_map=[i32 @ ss0+0]
+;; @0034                               v60 = call fn0(v0), stack_map=[i32 @ ss0+0]
 ;; @0034                               jump block6
 ;;
 ;;                                 block6:
 ;; @0034                               jump block4
 ;;
 ;;                                 block4:
-;;                                     v63 = load.i32 notrap v80
 ;; @0036                               jump block1
 ;;
 ;;                                 block1:
-;; @0036                               return v63
+;;                                     v62 = load.i32 notrap v79
+;; @0036                               return v62
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) tail {

--- a/tests/disas/gc/drc/funcref-in-gc-heap-get.wat
+++ b/tests/disas/gc/drc/funcref-in-gc-heap-get.wat
@@ -24,17 +24,17 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0020                               trapz v2, user16
-;; @0020                               v5 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0020                               v6 = load.i64 notrap aligned readonly can_move region2 v5+32
-;; @0020                               v4 = uextend.i64 v2
-;; @0020                               v7 = iadd v6, v4
-;; @0020                               v8 = iconst.i64 24
-;; @0020                               v9 = iadd v7, v8  ; v8 = 24
-;; @0020                               v11 = load.i32 user2 little region4 v9
-;; @0020                               v10 = iconst.i32 -1
-;; @0020                               v12 = call fn0(v0, v11, v10)  ; v10 = -1
+;; @0020                               v4 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @0020                               v5 = load.i64 notrap aligned readonly can_move region2 v4+32
+;; @0020                               v3 = uextend.i64 v2
+;; @0020                               v6 = iadd v5, v3
+;; @0020                               v7 = iconst.i64 24
+;; @0020                               v8 = iadd v6, v7  ; v7 = 24
+;; @0020                               v10 = load.i32 user2 little region4 v8
+;; @0020                               v9 = iconst.i32 -1
+;; @0020                               v11 = call fn0(v0, v10, v9)  ; v9 = -1
 ;; @0024                               jump block1
 ;;
 ;;                                 block1:
-;; @0024                               return v12
+;; @0024                               return v11
 ;; }

--- a/tests/disas/gc/drc/funcref-in-gc-heap-new.wat
+++ b/tests/disas/gc/drc/funcref-in-gc-heap-new.wat
@@ -26,26 +26,26 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0020                               v5 = iconst.i32 -1342177280
-;; @0020                               v6 = load.i64 notrap aligned readonly can_move region2 v0+40
-;; @0020                               v7 = load.i32 notrap aligned readonly can_move v6
-;; @0020                               v4 = iconst.i32 32
-;; @0020                               v8 = iconst.i32 8
-;; @0020                               v9 = call fn0(v0, v5, v7, v4, v8)  ; v5 = -1342177280, v4 = 32, v8 = 8
-;;                                     v22 = stack_addr.i64 ss0
-;;                                     store notrap v9, v22
-;; @0020                               v16 = call fn1(v0, v2), stack_map=[i32 @ ss0+0]
-;; @0020                               v17 = ireduce.i32 v16
-;; @0020                               v10 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0020                               v11 = load.i64 notrap aligned readonly can_move region3 v10+32
-;; @0020                               v12 = uextend.i64 v9
-;; @0020                               v13 = iadd v11, v12
-;; @0020                               v14 = iconst.i64 24
-;; @0020                               v15 = iadd v13, v14  ; v14 = 24
-;; @0020                               store user2 little region4 v17, v15
-;;                                     v19 = load.i32 notrap v22
+;; @0020                               v4 = iconst.i32 -1342177280
+;; @0020                               v5 = load.i64 notrap aligned readonly can_move region2 v0+40
+;; @0020                               v6 = load.i32 notrap aligned readonly can_move v5
+;; @0020                               v3 = iconst.i32 32
+;; @0020                               v7 = iconst.i32 8
+;; @0020                               v8 = call fn0(v0, v4, v6, v3, v7)  ; v4 = -1342177280, v3 = 32, v7 = 8
+;;                                     v21 = stack_addr.i64 ss0
+;;                                     store notrap v8, v21
+;; @0020                               v15 = call fn1(v0, v2), stack_map=[i32 @ ss0+0]
+;; @0020                               v16 = ireduce.i32 v15
+;; @0020                               v9 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @0020                               v10 = load.i64 notrap aligned readonly can_move region3 v9+32
+;; @0020                               v11 = uextend.i64 v8
+;; @0020                               v12 = iadd v10, v11
+;; @0020                               v13 = iconst.i64 24
+;; @0020                               v14 = iadd v12, v13  ; v13 = 24
+;; @0020                               store user2 little region4 v16, v14
 ;; @0023                               jump block1
 ;;
 ;;                                 block1:
-;; @0023                               return v19
+;;                                     v18 = load.i32 notrap v21
+;; @0023                               return v18
 ;; }

--- a/tests/disas/gc/drc/i31ref-globals.wat
+++ b/tests/disas/gc/drc/i31ref-globals.wat
@@ -22,13 +22,13 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @0036                               v3 = iconst.i64 48
-;; @0036                               v4 = iadd v0, v3  ; v3 = 48
-;; @0036                               v5 = load.i32 notrap aligned region2 v4
+;; @0036                               v2 = iconst.i64 48
+;; @0036                               v3 = iadd v0, v2  ; v2 = 48
+;; @0036                               v4 = load.i32 notrap aligned region2 v3
 ;; @0038                               jump block1
 ;;
 ;;                                 block1:
-;; @0038                               return v5
+;; @0038                               return v4
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) tail {

--- a/tests/disas/gc/drc/multiple-array-get.wat
+++ b/tests/disas/gc/drc/multiple-array-get.wat
@@ -23,44 +23,44 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
 ;; @0024                               trapz v2, user16
-;; @0024                               v8 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0024                               v9 = load.i64 notrap aligned readonly can_move region2 v8+32
-;; @0024                               v7 = uextend.i64 v2
-;; @0024                               v10 = iadd v9, v7
-;; @0024                               v11 = iconst.i64 24
-;; @0024                               v12 = iadd v10, v11  ; v11 = 24
-;; @0024                               v13 = load.i32 user2 readonly region4 v12
-;; @0024                               v14 = icmp ult v3, v13
-;; @0024                               trapz v14, user17
-;; @0024                               v16 = uextend.i64 v13
-;;                                     v63 = iconst.i64 3
-;;                                     v64 = ishl v16, v63  ; v63 = 3
-;; @0024                               v18 = iconst.i64 32
-;; @0024                               v19 = ushr v64, v18  ; v18 = 32
-;; @0024                               trapnz v19, user2
-;;                                     v73 = iconst.i32 3
-;;                                     v74 = ishl v13, v73  ; v73 = 3
-;; @0024                               v21 = iconst.i32 32
-;; @0024                               v22 = uadd_overflow_trap v74, v21, user2  ; v21 = 32
-;; @0024                               v26 = uadd_overflow_trap v2, v22, user2
-;; @0024                               v27 = uextend.i64 v26
-;; @0024                               v30 = iadd v9, v27
-;;                                     v80 = ishl v3, v73  ; v73 = 3
-;; @0024                               v25 = iadd v80, v21  ; v21 = 32
-;; @0024                               v31 = isub v22, v25
-;; @0024                               v32 = uextend.i64 v31
-;; @0024                               v33 = isub v30, v32
-;; @0024                               v34 = load.i64 user2 little region4 v33
-;; @002b                               v42 = icmp ult v4, v13
-;; @002b                               trapz v42, user17
-;;                                     v82 = ishl v4, v73  ; v73 = 3
-;; @002b                               v53 = iadd v82, v21  ; v21 = 32
-;; @002b                               v59 = isub v22, v53
-;; @002b                               v60 = uextend.i64 v59
-;; @002b                               v61 = isub v30, v60
-;; @002b                               v62 = load.i64 user2 little region4 v61
+;; @0024                               v6 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @0024                               v7 = load.i64 notrap aligned readonly can_move region2 v6+32
+;; @0024                               v5 = uextend.i64 v2
+;; @0024                               v8 = iadd v7, v5
+;; @0024                               v9 = iconst.i64 24
+;; @0024                               v10 = iadd v8, v9  ; v9 = 24
+;; @0024                               v11 = load.i32 user2 readonly region4 v10
+;; @0024                               v12 = icmp ult v3, v11
+;; @0024                               trapz v12, user17
+;; @0024                               v14 = uextend.i64 v11
+;;                                     v61 = iconst.i64 3
+;;                                     v62 = ishl v14, v61  ; v61 = 3
+;; @0024                               v16 = iconst.i64 32
+;; @0024                               v17 = ushr v62, v16  ; v16 = 32
+;; @0024                               trapnz v17, user2
+;;                                     v71 = iconst.i32 3
+;;                                     v72 = ishl v11, v71  ; v71 = 3
+;; @0024                               v19 = iconst.i32 32
+;; @0024                               v20 = uadd_overflow_trap v72, v19, user2  ; v19 = 32
+;; @0024                               v24 = uadd_overflow_trap v2, v20, user2
+;; @0024                               v25 = uextend.i64 v24
+;; @0024                               v28 = iadd v7, v25
+;;                                     v78 = ishl v3, v71  ; v71 = 3
+;; @0024                               v23 = iadd v78, v19  ; v19 = 32
+;; @0024                               v29 = isub v20, v23
+;; @0024                               v30 = uextend.i64 v29
+;; @0024                               v31 = isub v28, v30
+;; @0024                               v32 = load.i64 user2 little region4 v31
+;; @002b                               v40 = icmp ult v4, v11
+;; @002b                               trapz v40, user17
+;;                                     v80 = ishl v4, v71  ; v71 = 3
+;; @002b                               v51 = iadd v80, v19  ; v19 = 32
+;; @002b                               v57 = isub v20, v51
+;; @002b                               v58 = uextend.i64 v57
+;; @002b                               v59 = isub v28, v58
+;; @002b                               v60 = load.i64 user2 little region4 v59
 ;; @002e                               jump block1
 ;;
 ;;                                 block1:
-;; @002e                               return v34, v62
+;; @002e                               return v32, v60
 ;; }

--- a/tests/disas/gc/drc/multiple-struct-get.wat
+++ b/tests/disas/gc/drc/multiple-struct-get.wat
@@ -24,19 +24,19 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0023                               trapz v2, user16
-;; @0023                               v6 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0023                               v7 = load.i64 notrap aligned readonly can_move region2 v6+32
-;; @0023                               v5 = uextend.i64 v2
-;; @0023                               v8 = iadd v7, v5
-;; @0023                               v9 = iconst.i64 24
-;; @0023                               v10 = iadd v8, v9  ; v9 = 24
-;; @0023                               v11 = load.f32 user2 little region4 v10
-;; @0029                               v16 = iconst.i64 28
-;; @0029                               v17 = iadd v8, v16  ; v16 = 28
-;; @0029                               v18 = load.i8 user2 little region4 v17
+;; @0023                               v4 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @0023                               v5 = load.i64 notrap aligned readonly can_move region2 v4+32
+;; @0023                               v3 = uextend.i64 v2
+;; @0023                               v6 = iadd v5, v3
+;; @0023                               v7 = iconst.i64 24
+;; @0023                               v8 = iadd v6, v7  ; v7 = 24
+;; @0023                               v9 = load.f32 user2 little region4 v8
+;; @0029                               v14 = iconst.i64 28
+;; @0029                               v15 = iadd v6, v14  ; v14 = 28
+;; @0029                               v16 = load.i8 user2 little region4 v15
 ;; @002d                               jump block1
 ;;
 ;;                                 block1:
-;; @0029                               v19 = sextend.i32 v18
-;; @002d                               return v11, v19
+;; @0029                               v17 = sextend.i32 v16
+;; @002d                               return v9, v17
 ;; }

--- a/tests/disas/gc/drc/ref-cast.wat
+++ b/tests/disas/gc/drc/ref-cast.wat
@@ -21,32 +21,32 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @001e                               v4 = iconst.i32 0
-;; @001e                               v5 = icmp eq v2, v4  ; v4 = 0
-;; @001e                               brif v5, block4(v4), block2  ; v4 = 0
+;; @001e                               v3 = iconst.i32 0
+;; @001e                               v4 = icmp eq v2, v3  ; v3 = 0
+;; @001e                               brif v4, block4(v3), block2  ; v3 = 0
 ;;
 ;;                                 block2:
-;; @001e                               v8 = iconst.i32 1
-;; @001e                               v9 = band.i32 v2, v8  ; v8 = 1
-;;                                     v23 = iconst.i32 0
-;; @001e                               brif v9, block4(v23), block3  ; v23 = 0
+;; @001e                               v7 = iconst.i32 1
+;; @001e                               v8 = band.i32 v2, v7  ; v7 = 1
+;;                                     v22 = iconst.i32 0
+;; @001e                               brif v8, block4(v22), block3  ; v22 = 0
 ;;
 ;;                                 block3:
-;; @001e                               v14 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @001e                               v15 = load.i64 notrap aligned readonly can_move region3 v14+32
-;; @001e                               v13 = uextend.i64 v2
-;; @001e                               v16 = iadd v15, v13
-;; @001e                               v17 = iconst.i64 4
-;; @001e                               v18 = iadd v16, v17  ; v17 = 4
-;; @001e                               v19 = load.i32 user2 readonly region5 v18
-;; @001e                               v11 = load.i64 notrap aligned readonly can_move region2 v0+40
-;; @001e                               v12 = load.i32 notrap aligned readonly can_move v11
-;; @001e                               v20 = icmp eq v19, v12
-;; @001e                               v21 = uextend.i32 v20
-;; @001e                               jump block4(v21)
+;; @001e                               v13 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @001e                               v14 = load.i64 notrap aligned readonly can_move region3 v13+32
+;; @001e                               v12 = uextend.i64 v2
+;; @001e                               v15 = iadd v14, v12
+;; @001e                               v16 = iconst.i64 4
+;; @001e                               v17 = iadd v15, v16  ; v16 = 4
+;; @001e                               v18 = load.i32 user2 readonly region5 v17
+;; @001e                               v10 = load.i64 notrap aligned readonly can_move region2 v0+40
+;; @001e                               v11 = load.i32 notrap aligned readonly can_move v10
+;; @001e                               v19 = icmp eq v18, v11
+;; @001e                               v20 = uextend.i32 v19
+;; @001e                               jump block4(v20)
 ;;
-;;                                 block4(v22: i32):
-;; @001e                               trapz v22, user19
+;;                                 block4(v21: i32):
+;; @001e                               trapz v21, user19
 ;; @0021                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/drc/ref-is-null.wat
+++ b/tests/disas/gc/drc/ref-is-null.wat
@@ -22,10 +22,10 @@
 ;; @0023                               jump block1
 ;;
 ;;                                 block1:
-;;                                     v4 = iconst.i32 0
-;;                                     v5 = icmp.i32 eq v2, v4  ; v4 = 0
-;;                                     v6 = uextend.i32 v5
-;; @0023                               return v6
+;;                                     v3 = iconst.i32 0
+;;                                     v4 = icmp.i32 eq v2, v3  ; v3 = 0
+;;                                     v5 = uextend.i32 v4
+;; @0023                               return v5
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
@@ -40,6 +40,6 @@
 ;; @0029                               jump block1
 ;;
 ;;                                 block1:
-;;                                     v4 = iconst.i32 0
-;; @0029                               return v4  ; v4 = 0
+;;                                     v3 = iconst.i32 0
+;; @0029                               return v3  ; v3 = 0
 ;; }

--- a/tests/disas/gc/drc/ref-test-any.wat
+++ b/tests/disas/gc/drc/ref-test-any.wat
@@ -22,10 +22,10 @@
 ;; @0025                               jump block1
 ;;
 ;;                                 block1:
-;; @0022                               v8 = iconst.i32 1
-;; @0022                               v4 = iconst.i32 0
-;;                                     v14 = select v2, v8, v4  ; v8 = 1, v4 = 0
-;; @0025                               return v14
+;; @0022                               v7 = iconst.i32 1
+;; @0022                               v3 = iconst.i32 0
+;;                                     v13 = select v2, v7, v3  ; v7 = 1, v3 = 0
+;; @0025                               return v13
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
@@ -40,6 +40,6 @@
 ;; @002d                               jump block1
 ;;
 ;;                                 block1:
-;; @002a                               v6 = iconst.i32 1
-;; @002d                               return v6  ; v6 = 1
+;; @002a                               v5 = iconst.i32 1
+;; @002d                               return v5  ; v5 = 1
 ;; }

--- a/tests/disas/gc/drc/ref-test-array.wat
+++ b/tests/disas/gc/drc/ref-test-array.wat
@@ -19,31 +19,31 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @001b                               v4 = iconst.i32 0
-;; @001b                               v5 = icmp eq v2, v4  ; v4 = 0
-;; @001b                               brif v5, block4(v4), block2  ; v4 = 0
+;; @001b                               v3 = iconst.i32 0
+;; @001b                               v4 = icmp eq v2, v3  ; v3 = 0
+;; @001b                               brif v4, block4(v3), block2  ; v3 = 0
 ;;
 ;;                                 block2:
-;; @001b                               v8 = iconst.i32 1
-;; @001b                               v9 = band.i32 v2, v8  ; v8 = 1
-;;                                     v23 = iconst.i32 0
-;; @001b                               brif v9, block4(v23), block3  ; v23 = 0
+;; @001b                               v7 = iconst.i32 1
+;; @001b                               v8 = band.i32 v2, v7  ; v7 = 1
+;;                                     v22 = iconst.i32 0
+;; @001b                               brif v8, block4(v22), block3  ; v22 = 0
 ;;
 ;;                                 block3:
-;; @001b                               v12 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @001b                               v13 = load.i64 notrap aligned readonly can_move region2 v12+32
-;; @001b                               v11 = uextend.i64 v2
-;; @001b                               v14 = iadd v13, v11
-;; @001b                               v17 = load.i32 user2 readonly region4 v14
-;; @001b                               v18 = iconst.i32 -1476395008
-;; @001b                               v19 = band v17, v18  ; v18 = -1476395008
-;; @001b                               v20 = icmp eq v19, v18  ; v18 = -1476395008
-;; @001b                               v21 = uextend.i32 v20
-;; @001b                               jump block4(v21)
+;; @001b                               v11 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @001b                               v12 = load.i64 notrap aligned readonly can_move region2 v11+32
+;; @001b                               v10 = uextend.i64 v2
+;; @001b                               v13 = iadd v12, v10
+;; @001b                               v16 = load.i32 user2 readonly region4 v13
+;; @001b                               v17 = iconst.i32 -1476395008
+;; @001b                               v18 = band v16, v17  ; v17 = -1476395008
+;; @001b                               v19 = icmp eq v18, v17  ; v17 = -1476395008
+;; @001b                               v20 = uextend.i32 v19
+;; @001b                               jump block4(v20)
 ;;
-;;                                 block4(v22: i32):
-;; @001e                               jump block1(v22)
+;;                                 block4(v21: i32):
+;; @001e                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @001e                               return v3
+;;                                 block1:
+;; @001e                               return v21
 ;; }

--- a/tests/disas/gc/drc/ref-test-concrete-func-type.wat
+++ b/tests/disas/gc/drc/ref-test-concrete-func-type.wat
@@ -19,25 +19,25 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0020                               v4 = iconst.i64 0
-;; @0020                               v5 = icmp eq v2, v4  ; v4 = 0
-;; @0020                               v7 = iconst.i32 0
-;; @0020                               brif v5, block4(v7), block2  ; v7 = 0
+;; @0020                               v3 = iconst.i64 0
+;; @0020                               v4 = icmp eq v2, v3  ; v3 = 0
+;; @0020                               v6 = iconst.i32 0
+;; @0020                               brif v4, block4(v6), block2  ; v6 = 0
 ;;
 ;;                                 block2:
 ;; @0020                               jump block3
 ;;
 ;;                                 block3:
-;; @0020                               v10 = load.i32 user2 readonly region3 v2+16
-;; @0020                               v8 = load.i64 notrap aligned readonly can_move region2 v0+40
-;; @0020                               v9 = load.i32 notrap aligned readonly can_move v8
-;; @0020                               v11 = icmp eq v10, v9
-;; @0020                               v12 = uextend.i32 v11
-;; @0020                               jump block4(v12)
+;; @0020                               v9 = load.i32 user2 readonly region3 v2+16
+;; @0020                               v7 = load.i64 notrap aligned readonly can_move region2 v0+40
+;; @0020                               v8 = load.i32 notrap aligned readonly can_move v7
+;; @0020                               v10 = icmp eq v9, v8
+;; @0020                               v11 = uextend.i32 v10
+;; @0020                               jump block4(v11)
 ;;
-;;                                 block4(v13: i32):
-;; @0023                               jump block1(v13)
+;;                                 block4(v12: i32):
+;; @0023                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @0023                               return v3
+;;                                 block1:
+;; @0023                               return v12
 ;; }

--- a/tests/disas/gc/drc/ref-test-concrete-type.wat
+++ b/tests/disas/gc/drc/ref-test-concrete-type.wat
@@ -21,33 +21,33 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @001d                               v4 = iconst.i32 0
-;; @001d                               v5 = icmp eq v2, v4  ; v4 = 0
-;; @001d                               brif v5, block4(v4), block2  ; v4 = 0
+;; @001d                               v3 = iconst.i32 0
+;; @001d                               v4 = icmp eq v2, v3  ; v3 = 0
+;; @001d                               brif v4, block4(v3), block2  ; v3 = 0
 ;;
 ;;                                 block2:
-;; @001d                               v8 = iconst.i32 1
-;; @001d                               v9 = band.i32 v2, v8  ; v8 = 1
-;;                                     v23 = iconst.i32 0
-;; @001d                               brif v9, block4(v23), block3  ; v23 = 0
+;; @001d                               v7 = iconst.i32 1
+;; @001d                               v8 = band.i32 v2, v7  ; v7 = 1
+;;                                     v22 = iconst.i32 0
+;; @001d                               brif v8, block4(v22), block3  ; v22 = 0
 ;;
 ;;                                 block3:
-;; @001d                               v14 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @001d                               v15 = load.i64 notrap aligned readonly can_move region3 v14+32
-;; @001d                               v13 = uextend.i64 v2
-;; @001d                               v16 = iadd v15, v13
-;; @001d                               v17 = iconst.i64 4
-;; @001d                               v18 = iadd v16, v17  ; v17 = 4
-;; @001d                               v19 = load.i32 user2 readonly region5 v18
-;; @001d                               v11 = load.i64 notrap aligned readonly can_move region2 v0+40
-;; @001d                               v12 = load.i32 notrap aligned readonly can_move v11
-;; @001d                               v20 = icmp eq v19, v12
-;; @001d                               v21 = uextend.i32 v20
-;; @001d                               jump block4(v21)
+;; @001d                               v13 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @001d                               v14 = load.i64 notrap aligned readonly can_move region3 v13+32
+;; @001d                               v12 = uextend.i64 v2
+;; @001d                               v15 = iadd v14, v12
+;; @001d                               v16 = iconst.i64 4
+;; @001d                               v17 = iadd v15, v16  ; v16 = 4
+;; @001d                               v18 = load.i32 user2 readonly region5 v17
+;; @001d                               v10 = load.i64 notrap aligned readonly can_move region2 v0+40
+;; @001d                               v11 = load.i32 notrap aligned readonly can_move v10
+;; @001d                               v19 = icmp eq v18, v11
+;; @001d                               v20 = uextend.i32 v19
+;; @001d                               jump block4(v20)
 ;;
-;;                                 block4(v22: i32):
-;; @0020                               jump block1(v22)
+;;                                 block4(v21: i32):
+;; @0020                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @0020                               return v3
+;;                                 block1:
+;; @0020                               return v21
 ;; }

--- a/tests/disas/gc/drc/ref-test-eq.wat
+++ b/tests/disas/gc/drc/ref-test-eq.wat
@@ -19,30 +19,30 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @001b                               v4 = iconst.i32 0
-;; @001b                               v5 = icmp eq v2, v4  ; v4 = 0
-;; @001b                               brif v5, block4(v4), block2  ; v4 = 0
+;; @001b                               v3 = iconst.i32 0
+;; @001b                               v4 = icmp eq v2, v3  ; v3 = 0
+;; @001b                               brif v4, block4(v3), block2  ; v3 = 0
 ;;
 ;;                                 block2:
-;; @001b                               v8 = iconst.i32 1
-;; @001b                               v9 = band.i32 v2, v8  ; v8 = 1
-;; @001b                               brif v9, block4(v8), block3  ; v8 = 1
+;; @001b                               v7 = iconst.i32 1
+;; @001b                               v8 = band.i32 v2, v7  ; v7 = 1
+;; @001b                               brif v8, block4(v7), block3  ; v7 = 1
 ;;
 ;;                                 block3:
-;; @001b                               v12 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @001b                               v13 = load.i64 notrap aligned readonly can_move region2 v12+32
-;; @001b                               v11 = uextend.i64 v2
-;; @001b                               v14 = iadd v13, v11
-;; @001b                               v17 = load.i32 user2 readonly region4 v14
-;; @001b                               v18 = iconst.i32 -1610612736
-;; @001b                               v19 = band v17, v18  ; v18 = -1610612736
-;; @001b                               v20 = icmp eq v19, v18  ; v18 = -1610612736
-;; @001b                               v21 = uextend.i32 v20
-;; @001b                               jump block4(v21)
+;; @001b                               v11 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @001b                               v12 = load.i64 notrap aligned readonly can_move region2 v11+32
+;; @001b                               v10 = uextend.i64 v2
+;; @001b                               v13 = iadd v12, v10
+;; @001b                               v16 = load.i32 user2 readonly region4 v13
+;; @001b                               v17 = iconst.i32 -1610612736
+;; @001b                               v18 = band v16, v17  ; v17 = -1610612736
+;; @001b                               v19 = icmp eq v18, v17  ; v17 = -1610612736
+;; @001b                               v20 = uextend.i32 v19
+;; @001b                               jump block4(v20)
 ;;
-;;                                 block4(v22: i32):
-;; @001e                               jump block1(v22)
+;;                                 block4(v21: i32):
+;; @001e                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @001e                               return v3
+;;                                 block1:
+;; @001e                               return v21
 ;; }

--- a/tests/disas/gc/drc/ref-test-i31.wat
+++ b/tests/disas/gc/drc/ref-test-i31.wat
@@ -19,7 +19,7 @@
 ;; @001e                               jump block1
 ;;
 ;;                                 block1:
-;; @001b                               v4 = iconst.i32 1
-;; @001b                               v5 = band.i32 v2, v4  ; v4 = 1
-;; @001e                               return v5
+;; @001b                               v3 = iconst.i32 1
+;; @001b                               v4 = band.i32 v2, v3  ; v3 = 1
+;; @001e                               return v4
 ;; }

--- a/tests/disas/gc/drc/ref-test-none.wat
+++ b/tests/disas/gc/drc/ref-test-none.wat
@@ -22,8 +22,8 @@
 ;; @001f                               jump block1
 ;;
 ;;                                 block1:
-;; @001c                               v4 = iconst.i32 0
-;; @001f                               return v4  ; v4 = 0
+;; @001c                               v3 = iconst.i32 0
+;; @001f                               return v3  ; v3 = 0
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
@@ -38,8 +38,8 @@
 ;; @0027                               jump block1
 ;;
 ;;                                 block1:
-;; @0024                               v4 = iconst.i32 0
-;; @0024                               v5 = icmp.i32 eq v2, v4  ; v4 = 0
-;; @0024                               v6 = uextend.i32 v5
-;; @0027                               return v6
+;; @0024                               v3 = iconst.i32 0
+;; @0024                               v4 = icmp.i32 eq v2, v3  ; v3 = 0
+;; @0024                               v5 = uextend.i32 v4
+;; @0027                               return v5
 ;; }

--- a/tests/disas/gc/drc/ref-test-struct.wat
+++ b/tests/disas/gc/drc/ref-test-struct.wat
@@ -19,31 +19,31 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @001b                               v4 = iconst.i32 0
-;; @001b                               v5 = icmp eq v2, v4  ; v4 = 0
-;; @001b                               brif v5, block4(v4), block2  ; v4 = 0
+;; @001b                               v3 = iconst.i32 0
+;; @001b                               v4 = icmp eq v2, v3  ; v3 = 0
+;; @001b                               brif v4, block4(v3), block2  ; v3 = 0
 ;;
 ;;                                 block2:
-;; @001b                               v8 = iconst.i32 1
-;; @001b                               v9 = band.i32 v2, v8  ; v8 = 1
-;;                                     v23 = iconst.i32 0
-;; @001b                               brif v9, block4(v23), block3  ; v23 = 0
+;; @001b                               v7 = iconst.i32 1
+;; @001b                               v8 = band.i32 v2, v7  ; v7 = 1
+;;                                     v22 = iconst.i32 0
+;; @001b                               brif v8, block4(v22), block3  ; v22 = 0
 ;;
 ;;                                 block3:
-;; @001b                               v12 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @001b                               v13 = load.i64 notrap aligned readonly can_move region2 v12+32
-;; @001b                               v11 = uextend.i64 v2
-;; @001b                               v14 = iadd v13, v11
-;; @001b                               v17 = load.i32 user2 readonly region4 v14
-;; @001b                               v18 = iconst.i32 -1342177280
-;; @001b                               v19 = band v17, v18  ; v18 = -1342177280
-;; @001b                               v20 = icmp eq v19, v18  ; v18 = -1342177280
-;; @001b                               v21 = uextend.i32 v20
-;; @001b                               jump block4(v21)
+;; @001b                               v11 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @001b                               v12 = load.i64 notrap aligned readonly can_move region2 v11+32
+;; @001b                               v10 = uextend.i64 v2
+;; @001b                               v13 = iadd v12, v10
+;; @001b                               v16 = load.i32 user2 readonly region4 v13
+;; @001b                               v17 = iconst.i32 -1342177280
+;; @001b                               v18 = band v16, v17  ; v17 = -1342177280
+;; @001b                               v19 = icmp eq v18, v17  ; v17 = -1342177280
+;; @001b                               v20 = uextend.i32 v19
+;; @001b                               jump block4(v20)
 ;;
-;;                                 block4(v22: i32):
-;; @001e                               jump block1(v22)
+;;                                 block4(v21: i32):
+;; @001e                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @001e                               return v3
+;;                                 block1:
+;; @001e                               return v21
 ;; }

--- a/tests/disas/gc/drc/struct-get.wat
+++ b/tests/disas/gc/drc/struct-get.wat
@@ -36,17 +36,17 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0033                               trapz v2, user16
-;; @0033                               v5 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0033                               v6 = load.i64 notrap aligned readonly can_move region2 v5+32
-;; @0033                               v4 = uextend.i64 v2
-;; @0033                               v7 = iadd v6, v4
-;; @0033                               v8 = iconst.i64 24
-;; @0033                               v9 = iadd v7, v8  ; v8 = 24
-;; @0033                               v10 = load.f32 user2 little region4 v9
+;; @0033                               v4 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @0033                               v5 = load.i64 notrap aligned readonly can_move region2 v4+32
+;; @0033                               v3 = uextend.i64 v2
+;; @0033                               v6 = iadd v5, v3
+;; @0033                               v7 = iconst.i64 24
+;; @0033                               v8 = iadd v6, v7  ; v7 = 24
+;; @0033                               v9 = load.f32 user2 little region4 v8
 ;; @0037                               jump block1
 ;;
 ;;                                 block1:
-;; @0037                               return v10
+;; @0037                               return v9
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
@@ -62,18 +62,18 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @003c                               trapz v2, user16
-;; @003c                               v5 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @003c                               v6 = load.i64 notrap aligned readonly can_move region2 v5+32
-;; @003c                               v4 = uextend.i64 v2
-;; @003c                               v7 = iadd v6, v4
-;; @003c                               v8 = iconst.i64 28
-;; @003c                               v9 = iadd v7, v8  ; v8 = 28
-;; @003c                               v10 = load.i8 user2 little region4 v9
+;; @003c                               v4 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @003c                               v5 = load.i64 notrap aligned readonly can_move region2 v4+32
+;; @003c                               v3 = uextend.i64 v2
+;; @003c                               v6 = iadd v5, v3
+;; @003c                               v7 = iconst.i64 28
+;; @003c                               v8 = iadd v6, v7  ; v7 = 28
+;; @003c                               v9 = load.i8 user2 little region4 v8
 ;; @0040                               jump block1
 ;;
 ;;                                 block1:
-;; @003c                               v11 = sextend.i32 v10
-;; @0040                               return v11
+;; @003c                               v10 = sextend.i32 v9
+;; @0040                               return v10
 ;; }
 ;;
 ;; function u0:2(i64 vmctx, i64, i32) -> i32 tail {
@@ -89,18 +89,18 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0045                               trapz v2, user16
-;; @0045                               v5 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0045                               v6 = load.i64 notrap aligned readonly can_move region2 v5+32
-;; @0045                               v4 = uextend.i64 v2
-;; @0045                               v7 = iadd v6, v4
-;; @0045                               v8 = iconst.i64 28
-;; @0045                               v9 = iadd v7, v8  ; v8 = 28
-;; @0045                               v10 = load.i8 user2 little region4 v9
+;; @0045                               v4 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @0045                               v5 = load.i64 notrap aligned readonly can_move region2 v4+32
+;; @0045                               v3 = uextend.i64 v2
+;; @0045                               v6 = iadd v5, v3
+;; @0045                               v7 = iconst.i64 28
+;; @0045                               v8 = iadd v6, v7  ; v7 = 28
+;; @0045                               v9 = load.i8 user2 little region4 v8
 ;; @0049                               jump block1
 ;;
 ;;                                 block1:
-;; @0045                               v11 = uextend.i32 v10
-;; @0049                               return v11
+;; @0045                               v10 = uextend.i32 v9
+;; @0049                               return v10
 ;; }
 ;;
 ;; function u0:3(i64 vmctx, i64, i32) -> i32 tail {
@@ -120,69 +120,69 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @004e                               trapz v2, user16
-;; @004e                               v5 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @004e                               v6 = load.i64 notrap aligned readonly can_move region2 v5+32
-;; @004e                               v4 = uextend.i64 v2
-;; @004e                               v7 = iadd v6, v4
-;; @004e                               v8 = iconst.i64 32
-;; @004e                               v9 = iadd v7, v8  ; v8 = 32
-;; @004e                               v10 = load.i32 user2 little region4 v9
-;;                                     v85 = stack_addr.i64 ss0
-;;                                     store notrap v10, v85
-;; @004e                               v11 = iconst.i32 1
-;; @004e                               v12 = band v10, v11  ; v11 = 1
-;; @004e                               v13 = iconst.i32 0
-;; @004e                               v14 = icmp eq v10, v13  ; v13 = 0
-;; @004e                               v15 = uextend.i32 v14
-;; @004e                               v16 = bor v12, v15
-;; @004e                               brif v16, block4, block2
+;; @004e                               v4 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @004e                               v5 = load.i64 notrap aligned readonly can_move region2 v4+32
+;; @004e                               v3 = uextend.i64 v2
+;; @004e                               v6 = iadd v5, v3
+;; @004e                               v7 = iconst.i64 32
+;; @004e                               v8 = iadd v6, v7  ; v7 = 32
+;; @004e                               v9 = load.i32 user2 little region4 v8
+;;                                     v84 = stack_addr.i64 ss0
+;;                                     store notrap v9, v84
+;; @004e                               v10 = iconst.i32 1
+;; @004e                               v11 = band v9, v10  ; v10 = 1
+;; @004e                               v12 = iconst.i32 0
+;; @004e                               v13 = icmp eq v9, v12  ; v12 = 0
+;; @004e                               v14 = uextend.i32 v13
+;; @004e                               v15 = bor v11, v14
+;; @004e                               brif v15, block4, block2
 ;;
 ;;                                 block2:
-;; @004e                               v17 = uextend.i64 v10
-;; @004e                               v20 = iadd.i64 v6, v17
-;; @004e                               v21 = load.i32 user2 region4 v20
-;; @004e                               v22 = iconst.i32 2
-;; @004e                               v23 = band v21, v22  ; v22 = 2
-;; @004e                               brif v23, block4, block3
+;; @004e                               v16 = uextend.i64 v9
+;; @004e                               v19 = iadd.i64 v5, v16
+;; @004e                               v20 = load.i32 user2 region4 v19
+;; @004e                               v21 = iconst.i32 2
+;; @004e                               v22 = band v20, v21  ; v21 = 2
+;; @004e                               brif v22, block4, block3
 ;;
 ;;                                 block3:
-;; @004e                               v24 = load.i64 notrap aligned readonly can_move region5 v0+32
-;; @004e                               v25 = load.i32 user2 region4 v24
-;; @004e                               v30 = iconst.i64 16
-;; @004e                               v31 = iadd.i64 v20, v30  ; v30 = 16
-;; @004e                               store user2 region4 v25, v31
-;;                                     v86 = iconst.i32 2
-;;                                     v87 = bor.i32 v21, v86  ; v86 = 2
-;; @004e                               store user2 region4 v87, v20
-;; @004e                               v42 = iconst.i64 8
-;; @004e                               v43 = iadd.i64 v20, v42  ; v42 = 8
-;; @004e                               v44 = load.i64 user2 region4 v43
-;; @004e                               v45 = iconst.i64 1
-;; @004e                               v46 = iadd v44, v45  ; v45 = 1
-;; @004e                               store user2 region4 v46, v43
-;; @004e                               store.i32 user2 region4 v10, v24
-;; @004e                               v54 = load.i32 notrap aligned v24+4
-;;                                     v88 = iconst.i32 1
-;;                                     v89 = iadd v54, v88  ; v88 = 1
-;; @004e                               store notrap aligned v89, v24+4
-;; @004e                               v61 = load.i32 notrap aligned v24+8
-;; @004e                               v62 = iadd v61, v61
-;; @004e                               v63 = iconst.i32 1024
-;; @004e                               v64 = umax v62, v63  ; v63 = 1024
-;; @004e                               v65 = icmp uge v89, v64
-;; @004e                               brif v65, block5, block6
+;; @004e                               v23 = load.i64 notrap aligned readonly can_move region5 v0+32
+;; @004e                               v24 = load.i32 user2 region4 v23
+;; @004e                               v29 = iconst.i64 16
+;; @004e                               v30 = iadd.i64 v19, v29  ; v29 = 16
+;; @004e                               store user2 region4 v24, v30
+;;                                     v85 = iconst.i32 2
+;;                                     v86 = bor.i32 v20, v85  ; v85 = 2
+;; @004e                               store user2 region4 v86, v19
+;; @004e                               v41 = iconst.i64 8
+;; @004e                               v42 = iadd.i64 v19, v41  ; v41 = 8
+;; @004e                               v43 = load.i64 user2 region4 v42
+;; @004e                               v44 = iconst.i64 1
+;; @004e                               v45 = iadd v43, v44  ; v44 = 1
+;; @004e                               store user2 region4 v45, v42
+;; @004e                               store.i32 user2 region4 v9, v23
+;; @004e                               v53 = load.i32 notrap aligned v23+4
+;;                                     v87 = iconst.i32 1
+;;                                     v88 = iadd v53, v87  ; v87 = 1
+;; @004e                               store notrap aligned v88, v23+4
+;; @004e                               v60 = load.i32 notrap aligned v23+8
+;; @004e                               v61 = iadd v60, v60
+;; @004e                               v62 = iconst.i32 1024
+;; @004e                               v63 = umax v61, v62  ; v62 = 1024
+;; @004e                               v64 = icmp uge v88, v63
+;; @004e                               brif v64, block5, block6
 ;;
 ;;                                 block5 cold:
-;; @004e                               v66 = call fn0(v0), stack_map=[i32 @ ss0+0]
+;; @004e                               v65 = call fn0(v0), stack_map=[i32 @ ss0+0]
 ;; @004e                               jump block6
 ;;
 ;;                                 block6:
 ;; @004e                               jump block4
 ;;
 ;;                                 block4:
-;;                                     v68 = load.i32 notrap v85
 ;; @0052                               jump block1
 ;;
 ;;                                 block1:
-;; @0052                               return v68
+;;                                     v67 = load.i32 notrap v84
+;; @0052                               return v67
 ;; }

--- a/tests/disas/gc/drc/struct-new-default.wat
+++ b/tests/disas/gc/drc/struct-new-default.wat
@@ -26,33 +26,33 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @0021                               v7 = iconst.i32 -1342177280
-;; @0021                               v8 = load.i64 notrap aligned readonly can_move region2 v0+40
-;; @0021                               v9 = load.i32 notrap aligned readonly can_move v8
-;; @0021                               v6 = iconst.i32 40
-;; @0021                               v10 = iconst.i32 8
-;; @0021                               v11 = call fn0(v0, v7, v9, v6, v10)  ; v7 = -1342177280, v6 = 40, v10 = 8
-;; @0021                               v3 = f32const 0.0
-;; @0021                               v12 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0021                               v13 = load.i64 notrap aligned readonly can_move region3 v12+32
-;; @0021                               v14 = uextend.i64 v11
-;; @0021                               v15 = iadd v13, v14
-;; @0021                               v16 = iconst.i64 24
-;; @0021                               v17 = iadd v15, v16  ; v16 = 24
-;; @0021                               store user2 little region4 v3, v17  ; v3 = 0.0
-;; @0021                               v4 = iconst.i32 0
-;; @0021                               v18 = iconst.i64 28
-;; @0021                               v19 = iadd v15, v18  ; v18 = 28
-;; @0021                               istore8 user2 little region4 v4, v19  ; v4 = 0
+;; @0021                               v6 = iconst.i32 -1342177280
+;; @0021                               v7 = load.i64 notrap aligned readonly can_move region2 v0+40
+;; @0021                               v8 = load.i32 notrap aligned readonly can_move v7
+;; @0021                               v5 = iconst.i32 40
+;; @0021                               v9 = iconst.i32 8
+;; @0021                               v10 = call fn0(v0, v6, v8, v5, v9)  ; v6 = -1342177280, v5 = 40, v9 = 8
+;; @0021                               v2 = f32const 0.0
+;; @0021                               v11 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @0021                               v12 = load.i64 notrap aligned readonly can_move region3 v11+32
+;; @0021                               v13 = uextend.i64 v10
+;; @0021                               v14 = iadd v12, v13
+;; @0021                               v15 = iconst.i64 24
+;; @0021                               v16 = iadd v14, v15  ; v15 = 24
+;; @0021                               store user2 little region4 v2, v16  ; v2 = 0.0
+;; @0021                               v3 = iconst.i32 0
+;; @0021                               v17 = iconst.i64 28
+;; @0021                               v18 = iadd v14, v17  ; v17 = 28
+;; @0021                               istore8 user2 little region4 v3, v18  ; v3 = 0
 ;; @0021                               jump block3
 ;;
 ;;                                 block3:
-;;                                     v60 = iconst.i32 0
-;; @0021                               v20 = iconst.i64 32
-;; @0021                               v21 = iadd.i64 v15, v20  ; v20 = 32
-;; @0021                               store user2 little region4 v60, v21  ; v60 = 0
+;;                                     v59 = iconst.i32 0
+;; @0021                               v19 = iconst.i64 32
+;; @0021                               v20 = iadd.i64 v14, v19  ; v19 = 32
+;; @0021                               store user2 little region4 v59, v20  ; v59 = 0
 ;; @0024                               jump block1
 ;;
 ;;                                 block1:
-;; @0024                               return v11
+;; @0024                               return v10
 ;; }

--- a/tests/disas/gc/drc/struct-new.wat
+++ b/tests/disas/gc/drc/struct-new.wat
@@ -27,50 +27,50 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: f32, v3: i32, v4: i32):
-;;                                     v53 = stack_addr.i64 ss0
-;;                                     store notrap v4, v53
-;; @002a                               v7 = iconst.i32 -1342177280
-;; @002a                               v8 = load.i64 notrap aligned readonly can_move region2 v0+40
-;; @002a                               v9 = load.i32 notrap aligned readonly can_move v8
-;; @002a                               v6 = iconst.i32 40
-;; @002a                               v10 = iconst.i32 8
-;; @002a                               v11 = call fn0(v0, v7, v9, v6, v10), stack_map=[i32 @ ss0+0]  ; v7 = -1342177280, v6 = 40, v10 = 8
-;; @002a                               v12 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @002a                               v13 = load.i64 notrap aligned readonly can_move region3 v12+32
-;; @002a                               v14 = uextend.i64 v11
-;; @002a                               v15 = iadd v13, v14
-;; @002a                               v16 = iconst.i64 24
-;; @002a                               v17 = iadd v15, v16  ; v16 = 24
-;; @002a                               store user2 little region4 v2, v17
-;; @002a                               v18 = iconst.i64 28
-;; @002a                               v19 = iadd v15, v18  ; v18 = 28
-;; @002a                               istore8 user2 little region4 v3, v19
-;;                                     v52 = load.i32 notrap v53
-;; @002a                               v22 = iconst.i32 1
-;; @002a                               v23 = band v52, v22  ; v22 = 1
-;; @002a                               v24 = iconst.i32 0
-;; @002a                               v25 = icmp eq v52, v24  ; v24 = 0
-;; @002a                               v26 = uextend.i32 v25
-;; @002a                               v27 = bor v23, v26
-;; @002a                               brif v27, block3, block2
+;;                                     v52 = stack_addr.i64 ss0
+;;                                     store notrap v4, v52
+;; @002a                               v6 = iconst.i32 -1342177280
+;; @002a                               v7 = load.i64 notrap aligned readonly can_move region2 v0+40
+;; @002a                               v8 = load.i32 notrap aligned readonly can_move v7
+;; @002a                               v5 = iconst.i32 40
+;; @002a                               v9 = iconst.i32 8
+;; @002a                               v10 = call fn0(v0, v6, v8, v5, v9), stack_map=[i32 @ ss0+0]  ; v6 = -1342177280, v5 = 40, v9 = 8
+;; @002a                               v11 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @002a                               v12 = load.i64 notrap aligned readonly can_move region3 v11+32
+;; @002a                               v13 = uextend.i64 v10
+;; @002a                               v14 = iadd v12, v13
+;; @002a                               v15 = iconst.i64 24
+;; @002a                               v16 = iadd v14, v15  ; v15 = 24
+;; @002a                               store user2 little region4 v2, v16
+;; @002a                               v17 = iconst.i64 28
+;; @002a                               v18 = iadd v14, v17  ; v17 = 28
+;; @002a                               istore8 user2 little region4 v3, v18
+;;                                     v51 = load.i32 notrap v52
+;; @002a                               v21 = iconst.i32 1
+;; @002a                               v22 = band v51, v21  ; v21 = 1
+;; @002a                               v23 = iconst.i32 0
+;; @002a                               v24 = icmp eq v51, v23  ; v23 = 0
+;; @002a                               v25 = uextend.i32 v24
+;; @002a                               v26 = bor v22, v25
+;; @002a                               brif v26, block3, block2
 ;;
 ;;                                 block2:
-;; @002a                               v28 = uextend.i64 v52
-;; @002a                               v31 = iadd.i64 v13, v28
-;; @002a                               v32 = iconst.i64 8
-;; @002a                               v33 = iadd v31, v32  ; v32 = 8
-;; @002a                               v34 = load.i64 user2 region4 v33
-;; @002a                               v35 = iconst.i64 1
-;; @002a                               v36 = iadd v34, v35  ; v35 = 1
-;; @002a                               store user2 region4 v36, v33
+;; @002a                               v27 = uextend.i64 v51
+;; @002a                               v30 = iadd.i64 v12, v27
+;; @002a                               v31 = iconst.i64 8
+;; @002a                               v32 = iadd v30, v31  ; v31 = 8
+;; @002a                               v33 = load.i64 user2 region4 v32
+;; @002a                               v34 = iconst.i64 1
+;; @002a                               v35 = iadd v33, v34  ; v34 = 1
+;; @002a                               store user2 region4 v35, v32
 ;; @002a                               jump block3
 ;;
 ;;                                 block3:
-;; @002a                               v20 = iconst.i64 32
-;; @002a                               v21 = iadd.i64 v15, v20  ; v20 = 32
-;; @002a                               store.i32 user2 little region4 v52, v21
+;; @002a                               v19 = iconst.i64 32
+;; @002a                               v20 = iadd.i64 v14, v19  ; v19 = 32
+;; @002a                               store.i32 user2 little region4 v51, v20
 ;; @002d                               jump block1
 ;;
 ;;                                 block1:
-;; @002d                               return v11
+;; @002d                               return v10
 ;; }

--- a/tests/disas/gc/null/array-get-s.wat
+++ b/tests/disas/gc/null/array-get-s.wat
@@ -22,32 +22,32 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0022                               trapz v2, user16
-;; @0022                               v6 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0022                               v7 = load.i64 notrap aligned readonly can_move region2 v6+32
-;; @0022                               v5 = uextend.i64 v2
-;; @0022                               v8 = iadd v7, v5
-;; @0022                               v9 = iconst.i64 8
-;; @0022                               v10 = iadd v8, v9  ; v9 = 8
-;; @0022                               v11 = load.i32 user2 readonly region4 v10
-;; @0022                               v12 = icmp ult v3, v11
-;; @0022                               trapz v12, user17
-;; @0022                               v14 = uextend.i64 v11
-;; @0022                               v16 = iconst.i64 32
-;; @0022                               v17 = ushr v14, v16  ; v16 = 32
-;; @0022                               trapnz v17, user2
-;; @0022                               v19 = iconst.i32 12
-;; @0022                               v20 = uadd_overflow_trap v11, v19, user2  ; v19 = 12
-;; @0022                               v24 = uadd_overflow_trap v2, v20, user2
-;; @0022                               v25 = uextend.i64 v24
-;; @0022                               v28 = iadd v7, v25
-;; @0022                               v23 = iadd v3, v19  ; v19 = 12
-;; @0022                               v29 = isub v20, v23
-;; @0022                               v30 = uextend.i64 v29
-;; @0022                               v31 = isub v28, v30
-;; @0022                               v32 = load.i8 user2 little region4 v31
+;; @0022                               v5 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @0022                               v6 = load.i64 notrap aligned readonly can_move region2 v5+32
+;; @0022                               v4 = uextend.i64 v2
+;; @0022                               v7 = iadd v6, v4
+;; @0022                               v8 = iconst.i64 8
+;; @0022                               v9 = iadd v7, v8  ; v8 = 8
+;; @0022                               v10 = load.i32 user2 readonly region4 v9
+;; @0022                               v11 = icmp ult v3, v10
+;; @0022                               trapz v11, user17
+;; @0022                               v13 = uextend.i64 v10
+;; @0022                               v15 = iconst.i64 32
+;; @0022                               v16 = ushr v13, v15  ; v15 = 32
+;; @0022                               trapnz v16, user2
+;; @0022                               v18 = iconst.i32 12
+;; @0022                               v19 = uadd_overflow_trap v10, v18, user2  ; v18 = 12
+;; @0022                               v23 = uadd_overflow_trap v2, v19, user2
+;; @0022                               v24 = uextend.i64 v23
+;; @0022                               v27 = iadd v6, v24
+;; @0022                               v22 = iadd v3, v18  ; v18 = 12
+;; @0022                               v28 = isub v19, v22
+;; @0022                               v29 = uextend.i64 v28
+;; @0022                               v30 = isub v27, v29
+;; @0022                               v31 = load.i8 user2 little region4 v30
 ;; @0025                               jump block1
 ;;
 ;;                                 block1:
-;; @0022                               v33 = sextend.i32 v32
-;; @0025                               return v33
+;; @0022                               v32 = sextend.i32 v31
+;; @0025                               return v32
 ;; }

--- a/tests/disas/gc/null/array-get-u.wat
+++ b/tests/disas/gc/null/array-get-u.wat
@@ -22,32 +22,32 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0022                               trapz v2, user16
-;; @0022                               v6 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0022                               v7 = load.i64 notrap aligned readonly can_move region2 v6+32
-;; @0022                               v5 = uextend.i64 v2
-;; @0022                               v8 = iadd v7, v5
-;; @0022                               v9 = iconst.i64 8
-;; @0022                               v10 = iadd v8, v9  ; v9 = 8
-;; @0022                               v11 = load.i32 user2 readonly region4 v10
-;; @0022                               v12 = icmp ult v3, v11
-;; @0022                               trapz v12, user17
-;; @0022                               v14 = uextend.i64 v11
-;; @0022                               v16 = iconst.i64 32
-;; @0022                               v17 = ushr v14, v16  ; v16 = 32
-;; @0022                               trapnz v17, user2
-;; @0022                               v19 = iconst.i32 12
-;; @0022                               v20 = uadd_overflow_trap v11, v19, user2  ; v19 = 12
-;; @0022                               v24 = uadd_overflow_trap v2, v20, user2
-;; @0022                               v25 = uextend.i64 v24
-;; @0022                               v28 = iadd v7, v25
-;; @0022                               v23 = iadd v3, v19  ; v19 = 12
-;; @0022                               v29 = isub v20, v23
-;; @0022                               v30 = uextend.i64 v29
-;; @0022                               v31 = isub v28, v30
-;; @0022                               v32 = load.i8 user2 little region4 v31
+;; @0022                               v5 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @0022                               v6 = load.i64 notrap aligned readonly can_move region2 v5+32
+;; @0022                               v4 = uextend.i64 v2
+;; @0022                               v7 = iadd v6, v4
+;; @0022                               v8 = iconst.i64 8
+;; @0022                               v9 = iadd v7, v8  ; v8 = 8
+;; @0022                               v10 = load.i32 user2 readonly region4 v9
+;; @0022                               v11 = icmp ult v3, v10
+;; @0022                               trapz v11, user17
+;; @0022                               v13 = uextend.i64 v10
+;; @0022                               v15 = iconst.i64 32
+;; @0022                               v16 = ushr v13, v15  ; v15 = 32
+;; @0022                               trapnz v16, user2
+;; @0022                               v18 = iconst.i32 12
+;; @0022                               v19 = uadd_overflow_trap v10, v18, user2  ; v18 = 12
+;; @0022                               v23 = uadd_overflow_trap v2, v19, user2
+;; @0022                               v24 = uextend.i64 v23
+;; @0022                               v27 = iadd v6, v24
+;; @0022                               v22 = iadd v3, v18  ; v18 = 12
+;; @0022                               v28 = isub v19, v22
+;; @0022                               v29 = uextend.i64 v28
+;; @0022                               v30 = isub v27, v29
+;; @0022                               v31 = load.i8 user2 little region4 v30
 ;; @0025                               jump block1
 ;;
 ;;                                 block1:
-;; @0022                               v33 = uextend.i32 v32
-;; @0025                               return v33
+;; @0022                               v32 = uextend.i32 v31
+;; @0025                               return v32
 ;; }

--- a/tests/disas/gc/null/array-get.wat
+++ b/tests/disas/gc/null/array-get.wat
@@ -22,36 +22,36 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0022                               trapz v2, user16
-;; @0022                               v6 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0022                               v7 = load.i64 notrap aligned readonly can_move region2 v6+32
-;; @0022                               v5 = uextend.i64 v2
-;; @0022                               v8 = iadd v7, v5
-;; @0022                               v9 = iconst.i64 8
-;; @0022                               v10 = iadd v8, v9  ; v9 = 8
-;; @0022                               v11 = load.i32 user2 readonly region4 v10
-;; @0022                               v12 = icmp ult v3, v11
-;; @0022                               trapz v12, user17
-;; @0022                               v14 = uextend.i64 v11
-;;                                     v33 = iconst.i64 3
-;;                                     v34 = ishl v14, v33  ; v33 = 3
-;; @0022                               v16 = iconst.i64 32
-;; @0022                               v17 = ushr v34, v16  ; v16 = 32
-;; @0022                               trapnz v17, user2
-;;                                     v43 = iconst.i32 3
-;;                                     v44 = ishl v11, v43  ; v43 = 3
-;; @0022                               v19 = iconst.i32 16
-;; @0022                               v20 = uadd_overflow_trap v44, v19, user2  ; v19 = 16
-;; @0022                               v24 = uadd_overflow_trap v2, v20, user2
-;; @0022                               v25 = uextend.i64 v24
-;; @0022                               v28 = iadd v7, v25
-;;                                     v50 = ishl v3, v43  ; v43 = 3
-;; @0022                               v23 = iadd v50, v19  ; v19 = 16
-;; @0022                               v29 = isub v20, v23
-;; @0022                               v30 = uextend.i64 v29
-;; @0022                               v31 = isub v28, v30
-;; @0022                               v32 = load.i64 user2 little region4 v31
+;; @0022                               v5 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @0022                               v6 = load.i64 notrap aligned readonly can_move region2 v5+32
+;; @0022                               v4 = uextend.i64 v2
+;; @0022                               v7 = iadd v6, v4
+;; @0022                               v8 = iconst.i64 8
+;; @0022                               v9 = iadd v7, v8  ; v8 = 8
+;; @0022                               v10 = load.i32 user2 readonly region4 v9
+;; @0022                               v11 = icmp ult v3, v10
+;; @0022                               trapz v11, user17
+;; @0022                               v13 = uextend.i64 v10
+;;                                     v32 = iconst.i64 3
+;;                                     v33 = ishl v13, v32  ; v32 = 3
+;; @0022                               v15 = iconst.i64 32
+;; @0022                               v16 = ushr v33, v15  ; v15 = 32
+;; @0022                               trapnz v16, user2
+;;                                     v42 = iconst.i32 3
+;;                                     v43 = ishl v10, v42  ; v42 = 3
+;; @0022                               v18 = iconst.i32 16
+;; @0022                               v19 = uadd_overflow_trap v43, v18, user2  ; v18 = 16
+;; @0022                               v23 = uadd_overflow_trap v2, v19, user2
+;; @0022                               v24 = uextend.i64 v23
+;; @0022                               v27 = iadd v6, v24
+;;                                     v49 = ishl v3, v42  ; v42 = 3
+;; @0022                               v22 = iadd v49, v18  ; v18 = 16
+;; @0022                               v28 = isub v19, v22
+;; @0022                               v29 = uextend.i64 v28
+;; @0022                               v30 = isub v27, v29
+;; @0022                               v31 = load.i64 user2 little region4 v30
 ;; @0025                               jump block1
 ;;
 ;;                                 block1:
-;; @0025                               return v32
+;; @0025                               return v31
 ;; }

--- a/tests/disas/gc/null/array-len.wat
+++ b/tests/disas/gc/null/array-len.wat
@@ -22,15 +22,15 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @001f                               trapz v2, user16
-;; @001f                               v5 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @001f                               v6 = load.i64 notrap aligned readonly can_move region2 v5+32
-;; @001f                               v4 = uextend.i64 v2
-;; @001f                               v7 = iadd v6, v4
-;; @001f                               v8 = iconst.i64 8
-;; @001f                               v9 = iadd v7, v8  ; v8 = 8
-;; @001f                               v10 = load.i32 user2 readonly region4 v9
+;; @001f                               v4 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @001f                               v5 = load.i64 notrap aligned readonly can_move region2 v4+32
+;; @001f                               v3 = uextend.i64 v2
+;; @001f                               v6 = iadd v5, v3
+;; @001f                               v7 = iconst.i64 8
+;; @001f                               v8 = iadd v6, v7  ; v7 = 8
+;; @001f                               v9 = load.i32 user2 readonly region4 v8
 ;; @0021                               jump block1
 ;;
 ;;                                 block1:
-;; @0021                               return v10
+;; @0021                               return v9
 ;; }

--- a/tests/disas/gc/null/array-new-fixed-of-gc-refs.wat
+++ b/tests/disas/gc/null/array-new-fixed-of-gc-refs.wat
@@ -28,99 +28,99 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
-;;                                     v132 = stack_addr.i64 ss2
-;;                                     store notrap v2, v132
-;;                                     v133 = stack_addr.i64 ss1
-;;                                     store notrap v3, v133
-;;                                     v134 = stack_addr.i64 ss0
-;;                                     store notrap v4, v134
-;; @0025                               v18 = load.i64 notrap aligned readonly can_move region2 v0+32
-;; @0025                               v19 = load.i32 user2 region3 v18
-;;                                     v152 = iconst.i32 7
-;; @0025                               v22 = uadd_overflow_trap v19, v152, user18  ; v152 = 7
-;;                                     v158 = iconst.i32 -8
-;; @0025                               v24 = band v22, v158  ; v158 = -8
-;;                                     v145 = iconst.i32 24
-;; @0025                               v25 = uadd_overflow_trap v24, v145, user18  ; v145 = 24
-;; @0025                               v27 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0025                               v28 = load.i64 notrap aligned region4 v27+40
-;; @0025                               v26 = uextend.i64 v25
-;; @0025                               v29 = icmp ule v26, v28
-;; @0025                               brif v29, block2, block3
+;;                                     v131 = stack_addr.i64 ss2
+;;                                     store notrap v2, v131
+;;                                     v132 = stack_addr.i64 ss1
+;;                                     store notrap v3, v132
+;;                                     v133 = stack_addr.i64 ss0
+;;                                     store notrap v4, v133
+;; @0025                               v17 = load.i64 notrap aligned readonly can_move region2 v0+32
+;; @0025                               v18 = load.i32 user2 region3 v17
+;;                                     v151 = iconst.i32 7
+;; @0025                               v21 = uadd_overflow_trap v18, v151, user18  ; v151 = 7
+;;                                     v157 = iconst.i32 -8
+;; @0025                               v23 = band v21, v157  ; v157 = -8
+;;                                     v144 = iconst.i32 24
+;; @0025                               v24 = uadd_overflow_trap v23, v144, user18  ; v144 = 24
+;; @0025                               v26 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @0025                               v27 = load.i64 notrap aligned region4 v26+40
+;; @0025                               v25 = uextend.i64 v24
+;; @0025                               v28 = icmp ule v25, v27
+;; @0025                               brif v28, block2, block3
 ;;
 ;;                                 block2:
-;;                                     v159 = iconst.i32 -1476394984
-;; @0025                               v33 = load.i64 notrap aligned readonly can_move region5 v27+32
-;;                                     v257 = band.i32 v22, v158  ; v158 = -8
-;;                                     v258 = uextend.i64 v257
-;; @0025                               v35 = iadd v33, v258
-;; @0025                               store user2 region3 v159, v35  ; v159 = -1476394984
-;; @0025                               v38 = load.i64 notrap aligned readonly can_move region6 v0+40
-;; @0025                               v39 = load.i32 notrap aligned readonly can_move v38
-;; @0025                               store user2 region3 v39, v35+4
-;; @0025                               store.i32 user2 region3 v25, v18
-;; @0025                               v6 = iconst.i32 3
-;; @0025                               v40 = iconst.i64 8
-;; @0025                               v41 = iadd v35, v40  ; v40 = 8
-;; @0025                               store user2 region3 v6, v41  ; v6 = 3
-;; @0025                               trapz v257, user16
-;;                                     v259 = iconst.i32 24
-;; @0025                               v62 = uadd_overflow_trap v257, v259, user2  ; v259 = 24
-;;                                     v131 = load.i32 notrap v132
-;; @0025                               v63 = uextend.i64 v62
-;; @0025                               v66 = iadd v33, v63
-;;                                     v136 = iconst.i64 12
-;; @0025                               v69 = isub v66, v136  ; v136 = 12
-;; @0025                               store user2 little region3 v131, v69
-;; @0025                               v77 = load.i32 user2 readonly region3 v41
-;; @0025                               v70 = iconst.i32 1
-;;                                     v197 = icmp ugt v77, v70  ; v70 = 1
-;; @0025                               trapz v197, user17
-;; @0025                               v80 = uextend.i64 v77
-;;                                     v137 = iconst.i64 2
-;;                                     v199 = ishl v80, v137  ; v137 = 2
-;; @0025                               v11 = iconst.i64 32
-;; @0025                               v83 = ushr v199, v11  ; v11 = 32
-;; @0025                               trapnz v83, user2
-;;                                     v176 = iconst.i32 2
-;;                                     v206 = ishl v77, v176  ; v176 = 2
-;; @0025                               v7 = iconst.i32 12
-;; @0025                               v86 = uadd_overflow_trap v206, v7, user2  ; v7 = 12
-;; @0025                               v90 = uadd_overflow_trap v257, v86, user2
-;;                                     v129 = load.i32 notrap v133
-;; @0025                               v91 = uextend.i64 v90
-;; @0025                               v94 = iadd v33, v91
-;;                                     v219 = iconst.i32 16
-;; @0025                               v95 = isub v86, v219  ; v219 = 16
-;; @0025                               v96 = uextend.i64 v95
-;; @0025                               v97 = isub v94, v96
-;; @0025                               store user2 little region3 v129, v97
-;; @0025                               v105 = load.i32 user2 readonly region3 v41
-;;                                     v225 = icmp ugt v105, v176  ; v176 = 2
-;; @0025                               trapz v225, user17
-;; @0025                               v108 = uextend.i64 v105
-;;                                     v227 = ishl v108, v137  ; v137 = 2
-;; @0025                               v111 = ushr v227, v11  ; v11 = 32
-;; @0025                               trapnz v111, user2
-;;                                     v234 = ishl v105, v176  ; v176 = 2
-;; @0025                               v114 = uadd_overflow_trap v234, v7, user2  ; v7 = 12
-;; @0025                               v118 = uadd_overflow_trap v257, v114, user2
-;;                                     v127 = load.i32 notrap v134
-;; @0025                               v119 = uextend.i64 v118
-;; @0025                               v122 = iadd v33, v119
-;;                                     v251 = iconst.i32 20
-;; @0025                               v123 = isub v114, v251  ; v251 = 20
-;; @0025                               v124 = uextend.i64 v123
-;; @0025                               v125 = isub v122, v124
-;; @0025                               store user2 little region3 v127, v125
+;;                                     v158 = iconst.i32 -1476394984
+;; @0025                               v32 = load.i64 notrap aligned readonly can_move region5 v26+32
+;;                                     v256 = band.i32 v21, v157  ; v157 = -8
+;;                                     v257 = uextend.i64 v256
+;; @0025                               v34 = iadd v32, v257
+;; @0025                               store user2 region3 v158, v34  ; v158 = -1476394984
+;; @0025                               v37 = load.i64 notrap aligned readonly can_move region6 v0+40
+;; @0025                               v38 = load.i32 notrap aligned readonly can_move v37
+;; @0025                               store user2 region3 v38, v34+4
+;; @0025                               store.i32 user2 region3 v24, v17
+;; @0025                               v5 = iconst.i32 3
+;; @0025                               v39 = iconst.i64 8
+;; @0025                               v40 = iadd v34, v39  ; v39 = 8
+;; @0025                               store user2 region3 v5, v40  ; v5 = 3
+;; @0025                               trapz v256, user16
+;;                                     v258 = iconst.i32 24
+;; @0025                               v61 = uadd_overflow_trap v256, v258, user2  ; v258 = 24
+;;                                     v130 = load.i32 notrap v131
+;; @0025                               v62 = uextend.i64 v61
+;; @0025                               v65 = iadd v32, v62
+;;                                     v135 = iconst.i64 12
+;; @0025                               v68 = isub v65, v135  ; v135 = 12
+;; @0025                               store user2 little region3 v130, v68
+;; @0025                               v76 = load.i32 user2 readonly region3 v40
+;; @0025                               v69 = iconst.i32 1
+;;                                     v196 = icmp ugt v76, v69  ; v69 = 1
+;; @0025                               trapz v196, user17
+;; @0025                               v79 = uextend.i64 v76
+;;                                     v136 = iconst.i64 2
+;;                                     v198 = ishl v79, v136  ; v136 = 2
+;; @0025                               v10 = iconst.i64 32
+;; @0025                               v82 = ushr v198, v10  ; v10 = 32
+;; @0025                               trapnz v82, user2
+;;                                     v175 = iconst.i32 2
+;;                                     v205 = ishl v76, v175  ; v175 = 2
+;; @0025                               v6 = iconst.i32 12
+;; @0025                               v85 = uadd_overflow_trap v205, v6, user2  ; v6 = 12
+;; @0025                               v89 = uadd_overflow_trap v256, v85, user2
+;;                                     v128 = load.i32 notrap v132
+;; @0025                               v90 = uextend.i64 v89
+;; @0025                               v93 = iadd v32, v90
+;;                                     v218 = iconst.i32 16
+;; @0025                               v94 = isub v85, v218  ; v218 = 16
+;; @0025                               v95 = uextend.i64 v94
+;; @0025                               v96 = isub v93, v95
+;; @0025                               store user2 little region3 v128, v96
+;; @0025                               v104 = load.i32 user2 readonly region3 v40
+;;                                     v224 = icmp ugt v104, v175  ; v175 = 2
+;; @0025                               trapz v224, user17
+;; @0025                               v107 = uextend.i64 v104
+;;                                     v226 = ishl v107, v136  ; v136 = 2
+;; @0025                               v110 = ushr v226, v10  ; v10 = 32
+;; @0025                               trapnz v110, user2
+;;                                     v233 = ishl v104, v175  ; v175 = 2
+;; @0025                               v113 = uadd_overflow_trap v233, v6, user2  ; v6 = 12
+;; @0025                               v117 = uadd_overflow_trap v256, v113, user2
+;;                                     v126 = load.i32 notrap v133
+;; @0025                               v118 = uextend.i64 v117
+;; @0025                               v121 = iadd v32, v118
+;;                                     v250 = iconst.i32 20
+;; @0025                               v122 = isub v113, v250  ; v250 = 20
+;; @0025                               v123 = uextend.i64 v122
+;; @0025                               v124 = isub v121, v123
+;; @0025                               store user2 little region3 v126, v124
 ;; @0029                               jump block1
 ;;
 ;;                                 block3 cold:
-;; @0025                               v30 = isub.i64 v26, v28
-;; @0025                               v31 = call fn0(v0, v30), stack_map=[i32 @ ss2+0, i32 @ ss1+0, i32 @ ss0+0]
+;; @0025                               v29 = isub.i64 v25, v27
+;; @0025                               v30 = call fn0(v0, v29), stack_map=[i32 @ ss2+0, i32 @ ss1+0, i32 @ ss0+0]
 ;; @0025                               jump block2
 ;;
 ;;                                 block1:
-;;                                     v260 = band.i32 v22, v158  ; v158 = -8
-;; @0029                               return v260
+;;                                     v259 = band.i32 v21, v157  ; v157 = -8
+;; @0029                               return v259
 ;; }

--- a/tests/disas/gc/null/array-new-fixed.wat
+++ b/tests/disas/gc/null/array-new-fixed.wat
@@ -25,90 +25,90 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i64, v4: i64):
-;; @0025                               v18 = load.i64 notrap aligned readonly can_move region2 v0+32
-;; @0025                               v19 = load.i32 user2 region3 v18
-;;                                     v143 = iconst.i32 7
-;; @0025                               v22 = uadd_overflow_trap v19, v143, user18  ; v143 = 7
-;;                                     v149 = iconst.i32 -8
-;; @0025                               v24 = band v22, v149  ; v149 = -8
-;;                                     v136 = iconst.i32 40
-;; @0025                               v25 = uadd_overflow_trap v24, v136, user18  ; v136 = 40
-;; @0025                               v27 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0025                               v28 = load.i64 notrap aligned region4 v27+40
-;; @0025                               v26 = uextend.i64 v25
-;; @0025                               v29 = icmp ule v26, v28
-;; @0025                               brif v29, block2, block3
+;; @0025                               v17 = load.i64 notrap aligned readonly can_move region2 v0+32
+;; @0025                               v18 = load.i32 user2 region3 v17
+;;                                     v142 = iconst.i32 7
+;; @0025                               v21 = uadd_overflow_trap v18, v142, user18  ; v142 = 7
+;;                                     v148 = iconst.i32 -8
+;; @0025                               v23 = band v21, v148  ; v148 = -8
+;;                                     v135 = iconst.i32 40
+;; @0025                               v24 = uadd_overflow_trap v23, v135, user18  ; v135 = 40
+;; @0025                               v26 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @0025                               v27 = load.i64 notrap aligned region4 v26+40
+;; @0025                               v25 = uextend.i64 v24
+;; @0025                               v28 = icmp ule v25, v27
+;; @0025                               brif v28, block2, block3
 ;;
 ;;                                 block2:
-;;                                     v150 = iconst.i32 -1476394968
-;; @0025                               v33 = load.i64 notrap aligned readonly can_move region5 v27+32
-;;                                     v245 = band.i32 v22, v149  ; v149 = -8
-;;                                     v246 = uextend.i64 v245
-;; @0025                               v35 = iadd v33, v246
-;; @0025                               store user2 region3 v150, v35  ; v150 = -1476394968
-;; @0025                               v38 = load.i64 notrap aligned readonly can_move region6 v0+40
-;; @0025                               v39 = load.i32 notrap aligned readonly can_move v38
-;; @0025                               store user2 region3 v39, v35+4
-;; @0025                               store.i32 user2 region3 v25, v18
-;; @0025                               v6 = iconst.i32 3
-;; @0025                               v9 = iconst.i64 8
-;; @0025                               v41 = iadd v35, v9  ; v9 = 8
-;; @0025                               store user2 region3 v6, v41  ; v6 = 3
-;; @0025                               trapz v245, user16
-;;                                     v247 = iconst.i32 40
-;; @0025                               v62 = uadd_overflow_trap v245, v247, user2  ; v247 = 40
-;; @0025                               v63 = uextend.i64 v62
-;; @0025                               v66 = iadd v33, v63
-;;                                     v127 = iconst.i64 24
-;; @0025                               v69 = isub v66, v127  ; v127 = 24
-;; @0025                               store.i64 user2 little region3 v2, v69
-;; @0025                               v77 = load.i32 user2 readonly region3 v41
-;; @0025                               v70 = iconst.i32 1
-;;                                     v186 = icmp ugt v77, v70  ; v70 = 1
-;; @0025                               trapz v186, user17
-;; @0025                               v80 = uextend.i64 v77
-;;                                     v126 = iconst.i64 3
-;;                                     v188 = ishl v80, v126  ; v126 = 3
-;; @0025                               v11 = iconst.i64 32
-;; @0025                               v83 = ushr v188, v11  ; v11 = 32
-;; @0025                               trapnz v83, user2
-;;                                     v195 = ishl v77, v6  ; v6 = 3
-;; @0025                               v7 = iconst.i32 16
-;; @0025                               v86 = uadd_overflow_trap v195, v7, user2  ; v7 = 16
-;; @0025                               v90 = uadd_overflow_trap v245, v86, user2
-;; @0025                               v91 = uextend.i64 v90
-;; @0025                               v94 = iadd v33, v91
-;;                                     v135 = iconst.i32 24
-;; @0025                               v95 = isub v86, v135  ; v135 = 24
-;; @0025                               v96 = uextend.i64 v95
-;; @0025                               v97 = isub v94, v96
-;; @0025                               store.i64 user2 little region3 v3, v97
-;; @0025                               v105 = load.i32 user2 readonly region3 v41
-;; @0025                               v98 = iconst.i32 2
-;;                                     v213 = icmp ugt v105, v98  ; v98 = 2
-;; @0025                               trapz v213, user17
-;; @0025                               v108 = uextend.i64 v105
-;;                                     v215 = ishl v108, v126  ; v126 = 3
-;; @0025                               v111 = ushr v215, v11  ; v11 = 32
-;; @0025                               trapnz v111, user2
-;;                                     v222 = ishl v105, v6  ; v6 = 3
-;; @0025                               v114 = uadd_overflow_trap v222, v7, user2  ; v7 = 16
-;; @0025                               v118 = uadd_overflow_trap v245, v114, user2
-;; @0025                               v119 = uextend.i64 v118
-;; @0025                               v122 = iadd v33, v119
-;;                                     v239 = iconst.i32 32
-;; @0025                               v123 = isub v114, v239  ; v239 = 32
-;; @0025                               v124 = uextend.i64 v123
-;; @0025                               v125 = isub v122, v124
-;; @0025                               store.i64 user2 little region3 v4, v125
+;;                                     v149 = iconst.i32 -1476394968
+;; @0025                               v32 = load.i64 notrap aligned readonly can_move region5 v26+32
+;;                                     v244 = band.i32 v21, v148  ; v148 = -8
+;;                                     v245 = uextend.i64 v244
+;; @0025                               v34 = iadd v32, v245
+;; @0025                               store user2 region3 v149, v34  ; v149 = -1476394968
+;; @0025                               v37 = load.i64 notrap aligned readonly can_move region6 v0+40
+;; @0025                               v38 = load.i32 notrap aligned readonly can_move v37
+;; @0025                               store user2 region3 v38, v34+4
+;; @0025                               store.i32 user2 region3 v24, v17
+;; @0025                               v5 = iconst.i32 3
+;; @0025                               v8 = iconst.i64 8
+;; @0025                               v40 = iadd v34, v8  ; v8 = 8
+;; @0025                               store user2 region3 v5, v40  ; v5 = 3
+;; @0025                               trapz v244, user16
+;;                                     v246 = iconst.i32 40
+;; @0025                               v61 = uadd_overflow_trap v244, v246, user2  ; v246 = 40
+;; @0025                               v62 = uextend.i64 v61
+;; @0025                               v65 = iadd v32, v62
+;;                                     v126 = iconst.i64 24
+;; @0025                               v68 = isub v65, v126  ; v126 = 24
+;; @0025                               store.i64 user2 little region3 v2, v68
+;; @0025                               v76 = load.i32 user2 readonly region3 v40
+;; @0025                               v69 = iconst.i32 1
+;;                                     v185 = icmp ugt v76, v69  ; v69 = 1
+;; @0025                               trapz v185, user17
+;; @0025                               v79 = uextend.i64 v76
+;;                                     v125 = iconst.i64 3
+;;                                     v187 = ishl v79, v125  ; v125 = 3
+;; @0025                               v10 = iconst.i64 32
+;; @0025                               v82 = ushr v187, v10  ; v10 = 32
+;; @0025                               trapnz v82, user2
+;;                                     v194 = ishl v76, v5  ; v5 = 3
+;; @0025                               v6 = iconst.i32 16
+;; @0025                               v85 = uadd_overflow_trap v194, v6, user2  ; v6 = 16
+;; @0025                               v89 = uadd_overflow_trap v244, v85, user2
+;; @0025                               v90 = uextend.i64 v89
+;; @0025                               v93 = iadd v32, v90
+;;                                     v134 = iconst.i32 24
+;; @0025                               v94 = isub v85, v134  ; v134 = 24
+;; @0025                               v95 = uextend.i64 v94
+;; @0025                               v96 = isub v93, v95
+;; @0025                               store.i64 user2 little region3 v3, v96
+;; @0025                               v104 = load.i32 user2 readonly region3 v40
+;; @0025                               v97 = iconst.i32 2
+;;                                     v212 = icmp ugt v104, v97  ; v97 = 2
+;; @0025                               trapz v212, user17
+;; @0025                               v107 = uextend.i64 v104
+;;                                     v214 = ishl v107, v125  ; v125 = 3
+;; @0025                               v110 = ushr v214, v10  ; v10 = 32
+;; @0025                               trapnz v110, user2
+;;                                     v221 = ishl v104, v5  ; v5 = 3
+;; @0025                               v113 = uadd_overflow_trap v221, v6, user2  ; v6 = 16
+;; @0025                               v117 = uadd_overflow_trap v244, v113, user2
+;; @0025                               v118 = uextend.i64 v117
+;; @0025                               v121 = iadd v32, v118
+;;                                     v238 = iconst.i32 32
+;; @0025                               v122 = isub v113, v238  ; v238 = 32
+;; @0025                               v123 = uextend.i64 v122
+;; @0025                               v124 = isub v121, v123
+;; @0025                               store.i64 user2 little region3 v4, v124
 ;; @0029                               jump block1
 ;;
 ;;                                 block3 cold:
-;; @0025                               v30 = isub.i64 v26, v28
-;; @0025                               v31 = call fn0(v0, v30)
+;; @0025                               v29 = isub.i64 v25, v27
+;; @0025                               v30 = call fn0(v0, v29)
 ;; @0025                               jump block2
 ;;
 ;;                                 block1:
-;;                                     v248 = band.i32 v22, v149  ; v149 = -8
-;; @0029                               return v248
+;;                                     v247 = band.i32 v21, v148  ; v148 = -8
+;; @0029                               return v247
 ;; }

--- a/tests/disas/gc/null/array-new.wat
+++ b/tests/disas/gc/null/array-new.wat
@@ -25,76 +25,76 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
-;; @0022                               v6 = uextend.i64 v3
-;;                                     v82 = iconst.i64 3
-;;                                     v83 = ishl v6, v82  ; v82 = 3
-;; @0022                               v9 = iconst.i64 32
-;; @0022                               v10 = ushr v83, v9  ; v9 = 32
-;; @0022                               trapnz v10, user18
-;; @0022                               v5 = iconst.i32 16
-;;                                     v89 = iconst.i32 3
-;;                                     v90 = ishl v3, v89  ; v89 = 3
-;; @0022                               v12 = uadd_overflow_trap v5, v90, user18  ; v5 = 16
-;; @0022                               v14 = iconst.i32 -67108864
-;; @0022                               v15 = band v12, v14  ; v14 = -67108864
-;; @0022                               trapnz v15, user18
-;; @0022                               v16 = load.i64 notrap aligned readonly can_move region2 v0+32
-;; @0022                               v17 = load.i32 user2 region3 v16
-;;                                     v93 = iconst.i32 7
-;; @0022                               v20 = uadd_overflow_trap v17, v93, user18  ; v93 = 7
-;;                                     v99 = iconst.i32 -8
-;; @0022                               v22 = band v20, v99  ; v99 = -8
-;; @0022                               v23 = uadd_overflow_trap v22, v12, user18
-;; @0022                               v25 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0022                               v26 = load.i64 notrap aligned region4 v25+40
-;; @0022                               v24 = uextend.i64 v23
-;; @0022                               v27 = icmp ule v24, v26
-;; @0022                               brif v27, block2, block3
+;; @0022                               v5 = uextend.i64 v3
+;;                                     v81 = iconst.i64 3
+;;                                     v82 = ishl v5, v81  ; v81 = 3
+;; @0022                               v8 = iconst.i64 32
+;; @0022                               v9 = ushr v82, v8  ; v8 = 32
+;; @0022                               trapnz v9, user18
+;; @0022                               v4 = iconst.i32 16
+;;                                     v88 = iconst.i32 3
+;;                                     v89 = ishl v3, v88  ; v88 = 3
+;; @0022                               v11 = uadd_overflow_trap v4, v89, user18  ; v4 = 16
+;; @0022                               v13 = iconst.i32 -67108864
+;; @0022                               v14 = band v11, v13  ; v13 = -67108864
+;; @0022                               trapnz v14, user18
+;; @0022                               v15 = load.i64 notrap aligned readonly can_move region2 v0+32
+;; @0022                               v16 = load.i32 user2 region3 v15
+;;                                     v92 = iconst.i32 7
+;; @0022                               v19 = uadd_overflow_trap v16, v92, user18  ; v92 = 7
+;;                                     v98 = iconst.i32 -8
+;; @0022                               v21 = band v19, v98  ; v98 = -8
+;; @0022                               v22 = uadd_overflow_trap v21, v11, user18
+;; @0022                               v24 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @0022                               v25 = load.i64 notrap aligned region4 v24+40
+;; @0022                               v23 = uextend.i64 v22
+;; @0022                               v26 = icmp ule v23, v25
+;; @0022                               brif v26, block2, block3
 ;;
 ;;                                 block2:
-;; @0022                               v34 = iconst.i32 -1476395008
-;;                                     v100 = bor.i32 v12, v34  ; v34 = -1476395008
-;; @0022                               v31 = load.i64 notrap aligned readonly can_move region5 v25+32
-;;                                     v117 = band.i32 v20, v99  ; v99 = -8
-;;                                     v118 = uextend.i64 v117
-;; @0022                               v33 = iadd v31, v118
-;; @0022                               store user2 region3 v100, v33
-;; @0022                               v36 = load.i64 notrap aligned readonly can_move region6 v0+40
-;; @0022                               v37 = load.i32 notrap aligned readonly can_move v36
-;; @0022                               store user2 region3 v37, v33+4
-;; @0022                               store.i32 user2 region3 v23, v16
-;; @0022                               v7 = iconst.i64 8
-;; @0022                               v39 = iadd v33, v7  ; v7 = 8
-;; @0022                               store.i32 user2 region3 v3, v39
-;; @0022                               trapz v117, user16
-;; @0022                               v71 = load.i64 notrap aligned region4 v25+40
-;; @0022                               v59 = iconst.i64 16
-;; @0022                               v60 = iadd v33, v59  ; v59 = 16
-;; @0022                               v73 = uadd_overflow_trap v60, v83, user2
-;; @0022                               v72 = iadd v31, v71
-;; @0022                               v74 = icmp ugt v73, v72
-;; @0022                               trapnz v74, user2
-;;                                     v102 = iconst.i64 0
-;; @0022                               v77 = icmp.i64 eq v6, v102  ; v102 = 0
-;; @0022                               v75 = iadd v60, v83
-;; @0022                               brif v77, block5, block4(v60)
+;; @0022                               v33 = iconst.i32 -1476395008
+;;                                     v99 = bor.i32 v11, v33  ; v33 = -1476395008
+;; @0022                               v30 = load.i64 notrap aligned readonly can_move region5 v24+32
+;;                                     v116 = band.i32 v19, v98  ; v98 = -8
+;;                                     v117 = uextend.i64 v116
+;; @0022                               v32 = iadd v30, v117
+;; @0022                               store user2 region3 v99, v32
+;; @0022                               v35 = load.i64 notrap aligned readonly can_move region6 v0+40
+;; @0022                               v36 = load.i32 notrap aligned readonly can_move v35
+;; @0022                               store user2 region3 v36, v32+4
+;; @0022                               store.i32 user2 region3 v22, v15
+;; @0022                               v6 = iconst.i64 8
+;; @0022                               v38 = iadd v32, v6  ; v6 = 8
+;; @0022                               store.i32 user2 region3 v3, v38
+;; @0022                               trapz v116, user16
+;; @0022                               v70 = load.i64 notrap aligned region4 v24+40
+;; @0022                               v58 = iconst.i64 16
+;; @0022                               v59 = iadd v32, v58  ; v58 = 16
+;; @0022                               v72 = uadd_overflow_trap v59, v82, user2
+;; @0022                               v71 = iadd v30, v70
+;; @0022                               v73 = icmp ugt v72, v71
+;; @0022                               trapnz v73, user2
+;;                                     v101 = iconst.i64 0
+;; @0022                               v76 = icmp.i64 eq v5, v101  ; v101 = 0
+;; @0022                               v74 = iadd v59, v82
+;; @0022                               brif v76, block5, block4(v59)
 ;;
-;;                                 block4(v78: i64):
-;; @0022                               store.i64 user2 little region3 v2, v78
-;;                                     v119 = iconst.i64 8
-;;                                     v120 = iadd v78, v119  ; v119 = 8
-;; @0022                               v81 = icmp eq v120, v75
-;; @0022                               brif v81, block5, block4(v120)
+;;                                 block4(v77: i64):
+;; @0022                               store.i64 user2 little region3 v2, v77
+;;                                     v118 = iconst.i64 8
+;;                                     v119 = iadd v77, v118  ; v118 = 8
+;; @0022                               v80 = icmp eq v119, v74
+;; @0022                               brif v80, block5, block4(v119)
 ;;
 ;;                                 block5:
 ;; @0025                               jump block1
 ;;
 ;;                                 block3 cold:
-;; @0022                               v28 = isub.i64 v24, v26
-;; @0022                               v29 = call fn0(v0, v28)
+;; @0022                               v27 = isub.i64 v23, v25
+;; @0022                               v28 = call fn0(v0, v27)
 ;; @0022                               jump block2
 ;;
 ;;                                 block1:
-;;                                     v121 = band.i32 v20, v99  ; v99 = -8
-;; @0025                               return v121
+;;                                     v120 = band.i32 v19, v98  ; v98 = -8
+;; @0025                               return v120
 ;; }

--- a/tests/disas/gc/null/br-on-cast-fail.wat
+++ b/tests/disas/gc/null/br-on-cast-fail.wat
@@ -34,42 +34,42 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @002e                               v4 = iconst.i32 0
-;; @002e                               v5 = icmp eq v2, v4  ; v4 = 0
-;; @002e                               brif v5, block5(v4), block3  ; v4 = 0
+;; @002e                               v3 = iconst.i32 0
+;; @002e                               v4 = icmp eq v2, v3  ; v3 = 0
+;; @002e                               brif v4, block5(v3), block3  ; v3 = 0
 ;;
 ;;                                 block3:
-;; @002e                               v8 = iconst.i32 1
-;; @002e                               v9 = band.i32 v2, v8  ; v8 = 1
-;;                                     v27 = iconst.i32 0
-;; @002e                               brif v9, block5(v27), block4  ; v27 = 0
+;; @002e                               v7 = iconst.i32 1
+;; @002e                               v8 = band.i32 v2, v7  ; v7 = 1
+;;                                     v26 = iconst.i32 0
+;; @002e                               brif v8, block5(v26), block4  ; v26 = 0
 ;;
 ;;                                 block4:
-;; @002e                               v14 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @002e                               v15 = load.i64 notrap aligned readonly can_move region3 v14+32
-;; @002e                               v13 = uextend.i64 v2
-;; @002e                               v16 = iadd v15, v13
-;; @002e                               v17 = iconst.i64 4
-;; @002e                               v18 = iadd v16, v17  ; v17 = 4
-;; @002e                               v19 = load.i32 user2 readonly region5 v18
-;; @002e                               v11 = load.i64 notrap aligned readonly can_move region2 v0+40
-;; @002e                               v12 = load.i32 notrap aligned readonly can_move v11
-;; @002e                               v20 = icmp eq v19, v12
-;; @002e                               v21 = uextend.i32 v20
-;; @002e                               jump block5(v21)
+;; @002e                               v13 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @002e                               v14 = load.i64 notrap aligned readonly can_move region3 v13+32
+;; @002e                               v12 = uextend.i64 v2
+;; @002e                               v15 = iadd v14, v12
+;; @002e                               v16 = iconst.i64 4
+;; @002e                               v17 = iadd v15, v16  ; v16 = 4
+;; @002e                               v18 = load.i32 user2 readonly region5 v17
+;; @002e                               v10 = load.i64 notrap aligned readonly can_move region2 v0+40
+;; @002e                               v11 = load.i32 notrap aligned readonly can_move v10
+;; @002e                               v19 = icmp eq v18, v11
+;; @002e                               v20 = uextend.i32 v19
+;; @002e                               jump block5(v20)
 ;;
-;;                                 block5(v22: i32):
-;; @002e                               brif v22, block6, block2
+;;                                 block5(v21: i32):
+;; @002e                               brif v21, block6, block2
 ;;
 ;;                                 block6:
-;; @0034                               v24 = load.i64 notrap aligned readonly can_move region7 v0+56
-;; @0034                               v23 = load.i64 notrap aligned readonly can_move region6 v0+72
-;; @0034                               call_indirect sig0, v24(v23, v0)
+;; @0034                               v23 = load.i64 notrap aligned readonly can_move region7 v0+56
+;; @0034                               v22 = load.i64 notrap aligned readonly can_move region6 v0+72
+;; @0034                               call_indirect sig0, v23(v22, v0)
 ;; @0036                               return
 ;;
 ;;                                 block2:
-;; @0038                               v26 = load.i64 notrap aligned readonly can_move region9 v0+88
-;; @0038                               v25 = load.i64 notrap aligned readonly can_move region8 v0+104
-;; @0038                               call_indirect sig0, v26(v25, v0)
+;; @0038                               v25 = load.i64 notrap aligned readonly can_move region9 v0+88
+;; @0038                               v24 = load.i64 notrap aligned readonly can_move region8 v0+104
+;; @0038                               call_indirect sig0, v25(v24, v0)
 ;; @003a                               return
 ;; }

--- a/tests/disas/gc/null/br-on-cast.wat
+++ b/tests/disas/gc/null/br-on-cast.wat
@@ -34,42 +34,42 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @002f                               v4 = iconst.i32 0
-;; @002f                               v5 = icmp eq v2, v4  ; v4 = 0
-;; @002f                               brif v5, block5(v4), block3  ; v4 = 0
+;; @002f                               v3 = iconst.i32 0
+;; @002f                               v4 = icmp eq v2, v3  ; v3 = 0
+;; @002f                               brif v4, block5(v3), block3  ; v3 = 0
 ;;
 ;;                                 block3:
-;; @002f                               v8 = iconst.i32 1
-;; @002f                               v9 = band.i32 v2, v8  ; v8 = 1
-;;                                     v27 = iconst.i32 0
-;; @002f                               brif v9, block5(v27), block4  ; v27 = 0
+;; @002f                               v7 = iconst.i32 1
+;; @002f                               v8 = band.i32 v2, v7  ; v7 = 1
+;;                                     v26 = iconst.i32 0
+;; @002f                               brif v8, block5(v26), block4  ; v26 = 0
 ;;
 ;;                                 block4:
-;; @002f                               v14 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @002f                               v15 = load.i64 notrap aligned readonly can_move region3 v14+32
-;; @002f                               v13 = uextend.i64 v2
-;; @002f                               v16 = iadd v15, v13
-;; @002f                               v17 = iconst.i64 4
-;; @002f                               v18 = iadd v16, v17  ; v17 = 4
-;; @002f                               v19 = load.i32 user2 readonly region5 v18
-;; @002f                               v11 = load.i64 notrap aligned readonly can_move region2 v0+40
-;; @002f                               v12 = load.i32 notrap aligned readonly can_move v11
-;; @002f                               v20 = icmp eq v19, v12
-;; @002f                               v21 = uextend.i32 v20
-;; @002f                               jump block5(v21)
+;; @002f                               v13 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @002f                               v14 = load.i64 notrap aligned readonly can_move region3 v13+32
+;; @002f                               v12 = uextend.i64 v2
+;; @002f                               v15 = iadd v14, v12
+;; @002f                               v16 = iconst.i64 4
+;; @002f                               v17 = iadd v15, v16  ; v16 = 4
+;; @002f                               v18 = load.i32 user2 readonly region5 v17
+;; @002f                               v10 = load.i64 notrap aligned readonly can_move region2 v0+40
+;; @002f                               v11 = load.i32 notrap aligned readonly can_move v10
+;; @002f                               v19 = icmp eq v18, v11
+;; @002f                               v20 = uextend.i32 v19
+;; @002f                               jump block5(v20)
 ;;
-;;                                 block5(v22: i32):
-;; @002f                               brif v22, block2, block6
+;;                                 block5(v21: i32):
+;; @002f                               brif v21, block2, block6
 ;;
 ;;                                 block6:
-;; @0035                               v24 = load.i64 notrap aligned readonly can_move region7 v0+56
-;; @0035                               v23 = load.i64 notrap aligned readonly can_move region6 v0+72
-;; @0035                               call_indirect sig0, v24(v23, v0)
+;; @0035                               v23 = load.i64 notrap aligned readonly can_move region7 v0+56
+;; @0035                               v22 = load.i64 notrap aligned readonly can_move region6 v0+72
+;; @0035                               call_indirect sig0, v23(v22, v0)
 ;; @0037                               return
 ;;
 ;;                                 block2:
-;; @0039                               v26 = load.i64 notrap aligned readonly can_move region9 v0+88
-;; @0039                               v25 = load.i64 notrap aligned readonly can_move region8 v0+104
-;; @0039                               call_indirect sig0, v26(v25, v0)
+;; @0039                               v25 = load.i64 notrap aligned readonly can_move region9 v0+88
+;; @0039                               v24 = load.i64 notrap aligned readonly can_move region8 v0+104
+;; @0039                               call_indirect sig0, v25(v24, v0)
 ;; @003b                               return
 ;; }

--- a/tests/disas/gc/null/externref-globals.wat
+++ b/tests/disas/gc/null/externref-globals.wat
@@ -22,13 +22,13 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @0034                               v3 = iconst.i64 48
-;; @0034                               v4 = iadd v0, v3  ; v3 = 48
-;; @0034                               v5 = load.i32 notrap aligned region2 v4
+;; @0034                               v2 = iconst.i64 48
+;; @0034                               v3 = iadd v0, v2  ; v2 = 48
+;; @0034                               v4 = load.i32 notrap aligned region2 v3
 ;; @0036                               jump block1
 ;;
 ;;                                 block1:
-;; @0036                               return v5
+;; @0036                               return v4
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) tail {

--- a/tests/disas/gc/null/funcref-in-gc-heap-get.wat
+++ b/tests/disas/gc/null/funcref-in-gc-heap-get.wat
@@ -24,17 +24,17 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0020                               trapz v2, user16
-;; @0020                               v5 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0020                               v6 = load.i64 notrap aligned readonly can_move region2 v5+32
-;; @0020                               v4 = uextend.i64 v2
-;; @0020                               v7 = iadd v6, v4
-;; @0020                               v8 = iconst.i64 8
-;; @0020                               v9 = iadd v7, v8  ; v8 = 8
-;; @0020                               v11 = load.i32 user2 little region4 v9
-;; @0020                               v10 = iconst.i32 -1
-;; @0020                               v12 = call fn0(v0, v11, v10)  ; v10 = -1
+;; @0020                               v4 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @0020                               v5 = load.i64 notrap aligned readonly can_move region2 v4+32
+;; @0020                               v3 = uextend.i64 v2
+;; @0020                               v6 = iadd v5, v3
+;; @0020                               v7 = iconst.i64 8
+;; @0020                               v8 = iadd v6, v7  ; v7 = 8
+;; @0020                               v10 = load.i32 user2 little region4 v8
+;; @0020                               v9 = iconst.i32 -1
+;; @0020                               v11 = call fn0(v0, v10, v9)  ; v9 = -1
 ;; @0024                               jump block1
 ;;
 ;;                                 block1:
-;; @0024                               return v12
+;; @0024                               return v11
 ;; }

--- a/tests/disas/gc/null/funcref-in-gc-heap-new.wat
+++ b/tests/disas/gc/null/funcref-in-gc-heap-new.wat
@@ -27,44 +27,44 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0020                               v8 = load.i64 notrap aligned readonly can_move region2 v0+32
-;; @0020                               v9 = load.i32 user2 region3 v8
-;;                                     v40 = iconst.i32 7
-;; @0020                               v12 = uadd_overflow_trap v9, v40, user18  ; v40 = 7
-;;                                     v46 = iconst.i32 -8
-;; @0020                               v14 = band v12, v46  ; v46 = -8
-;; @0020                               v4 = iconst.i32 16
-;; @0020                               v15 = uadd_overflow_trap v14, v4, user18  ; v4 = 16
-;; @0020                               v17 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0020                               v18 = load.i64 notrap aligned region4 v17+40
-;; @0020                               v16 = uextend.i64 v15
-;; @0020                               v19 = icmp ule v16, v18
-;; @0020                               brif v19, block2, block3
+;; @0020                               v7 = load.i64 notrap aligned readonly can_move region2 v0+32
+;; @0020                               v8 = load.i32 user2 region3 v7
+;;                                     v39 = iconst.i32 7
+;; @0020                               v11 = uadd_overflow_trap v8, v39, user18  ; v39 = 7
+;;                                     v45 = iconst.i32 -8
+;; @0020                               v13 = band v11, v45  ; v45 = -8
+;; @0020                               v3 = iconst.i32 16
+;; @0020                               v14 = uadd_overflow_trap v13, v3, user18  ; v3 = 16
+;; @0020                               v16 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @0020                               v17 = load.i64 notrap aligned region4 v16+40
+;; @0020                               v15 = uextend.i64 v14
+;; @0020                               v18 = icmp ule v15, v17
+;; @0020                               brif v18, block2, block3
 ;;
 ;;                                 block2:
-;;                                     v47 = iconst.i32 -1342177264
-;; @0020                               v23 = load.i64 notrap aligned readonly can_move region5 v17+32
-;;                                     v53 = band.i32 v12, v46  ; v46 = -8
-;;                                     v54 = uextend.i64 v53
-;; @0020                               v25 = iadd v23, v54
-;; @0020                               store user2 region3 v47, v25  ; v47 = -1342177264
-;; @0020                               v28 = load.i64 notrap aligned readonly can_move region6 v0+40
-;; @0020                               v29 = load.i32 notrap aligned readonly can_move v28
-;; @0020                               store user2 region3 v29, v25+4
-;; @0020                               store.i32 user2 region3 v15, v8
-;; @0020                               v32 = call fn1(v0, v2)
-;; @0020                               v33 = ireduce.i32 v32
-;; @0020                               v30 = iconst.i64 8
-;; @0020                               v31 = iadd v25, v30  ; v30 = 8
-;; @0020                               store user2 little region3 v33, v31
+;;                                     v46 = iconst.i32 -1342177264
+;; @0020                               v22 = load.i64 notrap aligned readonly can_move region5 v16+32
+;;                                     v52 = band.i32 v11, v45  ; v45 = -8
+;;                                     v53 = uextend.i64 v52
+;; @0020                               v24 = iadd v22, v53
+;; @0020                               store user2 region3 v46, v24  ; v46 = -1342177264
+;; @0020                               v27 = load.i64 notrap aligned readonly can_move region6 v0+40
+;; @0020                               v28 = load.i32 notrap aligned readonly can_move v27
+;; @0020                               store user2 region3 v28, v24+4
+;; @0020                               store.i32 user2 region3 v14, v7
+;; @0020                               v31 = call fn1(v0, v2)
+;; @0020                               v32 = ireduce.i32 v31
+;; @0020                               v29 = iconst.i64 8
+;; @0020                               v30 = iadd v24, v29  ; v29 = 8
+;; @0020                               store user2 little region3 v32, v30
 ;; @0023                               jump block1
 ;;
 ;;                                 block3 cold:
-;; @0020                               v20 = isub.i64 v16, v18
-;; @0020                               v21 = call fn0(v0, v20)
+;; @0020                               v19 = isub.i64 v15, v17
+;; @0020                               v20 = call fn0(v0, v19)
 ;; @0020                               jump block2
 ;;
 ;;                                 block1:
-;;                                     v55 = band.i32 v12, v46  ; v46 = -8
-;; @0023                               return v55
+;;                                     v54 = band.i32 v11, v45  ; v45 = -8
+;; @0023                               return v54
 ;; }

--- a/tests/disas/gc/null/i31ref-globals.wat
+++ b/tests/disas/gc/null/i31ref-globals.wat
@@ -22,13 +22,13 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @0036                               v3 = iconst.i64 48
-;; @0036                               v4 = iadd v0, v3  ; v3 = 48
-;; @0036                               v5 = load.i32 notrap aligned region2 v4
+;; @0036                               v2 = iconst.i64 48
+;; @0036                               v3 = iadd v0, v2  ; v2 = 48
+;; @0036                               v4 = load.i32 notrap aligned region2 v3
 ;; @0038                               jump block1
 ;;
 ;;                                 block1:
-;; @0038                               return v5
+;; @0038                               return v4
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) tail {

--- a/tests/disas/gc/null/multiple-array-get.wat
+++ b/tests/disas/gc/null/multiple-array-get.wat
@@ -23,44 +23,44 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
 ;; @0024                               trapz v2, user16
-;; @0024                               v8 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0024                               v9 = load.i64 notrap aligned readonly can_move region2 v8+32
-;; @0024                               v7 = uextend.i64 v2
-;; @0024                               v10 = iadd v9, v7
-;; @0024                               v11 = iconst.i64 8
-;; @0024                               v12 = iadd v10, v11  ; v11 = 8
-;; @0024                               v13 = load.i32 user2 readonly region4 v12
-;; @0024                               v14 = icmp ult v3, v13
-;; @0024                               trapz v14, user17
-;; @0024                               v16 = uextend.i64 v13
-;;                                     v63 = iconst.i64 3
-;;                                     v64 = ishl v16, v63  ; v63 = 3
-;; @0024                               v18 = iconst.i64 32
-;; @0024                               v19 = ushr v64, v18  ; v18 = 32
-;; @0024                               trapnz v19, user2
-;;                                     v73 = iconst.i32 3
-;;                                     v74 = ishl v13, v73  ; v73 = 3
-;; @0024                               v21 = iconst.i32 16
-;; @0024                               v22 = uadd_overflow_trap v74, v21, user2  ; v21 = 16
-;; @0024                               v26 = uadd_overflow_trap v2, v22, user2
-;; @0024                               v27 = uextend.i64 v26
-;; @0024                               v30 = iadd v9, v27
-;;                                     v80 = ishl v3, v73  ; v73 = 3
-;; @0024                               v25 = iadd v80, v21  ; v21 = 16
-;; @0024                               v31 = isub v22, v25
-;; @0024                               v32 = uextend.i64 v31
-;; @0024                               v33 = isub v30, v32
-;; @0024                               v34 = load.i64 user2 little region4 v33
-;; @002b                               v42 = icmp ult v4, v13
-;; @002b                               trapz v42, user17
-;;                                     v82 = ishl v4, v73  ; v73 = 3
-;; @002b                               v53 = iadd v82, v21  ; v21 = 16
-;; @002b                               v59 = isub v22, v53
-;; @002b                               v60 = uextend.i64 v59
-;; @002b                               v61 = isub v30, v60
-;; @002b                               v62 = load.i64 user2 little region4 v61
+;; @0024                               v6 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @0024                               v7 = load.i64 notrap aligned readonly can_move region2 v6+32
+;; @0024                               v5 = uextend.i64 v2
+;; @0024                               v8 = iadd v7, v5
+;; @0024                               v9 = iconst.i64 8
+;; @0024                               v10 = iadd v8, v9  ; v9 = 8
+;; @0024                               v11 = load.i32 user2 readonly region4 v10
+;; @0024                               v12 = icmp ult v3, v11
+;; @0024                               trapz v12, user17
+;; @0024                               v14 = uextend.i64 v11
+;;                                     v61 = iconst.i64 3
+;;                                     v62 = ishl v14, v61  ; v61 = 3
+;; @0024                               v16 = iconst.i64 32
+;; @0024                               v17 = ushr v62, v16  ; v16 = 32
+;; @0024                               trapnz v17, user2
+;;                                     v71 = iconst.i32 3
+;;                                     v72 = ishl v11, v71  ; v71 = 3
+;; @0024                               v19 = iconst.i32 16
+;; @0024                               v20 = uadd_overflow_trap v72, v19, user2  ; v19 = 16
+;; @0024                               v24 = uadd_overflow_trap v2, v20, user2
+;; @0024                               v25 = uextend.i64 v24
+;; @0024                               v28 = iadd v7, v25
+;;                                     v78 = ishl v3, v71  ; v71 = 3
+;; @0024                               v23 = iadd v78, v19  ; v19 = 16
+;; @0024                               v29 = isub v20, v23
+;; @0024                               v30 = uextend.i64 v29
+;; @0024                               v31 = isub v28, v30
+;; @0024                               v32 = load.i64 user2 little region4 v31
+;; @002b                               v40 = icmp ult v4, v11
+;; @002b                               trapz v40, user17
+;;                                     v80 = ishl v4, v71  ; v71 = 3
+;; @002b                               v51 = iadd v80, v19  ; v19 = 16
+;; @002b                               v57 = isub v20, v51
+;; @002b                               v58 = uextend.i64 v57
+;; @002b                               v59 = isub v28, v58
+;; @002b                               v60 = load.i64 user2 little region4 v59
 ;; @002e                               jump block1
 ;;
 ;;                                 block1:
-;; @002e                               return v34, v62
+;; @002e                               return v32, v60
 ;; }

--- a/tests/disas/gc/null/multiple-struct-get.wat
+++ b/tests/disas/gc/null/multiple-struct-get.wat
@@ -24,19 +24,19 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0023                               trapz v2, user16
-;; @0023                               v6 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0023                               v7 = load.i64 notrap aligned readonly can_move region2 v6+32
-;; @0023                               v5 = uextend.i64 v2
-;; @0023                               v8 = iadd v7, v5
-;; @0023                               v9 = iconst.i64 8
-;; @0023                               v10 = iadd v8, v9  ; v9 = 8
-;; @0023                               v11 = load.f32 user2 little region4 v10
-;; @0029                               v16 = iconst.i64 12
-;; @0029                               v17 = iadd v8, v16  ; v16 = 12
-;; @0029                               v18 = load.i8 user2 little region4 v17
+;; @0023                               v4 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @0023                               v5 = load.i64 notrap aligned readonly can_move region2 v4+32
+;; @0023                               v3 = uextend.i64 v2
+;; @0023                               v6 = iadd v5, v3
+;; @0023                               v7 = iconst.i64 8
+;; @0023                               v8 = iadd v6, v7  ; v7 = 8
+;; @0023                               v9 = load.f32 user2 little region4 v8
+;; @0029                               v14 = iconst.i64 12
+;; @0029                               v15 = iadd v6, v14  ; v14 = 12
+;; @0029                               v16 = load.i8 user2 little region4 v15
 ;; @002d                               jump block1
 ;;
 ;;                                 block1:
-;; @0029                               v19 = sextend.i32 v18
-;; @002d                               return v11, v19
+;; @0029                               v17 = sextend.i32 v16
+;; @002d                               return v9, v17
 ;; }

--- a/tests/disas/gc/null/ref-cast.wat
+++ b/tests/disas/gc/null/ref-cast.wat
@@ -21,32 +21,32 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @001e                               v4 = iconst.i32 0
-;; @001e                               v5 = icmp eq v2, v4  ; v4 = 0
-;; @001e                               brif v5, block4(v4), block2  ; v4 = 0
+;; @001e                               v3 = iconst.i32 0
+;; @001e                               v4 = icmp eq v2, v3  ; v3 = 0
+;; @001e                               brif v4, block4(v3), block2  ; v3 = 0
 ;;
 ;;                                 block2:
-;; @001e                               v8 = iconst.i32 1
-;; @001e                               v9 = band.i32 v2, v8  ; v8 = 1
-;;                                     v23 = iconst.i32 0
-;; @001e                               brif v9, block4(v23), block3  ; v23 = 0
+;; @001e                               v7 = iconst.i32 1
+;; @001e                               v8 = band.i32 v2, v7  ; v7 = 1
+;;                                     v22 = iconst.i32 0
+;; @001e                               brif v8, block4(v22), block3  ; v22 = 0
 ;;
 ;;                                 block3:
-;; @001e                               v14 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @001e                               v15 = load.i64 notrap aligned readonly can_move region3 v14+32
-;; @001e                               v13 = uextend.i64 v2
-;; @001e                               v16 = iadd v15, v13
-;; @001e                               v17 = iconst.i64 4
-;; @001e                               v18 = iadd v16, v17  ; v17 = 4
-;; @001e                               v19 = load.i32 user2 readonly region5 v18
-;; @001e                               v11 = load.i64 notrap aligned readonly can_move region2 v0+40
-;; @001e                               v12 = load.i32 notrap aligned readonly can_move v11
-;; @001e                               v20 = icmp eq v19, v12
-;; @001e                               v21 = uextend.i32 v20
-;; @001e                               jump block4(v21)
+;; @001e                               v13 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @001e                               v14 = load.i64 notrap aligned readonly can_move region3 v13+32
+;; @001e                               v12 = uextend.i64 v2
+;; @001e                               v15 = iadd v14, v12
+;; @001e                               v16 = iconst.i64 4
+;; @001e                               v17 = iadd v15, v16  ; v16 = 4
+;; @001e                               v18 = load.i32 user2 readonly region5 v17
+;; @001e                               v10 = load.i64 notrap aligned readonly can_move region2 v0+40
+;; @001e                               v11 = load.i32 notrap aligned readonly can_move v10
+;; @001e                               v19 = icmp eq v18, v11
+;; @001e                               v20 = uextend.i32 v19
+;; @001e                               jump block4(v20)
 ;;
-;;                                 block4(v22: i32):
-;; @001e                               trapz v22, user19
+;;                                 block4(v21: i32):
+;; @001e                               trapz v21, user19
 ;; @0021                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/null/ref-is-null.wat
+++ b/tests/disas/gc/null/ref-is-null.wat
@@ -22,10 +22,10 @@
 ;; @0023                               jump block1
 ;;
 ;;                                 block1:
-;;                                     v4 = iconst.i32 0
-;;                                     v5 = icmp.i32 eq v2, v4  ; v4 = 0
-;;                                     v6 = uextend.i32 v5
-;; @0023                               return v6
+;;                                     v3 = iconst.i32 0
+;;                                     v4 = icmp.i32 eq v2, v3  ; v3 = 0
+;;                                     v5 = uextend.i32 v4
+;; @0023                               return v5
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
@@ -40,6 +40,6 @@
 ;; @0029                               jump block1
 ;;
 ;;                                 block1:
-;;                                     v4 = iconst.i32 0
-;; @0029                               return v4  ; v4 = 0
+;;                                     v3 = iconst.i32 0
+;; @0029                               return v3  ; v3 = 0
 ;; }

--- a/tests/disas/gc/null/ref-test-any.wat
+++ b/tests/disas/gc/null/ref-test-any.wat
@@ -22,10 +22,10 @@
 ;; @0025                               jump block1
 ;;
 ;;                                 block1:
-;; @0022                               v8 = iconst.i32 1
-;; @0022                               v4 = iconst.i32 0
-;;                                     v14 = select v2, v8, v4  ; v8 = 1, v4 = 0
-;; @0025                               return v14
+;; @0022                               v7 = iconst.i32 1
+;; @0022                               v3 = iconst.i32 0
+;;                                     v13 = select v2, v7, v3  ; v7 = 1, v3 = 0
+;; @0025                               return v13
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
@@ -40,6 +40,6 @@
 ;; @002d                               jump block1
 ;;
 ;;                                 block1:
-;; @002a                               v6 = iconst.i32 1
-;; @002d                               return v6  ; v6 = 1
+;; @002a                               v5 = iconst.i32 1
+;; @002d                               return v5  ; v5 = 1
 ;; }

--- a/tests/disas/gc/null/ref-test-array.wat
+++ b/tests/disas/gc/null/ref-test-array.wat
@@ -19,31 +19,31 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @001b                               v4 = iconst.i32 0
-;; @001b                               v5 = icmp eq v2, v4  ; v4 = 0
-;; @001b                               brif v5, block4(v4), block2  ; v4 = 0
+;; @001b                               v3 = iconst.i32 0
+;; @001b                               v4 = icmp eq v2, v3  ; v3 = 0
+;; @001b                               brif v4, block4(v3), block2  ; v3 = 0
 ;;
 ;;                                 block2:
-;; @001b                               v8 = iconst.i32 1
-;; @001b                               v9 = band.i32 v2, v8  ; v8 = 1
-;;                                     v23 = iconst.i32 0
-;; @001b                               brif v9, block4(v23), block3  ; v23 = 0
+;; @001b                               v7 = iconst.i32 1
+;; @001b                               v8 = band.i32 v2, v7  ; v7 = 1
+;;                                     v22 = iconst.i32 0
+;; @001b                               brif v8, block4(v22), block3  ; v22 = 0
 ;;
 ;;                                 block3:
-;; @001b                               v12 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @001b                               v13 = load.i64 notrap aligned readonly can_move region2 v12+32
-;; @001b                               v11 = uextend.i64 v2
-;; @001b                               v14 = iadd v13, v11
-;; @001b                               v17 = load.i32 user2 readonly region4 v14
-;; @001b                               v18 = iconst.i32 -1476395008
-;; @001b                               v19 = band v17, v18  ; v18 = -1476395008
-;; @001b                               v20 = icmp eq v19, v18  ; v18 = -1476395008
-;; @001b                               v21 = uextend.i32 v20
-;; @001b                               jump block4(v21)
+;; @001b                               v11 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @001b                               v12 = load.i64 notrap aligned readonly can_move region2 v11+32
+;; @001b                               v10 = uextend.i64 v2
+;; @001b                               v13 = iadd v12, v10
+;; @001b                               v16 = load.i32 user2 readonly region4 v13
+;; @001b                               v17 = iconst.i32 -1476395008
+;; @001b                               v18 = band v16, v17  ; v17 = -1476395008
+;; @001b                               v19 = icmp eq v18, v17  ; v17 = -1476395008
+;; @001b                               v20 = uextend.i32 v19
+;; @001b                               jump block4(v20)
 ;;
-;;                                 block4(v22: i32):
-;; @001e                               jump block1(v22)
+;;                                 block4(v21: i32):
+;; @001e                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @001e                               return v3
+;;                                 block1:
+;; @001e                               return v21
 ;; }

--- a/tests/disas/gc/null/ref-test-concrete-func-type.wat
+++ b/tests/disas/gc/null/ref-test-concrete-func-type.wat
@@ -19,25 +19,25 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0020                               v4 = iconst.i64 0
-;; @0020                               v5 = icmp eq v2, v4  ; v4 = 0
-;; @0020                               v7 = iconst.i32 0
-;; @0020                               brif v5, block4(v7), block2  ; v7 = 0
+;; @0020                               v3 = iconst.i64 0
+;; @0020                               v4 = icmp eq v2, v3  ; v3 = 0
+;; @0020                               v6 = iconst.i32 0
+;; @0020                               brif v4, block4(v6), block2  ; v6 = 0
 ;;
 ;;                                 block2:
 ;; @0020                               jump block3
 ;;
 ;;                                 block3:
-;; @0020                               v10 = load.i32 user2 readonly region3 v2+16
-;; @0020                               v8 = load.i64 notrap aligned readonly can_move region2 v0+40
-;; @0020                               v9 = load.i32 notrap aligned readonly can_move v8
-;; @0020                               v11 = icmp eq v10, v9
-;; @0020                               v12 = uextend.i32 v11
-;; @0020                               jump block4(v12)
+;; @0020                               v9 = load.i32 user2 readonly region3 v2+16
+;; @0020                               v7 = load.i64 notrap aligned readonly can_move region2 v0+40
+;; @0020                               v8 = load.i32 notrap aligned readonly can_move v7
+;; @0020                               v10 = icmp eq v9, v8
+;; @0020                               v11 = uextend.i32 v10
+;; @0020                               jump block4(v11)
 ;;
-;;                                 block4(v13: i32):
-;; @0023                               jump block1(v13)
+;;                                 block4(v12: i32):
+;; @0023                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @0023                               return v3
+;;                                 block1:
+;; @0023                               return v12
 ;; }

--- a/tests/disas/gc/null/ref-test-concrete-type.wat
+++ b/tests/disas/gc/null/ref-test-concrete-type.wat
@@ -21,33 +21,33 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @001d                               v4 = iconst.i32 0
-;; @001d                               v5 = icmp eq v2, v4  ; v4 = 0
-;; @001d                               brif v5, block4(v4), block2  ; v4 = 0
+;; @001d                               v3 = iconst.i32 0
+;; @001d                               v4 = icmp eq v2, v3  ; v3 = 0
+;; @001d                               brif v4, block4(v3), block2  ; v3 = 0
 ;;
 ;;                                 block2:
-;; @001d                               v8 = iconst.i32 1
-;; @001d                               v9 = band.i32 v2, v8  ; v8 = 1
-;;                                     v23 = iconst.i32 0
-;; @001d                               brif v9, block4(v23), block3  ; v23 = 0
+;; @001d                               v7 = iconst.i32 1
+;; @001d                               v8 = band.i32 v2, v7  ; v7 = 1
+;;                                     v22 = iconst.i32 0
+;; @001d                               brif v8, block4(v22), block3  ; v22 = 0
 ;;
 ;;                                 block3:
-;; @001d                               v14 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @001d                               v15 = load.i64 notrap aligned readonly can_move region3 v14+32
-;; @001d                               v13 = uextend.i64 v2
-;; @001d                               v16 = iadd v15, v13
-;; @001d                               v17 = iconst.i64 4
-;; @001d                               v18 = iadd v16, v17  ; v17 = 4
-;; @001d                               v19 = load.i32 user2 readonly region5 v18
-;; @001d                               v11 = load.i64 notrap aligned readonly can_move region2 v0+40
-;; @001d                               v12 = load.i32 notrap aligned readonly can_move v11
-;; @001d                               v20 = icmp eq v19, v12
-;; @001d                               v21 = uextend.i32 v20
-;; @001d                               jump block4(v21)
+;; @001d                               v13 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @001d                               v14 = load.i64 notrap aligned readonly can_move region3 v13+32
+;; @001d                               v12 = uextend.i64 v2
+;; @001d                               v15 = iadd v14, v12
+;; @001d                               v16 = iconst.i64 4
+;; @001d                               v17 = iadd v15, v16  ; v16 = 4
+;; @001d                               v18 = load.i32 user2 readonly region5 v17
+;; @001d                               v10 = load.i64 notrap aligned readonly can_move region2 v0+40
+;; @001d                               v11 = load.i32 notrap aligned readonly can_move v10
+;; @001d                               v19 = icmp eq v18, v11
+;; @001d                               v20 = uextend.i32 v19
+;; @001d                               jump block4(v20)
 ;;
-;;                                 block4(v22: i32):
-;; @0020                               jump block1(v22)
+;;                                 block4(v21: i32):
+;; @0020                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @0020                               return v3
+;;                                 block1:
+;; @0020                               return v21
 ;; }

--- a/tests/disas/gc/null/ref-test-eq.wat
+++ b/tests/disas/gc/null/ref-test-eq.wat
@@ -19,30 +19,30 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @001b                               v4 = iconst.i32 0
-;; @001b                               v5 = icmp eq v2, v4  ; v4 = 0
-;; @001b                               brif v5, block4(v4), block2  ; v4 = 0
+;; @001b                               v3 = iconst.i32 0
+;; @001b                               v4 = icmp eq v2, v3  ; v3 = 0
+;; @001b                               brif v4, block4(v3), block2  ; v3 = 0
 ;;
 ;;                                 block2:
-;; @001b                               v8 = iconst.i32 1
-;; @001b                               v9 = band.i32 v2, v8  ; v8 = 1
-;; @001b                               brif v9, block4(v8), block3  ; v8 = 1
+;; @001b                               v7 = iconst.i32 1
+;; @001b                               v8 = band.i32 v2, v7  ; v7 = 1
+;; @001b                               brif v8, block4(v7), block3  ; v7 = 1
 ;;
 ;;                                 block3:
-;; @001b                               v12 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @001b                               v13 = load.i64 notrap aligned readonly can_move region2 v12+32
-;; @001b                               v11 = uextend.i64 v2
-;; @001b                               v14 = iadd v13, v11
-;; @001b                               v17 = load.i32 user2 readonly region4 v14
-;; @001b                               v18 = iconst.i32 -1610612736
-;; @001b                               v19 = band v17, v18  ; v18 = -1610612736
-;; @001b                               v20 = icmp eq v19, v18  ; v18 = -1610612736
-;; @001b                               v21 = uextend.i32 v20
-;; @001b                               jump block4(v21)
+;; @001b                               v11 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @001b                               v12 = load.i64 notrap aligned readonly can_move region2 v11+32
+;; @001b                               v10 = uextend.i64 v2
+;; @001b                               v13 = iadd v12, v10
+;; @001b                               v16 = load.i32 user2 readonly region4 v13
+;; @001b                               v17 = iconst.i32 -1610612736
+;; @001b                               v18 = band v16, v17  ; v17 = -1610612736
+;; @001b                               v19 = icmp eq v18, v17  ; v17 = -1610612736
+;; @001b                               v20 = uextend.i32 v19
+;; @001b                               jump block4(v20)
 ;;
-;;                                 block4(v22: i32):
-;; @001e                               jump block1(v22)
+;;                                 block4(v21: i32):
+;; @001e                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @001e                               return v3
+;;                                 block1:
+;; @001e                               return v21
 ;; }

--- a/tests/disas/gc/null/ref-test-i31.wat
+++ b/tests/disas/gc/null/ref-test-i31.wat
@@ -19,7 +19,7 @@
 ;; @001e                               jump block1
 ;;
 ;;                                 block1:
-;; @001b                               v4 = iconst.i32 1
-;; @001b                               v5 = band.i32 v2, v4  ; v4 = 1
-;; @001e                               return v5
+;; @001b                               v3 = iconst.i32 1
+;; @001b                               v4 = band.i32 v2, v3  ; v3 = 1
+;; @001e                               return v4
 ;; }

--- a/tests/disas/gc/null/ref-test-none.wat
+++ b/tests/disas/gc/null/ref-test-none.wat
@@ -22,8 +22,8 @@
 ;; @001f                               jump block1
 ;;
 ;;                                 block1:
-;; @001c                               v4 = iconst.i32 0
-;; @001f                               return v4  ; v4 = 0
+;; @001c                               v3 = iconst.i32 0
+;; @001f                               return v3  ; v3 = 0
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
@@ -38,8 +38,8 @@
 ;; @0027                               jump block1
 ;;
 ;;                                 block1:
-;; @0024                               v4 = iconst.i32 0
-;; @0024                               v5 = icmp.i32 eq v2, v4  ; v4 = 0
-;; @0024                               v6 = uextend.i32 v5
-;; @0027                               return v6
+;; @0024                               v3 = iconst.i32 0
+;; @0024                               v4 = icmp.i32 eq v2, v3  ; v3 = 0
+;; @0024                               v5 = uextend.i32 v4
+;; @0027                               return v5
 ;; }

--- a/tests/disas/gc/null/ref-test-struct.wat
+++ b/tests/disas/gc/null/ref-test-struct.wat
@@ -19,31 +19,31 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @001b                               v4 = iconst.i32 0
-;; @001b                               v5 = icmp eq v2, v4  ; v4 = 0
-;; @001b                               brif v5, block4(v4), block2  ; v4 = 0
+;; @001b                               v3 = iconst.i32 0
+;; @001b                               v4 = icmp eq v2, v3  ; v3 = 0
+;; @001b                               brif v4, block4(v3), block2  ; v3 = 0
 ;;
 ;;                                 block2:
-;; @001b                               v8 = iconst.i32 1
-;; @001b                               v9 = band.i32 v2, v8  ; v8 = 1
-;;                                     v23 = iconst.i32 0
-;; @001b                               brif v9, block4(v23), block3  ; v23 = 0
+;; @001b                               v7 = iconst.i32 1
+;; @001b                               v8 = band.i32 v2, v7  ; v7 = 1
+;;                                     v22 = iconst.i32 0
+;; @001b                               brif v8, block4(v22), block3  ; v22 = 0
 ;;
 ;;                                 block3:
-;; @001b                               v12 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @001b                               v13 = load.i64 notrap aligned readonly can_move region2 v12+32
-;; @001b                               v11 = uextend.i64 v2
-;; @001b                               v14 = iadd v13, v11
-;; @001b                               v17 = load.i32 user2 readonly region4 v14
-;; @001b                               v18 = iconst.i32 -1342177280
-;; @001b                               v19 = band v17, v18  ; v18 = -1342177280
-;; @001b                               v20 = icmp eq v19, v18  ; v18 = -1342177280
-;; @001b                               v21 = uextend.i32 v20
-;; @001b                               jump block4(v21)
+;; @001b                               v11 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @001b                               v12 = load.i64 notrap aligned readonly can_move region2 v11+32
+;; @001b                               v10 = uextend.i64 v2
+;; @001b                               v13 = iadd v12, v10
+;; @001b                               v16 = load.i32 user2 readonly region4 v13
+;; @001b                               v17 = iconst.i32 -1342177280
+;; @001b                               v18 = band v16, v17  ; v17 = -1342177280
+;; @001b                               v19 = icmp eq v18, v17  ; v17 = -1342177280
+;; @001b                               v20 = uextend.i32 v19
+;; @001b                               jump block4(v20)
 ;;
-;;                                 block4(v22: i32):
-;; @001e                               jump block1(v22)
+;;                                 block4(v21: i32):
+;; @001e                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @001e                               return v3
+;;                                 block1:
+;; @001e                               return v21
 ;; }

--- a/tests/disas/gc/null/struct-get-guard-pages.wat
+++ b/tests/disas/gc/null/struct-get-guard-pages.wat
@@ -36,17 +36,17 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0033                               trapz v2, user16
-;; @0033                               v5 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0033                               v6 = load.i64 notrap aligned readonly can_move region2 v5+32
-;; @0033                               v4 = uextend.i64 v2
-;; @0033                               v7 = iadd v6, v4
-;; @0033                               v8 = iconst.i64 8
-;; @0033                               v9 = iadd v7, v8  ; v8 = 8
-;; @0033                               v10 = load.f32 user2 little region4 v9
+;; @0033                               v4 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @0033                               v5 = load.i64 notrap aligned readonly can_move region2 v4+32
+;; @0033                               v3 = uextend.i64 v2
+;; @0033                               v6 = iadd v5, v3
+;; @0033                               v7 = iconst.i64 8
+;; @0033                               v8 = iadd v6, v7  ; v7 = 8
+;; @0033                               v9 = load.f32 user2 little region4 v8
 ;; @0037                               jump block1
 ;;
 ;;                                 block1:
-;; @0037                               return v10
+;; @0037                               return v9
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
@@ -62,18 +62,18 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @003c                               trapz v2, user16
-;; @003c                               v5 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @003c                               v6 = load.i64 notrap aligned readonly can_move region2 v5+32
-;; @003c                               v4 = uextend.i64 v2
-;; @003c                               v7 = iadd v6, v4
-;; @003c                               v8 = iconst.i64 12
-;; @003c                               v9 = iadd v7, v8  ; v8 = 12
-;; @003c                               v10 = load.i8 user2 little region4 v9
+;; @003c                               v4 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @003c                               v5 = load.i64 notrap aligned readonly can_move region2 v4+32
+;; @003c                               v3 = uextend.i64 v2
+;; @003c                               v6 = iadd v5, v3
+;; @003c                               v7 = iconst.i64 12
+;; @003c                               v8 = iadd v6, v7  ; v7 = 12
+;; @003c                               v9 = load.i8 user2 little region4 v8
 ;; @0040                               jump block1
 ;;
 ;;                                 block1:
-;; @003c                               v11 = sextend.i32 v10
-;; @0040                               return v11
+;; @003c                               v10 = sextend.i32 v9
+;; @0040                               return v10
 ;; }
 ;;
 ;; function u0:2(i64 vmctx, i64, i32) -> i32 tail {
@@ -89,18 +89,18 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0045                               trapz v2, user16
-;; @0045                               v5 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0045                               v6 = load.i64 notrap aligned readonly can_move region2 v5+32
-;; @0045                               v4 = uextend.i64 v2
-;; @0045                               v7 = iadd v6, v4
-;; @0045                               v8 = iconst.i64 12
-;; @0045                               v9 = iadd v7, v8  ; v8 = 12
-;; @0045                               v10 = load.i8 user2 little region4 v9
+;; @0045                               v4 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @0045                               v5 = load.i64 notrap aligned readonly can_move region2 v4+32
+;; @0045                               v3 = uextend.i64 v2
+;; @0045                               v6 = iadd v5, v3
+;; @0045                               v7 = iconst.i64 12
+;; @0045                               v8 = iadd v6, v7  ; v7 = 12
+;; @0045                               v9 = load.i8 user2 little region4 v8
 ;; @0049                               jump block1
 ;;
 ;;                                 block1:
-;; @0045                               v11 = uextend.i32 v10
-;; @0049                               return v11
+;; @0045                               v10 = uextend.i32 v9
+;; @0049                               return v10
 ;; }
 ;;
 ;; function u0:3(i64 vmctx, i64, i32) -> i32 tail {
@@ -116,15 +116,15 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @004e                               trapz v2, user16
-;; @004e                               v5 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @004e                               v6 = load.i64 notrap aligned readonly can_move region2 v5+32
-;; @004e                               v4 = uextend.i64 v2
-;; @004e                               v7 = iadd v6, v4
-;; @004e                               v8 = iconst.i64 16
-;; @004e                               v9 = iadd v7, v8  ; v8 = 16
-;; @004e                               v10 = load.i32 user2 little region4 v9
+;; @004e                               v4 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @004e                               v5 = load.i64 notrap aligned readonly can_move region2 v4+32
+;; @004e                               v3 = uextend.i64 v2
+;; @004e                               v6 = iadd v5, v3
+;; @004e                               v7 = iconst.i64 16
+;; @004e                               v8 = iadd v6, v7  ; v7 = 16
+;; @004e                               v9 = load.i32 user2 little region4 v8
 ;; @0052                               jump block1
 ;;
 ;;                                 block1:
-;; @0052                               return v10
+;; @0052                               return v9
 ;; }

--- a/tests/disas/gc/null/struct-get-no-guard-pages.wat
+++ b/tests/disas/gc/null/struct-get-no-guard-pages.wat
@@ -36,23 +36,23 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0033                               trapz v2, user16
-;; @0033                               v4 = uextend.i64 v2
-;; @0033                               v5 = iconst.i64 24
-;; @0033                               v6 = uadd_overflow_trap v4, v5, user2  ; v5 = 24
-;; @0033                               v7 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0033                               v8 = load.i64 notrap aligned region3 v7+40
-;; @0033                               v11 = load.i64 notrap aligned region2 v7+32
-;; @0033                               v9 = icmp ugt v6, v8
-;; @0033                               v13 = iconst.i64 0
-;; @0033                               v12 = iadd v11, v4
-;; @0033                               v14 = select_spectre_guard v9, v13, v12  ; v13 = 0
-;; @0033                               v15 = iconst.i64 8
-;; @0033                               v16 = iadd v14, v15  ; v15 = 8
-;; @0033                               v17 = load.f32 user2 little region4 v16
+;; @0033                               v3 = uextend.i64 v2
+;; @0033                               v4 = iconst.i64 24
+;; @0033                               v5 = uadd_overflow_trap v3, v4, user2  ; v4 = 24
+;; @0033                               v6 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @0033                               v7 = load.i64 notrap aligned region3 v6+40
+;; @0033                               v10 = load.i64 notrap aligned region2 v6+32
+;; @0033                               v8 = icmp ugt v5, v7
+;; @0033                               v12 = iconst.i64 0
+;; @0033                               v11 = iadd v10, v3
+;; @0033                               v13 = select_spectre_guard v8, v12, v11  ; v12 = 0
+;; @0033                               v14 = iconst.i64 8
+;; @0033                               v15 = iadd v13, v14  ; v14 = 8
+;; @0033                               v16 = load.f32 user2 little region4 v15
 ;; @0037                               jump block1
 ;;
 ;;                                 block1:
-;; @0037                               return v17
+;; @0037                               return v16
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
@@ -68,24 +68,24 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @003c                               trapz v2, user16
-;; @003c                               v4 = uextend.i64 v2
-;; @003c                               v5 = iconst.i64 24
-;; @003c                               v6 = uadd_overflow_trap v4, v5, user2  ; v5 = 24
-;; @003c                               v7 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @003c                               v8 = load.i64 notrap aligned region3 v7+40
-;; @003c                               v11 = load.i64 notrap aligned region2 v7+32
-;; @003c                               v9 = icmp ugt v6, v8
-;; @003c                               v13 = iconst.i64 0
-;; @003c                               v12 = iadd v11, v4
-;; @003c                               v14 = select_spectre_guard v9, v13, v12  ; v13 = 0
-;; @003c                               v15 = iconst.i64 12
-;; @003c                               v16 = iadd v14, v15  ; v15 = 12
-;; @003c                               v17 = load.i8 user2 little region4 v16
+;; @003c                               v3 = uextend.i64 v2
+;; @003c                               v4 = iconst.i64 24
+;; @003c                               v5 = uadd_overflow_trap v3, v4, user2  ; v4 = 24
+;; @003c                               v6 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @003c                               v7 = load.i64 notrap aligned region3 v6+40
+;; @003c                               v10 = load.i64 notrap aligned region2 v6+32
+;; @003c                               v8 = icmp ugt v5, v7
+;; @003c                               v12 = iconst.i64 0
+;; @003c                               v11 = iadd v10, v3
+;; @003c                               v13 = select_spectre_guard v8, v12, v11  ; v12 = 0
+;; @003c                               v14 = iconst.i64 12
+;; @003c                               v15 = iadd v13, v14  ; v14 = 12
+;; @003c                               v16 = load.i8 user2 little region4 v15
 ;; @0040                               jump block1
 ;;
 ;;                                 block1:
-;; @003c                               v18 = sextend.i32 v17
-;; @0040                               return v18
+;; @003c                               v17 = sextend.i32 v16
+;; @0040                               return v17
 ;; }
 ;;
 ;; function u0:2(i64 vmctx, i64, i32) -> i32 tail {
@@ -101,24 +101,24 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0045                               trapz v2, user16
-;; @0045                               v4 = uextend.i64 v2
-;; @0045                               v5 = iconst.i64 24
-;; @0045                               v6 = uadd_overflow_trap v4, v5, user2  ; v5 = 24
-;; @0045                               v7 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0045                               v8 = load.i64 notrap aligned region3 v7+40
-;; @0045                               v11 = load.i64 notrap aligned region2 v7+32
-;; @0045                               v9 = icmp ugt v6, v8
-;; @0045                               v13 = iconst.i64 0
-;; @0045                               v12 = iadd v11, v4
-;; @0045                               v14 = select_spectre_guard v9, v13, v12  ; v13 = 0
-;; @0045                               v15 = iconst.i64 12
-;; @0045                               v16 = iadd v14, v15  ; v15 = 12
-;; @0045                               v17 = load.i8 user2 little region4 v16
+;; @0045                               v3 = uextend.i64 v2
+;; @0045                               v4 = iconst.i64 24
+;; @0045                               v5 = uadd_overflow_trap v3, v4, user2  ; v4 = 24
+;; @0045                               v6 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @0045                               v7 = load.i64 notrap aligned region3 v6+40
+;; @0045                               v10 = load.i64 notrap aligned region2 v6+32
+;; @0045                               v8 = icmp ugt v5, v7
+;; @0045                               v12 = iconst.i64 0
+;; @0045                               v11 = iadd v10, v3
+;; @0045                               v13 = select_spectre_guard v8, v12, v11  ; v12 = 0
+;; @0045                               v14 = iconst.i64 12
+;; @0045                               v15 = iadd v13, v14  ; v14 = 12
+;; @0045                               v16 = load.i8 user2 little region4 v15
 ;; @0049                               jump block1
 ;;
 ;;                                 block1:
-;; @0045                               v18 = uextend.i32 v17
-;; @0049                               return v18
+;; @0045                               v17 = uextend.i32 v16
+;; @0049                               return v17
 ;; }
 ;;
 ;; function u0:3(i64 vmctx, i64, i32) -> i32 tail {
@@ -134,21 +134,21 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @004e                               trapz v2, user16
-;; @004e                               v4 = uextend.i64 v2
-;; @004e                               v5 = iconst.i64 24
-;; @004e                               v6 = uadd_overflow_trap v4, v5, user2  ; v5 = 24
-;; @004e                               v7 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @004e                               v8 = load.i64 notrap aligned region3 v7+40
-;; @004e                               v11 = load.i64 notrap aligned region2 v7+32
-;; @004e                               v9 = icmp ugt v6, v8
-;; @004e                               v13 = iconst.i64 0
-;; @004e                               v12 = iadd v11, v4
-;; @004e                               v14 = select_spectre_guard v9, v13, v12  ; v13 = 0
-;; @004e                               v15 = iconst.i64 16
-;; @004e                               v16 = iadd v14, v15  ; v15 = 16
-;; @004e                               v17 = load.i32 user2 little region4 v16
+;; @004e                               v3 = uextend.i64 v2
+;; @004e                               v4 = iconst.i64 24
+;; @004e                               v5 = uadd_overflow_trap v3, v4, user2  ; v4 = 24
+;; @004e                               v6 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @004e                               v7 = load.i64 notrap aligned region3 v6+40
+;; @004e                               v10 = load.i64 notrap aligned region2 v6+32
+;; @004e                               v8 = icmp ugt v5, v7
+;; @004e                               v12 = iconst.i64 0
+;; @004e                               v11 = iadd v10, v3
+;; @004e                               v13 = select_spectre_guard v8, v12, v11  ; v12 = 0
+;; @004e                               v14 = iconst.i64 16
+;; @004e                               v15 = iadd v13, v14  ; v14 = 16
+;; @004e                               v16 = load.i32 user2 little region4 v15
 ;; @0052                               jump block1
 ;;
 ;;                                 block1:
-;; @0052                               return v17
+;; @0052                               return v16
 ;; }

--- a/tests/disas/gc/null/struct-get.wat
+++ b/tests/disas/gc/null/struct-get.wat
@@ -36,17 +36,17 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0033                               trapz v2, user16
-;; @0033                               v5 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0033                               v6 = load.i64 notrap aligned readonly can_move region2 v5+32
-;; @0033                               v4 = uextend.i64 v2
-;; @0033                               v7 = iadd v6, v4
-;; @0033                               v8 = iconst.i64 8
-;; @0033                               v9 = iadd v7, v8  ; v8 = 8
-;; @0033                               v10 = load.f32 user2 little region4 v9
+;; @0033                               v4 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @0033                               v5 = load.i64 notrap aligned readonly can_move region2 v4+32
+;; @0033                               v3 = uextend.i64 v2
+;; @0033                               v6 = iadd v5, v3
+;; @0033                               v7 = iconst.i64 8
+;; @0033                               v8 = iadd v6, v7  ; v7 = 8
+;; @0033                               v9 = load.f32 user2 little region4 v8
 ;; @0037                               jump block1
 ;;
 ;;                                 block1:
-;; @0037                               return v10
+;; @0037                               return v9
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
@@ -62,18 +62,18 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @003c                               trapz v2, user16
-;; @003c                               v5 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @003c                               v6 = load.i64 notrap aligned readonly can_move region2 v5+32
-;; @003c                               v4 = uextend.i64 v2
-;; @003c                               v7 = iadd v6, v4
-;; @003c                               v8 = iconst.i64 12
-;; @003c                               v9 = iadd v7, v8  ; v8 = 12
-;; @003c                               v10 = load.i8 user2 little region4 v9
+;; @003c                               v4 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @003c                               v5 = load.i64 notrap aligned readonly can_move region2 v4+32
+;; @003c                               v3 = uextend.i64 v2
+;; @003c                               v6 = iadd v5, v3
+;; @003c                               v7 = iconst.i64 12
+;; @003c                               v8 = iadd v6, v7  ; v7 = 12
+;; @003c                               v9 = load.i8 user2 little region4 v8
 ;; @0040                               jump block1
 ;;
 ;;                                 block1:
-;; @003c                               v11 = sextend.i32 v10
-;; @0040                               return v11
+;; @003c                               v10 = sextend.i32 v9
+;; @0040                               return v10
 ;; }
 ;;
 ;; function u0:2(i64 vmctx, i64, i32) -> i32 tail {
@@ -89,18 +89,18 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0045                               trapz v2, user16
-;; @0045                               v5 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0045                               v6 = load.i64 notrap aligned readonly can_move region2 v5+32
-;; @0045                               v4 = uextend.i64 v2
-;; @0045                               v7 = iadd v6, v4
-;; @0045                               v8 = iconst.i64 12
-;; @0045                               v9 = iadd v7, v8  ; v8 = 12
-;; @0045                               v10 = load.i8 user2 little region4 v9
+;; @0045                               v4 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @0045                               v5 = load.i64 notrap aligned readonly can_move region2 v4+32
+;; @0045                               v3 = uextend.i64 v2
+;; @0045                               v6 = iadd v5, v3
+;; @0045                               v7 = iconst.i64 12
+;; @0045                               v8 = iadd v6, v7  ; v7 = 12
+;; @0045                               v9 = load.i8 user2 little region4 v8
 ;; @0049                               jump block1
 ;;
 ;;                                 block1:
-;; @0045                               v11 = uextend.i32 v10
-;; @0049                               return v11
+;; @0045                               v10 = uextend.i32 v9
+;; @0049                               return v10
 ;; }
 ;;
 ;; function u0:3(i64 vmctx, i64, i32) -> i32 tail {
@@ -116,15 +116,15 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @004e                               trapz v2, user16
-;; @004e                               v5 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @004e                               v6 = load.i64 notrap aligned readonly can_move region2 v5+32
-;; @004e                               v4 = uextend.i64 v2
-;; @004e                               v7 = iadd v6, v4
-;; @004e                               v8 = iconst.i64 16
-;; @004e                               v9 = iadd v7, v8  ; v8 = 16
-;; @004e                               v10 = load.i32 user2 little region4 v9
+;; @004e                               v4 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @004e                               v5 = load.i64 notrap aligned readonly can_move region2 v4+32
+;; @004e                               v3 = uextend.i64 v2
+;; @004e                               v6 = iadd v5, v3
+;; @004e                               v7 = iconst.i64 16
+;; @004e                               v8 = iadd v6, v7  ; v7 = 16
+;; @004e                               v9 = load.i32 user2 little region4 v8
 ;; @0052                               jump block1
 ;;
 ;;                                 block1:
-;; @0052                               return v10
+;; @0052                               return v9
 ;; }

--- a/tests/disas/gc/null/struct-new-default.wat
+++ b/tests/disas/gc/null/struct-new-default.wat
@@ -27,50 +27,50 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @0021                               v10 = load.i64 notrap aligned readonly can_move region2 v0+32
-;; @0021                               v11 = load.i32 user2 region3 v10
-;;                                     v43 = iconst.i32 7
-;; @0021                               v14 = uadd_overflow_trap v11, v43, user18  ; v43 = 7
-;;                                     v49 = iconst.i32 -8
-;; @0021                               v16 = band v14, v49  ; v49 = -8
-;; @0021                               v6 = iconst.i32 24
-;; @0021                               v17 = uadd_overflow_trap v16, v6, user18  ; v6 = 24
-;; @0021                               v19 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0021                               v20 = load.i64 notrap aligned region4 v19+40
-;; @0021                               v18 = uextend.i64 v17
-;; @0021                               v21 = icmp ule v18, v20
-;; @0021                               brif v21, block2, block3
+;; @0021                               v9 = load.i64 notrap aligned readonly can_move region2 v0+32
+;; @0021                               v10 = load.i32 user2 region3 v9
+;;                                     v42 = iconst.i32 7
+;; @0021                               v13 = uadd_overflow_trap v10, v42, user18  ; v42 = 7
+;;                                     v48 = iconst.i32 -8
+;; @0021                               v15 = band v13, v48  ; v48 = -8
+;; @0021                               v5 = iconst.i32 24
+;; @0021                               v16 = uadd_overflow_trap v15, v5, user18  ; v5 = 24
+;; @0021                               v18 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @0021                               v19 = load.i64 notrap aligned region4 v18+40
+;; @0021                               v17 = uextend.i64 v16
+;; @0021                               v20 = icmp ule v17, v19
+;; @0021                               brif v20, block2, block3
 ;;
 ;;                                 block2:
-;;                                     v50 = iconst.i32 -1342177256
-;; @0021                               v25 = load.i64 notrap aligned readonly can_move region5 v19+32
-;;                                     v56 = band.i32 v14, v49  ; v49 = -8
-;;                                     v57 = uextend.i64 v56
-;; @0021                               v27 = iadd v25, v57
-;; @0021                               store user2 region3 v50, v27  ; v50 = -1342177256
-;; @0021                               v30 = load.i64 notrap aligned readonly can_move region6 v0+40
-;; @0021                               v31 = load.i32 notrap aligned readonly can_move v30
-;; @0021                               store user2 region3 v31, v27+4
-;; @0021                               store.i32 user2 region3 v17, v10
-;; @0021                               v3 = f32const 0.0
-;; @0021                               v32 = iconst.i64 8
-;; @0021                               v33 = iadd v27, v32  ; v32 = 8
-;; @0021                               store user2 little region3 v3, v33  ; v3 = 0.0
-;; @0021                               v4 = iconst.i32 0
-;; @0021                               v34 = iconst.i64 12
-;; @0021                               v35 = iadd v27, v34  ; v34 = 12
-;; @0021                               istore8 user2 little region3 v4, v35  ; v4 = 0
-;; @0021                               v36 = iconst.i64 16
-;; @0021                               v37 = iadd v27, v36  ; v36 = 16
-;; @0021                               store user2 little region3 v4, v37  ; v4 = 0
+;;                                     v49 = iconst.i32 -1342177256
+;; @0021                               v24 = load.i64 notrap aligned readonly can_move region5 v18+32
+;;                                     v55 = band.i32 v13, v48  ; v48 = -8
+;;                                     v56 = uextend.i64 v55
+;; @0021                               v26 = iadd v24, v56
+;; @0021                               store user2 region3 v49, v26  ; v49 = -1342177256
+;; @0021                               v29 = load.i64 notrap aligned readonly can_move region6 v0+40
+;; @0021                               v30 = load.i32 notrap aligned readonly can_move v29
+;; @0021                               store user2 region3 v30, v26+4
+;; @0021                               store.i32 user2 region3 v16, v9
+;; @0021                               v2 = f32const 0.0
+;; @0021                               v31 = iconst.i64 8
+;; @0021                               v32 = iadd v26, v31  ; v31 = 8
+;; @0021                               store user2 little region3 v2, v32  ; v2 = 0.0
+;; @0021                               v3 = iconst.i32 0
+;; @0021                               v33 = iconst.i64 12
+;; @0021                               v34 = iadd v26, v33  ; v33 = 12
+;; @0021                               istore8 user2 little region3 v3, v34  ; v3 = 0
+;; @0021                               v35 = iconst.i64 16
+;; @0021                               v36 = iadd v26, v35  ; v35 = 16
+;; @0021                               store user2 little region3 v3, v36  ; v3 = 0
 ;; @0024                               jump block1
 ;;
 ;;                                 block3 cold:
-;; @0021                               v22 = isub.i64 v18, v20
-;; @0021                               v23 = call fn0(v0, v22)
+;; @0021                               v21 = isub.i64 v17, v19
+;; @0021                               v22 = call fn0(v0, v21)
 ;; @0021                               jump block2
 ;;
 ;;                                 block1:
-;;                                     v58 = band.i32 v14, v49  ; v49 = -8
-;; @0024                               return v58
+;;                                     v57 = band.i32 v13, v48  ; v48 = -8
+;; @0024                               return v57
 ;; }

--- a/tests/disas/gc/null/struct-new.wat
+++ b/tests/disas/gc/null/struct-new.wat
@@ -28,51 +28,51 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: f32, v3: i32, v4: i32):
-;;                                     v40 = stack_addr.i64 ss0
-;;                                     store notrap v4, v40
-;; @002a                               v10 = load.i64 notrap aligned readonly can_move region2 v0+32
-;; @002a                               v11 = load.i32 user2 region3 v10
-;;                                     v47 = iconst.i32 7
-;; @002a                               v14 = uadd_overflow_trap v11, v47, user18  ; v47 = 7
-;;                                     v53 = iconst.i32 -8
-;; @002a                               v16 = band v14, v53  ; v53 = -8
-;; @002a                               v6 = iconst.i32 24
-;; @002a                               v17 = uadd_overflow_trap v16, v6, user18  ; v6 = 24
-;; @002a                               v19 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @002a                               v20 = load.i64 notrap aligned region4 v19+40
-;; @002a                               v18 = uextend.i64 v17
-;; @002a                               v21 = icmp ule v18, v20
-;; @002a                               brif v21, block2, block3
+;;                                     v39 = stack_addr.i64 ss0
+;;                                     store notrap v4, v39
+;; @002a                               v9 = load.i64 notrap aligned readonly can_move region2 v0+32
+;; @002a                               v10 = load.i32 user2 region3 v9
+;;                                     v46 = iconst.i32 7
+;; @002a                               v13 = uadd_overflow_trap v10, v46, user18  ; v46 = 7
+;;                                     v52 = iconst.i32 -8
+;; @002a                               v15 = band v13, v52  ; v52 = -8
+;; @002a                               v5 = iconst.i32 24
+;; @002a                               v16 = uadd_overflow_trap v15, v5, user18  ; v5 = 24
+;; @002a                               v18 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @002a                               v19 = load.i64 notrap aligned region4 v18+40
+;; @002a                               v17 = uextend.i64 v16
+;; @002a                               v20 = icmp ule v17, v19
+;; @002a                               brif v20, block2, block3
 ;;
 ;;                                 block2:
-;;                                     v54 = iconst.i32 -1342177256
-;; @002a                               v25 = load.i64 notrap aligned readonly can_move region5 v19+32
-;;                                     v60 = band.i32 v14, v53  ; v53 = -8
-;;                                     v61 = uextend.i64 v60
-;; @002a                               v27 = iadd v25, v61
-;; @002a                               store user2 region3 v54, v27  ; v54 = -1342177256
-;; @002a                               v30 = load.i64 notrap aligned readonly can_move region6 v0+40
-;; @002a                               v31 = load.i32 notrap aligned readonly can_move v30
-;; @002a                               store user2 region3 v31, v27+4
-;; @002a                               store.i32 user2 region3 v17, v10
-;; @002a                               v32 = iconst.i64 8
-;; @002a                               v33 = iadd v27, v32  ; v32 = 8
-;; @002a                               store.f32 user2 little region3 v2, v33
-;; @002a                               v34 = iconst.i64 12
-;; @002a                               v35 = iadd v27, v34  ; v34 = 12
-;; @002a                               istore8.i32 user2 little region3 v3, v35
-;;                                     v39 = load.i32 notrap v40
-;; @002a                               v36 = iconst.i64 16
-;; @002a                               v37 = iadd v27, v36  ; v36 = 16
-;; @002a                               store user2 little region3 v39, v37
+;;                                     v53 = iconst.i32 -1342177256
+;; @002a                               v24 = load.i64 notrap aligned readonly can_move region5 v18+32
+;;                                     v59 = band.i32 v13, v52  ; v52 = -8
+;;                                     v60 = uextend.i64 v59
+;; @002a                               v26 = iadd v24, v60
+;; @002a                               store user2 region3 v53, v26  ; v53 = -1342177256
+;; @002a                               v29 = load.i64 notrap aligned readonly can_move region6 v0+40
+;; @002a                               v30 = load.i32 notrap aligned readonly can_move v29
+;; @002a                               store user2 region3 v30, v26+4
+;; @002a                               store.i32 user2 region3 v16, v9
+;; @002a                               v31 = iconst.i64 8
+;; @002a                               v32 = iadd v26, v31  ; v31 = 8
+;; @002a                               store.f32 user2 little region3 v2, v32
+;; @002a                               v33 = iconst.i64 12
+;; @002a                               v34 = iadd v26, v33  ; v33 = 12
+;; @002a                               istore8.i32 user2 little region3 v3, v34
+;;                                     v38 = load.i32 notrap v39
+;; @002a                               v35 = iconst.i64 16
+;; @002a                               v36 = iadd v26, v35  ; v35 = 16
+;; @002a                               store user2 little region3 v38, v36
 ;; @002d                               jump block1
 ;;
 ;;                                 block3 cold:
-;; @002a                               v22 = isub.i64 v18, v20
-;; @002a                               v23 = call fn0(v0, v22), stack_map=[i32 @ ss0+0]
+;; @002a                               v21 = isub.i64 v17, v19
+;; @002a                               v22 = call fn0(v0, v21), stack_map=[i32 @ ss0+0]
 ;; @002a                               jump block2
 ;;
 ;;                                 block1:
-;;                                     v62 = band.i32 v14, v53  ; v53 = -8
-;; @002d                               return v62
+;;                                     v61 = band.i32 v13, v52  ; v52 = -8
+;; @002d                               return v61
 ;; }

--- a/tests/disas/gc/null/v128-fields.wat
+++ b/tests/disas/gc/null/v128-fields.wat
@@ -24,16 +24,16 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0022                               trapz v2, user16
-;; @0022                               v5 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0022                               v6 = load.i64 notrap aligned readonly can_move region2 v5+32
-;; @0022                               v4 = uextend.i64 v2
-;; @0022                               v7 = iadd v6, v4
-;; @0022                               v8 = iconst.i64 16
-;; @0022                               v9 = iadd v7, v8  ; v8 = 16
-;; @0022                               v10 = load.i8x16 user2 little region4 v9
+;; @0022                               v4 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @0022                               v5 = load.i64 notrap aligned readonly can_move region2 v4+32
+;; @0022                               v3 = uextend.i64 v2
+;; @0022                               v6 = iadd v5, v3
+;; @0022                               v7 = iconst.i64 16
+;; @0022                               v8 = iadd v6, v7  ; v7 = 16
+;; @0022                               v9 = load.i8x16 user2 little region4 v8
 ;; @002e                               jump block1
 ;;
 ;;                                 block1:
-;; @002c                               v18 = bxor.i8x16 v10, v10
-;; @002e                               return v18
+;; @002c                               v17 = bxor.i8x16 v9, v9
+;; @002e                               return v17
 ;; }

--- a/tests/disas/gc/ref-test-cast-final-type.wat
+++ b/tests/disas/gc/ref-test-cast-final-type.wat
@@ -27,35 +27,35 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0024                               v4 = iconst.i32 0
-;; @0024                               v5 = icmp eq v2, v4  ; v4 = 0
-;; @0024                               brif v5, block4(v4), block2  ; v4 = 0
+;; @0024                               v3 = iconst.i32 0
+;; @0024                               v4 = icmp eq v2, v3  ; v3 = 0
+;; @0024                               brif v4, block4(v3), block2  ; v3 = 0
 ;;
 ;;                                 block2:
-;; @0024                               v8 = iconst.i32 1
-;; @0024                               v9 = band.i32 v2, v8  ; v8 = 1
-;;                                     v23 = iconst.i32 0
-;; @0024                               brif v9, block4(v23), block3  ; v23 = 0
+;; @0024                               v7 = iconst.i32 1
+;; @0024                               v8 = band.i32 v2, v7  ; v7 = 1
+;;                                     v22 = iconst.i32 0
+;; @0024                               brif v8, block4(v22), block3  ; v22 = 0
 ;;
 ;;                                 block3:
-;; @0024                               v14 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0024                               v15 = load.i64 notrap aligned readonly can_move region3 v14+32
-;; @0024                               v13 = uextend.i64 v2
-;; @0024                               v16 = iadd v15, v13
-;; @0024                               v17 = iconst.i64 4
-;; @0024                               v18 = iadd v16, v17  ; v17 = 4
-;; @0024                               v19 = load.i32 user2 readonly region5 v18
-;; @0024                               v11 = load.i64 notrap aligned readonly can_move region2 v0+40
-;; @0024                               v12 = load.i32 notrap aligned readonly can_move v11
-;; @0024                               v20 = icmp eq v19, v12
-;; @0024                               v21 = uextend.i32 v20
-;; @0024                               jump block4(v21)
+;; @0024                               v13 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @0024                               v14 = load.i64 notrap aligned readonly can_move region3 v13+32
+;; @0024                               v12 = uextend.i64 v2
+;; @0024                               v15 = iadd v14, v12
+;; @0024                               v16 = iconst.i64 4
+;; @0024                               v17 = iadd v15, v16  ; v16 = 4
+;; @0024                               v18 = load.i32 user2 readonly region5 v17
+;; @0024                               v10 = load.i64 notrap aligned readonly can_move region2 v0+40
+;; @0024                               v11 = load.i32 notrap aligned readonly can_move v10
+;; @0024                               v19 = icmp eq v18, v11
+;; @0024                               v20 = uextend.i32 v19
+;; @0024                               jump block4(v20)
 ;;
-;;                                 block4(v22: i32):
-;; @0027                               jump block1(v22)
+;;                                 block4(v21: i32):
+;; @0027                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @0027                               return v3
+;;                                 block1:
+;; @0027                               return v21
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
@@ -71,32 +71,32 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @002c                               v4 = iconst.i32 0
-;; @002c                               v5 = icmp eq v2, v4  ; v4 = 0
-;; @002c                               brif v5, block4(v4), block2  ; v4 = 0
+;; @002c                               v3 = iconst.i32 0
+;; @002c                               v4 = icmp eq v2, v3  ; v3 = 0
+;; @002c                               brif v4, block4(v3), block2  ; v3 = 0
 ;;
 ;;                                 block2:
-;; @002c                               v8 = iconst.i32 1
-;; @002c                               v9 = band.i32 v2, v8  ; v8 = 1
-;;                                     v23 = iconst.i32 0
-;; @002c                               brif v9, block4(v23), block3  ; v23 = 0
+;; @002c                               v7 = iconst.i32 1
+;; @002c                               v8 = band.i32 v2, v7  ; v7 = 1
+;;                                     v22 = iconst.i32 0
+;; @002c                               brif v8, block4(v22), block3  ; v22 = 0
 ;;
 ;;                                 block3:
-;; @002c                               v14 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @002c                               v15 = load.i64 notrap aligned readonly can_move region3 v14+32
-;; @002c                               v13 = uextend.i64 v2
-;; @002c                               v16 = iadd v15, v13
-;; @002c                               v17 = iconst.i64 4
-;; @002c                               v18 = iadd v16, v17  ; v17 = 4
-;; @002c                               v19 = load.i32 user2 readonly region5 v18
-;; @002c                               v11 = load.i64 notrap aligned readonly can_move region2 v0+40
-;; @002c                               v12 = load.i32 notrap aligned readonly can_move v11
-;; @002c                               v20 = icmp eq v19, v12
-;; @002c                               v21 = uextend.i32 v20
-;; @002c                               jump block4(v21)
+;; @002c                               v13 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @002c                               v14 = load.i64 notrap aligned readonly can_move region3 v13+32
+;; @002c                               v12 = uextend.i64 v2
+;; @002c                               v15 = iadd v14, v12
+;; @002c                               v16 = iconst.i64 4
+;; @002c                               v17 = iadd v15, v16  ; v16 = 4
+;; @002c                               v18 = load.i32 user2 readonly region5 v17
+;; @002c                               v10 = load.i64 notrap aligned readonly can_move region2 v0+40
+;; @002c                               v11 = load.i32 notrap aligned readonly can_move v10
+;; @002c                               v19 = icmp eq v18, v11
+;; @002c                               v20 = uextend.i32 v19
+;; @002c                               jump block4(v20)
 ;;
-;;                                 block4(v22: i32):
-;; @002c                               trapz v22, user19
+;;                                 block4(v21: i32):
+;; @002c                               trapz v21, user19
 ;; @002f                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/struct-new-default.wat
+++ b/tests/disas/gc/struct-new-default.wat
@@ -28,63 +28,63 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @0023                               v8 = load.i64 notrap aligned readonly can_move region2 v0+32
-;; @0023                               v9 = load.i32 notrap aligned v8
-;; @0023                               v10 = load.i32 notrap aligned v8+4
-;; @0023                               v16 = uextend.i64 v9
-;;                                     v47 = iconst.i64 48
-;; @0023                               v17 = iadd v16, v47  ; v47 = 48
-;; @0023                               v18 = uextend.i64 v10
-;; @0023                               v19 = icmp ule v17, v18
-;; @0023                               brif v19, block2, block3
+;; @0023                               v7 = load.i64 notrap aligned readonly can_move region2 v0+32
+;; @0023                               v8 = load.i32 notrap aligned v7
+;; @0023                               v9 = load.i32 notrap aligned v7+4
+;; @0023                               v15 = uextend.i64 v8
+;;                                     v46 = iconst.i64 48
+;; @0023                               v16 = iadd v15, v46  ; v46 = 48
+;; @0023                               v17 = uextend.i64 v9
+;; @0023                               v18 = icmp ule v16, v17
+;; @0023                               brif v18, block2, block3
 ;;
 ;;                                 block2:
-;;                                     v63 = iconst.i32 48
-;;                                     v61 = iadd.i32 v9, v63  ; v63 = 48
-;; @0023                               store notrap aligned v61, v8
-;;                                     v64 = iconst.i32 -1342177246
-;;                                     v65 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v66 = load.i64 notrap aligned readonly can_move region4 v65+32
-;; @0023                               v33 = iadd v66, v16
-;; @0023                               store notrap aligned v64, v33  ; v64 = -1342177246
-;;                                     v67 = load.i64 notrap aligned readonly can_move region3 v0+40
-;;                                     v68 = load.i32 notrap aligned readonly can_move v67
-;; @0023                               store notrap aligned v68, v33+4
-;;                                     v69 = iconst.i64 48
-;; @0023                               istore32 notrap aligned v69, v33+8  ; v69 = 48
-;; @0023                               jump block4(v9, v33)
+;;                                     v62 = iconst.i32 48
+;;                                     v60 = iadd.i32 v8, v62  ; v62 = 48
+;; @0023                               store notrap aligned v60, v7
+;;                                     v63 = iconst.i32 -1342177246
+;;                                     v64 = load.i64 notrap aligned readonly can_move region0 v0+8
+;;                                     v65 = load.i64 notrap aligned readonly can_move region4 v64+32
+;; @0023                               v32 = iadd v65, v15
+;; @0023                               store notrap aligned v63, v32  ; v63 = -1342177246
+;;                                     v66 = load.i64 notrap aligned readonly can_move region3 v0+40
+;;                                     v67 = load.i32 notrap aligned readonly can_move v66
+;; @0023                               store notrap aligned v67, v32+4
+;;                                     v68 = iconst.i64 48
+;; @0023                               istore32 notrap aligned v68, v32+8  ; v68 = 48
+;; @0023                               jump block4(v8, v32)
 ;;
 ;;                                 block3 cold:
-;; @0023                               v20 = iconst.i32 -1342177246
-;; @0023                               v21 = load.i64 notrap aligned readonly can_move region3 v0+40
-;; @0023                               v22 = load.i32 notrap aligned readonly can_move v21
-;; @0023                               v7 = iconst.i32 48
-;; @0023                               v23 = iconst.i32 16
-;; @0023                               v24 = call fn0(v0, v20, v22, v7, v23)  ; v20 = -1342177246, v7 = 48, v23 = 16
-;; @0023                               v25 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0023                               v26 = load.i64 notrap aligned readonly can_move region4 v25+32
-;; @0023                               v27 = uextend.i64 v24
-;; @0023                               v28 = iadd v26, v27
-;; @0023                               jump block4(v24, v28)
+;; @0023                               v19 = iconst.i32 -1342177246
+;; @0023                               v20 = load.i64 notrap aligned readonly can_move region3 v0+40
+;; @0023                               v21 = load.i32 notrap aligned readonly can_move v20
+;; @0023                               v6 = iconst.i32 48
+;; @0023                               v22 = iconst.i32 16
+;; @0023                               v23 = call fn0(v0, v19, v21, v6, v22)  ; v19 = -1342177246, v6 = 48, v22 = 16
+;; @0023                               v24 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @0023                               v25 = load.i64 notrap aligned readonly can_move region4 v24+32
+;; @0023                               v26 = uextend.i64 v23
+;; @0023                               v27 = iadd v25, v26
+;; @0023                               jump block4(v23, v27)
 ;;
-;;                                 block4(v37: i32, v38: i64):
-;; @0023                               v3 = f32const 0.0
-;; @0023                               v39 = iconst.i64 16
-;; @0023                               v40 = iadd v38, v39  ; v39 = 16
-;; @0023                               store user2 little region5 v3, v40  ; v3 = 0.0
-;; @0023                               v4 = iconst.i32 0
-;; @0023                               v41 = iconst.i64 20
-;; @0023                               v42 = iadd v38, v41  ; v41 = 20
-;; @0023                               istore8 user2 little region5 v4, v42  ; v4 = 0
-;; @0023                               v43 = iconst.i64 24
-;; @0023                               v44 = iadd v38, v43  ; v43 = 24
-;; @0023                               store user2 little region5 v4, v44  ; v4 = 0
-;; @0023                               v6 = vconst.i8x16 const0
-;; @0023                               v45 = iconst.i64 32
-;; @0023                               v46 = iadd v38, v45  ; v45 = 32
-;; @0023                               store user2 little region5 v6, v46  ; v6 = const0
-;; @0026                               jump block1(v37)
+;;                                 block4(v36: i32, v37: i64):
+;; @0023                               v2 = f32const 0.0
+;; @0023                               v38 = iconst.i64 16
+;; @0023                               v39 = iadd v37, v38  ; v38 = 16
+;; @0023                               store user2 little region5 v2, v39  ; v2 = 0.0
+;; @0023                               v3 = iconst.i32 0
+;; @0023                               v40 = iconst.i64 20
+;; @0023                               v41 = iadd v37, v40  ; v40 = 20
+;; @0023                               istore8 user2 little region5 v3, v41  ; v3 = 0
+;; @0023                               v42 = iconst.i64 24
+;; @0023                               v43 = iadd v37, v42  ; v42 = 24
+;; @0023                               store user2 little region5 v3, v43  ; v3 = 0
+;; @0023                               v5 = vconst.i8x16 const0
+;; @0023                               v44 = iconst.i64 32
+;; @0023                               v45 = iadd v37, v44  ; v44 = 32
+;; @0023                               store user2 little region5 v5, v45  ; v5 = const0
+;; @0026                               jump block1
 ;;
-;;                                 block1(v2: i32):
-;; @0026                               return v2
+;;                                 block1:
+;; @0026                               return v36
 ;; }

--- a/tests/disas/gc/struct-new.wat
+++ b/tests/disas/gc/struct-new.wat
@@ -27,60 +27,60 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: f32, v3: i32, v4: i32):
-;;                                     v46 = stack_addr.i64 ss0
-;;                                     store notrap v4, v46
-;; @002a                               v7 = load.i64 notrap aligned readonly can_move region2 v0+32
-;; @002a                               v8 = load.i32 notrap aligned v7
-;; @002a                               v9 = load.i32 notrap aligned v7+4
-;; @002a                               v15 = uextend.i64 v8
-;;                                     v47 = iconst.i64 32
-;; @002a                               v16 = iadd v15, v47  ; v47 = 32
-;; @002a                               v17 = uextend.i64 v9
-;; @002a                               v18 = icmp ule v16, v17
-;; @002a                               brif v18, block2, block3
+;;                                     v45 = stack_addr.i64 ss0
+;;                                     store notrap v4, v45
+;; @002a                               v6 = load.i64 notrap aligned readonly can_move region2 v0+32
+;; @002a                               v7 = load.i32 notrap aligned v6
+;; @002a                               v8 = load.i32 notrap aligned v6+4
+;; @002a                               v14 = uextend.i64 v7
+;;                                     v46 = iconst.i64 32
+;; @002a                               v15 = iadd v14, v46  ; v46 = 32
+;; @002a                               v16 = uextend.i64 v8
+;; @002a                               v17 = icmp ule v15, v16
+;; @002a                               brif v17, block2, block3
 ;;
 ;;                                 block2:
-;;                                     v63 = iconst.i32 32
-;;                                     v61 = iadd.i32 v8, v63  ; v63 = 32
-;; @002a                               store notrap aligned v61, v7
-;;                                     v64 = iconst.i32 -1342177246
-;;                                     v65 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v66 = load.i64 notrap aligned readonly can_move region4 v65+32
-;; @002a                               v32 = iadd v66, v15
-;; @002a                               store notrap aligned v64, v32  ; v64 = -1342177246
-;;                                     v67 = load.i64 notrap aligned readonly can_move region3 v0+40
-;;                                     v68 = load.i32 notrap aligned readonly can_move v67
-;; @002a                               store notrap aligned v68, v32+4
-;;                                     v69 = iconst.i64 32
-;; @002a                               istore32 notrap aligned v69, v32+8  ; v69 = 32
-;; @002a                               jump block4(v8, v32)
+;;                                     v62 = iconst.i32 32
+;;                                     v60 = iadd.i32 v7, v62  ; v62 = 32
+;; @002a                               store notrap aligned v60, v6
+;;                                     v63 = iconst.i32 -1342177246
+;;                                     v64 = load.i64 notrap aligned readonly can_move region0 v0+8
+;;                                     v65 = load.i64 notrap aligned readonly can_move region4 v64+32
+;; @002a                               v31 = iadd v65, v14
+;; @002a                               store notrap aligned v63, v31  ; v63 = -1342177246
+;;                                     v66 = load.i64 notrap aligned readonly can_move region3 v0+40
+;;                                     v67 = load.i32 notrap aligned readonly can_move v66
+;; @002a                               store notrap aligned v67, v31+4
+;;                                     v68 = iconst.i64 32
+;; @002a                               istore32 notrap aligned v68, v31+8  ; v68 = 32
+;; @002a                               jump block4(v7, v31)
 ;;
 ;;                                 block3 cold:
-;; @002a                               v19 = iconst.i32 -1342177246
-;; @002a                               v20 = load.i64 notrap aligned readonly can_move region3 v0+40
-;; @002a                               v21 = load.i32 notrap aligned readonly can_move v20
-;; @002a                               v6 = iconst.i32 32
-;; @002a                               v22 = iconst.i32 16
-;; @002a                               v23 = call fn0(v0, v19, v21, v6, v22), stack_map=[i32 @ ss0+0]  ; v19 = -1342177246, v6 = 32, v22 = 16
-;; @002a                               v24 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @002a                               v25 = load.i64 notrap aligned readonly can_move region4 v24+32
-;; @002a                               v26 = uextend.i64 v23
-;; @002a                               v27 = iadd v25, v26
-;; @002a                               jump block4(v23, v27)
+;; @002a                               v18 = iconst.i32 -1342177246
+;; @002a                               v19 = load.i64 notrap aligned readonly can_move region3 v0+40
+;; @002a                               v20 = load.i32 notrap aligned readonly can_move v19
+;; @002a                               v5 = iconst.i32 32
+;; @002a                               v21 = iconst.i32 16
+;; @002a                               v22 = call fn0(v0, v18, v20, v5, v21), stack_map=[i32 @ ss0+0]  ; v18 = -1342177246, v5 = 32, v21 = 16
+;; @002a                               v23 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @002a                               v24 = load.i64 notrap aligned readonly can_move region4 v23+32
+;; @002a                               v25 = uextend.i64 v22
+;; @002a                               v26 = iadd v24, v25
+;; @002a                               jump block4(v22, v26)
 ;;
-;;                                 block4(v36: i32, v37: i64):
-;; @002a                               v38 = iconst.i64 16
-;; @002a                               v39 = iadd v37, v38  ; v38 = 16
-;; @002a                               store.f32 user2 little region5 v2, v39
-;; @002a                               v40 = iconst.i64 20
-;; @002a                               v41 = iadd v37, v40  ; v40 = 20
-;; @002a                               istore8.i32 user2 little region5 v3, v41
-;;                                     v45 = load.i32 notrap v46
-;; @002a                               v42 = iconst.i64 24
-;; @002a                               v43 = iadd v37, v42  ; v42 = 24
-;; @002a                               store user2 little region5 v45, v43
-;; @002d                               jump block1(v36)
+;;                                 block4(v35: i32, v36: i64):
+;; @002a                               v37 = iconst.i64 16
+;; @002a                               v38 = iadd v36, v37  ; v37 = 16
+;; @002a                               store.f32 user2 little region5 v2, v38
+;; @002a                               v39 = iconst.i64 20
+;; @002a                               v40 = iadd v36, v39  ; v39 = 20
+;; @002a                               istore8.i32 user2 little region5 v3, v40
+;;                                     v44 = load.i32 notrap v45
+;; @002a                               v41 = iconst.i64 24
+;; @002a                               v42 = iadd v36, v41  ; v41 = 24
+;; @002a                               store user2 little region5 v44, v42
+;; @002d                               jump block1
 ;;
-;;                                 block1(v5: i32):
-;; @002d                               return v5
+;;                                 block1:
+;; @002d                               return v35
 ;; }

--- a/tests/disas/global-get.wat
+++ b/tests/disas/global-get.wat
@@ -41,12 +41,12 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @003d                               v3 = load.i64 notrap aligned readonly can_move region2 v0+48
-;; @003d                               v4 = load.i32 notrap aligned region3 v3
+;; @003d                               v2 = load.i64 notrap aligned readonly can_move region2 v0+48
+;; @003d                               v3 = load.i32 notrap aligned region3 v2
 ;; @003f                               jump block1
 ;;
 ;;                                 block1:
-;; @003f                               return v4
+;; @003f                               return v3
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64) -> i32 tail {
@@ -60,12 +60,12 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @0042                               v3 = load.i64 notrap aligned readonly can_move region2 v0+72
-;; @0042                               v4 = load.i32 notrap aligned region3 v3
+;; @0042                               v2 = load.i64 notrap aligned readonly can_move region2 v0+72
+;; @0042                               v3 = load.i32 notrap aligned region3 v2
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
-;; @0044                               return v4
+;; @0044                               return v3
 ;; }
 ;;
 ;; function u0:2(i64 vmctx, i64) -> i32 tail {
@@ -77,11 +77,11 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @0047                               v3 = iconst.i32 42
+;; @0047                               v2 = iconst.i32 42
 ;; @0049                               jump block1
 ;;
 ;;                                 block1:
-;; @0049                               return v3  ; v3 = 42
+;; @0049                               return v2  ; v2 = 42
 ;; }
 ;;
 ;; function u0:3(i64 vmctx, i64) -> i32 tail {
@@ -94,9 +94,9 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @004c                               v3 = load.i32 notrap aligned region2 v0+112
+;; @004c                               v2 = load.i32 notrap aligned region2 v0+112
 ;; @004e                               jump block1
 ;;
 ;;                                 block1:
-;; @004e                               return v3
+;; @004e                               return v2
 ;; }

--- a/tests/disas/i128-cmp.wat
+++ b/tests/disas/i128-cmp.wat
@@ -111,11 +111,11 @@
 ;; @0034                               jump block1
 ;;
 ;;                                 block1:
-;;                                     v16 = iconcat.i64 v2, v3
-;;                                     v17 = iconcat.i64 v4, v5
-;;                                     v18 = icmp slt v16, v17
-;;                                     v24 = uextend.i32 v18
-;; @0034                               return v24
+;;                                     v15 = iconcat.i64 v2, v3
+;;                                     v16 = iconcat.i64 v4, v5
+;;                                     v17 = icmp slt v15, v16
+;;                                     v23 = uextend.i32 v17
+;; @0034                               return v23
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i64, i64, i64, i64) -> i32 tail {
@@ -130,11 +130,11 @@
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
-;;                                     v16 = iconcat.i64 v2, v3
-;;                                     v17 = iconcat.i64 v4, v5
-;;                                     v18 = icmp ult v16, v17
-;;                                     v24 = uextend.i32 v18
-;; @0047                               return v24
+;;                                     v15 = iconcat.i64 v2, v3
+;;                                     v16 = iconcat.i64 v4, v5
+;;                                     v17 = icmp ult v15, v16
+;;                                     v23 = uextend.i32 v17
+;; @0047                               return v23
 ;; }
 ;;
 ;; function u0:2(i64 vmctx, i64, i64, i64, i64, i64) -> i32 tail {
@@ -149,11 +149,11 @@
 ;; @005a                               jump block1
 ;;
 ;;                                 block1:
-;;                                     v16 = iconcat.i64 v2, v3
-;;                                     v17 = iconcat.i64 v4, v5
-;;                                     v18 = icmp sle v16, v17
-;;                                     v24 = uextend.i32 v18
-;; @005a                               return v24
+;;                                     v15 = iconcat.i64 v2, v3
+;;                                     v16 = iconcat.i64 v4, v5
+;;                                     v17 = icmp sle v15, v16
+;;                                     v23 = uextend.i32 v17
+;; @005a                               return v23
 ;; }
 ;;
 ;; function u0:3(i64 vmctx, i64, i64, i64, i64, i64) -> i32 tail {
@@ -168,11 +168,11 @@
 ;; @006d                               jump block1
 ;;
 ;;                                 block1:
-;;                                     v16 = iconcat.i64 v2, v3
-;;                                     v17 = iconcat.i64 v4, v5
-;;                                     v18 = icmp ule v16, v17
-;;                                     v24 = uextend.i32 v18
-;; @006d                               return v24
+;;                                     v15 = iconcat.i64 v2, v3
+;;                                     v16 = iconcat.i64 v4, v5
+;;                                     v17 = icmp ule v15, v16
+;;                                     v23 = uextend.i32 v17
+;; @006d                               return v23
 ;; }
 ;;
 ;; function u0:4(i64 vmctx, i64, i64, i64, i64, i64) -> i32 tail {
@@ -187,11 +187,11 @@
 ;; @0080                               jump block1
 ;;
 ;;                                 block1:
-;;                                     v16 = iconcat.i64 v2, v3
-;;                                     v17 = iconcat.i64 v4, v5
-;;                                     v18 = icmp sgt v16, v17
-;;                                     v24 = uextend.i32 v18
-;; @0080                               return v24
+;;                                     v15 = iconcat.i64 v2, v3
+;;                                     v16 = iconcat.i64 v4, v5
+;;                                     v17 = icmp sgt v15, v16
+;;                                     v23 = uextend.i32 v17
+;; @0080                               return v23
 ;; }
 ;;
 ;; function u0:5(i64 vmctx, i64, i64, i64, i64, i64) -> i32 tail {
@@ -206,11 +206,11 @@
 ;; @0093                               jump block1
 ;;
 ;;                                 block1:
-;;                                     v16 = iconcat.i64 v2, v3
-;;                                     v17 = iconcat.i64 v4, v5
-;;                                     v18 = icmp ugt v16, v17
-;;                                     v24 = uextend.i32 v18
-;; @0093                               return v24
+;;                                     v15 = iconcat.i64 v2, v3
+;;                                     v16 = iconcat.i64 v4, v5
+;;                                     v17 = icmp ugt v15, v16
+;;                                     v23 = uextend.i32 v17
+;; @0093                               return v23
 ;; }
 ;;
 ;; function u0:6(i64 vmctx, i64, i64, i64, i64, i64) -> i32 tail {
@@ -225,11 +225,11 @@
 ;; @00a6                               jump block1
 ;;
 ;;                                 block1:
-;;                                     v16 = iconcat.i64 v2, v3
-;;                                     v17 = iconcat.i64 v4, v5
-;;                                     v18 = icmp sge v16, v17
-;;                                     v24 = uextend.i32 v18
-;; @00a6                               return v24
+;;                                     v15 = iconcat.i64 v2, v3
+;;                                     v16 = iconcat.i64 v4, v5
+;;                                     v17 = icmp sge v15, v16
+;;                                     v23 = uextend.i32 v17
+;; @00a6                               return v23
 ;; }
 ;;
 ;; function u0:7(i64 vmctx, i64, i64, i64, i64, i64) -> i32 tail {
@@ -244,9 +244,9 @@
 ;; @00b9                               jump block1
 ;;
 ;;                                 block1:
-;;                                     v16 = iconcat.i64 v2, v3
-;;                                     v17 = iconcat.i64 v4, v5
-;;                                     v18 = icmp uge v16, v17
-;;                                     v24 = uextend.i32 v18
-;; @00b9                               return v24
+;;                                     v15 = iconcat.i64 v2, v3
+;;                                     v16 = iconcat.i64 v4, v5
+;;                                     v17 = icmp uge v15, v16
+;;                                     v23 = uextend.i32 v17
+;; @00b9                               return v23
 ;; }

--- a/tests/disas/i32-load.wat
+++ b/tests/disas/i32-load.wat
@@ -20,12 +20,12 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @002e                               v4 = uextend.i64 v2
-;; @002e                               v5 = load.i64 notrap aligned readonly can_move region2 v0+56
-;; @002e                               v6 = iadd v5, v4
-;; @002e                               v7 = load.i32 little region4 v6
+;; @002e                               v3 = uextend.i64 v2
+;; @002e                               v4 = load.i64 notrap aligned readonly can_move region2 v0+56
+;; @002e                               v5 = iadd v4, v3
+;; @002e                               v6 = load.i32 little region4 v5
 ;; @0031                               jump block1
 ;;
 ;;                                 block1:
-;; @0031                               return v7
+;; @0031                               return v6
 ;; }

--- a/tests/disas/i32-load16-s.wat
+++ b/tests/disas/i32-load16-s.wat
@@ -20,12 +20,12 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0032                               v4 = uextend.i64 v2
-;; @0032                               v5 = load.i64 notrap aligned readonly can_move region2 v0+56
-;; @0032                               v6 = iadd v5, v4
-;; @0032                               v7 = sload16.i32 little region4 v6
+;; @0032                               v3 = uextend.i64 v2
+;; @0032                               v4 = load.i64 notrap aligned readonly can_move region2 v0+56
+;; @0032                               v5 = iadd v4, v3
+;; @0032                               v6 = sload16.i32 little region4 v5
 ;; @0035                               jump block1
 ;;
 ;;                                 block1:
-;; @0035                               return v7
+;; @0035                               return v6
 ;; }

--- a/tests/disas/i32-load16-u.wat
+++ b/tests/disas/i32-load16-u.wat
@@ -20,12 +20,12 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0032                               v4 = uextend.i64 v2
-;; @0032                               v5 = load.i64 notrap aligned readonly can_move region2 v0+56
-;; @0032                               v6 = iadd v5, v4
-;; @0032                               v7 = uload16.i32 little region4 v6
+;; @0032                               v3 = uextend.i64 v2
+;; @0032                               v4 = load.i64 notrap aligned readonly can_move region2 v0+56
+;; @0032                               v5 = iadd v4, v3
+;; @0032                               v6 = uload16.i32 little region4 v5
 ;; @0035                               jump block1
 ;;
 ;;                                 block1:
-;; @0035                               return v7
+;; @0035                               return v6
 ;; }

--- a/tests/disas/i32-load8-s.wat
+++ b/tests/disas/i32-load8-s.wat
@@ -20,12 +20,12 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0031                               v4 = uextend.i64 v2
-;; @0031                               v5 = load.i64 notrap aligned readonly can_move region2 v0+56
-;; @0031                               v6 = iadd v5, v4
-;; @0031                               v7 = sload8.i32 little region4 v6
+;; @0031                               v3 = uextend.i64 v2
+;; @0031                               v4 = load.i64 notrap aligned readonly can_move region2 v0+56
+;; @0031                               v5 = iadd v4, v3
+;; @0031                               v6 = sload8.i32 little region4 v5
 ;; @0034                               jump block1
 ;;
 ;;                                 block1:
-;; @0034                               return v7
+;; @0034                               return v6
 ;; }

--- a/tests/disas/i32-load8-u.wat
+++ b/tests/disas/i32-load8-u.wat
@@ -20,12 +20,12 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0031                               v4 = uextend.i64 v2
-;; @0031                               v5 = load.i64 notrap aligned readonly can_move region2 v0+56
-;; @0031                               v6 = iadd v5, v4
-;; @0031                               v7 = uload8.i32 little region4 v6
+;; @0031                               v3 = uextend.i64 v2
+;; @0031                               v4 = load.i64 notrap aligned readonly can_move region2 v0+56
+;; @0031                               v5 = iadd v4, v3
+;; @0031                               v6 = uload8.i32 little region4 v5
 ;; @0034                               jump block1
 ;;
 ;;                                 block1:
-;; @0034                               return v7
+;; @0034                               return v6
 ;; }

--- a/tests/disas/i64-load.wat
+++ b/tests/disas/i64-load.wat
@@ -20,12 +20,12 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @002e                               v4 = uextend.i64 v2
-;; @002e                               v5 = load.i64 notrap aligned readonly can_move region2 v0+56
-;; @002e                               v6 = iadd v5, v4
-;; @002e                               v7 = load.i64 little region4 v6
+;; @002e                               v3 = uextend.i64 v2
+;; @002e                               v4 = load.i64 notrap aligned readonly can_move region2 v0+56
+;; @002e                               v5 = iadd v4, v3
+;; @002e                               v6 = load.i64 little region4 v5
 ;; @0031                               jump block1
 ;;
 ;;                                 block1:
-;; @0031                               return v7
+;; @0031                               return v6
 ;; }

--- a/tests/disas/i64-load16-s.wat
+++ b/tests/disas/i64-load16-s.wat
@@ -20,12 +20,12 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0032                               v4 = uextend.i64 v2
-;; @0032                               v5 = load.i64 notrap aligned readonly can_move region2 v0+56
-;; @0032                               v6 = iadd v5, v4
-;; @0032                               v7 = sload16.i64 little region4 v6
+;; @0032                               v3 = uextend.i64 v2
+;; @0032                               v4 = load.i64 notrap aligned readonly can_move region2 v0+56
+;; @0032                               v5 = iadd v4, v3
+;; @0032                               v6 = sload16.i64 little region4 v5
 ;; @0035                               jump block1
 ;;
 ;;                                 block1:
-;; @0035                               return v7
+;; @0035                               return v6
 ;; }

--- a/tests/disas/i64-load16-u.wat
+++ b/tests/disas/i64-load16-u.wat
@@ -20,12 +20,12 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0032                               v4 = uextend.i64 v2
-;; @0032                               v5 = load.i64 notrap aligned readonly can_move region2 v0+56
-;; @0032                               v6 = iadd v5, v4
-;; @0032                               v7 = uload16.i64 little region4 v6
+;; @0032                               v3 = uextend.i64 v2
+;; @0032                               v4 = load.i64 notrap aligned readonly can_move region2 v0+56
+;; @0032                               v5 = iadd v4, v3
+;; @0032                               v6 = uload16.i64 little region4 v5
 ;; @0035                               jump block1
 ;;
 ;;                                 block1:
-;; @0035                               return v7
+;; @0035                               return v6
 ;; }

--- a/tests/disas/i64-load8-s.wat
+++ b/tests/disas/i64-load8-s.wat
@@ -20,12 +20,12 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0031                               v4 = uextend.i64 v2
-;; @0031                               v5 = load.i64 notrap aligned readonly can_move region2 v0+56
-;; @0031                               v6 = iadd v5, v4
-;; @0031                               v7 = sload8.i64 little region4 v6
+;; @0031                               v3 = uextend.i64 v2
+;; @0031                               v4 = load.i64 notrap aligned readonly can_move region2 v0+56
+;; @0031                               v5 = iadd v4, v3
+;; @0031                               v6 = sload8.i64 little region4 v5
 ;; @0034                               jump block1
 ;;
 ;;                                 block1:
-;; @0034                               return v7
+;; @0034                               return v6
 ;; }

--- a/tests/disas/i64-load8-u.wat
+++ b/tests/disas/i64-load8-u.wat
@@ -20,12 +20,12 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0031                               v4 = uextend.i64 v2
-;; @0031                               v5 = load.i64 notrap aligned readonly can_move region2 v0+56
-;; @0031                               v6 = iadd v5, v4
-;; @0031                               v7 = uload8.i64 little region4 v6
+;; @0031                               v3 = uextend.i64 v2
+;; @0031                               v4 = load.i64 notrap aligned readonly can_move region2 v0+56
+;; @0031                               v5 = iadd v4, v3
+;; @0031                               v6 = uload8.i64 little region4 v5
 ;; @0034                               jump block1
 ;;
 ;;                                 block1:
-;; @0034                               return v7
+;; @0034                               return v6
 ;; }

--- a/tests/disas/icall-simd.wat
+++ b/tests/disas/icall-simd.wat
@@ -23,38 +23,38 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i8x16):
-;; @0033                               v5 = iconst.i32 23
-;; @0033                               v6 = icmp uge v2, v5  ; v5 = 23
-;; @0033                               v7 = uextend.i64 v2
-;; @0033                               v8 = load.i64 notrap aligned readonly can_move region2 v0+48
-;; @0033                               v9 = iconst.i64 3
-;; @0033                               v10 = ishl v7, v9  ; v9 = 3
-;; @0033                               v11 = iadd v8, v10
-;; @0033                               v12 = iconst.i64 0
-;; @0033                               v13 = select_spectre_guard v6, v12, v11  ; v12 = 0
-;; @0033                               v14 = load.i64 user6 aligned region3 v13
-;; @0033                               v15 = iconst.i64 -2
-;; @0033                               v16 = band v14, v15  ; v15 = -2
-;; @0033                               brif v14, block3(v16), block2
+;; @0033                               v4 = iconst.i32 23
+;; @0033                               v5 = icmp uge v2, v4  ; v4 = 23
+;; @0033                               v6 = uextend.i64 v2
+;; @0033                               v7 = load.i64 notrap aligned readonly can_move region2 v0+48
+;; @0033                               v8 = iconst.i64 3
+;; @0033                               v9 = ishl v6, v8  ; v8 = 3
+;; @0033                               v10 = iadd v7, v9
+;; @0033                               v11 = iconst.i64 0
+;; @0033                               v12 = select_spectre_guard v5, v11, v10  ; v11 = 0
+;; @0033                               v13 = load.i64 user6 aligned region3 v12
+;; @0033                               v14 = iconst.i64 -2
+;; @0033                               v15 = band v13, v14  ; v14 = -2
+;; @0033                               brif v13, block3(v15), block2
 ;;
 ;;                                 block2 cold:
-;; @0033                               v18 = iconst.i32 0
-;; @0033                               v19 = uextend.i64 v2
-;; @0033                               v20 = call fn0(v0, v18, v19)  ; v18 = 0
-;; @0033                               jump block3(v20)
+;; @0033                               v17 = iconst.i32 0
+;; @0033                               v18 = uextend.i64 v2
+;; @0033                               v19 = call fn0(v0, v17, v18)  ; v17 = 0
+;; @0033                               jump block3(v19)
 ;;
-;;                                 block3(v17: i64):
-;; @0033                               v21 = load.i64 notrap aligned readonly can_move region4 v0+40
-;; @0033                               v22 = load.i32 notrap aligned readonly can_move v21
-;; @0033                               v23 = load.i32 user7 aligned readonly v17+16
-;; @0033                               v24 = icmp eq v23, v22
-;; @0033                               v25 = uextend.i32 v24
-;; @0033                               trapz v25, user8
-;; @0033                               v26 = load.i64 notrap aligned readonly v17+8
-;; @0033                               v27 = load.i64 notrap aligned readonly v17+24
-;; @0033                               v28 = call_indirect sig0, v26(v27, v0, v3)
+;;                                 block3(v16: i64):
+;; @0033                               v20 = load.i64 notrap aligned readonly can_move region4 v0+40
+;; @0033                               v21 = load.i32 notrap aligned readonly can_move v20
+;; @0033                               v22 = load.i32 user7 aligned readonly v16+16
+;; @0033                               v23 = icmp eq v22, v21
+;; @0033                               v24 = uextend.i32 v23
+;; @0033                               trapz v24, user8
+;; @0033                               v25 = load.i64 notrap aligned readonly v16+8
+;; @0033                               v26 = load.i64 notrap aligned readonly v16+24
+;; @0033                               v27 = call_indirect sig0, v25(v26, v0, v3)
 ;; @0036                               jump block1
 ;;
 ;;                                 block1:
-;; @0036                               return v28
+;; @0036                               return v27
 ;; }

--- a/tests/disas/icall.wat
+++ b/tests/disas/icall.wat
@@ -23,38 +23,38 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: f32):
-;; @0033                               v5 = iconst.i32 23
-;; @0033                               v6 = icmp uge v2, v5  ; v5 = 23
-;; @0033                               v7 = uextend.i64 v2
-;; @0033                               v8 = load.i64 notrap aligned readonly can_move region2 v0+48
-;; @0033                               v9 = iconst.i64 3
-;; @0033                               v10 = ishl v7, v9  ; v9 = 3
-;; @0033                               v11 = iadd v8, v10
-;; @0033                               v12 = iconst.i64 0
-;; @0033                               v13 = select_spectre_guard v6, v12, v11  ; v12 = 0
-;; @0033                               v14 = load.i64 user6 aligned region3 v13
-;; @0033                               v15 = iconst.i64 -2
-;; @0033                               v16 = band v14, v15  ; v15 = -2
-;; @0033                               brif v14, block3(v16), block2
+;; @0033                               v4 = iconst.i32 23
+;; @0033                               v5 = icmp uge v2, v4  ; v4 = 23
+;; @0033                               v6 = uextend.i64 v2
+;; @0033                               v7 = load.i64 notrap aligned readonly can_move region2 v0+48
+;; @0033                               v8 = iconst.i64 3
+;; @0033                               v9 = ishl v6, v8  ; v8 = 3
+;; @0033                               v10 = iadd v7, v9
+;; @0033                               v11 = iconst.i64 0
+;; @0033                               v12 = select_spectre_guard v5, v11, v10  ; v11 = 0
+;; @0033                               v13 = load.i64 user6 aligned region3 v12
+;; @0033                               v14 = iconst.i64 -2
+;; @0033                               v15 = band v13, v14  ; v14 = -2
+;; @0033                               brif v13, block3(v15), block2
 ;;
 ;;                                 block2 cold:
-;; @0033                               v18 = iconst.i32 0
-;; @0033                               v19 = uextend.i64 v2
-;; @0033                               v20 = call fn0(v0, v18, v19)  ; v18 = 0
-;; @0033                               jump block3(v20)
+;; @0033                               v17 = iconst.i32 0
+;; @0033                               v18 = uextend.i64 v2
+;; @0033                               v19 = call fn0(v0, v17, v18)  ; v17 = 0
+;; @0033                               jump block3(v19)
 ;;
-;;                                 block3(v17: i64):
-;; @0033                               v21 = load.i64 notrap aligned readonly can_move region4 v0+40
-;; @0033                               v22 = load.i32 notrap aligned readonly can_move v21
-;; @0033                               v23 = load.i32 user7 aligned readonly v17+16
-;; @0033                               v24 = icmp eq v23, v22
-;; @0033                               v25 = uextend.i32 v24
-;; @0033                               trapz v25, user8
-;; @0033                               v26 = load.i64 notrap aligned readonly v17+8
-;; @0033                               v27 = load.i64 notrap aligned readonly v17+24
-;; @0033                               v28 = call_indirect sig0, v26(v27, v0, v3)
+;;                                 block3(v16: i64):
+;; @0033                               v20 = load.i64 notrap aligned readonly can_move region4 v0+40
+;; @0033                               v21 = load.i32 notrap aligned readonly can_move v20
+;; @0033                               v22 = load.i32 user7 aligned readonly v16+16
+;; @0033                               v23 = icmp eq v22, v21
+;; @0033                               v24 = uextend.i32 v23
+;; @0033                               trapz v24, user8
+;; @0033                               v25 = load.i64 notrap aligned readonly v16+8
+;; @0033                               v26 = load.i64 notrap aligned readonly v16+24
+;; @0033                               v27 = call_indirect sig0, v25(v26, v0, v3)
 ;; @0036                               jump block1
 ;;
 ;;                                 block1:
-;; @0036                               return v28
+;; @0036                               return v27
 ;; }

--- a/tests/disas/if-reachability-translation-1.wat
+++ b/tests/disas/if-reachability-translation-1.wat
@@ -31,9 +31,9 @@
 ;; @0020                               jump block3
 ;;
 ;;                                 block3:
-;; @0021                               v4 = iconst.i32 0
+;; @0021                               v3 = iconst.i32 0
 ;; @0023                               jump block1
 ;;
 ;;                                 block1:
-;; @0023                               return v4  ; v4 = 0
+;; @0023                               return v3  ; v3 = 0
 ;; }

--- a/tests/disas/if-reachability-translation-2.wat
+++ b/tests/disas/if-reachability-translation-2.wat
@@ -31,9 +31,9 @@
 ;; @0020                               jump block3
 ;;
 ;;                                 block3:
-;; @0021                               v4 = iconst.i32 0
+;; @0021                               v3 = iconst.i32 0
 ;; @0023                               jump block1
 ;;
 ;;                                 block1:
-;; @0023                               return v4  ; v4 = 0
+;; @0023                               return v3  ; v3 = 0
 ;; }

--- a/tests/disas/if-reachability-translation-3.wat
+++ b/tests/disas/if-reachability-translation-3.wat
@@ -31,9 +31,9 @@
 ;; @001f                               trap user12
 ;;
 ;;                                 block3:
-;; @0021                               v4 = iconst.i32 0
+;; @0021                               v3 = iconst.i32 0
 ;; @0023                               jump block1
 ;;
 ;;                                 block1:
-;; @0023                               return v4  ; v4 = 0
+;; @0023                               return v3  ; v3 = 0
 ;; }

--- a/tests/disas/if-reachability-translation-5.wat
+++ b/tests/disas/if-reachability-translation-5.wat
@@ -36,9 +36,9 @@
 ;; @0024                               trap user12
 ;;
 ;;                                 block3:
-;; @0026                               v5 = iconst.i32 0
+;; @0026                               v4 = iconst.i32 0
 ;; @0028                               jump block1
 ;;
 ;;                                 block1:
-;; @0028                               return v5  ; v5 = 0
+;; @0028                               return v4  ; v4 = 0
 ;; }

--- a/tests/disas/if-reachability-translation-6.wat
+++ b/tests/disas/if-reachability-translation-6.wat
@@ -36,9 +36,9 @@
 ;; @0024                               trap user12
 ;;
 ;;                                 block3:
-;; @0026                               v5 = iconst.i32 0
+;; @0026                               v4 = iconst.i32 0
 ;; @0028                               jump block1
 ;;
 ;;                                 block1:
-;; @0028                               return v5  ; v5 = 0
+;; @0028                               return v4  ; v4 = 0
 ;; }

--- a/tests/disas/if-unreachable-else-params-2.wat
+++ b/tests/disas/if-unreachable-else-params-2.wat
@@ -31,14 +31,14 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
-;; @0049                               v5 = f64const 0x1.0000000000000p0
+;; @0049                               v4 = f64const 0x1.0000000000000p0
 ;; @0056                               brif v3, block2, block4
 ;;
 ;;                                 block2:
-;; @0058                               v6 = uextend.i64 v2
-;; @0058                               v7 = load.i64 notrap aligned readonly can_move region2 v0+56
-;; @0058                               v8 = iadd v7, v6
-;; @0058                               v9 = sload16.i64 little region4 v8
+;; @0058                               v5 = uextend.i64 v2
+;; @0058                               v6 = load.i64 notrap aligned readonly can_move region2 v0+56
+;; @0058                               v7 = iadd v6, v5
+;; @0058                               v8 = sload16.i64 little region4 v7
 ;; @005c                               jump block3
 ;;
 ;;                                 block4:
@@ -48,5 +48,5 @@
 ;; @005f                               jump block1
 ;;
 ;;                                 block1:
-;; @005f                               return v5  ; v5 = 0x1.0000000000000p0
+;; @005f                               return v4  ; v4 = 0x1.0000000000000p0
 ;; }

--- a/tests/disas/if-unreachable-else-params-2.wat
+++ b/tests/disas/if-unreachable-else-params-2.wat
@@ -35,10 +35,10 @@
 ;; @0056                               brif v3, block2, block4
 ;;
 ;;                                 block2:
-;; @0058                               v7 = uextend.i64 v2
-;; @0058                               v8 = load.i64 notrap aligned readonly can_move region2 v0+56
-;; @0058                               v9 = iadd v8, v7
-;; @0058                               v10 = sload16.i64 little region4 v9
+;; @0058                               v6 = uextend.i64 v2
+;; @0058                               v7 = load.i64 notrap aligned readonly can_move region2 v0+56
+;; @0058                               v8 = iadd v7, v6
+;; @0058                               v9 = sload16.i64 little region4 v8
 ;; @005c                               jump block3
 ;;
 ;;                                 block4:

--- a/tests/disas/if-unreachable-else-params.wat
+++ b/tests/disas/if-unreachable-else-params.wat
@@ -61,13 +61,13 @@
 ;; @0049                               brif.i32 v2, block4, block6
 ;;
 ;;                                 block4:
-;; @004b                               v7 = uextend.i64 v3  ; v3 = 35
-;; @004b                               v8 = load.i64 notrap aligned readonly can_move region2 v0+56
-;; @004b                               v9 = iadd v8, v7
-;; @004b                               v10 = sload16.i64 little region4 v9
+;; @004b                               v6 = uextend.i64 v3  ; v3 = 35
+;; @004b                               v7 = load.i64 notrap aligned readonly can_move region2 v0+56
+;; @004b                               v8 = iadd v7, v6
+;; @004b                               v9 = sload16.i64 little region4 v8
 ;; @004e                               trap user12
 ;;
 ;;                                 block6:
-;; @005d                               v11 = popcnt.i32 v3  ; v3 = 35
+;; @005d                               v10 = popcnt.i32 v3  ; v3 = 35
 ;; @0060                               return
 ;; }

--- a/tests/disas/indirect-call-no-caching.wat
+++ b/tests/disas/indirect-call-no-caching.wat
@@ -29,11 +29,11 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @003f                               v3 = iconst.i32 1
+;; @003f                               v2 = iconst.i32 1
 ;; @0041                               jump block1
 ;;
 ;;                                 block1:
-;; @0041                               return v3  ; v3 = 1
+;; @0041                               return v2  ; v2 = 1
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64) -> i32 tail {
@@ -45,11 +45,11 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @0044                               v3 = iconst.i32 2
+;; @0044                               v2 = iconst.i32 2
 ;; @0046                               jump block1
 ;;
 ;;                                 block1:
-;; @0046                               return v3  ; v3 = 2
+;; @0046                               return v2  ; v2 = 2
 ;; }
 ;;
 ;; function u0:2(i64 vmctx, i64) -> i32 tail {
@@ -61,11 +61,11 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @0049                               v3 = iconst.i32 3
+;; @0049                               v2 = iconst.i32 3
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:
-;; @004b                               return v3  ; v3 = 3
+;; @004b                               return v2  ; v2 = 3
 ;; }
 ;;
 ;; function u0:3(i64 vmctx, i64, i32) -> i32 tail {
@@ -83,38 +83,38 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0050                               v4 = iconst.i32 10
-;; @0050                               v5 = icmp uge v2, v4  ; v4 = 10
-;; @0050                               v6 = uextend.i64 v2
-;; @0050                               v7 = load.i64 notrap aligned readonly can_move region2 v0+48
-;; @0050                               v8 = iconst.i64 3
-;; @0050                               v9 = ishl v6, v8  ; v8 = 3
-;; @0050                               v10 = iadd v7, v9
-;; @0050                               v11 = iconst.i64 0
-;; @0050                               v12 = select_spectre_guard v5, v11, v10  ; v11 = 0
-;; @0050                               v13 = load.i64 user6 aligned region3 v12
-;; @0050                               v14 = iconst.i64 -2
-;; @0050                               v15 = band v13, v14  ; v14 = -2
-;; @0050                               brif v13, block3(v15), block2
+;; @0050                               v3 = iconst.i32 10
+;; @0050                               v4 = icmp uge v2, v3  ; v3 = 10
+;; @0050                               v5 = uextend.i64 v2
+;; @0050                               v6 = load.i64 notrap aligned readonly can_move region2 v0+48
+;; @0050                               v7 = iconst.i64 3
+;; @0050                               v8 = ishl v5, v7  ; v7 = 3
+;; @0050                               v9 = iadd v6, v8
+;; @0050                               v10 = iconst.i64 0
+;; @0050                               v11 = select_spectre_guard v4, v10, v9  ; v10 = 0
+;; @0050                               v12 = load.i64 user6 aligned region3 v11
+;; @0050                               v13 = iconst.i64 -2
+;; @0050                               v14 = band v12, v13  ; v13 = -2
+;; @0050                               brif v12, block3(v14), block2
 ;;
 ;;                                 block2 cold:
-;; @0050                               v17 = iconst.i32 0
-;; @0050                               v18 = uextend.i64 v2
-;; @0050                               v19 = call fn0(v0, v17, v18)  ; v17 = 0
-;; @0050                               jump block3(v19)
+;; @0050                               v16 = iconst.i32 0
+;; @0050                               v17 = uextend.i64 v2
+;; @0050                               v18 = call fn0(v0, v16, v17)  ; v16 = 0
+;; @0050                               jump block3(v18)
 ;;
-;;                                 block3(v16: i64):
-;; @0050                               v20 = load.i64 notrap aligned readonly can_move region4 v0+40
-;; @0050                               v21 = load.i32 notrap aligned readonly can_move v20
-;; @0050                               v22 = load.i32 user7 aligned readonly v16+16
-;; @0050                               v23 = icmp eq v22, v21
-;; @0050                               v24 = uextend.i32 v23
-;; @0050                               trapz v24, user8
-;; @0050                               v25 = load.i64 notrap aligned readonly v16+8
-;; @0050                               v26 = load.i64 notrap aligned readonly v16+24
-;; @0050                               v27 = call_indirect sig0, v25(v26, v0)
+;;                                 block3(v15: i64):
+;; @0050                               v19 = load.i64 notrap aligned readonly can_move region4 v0+40
+;; @0050                               v20 = load.i32 notrap aligned readonly can_move v19
+;; @0050                               v21 = load.i32 user7 aligned readonly v15+16
+;; @0050                               v22 = icmp eq v21, v20
+;; @0050                               v23 = uextend.i32 v22
+;; @0050                               trapz v23, user8
+;; @0050                               v24 = load.i64 notrap aligned readonly v15+8
+;; @0050                               v25 = load.i64 notrap aligned readonly v15+24
+;; @0050                               v26 = call_indirect sig0, v24(v25, v0)
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:
-;; @0053                               return v27
+;; @0053                               return v26
 ;; }

--- a/tests/disas/intra-module-inlining.wat
+++ b/tests/disas/intra-module-inlining.wat
@@ -21,8 +21,8 @@
 ;; @001b                               jump block1
 ;;
 ;;                                 block1:
-;; @0019                               v3 = iconst.i32 42
-;; @001b                               return v3  ; v3 = 42
+;; @0019                               v2 = iconst.i32 42
+;; @001b                               return v2  ; v2 = 42
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64) -> i32 tail {
@@ -51,6 +51,6 @@
 ;; @0020                               jump block1
 ;;
 ;;                                 block1:
-;;                                     v6 = iconst.i32 42
-;; @0020                               return v6  ; v6 = 42
+;;                                     v4 = iconst.i32 42
+;; @0020                               return v4  ; v4 = 42
 ;; }

--- a/tests/disas/issue-10929-v128-icmp-egraphs.wat
+++ b/tests/disas/issue-10929-v128-icmp-egraphs.wat
@@ -23,7 +23,7 @@
 ;; @0025                               jump block1
 ;;
 ;;                                 block1:
-;;                                     v9 = vconst.i8x16 const0
-;; @0023                               v6 = icmp.i8x16 ne v2, v9  ; v9 = const0
-;; @0025                               return v6
+;;                                     v8 = vconst.i8x16 const0
+;; @0023                               v5 = icmp.i8x16 ne v2, v8  ; v8 = const0
+;; @0025                               return v5
 ;; }

--- a/tests/disas/issue-5696.wat
+++ b/tests/disas/issue-5696.wat
@@ -21,6 +21,6 @@
 ;; @001e                               jump block1
 ;;
 ;;                                 block1:
-;;                                     v7 = iconst.i64 0
-;; @001e                               return v7  ; v7 = 0
+;;                                     v6 = iconst.i64 0
+;; @001e                               return v6  ; v6 = 0
 ;; }

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0_offset.wat
@@ -57,17 +57,17 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0048                               v4 = uextend.i64 v2
-;; @0048                               v5 = load.i64 notrap aligned region3 v0+64
-;; @0048                               v6 = iconst.i64 4
-;; @0048                               v7 = isub v5, v6  ; v6 = 4
-;; @0048                               v8 = icmp ugt v4, v7
-;; @0048                               trapnz v8, heap_oob
-;; @0048                               v9 = load.i64 notrap aligned can_move region2 v0+56
-;; @0048                               v10 = iadd v9, v4
-;; @0048                               v11 = load.i32 little region4 v10
+;; @0048                               v3 = uextend.i64 v2
+;; @0048                               v4 = load.i64 notrap aligned region3 v0+64
+;; @0048                               v5 = iconst.i64 4
+;; @0048                               v6 = isub v4, v5  ; v5 = 4
+;; @0048                               v7 = icmp ugt v3, v6
+;; @0048                               trapnz v7, heap_oob
+;; @0048                               v8 = load.i64 notrap aligned can_move region2 v0+56
+;; @0048                               v9 = iadd v8, v3
+;; @0048                               v10 = load.i32 little region4 v9
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:
-;; @004b                               return v11
+;; @004b                               return v10
 ;; }

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -59,19 +59,19 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0049                               v4 = uextend.i64 v2
-;; @0049                               v5 = load.i64 notrap aligned region3 v0+64
-;; @0049                               v6 = iconst.i64 4100
-;; @0049                               v7 = isub v5, v6  ; v6 = 4100
-;; @0049                               v8 = icmp ugt v4, v7
-;; @0049                               trapnz v8, heap_oob
-;; @0049                               v9 = load.i64 notrap aligned can_move region2 v0+56
-;; @0049                               v10 = iadd v9, v4
-;; @0049                               v11 = iconst.i64 4096
-;; @0049                               v12 = iadd v10, v11  ; v11 = 4096
-;; @0049                               v13 = load.i32 little region4 v12
+;; @0049                               v3 = uextend.i64 v2
+;; @0049                               v4 = load.i64 notrap aligned region3 v0+64
+;; @0049                               v5 = iconst.i64 4100
+;; @0049                               v6 = isub v4, v5  ; v5 = 4100
+;; @0049                               v7 = icmp ugt v3, v6
+;; @0049                               trapnz v7, heap_oob
+;; @0049                               v8 = load.i64 notrap aligned can_move region2 v0+56
+;; @0049                               v9 = iadd v8, v3
+;; @0049                               v10 = iconst.i64 4096
+;; @0049                               v11 = iadd v9, v10  ; v10 = 4096
+;; @0049                               v12 = load.i32 little region4 v11
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:
-;; @004d                               return v13
+;; @004d                               return v12
 ;; }

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -59,19 +59,19 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @004c                               v4 = uextend.i64 v2
-;; @004c                               v5 = iconst.i64 0xffff_0004
-;; @004c                               v6 = uadd_overflow_trap v4, v5, heap_oob  ; v5 = 0xffff_0004
-;; @004c                               v7 = load.i64 notrap aligned region3 v0+64
-;; @004c                               v8 = icmp ugt v6, v7
-;; @004c                               trapnz v8, heap_oob
-;; @004c                               v9 = load.i64 notrap aligned can_move region2 v0+56
-;; @004c                               v10 = iadd v9, v4
-;; @004c                               v11 = iconst.i64 0xffff_0000
-;; @004c                               v12 = iadd v10, v11  ; v11 = 0xffff_0000
-;; @004c                               v13 = load.i32 little region4 v12
+;; @004c                               v3 = uextend.i64 v2
+;; @004c                               v4 = iconst.i64 0xffff_0004
+;; @004c                               v5 = uadd_overflow_trap v3, v4, heap_oob  ; v4 = 0xffff_0004
+;; @004c                               v6 = load.i64 notrap aligned region3 v0+64
+;; @004c                               v7 = icmp ugt v5, v6
+;; @004c                               trapnz v7, heap_oob
+;; @004c                               v8 = load.i64 notrap aligned can_move region2 v0+56
+;; @004c                               v9 = iadd v8, v3
+;; @004c                               v10 = iconst.i64 0xffff_0000
+;; @004c                               v11 = iadd v9, v10  ; v10 = 0xffff_0000
+;; @004c                               v12 = load.i32 little region4 v11
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:
-;; @0053                               return v13
+;; @0053                               return v12
 ;; }

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0_offset.wat
@@ -55,15 +55,15 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0048                               v4 = uextend.i64 v2
-;; @0048                               v5 = load.i64 notrap aligned region3 v0+64
-;; @0048                               v6 = icmp uge v4, v5
-;; @0048                               trapnz v6, heap_oob
-;; @0048                               v7 = load.i64 notrap aligned can_move region2 v0+56
-;; @0048                               v8 = iadd v7, v4
-;; @0048                               v9 = uload8.i32 little region4 v8
+;; @0048                               v3 = uextend.i64 v2
+;; @0048                               v4 = load.i64 notrap aligned region3 v0+64
+;; @0048                               v5 = icmp uge v3, v4
+;; @0048                               trapnz v5, heap_oob
+;; @0048                               v6 = load.i64 notrap aligned can_move region2 v0+56
+;; @0048                               v7 = iadd v6, v3
+;; @0048                               v8 = uload8.i32 little region4 v7
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:
-;; @004b                               return v9
+;; @004b                               return v8
 ;; }

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -59,19 +59,19 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0049                               v4 = uextend.i64 v2
-;; @0049                               v5 = load.i64 notrap aligned region3 v0+64
-;; @0049                               v6 = iconst.i64 4097
-;; @0049                               v7 = isub v5, v6  ; v6 = 4097
-;; @0049                               v8 = icmp ugt v4, v7
-;; @0049                               trapnz v8, heap_oob
-;; @0049                               v9 = load.i64 notrap aligned can_move region2 v0+56
-;; @0049                               v10 = iadd v9, v4
-;; @0049                               v11 = iconst.i64 4096
-;; @0049                               v12 = iadd v10, v11  ; v11 = 4096
-;; @0049                               v13 = uload8.i32 little region4 v12
+;; @0049                               v3 = uextend.i64 v2
+;; @0049                               v4 = load.i64 notrap aligned region3 v0+64
+;; @0049                               v5 = iconst.i64 4097
+;; @0049                               v6 = isub v4, v5  ; v5 = 4097
+;; @0049                               v7 = icmp ugt v3, v6
+;; @0049                               trapnz v7, heap_oob
+;; @0049                               v8 = load.i64 notrap aligned can_move region2 v0+56
+;; @0049                               v9 = iadd v8, v3
+;; @0049                               v10 = iconst.i64 4096
+;; @0049                               v11 = iadd v9, v10  ; v10 = 4096
+;; @0049                               v12 = uload8.i32 little region4 v11
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:
-;; @004d                               return v13
+;; @004d                               return v12
 ;; }

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -59,19 +59,19 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @004c                               v4 = uextend.i64 v2
-;; @004c                               v5 = iconst.i64 0xffff_0001
-;; @004c                               v6 = uadd_overflow_trap v4, v5, heap_oob  ; v5 = 0xffff_0001
-;; @004c                               v7 = load.i64 notrap aligned region3 v0+64
-;; @004c                               v8 = icmp ugt v6, v7
-;; @004c                               trapnz v8, heap_oob
-;; @004c                               v9 = load.i64 notrap aligned can_move region2 v0+56
-;; @004c                               v10 = iadd v9, v4
-;; @004c                               v11 = iconst.i64 0xffff_0000
-;; @004c                               v12 = iadd v10, v11  ; v11 = 0xffff_0000
-;; @004c                               v13 = uload8.i32 little region4 v12
+;; @004c                               v3 = uextend.i64 v2
+;; @004c                               v4 = iconst.i64 0xffff_0001
+;; @004c                               v5 = uadd_overflow_trap v3, v4, heap_oob  ; v4 = 0xffff_0001
+;; @004c                               v6 = load.i64 notrap aligned region3 v0+64
+;; @004c                               v7 = icmp ugt v5, v6
+;; @004c                               trapnz v7, heap_oob
+;; @004c                               v8 = load.i64 notrap aligned can_move region2 v0+56
+;; @004c                               v9 = iadd v8, v3
+;; @004c                               v10 = iconst.i64 0xffff_0000
+;; @004c                               v11 = iadd v9, v10  ; v10 = 0xffff_0000
+;; @004c                               v12 = uload8.i32 little region4 v11
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:
-;; @0053                               return v13
+;; @0053                               return v12
 ;; }

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0_offset.wat
@@ -58,18 +58,18 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0048                               v4 = uextend.i64 v2
-;; @0048                               v5 = load.i64 notrap aligned region3 v0+64
-;; @0048                               v6 = iconst.i64 4
-;; @0048                               v7 = isub v5, v6  ; v6 = 4
-;; @0048                               v8 = icmp ugt v4, v7
-;; @0048                               v9 = load.i64 notrap aligned can_move region2 v0+56
-;; @0048                               v10 = iadd v9, v4
-;; @0048                               v11 = iconst.i64 0
-;; @0048                               v12 = select_spectre_guard v8, v11, v10  ; v11 = 0
-;; @0048                               v13 = load.i32 little region4 v12
+;; @0048                               v3 = uextend.i64 v2
+;; @0048                               v4 = load.i64 notrap aligned region3 v0+64
+;; @0048                               v5 = iconst.i64 4
+;; @0048                               v6 = isub v4, v5  ; v5 = 4
+;; @0048                               v7 = icmp ugt v3, v6
+;; @0048                               v8 = load.i64 notrap aligned can_move region2 v0+56
+;; @0048                               v9 = iadd v8, v3
+;; @0048                               v10 = iconst.i64 0
+;; @0048                               v11 = select_spectre_guard v7, v10, v9  ; v10 = 0
+;; @0048                               v12 = load.i32 little region4 v11
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:
-;; @004b                               return v13
+;; @004b                               return v12
 ;; }

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -60,20 +60,20 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0049                               v4 = uextend.i64 v2
-;; @0049                               v5 = load.i64 notrap aligned region3 v0+64
-;; @0049                               v6 = iconst.i64 4100
-;; @0049                               v7 = isub v5, v6  ; v6 = 4100
-;; @0049                               v8 = icmp ugt v4, v7
-;; @0049                               v9 = load.i64 notrap aligned can_move region2 v0+56
-;; @0049                               v10 = iadd v9, v4
-;; @0049                               v11 = iconst.i64 4096
-;; @0049                               v12 = iadd v10, v11  ; v11 = 4096
-;; @0049                               v13 = iconst.i64 0
-;; @0049                               v14 = select_spectre_guard v8, v13, v12  ; v13 = 0
-;; @0049                               v15 = load.i32 little region4 v14
+;; @0049                               v3 = uextend.i64 v2
+;; @0049                               v4 = load.i64 notrap aligned region3 v0+64
+;; @0049                               v5 = iconst.i64 4100
+;; @0049                               v6 = isub v4, v5  ; v5 = 4100
+;; @0049                               v7 = icmp ugt v3, v6
+;; @0049                               v8 = load.i64 notrap aligned can_move region2 v0+56
+;; @0049                               v9 = iadd v8, v3
+;; @0049                               v10 = iconst.i64 4096
+;; @0049                               v11 = iadd v9, v10  ; v10 = 4096
+;; @0049                               v12 = iconst.i64 0
+;; @0049                               v13 = select_spectre_guard v7, v12, v11  ; v12 = 0
+;; @0049                               v14 = load.i32 little region4 v13
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:
-;; @004d                               return v15
+;; @004d                               return v14
 ;; }

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -60,20 +60,20 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @004c                               v4 = uextend.i64 v2
-;; @004c                               v5 = iconst.i64 0xffff_0004
-;; @004c                               v6 = uadd_overflow_trap v4, v5, heap_oob  ; v5 = 0xffff_0004
-;; @004c                               v7 = load.i64 notrap aligned region3 v0+64
-;; @004c                               v8 = icmp ugt v6, v7
-;; @004c                               v9 = load.i64 notrap aligned can_move region2 v0+56
-;; @004c                               v10 = iadd v9, v4
-;; @004c                               v11 = iconst.i64 0xffff_0000
-;; @004c                               v12 = iadd v10, v11  ; v11 = 0xffff_0000
-;; @004c                               v13 = iconst.i64 0
-;; @004c                               v14 = select_spectre_guard v8, v13, v12  ; v13 = 0
-;; @004c                               v15 = load.i32 little region4 v14
+;; @004c                               v3 = uextend.i64 v2
+;; @004c                               v4 = iconst.i64 0xffff_0004
+;; @004c                               v5 = uadd_overflow_trap v3, v4, heap_oob  ; v4 = 0xffff_0004
+;; @004c                               v6 = load.i64 notrap aligned region3 v0+64
+;; @004c                               v7 = icmp ugt v5, v6
+;; @004c                               v8 = load.i64 notrap aligned can_move region2 v0+56
+;; @004c                               v9 = iadd v8, v3
+;; @004c                               v10 = iconst.i64 0xffff_0000
+;; @004c                               v11 = iadd v9, v10  ; v10 = 0xffff_0000
+;; @004c                               v12 = iconst.i64 0
+;; @004c                               v13 = select_spectre_guard v7, v12, v11  ; v12 = 0
+;; @004c                               v14 = load.i32 little region4 v13
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:
-;; @0053                               return v15
+;; @0053                               return v14
 ;; }

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0_offset.wat
@@ -56,16 +56,16 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0048                               v4 = uextend.i64 v2
-;; @0048                               v5 = load.i64 notrap aligned region3 v0+64
-;; @0048                               v6 = icmp uge v4, v5
-;; @0048                               v7 = load.i64 notrap aligned can_move region2 v0+56
-;; @0048                               v8 = iadd v7, v4
-;; @0048                               v9 = iconst.i64 0
-;; @0048                               v10 = select_spectre_guard v6, v9, v8  ; v9 = 0
-;; @0048                               v11 = uload8.i32 little region4 v10
+;; @0048                               v3 = uextend.i64 v2
+;; @0048                               v4 = load.i64 notrap aligned region3 v0+64
+;; @0048                               v5 = icmp uge v3, v4
+;; @0048                               v6 = load.i64 notrap aligned can_move region2 v0+56
+;; @0048                               v7 = iadd v6, v3
+;; @0048                               v8 = iconst.i64 0
+;; @0048                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0
+;; @0048                               v10 = uload8.i32 little region4 v9
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:
-;; @004b                               return v11
+;; @004b                               return v10
 ;; }

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -60,20 +60,20 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0049                               v4 = uextend.i64 v2
-;; @0049                               v5 = load.i64 notrap aligned region3 v0+64
-;; @0049                               v6 = iconst.i64 4097
-;; @0049                               v7 = isub v5, v6  ; v6 = 4097
-;; @0049                               v8 = icmp ugt v4, v7
-;; @0049                               v9 = load.i64 notrap aligned can_move region2 v0+56
-;; @0049                               v10 = iadd v9, v4
-;; @0049                               v11 = iconst.i64 4096
-;; @0049                               v12 = iadd v10, v11  ; v11 = 4096
-;; @0049                               v13 = iconst.i64 0
-;; @0049                               v14 = select_spectre_guard v8, v13, v12  ; v13 = 0
-;; @0049                               v15 = uload8.i32 little region4 v14
+;; @0049                               v3 = uextend.i64 v2
+;; @0049                               v4 = load.i64 notrap aligned region3 v0+64
+;; @0049                               v5 = iconst.i64 4097
+;; @0049                               v6 = isub v4, v5  ; v5 = 4097
+;; @0049                               v7 = icmp ugt v3, v6
+;; @0049                               v8 = load.i64 notrap aligned can_move region2 v0+56
+;; @0049                               v9 = iadd v8, v3
+;; @0049                               v10 = iconst.i64 4096
+;; @0049                               v11 = iadd v9, v10  ; v10 = 4096
+;; @0049                               v12 = iconst.i64 0
+;; @0049                               v13 = select_spectre_guard v7, v12, v11  ; v12 = 0
+;; @0049                               v14 = uload8.i32 little region4 v13
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:
-;; @004d                               return v15
+;; @004d                               return v14
 ;; }

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -60,20 +60,20 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @004c                               v4 = uextend.i64 v2
-;; @004c                               v5 = iconst.i64 0xffff_0001
-;; @004c                               v6 = uadd_overflow_trap v4, v5, heap_oob  ; v5 = 0xffff_0001
-;; @004c                               v7 = load.i64 notrap aligned region3 v0+64
-;; @004c                               v8 = icmp ugt v6, v7
-;; @004c                               v9 = load.i64 notrap aligned can_move region2 v0+56
-;; @004c                               v10 = iadd v9, v4
-;; @004c                               v11 = iconst.i64 0xffff_0000
-;; @004c                               v12 = iadd v10, v11  ; v11 = 0xffff_0000
-;; @004c                               v13 = iconst.i64 0
-;; @004c                               v14 = select_spectre_guard v8, v13, v12  ; v13 = 0
-;; @004c                               v15 = uload8.i32 little region4 v14
+;; @004c                               v3 = uextend.i64 v2
+;; @004c                               v4 = iconst.i64 0xffff_0001
+;; @004c                               v5 = uadd_overflow_trap v3, v4, heap_oob  ; v4 = 0xffff_0001
+;; @004c                               v6 = load.i64 notrap aligned region3 v0+64
+;; @004c                               v7 = icmp ugt v5, v6
+;; @004c                               v8 = load.i64 notrap aligned can_move region2 v0+56
+;; @004c                               v9 = iadd v8, v3
+;; @004c                               v10 = iconst.i64 0xffff_0000
+;; @004c                               v11 = iadd v9, v10  ; v10 = 0xffff_0000
+;; @004c                               v12 = iconst.i64 0
+;; @004c                               v13 = select_spectre_guard v7, v12, v11  ; v12 = 0
+;; @004c                               v14 = uload8.i32 little region4 v13
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:
-;; @0053                               return v15
+;; @0053                               return v14
 ;; }

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
@@ -55,15 +55,15 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0048                               v4 = uextend.i64 v2
-;; @0048                               v5 = load.i64 notrap aligned region3 v0+64
-;; @0048                               v6 = icmp ugt v4, v5
-;; @0048                               trapnz v6, heap_oob
-;; @0048                               v7 = load.i64 notrap aligned can_move region2 v0+56
-;; @0048                               v8 = iadd v7, v4
-;; @0048                               v9 = load.i32 little region4 v8
+;; @0048                               v3 = uextend.i64 v2
+;; @0048                               v4 = load.i64 notrap aligned region3 v0+64
+;; @0048                               v5 = icmp ugt v3, v4
+;; @0048                               trapnz v5, heap_oob
+;; @0048                               v6 = load.i64 notrap aligned can_move region2 v0+56
+;; @0048                               v7 = iadd v6, v3
+;; @0048                               v8 = load.i32 little region4 v7
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:
-;; @004b                               return v9
+;; @004b                               return v8
 ;; }

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -57,17 +57,17 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0049                               v4 = uextend.i64 v2
-;; @0049                               v5 = load.i64 notrap aligned region3 v0+64
-;; @0049                               v6 = icmp ugt v4, v5
-;; @0049                               trapnz v6, heap_oob
-;; @0049                               v7 = load.i64 notrap aligned can_move region2 v0+56
-;; @0049                               v8 = iadd v7, v4
-;; @0049                               v9 = iconst.i64 4096
-;; @0049                               v10 = iadd v8, v9  ; v9 = 4096
-;; @0049                               v11 = load.i32 little region4 v10
+;; @0049                               v3 = uextend.i64 v2
+;; @0049                               v4 = load.i64 notrap aligned region3 v0+64
+;; @0049                               v5 = icmp ugt v3, v4
+;; @0049                               trapnz v5, heap_oob
+;; @0049                               v6 = load.i64 notrap aligned can_move region2 v0+56
+;; @0049                               v7 = iadd v6, v3
+;; @0049                               v8 = iconst.i64 4096
+;; @0049                               v9 = iadd v7, v8  ; v8 = 4096
+;; @0049                               v10 = load.i32 little region4 v9
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:
-;; @004d                               return v11
+;; @004d                               return v10
 ;; }

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -57,17 +57,17 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @004c                               v4 = uextend.i64 v2
-;; @004c                               v5 = load.i64 notrap aligned region3 v0+64
-;; @004c                               v6 = icmp ugt v4, v5
-;; @004c                               trapnz v6, heap_oob
-;; @004c                               v7 = load.i64 notrap aligned can_move region2 v0+56
-;; @004c                               v8 = iadd v7, v4
-;; @004c                               v9 = iconst.i64 0xffff_0000
-;; @004c                               v10 = iadd v8, v9  ; v9 = 0xffff_0000
-;; @004c                               v11 = load.i32 little region4 v10
+;; @004c                               v3 = uextend.i64 v2
+;; @004c                               v4 = load.i64 notrap aligned region3 v0+64
+;; @004c                               v5 = icmp ugt v3, v4
+;; @004c                               trapnz v5, heap_oob
+;; @004c                               v6 = load.i64 notrap aligned can_move region2 v0+56
+;; @004c                               v7 = iadd v6, v3
+;; @004c                               v8 = iconst.i64 0xffff_0000
+;; @004c                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
+;; @004c                               v10 = load.i32 little region4 v9
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:
-;; @0053                               return v11
+;; @0053                               return v10
 ;; }

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
@@ -55,15 +55,15 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0048                               v4 = uextend.i64 v2
-;; @0048                               v5 = load.i64 notrap aligned region3 v0+64
-;; @0048                               v6 = icmp uge v4, v5
-;; @0048                               trapnz v6, heap_oob
-;; @0048                               v7 = load.i64 notrap aligned can_move region2 v0+56
-;; @0048                               v8 = iadd v7, v4
-;; @0048                               v9 = uload8.i32 little region4 v8
+;; @0048                               v3 = uextend.i64 v2
+;; @0048                               v4 = load.i64 notrap aligned region3 v0+64
+;; @0048                               v5 = icmp uge v3, v4
+;; @0048                               trapnz v5, heap_oob
+;; @0048                               v6 = load.i64 notrap aligned can_move region2 v0+56
+;; @0048                               v7 = iadd v6, v3
+;; @0048                               v8 = uload8.i32 little region4 v7
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:
-;; @004b                               return v9
+;; @004b                               return v8
 ;; }

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -57,17 +57,17 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0049                               v4 = uextend.i64 v2
-;; @0049                               v5 = load.i64 notrap aligned region3 v0+64
-;; @0049                               v6 = icmp ugt v4, v5
-;; @0049                               trapnz v6, heap_oob
-;; @0049                               v7 = load.i64 notrap aligned can_move region2 v0+56
-;; @0049                               v8 = iadd v7, v4
-;; @0049                               v9 = iconst.i64 4096
-;; @0049                               v10 = iadd v8, v9  ; v9 = 4096
-;; @0049                               v11 = uload8.i32 little region4 v10
+;; @0049                               v3 = uextend.i64 v2
+;; @0049                               v4 = load.i64 notrap aligned region3 v0+64
+;; @0049                               v5 = icmp ugt v3, v4
+;; @0049                               trapnz v5, heap_oob
+;; @0049                               v6 = load.i64 notrap aligned can_move region2 v0+56
+;; @0049                               v7 = iadd v6, v3
+;; @0049                               v8 = iconst.i64 4096
+;; @0049                               v9 = iadd v7, v8  ; v8 = 4096
+;; @0049                               v10 = uload8.i32 little region4 v9
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:
-;; @004d                               return v11
+;; @004d                               return v10
 ;; }

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -57,17 +57,17 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @004c                               v4 = uextend.i64 v2
-;; @004c                               v5 = load.i64 notrap aligned region3 v0+64
-;; @004c                               v6 = icmp ugt v4, v5
-;; @004c                               trapnz v6, heap_oob
-;; @004c                               v7 = load.i64 notrap aligned can_move region2 v0+56
-;; @004c                               v8 = iadd v7, v4
-;; @004c                               v9 = iconst.i64 0xffff_0000
-;; @004c                               v10 = iadd v8, v9  ; v9 = 0xffff_0000
-;; @004c                               v11 = uload8.i32 little region4 v10
+;; @004c                               v3 = uextend.i64 v2
+;; @004c                               v4 = load.i64 notrap aligned region3 v0+64
+;; @004c                               v5 = icmp ugt v3, v4
+;; @004c                               trapnz v5, heap_oob
+;; @004c                               v6 = load.i64 notrap aligned can_move region2 v0+56
+;; @004c                               v7 = iadd v6, v3
+;; @004c                               v8 = iconst.i64 0xffff_0000
+;; @004c                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
+;; @004c                               v10 = uload8.i32 little region4 v9
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:
-;; @0053                               return v11
+;; @0053                               return v10
 ;; }

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
@@ -56,16 +56,16 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0048                               v4 = uextend.i64 v2
-;; @0048                               v5 = load.i64 notrap aligned region3 v0+64
-;; @0048                               v6 = icmp ugt v4, v5
-;; @0048                               v7 = load.i64 notrap aligned can_move region2 v0+56
-;; @0048                               v8 = iadd v7, v4
-;; @0048                               v9 = iconst.i64 0
-;; @0048                               v10 = select_spectre_guard v6, v9, v8  ; v9 = 0
-;; @0048                               v11 = load.i32 little region4 v10
+;; @0048                               v3 = uextend.i64 v2
+;; @0048                               v4 = load.i64 notrap aligned region3 v0+64
+;; @0048                               v5 = icmp ugt v3, v4
+;; @0048                               v6 = load.i64 notrap aligned can_move region2 v0+56
+;; @0048                               v7 = iadd v6, v3
+;; @0048                               v8 = iconst.i64 0
+;; @0048                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0
+;; @0048                               v10 = load.i32 little region4 v9
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:
-;; @004b                               return v11
+;; @004b                               return v10
 ;; }

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -58,18 +58,18 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0049                               v4 = uextend.i64 v2
-;; @0049                               v5 = load.i64 notrap aligned region3 v0+64
-;; @0049                               v6 = icmp ugt v4, v5
-;; @0049                               v7 = load.i64 notrap aligned can_move region2 v0+56
-;; @0049                               v8 = iadd v7, v4
-;; @0049                               v9 = iconst.i64 4096
-;; @0049                               v10 = iadd v8, v9  ; v9 = 4096
-;; @0049                               v11 = iconst.i64 0
-;; @0049                               v12 = select_spectre_guard v6, v11, v10  ; v11 = 0
-;; @0049                               v13 = load.i32 little region4 v12
+;; @0049                               v3 = uextend.i64 v2
+;; @0049                               v4 = load.i64 notrap aligned region3 v0+64
+;; @0049                               v5 = icmp ugt v3, v4
+;; @0049                               v6 = load.i64 notrap aligned can_move region2 v0+56
+;; @0049                               v7 = iadd v6, v3
+;; @0049                               v8 = iconst.i64 4096
+;; @0049                               v9 = iadd v7, v8  ; v8 = 4096
+;; @0049                               v10 = iconst.i64 0
+;; @0049                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
+;; @0049                               v12 = load.i32 little region4 v11
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:
-;; @004d                               return v13
+;; @004d                               return v12
 ;; }

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -58,18 +58,18 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @004c                               v4 = uextend.i64 v2
-;; @004c                               v5 = load.i64 notrap aligned region3 v0+64
-;; @004c                               v6 = icmp ugt v4, v5
-;; @004c                               v7 = load.i64 notrap aligned can_move region2 v0+56
-;; @004c                               v8 = iadd v7, v4
-;; @004c                               v9 = iconst.i64 0xffff_0000
-;; @004c                               v10 = iadd v8, v9  ; v9 = 0xffff_0000
-;; @004c                               v11 = iconst.i64 0
-;; @004c                               v12 = select_spectre_guard v6, v11, v10  ; v11 = 0
-;; @004c                               v13 = load.i32 little region4 v12
+;; @004c                               v3 = uextend.i64 v2
+;; @004c                               v4 = load.i64 notrap aligned region3 v0+64
+;; @004c                               v5 = icmp ugt v3, v4
+;; @004c                               v6 = load.i64 notrap aligned can_move region2 v0+56
+;; @004c                               v7 = iadd v6, v3
+;; @004c                               v8 = iconst.i64 0xffff_0000
+;; @004c                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
+;; @004c                               v10 = iconst.i64 0
+;; @004c                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
+;; @004c                               v12 = load.i32 little region4 v11
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:
-;; @0053                               return v13
+;; @0053                               return v12
 ;; }

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
@@ -56,16 +56,16 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0048                               v4 = uextend.i64 v2
-;; @0048                               v5 = load.i64 notrap aligned region3 v0+64
-;; @0048                               v6 = icmp uge v4, v5
-;; @0048                               v7 = load.i64 notrap aligned can_move region2 v0+56
-;; @0048                               v8 = iadd v7, v4
-;; @0048                               v9 = iconst.i64 0
-;; @0048                               v10 = select_spectre_guard v6, v9, v8  ; v9 = 0
-;; @0048                               v11 = uload8.i32 little region4 v10
+;; @0048                               v3 = uextend.i64 v2
+;; @0048                               v4 = load.i64 notrap aligned region3 v0+64
+;; @0048                               v5 = icmp uge v3, v4
+;; @0048                               v6 = load.i64 notrap aligned can_move region2 v0+56
+;; @0048                               v7 = iadd v6, v3
+;; @0048                               v8 = iconst.i64 0
+;; @0048                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0
+;; @0048                               v10 = uload8.i32 little region4 v9
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:
-;; @004b                               return v11
+;; @004b                               return v10
 ;; }

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -58,18 +58,18 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0049                               v4 = uextend.i64 v2
-;; @0049                               v5 = load.i64 notrap aligned region3 v0+64
-;; @0049                               v6 = icmp ugt v4, v5
-;; @0049                               v7 = load.i64 notrap aligned can_move region2 v0+56
-;; @0049                               v8 = iadd v7, v4
-;; @0049                               v9 = iconst.i64 4096
-;; @0049                               v10 = iadd v8, v9  ; v9 = 4096
-;; @0049                               v11 = iconst.i64 0
-;; @0049                               v12 = select_spectre_guard v6, v11, v10  ; v11 = 0
-;; @0049                               v13 = uload8.i32 little region4 v12
+;; @0049                               v3 = uextend.i64 v2
+;; @0049                               v4 = load.i64 notrap aligned region3 v0+64
+;; @0049                               v5 = icmp ugt v3, v4
+;; @0049                               v6 = load.i64 notrap aligned can_move region2 v0+56
+;; @0049                               v7 = iadd v6, v3
+;; @0049                               v8 = iconst.i64 4096
+;; @0049                               v9 = iadd v7, v8  ; v8 = 4096
+;; @0049                               v10 = iconst.i64 0
+;; @0049                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
+;; @0049                               v12 = uload8.i32 little region4 v11
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:
-;; @004d                               return v13
+;; @004d                               return v12
 ;; }

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -58,18 +58,18 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @004c                               v4 = uextend.i64 v2
-;; @004c                               v5 = load.i64 notrap aligned region3 v0+64
-;; @004c                               v6 = icmp ugt v4, v5
-;; @004c                               v7 = load.i64 notrap aligned can_move region2 v0+56
-;; @004c                               v8 = iadd v7, v4
-;; @004c                               v9 = iconst.i64 0xffff_0000
-;; @004c                               v10 = iadd v8, v9  ; v9 = 0xffff_0000
-;; @004c                               v11 = iconst.i64 0
-;; @004c                               v12 = select_spectre_guard v6, v11, v10  ; v11 = 0
-;; @004c                               v13 = uload8.i32 little region4 v12
+;; @004c                               v3 = uextend.i64 v2
+;; @004c                               v4 = load.i64 notrap aligned region3 v0+64
+;; @004c                               v5 = icmp ugt v3, v4
+;; @004c                               v6 = load.i64 notrap aligned can_move region2 v0+56
+;; @004c                               v7 = iadd v6, v3
+;; @004c                               v8 = iconst.i64 0xffff_0000
+;; @004c                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
+;; @004c                               v10 = iconst.i64 0
+;; @004c                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
+;; @004c                               v12 = uload8.i32 little region4 v11
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:
-;; @0053                               return v13
+;; @0053                               return v12
 ;; }

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0_offset.wat
@@ -56,16 +56,16 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0048                               v4 = load.i64 notrap aligned region3 v0+64
-;; @0048                               v5 = iconst.i64 4
-;; @0048                               v6 = isub v4, v5  ; v5 = 4
-;; @0048                               v7 = icmp ugt v2, v6
-;; @0048                               trapnz v7, heap_oob
-;; @0048                               v8 = load.i64 notrap aligned can_move region2 v0+56
-;; @0048                               v9 = iadd v8, v2
-;; @0048                               v10 = load.i32 little region4 v9
+;; @0048                               v3 = load.i64 notrap aligned region3 v0+64
+;; @0048                               v4 = iconst.i64 4
+;; @0048                               v5 = isub v3, v4  ; v4 = 4
+;; @0048                               v6 = icmp ugt v2, v5
+;; @0048                               trapnz v6, heap_oob
+;; @0048                               v7 = load.i64 notrap aligned can_move region2 v0+56
+;; @0048                               v8 = iadd v7, v2
+;; @0048                               v9 = load.i32 little region4 v8
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:
-;; @004b                               return v10
+;; @004b                               return v9
 ;; }

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -58,18 +58,18 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0049                               v4 = load.i64 notrap aligned region3 v0+64
-;; @0049                               v5 = iconst.i64 4100
-;; @0049                               v6 = isub v4, v5  ; v5 = 4100
-;; @0049                               v7 = icmp ugt v2, v6
-;; @0049                               trapnz v7, heap_oob
-;; @0049                               v8 = load.i64 notrap aligned can_move region2 v0+56
-;; @0049                               v9 = iadd v8, v2
-;; @0049                               v10 = iconst.i64 4096
-;; @0049                               v11 = iadd v9, v10  ; v10 = 4096
-;; @0049                               v12 = load.i32 little region4 v11
+;; @0049                               v3 = load.i64 notrap aligned region3 v0+64
+;; @0049                               v4 = iconst.i64 4100
+;; @0049                               v5 = isub v3, v4  ; v4 = 4100
+;; @0049                               v6 = icmp ugt v2, v5
+;; @0049                               trapnz v6, heap_oob
+;; @0049                               v7 = load.i64 notrap aligned can_move region2 v0+56
+;; @0049                               v8 = iadd v7, v2
+;; @0049                               v9 = iconst.i64 4096
+;; @0049                               v10 = iadd v8, v9  ; v9 = 4096
+;; @0049                               v11 = load.i32 little region4 v10
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:
-;; @004d                               return v12
+;; @004d                               return v11
 ;; }

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -58,18 +58,18 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @004c                               v4 = iconst.i64 0xffff_0004
-;; @004c                               v5 = uadd_overflow_trap v2, v4, heap_oob  ; v4 = 0xffff_0004
-;; @004c                               v6 = load.i64 notrap aligned region3 v0+64
-;; @004c                               v7 = icmp ugt v5, v6
-;; @004c                               trapnz v7, heap_oob
-;; @004c                               v8 = load.i64 notrap aligned can_move region2 v0+56
-;; @004c                               v9 = iadd v8, v2
-;; @004c                               v10 = iconst.i64 0xffff_0000
-;; @004c                               v11 = iadd v9, v10  ; v10 = 0xffff_0000
-;; @004c                               v12 = load.i32 little region4 v11
+;; @004c                               v3 = iconst.i64 0xffff_0004
+;; @004c                               v4 = uadd_overflow_trap v2, v3, heap_oob  ; v3 = 0xffff_0004
+;; @004c                               v5 = load.i64 notrap aligned region3 v0+64
+;; @004c                               v6 = icmp ugt v4, v5
+;; @004c                               trapnz v6, heap_oob
+;; @004c                               v7 = load.i64 notrap aligned can_move region2 v0+56
+;; @004c                               v8 = iadd v7, v2
+;; @004c                               v9 = iconst.i64 0xffff_0000
+;; @004c                               v10 = iadd v8, v9  ; v9 = 0xffff_0000
+;; @004c                               v11 = load.i32 little region4 v10
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:
-;; @0053                               return v12
+;; @0053                               return v11
 ;; }

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0_offset.wat
@@ -54,14 +54,14 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0048                               v4 = load.i64 notrap aligned region3 v0+64
-;; @0048                               v5 = icmp uge v2, v4
-;; @0048                               trapnz v5, heap_oob
-;; @0048                               v6 = load.i64 notrap aligned can_move region2 v0+56
-;; @0048                               v7 = iadd v6, v2
-;; @0048                               v8 = uload8.i32 little region4 v7
+;; @0048                               v3 = load.i64 notrap aligned region3 v0+64
+;; @0048                               v4 = icmp uge v2, v3
+;; @0048                               trapnz v4, heap_oob
+;; @0048                               v5 = load.i64 notrap aligned can_move region2 v0+56
+;; @0048                               v6 = iadd v5, v2
+;; @0048                               v7 = uload8.i32 little region4 v6
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:
-;; @004b                               return v8
+;; @004b                               return v7
 ;; }

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -58,18 +58,18 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0049                               v4 = load.i64 notrap aligned region3 v0+64
-;; @0049                               v5 = iconst.i64 4097
-;; @0049                               v6 = isub v4, v5  ; v5 = 4097
-;; @0049                               v7 = icmp ugt v2, v6
-;; @0049                               trapnz v7, heap_oob
-;; @0049                               v8 = load.i64 notrap aligned can_move region2 v0+56
-;; @0049                               v9 = iadd v8, v2
-;; @0049                               v10 = iconst.i64 4096
-;; @0049                               v11 = iadd v9, v10  ; v10 = 4096
-;; @0049                               v12 = uload8.i32 little region4 v11
+;; @0049                               v3 = load.i64 notrap aligned region3 v0+64
+;; @0049                               v4 = iconst.i64 4097
+;; @0049                               v5 = isub v3, v4  ; v4 = 4097
+;; @0049                               v6 = icmp ugt v2, v5
+;; @0049                               trapnz v6, heap_oob
+;; @0049                               v7 = load.i64 notrap aligned can_move region2 v0+56
+;; @0049                               v8 = iadd v7, v2
+;; @0049                               v9 = iconst.i64 4096
+;; @0049                               v10 = iadd v8, v9  ; v9 = 4096
+;; @0049                               v11 = uload8.i32 little region4 v10
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:
-;; @004d                               return v12
+;; @004d                               return v11
 ;; }

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -58,18 +58,18 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @004c                               v4 = iconst.i64 0xffff_0001
-;; @004c                               v5 = uadd_overflow_trap v2, v4, heap_oob  ; v4 = 0xffff_0001
-;; @004c                               v6 = load.i64 notrap aligned region3 v0+64
-;; @004c                               v7 = icmp ugt v5, v6
-;; @004c                               trapnz v7, heap_oob
-;; @004c                               v8 = load.i64 notrap aligned can_move region2 v0+56
-;; @004c                               v9 = iadd v8, v2
-;; @004c                               v10 = iconst.i64 0xffff_0000
-;; @004c                               v11 = iadd v9, v10  ; v10 = 0xffff_0000
-;; @004c                               v12 = uload8.i32 little region4 v11
+;; @004c                               v3 = iconst.i64 0xffff_0001
+;; @004c                               v4 = uadd_overflow_trap v2, v3, heap_oob  ; v3 = 0xffff_0001
+;; @004c                               v5 = load.i64 notrap aligned region3 v0+64
+;; @004c                               v6 = icmp ugt v4, v5
+;; @004c                               trapnz v6, heap_oob
+;; @004c                               v7 = load.i64 notrap aligned can_move region2 v0+56
+;; @004c                               v8 = iadd v7, v2
+;; @004c                               v9 = iconst.i64 0xffff_0000
+;; @004c                               v10 = iadd v8, v9  ; v9 = 0xffff_0000
+;; @004c                               v11 = uload8.i32 little region4 v10
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:
-;; @0053                               return v12
+;; @0053                               return v11
 ;; }

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0_offset.wat
@@ -57,17 +57,17 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0048                               v4 = load.i64 notrap aligned region3 v0+64
-;; @0048                               v5 = iconst.i64 4
-;; @0048                               v6 = isub v4, v5  ; v5 = 4
-;; @0048                               v7 = icmp ugt v2, v6
-;; @0048                               v8 = load.i64 notrap aligned can_move region2 v0+56
-;; @0048                               v9 = iadd v8, v2
-;; @0048                               v10 = iconst.i64 0
-;; @0048                               v11 = select_spectre_guard v7, v10, v9  ; v10 = 0
-;; @0048                               v12 = load.i32 little region4 v11
+;; @0048                               v3 = load.i64 notrap aligned region3 v0+64
+;; @0048                               v4 = iconst.i64 4
+;; @0048                               v5 = isub v3, v4  ; v4 = 4
+;; @0048                               v6 = icmp ugt v2, v5
+;; @0048                               v7 = load.i64 notrap aligned can_move region2 v0+56
+;; @0048                               v8 = iadd v7, v2
+;; @0048                               v9 = iconst.i64 0
+;; @0048                               v10 = select_spectre_guard v6, v9, v8  ; v9 = 0
+;; @0048                               v11 = load.i32 little region4 v10
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:
-;; @004b                               return v12
+;; @004b                               return v11
 ;; }

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -59,19 +59,19 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0049                               v4 = load.i64 notrap aligned region3 v0+64
-;; @0049                               v5 = iconst.i64 4100
-;; @0049                               v6 = isub v4, v5  ; v5 = 4100
-;; @0049                               v7 = icmp ugt v2, v6
-;; @0049                               v8 = load.i64 notrap aligned can_move region2 v0+56
-;; @0049                               v9 = iadd v8, v2
-;; @0049                               v10 = iconst.i64 4096
-;; @0049                               v11 = iadd v9, v10  ; v10 = 4096
-;; @0049                               v12 = iconst.i64 0
-;; @0049                               v13 = select_spectre_guard v7, v12, v11  ; v12 = 0
-;; @0049                               v14 = load.i32 little region4 v13
+;; @0049                               v3 = load.i64 notrap aligned region3 v0+64
+;; @0049                               v4 = iconst.i64 4100
+;; @0049                               v5 = isub v3, v4  ; v4 = 4100
+;; @0049                               v6 = icmp ugt v2, v5
+;; @0049                               v7 = load.i64 notrap aligned can_move region2 v0+56
+;; @0049                               v8 = iadd v7, v2
+;; @0049                               v9 = iconst.i64 4096
+;; @0049                               v10 = iadd v8, v9  ; v9 = 4096
+;; @0049                               v11 = iconst.i64 0
+;; @0049                               v12 = select_spectre_guard v6, v11, v10  ; v11 = 0
+;; @0049                               v13 = load.i32 little region4 v12
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:
-;; @004d                               return v14
+;; @004d                               return v13
 ;; }

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -59,19 +59,19 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @004c                               v4 = iconst.i64 0xffff_0004
-;; @004c                               v5 = uadd_overflow_trap v2, v4, heap_oob  ; v4 = 0xffff_0004
-;; @004c                               v6 = load.i64 notrap aligned region3 v0+64
-;; @004c                               v7 = icmp ugt v5, v6
-;; @004c                               v8 = load.i64 notrap aligned can_move region2 v0+56
-;; @004c                               v9 = iadd v8, v2
-;; @004c                               v10 = iconst.i64 0xffff_0000
-;; @004c                               v11 = iadd v9, v10  ; v10 = 0xffff_0000
-;; @004c                               v12 = iconst.i64 0
-;; @004c                               v13 = select_spectre_guard v7, v12, v11  ; v12 = 0
-;; @004c                               v14 = load.i32 little region4 v13
+;; @004c                               v3 = iconst.i64 0xffff_0004
+;; @004c                               v4 = uadd_overflow_trap v2, v3, heap_oob  ; v3 = 0xffff_0004
+;; @004c                               v5 = load.i64 notrap aligned region3 v0+64
+;; @004c                               v6 = icmp ugt v4, v5
+;; @004c                               v7 = load.i64 notrap aligned can_move region2 v0+56
+;; @004c                               v8 = iadd v7, v2
+;; @004c                               v9 = iconst.i64 0xffff_0000
+;; @004c                               v10 = iadd v8, v9  ; v9 = 0xffff_0000
+;; @004c                               v11 = iconst.i64 0
+;; @004c                               v12 = select_spectre_guard v6, v11, v10  ; v11 = 0
+;; @004c                               v13 = load.i32 little region4 v12
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:
-;; @0053                               return v14
+;; @0053                               return v13
 ;; }

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0_offset.wat
@@ -55,15 +55,15 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0048                               v4 = load.i64 notrap aligned region3 v0+64
-;; @0048                               v5 = icmp uge v2, v4
-;; @0048                               v6 = load.i64 notrap aligned can_move region2 v0+56
-;; @0048                               v7 = iadd v6, v2
-;; @0048                               v8 = iconst.i64 0
-;; @0048                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0
-;; @0048                               v10 = uload8.i32 little region4 v9
+;; @0048                               v3 = load.i64 notrap aligned region3 v0+64
+;; @0048                               v4 = icmp uge v2, v3
+;; @0048                               v5 = load.i64 notrap aligned can_move region2 v0+56
+;; @0048                               v6 = iadd v5, v2
+;; @0048                               v7 = iconst.i64 0
+;; @0048                               v8 = select_spectre_guard v4, v7, v6  ; v7 = 0
+;; @0048                               v9 = uload8.i32 little region4 v8
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:
-;; @004b                               return v10
+;; @004b                               return v9
 ;; }

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -59,19 +59,19 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0049                               v4 = load.i64 notrap aligned region3 v0+64
-;; @0049                               v5 = iconst.i64 4097
-;; @0049                               v6 = isub v4, v5  ; v5 = 4097
-;; @0049                               v7 = icmp ugt v2, v6
-;; @0049                               v8 = load.i64 notrap aligned can_move region2 v0+56
-;; @0049                               v9 = iadd v8, v2
-;; @0049                               v10 = iconst.i64 4096
-;; @0049                               v11 = iadd v9, v10  ; v10 = 4096
-;; @0049                               v12 = iconst.i64 0
-;; @0049                               v13 = select_spectre_guard v7, v12, v11  ; v12 = 0
-;; @0049                               v14 = uload8.i32 little region4 v13
+;; @0049                               v3 = load.i64 notrap aligned region3 v0+64
+;; @0049                               v4 = iconst.i64 4097
+;; @0049                               v5 = isub v3, v4  ; v4 = 4097
+;; @0049                               v6 = icmp ugt v2, v5
+;; @0049                               v7 = load.i64 notrap aligned can_move region2 v0+56
+;; @0049                               v8 = iadd v7, v2
+;; @0049                               v9 = iconst.i64 4096
+;; @0049                               v10 = iadd v8, v9  ; v9 = 4096
+;; @0049                               v11 = iconst.i64 0
+;; @0049                               v12 = select_spectre_guard v6, v11, v10  ; v11 = 0
+;; @0049                               v13 = uload8.i32 little region4 v12
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:
-;; @004d                               return v14
+;; @004d                               return v13
 ;; }

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -59,19 +59,19 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @004c                               v4 = iconst.i64 0xffff_0001
-;; @004c                               v5 = uadd_overflow_trap v2, v4, heap_oob  ; v4 = 0xffff_0001
-;; @004c                               v6 = load.i64 notrap aligned region3 v0+64
-;; @004c                               v7 = icmp ugt v5, v6
-;; @004c                               v8 = load.i64 notrap aligned can_move region2 v0+56
-;; @004c                               v9 = iadd v8, v2
-;; @004c                               v10 = iconst.i64 0xffff_0000
-;; @004c                               v11 = iadd v9, v10  ; v10 = 0xffff_0000
-;; @004c                               v12 = iconst.i64 0
-;; @004c                               v13 = select_spectre_guard v7, v12, v11  ; v12 = 0
-;; @004c                               v14 = uload8.i32 little region4 v13
+;; @004c                               v3 = iconst.i64 0xffff_0001
+;; @004c                               v4 = uadd_overflow_trap v2, v3, heap_oob  ; v3 = 0xffff_0001
+;; @004c                               v5 = load.i64 notrap aligned region3 v0+64
+;; @004c                               v6 = icmp ugt v4, v5
+;; @004c                               v7 = load.i64 notrap aligned can_move region2 v0+56
+;; @004c                               v8 = iadd v7, v2
+;; @004c                               v9 = iconst.i64 0xffff_0000
+;; @004c                               v10 = iadd v8, v9  ; v9 = 0xffff_0000
+;; @004c                               v11 = iconst.i64 0
+;; @004c                               v12 = select_spectre_guard v6, v11, v10  ; v11 = 0
+;; @004c                               v13 = uload8.i32 little region4 v12
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:
-;; @0053                               return v14
+;; @0053                               return v13
 ;; }

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
@@ -54,14 +54,14 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0048                               v4 = load.i64 notrap aligned region3 v0+64
-;; @0048                               v5 = icmp ugt v2, v4
-;; @0048                               trapnz v5, heap_oob
-;; @0048                               v6 = load.i64 notrap aligned can_move region2 v0+56
-;; @0048                               v7 = iadd v6, v2
-;; @0048                               v8 = load.i32 little region4 v7
+;; @0048                               v3 = load.i64 notrap aligned region3 v0+64
+;; @0048                               v4 = icmp ugt v2, v3
+;; @0048                               trapnz v4, heap_oob
+;; @0048                               v5 = load.i64 notrap aligned can_move region2 v0+56
+;; @0048                               v6 = iadd v5, v2
+;; @0048                               v7 = load.i32 little region4 v6
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:
-;; @004b                               return v8
+;; @004b                               return v7
 ;; }

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -56,16 +56,16 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0049                               v4 = load.i64 notrap aligned region3 v0+64
-;; @0049                               v5 = icmp ugt v2, v4
-;; @0049                               trapnz v5, heap_oob
-;; @0049                               v6 = load.i64 notrap aligned can_move region2 v0+56
-;; @0049                               v7 = iadd v6, v2
-;; @0049                               v8 = iconst.i64 4096
-;; @0049                               v9 = iadd v7, v8  ; v8 = 4096
-;; @0049                               v10 = load.i32 little region4 v9
+;; @0049                               v3 = load.i64 notrap aligned region3 v0+64
+;; @0049                               v4 = icmp ugt v2, v3
+;; @0049                               trapnz v4, heap_oob
+;; @0049                               v5 = load.i64 notrap aligned can_move region2 v0+56
+;; @0049                               v6 = iadd v5, v2
+;; @0049                               v7 = iconst.i64 4096
+;; @0049                               v8 = iadd v6, v7  ; v7 = 4096
+;; @0049                               v9 = load.i32 little region4 v8
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:
-;; @004d                               return v10
+;; @004d                               return v9
 ;; }

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -56,16 +56,16 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @004c                               v4 = load.i64 notrap aligned region3 v0+64
-;; @004c                               v5 = icmp ugt v2, v4
-;; @004c                               trapnz v5, heap_oob
-;; @004c                               v6 = load.i64 notrap aligned can_move region2 v0+56
-;; @004c                               v7 = iadd v6, v2
-;; @004c                               v8 = iconst.i64 0xffff_0000
-;; @004c                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
-;; @004c                               v10 = load.i32 little region4 v9
+;; @004c                               v3 = load.i64 notrap aligned region3 v0+64
+;; @004c                               v4 = icmp ugt v2, v3
+;; @004c                               trapnz v4, heap_oob
+;; @004c                               v5 = load.i64 notrap aligned can_move region2 v0+56
+;; @004c                               v6 = iadd v5, v2
+;; @004c                               v7 = iconst.i64 0xffff_0000
+;; @004c                               v8 = iadd v6, v7  ; v7 = 0xffff_0000
+;; @004c                               v9 = load.i32 little region4 v8
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:
-;; @0053                               return v10
+;; @0053                               return v9
 ;; }

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
@@ -54,14 +54,14 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0048                               v4 = load.i64 notrap aligned region3 v0+64
-;; @0048                               v5 = icmp uge v2, v4
-;; @0048                               trapnz v5, heap_oob
-;; @0048                               v6 = load.i64 notrap aligned can_move region2 v0+56
-;; @0048                               v7 = iadd v6, v2
-;; @0048                               v8 = uload8.i32 little region4 v7
+;; @0048                               v3 = load.i64 notrap aligned region3 v0+64
+;; @0048                               v4 = icmp uge v2, v3
+;; @0048                               trapnz v4, heap_oob
+;; @0048                               v5 = load.i64 notrap aligned can_move region2 v0+56
+;; @0048                               v6 = iadd v5, v2
+;; @0048                               v7 = uload8.i32 little region4 v6
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:
-;; @004b                               return v8
+;; @004b                               return v7
 ;; }

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -56,16 +56,16 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0049                               v4 = load.i64 notrap aligned region3 v0+64
-;; @0049                               v5 = icmp ugt v2, v4
-;; @0049                               trapnz v5, heap_oob
-;; @0049                               v6 = load.i64 notrap aligned can_move region2 v0+56
-;; @0049                               v7 = iadd v6, v2
-;; @0049                               v8 = iconst.i64 4096
-;; @0049                               v9 = iadd v7, v8  ; v8 = 4096
-;; @0049                               v10 = uload8.i32 little region4 v9
+;; @0049                               v3 = load.i64 notrap aligned region3 v0+64
+;; @0049                               v4 = icmp ugt v2, v3
+;; @0049                               trapnz v4, heap_oob
+;; @0049                               v5 = load.i64 notrap aligned can_move region2 v0+56
+;; @0049                               v6 = iadd v5, v2
+;; @0049                               v7 = iconst.i64 4096
+;; @0049                               v8 = iadd v6, v7  ; v7 = 4096
+;; @0049                               v9 = uload8.i32 little region4 v8
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:
-;; @004d                               return v10
+;; @004d                               return v9
 ;; }

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -56,16 +56,16 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @004c                               v4 = load.i64 notrap aligned region3 v0+64
-;; @004c                               v5 = icmp ugt v2, v4
-;; @004c                               trapnz v5, heap_oob
-;; @004c                               v6 = load.i64 notrap aligned can_move region2 v0+56
-;; @004c                               v7 = iadd v6, v2
-;; @004c                               v8 = iconst.i64 0xffff_0000
-;; @004c                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
-;; @004c                               v10 = uload8.i32 little region4 v9
+;; @004c                               v3 = load.i64 notrap aligned region3 v0+64
+;; @004c                               v4 = icmp ugt v2, v3
+;; @004c                               trapnz v4, heap_oob
+;; @004c                               v5 = load.i64 notrap aligned can_move region2 v0+56
+;; @004c                               v6 = iadd v5, v2
+;; @004c                               v7 = iconst.i64 0xffff_0000
+;; @004c                               v8 = iadd v6, v7  ; v7 = 0xffff_0000
+;; @004c                               v9 = uload8.i32 little region4 v8
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:
-;; @0053                               return v10
+;; @0053                               return v9
 ;; }

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
@@ -55,15 +55,15 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0048                               v4 = load.i64 notrap aligned region3 v0+64
-;; @0048                               v5 = icmp ugt v2, v4
-;; @0048                               v6 = load.i64 notrap aligned can_move region2 v0+56
-;; @0048                               v7 = iadd v6, v2
-;; @0048                               v8 = iconst.i64 0
-;; @0048                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0
-;; @0048                               v10 = load.i32 little region4 v9
+;; @0048                               v3 = load.i64 notrap aligned region3 v0+64
+;; @0048                               v4 = icmp ugt v2, v3
+;; @0048                               v5 = load.i64 notrap aligned can_move region2 v0+56
+;; @0048                               v6 = iadd v5, v2
+;; @0048                               v7 = iconst.i64 0
+;; @0048                               v8 = select_spectre_guard v4, v7, v6  ; v7 = 0
+;; @0048                               v9 = load.i32 little region4 v8
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:
-;; @004b                               return v10
+;; @004b                               return v9
 ;; }

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -57,17 +57,17 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0049                               v4 = load.i64 notrap aligned region3 v0+64
-;; @0049                               v5 = icmp ugt v2, v4
-;; @0049                               v6 = load.i64 notrap aligned can_move region2 v0+56
-;; @0049                               v7 = iadd v6, v2
-;; @0049                               v8 = iconst.i64 4096
-;; @0049                               v9 = iadd v7, v8  ; v8 = 4096
-;; @0049                               v10 = iconst.i64 0
-;; @0049                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
-;; @0049                               v12 = load.i32 little region4 v11
+;; @0049                               v3 = load.i64 notrap aligned region3 v0+64
+;; @0049                               v4 = icmp ugt v2, v3
+;; @0049                               v5 = load.i64 notrap aligned can_move region2 v0+56
+;; @0049                               v6 = iadd v5, v2
+;; @0049                               v7 = iconst.i64 4096
+;; @0049                               v8 = iadd v6, v7  ; v7 = 4096
+;; @0049                               v9 = iconst.i64 0
+;; @0049                               v10 = select_spectre_guard v4, v9, v8  ; v9 = 0
+;; @0049                               v11 = load.i32 little region4 v10
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:
-;; @004d                               return v12
+;; @004d                               return v11
 ;; }

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -57,17 +57,17 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @004c                               v4 = load.i64 notrap aligned region3 v0+64
-;; @004c                               v5 = icmp ugt v2, v4
-;; @004c                               v6 = load.i64 notrap aligned can_move region2 v0+56
-;; @004c                               v7 = iadd v6, v2
-;; @004c                               v8 = iconst.i64 0xffff_0000
-;; @004c                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
-;; @004c                               v10 = iconst.i64 0
-;; @004c                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
-;; @004c                               v12 = load.i32 little region4 v11
+;; @004c                               v3 = load.i64 notrap aligned region3 v0+64
+;; @004c                               v4 = icmp ugt v2, v3
+;; @004c                               v5 = load.i64 notrap aligned can_move region2 v0+56
+;; @004c                               v6 = iadd v5, v2
+;; @004c                               v7 = iconst.i64 0xffff_0000
+;; @004c                               v8 = iadd v6, v7  ; v7 = 0xffff_0000
+;; @004c                               v9 = iconst.i64 0
+;; @004c                               v10 = select_spectre_guard v4, v9, v8  ; v9 = 0
+;; @004c                               v11 = load.i32 little region4 v10
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:
-;; @0053                               return v12
+;; @0053                               return v11
 ;; }

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
@@ -55,15 +55,15 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0048                               v4 = load.i64 notrap aligned region3 v0+64
-;; @0048                               v5 = icmp uge v2, v4
-;; @0048                               v6 = load.i64 notrap aligned can_move region2 v0+56
-;; @0048                               v7 = iadd v6, v2
-;; @0048                               v8 = iconst.i64 0
-;; @0048                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0
-;; @0048                               v10 = uload8.i32 little region4 v9
+;; @0048                               v3 = load.i64 notrap aligned region3 v0+64
+;; @0048                               v4 = icmp uge v2, v3
+;; @0048                               v5 = load.i64 notrap aligned can_move region2 v0+56
+;; @0048                               v6 = iadd v5, v2
+;; @0048                               v7 = iconst.i64 0
+;; @0048                               v8 = select_spectre_guard v4, v7, v6  ; v7 = 0
+;; @0048                               v9 = uload8.i32 little region4 v8
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:
-;; @004b                               return v10
+;; @004b                               return v9
 ;; }

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -57,17 +57,17 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0049                               v4 = load.i64 notrap aligned region3 v0+64
-;; @0049                               v5 = icmp ugt v2, v4
-;; @0049                               v6 = load.i64 notrap aligned can_move region2 v0+56
-;; @0049                               v7 = iadd v6, v2
-;; @0049                               v8 = iconst.i64 4096
-;; @0049                               v9 = iadd v7, v8  ; v8 = 4096
-;; @0049                               v10 = iconst.i64 0
-;; @0049                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
-;; @0049                               v12 = uload8.i32 little region4 v11
+;; @0049                               v3 = load.i64 notrap aligned region3 v0+64
+;; @0049                               v4 = icmp ugt v2, v3
+;; @0049                               v5 = load.i64 notrap aligned can_move region2 v0+56
+;; @0049                               v6 = iadd v5, v2
+;; @0049                               v7 = iconst.i64 4096
+;; @0049                               v8 = iadd v6, v7  ; v7 = 4096
+;; @0049                               v9 = iconst.i64 0
+;; @0049                               v10 = select_spectre_guard v4, v9, v8  ; v9 = 0
+;; @0049                               v11 = uload8.i32 little region4 v10
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:
-;; @004d                               return v12
+;; @004d                               return v11
 ;; }

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -57,17 +57,17 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @004c                               v4 = load.i64 notrap aligned region3 v0+64
-;; @004c                               v5 = icmp ugt v2, v4
-;; @004c                               v6 = load.i64 notrap aligned can_move region2 v0+56
-;; @004c                               v7 = iadd v6, v2
-;; @004c                               v8 = iconst.i64 0xffff_0000
-;; @004c                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
-;; @004c                               v10 = iconst.i64 0
-;; @004c                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
-;; @004c                               v12 = uload8.i32 little region4 v11
+;; @004c                               v3 = load.i64 notrap aligned region3 v0+64
+;; @004c                               v4 = icmp ugt v2, v3
+;; @004c                               v5 = load.i64 notrap aligned can_move region2 v0+56
+;; @004c                               v6 = iadd v5, v2
+;; @004c                               v7 = iconst.i64 0xffff_0000
+;; @004c                               v8 = iadd v6, v7  ; v7 = 0xffff_0000
+;; @004c                               v9 = iconst.i64 0
+;; @004c                               v10 = select_spectre_guard v4, v9, v8  ; v9 = 0
+;; @004c                               v11 = uload8.i32 little region4 v10
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:
-;; @0053                               return v12
+;; @0053                               return v11
 ;; }

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0_offset.wat
@@ -55,15 +55,15 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0048                               v4 = uextend.i64 v2
-;; @0048                               v5 = iconst.i64 0xffff_fffc
-;; @0048                               v6 = icmp ugt v4, v5  ; v5 = 0xffff_fffc
-;; @0048                               trapnz v6, heap_oob
-;; @0048                               v7 = load.i64 notrap aligned readonly can_move region2 v0+56
-;; @0048                               v8 = iadd v7, v4
-;; @0048                               v9 = load.i32 little region4 v8
+;; @0048                               v3 = uextend.i64 v2
+;; @0048                               v4 = iconst.i64 0xffff_fffc
+;; @0048                               v5 = icmp ugt v3, v4  ; v4 = 0xffff_fffc
+;; @0048                               trapnz v5, heap_oob
+;; @0048                               v6 = load.i64 notrap aligned readonly can_move region2 v0+56
+;; @0048                               v7 = iadd v6, v3
+;; @0048                               v8 = load.i32 little region4 v7
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:
-;; @004b                               return v9
+;; @004b                               return v8
 ;; }

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -57,17 +57,17 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0049                               v4 = uextend.i64 v2
-;; @0049                               v5 = iconst.i64 0xffff_effc
-;; @0049                               v6 = icmp ugt v4, v5  ; v5 = 0xffff_effc
-;; @0049                               trapnz v6, heap_oob
-;; @0049                               v7 = load.i64 notrap aligned readonly can_move region2 v0+56
-;; @0049                               v8 = iadd v7, v4
-;; @0049                               v9 = iconst.i64 4096
-;; @0049                               v10 = iadd v8, v9  ; v9 = 4096
-;; @0049                               v11 = load.i32 little region4 v10
+;; @0049                               v3 = uextend.i64 v2
+;; @0049                               v4 = iconst.i64 0xffff_effc
+;; @0049                               v5 = icmp ugt v3, v4  ; v4 = 0xffff_effc
+;; @0049                               trapnz v5, heap_oob
+;; @0049                               v6 = load.i64 notrap aligned readonly can_move region2 v0+56
+;; @0049                               v7 = iadd v6, v3
+;; @0049                               v8 = iconst.i64 4096
+;; @0049                               v9 = iadd v7, v8  ; v8 = 4096
+;; @0049                               v10 = load.i32 little region4 v9
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:
-;; @004d                               return v11
+;; @004d                               return v10
 ;; }

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -57,17 +57,17 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @004c                               v4 = uextend.i64 v2
-;; @004c                               v5 = iconst.i64 0xfffc
-;; @004c                               v6 = icmp ugt v4, v5  ; v5 = 0xfffc
-;; @004c                               trapnz v6, heap_oob
-;; @004c                               v7 = load.i64 notrap aligned readonly can_move region2 v0+56
-;; @004c                               v8 = iadd v7, v4
-;; @004c                               v9 = iconst.i64 0xffff_0000
-;; @004c                               v10 = iadd v8, v9  ; v9 = 0xffff_0000
-;; @004c                               v11 = load.i32 little region4 v10
+;; @004c                               v3 = uextend.i64 v2
+;; @004c                               v4 = iconst.i64 0xfffc
+;; @004c                               v5 = icmp ugt v3, v4  ; v4 = 0xfffc
+;; @004c                               trapnz v5, heap_oob
+;; @004c                               v6 = load.i64 notrap aligned readonly can_move region2 v0+56
+;; @004c                               v7 = iadd v6, v3
+;; @004c                               v8 = iconst.i64 0xffff_0000
+;; @004c                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
+;; @004c                               v10 = load.i32 little region4 v9
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:
-;; @0053                               return v11
+;; @0053                               return v10
 ;; }

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0_offset.wat
@@ -52,12 +52,12 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0048                               v4 = uextend.i64 v2
-;; @0048                               v5 = load.i64 notrap aligned readonly can_move region2 v0+56
-;; @0048                               v6 = iadd v5, v4
-;; @0048                               v7 = uload8.i32 little region4 v6
+;; @0048                               v3 = uextend.i64 v2
+;; @0048                               v4 = load.i64 notrap aligned readonly can_move region2 v0+56
+;; @0048                               v5 = iadd v4, v3
+;; @0048                               v6 = uload8.i32 little region4 v5
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:
-;; @004b                               return v7
+;; @004b                               return v6
 ;; }

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -57,17 +57,17 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0049                               v4 = uextend.i64 v2
-;; @0049                               v5 = iconst.i64 0xffff_efff
-;; @0049                               v6 = icmp ugt v4, v5  ; v5 = 0xffff_efff
-;; @0049                               trapnz v6, heap_oob
-;; @0049                               v7 = load.i64 notrap aligned readonly can_move region2 v0+56
-;; @0049                               v8 = iadd v7, v4
-;; @0049                               v9 = iconst.i64 4096
-;; @0049                               v10 = iadd v8, v9  ; v9 = 4096
-;; @0049                               v11 = uload8.i32 little region4 v10
+;; @0049                               v3 = uextend.i64 v2
+;; @0049                               v4 = iconst.i64 0xffff_efff
+;; @0049                               v5 = icmp ugt v3, v4  ; v4 = 0xffff_efff
+;; @0049                               trapnz v5, heap_oob
+;; @0049                               v6 = load.i64 notrap aligned readonly can_move region2 v0+56
+;; @0049                               v7 = iadd v6, v3
+;; @0049                               v8 = iconst.i64 4096
+;; @0049                               v9 = iadd v7, v8  ; v8 = 4096
+;; @0049                               v10 = uload8.i32 little region4 v9
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:
-;; @004d                               return v11
+;; @004d                               return v10
 ;; }

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -57,17 +57,17 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @004c                               v4 = uextend.i64 v2
-;; @004c                               v5 = iconst.i64 0xffff
-;; @004c                               v6 = icmp ugt v4, v5  ; v5 = 0xffff
-;; @004c                               trapnz v6, heap_oob
-;; @004c                               v7 = load.i64 notrap aligned readonly can_move region2 v0+56
-;; @004c                               v8 = iadd v7, v4
-;; @004c                               v9 = iconst.i64 0xffff_0000
-;; @004c                               v10 = iadd v8, v9  ; v9 = 0xffff_0000
-;; @004c                               v11 = uload8.i32 little region4 v10
+;; @004c                               v3 = uextend.i64 v2
+;; @004c                               v4 = iconst.i64 0xffff
+;; @004c                               v5 = icmp ugt v3, v4  ; v4 = 0xffff
+;; @004c                               trapnz v5, heap_oob
+;; @004c                               v6 = load.i64 notrap aligned readonly can_move region2 v0+56
+;; @004c                               v7 = iadd v6, v3
+;; @004c                               v8 = iconst.i64 0xffff_0000
+;; @004c                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
+;; @004c                               v10 = uload8.i32 little region4 v9
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:
-;; @0053                               return v11
+;; @0053                               return v10
 ;; }

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0_offset.wat
@@ -56,16 +56,16 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0048                               v4 = uextend.i64 v2
-;; @0048                               v5 = iconst.i64 0xffff_fffc
-;; @0048                               v6 = icmp ugt v4, v5  ; v5 = 0xffff_fffc
-;; @0048                               v7 = load.i64 notrap aligned readonly can_move region2 v0+56
-;; @0048                               v8 = iadd v7, v4
-;; @0048                               v9 = iconst.i64 0
-;; @0048                               v10 = select_spectre_guard v6, v9, v8  ; v9 = 0
-;; @0048                               v11 = load.i32 little region4 v10
+;; @0048                               v3 = uextend.i64 v2
+;; @0048                               v4 = iconst.i64 0xffff_fffc
+;; @0048                               v5 = icmp ugt v3, v4  ; v4 = 0xffff_fffc
+;; @0048                               v6 = load.i64 notrap aligned readonly can_move region2 v0+56
+;; @0048                               v7 = iadd v6, v3
+;; @0048                               v8 = iconst.i64 0
+;; @0048                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0
+;; @0048                               v10 = load.i32 little region4 v9
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:
-;; @004b                               return v11
+;; @004b                               return v10
 ;; }

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -58,18 +58,18 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0049                               v4 = uextend.i64 v2
-;; @0049                               v5 = iconst.i64 0xffff_effc
-;; @0049                               v6 = icmp ugt v4, v5  ; v5 = 0xffff_effc
-;; @0049                               v7 = load.i64 notrap aligned readonly can_move region2 v0+56
-;; @0049                               v8 = iadd v7, v4
-;; @0049                               v9 = iconst.i64 4096
-;; @0049                               v10 = iadd v8, v9  ; v9 = 4096
-;; @0049                               v11 = iconst.i64 0
-;; @0049                               v12 = select_spectre_guard v6, v11, v10  ; v11 = 0
-;; @0049                               v13 = load.i32 little region4 v12
+;; @0049                               v3 = uextend.i64 v2
+;; @0049                               v4 = iconst.i64 0xffff_effc
+;; @0049                               v5 = icmp ugt v3, v4  ; v4 = 0xffff_effc
+;; @0049                               v6 = load.i64 notrap aligned readonly can_move region2 v0+56
+;; @0049                               v7 = iadd v6, v3
+;; @0049                               v8 = iconst.i64 4096
+;; @0049                               v9 = iadd v7, v8  ; v8 = 4096
+;; @0049                               v10 = iconst.i64 0
+;; @0049                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
+;; @0049                               v12 = load.i32 little region4 v11
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:
-;; @004d                               return v13
+;; @004d                               return v12
 ;; }

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -58,18 +58,18 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @004c                               v4 = uextend.i64 v2
-;; @004c                               v5 = iconst.i64 0xfffc
-;; @004c                               v6 = icmp ugt v4, v5  ; v5 = 0xfffc
-;; @004c                               v7 = load.i64 notrap aligned readonly can_move region2 v0+56
-;; @004c                               v8 = iadd v7, v4
-;; @004c                               v9 = iconst.i64 0xffff_0000
-;; @004c                               v10 = iadd v8, v9  ; v9 = 0xffff_0000
-;; @004c                               v11 = iconst.i64 0
-;; @004c                               v12 = select_spectre_guard v6, v11, v10  ; v11 = 0
-;; @004c                               v13 = load.i32 little region4 v12
+;; @004c                               v3 = uextend.i64 v2
+;; @004c                               v4 = iconst.i64 0xfffc
+;; @004c                               v5 = icmp ugt v3, v4  ; v4 = 0xfffc
+;; @004c                               v6 = load.i64 notrap aligned readonly can_move region2 v0+56
+;; @004c                               v7 = iadd v6, v3
+;; @004c                               v8 = iconst.i64 0xffff_0000
+;; @004c                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
+;; @004c                               v10 = iconst.i64 0
+;; @004c                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
+;; @004c                               v12 = load.i32 little region4 v11
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:
-;; @0053                               return v13
+;; @0053                               return v12
 ;; }

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i8_access_0_offset.wat
@@ -52,12 +52,12 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0048                               v4 = uextend.i64 v2
-;; @0048                               v5 = load.i64 notrap aligned readonly can_move region2 v0+56
-;; @0048                               v6 = iadd v5, v4
-;; @0048                               v7 = uload8.i32 little region4 v6
+;; @0048                               v3 = uextend.i64 v2
+;; @0048                               v4 = load.i64 notrap aligned readonly can_move region2 v0+56
+;; @0048                               v5 = iadd v4, v3
+;; @0048                               v6 = uload8.i32 little region4 v5
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:
-;; @004b                               return v7
+;; @004b                               return v6
 ;; }

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -58,18 +58,18 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0049                               v4 = uextend.i64 v2
-;; @0049                               v5 = iconst.i64 0xffff_efff
-;; @0049                               v6 = icmp ugt v4, v5  ; v5 = 0xffff_efff
-;; @0049                               v7 = load.i64 notrap aligned readonly can_move region2 v0+56
-;; @0049                               v8 = iadd v7, v4
-;; @0049                               v9 = iconst.i64 4096
-;; @0049                               v10 = iadd v8, v9  ; v9 = 4096
-;; @0049                               v11 = iconst.i64 0
-;; @0049                               v12 = select_spectre_guard v6, v11, v10  ; v11 = 0
-;; @0049                               v13 = uload8.i32 little region4 v12
+;; @0049                               v3 = uextend.i64 v2
+;; @0049                               v4 = iconst.i64 0xffff_efff
+;; @0049                               v5 = icmp ugt v3, v4  ; v4 = 0xffff_efff
+;; @0049                               v6 = load.i64 notrap aligned readonly can_move region2 v0+56
+;; @0049                               v7 = iadd v6, v3
+;; @0049                               v8 = iconst.i64 4096
+;; @0049                               v9 = iadd v7, v8  ; v8 = 4096
+;; @0049                               v10 = iconst.i64 0
+;; @0049                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
+;; @0049                               v12 = uload8.i32 little region4 v11
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:
-;; @004d                               return v13
+;; @004d                               return v12
 ;; }

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -58,18 +58,18 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @004c                               v4 = uextend.i64 v2
-;; @004c                               v5 = iconst.i64 0xffff
-;; @004c                               v6 = icmp ugt v4, v5  ; v5 = 0xffff
-;; @004c                               v7 = load.i64 notrap aligned readonly can_move region2 v0+56
-;; @004c                               v8 = iadd v7, v4
-;; @004c                               v9 = iconst.i64 0xffff_0000
-;; @004c                               v10 = iadd v8, v9  ; v9 = 0xffff_0000
-;; @004c                               v11 = iconst.i64 0
-;; @004c                               v12 = select_spectre_guard v6, v11, v10  ; v11 = 0
-;; @004c                               v13 = uload8.i32 little region4 v12
+;; @004c                               v3 = uextend.i64 v2
+;; @004c                               v4 = iconst.i64 0xffff
+;; @004c                               v5 = icmp ugt v3, v4  ; v4 = 0xffff
+;; @004c                               v6 = load.i64 notrap aligned readonly can_move region2 v0+56
+;; @004c                               v7 = iadd v6, v3
+;; @004c                               v8 = iconst.i64 0xffff_0000
+;; @004c                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
+;; @004c                               v10 = iconst.i64 0
+;; @004c                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
+;; @004c                               v12 = uload8.i32 little region4 v11
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:
-;; @0053                               return v13
+;; @0053                               return v12
 ;; }

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
@@ -52,12 +52,12 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0048                               v4 = uextend.i64 v2
-;; @0048                               v5 = load.i64 notrap aligned readonly can_move region2 v0+56
-;; @0048                               v6 = iadd v5, v4
-;; @0048                               v7 = load.i32 little region4 v6
+;; @0048                               v3 = uextend.i64 v2
+;; @0048                               v4 = load.i64 notrap aligned readonly can_move region2 v0+56
+;; @0048                               v5 = iadd v4, v3
+;; @0048                               v6 = load.i32 little region4 v5
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:
-;; @004b                               return v7
+;; @004b                               return v6
 ;; }

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -54,14 +54,14 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0049                               v4 = uextend.i64 v2
-;; @0049                               v5 = load.i64 notrap aligned readonly can_move region2 v0+56
-;; @0049                               v6 = iadd v5, v4
-;; @0049                               v7 = iconst.i64 4096
-;; @0049                               v8 = iadd v6, v7  ; v7 = 4096
-;; @0049                               v9 = load.i32 little region4 v8
+;; @0049                               v3 = uextend.i64 v2
+;; @0049                               v4 = load.i64 notrap aligned readonly can_move region2 v0+56
+;; @0049                               v5 = iadd v4, v3
+;; @0049                               v6 = iconst.i64 4096
+;; @0049                               v7 = iadd v5, v6  ; v6 = 4096
+;; @0049                               v8 = load.i32 little region4 v7
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:
-;; @004d                               return v9
+;; @004d                               return v8
 ;; }

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -54,14 +54,14 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @004c                               v4 = uextend.i64 v2
-;; @004c                               v5 = load.i64 notrap aligned readonly can_move region2 v0+56
-;; @004c                               v6 = iadd v5, v4
-;; @004c                               v7 = iconst.i64 0xffff_0000
-;; @004c                               v8 = iadd v6, v7  ; v7 = 0xffff_0000
-;; @004c                               v9 = load.i32 little region4 v8
+;; @004c                               v3 = uextend.i64 v2
+;; @004c                               v4 = load.i64 notrap aligned readonly can_move region2 v0+56
+;; @004c                               v5 = iadd v4, v3
+;; @004c                               v6 = iconst.i64 0xffff_0000
+;; @004c                               v7 = iadd v5, v6  ; v6 = 0xffff_0000
+;; @004c                               v8 = load.i32 little region4 v7
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:
-;; @0053                               return v9
+;; @0053                               return v8
 ;; }

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
@@ -52,12 +52,12 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0048                               v4 = uextend.i64 v2
-;; @0048                               v5 = load.i64 notrap aligned readonly can_move region2 v0+56
-;; @0048                               v6 = iadd v5, v4
-;; @0048                               v7 = uload8.i32 little region4 v6
+;; @0048                               v3 = uextend.i64 v2
+;; @0048                               v4 = load.i64 notrap aligned readonly can_move region2 v0+56
+;; @0048                               v5 = iadd v4, v3
+;; @0048                               v6 = uload8.i32 little region4 v5
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:
-;; @004b                               return v7
+;; @004b                               return v6
 ;; }

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -54,14 +54,14 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0049                               v4 = uextend.i64 v2
-;; @0049                               v5 = load.i64 notrap aligned readonly can_move region2 v0+56
-;; @0049                               v6 = iadd v5, v4
-;; @0049                               v7 = iconst.i64 4096
-;; @0049                               v8 = iadd v6, v7  ; v7 = 4096
-;; @0049                               v9 = uload8.i32 little region4 v8
+;; @0049                               v3 = uextend.i64 v2
+;; @0049                               v4 = load.i64 notrap aligned readonly can_move region2 v0+56
+;; @0049                               v5 = iadd v4, v3
+;; @0049                               v6 = iconst.i64 4096
+;; @0049                               v7 = iadd v5, v6  ; v6 = 4096
+;; @0049                               v8 = uload8.i32 little region4 v7
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:
-;; @004d                               return v9
+;; @004d                               return v8
 ;; }

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -54,14 +54,14 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @004c                               v4 = uextend.i64 v2
-;; @004c                               v5 = load.i64 notrap aligned readonly can_move region2 v0+56
-;; @004c                               v6 = iadd v5, v4
-;; @004c                               v7 = iconst.i64 0xffff_0000
-;; @004c                               v8 = iadd v6, v7  ; v7 = 0xffff_0000
-;; @004c                               v9 = uload8.i32 little region4 v8
+;; @004c                               v3 = uextend.i64 v2
+;; @004c                               v4 = load.i64 notrap aligned readonly can_move region2 v0+56
+;; @004c                               v5 = iadd v4, v3
+;; @004c                               v6 = iconst.i64 0xffff_0000
+;; @004c                               v7 = iadd v5, v6  ; v6 = 0xffff_0000
+;; @004c                               v8 = uload8.i32 little region4 v7
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:
-;; @0053                               return v9
+;; @0053                               return v8
 ;; }

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
@@ -52,12 +52,12 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0048                               v4 = uextend.i64 v2
-;; @0048                               v5 = load.i64 notrap aligned readonly can_move region2 v0+56
-;; @0048                               v6 = iadd v5, v4
-;; @0048                               v7 = load.i32 little region4 v6
+;; @0048                               v3 = uextend.i64 v2
+;; @0048                               v4 = load.i64 notrap aligned readonly can_move region2 v0+56
+;; @0048                               v5 = iadd v4, v3
+;; @0048                               v6 = load.i32 little region4 v5
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:
-;; @004b                               return v7
+;; @004b                               return v6
 ;; }

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -54,14 +54,14 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0049                               v4 = uextend.i64 v2
-;; @0049                               v5 = load.i64 notrap aligned readonly can_move region2 v0+56
-;; @0049                               v6 = iadd v5, v4
-;; @0049                               v7 = iconst.i64 4096
-;; @0049                               v8 = iadd v6, v7  ; v7 = 4096
-;; @0049                               v9 = load.i32 little region4 v8
+;; @0049                               v3 = uextend.i64 v2
+;; @0049                               v4 = load.i64 notrap aligned readonly can_move region2 v0+56
+;; @0049                               v5 = iadd v4, v3
+;; @0049                               v6 = iconst.i64 4096
+;; @0049                               v7 = iadd v5, v6  ; v6 = 4096
+;; @0049                               v8 = load.i32 little region4 v7
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:
-;; @004d                               return v9
+;; @004d                               return v8
 ;; }

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -54,14 +54,14 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @004c                               v4 = uextend.i64 v2
-;; @004c                               v5 = load.i64 notrap aligned readonly can_move region2 v0+56
-;; @004c                               v6 = iadd v5, v4
-;; @004c                               v7 = iconst.i64 0xffff_0000
-;; @004c                               v8 = iadd v6, v7  ; v7 = 0xffff_0000
-;; @004c                               v9 = load.i32 little region4 v8
+;; @004c                               v3 = uextend.i64 v2
+;; @004c                               v4 = load.i64 notrap aligned readonly can_move region2 v0+56
+;; @004c                               v5 = iadd v4, v3
+;; @004c                               v6 = iconst.i64 0xffff_0000
+;; @004c                               v7 = iadd v5, v6  ; v6 = 0xffff_0000
+;; @004c                               v8 = load.i32 little region4 v7
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:
-;; @0053                               return v9
+;; @0053                               return v8
 ;; }

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
@@ -52,12 +52,12 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0048                               v4 = uextend.i64 v2
-;; @0048                               v5 = load.i64 notrap aligned readonly can_move region2 v0+56
-;; @0048                               v6 = iadd v5, v4
-;; @0048                               v7 = uload8.i32 little region4 v6
+;; @0048                               v3 = uextend.i64 v2
+;; @0048                               v4 = load.i64 notrap aligned readonly can_move region2 v0+56
+;; @0048                               v5 = iadd v4, v3
+;; @0048                               v6 = uload8.i32 little region4 v5
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:
-;; @004b                               return v7
+;; @004b                               return v6
 ;; }

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -54,14 +54,14 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0049                               v4 = uextend.i64 v2
-;; @0049                               v5 = load.i64 notrap aligned readonly can_move region2 v0+56
-;; @0049                               v6 = iadd v5, v4
-;; @0049                               v7 = iconst.i64 4096
-;; @0049                               v8 = iadd v6, v7  ; v7 = 4096
-;; @0049                               v9 = uload8.i32 little region4 v8
+;; @0049                               v3 = uextend.i64 v2
+;; @0049                               v4 = load.i64 notrap aligned readonly can_move region2 v0+56
+;; @0049                               v5 = iadd v4, v3
+;; @0049                               v6 = iconst.i64 4096
+;; @0049                               v7 = iadd v5, v6  ; v6 = 4096
+;; @0049                               v8 = uload8.i32 little region4 v7
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:
-;; @004d                               return v9
+;; @004d                               return v8
 ;; }

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -54,14 +54,14 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @004c                               v4 = uextend.i64 v2
-;; @004c                               v5 = load.i64 notrap aligned readonly can_move region2 v0+56
-;; @004c                               v6 = iadd v5, v4
-;; @004c                               v7 = iconst.i64 0xffff_0000
-;; @004c                               v8 = iadd v6, v7  ; v7 = 0xffff_0000
-;; @004c                               v9 = uload8.i32 little region4 v8
+;; @004c                               v3 = uextend.i64 v2
+;; @004c                               v4 = load.i64 notrap aligned readonly can_move region2 v0+56
+;; @004c                               v5 = iadd v4, v3
+;; @004c                               v6 = iconst.i64 0xffff_0000
+;; @004c                               v7 = iadd v5, v6  ; v6 = 0xffff_0000
+;; @004c                               v8 = uload8.i32 little region4 v7
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:
-;; @0053                               return v9
+;; @0053                               return v8
 ;; }

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0_offset.wat
@@ -54,14 +54,14 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0048                               v4 = iconst.i64 0xffff_fffc
-;; @0048                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_fffc
-;; @0048                               trapnz v5, heap_oob
-;; @0048                               v6 = load.i64 notrap aligned readonly can_move region2 v0+56
-;; @0048                               v7 = iadd v6, v2
-;; @0048                               v8 = load.i32 little region4 v7
+;; @0048                               v3 = iconst.i64 0xffff_fffc
+;; @0048                               v4 = icmp ugt v2, v3  ; v3 = 0xffff_fffc
+;; @0048                               trapnz v4, heap_oob
+;; @0048                               v5 = load.i64 notrap aligned readonly can_move region2 v0+56
+;; @0048                               v6 = iadd v5, v2
+;; @0048                               v7 = load.i32 little region4 v6
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:
-;; @004b                               return v8
+;; @004b                               return v7
 ;; }

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -56,16 +56,16 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0049                               v4 = iconst.i64 0xffff_effc
-;; @0049                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_effc
-;; @0049                               trapnz v5, heap_oob
-;; @0049                               v6 = load.i64 notrap aligned readonly can_move region2 v0+56
-;; @0049                               v7 = iadd v6, v2
-;; @0049                               v8 = iconst.i64 4096
-;; @0049                               v9 = iadd v7, v8  ; v8 = 4096
-;; @0049                               v10 = load.i32 little region4 v9
+;; @0049                               v3 = iconst.i64 0xffff_effc
+;; @0049                               v4 = icmp ugt v2, v3  ; v3 = 0xffff_effc
+;; @0049                               trapnz v4, heap_oob
+;; @0049                               v5 = load.i64 notrap aligned readonly can_move region2 v0+56
+;; @0049                               v6 = iadd v5, v2
+;; @0049                               v7 = iconst.i64 4096
+;; @0049                               v8 = iadd v6, v7  ; v7 = 4096
+;; @0049                               v9 = load.i32 little region4 v8
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:
-;; @004d                               return v10
+;; @004d                               return v9
 ;; }

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -56,16 +56,16 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @004c                               v4 = iconst.i64 0xfffc
-;; @004c                               v5 = icmp ugt v2, v4  ; v4 = 0xfffc
-;; @004c                               trapnz v5, heap_oob
-;; @004c                               v6 = load.i64 notrap aligned readonly can_move region2 v0+56
-;; @004c                               v7 = iadd v6, v2
-;; @004c                               v8 = iconst.i64 0xffff_0000
-;; @004c                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
-;; @004c                               v10 = load.i32 little region4 v9
+;; @004c                               v3 = iconst.i64 0xfffc
+;; @004c                               v4 = icmp ugt v2, v3  ; v3 = 0xfffc
+;; @004c                               trapnz v4, heap_oob
+;; @004c                               v5 = load.i64 notrap aligned readonly can_move region2 v0+56
+;; @004c                               v6 = iadd v5, v2
+;; @004c                               v7 = iconst.i64 0xffff_0000
+;; @004c                               v8 = iadd v6, v7  ; v7 = 0xffff_0000
+;; @004c                               v9 = load.i32 little region4 v8
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:
-;; @0053                               return v10
+;; @0053                               return v9
 ;; }

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0_offset.wat
@@ -54,14 +54,14 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0048                               v4 = iconst.i64 0xffff_ffff
-;; @0048                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_ffff
-;; @0048                               trapnz v5, heap_oob
-;; @0048                               v6 = load.i64 notrap aligned readonly can_move region2 v0+56
-;; @0048                               v7 = iadd v6, v2
-;; @0048                               v8 = uload8.i32 little region4 v7
+;; @0048                               v3 = iconst.i64 0xffff_ffff
+;; @0048                               v4 = icmp ugt v2, v3  ; v3 = 0xffff_ffff
+;; @0048                               trapnz v4, heap_oob
+;; @0048                               v5 = load.i64 notrap aligned readonly can_move region2 v0+56
+;; @0048                               v6 = iadd v5, v2
+;; @0048                               v7 = uload8.i32 little region4 v6
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:
-;; @004b                               return v8
+;; @004b                               return v7
 ;; }

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -56,16 +56,16 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0049                               v4 = iconst.i64 0xffff_efff
-;; @0049                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_efff
-;; @0049                               trapnz v5, heap_oob
-;; @0049                               v6 = load.i64 notrap aligned readonly can_move region2 v0+56
-;; @0049                               v7 = iadd v6, v2
-;; @0049                               v8 = iconst.i64 4096
-;; @0049                               v9 = iadd v7, v8  ; v8 = 4096
-;; @0049                               v10 = uload8.i32 little region4 v9
+;; @0049                               v3 = iconst.i64 0xffff_efff
+;; @0049                               v4 = icmp ugt v2, v3  ; v3 = 0xffff_efff
+;; @0049                               trapnz v4, heap_oob
+;; @0049                               v5 = load.i64 notrap aligned readonly can_move region2 v0+56
+;; @0049                               v6 = iadd v5, v2
+;; @0049                               v7 = iconst.i64 4096
+;; @0049                               v8 = iadd v6, v7  ; v7 = 4096
+;; @0049                               v9 = uload8.i32 little region4 v8
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:
-;; @004d                               return v10
+;; @004d                               return v9
 ;; }

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -56,16 +56,16 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @004c                               v4 = iconst.i64 0xffff
-;; @004c                               v5 = icmp ugt v2, v4  ; v4 = 0xffff
-;; @004c                               trapnz v5, heap_oob
-;; @004c                               v6 = load.i64 notrap aligned readonly can_move region2 v0+56
-;; @004c                               v7 = iadd v6, v2
-;; @004c                               v8 = iconst.i64 0xffff_0000
-;; @004c                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
-;; @004c                               v10 = uload8.i32 little region4 v9
+;; @004c                               v3 = iconst.i64 0xffff
+;; @004c                               v4 = icmp ugt v2, v3  ; v3 = 0xffff
+;; @004c                               trapnz v4, heap_oob
+;; @004c                               v5 = load.i64 notrap aligned readonly can_move region2 v0+56
+;; @004c                               v6 = iadd v5, v2
+;; @004c                               v7 = iconst.i64 0xffff_0000
+;; @004c                               v8 = iadd v6, v7  ; v7 = 0xffff_0000
+;; @004c                               v9 = uload8.i32 little region4 v8
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:
-;; @0053                               return v10
+;; @0053                               return v9
 ;; }

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0_offset.wat
@@ -55,15 +55,15 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0048                               v4 = iconst.i64 0xffff_fffc
-;; @0048                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_fffc
-;; @0048                               v6 = load.i64 notrap aligned readonly can_move region2 v0+56
-;; @0048                               v7 = iadd v6, v2
-;; @0048                               v8 = iconst.i64 0
-;; @0048                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0
-;; @0048                               v10 = load.i32 little region4 v9
+;; @0048                               v3 = iconst.i64 0xffff_fffc
+;; @0048                               v4 = icmp ugt v2, v3  ; v3 = 0xffff_fffc
+;; @0048                               v5 = load.i64 notrap aligned readonly can_move region2 v0+56
+;; @0048                               v6 = iadd v5, v2
+;; @0048                               v7 = iconst.i64 0
+;; @0048                               v8 = select_spectre_guard v4, v7, v6  ; v7 = 0
+;; @0048                               v9 = load.i32 little region4 v8
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:
-;; @004b                               return v10
+;; @004b                               return v9
 ;; }

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -57,17 +57,17 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0049                               v4 = iconst.i64 0xffff_effc
-;; @0049                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_effc
-;; @0049                               v6 = load.i64 notrap aligned readonly can_move region2 v0+56
-;; @0049                               v7 = iadd v6, v2
-;; @0049                               v8 = iconst.i64 4096
-;; @0049                               v9 = iadd v7, v8  ; v8 = 4096
-;; @0049                               v10 = iconst.i64 0
-;; @0049                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
-;; @0049                               v12 = load.i32 little region4 v11
+;; @0049                               v3 = iconst.i64 0xffff_effc
+;; @0049                               v4 = icmp ugt v2, v3  ; v3 = 0xffff_effc
+;; @0049                               v5 = load.i64 notrap aligned readonly can_move region2 v0+56
+;; @0049                               v6 = iadd v5, v2
+;; @0049                               v7 = iconst.i64 4096
+;; @0049                               v8 = iadd v6, v7  ; v7 = 4096
+;; @0049                               v9 = iconst.i64 0
+;; @0049                               v10 = select_spectre_guard v4, v9, v8  ; v9 = 0
+;; @0049                               v11 = load.i32 little region4 v10
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:
-;; @004d                               return v12
+;; @004d                               return v11
 ;; }

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -57,17 +57,17 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @004c                               v4 = iconst.i64 0xfffc
-;; @004c                               v5 = icmp ugt v2, v4  ; v4 = 0xfffc
-;; @004c                               v6 = load.i64 notrap aligned readonly can_move region2 v0+56
-;; @004c                               v7 = iadd v6, v2
-;; @004c                               v8 = iconst.i64 0xffff_0000
-;; @004c                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
-;; @004c                               v10 = iconst.i64 0
-;; @004c                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
-;; @004c                               v12 = load.i32 little region4 v11
+;; @004c                               v3 = iconst.i64 0xfffc
+;; @004c                               v4 = icmp ugt v2, v3  ; v3 = 0xfffc
+;; @004c                               v5 = load.i64 notrap aligned readonly can_move region2 v0+56
+;; @004c                               v6 = iadd v5, v2
+;; @004c                               v7 = iconst.i64 0xffff_0000
+;; @004c                               v8 = iadd v6, v7  ; v7 = 0xffff_0000
+;; @004c                               v9 = iconst.i64 0
+;; @004c                               v10 = select_spectre_guard v4, v9, v8  ; v9 = 0
+;; @004c                               v11 = load.i32 little region4 v10
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:
-;; @0053                               return v12
+;; @0053                               return v11
 ;; }

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0_offset.wat
@@ -55,15 +55,15 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0048                               v4 = iconst.i64 0xffff_ffff
-;; @0048                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_ffff
-;; @0048                               v6 = load.i64 notrap aligned readonly can_move region2 v0+56
-;; @0048                               v7 = iadd v6, v2
-;; @0048                               v8 = iconst.i64 0
-;; @0048                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0
-;; @0048                               v10 = uload8.i32 little region4 v9
+;; @0048                               v3 = iconst.i64 0xffff_ffff
+;; @0048                               v4 = icmp ugt v2, v3  ; v3 = 0xffff_ffff
+;; @0048                               v5 = load.i64 notrap aligned readonly can_move region2 v0+56
+;; @0048                               v6 = iadd v5, v2
+;; @0048                               v7 = iconst.i64 0
+;; @0048                               v8 = select_spectre_guard v4, v7, v6  ; v7 = 0
+;; @0048                               v9 = uload8.i32 little region4 v8
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:
-;; @004b                               return v10
+;; @004b                               return v9
 ;; }

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -57,17 +57,17 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0049                               v4 = iconst.i64 0xffff_efff
-;; @0049                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_efff
-;; @0049                               v6 = load.i64 notrap aligned readonly can_move region2 v0+56
-;; @0049                               v7 = iadd v6, v2
-;; @0049                               v8 = iconst.i64 4096
-;; @0049                               v9 = iadd v7, v8  ; v8 = 4096
-;; @0049                               v10 = iconst.i64 0
-;; @0049                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
-;; @0049                               v12 = uload8.i32 little region4 v11
+;; @0049                               v3 = iconst.i64 0xffff_efff
+;; @0049                               v4 = icmp ugt v2, v3  ; v3 = 0xffff_efff
+;; @0049                               v5 = load.i64 notrap aligned readonly can_move region2 v0+56
+;; @0049                               v6 = iadd v5, v2
+;; @0049                               v7 = iconst.i64 4096
+;; @0049                               v8 = iadd v6, v7  ; v7 = 4096
+;; @0049                               v9 = iconst.i64 0
+;; @0049                               v10 = select_spectre_guard v4, v9, v8  ; v9 = 0
+;; @0049                               v11 = uload8.i32 little region4 v10
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:
-;; @004d                               return v12
+;; @004d                               return v11
 ;; }

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -57,17 +57,17 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @004c                               v4 = iconst.i64 0xffff
-;; @004c                               v5 = icmp ugt v2, v4  ; v4 = 0xffff
-;; @004c                               v6 = load.i64 notrap aligned readonly can_move region2 v0+56
-;; @004c                               v7 = iadd v6, v2
-;; @004c                               v8 = iconst.i64 0xffff_0000
-;; @004c                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
-;; @004c                               v10 = iconst.i64 0
-;; @004c                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
-;; @004c                               v12 = uload8.i32 little region4 v11
+;; @004c                               v3 = iconst.i64 0xffff
+;; @004c                               v4 = icmp ugt v2, v3  ; v3 = 0xffff
+;; @004c                               v5 = load.i64 notrap aligned readonly can_move region2 v0+56
+;; @004c                               v6 = iadd v5, v2
+;; @004c                               v7 = iconst.i64 0xffff_0000
+;; @004c                               v8 = iadd v6, v7  ; v7 = 0xffff_0000
+;; @004c                               v9 = iconst.i64 0
+;; @004c                               v10 = select_spectre_guard v4, v9, v8  ; v9 = 0
+;; @004c                               v11 = uload8.i32 little region4 v10
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:
-;; @0053                               return v12
+;; @0053                               return v11
 ;; }

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
@@ -54,14 +54,14 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0048                               v4 = iconst.i64 0xffff_fffc
-;; @0048                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_fffc
-;; @0048                               trapnz v5, heap_oob
-;; @0048                               v6 = load.i64 notrap aligned readonly can_move region2 v0+56
-;; @0048                               v7 = iadd v6, v2
-;; @0048                               v8 = load.i32 little region4 v7
+;; @0048                               v3 = iconst.i64 0xffff_fffc
+;; @0048                               v4 = icmp ugt v2, v3  ; v3 = 0xffff_fffc
+;; @0048                               trapnz v4, heap_oob
+;; @0048                               v5 = load.i64 notrap aligned readonly can_move region2 v0+56
+;; @0048                               v6 = iadd v5, v2
+;; @0048                               v7 = load.i32 little region4 v6
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:
-;; @004b                               return v8
+;; @004b                               return v7
 ;; }

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -56,16 +56,16 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0049                               v4 = iconst.i64 0xffff_effc
-;; @0049                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_effc
-;; @0049                               trapnz v5, heap_oob
-;; @0049                               v6 = load.i64 notrap aligned readonly can_move region2 v0+56
-;; @0049                               v7 = iadd v6, v2
-;; @0049                               v8 = iconst.i64 4096
-;; @0049                               v9 = iadd v7, v8  ; v8 = 4096
-;; @0049                               v10 = load.i32 little region4 v9
+;; @0049                               v3 = iconst.i64 0xffff_effc
+;; @0049                               v4 = icmp ugt v2, v3  ; v3 = 0xffff_effc
+;; @0049                               trapnz v4, heap_oob
+;; @0049                               v5 = load.i64 notrap aligned readonly can_move region2 v0+56
+;; @0049                               v6 = iadd v5, v2
+;; @0049                               v7 = iconst.i64 4096
+;; @0049                               v8 = iadd v6, v7  ; v7 = 4096
+;; @0049                               v9 = load.i32 little region4 v8
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:
-;; @004d                               return v10
+;; @004d                               return v9
 ;; }

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -56,16 +56,16 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @004c                               v4 = iconst.i64 0xfffc
-;; @004c                               v5 = icmp ugt v2, v4  ; v4 = 0xfffc
-;; @004c                               trapnz v5, heap_oob
-;; @004c                               v6 = load.i64 notrap aligned readonly can_move region2 v0+56
-;; @004c                               v7 = iadd v6, v2
-;; @004c                               v8 = iconst.i64 0xffff_0000
-;; @004c                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
-;; @004c                               v10 = load.i32 little region4 v9
+;; @004c                               v3 = iconst.i64 0xfffc
+;; @004c                               v4 = icmp ugt v2, v3  ; v3 = 0xfffc
+;; @004c                               trapnz v4, heap_oob
+;; @004c                               v5 = load.i64 notrap aligned readonly can_move region2 v0+56
+;; @004c                               v6 = iadd v5, v2
+;; @004c                               v7 = iconst.i64 0xffff_0000
+;; @004c                               v8 = iadd v6, v7  ; v7 = 0xffff_0000
+;; @004c                               v9 = load.i32 little region4 v8
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:
-;; @0053                               return v10
+;; @0053                               return v9
 ;; }

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
@@ -54,14 +54,14 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0048                               v4 = iconst.i64 0xffff_ffff
-;; @0048                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_ffff
-;; @0048                               trapnz v5, heap_oob
-;; @0048                               v6 = load.i64 notrap aligned readonly can_move region2 v0+56
-;; @0048                               v7 = iadd v6, v2
-;; @0048                               v8 = uload8.i32 little region4 v7
+;; @0048                               v3 = iconst.i64 0xffff_ffff
+;; @0048                               v4 = icmp ugt v2, v3  ; v3 = 0xffff_ffff
+;; @0048                               trapnz v4, heap_oob
+;; @0048                               v5 = load.i64 notrap aligned readonly can_move region2 v0+56
+;; @0048                               v6 = iadd v5, v2
+;; @0048                               v7 = uload8.i32 little region4 v6
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:
-;; @004b                               return v8
+;; @004b                               return v7
 ;; }

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -56,16 +56,16 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0049                               v4 = iconst.i64 0xffff_efff
-;; @0049                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_efff
-;; @0049                               trapnz v5, heap_oob
-;; @0049                               v6 = load.i64 notrap aligned readonly can_move region2 v0+56
-;; @0049                               v7 = iadd v6, v2
-;; @0049                               v8 = iconst.i64 4096
-;; @0049                               v9 = iadd v7, v8  ; v8 = 4096
-;; @0049                               v10 = uload8.i32 little region4 v9
+;; @0049                               v3 = iconst.i64 0xffff_efff
+;; @0049                               v4 = icmp ugt v2, v3  ; v3 = 0xffff_efff
+;; @0049                               trapnz v4, heap_oob
+;; @0049                               v5 = load.i64 notrap aligned readonly can_move region2 v0+56
+;; @0049                               v6 = iadd v5, v2
+;; @0049                               v7 = iconst.i64 4096
+;; @0049                               v8 = iadd v6, v7  ; v7 = 4096
+;; @0049                               v9 = uload8.i32 little region4 v8
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:
-;; @004d                               return v10
+;; @004d                               return v9
 ;; }

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -56,16 +56,16 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @004c                               v4 = iconst.i64 0xffff
-;; @004c                               v5 = icmp ugt v2, v4  ; v4 = 0xffff
-;; @004c                               trapnz v5, heap_oob
-;; @004c                               v6 = load.i64 notrap aligned readonly can_move region2 v0+56
-;; @004c                               v7 = iadd v6, v2
-;; @004c                               v8 = iconst.i64 0xffff_0000
-;; @004c                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
-;; @004c                               v10 = uload8.i32 little region4 v9
+;; @004c                               v3 = iconst.i64 0xffff
+;; @004c                               v4 = icmp ugt v2, v3  ; v3 = 0xffff
+;; @004c                               trapnz v4, heap_oob
+;; @004c                               v5 = load.i64 notrap aligned readonly can_move region2 v0+56
+;; @004c                               v6 = iadd v5, v2
+;; @004c                               v7 = iconst.i64 0xffff_0000
+;; @004c                               v8 = iadd v6, v7  ; v7 = 0xffff_0000
+;; @004c                               v9 = uload8.i32 little region4 v8
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:
-;; @0053                               return v10
+;; @0053                               return v9
 ;; }

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
@@ -55,15 +55,15 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0048                               v4 = iconst.i64 0xffff_fffc
-;; @0048                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_fffc
-;; @0048                               v6 = load.i64 notrap aligned readonly can_move region2 v0+56
-;; @0048                               v7 = iadd v6, v2
-;; @0048                               v8 = iconst.i64 0
-;; @0048                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0
-;; @0048                               v10 = load.i32 little region4 v9
+;; @0048                               v3 = iconst.i64 0xffff_fffc
+;; @0048                               v4 = icmp ugt v2, v3  ; v3 = 0xffff_fffc
+;; @0048                               v5 = load.i64 notrap aligned readonly can_move region2 v0+56
+;; @0048                               v6 = iadd v5, v2
+;; @0048                               v7 = iconst.i64 0
+;; @0048                               v8 = select_spectre_guard v4, v7, v6  ; v7 = 0
+;; @0048                               v9 = load.i32 little region4 v8
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:
-;; @004b                               return v10
+;; @004b                               return v9
 ;; }

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -57,17 +57,17 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0049                               v4 = iconst.i64 0xffff_effc
-;; @0049                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_effc
-;; @0049                               v6 = load.i64 notrap aligned readonly can_move region2 v0+56
-;; @0049                               v7 = iadd v6, v2
-;; @0049                               v8 = iconst.i64 4096
-;; @0049                               v9 = iadd v7, v8  ; v8 = 4096
-;; @0049                               v10 = iconst.i64 0
-;; @0049                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
-;; @0049                               v12 = load.i32 little region4 v11
+;; @0049                               v3 = iconst.i64 0xffff_effc
+;; @0049                               v4 = icmp ugt v2, v3  ; v3 = 0xffff_effc
+;; @0049                               v5 = load.i64 notrap aligned readonly can_move region2 v0+56
+;; @0049                               v6 = iadd v5, v2
+;; @0049                               v7 = iconst.i64 4096
+;; @0049                               v8 = iadd v6, v7  ; v7 = 4096
+;; @0049                               v9 = iconst.i64 0
+;; @0049                               v10 = select_spectre_guard v4, v9, v8  ; v9 = 0
+;; @0049                               v11 = load.i32 little region4 v10
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:
-;; @004d                               return v12
+;; @004d                               return v11
 ;; }

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -57,17 +57,17 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @004c                               v4 = iconst.i64 0xfffc
-;; @004c                               v5 = icmp ugt v2, v4  ; v4 = 0xfffc
-;; @004c                               v6 = load.i64 notrap aligned readonly can_move region2 v0+56
-;; @004c                               v7 = iadd v6, v2
-;; @004c                               v8 = iconst.i64 0xffff_0000
-;; @004c                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
-;; @004c                               v10 = iconst.i64 0
-;; @004c                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
-;; @004c                               v12 = load.i32 little region4 v11
+;; @004c                               v3 = iconst.i64 0xfffc
+;; @004c                               v4 = icmp ugt v2, v3  ; v3 = 0xfffc
+;; @004c                               v5 = load.i64 notrap aligned readonly can_move region2 v0+56
+;; @004c                               v6 = iadd v5, v2
+;; @004c                               v7 = iconst.i64 0xffff_0000
+;; @004c                               v8 = iadd v6, v7  ; v7 = 0xffff_0000
+;; @004c                               v9 = iconst.i64 0
+;; @004c                               v10 = select_spectre_guard v4, v9, v8  ; v9 = 0
+;; @004c                               v11 = load.i32 little region4 v10
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:
-;; @0053                               return v12
+;; @0053                               return v11
 ;; }

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
@@ -55,15 +55,15 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0048                               v4 = iconst.i64 0xffff_ffff
-;; @0048                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_ffff
-;; @0048                               v6 = load.i64 notrap aligned readonly can_move region2 v0+56
-;; @0048                               v7 = iadd v6, v2
-;; @0048                               v8 = iconst.i64 0
-;; @0048                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0
-;; @0048                               v10 = uload8.i32 little region4 v9
+;; @0048                               v3 = iconst.i64 0xffff_ffff
+;; @0048                               v4 = icmp ugt v2, v3  ; v3 = 0xffff_ffff
+;; @0048                               v5 = load.i64 notrap aligned readonly can_move region2 v0+56
+;; @0048                               v6 = iadd v5, v2
+;; @0048                               v7 = iconst.i64 0
+;; @0048                               v8 = select_spectre_guard v4, v7, v6  ; v7 = 0
+;; @0048                               v9 = uload8.i32 little region4 v8
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:
-;; @004b                               return v10
+;; @004b                               return v9
 ;; }

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -57,17 +57,17 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0049                               v4 = iconst.i64 0xffff_efff
-;; @0049                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_efff
-;; @0049                               v6 = load.i64 notrap aligned readonly can_move region2 v0+56
-;; @0049                               v7 = iadd v6, v2
-;; @0049                               v8 = iconst.i64 4096
-;; @0049                               v9 = iadd v7, v8  ; v8 = 4096
-;; @0049                               v10 = iconst.i64 0
-;; @0049                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
-;; @0049                               v12 = uload8.i32 little region4 v11
+;; @0049                               v3 = iconst.i64 0xffff_efff
+;; @0049                               v4 = icmp ugt v2, v3  ; v3 = 0xffff_efff
+;; @0049                               v5 = load.i64 notrap aligned readonly can_move region2 v0+56
+;; @0049                               v6 = iadd v5, v2
+;; @0049                               v7 = iconst.i64 4096
+;; @0049                               v8 = iadd v6, v7  ; v7 = 4096
+;; @0049                               v9 = iconst.i64 0
+;; @0049                               v10 = select_spectre_guard v4, v9, v8  ; v9 = 0
+;; @0049                               v11 = uload8.i32 little region4 v10
 ;; @004d                               jump block1
 ;;
 ;;                                 block1:
-;; @004d                               return v12
+;; @004d                               return v11
 ;; }

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -57,17 +57,17 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @004c                               v4 = iconst.i64 0xffff
-;; @004c                               v5 = icmp ugt v2, v4  ; v4 = 0xffff
-;; @004c                               v6 = load.i64 notrap aligned readonly can_move region2 v0+56
-;; @004c                               v7 = iadd v6, v2
-;; @004c                               v8 = iconst.i64 0xffff_0000
-;; @004c                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
-;; @004c                               v10 = iconst.i64 0
-;; @004c                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
-;; @004c                               v12 = uload8.i32 little region4 v11
+;; @004c                               v3 = iconst.i64 0xffff
+;; @004c                               v4 = icmp ugt v2, v3  ; v3 = 0xffff
+;; @004c                               v5 = load.i64 notrap aligned readonly can_move region2 v0+56
+;; @004c                               v6 = iadd v5, v2
+;; @004c                               v7 = iconst.i64 0xffff_0000
+;; @004c                               v8 = iadd v6, v7  ; v7 = 0xffff_0000
+;; @004c                               v9 = iconst.i64 0
+;; @004c                               v10 = select_spectre_guard v4, v9, v8  ; v9 = 0
+;; @004c                               v11 = uload8.i32 little region4 v10
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:
-;; @0053                               return v12
+;; @0053                               return v11
 ;; }

--- a/tests/disas/multi-1.wat
+++ b/tests/disas/multi-1.wat
@@ -16,12 +16,12 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
-;; @003a                               v10 = f64const 0x1.34a0000000000p10
+;; @003a                               v7 = f64const 0x1.34a0000000000p10
 ;; @0043                               jump block2
 ;;
 ;;                                 block2:
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
-;; @0044                               return v3, v2, v10  ; v10 = 0x1.34a0000000000p10
+;; @0044                               return v3, v2, v7  ; v7 = 0x1.34a0000000000p10
 ;; }

--- a/tests/disas/multi-1.wat
+++ b/tests/disas/multi-1.wat
@@ -16,12 +16,12 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
-;; @003a                               v7 = f64const 0x1.34a0000000000p10
+;; @003a                               v4 = f64const 0x1.34a0000000000p10
 ;; @0043                               jump block2
 ;;
 ;;                                 block2:
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
-;; @0044                               return v3, v2, v7  ; v7 = 0x1.34a0000000000p10
+;; @0044                               return v3, v2, v4  ; v4 = 0x1.34a0000000000p10
 ;; }

--- a/tests/disas/multi-10.wat
+++ b/tests/disas/multi-10.wat
@@ -23,15 +23,15 @@
 ;; @002c                               brif v3, block2, block4
 ;;
 ;;                                 block2:
-;; @002e                               v9 = iconst.i64 -1
-;; @0030                               jump block3(v9)  ; v9 = -1
+;; @002e                               v6 = iconst.i64 -1
+;; @0030                               jump block3(v6)  ; v6 = -1
 ;;
 ;;                                 block4:
-;; @0031                               v10 = iconst.i64 -2
-;; @0033                               jump block3(v10)  ; v10 = -2
+;; @0031                               v7 = iconst.i64 -2
+;; @0033                               jump block3(v7)  ; v7 = -2
 ;;
-;;                                 block3(v7: i64):
-;; @0034                               jump block1(v7)
+;;                                 block3(v9: i64):
+;; @0034                               jump block1(v9)
 ;;
 ;;                                 block1(v5: i64):
 ;; @0034                               return v2, v5

--- a/tests/disas/multi-10.wat
+++ b/tests/disas/multi-10.wat
@@ -23,16 +23,16 @@
 ;; @002c                               brif v3, block2, block4
 ;;
 ;;                                 block2:
-;; @002e                               v6 = iconst.i64 -1
-;; @0030                               jump block3(v6)  ; v6 = -1
+;; @002e                               v4 = iconst.i64 -1
+;; @0030                               jump block3(v4)  ; v4 = -1
 ;;
 ;;                                 block4:
-;; @0031                               v7 = iconst.i64 -2
-;; @0033                               jump block3(v7)  ; v7 = -2
+;; @0031                               v5 = iconst.i64 -2
+;; @0033                               jump block3(v5)  ; v5 = -2
 ;;
-;;                                 block3(v9: i64):
-;; @0034                               jump block1(v9)
+;;                                 block3(v7: i64):
+;; @0034                               jump block1
 ;;
-;;                                 block1(v5: i64):
-;; @0034                               return v2, v5
+;;                                 block1:
+;; @0034                               return v2, v7
 ;; }

--- a/tests/disas/multi-11.wat
+++ b/tests/disas/multi-11.wat
@@ -20,6 +20,6 @@
 ;; @002b                               jump block2
 ;;
 ;;                                 block2:
-;; @002d                               v6 = iconst.i64 42
-;; @002f                               return v2, v6  ; v6 = 42
+;; @002d                               v4 = iconst.i64 42
+;; @002f                               return v2, v4  ; v4 = 42
 ;; }

--- a/tests/disas/multi-11.wat
+++ b/tests/disas/multi-11.wat
@@ -20,6 +20,6 @@
 ;; @002b                               jump block2
 ;;
 ;;                                 block2:
-;; @002d                               v8 = iconst.i64 42
-;; @002f                               return v2, v8  ; v8 = 42
+;; @002d                               v6 = iconst.i64 42
+;; @002f                               return v2, v6  ; v6 = 42
 ;; }

--- a/tests/disas/multi-13.wat
+++ b/tests/disas/multi-13.wat
@@ -23,8 +23,8 @@
 ;; @002e                               brif v2, block3, block5
 ;;
 ;;                                 block3:
-;; @0030                               v7 = iconst.i32 3
-;; @0032                               jump block2(v7)  ; v7 = 3
+;; @0030                               v5 = iconst.i32 3
+;; @0032                               jump block2(v5)  ; v5 = 3
 ;;
 ;;                                 block5:
 ;; @0037                               jump block4
@@ -32,8 +32,8 @@
 ;;                                 block4:
 ;; @0038                               jump block2(v3)
 ;;
-;;                                 block2(v5: i32):
-;; @0039                               jump block1(v5)
+;;                                 block2(v6: i32):
+;; @0039                               jump block1(v6)
 ;;
 ;;                                 block1(v4: i32):
 ;; @0039                               return v4

--- a/tests/disas/multi-13.wat
+++ b/tests/disas/multi-13.wat
@@ -23,8 +23,8 @@
 ;; @002e                               brif v2, block3, block5
 ;;
 ;;                                 block3:
-;; @0030                               v5 = iconst.i32 3
-;; @0032                               jump block2(v5)  ; v5 = 3
+;; @0030                               v4 = iconst.i32 3
+;; @0032                               jump block2(v4)  ; v4 = 3
 ;;
 ;;                                 block5:
 ;; @0037                               jump block4
@@ -32,9 +32,9 @@
 ;;                                 block4:
 ;; @0038                               jump block2(v3)
 ;;
-;;                                 block2(v6: i32):
-;; @0039                               jump block1(v6)
+;;                                 block2(v5: i32):
+;; @0039                               jump block1
 ;;
-;;                                 block1(v4: i32):
-;; @0039                               return v4
+;;                                 block1:
+;; @0039                               return v5
 ;; }

--- a/tests/disas/multi-14.wat
+++ b/tests/disas/multi-14.wat
@@ -26,14 +26,14 @@
 ;; @0032                               jump block4
 ;;
 ;;                                 block5:
-;; @0033                               v7 = iconst.i32 4
-;; @0035                               jump block2(v7)  ; v7 = 4
+;; @0033                               v5 = iconst.i32 4
+;; @0035                               jump block2(v5)  ; v5 = 4
 ;;
 ;;                                 block4:
 ;; @0038                               jump block2(v3)
 ;;
-;;                                 block2(v5: i32):
-;; @0039                               jump block1(v5)
+;;                                 block2(v6: i32):
+;; @0039                               jump block1(v6)
 ;;
 ;;                                 block1(v4: i32):
 ;; @0039                               return v4

--- a/tests/disas/multi-14.wat
+++ b/tests/disas/multi-14.wat
@@ -26,15 +26,15 @@
 ;; @0032                               jump block4
 ;;
 ;;                                 block5:
-;; @0033                               v5 = iconst.i32 4
-;; @0035                               jump block2(v5)  ; v5 = 4
+;; @0033                               v4 = iconst.i32 4
+;; @0035                               jump block2(v4)  ; v4 = 4
 ;;
 ;;                                 block4:
 ;; @0038                               jump block2(v3)
 ;;
-;;                                 block2(v6: i32):
-;; @0039                               jump block1(v6)
+;;                                 block2(v5: i32):
+;; @0039                               jump block1
 ;;
-;;                                 block1(v4: i32):
-;; @0039                               return v4
+;;                                 block1:
+;; @0039                               return v5
 ;; }

--- a/tests/disas/multi-16.wat
+++ b/tests/disas/multi-16.wat
@@ -19,22 +19,22 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0024                               v4 = iconst.i32 1
+;; @0024                               v3 = iconst.i32 1
 ;; @0028                               brif v2, block2, block4
 ;;
 ;;                                 block2:
-;; @002a                               v5 = iconst.i32 2
-;; @002c                               v6 = iadd.i32 v4, v5  ; v4 = 1, v5 = 2
-;; @002d                               jump block3(v6)
+;; @002a                               v4 = iconst.i32 2
+;; @002c                               v5 = iadd.i32 v3, v4  ; v3 = 1, v4 = 2
+;; @002d                               jump block3(v5)
 ;;
 ;;                                 block4:
-;; @002e                               v7 = iconst.i32 -2
-;; @0030                               v8 = iadd.i32 v4, v7  ; v4 = 1, v7 = -2
-;; @0031                               jump block3(v8)
+;; @002e                               v6 = iconst.i32 -2
+;; @0030                               v7 = iadd.i32 v3, v6  ; v3 = 1, v6 = -2
+;; @0031                               jump block3(v7)
 ;;
-;;                                 block3(v9: i32):
-;; @0032                               jump block1(v9)
+;;                                 block3(v8: i32):
+;; @0032                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @0032                               return v3
+;;                                 block1:
+;; @0032                               return v8
 ;; }

--- a/tests/disas/multi-16.wat
+++ b/tests/disas/multi-16.wat
@@ -23,17 +23,17 @@
 ;; @0028                               brif v2, block2, block4
 ;;
 ;;                                 block2:
-;; @002a                               v6 = iconst.i32 2
-;; @002c                               v7 = iadd.i32 v4, v6  ; v4 = 1, v6 = 2
-;; @002d                               jump block3(v7)
+;; @002a                               v5 = iconst.i32 2
+;; @002c                               v6 = iadd.i32 v4, v5  ; v4 = 1, v5 = 2
+;; @002d                               jump block3(v6)
 ;;
 ;;                                 block4:
-;; @002e                               v9 = iconst.i32 -2
-;; @0030                               v10 = iadd.i32 v4, v9  ; v4 = 1, v9 = -2
-;; @0031                               jump block3(v10)
+;; @002e                               v7 = iconst.i32 -2
+;; @0030                               v8 = iadd.i32 v4, v7  ; v4 = 1, v7 = -2
+;; @0031                               jump block3(v8)
 ;;
-;;                                 block3(v5: i32):
-;; @0032                               jump block1(v5)
+;;                                 block3(v9: i32):
+;; @0032                               jump block1(v9)
 ;;
 ;;                                 block1(v3: i32):
 ;; @0032                               return v3

--- a/tests/disas/multi-17.wat
+++ b/tests/disas/multi-17.wat
@@ -49,18 +49,18 @@
 ;; @0031                               jump block3(v9)  ; v9 = 0
 ;;
 ;;                                 block4:
-;; @0034                               v15 = call fn0(v0, v0, v7, v8, v9)  ; v7 = 0, v8 = 0, v9 = 0
-;; @0036                               jump block3(v15)
+;; @0034                               v11 = call fn0(v0, v0, v7, v8, v9)  ; v7 = 0, v8 = 0, v9 = 0
+;; @0036                               jump block3(v11)
 ;;
-;;                                 block3(v11: i32):
-;; @0037                               v16 = iconst.i32 0
-;; @0039                               v17 = iconst.i32 0
-;; @003b                               brif v17, block5, block7(v11)  ; v17 = 0
+;;                                 block3(v12: i32):
+;; @0037                               v13 = iconst.i32 0
+;; @0039                               v14 = iconst.i32 0
+;; @003b                               brif v14, block5, block7  ; v14 = 0
 ;;
 ;;                                 block5:
 ;; @003f                               jump block6
 ;;
-;;                                 block7(v20: i32):
+;;                                 block7:
 ;; @0042                               jump block6
 ;;
 ;;                                 block6:

--- a/tests/disas/multi-17.wat
+++ b/tests/disas/multi-17.wat
@@ -38,24 +38,24 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
-;; @0025                               v6 = iconst.i32 0
-;; @0027                               v7 = iconst.i32 0
-;; @0029                               v8 = iconst.i32 0
-;; @002b                               v9 = iconst.i32 0
-;; @002d                               v10 = iconst.i32 0
-;; @002f                               brif v10, block2, block4  ; v10 = 0
+;; @0025                               v5 = iconst.i32 0
+;; @0027                               v6 = iconst.i32 0
+;; @0029                               v7 = iconst.i32 0
+;; @002b                               v8 = iconst.i32 0
+;; @002d                               v9 = iconst.i32 0
+;; @002f                               brif v9, block2, block4  ; v9 = 0
 ;;
 ;;                                 block2:
-;; @0031                               jump block3(v9)  ; v9 = 0
+;; @0031                               jump block3(v8)  ; v8 = 0
 ;;
 ;;                                 block4:
-;; @0034                               v11 = call fn0(v0, v0, v7, v8, v9)  ; v7 = 0, v8 = 0, v9 = 0
-;; @0036                               jump block3(v11)
+;; @0034                               v10 = call fn0(v0, v0, v6, v7, v8)  ; v6 = 0, v7 = 0, v8 = 0
+;; @0036                               jump block3(v10)
 ;;
-;;                                 block3(v12: i32):
-;; @0037                               v13 = iconst.i32 0
-;; @0039                               v14 = iconst.i32 0
-;; @003b                               brif v14, block5, block7  ; v14 = 0
+;;                                 block3(v11: i32):
+;; @0037                               v12 = iconst.i32 0
+;; @0039                               v13 = iconst.i32 0
+;; @003b                               brif v13, block5, block7  ; v13 = 0
 ;;
 ;;                                 block5:
 ;; @003f                               jump block6
@@ -67,5 +67,5 @@
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
-;; @0043                               return v6  ; v6 = 0
+;; @0043                               return v5  ; v5 = 0
 ;; }

--- a/tests/disas/multi-3.wat
+++ b/tests/disas/multi-3.wat
@@ -29,13 +29,13 @@
 ;; @0038                               return v4, v3
 ;;
 ;;                                 block4:
-;; @003c                               v7 = iconst.i64 0
-;; @003e                               v8 = iconst.i64 0
+;; @003c                               v5 = iconst.i64 0
+;; @003e                               v6 = iconst.i64 0
 ;; @0040                               jump block3
 ;;
 ;;                                 block3:
 ;; @0041                               jump block1
 ;;
 ;;                                 block1:
-;; @0041                               return v7, v8  ; v7 = 0, v8 = 0
+;; @0041                               return v5, v6  ; v5 = 0, v6 = 0
 ;; }

--- a/tests/disas/multi-3.wat
+++ b/tests/disas/multi-3.wat
@@ -29,13 +29,13 @@
 ;; @0038                               return v4, v3
 ;;
 ;;                                 block4:
-;; @003c                               v11 = iconst.i64 0
-;; @003e                               v12 = iconst.i64 0
+;; @003c                               v7 = iconst.i64 0
+;; @003e                               v8 = iconst.i64 0
 ;; @0040                               jump block3
 ;;
 ;;                                 block3:
 ;; @0041                               jump block1
 ;;
 ;;                                 block1:
-;; @0041                               return v11, v12  ; v11 = 0, v12 = 0
+;; @0041                               return v7, v8  ; v7 = 0, v8 = 0
 ;; }

--- a/tests/disas/multi-4.wat
+++ b/tests/disas/multi-4.wat
@@ -26,17 +26,17 @@
 ;; @0037                               brif v2, block2, block4
 ;;
 ;;                                 block2:
-;; @0039                               v9 = iadd.i64 v4, v3
-;; @003a                               v10 = iconst.i64 1
-;; @003c                               jump block3(v9, v10)  ; v10 = 1
+;; @0039                               v7 = iadd.i64 v4, v3
+;; @003a                               v8 = iconst.i64 1
+;; @003c                               jump block3(v7, v8)  ; v8 = 1
 ;;
 ;;                                 block4:
-;; @003d                               v13 = isub.i64 v4, v3
-;; @003e                               v14 = iconst.i64 2
-;; @0040                               jump block3(v13, v14)  ; v14 = 2
+;; @003d                               v9 = isub.i64 v4, v3
+;; @003e                               v10 = iconst.i64 2
+;; @0040                               jump block3(v9, v10)  ; v10 = 2
 ;;
-;;                                 block3(v7: i64, v8: i64):
-;; @0041                               jump block1(v7, v8)
+;;                                 block3(v11: i64, v12: i64):
+;; @0041                               jump block1(v11, v12)
 ;;
 ;;                                 block1(v5: i64, v6: i64):
 ;; @0041                               return v5, v6

--- a/tests/disas/multi-4.wat
+++ b/tests/disas/multi-4.wat
@@ -26,18 +26,18 @@
 ;; @0037                               brif v2, block2, block4
 ;;
 ;;                                 block2:
-;; @0039                               v7 = iadd.i64 v4, v3
-;; @003a                               v8 = iconst.i64 1
-;; @003c                               jump block3(v7, v8)  ; v8 = 1
+;; @0039                               v5 = iadd.i64 v4, v3
+;; @003a                               v6 = iconst.i64 1
+;; @003c                               jump block3(v5, v6)  ; v6 = 1
 ;;
 ;;                                 block4:
-;; @003d                               v9 = isub.i64 v4, v3
-;; @003e                               v10 = iconst.i64 2
-;; @0040                               jump block3(v9, v10)  ; v10 = 2
+;; @003d                               v7 = isub.i64 v4, v3
+;; @003e                               v8 = iconst.i64 2
+;; @0040                               jump block3(v7, v8)  ; v8 = 2
 ;;
-;;                                 block3(v11: i64, v12: i64):
-;; @0041                               jump block1(v11, v12)
+;;                                 block3(v9: i64, v10: i64):
+;; @0041                               jump block1
 ;;
-;;                                 block1(v5: i64, v6: i64):
-;; @0041                               return v5, v6
+;;                                 block1:
+;; @0041                               return v9, v10
 ;; }

--- a/tests/disas/multi-6.wat
+++ b/tests/disas/multi-6.wat
@@ -22,7 +22,7 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64):
 ;; @0026                               v2 = iconst.i32 1
-;; @002a                               v5 = iconst.i64 2
+;; @002a                               v3 = iconst.i64 2
 ;; @002c                               jump block2
 ;;
 ;;                                 block2:

--- a/tests/disas/multi-7.wat
+++ b/tests/disas/multi-7.wat
@@ -22,12 +22,12 @@
 ;; @002a                               brif v3, block2, block3(v2)
 ;;
 ;;                                 block2:
-;; @002d                               v5 = iconst.i64 -1
-;; @002f                               jump block3(v5)  ; v5 = -1
+;; @002d                               v4 = iconst.i64 -1
+;; @002f                               jump block3(v4)  ; v4 = -1
 ;;
-;;                                 block3(v6: i64):
-;; @0030                               jump block1(v6)
+;;                                 block3(v5: i64):
+;; @0030                               jump block1
 ;;
-;;                                 block1(v4: i64):
-;; @0030                               return v4
+;;                                 block1:
+;; @0030                               return v5
 ;; }

--- a/tests/disas/multi-7.wat
+++ b/tests/disas/multi-7.wat
@@ -22,11 +22,11 @@
 ;; @002a                               brif v3, block2, block3(v2)
 ;;
 ;;                                 block2:
-;; @002d                               v6 = iconst.i64 -1
-;; @002f                               jump block3(v6)  ; v6 = -1
+;; @002d                               v5 = iconst.i64 -1
+;; @002f                               jump block3(v5)  ; v5 = -1
 ;;
-;;                                 block3(v5: i64):
-;; @0030                               jump block1(v5)
+;;                                 block3(v6: i64):
+;; @0030                               jump block1(v6)
 ;;
 ;;                                 block1(v4: i64):
 ;; @0030                               return v4

--- a/tests/disas/multi-8.wat
+++ b/tests/disas/multi-8.wat
@@ -25,15 +25,15 @@
 ;; @002a                               brif v3, block2, block4
 ;;
 ;;                                 block2:
-;; @002d                               v6 = iconst.i64 -1
-;; @002f                               jump block3(v6)  ; v6 = -1
+;; @002d                               v5 = iconst.i64 -1
+;; @002f                               jump block3(v5)  ; v5 = -1
 ;;
 ;;                                 block4:
-;; @0031                               v8 = iconst.i64 -2
-;; @0033                               jump block3(v8)  ; v8 = -2
+;; @0031                               v6 = iconst.i64 -2
+;; @0033                               jump block3(v6)  ; v6 = -2
 ;;
-;;                                 block3(v5: i64):
-;; @0034                               jump block1(v5)
+;;                                 block3(v7: i64):
+;; @0034                               jump block1(v7)
 ;;
 ;;                                 block1(v4: i64):
 ;; @0034                               return v4

--- a/tests/disas/multi-8.wat
+++ b/tests/disas/multi-8.wat
@@ -25,16 +25,16 @@
 ;; @002a                               brif v3, block2, block4
 ;;
 ;;                                 block2:
-;; @002d                               v5 = iconst.i64 -1
-;; @002f                               jump block3(v5)  ; v5 = -1
+;; @002d                               v4 = iconst.i64 -1
+;; @002f                               jump block3(v4)  ; v4 = -1
 ;;
 ;;                                 block4:
-;; @0031                               v6 = iconst.i64 -2
-;; @0033                               jump block3(v6)  ; v6 = -2
+;; @0031                               v5 = iconst.i64 -2
+;; @0033                               jump block3(v5)  ; v5 = -2
 ;;
-;;                                 block3(v7: i64):
-;; @0034                               jump block1(v7)
+;;                                 block3(v6: i64):
+;; @0034                               jump block1
 ;;
-;;                                 block1(v4: i64):
-;; @0034                               return v4
+;;                                 block1:
+;; @0034                               return v6
 ;; }

--- a/tests/disas/multi-9.wat
+++ b/tests/disas/multi-9.wat
@@ -28,16 +28,16 @@
 ;; @0027                               brif v3, block2, block4
 ;;
 ;;                                 block2:
-;; @002b                               v5 = iconst.i64 -1
-;; @002d                               jump block3(v5)  ; v5 = -1
+;; @002b                               v4 = iconst.i64 -1
+;; @002d                               jump block3(v4)  ; v4 = -1
 ;;
 ;;                                 block4:
-;; @0030                               v6 = iconst.i64 -2
-;; @0032                               jump block3(v6)  ; v6 = -2
+;; @0030                               v5 = iconst.i64 -2
+;; @0032                               jump block3(v5)  ; v5 = -2
 ;;
-;;                                 block3(v7: i64):
-;; @0033                               jump block1(v7)
+;;                                 block3(v6: i64):
+;; @0033                               jump block1
 ;;
-;;                                 block1(v4: i64):
-;; @0033                               return v4
+;;                                 block1:
+;; @0033                               return v6
 ;; }

--- a/tests/disas/multi-9.wat
+++ b/tests/disas/multi-9.wat
@@ -28,15 +28,15 @@
 ;; @0027                               brif v3, block2, block4
 ;;
 ;;                                 block2:
-;; @002b                               v8 = iconst.i64 -1
-;; @002d                               jump block3(v8)  ; v8 = -1
+;; @002b                               v5 = iconst.i64 -1
+;; @002d                               jump block3(v5)  ; v5 = -1
 ;;
 ;;                                 block4:
-;; @0030                               v9 = iconst.i64 -2
-;; @0032                               jump block3(v9)  ; v9 = -2
+;; @0030                               v6 = iconst.i64 -2
+;; @0032                               jump block3(v6)  ; v6 = -2
 ;;
-;;                                 block3(v5: i64):
-;; @0033                               jump block1(v5)
+;;                                 block3(v7: i64):
+;; @0033                               jump block1(v7)
 ;;
 ;;                                 block1(v4: i64):
 ;; @0033                               return v4

--- a/tests/disas/non-fixed-size-memory.wat
+++ b/tests/disas/non-fixed-size-memory.wat
@@ -57,15 +57,15 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0049                               v4 = uextend.i64 v2
-;; @0049                               v5 = load.i64 notrap aligned region3 v0+64
-;; @0049                               v6 = icmp uge v4, v5
-;; @0049                               trapnz v6, heap_oob
-;; @0049                               v7 = load.i64 notrap aligned can_move region2 v0+56
-;; @0049                               v8 = iadd v7, v4
-;; @0049                               v9 = uload8.i32 little region4 v8
+;; @0049                               v3 = uextend.i64 v2
+;; @0049                               v4 = load.i64 notrap aligned region3 v0+64
+;; @0049                               v5 = icmp uge v3, v4
+;; @0049                               trapnz v5, heap_oob
+;; @0049                               v6 = load.i64 notrap aligned can_move region2 v0+56
+;; @0049                               v7 = iadd v6, v3
+;; @0049                               v8 = uload8.i32 little region4 v7
 ;; @004c                               jump block1
 ;;
 ;;                                 block1:
-;; @004c                               return v9
+;; @004c                               return v8
 ;; }

--- a/tests/disas/nullref.wat
+++ b/tests/disas/nullref.wat
@@ -37,12 +37,12 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @0020                               v4 = iconst.i32 0
+;; @0020                               v3 = iconst.i32 0
 ;; @0022                               jump block2
 ;;
 ;;                                 block2:
 ;; @0023                               jump block1
 ;;
 ;;                                 block1:
-;; @0023                               return v4  ; v4 = 0
+;; @0023                               return v3  ; v3 = 0
 ;; }

--- a/tests/disas/nullref.wat
+++ b/tests/disas/nullref.wat
@@ -21,11 +21,11 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @0019                               v3 = iconst.i32 0
+;; @0019                               v2 = iconst.i32 0
 ;; @001b                               jump block1
 ;;
 ;;                                 block1:
-;; @001b                               return v3  ; v3 = 0
+;; @001b                               return v2  ; v2 = 0
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64) -> i32 tail {
@@ -37,12 +37,12 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @0020                               v3 = iconst.i32 0
+;; @0020                               v2 = iconst.i32 0
 ;; @0022                               jump block2
 ;;
 ;;                                 block2:
 ;; @0023                               jump block1
 ;;
 ;;                                 block1:
-;; @0023                               return v3  ; v3 = 0
+;; @0023                               return v2  ; v2 = 0
 ;; }

--- a/tests/disas/pic.wat
+++ b/tests/disas/pic.wat
@@ -59,14 +59,14 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @005e                               v7 = load.i64 notrap aligned readonly can_move region2 v0+56
-;;                                     v15 = iconst.i64 0x0010_0000
-;; @005e                               v8 = iadd v7, v15  ; v15 = 0x0010_0000
-;; @005e                               v9 = load.i32 little region4 v8
+;; @005e                               v6 = load.i64 notrap aligned readonly can_move region2 v0+56
+;;                                     v14 = iconst.i64 0x0010_0000
+;; @005e                               v7 = iadd v6, v14  ; v14 = 0x0010_0000
+;; @005e                               v8 = load.i32 little region4 v7
 ;; @0061                               jump block1
 ;;
 ;;                                 block1:
-;; @0061                               return v9
+;; @0061                               return v8
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
@@ -85,30 +85,30 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0066                               v5 = load.i32 notrap aligned region2 v0+128
-;; @0068                               v6 = iconst.i32 16
-;; @006a                               v7 = isub v5, v6  ; v6 = 16
-;; @006d                               store notrap aligned region2 v7, v0+128
-;; @0073                               v9 = load.i64 notrap aligned readonly can_move region3 v0+56
-;; @0073                               v8 = uextend.i64 v2
-;; @0073                               v10 = iadd v9, v8
-;; @0073                               v11 = load.i32 little region5 v10
-;; @0078                               v12 = uextend.i64 v7
-;; @0078                               v14 = iadd v9, v12
-;; @0078                               v15 = iconst.i64 12
-;; @0078                               v16 = iadd v14, v15  ; v15 = 12
-;; @0078                               store little region5 v11, v16
-;; @0084                               v21 = load.i64 notrap aligned readonly can_move region7 v0+80
-;; @0084                               v20 = load.i64 notrap aligned readonly can_move region6 v0+96
-;;                                     v29 = iconst.i32 -4
-;;                                     v30 = iadd v5, v29  ; v29 = -4
-;; @0084                               call_indirect sig0, v21(v20, v0, v30)
-;;                                     v37 = iconst.i64 0x0010_0000
-;; @0090                               v26 = iadd v9, v37  ; v37 = 0x0010_0000
-;; @0090                               store little region5 v11, v26
-;; @0098                               store notrap aligned region2 v5, v0+128
+;; @0066                               v4 = load.i32 notrap aligned region2 v0+128
+;; @0068                               v5 = iconst.i32 16
+;; @006a                               v6 = isub v4, v5  ; v5 = 16
+;; @006d                               store notrap aligned region2 v6, v0+128
+;; @0073                               v8 = load.i64 notrap aligned readonly can_move region3 v0+56
+;; @0073                               v7 = uextend.i64 v2
+;; @0073                               v9 = iadd v8, v7
+;; @0073                               v10 = load.i32 little region5 v9
+;; @0078                               v11 = uextend.i64 v6
+;; @0078                               v13 = iadd v8, v11
+;; @0078                               v14 = iconst.i64 12
+;; @0078                               v15 = iadd v13, v14  ; v14 = 12
+;; @0078                               store little region5 v10, v15
+;; @0084                               v20 = load.i64 notrap aligned readonly can_move region7 v0+80
+;; @0084                               v19 = load.i64 notrap aligned readonly can_move region6 v0+96
+;;                                     v28 = iconst.i32 -4
+;;                                     v29 = iadd v4, v28  ; v28 = -4
+;; @0084                               call_indirect sig0, v20(v19, v0, v29)
+;;                                     v36 = iconst.i64 0x0010_0000
+;; @0090                               v25 = iadd v8, v36  ; v36 = 0x0010_0000
+;; @0090                               store little region5 v10, v25
+;; @0098                               store notrap aligned region2 v4, v0+128
 ;; @009c                               jump block1
 ;;
 ;;                                 block1:
-;; @009c                               return v11
+;; @009c                               return v10
 ;; }

--- a/tests/disas/pr2303.wat
+++ b/tests/disas/pr2303.wat
@@ -42,37 +42,37 @@
 ;; @0046                               brif v2, block2, block4
 ;;
 ;;                                 block2:
-;; @0048                               v16 = bitcast.i64x2 little v8
-;; @0048                               v17 = bitcast.i64x2 little v13
-;; @0048                               v18 = iadd v16, v17
-;; @004b                               v19 = iconst.i32 32
-;; @004d                               v20 = uextend.i64 v19  ; v19 = 32
-;; @004d                               v21 = load.i64 notrap aligned readonly can_move region2 v0+56
-;; @004d                               v22 = iadd v21, v20
-;; @004d                               v23 = load.i8x16 little region4 v22
-;; @0051                               v26 = bitcast.i8x16 little v18
-;; @0051                               jump block3(v26, v23)
+;; @0048                               v14 = bitcast.i64x2 little v8
+;; @0048                               v15 = bitcast.i64x2 little v13
+;; @0048                               v16 = iadd v14, v15
+;; @004b                               v17 = iconst.i32 32
+;; @004d                               v18 = uextend.i64 v17  ; v17 = 32
+;; @004d                               v19 = load.i64 notrap aligned readonly can_move region2 v0+56
+;; @004d                               v20 = iadd v19, v18
+;; @004d                               v21 = load.i8x16 little region4 v20
+;; @0051                               v22 = bitcast.i8x16 little v16
+;; @0051                               jump block3(v22, v21)
 ;;
 ;;                                 block4:
-;; @0052                               v27 = bitcast.i32x4 little v8
-;; @0052                               v28 = bitcast.i32x4 little v13
-;; @0052                               v29 = isub v27, v28
-;; @0055                               v30 = iconst.i32 0
-;; @0057                               v31 = uextend.i64 v30  ; v30 = 0
-;; @0057                               v32 = load.i64 notrap aligned readonly can_move region2 v0+56
-;; @0057                               v33 = iadd v32, v31
-;; @0057                               v34 = load.i8x16 little region4 v33
-;; @005b                               v35 = bitcast.i8x16 little v29
-;; @005b                               jump block3(v35, v34)
+;; @0052                               v23 = bitcast.i32x4 little v8
+;; @0052                               v24 = bitcast.i32x4 little v13
+;; @0052                               v25 = isub v23, v24
+;; @0055                               v26 = iconst.i32 0
+;; @0057                               v27 = uextend.i64 v26  ; v26 = 0
+;; @0057                               v28 = load.i64 notrap aligned readonly can_move region2 v0+56
+;; @0057                               v29 = iadd v28, v27
+;; @0057                               v30 = load.i8x16 little region4 v29
+;; @005b                               v31 = bitcast.i8x16 little v25
+;; @005b                               jump block3(v31, v30)
 ;;
-;;                                 block3(v14: i8x16, v15: i8x16):
-;; @005c                               v36 = bitcast.i16x8 little v14
-;; @005c                               v37 = bitcast.i16x8 little v15
-;; @005c                               v38 = imul v36, v37
-;; @005f                               v39 = uextend.i64 v3  ; v3 = 48
-;; @005f                               v40 = load.i64 notrap aligned readonly can_move region2 v0+56
-;; @005f                               v41 = iadd v40, v39
-;; @005f                               store little region4 v38, v41
+;;                                 block3(v32: i8x16, v33: i8x16):
+;; @005c                               v34 = bitcast.i16x8 little v32
+;; @005c                               v35 = bitcast.i16x8 little v33
+;; @005c                               v36 = imul v34, v35
+;; @005f                               v37 = uextend.i64 v3  ; v3 = 48
+;; @005f                               v38 = load.i64 notrap aligned readonly can_move region2 v0+56
+;; @005f                               v39 = iadd v38, v37
+;; @005f                               store little region4 v36, v39
 ;; @0063                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/pr2559.wat
+++ b/tests/disas/pr2559.wat
@@ -63,35 +63,35 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @002e                               v5, v6, v7 = call fn0(v0, v0)
-;; @0030                               v8 = iadd v6, v7
-;; @0032                               v9, v10, v11 = call fn0(v0, v0)
-;; @0034                               v12 = icmp uge v10, v11
-;; @0036                               v13 = bitcast.i16x8 little v9
-;; @0036                               v14 = bitcast.i16x8 little v12
-;; @0036                               v15 = icmp ne v13, v14
-;; @0038                               v16 = iconst.i32 13
-;; @003a                               v17 = bitcast.i8x16 little v15
-;; @003a                               brif v16, block1(v17), block2  ; v16 = 13
+;; @002e                               v2, v3, v4 = call fn0(v0, v0)
+;; @0030                               v5 = iadd v3, v4
+;; @0032                               v6, v7, v8 = call fn0(v0, v0)
+;; @0034                               v9 = icmp uge v7, v8
+;; @0036                               v10 = bitcast.i16x8 little v6
+;; @0036                               v11 = bitcast.i16x8 little v9
+;; @0036                               v12 = icmp ne v10, v11
+;; @0038                               v13 = iconst.i32 13
+;; @003a                               v14 = bitcast.i8x16 little v12
+;; @003a                               brif v13, block1(v14), block2  ; v13 = 13
 ;;
 ;;                                 block2:
-;; @003c                               v18 = iconst.i32 43
-;; @003e                               v19 = bitcast.i8x16 little v15
-;; @003e                               brif v18, block1(v19), block3  ; v18 = 43
+;; @003c                               v15 = iconst.i32 43
+;; @003e                               v16 = bitcast.i8x16 little v12
+;; @003e                               brif v15, block1(v16), block3  ; v15 = 43
 ;;
 ;;                                 block3:
-;; @0040                               v20 = iconst.i32 13
-;; @0042                               v21 = bitcast.i8x16 little v15
-;; @0042                               brif v20, block1(v21), block4  ; v20 = 13
+;; @0040                               v17 = iconst.i32 13
+;; @0042                               v18 = bitcast.i8x16 little v12
+;; @0042                               brif v17, block1(v18), block4  ; v17 = 13
 ;;
 ;;                                 block4:
-;; @0044                               v22 = iconst.i32 87
-;; @0047                               v23 = bitcast.i8x16 little v15
-;; @0047                               v24 = select.i8x16 v22, v8, v23  ; v22 = 87
+;; @0044                               v19 = iconst.i32 87
+;; @0047                               v20 = bitcast.i8x16 little v12
+;; @0047                               v21 = select.i8x16 v19, v5, v20  ; v19 = 87
 ;; @0048                               trap user12
 ;;
-;;                                 block1(v4: i8x16):
-;; @0055                               return v5, v8, v4
+;;                                 block1(v24: i8x16):
+;; @0055                               return v2, v5, v24
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64) -> i8x16, i8x16, i8x16 tail {
@@ -105,33 +105,33 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @0058                               v5, v6, v7 = call fn0(v0, v0)
-;; @005a                               v8 = iadd v6, v7
-;; @005c                               v9, v10, v11 = call fn0(v0, v0)
-;; @005e                               v12 = icmp uge v10, v11
-;; @0060                               v13 = bitcast.i16x8 little v9
-;; @0060                               v14 = bitcast.i16x8 little v12
-;; @0060                               v15 = icmp ne v13, v14
-;; @0062                               v16 = iconst.i32 13
-;; @0064                               v17 = bitcast.i8x16 little v15
-;; @0064                               brif v16, block1(v17), block2  ; v16 = 13
+;; @0058                               v2, v3, v4 = call fn0(v0, v0)
+;; @005a                               v5 = iadd v3, v4
+;; @005c                               v6, v7, v8 = call fn0(v0, v0)
+;; @005e                               v9 = icmp uge v7, v8
+;; @0060                               v10 = bitcast.i16x8 little v6
+;; @0060                               v11 = bitcast.i16x8 little v9
+;; @0060                               v12 = icmp ne v10, v11
+;; @0062                               v13 = iconst.i32 13
+;; @0064                               v14 = bitcast.i8x16 little v12
+;; @0064                               brif v13, block1(v14), block2  ; v13 = 13
 ;;
 ;;                                 block2:
-;; @0066                               v18 = iconst.i32 43
-;; @0068                               v19 = bitcast.i8x16 little v15
-;; @0068                               brif v18, block1(v19), block3  ; v18 = 43
+;; @0066                               v15 = iconst.i32 43
+;; @0068                               v16 = bitcast.i8x16 little v12
+;; @0068                               brif v15, block1(v16), block3  ; v15 = 43
 ;;
 ;;                                 block3:
-;; @006a                               v20 = iconst.i32 13
-;; @006c                               v21 = bitcast.i8x16 little v15
-;; @006c                               brif v20, block1(v21), block4  ; v20 = 13
+;; @006a                               v17 = iconst.i32 13
+;; @006c                               v18 = bitcast.i8x16 little v12
+;; @006c                               brif v17, block1(v18), block4  ; v17 = 13
 ;;
 ;;                                 block4:
-;; @006e                               v22 = iconst.i32 87
-;; @0071                               v23 = bitcast.i8x16 little v15
-;; @0071                               v24 = select.i8x16 v22, v8, v23  ; v22 = 87
+;; @006e                               v19 = iconst.i32 87
+;; @0071                               v20 = bitcast.i8x16 little v12
+;; @0071                               v21 = select.i8x16 v19, v5, v20  ; v19 = 87
 ;; @0074                               trap user12
 ;;
-;;                                 block1(v4: i8x16):
-;; @0081                               return v5, v8, v4
+;;                                 block1(v24: i8x16):
+;; @0081                               return v2, v5, v24
 ;; }

--- a/tests/disas/pulley/fib.wat
+++ b/tests/disas/pulley/fib.wat
@@ -49,23 +49,23 @@
   )
 )
 ;; wasm[0]::function[0]::fib:
-;;       push_frame_save 16, x16, x22
+;;       push_frame_save 16, x16, x21
 ;;       br_if_xeq32_i8 x2, 0, 0x47    // target = 0x4c
 ;;       br_if_xeq32_i8 x2, 1, 0x39    // target = 0x45
-;;   13: xsub32_u8 x14, x2, 1
+;;   13: xsub32_u8 x13, x2, 1
 ;;       xmov x16, x2
-;;       xmov x22, x0
-;;       call3 x22, x22, x14, -0x1d    // target = 0x0
+;;       xmov x21, x0
+;;       call3 x21, x21, x13, -0x1d    // target = 0x0
 ;;       xmov x2, x16
 ;;       xmov x16, x0
-;;       xmov x0, x22
-;;       xsub32_u8 x14, x2, 2
-;;       call3 x0, x0, x14, -0x32    // target = 0x0
+;;       xmov x0, x21
+;;       xsub32_u8 x13, x2, 2
+;;       call3 x0, x0, x13, -0x32    // target = 0x0
 ;;       xmov x1, x16
 ;;       xadd32 x0, x1, x0
 ;;       jump 0xe    // target = 0x4e
 ;;   45: xone x0
 ;;       jump 0x7    // target = 0x4e
 ;;   4c: xone x0
-;;       pop_frame_restore 16, x16, x22
+;;       pop_frame_restore 16, x16, x21
 ;;       ret

--- a/tests/disas/readonly-heap-base-pointer1.wat
+++ b/tests/disas/readonly-heap-base-pointer1.wat
@@ -19,16 +19,16 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0020                               v4 = uextend.i64 v2
-;; @0020                               v5 = iconst.i64 0x0001_fffc
-;; @0020                               v6 = icmp ugt v4, v5  ; v5 = 0x0001_fffc
-;; @0020                               v9 = iconst.i64 0
-;; @0020                               v7 = load.i64 notrap aligned readonly can_move region2 v0+56
-;; @0020                               v8 = iadd v7, v4
-;; @0020                               v10 = select_spectre_guard v6, v9, v8  ; v9 = 0
-;; @0020                               v11 = load.i32 little region4 v10
+;; @0020                               v3 = uextend.i64 v2
+;; @0020                               v4 = iconst.i64 0x0001_fffc
+;; @0020                               v5 = icmp ugt v3, v4  ; v4 = 0x0001_fffc
+;; @0020                               v8 = iconst.i64 0
+;; @0020                               v6 = load.i64 notrap aligned readonly can_move region2 v0+56
+;; @0020                               v7 = iadd v6, v3
+;; @0020                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0
+;; @0020                               v10 = load.i32 little region4 v9
 ;; @0023                               jump block1
 ;;
 ;;                                 block1:
-;; @0023                               return v11
+;; @0023                               return v10
 ;; }

--- a/tests/disas/readonly-heap-base-pointer2.wat
+++ b/tests/disas/readonly-heap-base-pointer2.wat
@@ -20,17 +20,17 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0022                               v4 = uextend.i64 v2
-;; @0022                               v5 = iconst.i64 0x0001_fffc
-;; @0022                               v6 = icmp ugt v4, v5  ; v5 = 0x0001_fffc
-;; @0022                               v10 = iconst.i64 0
-;; @0022                               v7 = load.i64 notrap aligned readonly can_move region2 v0+48
-;; @0022                               v8 = load.i64 notrap aligned readonly can_move region3 v7
-;; @0022                               v9 = iadd v8, v4
-;; @0022                               v11 = select_spectre_guard v6, v10, v9  ; v10 = 0
-;; @0022                               v12 = load.i32 little region5 v11
+;; @0022                               v3 = uextend.i64 v2
+;; @0022                               v4 = iconst.i64 0x0001_fffc
+;; @0022                               v5 = icmp ugt v3, v4  ; v4 = 0x0001_fffc
+;; @0022                               v9 = iconst.i64 0
+;; @0022                               v6 = load.i64 notrap aligned readonly can_move region2 v0+48
+;; @0022                               v7 = load.i64 notrap aligned readonly can_move region3 v6
+;; @0022                               v8 = iadd v7, v3
+;; @0022                               v10 = select_spectre_guard v5, v9, v8  ; v9 = 0
+;; @0022                               v11 = load.i32 little region5 v10
 ;; @0025                               jump block1
 ;;
 ;;                                 block1:
-;; @0025                               return v12
+;; @0025                               return v11
 ;; }

--- a/tests/disas/readonly-heap-base-pointer3.wat
+++ b/tests/disas/readonly-heap-base-pointer3.wat
@@ -19,15 +19,15 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0020                               v4 = iconst.i64 0xffff_fffc
-;; @0020                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_fffc
-;; @0020                               v8 = iconst.i64 0
-;; @0020                               v6 = load.i64 notrap aligned readonly can_move region2 v0+56
-;; @0020                               v7 = iadd v6, v2
-;; @0020                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0
-;; @0020                               v10 = load.i32 little region4 v9
+;; @0020                               v3 = iconst.i64 0xffff_fffc
+;; @0020                               v4 = icmp ugt v2, v3  ; v3 = 0xffff_fffc
+;; @0020                               v7 = iconst.i64 0
+;; @0020                               v5 = load.i64 notrap aligned readonly can_move region2 v0+56
+;; @0020                               v6 = iadd v5, v2
+;; @0020                               v8 = select_spectre_guard v4, v7, v6  ; v7 = 0
+;; @0020                               v9 = load.i32 little region4 v8
 ;; @0023                               jump block1
 ;;
 ;;                                 block1:
-;; @0023                               return v10
+;; @0023                               return v9
 ;; }

--- a/tests/disas/ref-func-0.wat
+++ b/tests/disas/ref-func-0.wat
@@ -23,16 +23,16 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @008f                               v6 = iconst.i64 80
-;; @008f                               v7 = iadd v0, v6  ; v6 = 80
-;; @008f                               v8 = load.i32 notrap aligned region2 v7
-;; @0091                               v9 = iconst.i64 96
-;; @0091                               v10 = iadd v0, v9  ; v9 = 96
-;; @0091                               v11 = load.i32 notrap aligned region2 v10
-;; @0093                               v12 = load.i64 notrap aligned region2 v0+112
-;; @0095                               v13 = load.i64 notrap aligned region2 v0+128
+;; @008f                               v2 = iconst.i64 80
+;; @008f                               v3 = iadd v0, v2  ; v2 = 80
+;; @008f                               v4 = load.i32 notrap aligned region2 v3
+;; @0091                               v5 = iconst.i64 96
+;; @0091                               v6 = iadd v0, v5  ; v5 = 96
+;; @0091                               v7 = load.i32 notrap aligned region2 v6
+;; @0093                               v8 = load.i64 notrap aligned region2 v0+112
+;; @0095                               v9 = load.i64 notrap aligned region2 v0+128
 ;; @0097                               jump block1
 ;;
 ;;                                 block1:
-;; @0097                               return v8, v11, v12, v13
+;; @0097                               return v4, v7, v8, v9
 ;; }

--- a/tests/disas/select.wat
+++ b/tests/disas/select.wat
@@ -29,14 +29,14 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @0023                               v3 = iconst.i32 42
-;; @0025                               v4 = iconst.i32 24
-;; @0027                               v5 = iconst.i32 1
-;; @0029                               v6 = select v5, v3, v4  ; v5 = 1, v3 = 42, v4 = 24
+;; @0023                               v2 = iconst.i32 42
+;; @0025                               v3 = iconst.i32 24
+;; @0027                               v4 = iconst.i32 1
+;; @0029                               v5 = select v4, v2, v3  ; v4 = 1, v2 = 42, v3 = 24
 ;; @002a                               jump block1
 ;;
 ;;                                 block1:
-;; @002a                               return v6
+;; @002a                               return v5
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64) -> i32 tail {
@@ -48,14 +48,14 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @002d                               v3 = iconst.i32 0
-;; @002f                               v4 = iconst.i32 0
-;; @0031                               v5 = iconst.i32 1
-;; @0033                               v6 = select v5, v3, v4  ; v5 = 1, v3 = 0, v4 = 0
+;; @002d                               v2 = iconst.i32 0
+;; @002f                               v3 = iconst.i32 0
+;; @0031                               v4 = iconst.i32 1
+;; @0033                               v5 = select v4, v2, v3  ; v4 = 1, v2 = 0, v3 = 0
 ;; @0036                               jump block1
 ;;
 ;;                                 block1:
-;; @0036                               return v6
+;; @0036                               return v5
 ;; }
 ;;
 ;; function u0:2(i64 vmctx, i64, i32) -> i32 tail {
@@ -67,11 +67,11 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0039                               v4 = iconst.i32 0
-;; @003d                               v5 = iconst.i32 1
-;; @003f                               v6 = select v5, v4, v2  ; v5 = 1, v4 = 0
+;; @0039                               v3 = iconst.i32 0
+;; @003d                               v4 = iconst.i32 1
+;; @003f                               v5 = select v4, v3, v2  ; v4 = 1, v3 = 0
 ;; @0042                               jump block1
 ;;
 ;;                                 block1:
-;; @0042                               return v6
+;; @0042                               return v5
 ;; }

--- a/tests/disas/simd.wat
+++ b/tests/disas/simd.wat
@@ -39,13 +39,13 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @004e                               v3 = iconst.i32 42
-;; @0050                               v4 = splat.i32x4 v3  ; v3 = 42
-;; @0052                               v5 = extractlane v4, 0
+;; @004e                               v2 = iconst.i32 42
+;; @0050                               v3 = splat.i32x4 v2  ; v2 = 42
+;; @0052                               v4 = extractlane v3, 0
 ;; @0055                               jump block1
 ;;
 ;;                                 block1:
-;; @0055                               return v5
+;; @0055                               return v4
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64) -> i32 tail {
@@ -58,15 +58,15 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @0058                               v3 = vconst.i8x16 const0
-;; @006a                               v4 = iconst.i32 99
-;; @006d                               v5 = bitcast.i32x4 little v3  ; v3 = const0
-;; @006d                               v6 = insertlane v5, v4, 1  ; v4 = 99
-;; @0070                               v7 = extractlane v6, 1
+;; @0058                               v2 = vconst.i8x16 const0
+;; @006a                               v3 = iconst.i32 99
+;; @006d                               v4 = bitcast.i32x4 little v2  ; v2 = const0
+;; @006d                               v5 = insertlane v4, v3, 1  ; v3 = 99
+;; @0070                               v6 = extractlane v5, 1
 ;; @0073                               jump block1
 ;;
 ;;                                 block1:
-;; @0073                               return v7
+;; @0073                               return v6
 ;; }
 ;;
 ;; function u0:2(i64 vmctx, i64) -> i32 tail {
@@ -79,13 +79,13 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @0076                               v3 = vconst.i8x16 const0
-;; @0088                               v4 = bitcast.i32x4 little v3  ; v3 = const0
-;; @0088                               v5 = extractlane v4, 3
+;; @0076                               v2 = vconst.i8x16 const0
+;; @0088                               v3 = bitcast.i32x4 little v2  ; v2 = const0
+;; @0088                               v4 = extractlane v3, 3
 ;; @008b                               jump block1
 ;;
 ;;                                 block1:
-;; @008b                               return v5
+;; @008b                               return v4
 ;; }
 ;;
 ;; function u0:3(i64 vmctx, i64) tail {

--- a/tests/disas/simple.wat
+++ b/tests/disas/simple.wat
@@ -61,8 +61,8 @@
 ;; @0030                               v3 = iconst.i32 0
 ;; @0032                               jump block2(v3)  ; v3 = 0
 ;;
-;;                                 block2(v5: i32):
-;; @0036                               v6 = iconst.i32 1
-;; @0038                               v7 = iadd v5, v6  ; v6 = 1
-;; @003b                               jump block2(v7)
+;;                                 block2(v4: i32):
+;; @0036                               v5 = iconst.i32 1
+;; @0038                               v6 = iadd v4, v5  ; v5 = 1
+;; @003b                               jump block2(v6)
 ;; }

--- a/tests/disas/simple.wat
+++ b/tests/disas/simple.wat
@@ -27,12 +27,12 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0021                               v4 = iconst.i32 1
-;; @0023                               v5 = iadd v2, v4  ; v4 = 1
+;; @0021                               v3 = iconst.i32 1
+;; @0023                               v4 = iadd v2, v3  ; v3 = 1
 ;; @0024                               jump block1
 ;;
 ;;                                 block1:
-;; @0024                               return v5
+;; @0024                               return v4
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
@@ -44,9 +44,9 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0029                               v4 = iconst.i32 1
-;; @002b                               v5 = iadd v2, v4  ; v4 = 1
-;; @002c                               return v5
+;; @0029                               v3 = iconst.i32 1
+;; @002b                               v4 = iadd v2, v3  ; v3 = 1
+;; @002c                               return v4
 ;; }
 ;;
 ;; function u0:2(i64 vmctx, i64) -> i32 tail {
@@ -58,11 +58,11 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @0030                               v3 = iconst.i32 0
-;; @0032                               jump block2(v3)  ; v3 = 0
+;; @0030                               v2 = iconst.i32 0
+;; @0032                               jump block2(v2)  ; v2 = 0
 ;;
-;;                                 block2(v4: i32):
-;; @0036                               v5 = iconst.i32 1
-;; @0038                               v6 = iadd v4, v5  ; v5 = 1
-;; @003b                               jump block2(v6)
+;;                                 block2(v3: i32):
+;; @0036                               v4 = iconst.i32 1
+;; @0038                               v5 = iadd v3, v4  ; v4 = 1
+;; @003b                               jump block2(v5)
 ;; }

--- a/tests/disas/stack-switching/resume-suspend-data-passing.wat
+++ b/tests/disas/stack-switching/resume-suspend-data-passing.wat
@@ -169,145 +169,145 @@
 ;; @0058                               v7 = load.i64 notrap aligned v6+72
 ;; @0058                               v9 = uextend.i128 v7
 ;; @0058                               v10 = iconst.i64 64
-;;                                     v117 = ishl v9, v10  ; v10 = 64
+;;                                     v115 = ishl v9, v10  ; v10 = 64
 ;; @0058                               v8 = uextend.i128 v6
-;; @0058                               v13 = bor v117, v8
-;; @0062                               v24 = iconst.i64 1
-;; @0062                               v27 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0062                               v30 = iconst.i64 0
-;; @0062                               v31 = iconst.i64 2
-;; @0062                               v35 = iconst.i32 1
-;; @0062                               v36 = iconst.i64 16
-;; @0062                               v38 = iconst.i32 2
-;; @0062                               v50 = iconst.i64 24
-;; @0062                               v53 = stack_addr.i64 ss0
-;; @0062                               v54 = iconst.i64 48
-;; @0062                               v55 = iadd v0, v54  ; v54 = 48
-;; @0062                               v62 = iconst.i64 80
-;; @0062                               v65 = iconst.i64 -24
-;;                                     v121 = iconst.i64 0x0001_0000_0000
-;; @0062                               v60 = iconst.i64 32
+;; @0058                               v13 = bor v115, v8
+;; @0062                               v22 = iconst.i64 1
+;; @0062                               v25 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @0062                               v28 = iconst.i64 0
+;; @0062                               v29 = iconst.i64 2
+;; @0062                               v33 = iconst.i32 1
+;; @0062                               v34 = iconst.i64 16
+;; @0062                               v36 = iconst.i32 2
+;; @0062                               v48 = iconst.i64 24
+;; @0062                               v51 = stack_addr.i64 ss0
+;; @0062                               v52 = iconst.i64 48
+;; @0062                               v53 = iadd v0, v52  ; v52 = 48
+;; @0062                               v60 = iconst.i64 80
+;; @0062                               v63 = iconst.i64 -24
+;;                                     v119 = iconst.i64 0x0001_0000_0000
+;; @0062                               v58 = iconst.i64 32
 ;; @005c                               jump block2(v13)
 ;;
-;;                                 block2(v16: i128):
+;;                                 block2(v14: i128):
 ;; @0062                               jump block5
 ;;
 ;;                                 block5:
-;; @0062                               v17 = ireduce.i64 v16
-;; @0062                               trapz v17, user16
-;; @0062                               v22 = load.i64 notrap aligned v17+72
-;;                                     v124 = iconst.i64 64
-;;                                     v125 = ushr.i128 v16, v124  ; v124 = 64
-;; @0062                               v21 = ireduce.i64 v125
-;; @0062                               v23 = icmp eq v22, v21
-;; @0062                               trapz v23, user23
-;;                                     v126 = iconst.i64 1
-;;                                     v127 = iadd v22, v126  ; v126 = 1
-;; @0062                               store notrap aligned v127, v17+72
-;; @0062                               v26 = load.i64 notrap aligned v17+64
-;; @0062                               v28 = load.i64 notrap aligned region2 v27+88
-;; @0062                               v29 = load.i64 notrap aligned region2 v27+96
-;; @0062                               store notrap aligned v28, v26+48
-;; @0062                               store notrap aligned v29, v26+56
-;;                                     v128 = iconst.i64 0
-;; @0062                               store notrap aligned v128, v17+64  ; v128 = 0
-;;                                     v129 = iconst.i64 2
-;; @0062                               store notrap aligned region2 v129, v27+88  ; v129 = 2
-;; @0062                               store notrap aligned region2 v17, v27+96
-;;                                     v130 = iconst.i32 1
-;;                                     v131 = iconst.i64 16
-;;                                     v132 = iadd v17, v131  ; v131 = 16
-;; @0062                               store notrap aligned v130, v132  ; v130 = 1
-;;                                     v133 = iconst.i32 2
-;;                                     v134 = iadd v29, v131  ; v131 = 16
-;; @0062                               store notrap aligned v133, v134  ; v133 = 2
-;; @0062                               v44 = load.i64 notrap aligned region3 v27+72
-;; @0062                               store notrap aligned v44, v29+8
-;; @0062                               v45 = load.i64 notrap aligned region1 v27+24
-;; @0062                               store notrap aligned v45, v29
-;; @0062                               v48 = load.i64 notrap aligned v17
-;; @0062                               store notrap aligned region1 v48, v27+24
-;; @0062                               v49 = load.i64 notrap aligned v17+8
-;; @0062                               store notrap aligned region3 v49, v27+72
-;;                                     v135 = iconst.i64 24
-;;                                     v136 = iadd v29, v135  ; v135 = 24
-;; @0062                               store notrap aligned v130, v136+4  ; v130 = 1
-;; @0062                               store.i64 notrap aligned v53, v136+8
-;;                                     v137 = iadd.i64 v0, v54  ; v54 = 48
-;; @0062                               store notrap aligned v137, v53
-;; @0062                               store notrap aligned v130, v136  ; v130 = 1
-;; @0062                               store notrap aligned v130, v29+40  ; v130 = 1
-;;                                     v138 = iconst.i64 80
-;;                                     v139 = iadd v26, v138  ; v138 = 80
-;; @0062                               v64 = load.i64 notrap aligned v139
-;;                                     v140 = iconst.i64 -24
-;;                                     v141 = iadd v64, v140  ; v140 = -24
-;;                                     v142 = iconst.i64 0x0001_0000_0000
-;; @0062                               v67 = stack_switch v141, v141, v142  ; v142 = 0x0001_0000_0000
-;; @0062                               v69 = load.i64 notrap aligned region2 v27+88
-;; @0062                               v70 = load.i64 notrap aligned region2 v27+96
-;; @0062                               store notrap aligned region2 v28, v27+88
-;; @0062                               store notrap aligned region2 v29, v27+96
-;; @0062                               store notrap aligned v130, v134  ; v130 = 1
-;;                                     v143 = iconst.i32 0
-;; @0062                               store notrap aligned v143, v136  ; v143 = 0
-;; @0062                               store notrap aligned v143, v136+4  ; v143 = 0
-;; @0062                               store notrap aligned v128, v136+8  ; v128 = 0
-;; @0062                               store notrap aligned v128, v29+40  ; v128 = 0
-;;                                     v144 = iconst.i64 32
-;;                                     v145 = ushr v67, v144  ; v144 = 32
-;; @0062                               brif v145, block7, block6
+;; @0062                               v15 = ireduce.i64 v14
+;; @0062                               trapz v15, user16
+;; @0062                               v20 = load.i64 notrap aligned v15+72
+;;                                     v122 = iconst.i64 64
+;;                                     v123 = ushr.i128 v14, v122  ; v122 = 64
+;; @0062                               v19 = ireduce.i64 v123
+;; @0062                               v21 = icmp eq v20, v19
+;; @0062                               trapz v21, user23
+;;                                     v124 = iconst.i64 1
+;;                                     v125 = iadd v20, v124  ; v124 = 1
+;; @0062                               store notrap aligned v125, v15+72
+;; @0062                               v24 = load.i64 notrap aligned v15+64
+;; @0062                               v26 = load.i64 notrap aligned region2 v25+88
+;; @0062                               v27 = load.i64 notrap aligned region2 v25+96
+;; @0062                               store notrap aligned v26, v24+48
+;; @0062                               store notrap aligned v27, v24+56
+;;                                     v126 = iconst.i64 0
+;; @0062                               store notrap aligned v126, v15+64  ; v126 = 0
+;;                                     v127 = iconst.i64 2
+;; @0062                               store notrap aligned region2 v127, v25+88  ; v127 = 2
+;; @0062                               store notrap aligned region2 v15, v25+96
+;;                                     v128 = iconst.i32 1
+;;                                     v129 = iconst.i64 16
+;;                                     v130 = iadd v15, v129  ; v129 = 16
+;; @0062                               store notrap aligned v128, v130  ; v128 = 1
+;;                                     v131 = iconst.i32 2
+;;                                     v132 = iadd v27, v129  ; v129 = 16
+;; @0062                               store notrap aligned v131, v132  ; v131 = 2
+;; @0062                               v42 = load.i64 notrap aligned region3 v25+72
+;; @0062                               store notrap aligned v42, v27+8
+;; @0062                               v43 = load.i64 notrap aligned region1 v25+24
+;; @0062                               store notrap aligned v43, v27
+;; @0062                               v46 = load.i64 notrap aligned v15
+;; @0062                               store notrap aligned region1 v46, v25+24
+;; @0062                               v47 = load.i64 notrap aligned v15+8
+;; @0062                               store notrap aligned region3 v47, v25+72
+;;                                     v133 = iconst.i64 24
+;;                                     v134 = iadd v27, v133  ; v133 = 24
+;; @0062                               store notrap aligned v128, v134+4  ; v128 = 1
+;; @0062                               store.i64 notrap aligned v51, v134+8
+;;                                     v135 = iadd.i64 v0, v52  ; v52 = 48
+;; @0062                               store notrap aligned v135, v51
+;; @0062                               store notrap aligned v128, v134  ; v128 = 1
+;; @0062                               store notrap aligned v128, v27+40  ; v128 = 1
+;;                                     v136 = iconst.i64 80
+;;                                     v137 = iadd v24, v136  ; v136 = 80
+;; @0062                               v62 = load.i64 notrap aligned v137
+;;                                     v138 = iconst.i64 -24
+;;                                     v139 = iadd v62, v138  ; v138 = -24
+;;                                     v140 = iconst.i64 0x0001_0000_0000
+;; @0062                               v65 = stack_switch v139, v139, v140  ; v140 = 0x0001_0000_0000
+;; @0062                               v67 = load.i64 notrap aligned region2 v25+88
+;; @0062                               v68 = load.i64 notrap aligned region2 v25+96
+;; @0062                               store notrap aligned region2 v26, v25+88
+;; @0062                               store notrap aligned region2 v27, v25+96
+;; @0062                               store notrap aligned v128, v132  ; v128 = 1
+;;                                     v141 = iconst.i32 0
+;; @0062                               store notrap aligned v141, v134  ; v141 = 0
+;; @0062                               store notrap aligned v141, v134+4  ; v141 = 0
+;; @0062                               store notrap aligned v126, v134+8  ; v126 = 0
+;; @0062                               store notrap aligned v126, v27+40  ; v126 = 0
+;;                                     v142 = iconst.i64 32
+;;                                     v143 = ushr v65, v142  ; v142 = 32
+;; @0062                               brif v143, block7, block6
 ;;
 ;;                                 block7:
-;; @0062                               v84 = load.i64 notrap aligned region3 v27+72
-;; @0062                               store notrap aligned v84, v70+8
-;; @0062                               v87 = load.i64 notrap aligned v29
-;; @0062                               store notrap aligned region1 v87, v27+24
-;; @0062                               v88 = load.i64 notrap aligned v29+8
-;; @0062                               store notrap aligned region3 v88, v27+72
-;; @0062                               v90 = load.i64 notrap aligned v70+72
+;; @0062                               v82 = load.i64 notrap aligned region3 v25+72
+;; @0062                               store notrap aligned v82, v68+8
+;; @0062                               v85 = load.i64 notrap aligned v27
+;; @0062                               store notrap aligned region1 v85, v25+24
+;; @0062                               v86 = load.i64 notrap aligned v27+8
+;; @0062                               store notrap aligned region3 v86, v25+72
+;; @0062                               v88 = load.i64 notrap aligned v68+72
 ;; @0062                               jump block8
 ;;
 ;;                                 block9 cold:
 ;; @0062                               trap user12
 ;;
 ;;                                 block10:
-;; @0062                               v97 = iconst.i64 120
-;; @0062                               v98 = iadd.i64 v70, v97  ; v97 = 120
-;; @0062                               v99 = load.i64 notrap aligned v98+8
-;; @0062                               v100 = load.i32 notrap aligned v99
-;;                                     v150 = iconst.i32 0
-;; @0062                               store notrap aligned v150, v98  ; v150 = 0
+;; @0062                               v95 = iconst.i64 120
+;; @0062                               v96 = iadd.i64 v68, v95  ; v95 = 120
+;; @0062                               v97 = load.i64 notrap aligned v96+8
+;; @0062                               v98 = load.i32 notrap aligned v97
+;;                                     v148 = iconst.i32 0
+;; @0062                               store notrap aligned v148, v96  ; v148 = 0
 ;; @0062                               jump block4
 ;;
 ;;                                 block8:
-;; @0062                               v89 = ireduce.i32 v67
-;; @0062                               br_table v89, block9, [block10]
+;; @0062                               v87 = ireduce.i32 v65
+;; @0062                               br_table v87, block9, [block10]
 ;;
 ;;                                 block6:
-;; @0062                               v104 = load.i64 notrap aligned v29
-;; @0062                               store notrap aligned region1 v104, v27+24
-;; @0062                               v105 = load.i64 notrap aligned v29+8
-;; @0062                               store notrap aligned region3 v105, v27+72
-;; @0062                               v108 = iconst.i32 4
-;;                                     v146 = iconst.i64 16
-;;                                     v147 = iadd.i64 v70, v146  ; v146 = 16
-;; @0062                               store notrap aligned v108, v147  ; v108 = 4
-;; @0062                               v111 = iconst.i64 104
-;; @0062                               v112 = iadd.i64 v70, v111  ; v111 = 104
-;; @0062                               v113 = load.i64 notrap aligned v112+8
-;;                                     v148 = iconst.i32 0
-;; @0062                               store notrap aligned v148, v112  ; v148 = 0
-;; @0062                               store notrap aligned v148, v112+4  ; v148 = 0
-;;                                     v149 = iconst.i64 0
-;; @0062                               store notrap aligned v149, v112+8  ; v149 = 0
+;; @0062                               v102 = load.i64 notrap aligned v27
+;; @0062                               store notrap aligned region1 v102, v25+24
+;; @0062                               v103 = load.i64 notrap aligned v27+8
+;; @0062                               store notrap aligned region3 v103, v25+72
+;; @0062                               v106 = iconst.i32 4
+;;                                     v144 = iconst.i64 16
+;;                                     v145 = iadd.i64 v68, v144  ; v144 = 16
+;; @0062                               store notrap aligned v106, v145  ; v106 = 4
+;; @0062                               v109 = iconst.i64 104
+;; @0062                               v110 = iadd.i64 v68, v109  ; v109 = 104
+;; @0062                               v111 = load.i64 notrap aligned v110+8
+;;                                     v146 = iconst.i32 0
+;; @0062                               store notrap aligned v146, v110  ; v146 = 0
+;; @0062                               store notrap aligned v146, v110+4  ; v146 = 0
+;;                                     v147 = iconst.i64 0
+;; @0062                               store notrap aligned v147, v110+8  ; v147 = 0
 ;; @0068                               return
 ;;
 ;;                                 block4:
-;; @0062                               v92 = uextend.i128 v90
-;;                                     v151 = iconst.i64 64
-;;                                     v152 = ishl v92, v151  ; v151 = 64
-;; @0062                               v91 = uextend.i128 v70
-;; @0062                               v96 = bor v152, v91
-;; @006d                               jump block2(v96)
+;; @0062                               v90 = uextend.i128 v88
+;;                                     v149 = iconst.i64 64
+;;                                     v150 = ishl v90, v149  ; v149 = 64
+;; @0062                               v89 = uextend.i128 v68
+;; @0062                               v94 = bor v150, v89
+;; @006d                               jump block2(v94)
 ;; }

--- a/tests/disas/stack-switching/resume-suspend.wat
+++ b/tests/disas/stack-switching/resume-suspend.wat
@@ -137,127 +137,127 @@
 ;;                                     v132 = ireduce.i64 v130
 ;;                                     v134 = bor v132, v13
 ;; @004e                               trapz v134, user16
-;; @004e                               v27 = load.i64 notrap aligned v134+72
+;; @004e                               v26 = load.i64 notrap aligned v134+72
 ;; @0045                               v15 = uextend.i128 v13
 ;; @0045                               v20 = bor v130, v15
 ;;                                     v136 = ushr v20, v5  ; v5 = 64
-;; @004e                               v26 = ireduce.i64 v136
-;; @004e                               v28 = icmp eq v27, v26
-;; @004e                               trapz v28, user23
-;; @004e                               v29 = iconst.i64 1
-;; @004e                               v30 = iadd v27, v29  ; v29 = 1
-;; @004e                               store notrap aligned v30, v134+72
-;; @004e                               v31 = load.i64 notrap aligned v134+64
-;; @004e                               v32 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @004e                               v33 = load.i64 notrap aligned region2 v32+88
-;; @004e                               v34 = load.i64 notrap aligned region2 v32+96
-;; @004e                               store notrap aligned v33, v31+48
-;; @004e                               store notrap aligned v34, v31+56
+;; @004e                               v25 = ireduce.i64 v136
+;; @004e                               v27 = icmp eq v26, v25
+;; @004e                               trapz v27, user23
+;; @004e                               v28 = iconst.i64 1
+;; @004e                               v29 = iadd v26, v28  ; v28 = 1
+;; @004e                               store notrap aligned v29, v134+72
+;; @004e                               v30 = load.i64 notrap aligned v134+64
+;; @004e                               v31 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @004e                               v32 = load.i64 notrap aligned region2 v31+88
+;; @004e                               v33 = load.i64 notrap aligned region2 v31+96
+;; @004e                               store notrap aligned v32, v30+48
+;; @004e                               store notrap aligned v33, v30+56
 ;; @0040                               v2 = iconst.i64 0
 ;; @004e                               store notrap aligned v2, v134+64  ; v2 = 0
-;; @004e                               v36 = iconst.i64 2
-;; @004e                               store notrap aligned region2 v36, v32+88  ; v36 = 2
-;; @004e                               store notrap aligned region2 v134, v32+96
-;; @004e                               v40 = iconst.i32 1
-;; @004e                               v41 = iconst.i64 16
-;; @004e                               v42 = iadd v134, v41  ; v41 = 16
-;; @004e                               store notrap aligned v40, v42  ; v40 = 1
-;; @004e                               v43 = iconst.i32 2
-;; @004e                               v45 = iadd v34, v41  ; v41 = 16
-;; @004e                               store notrap aligned v43, v45  ; v43 = 2
-;; @004e                               v49 = load.i64 notrap aligned region3 v32+72
-;; @004e                               store notrap aligned v49, v34+8
-;; @004e                               v50 = load.i64 notrap aligned region1 v32+24
-;; @004e                               store notrap aligned v50, v34
-;; @004e                               v53 = load.i64 notrap aligned v134
-;; @004e                               store notrap aligned region1 v53, v32+24
-;; @004e                               v54 = load.i64 notrap aligned v134+8
-;; @004e                               store notrap aligned region3 v54, v32+72
-;; @004e                               v55 = iconst.i64 24
-;; @004e                               v56 = iadd v34, v55  ; v55 = 24
-;; @004e                               store notrap aligned v40, v56+4  ; v40 = 1
-;; @004e                               v58 = stack_addr.i64 ss0
-;; @004e                               store notrap aligned v58, v56+8
-;; @004e                               v59 = iconst.i64 48
-;; @004e                               v60 = iadd.i64 v0, v59  ; v59 = 48
-;; @004e                               store notrap aligned v60, v58
-;; @004e                               store notrap aligned v40, v56  ; v40 = 1
-;; @004e                               store notrap aligned v40, v34+40  ; v40 = 1
-;; @004e                               v67 = iconst.i64 80
-;; @004e                               v68 = iadd v31, v67  ; v67 = 80
-;; @004e                               v69 = load.i64 notrap aligned v68
-;; @004e                               v70 = iconst.i64 -24
-;; @004e                               v71 = iadd v69, v70  ; v70 = -24
+;; @004e                               v35 = iconst.i64 2
+;; @004e                               store notrap aligned region2 v35, v31+88  ; v35 = 2
+;; @004e                               store notrap aligned region2 v134, v31+96
+;; @004e                               v39 = iconst.i32 1
+;; @004e                               v40 = iconst.i64 16
+;; @004e                               v41 = iadd v134, v40  ; v40 = 16
+;; @004e                               store notrap aligned v39, v41  ; v39 = 1
+;; @004e                               v42 = iconst.i32 2
+;; @004e                               v44 = iadd v33, v40  ; v40 = 16
+;; @004e                               store notrap aligned v42, v44  ; v42 = 2
+;; @004e                               v48 = load.i64 notrap aligned region3 v31+72
+;; @004e                               store notrap aligned v48, v33+8
+;; @004e                               v49 = load.i64 notrap aligned region1 v31+24
+;; @004e                               store notrap aligned v49, v33
+;; @004e                               v52 = load.i64 notrap aligned v134
+;; @004e                               store notrap aligned region1 v52, v31+24
+;; @004e                               v53 = load.i64 notrap aligned v134+8
+;; @004e                               store notrap aligned region3 v53, v31+72
+;; @004e                               v54 = iconst.i64 24
+;; @004e                               v55 = iadd v33, v54  ; v54 = 24
+;; @004e                               store notrap aligned v39, v55+4  ; v39 = 1
+;; @004e                               v57 = stack_addr.i64 ss0
+;; @004e                               store notrap aligned v57, v55+8
+;; @004e                               v58 = iconst.i64 48
+;; @004e                               v59 = iadd.i64 v0, v58  ; v58 = 48
+;; @004e                               store notrap aligned v59, v57
+;; @004e                               store notrap aligned v39, v55  ; v39 = 1
+;; @004e                               store notrap aligned v39, v33+40  ; v39 = 1
+;; @004e                               v66 = iconst.i64 80
+;; @004e                               v67 = iadd v30, v66  ; v66 = 80
+;; @004e                               v68 = load.i64 notrap aligned v67
+;; @004e                               v69 = iconst.i64 -24
+;; @004e                               v70 = iadd v68, v69  ; v69 = -24
 ;;                                     v138 = iconst.i64 0x0001_0000_0000
-;; @004e                               v72 = stack_switch v71, v71, v138  ; v138 = 0x0001_0000_0000
-;; @004e                               v74 = load.i64 notrap aligned region2 v32+88
-;; @004e                               v75 = load.i64 notrap aligned region2 v32+96
-;; @004e                               store notrap aligned region2 v33, v32+88
-;; @004e                               store notrap aligned region2 v34, v32+96
-;; @004e                               store notrap aligned v40, v45  ; v40 = 1
+;; @004e                               v71 = stack_switch v70, v70, v138  ; v138 = 0x0001_0000_0000
+;; @004e                               v73 = load.i64 notrap aligned region2 v31+88
+;; @004e                               v74 = load.i64 notrap aligned region2 v31+96
+;; @004e                               store notrap aligned region2 v32, v31+88
+;; @004e                               store notrap aligned region2 v33, v31+96
+;; @004e                               store notrap aligned v39, v44  ; v39 = 1
 ;;                                     v141 = iconst.i32 0
-;; @004e                               store notrap aligned v141, v56  ; v141 = 0
-;; @004e                               store notrap aligned v141, v56+4  ; v141 = 0
-;; @004e                               store notrap aligned v2, v56+8  ; v2 = 0
-;; @004e                               store notrap aligned v2, v34+40  ; v2 = 0
-;; @004e                               v65 = iconst.i64 32
-;; @004e                               v84 = ushr v72, v65  ; v65 = 32
-;; @004e                               brif v84, block5, block4
+;; @004e                               store notrap aligned v141, v55  ; v141 = 0
+;; @004e                               store notrap aligned v141, v55+4  ; v141 = 0
+;; @004e                               store notrap aligned v2, v55+8  ; v2 = 0
+;; @004e                               store notrap aligned v2, v33+40  ; v2 = 0
+;; @004e                               v64 = iconst.i64 32
+;; @004e                               v83 = ushr v71, v64  ; v64 = 32
+;; @004e                               brif v83, block5, block4
 ;;
 ;;                                 block5:
-;; @004e                               v89 = load.i64 notrap aligned region3 v32+72
-;; @004e                               store notrap aligned v89, v75+8
-;; @004e                               v92 = load.i64 notrap aligned v34
-;; @004e                               store notrap aligned region1 v92, v32+24
-;; @004e                               v93 = load.i64 notrap aligned v34+8
-;; @004e                               store notrap aligned region3 v93, v32+72
-;; @004e                               v95 = load.i64 notrap aligned v75+72
+;; @004e                               v88 = load.i64 notrap aligned region3 v31+72
+;; @004e                               store notrap aligned v88, v74+8
+;; @004e                               v91 = load.i64 notrap aligned v33
+;; @004e                               store notrap aligned region1 v91, v31+24
+;; @004e                               v92 = load.i64 notrap aligned v33+8
+;; @004e                               store notrap aligned region3 v92, v31+72
+;; @004e                               v94 = load.i64 notrap aligned v74+72
 ;; @004e                               jump block6
 ;;
 ;;                                 block7 cold:
 ;; @004e                               trap user12
 ;;
 ;;                                 block8:
-;; @004e                               v102 = iconst.i64 120
-;; @004e                               v103 = iadd.i64 v75, v102  ; v102 = 120
-;; @004e                               v104 = load.i64 notrap aligned v103+8
+;; @004e                               v101 = iconst.i64 120
+;; @004e                               v102 = iadd.i64 v74, v101  ; v101 = 120
+;; @004e                               v103 = load.i64 notrap aligned v102+8
 ;;                                     v149 = iconst.i32 0
-;; @004e                               store notrap aligned v149, v103  ; v149 = 0
-;; @004e                               v97 = uextend.i128 v95
+;; @004e                               store notrap aligned v149, v102  ; v149 = 0
+;; @004e                               v96 = uextend.i128 v94
 ;;                                     v150 = iconst.i64 64
-;;                                     v151 = ishl v97, v150  ; v150 = 64
-;; @004e                               v96 = uextend.i128 v75
-;; @004e                               v101 = bor v151, v96
-;; @004e                               jump block2(v101)
+;;                                     v151 = ishl v96, v150  ; v150 = 64
+;; @004e                               v95 = uextend.i128 v74
+;; @004e                               v100 = bor v151, v95
+;; @004e                               jump block2(v100)
 ;;
 ;;                                 block6:
-;; @004e                               v94 = ireduce.i32 v72
-;; @004e                               br_table v94, block7, [block8]
+;; @004e                               v93 = ireduce.i32 v71
+;; @004e                               br_table v93, block7, [block8]
 ;;
 ;;                                 block4:
-;; @004e                               v108 = load.i64 notrap aligned v34
-;; @004e                               store notrap aligned region1 v108, v32+24
-;; @004e                               v109 = load.i64 notrap aligned v34+8
-;; @004e                               store notrap aligned region3 v109, v32+72
-;; @004e                               v112 = iconst.i32 4
+;; @004e                               v107 = load.i64 notrap aligned v33
+;; @004e                               store notrap aligned region1 v107, v31+24
+;; @004e                               v108 = load.i64 notrap aligned v33+8
+;; @004e                               store notrap aligned region3 v108, v31+72
+;; @004e                               v111 = iconst.i32 4
 ;;                                     v142 = iconst.i64 16
-;;                                     v143 = iadd.i64 v75, v142  ; v142 = 16
-;; @004e                               store notrap aligned v112, v143  ; v112 = 4
-;; @004e                               v115 = iconst.i64 104
-;; @004e                               v116 = iadd.i64 v75, v115  ; v115 = 104
-;; @004e                               v117 = load.i64 notrap aligned v116+8
+;;                                     v143 = iadd.i64 v74, v142  ; v142 = 16
+;; @004e                               store notrap aligned v111, v143  ; v111 = 4
+;; @004e                               v114 = iconst.i64 104
+;; @004e                               v115 = iadd.i64 v74, v114  ; v114 = 104
+;; @004e                               v116 = load.i64 notrap aligned v115+8
 ;;                                     v144 = iconst.i32 0
-;; @004e                               store notrap aligned v144, v116  ; v144 = 0
-;; @004e                               store notrap aligned v144, v116+4  ; v144 = 0
+;; @004e                               store notrap aligned v144, v115  ; v144 = 0
+;; @004e                               store notrap aligned v144, v115+4  ; v144 = 0
 ;;                                     v145 = iconst.i64 0
-;; @004e                               store notrap aligned v145, v116+8  ; v145 = 0
+;; @004e                               store notrap aligned v145, v115+8  ; v145 = 0
 ;;                                     v146 = uextend.i128 v145  ; v145 = 0
 ;;                                     v147 = iconst.i64 64
 ;;                                     v148 = ishl v146, v147  ; v147 = 64
 ;; @0040                               v8 = bor v148, v146
 ;; @0056                               jump block2(v8)
 ;;
-;;                                 block2(v21: i128):
+;;                                 block2(v127: i128):
 ;; @0058                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/table-copy.wat
+++ b/tests/disas/table-copy.wat
@@ -83,126 +83,126 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):
-;; @0090                               v7 = load.i64 notrap aligned readonly can_move region2 v0+48
-;; @0090                               v8 = load.i64 notrap aligned region4 v7+8
-;; @0090                               v9 = ireduce.i32 v8
-;; @0090                               v10 = uextend.i64 v9
-;; @0090                               v11 = uextend.i64 v3
-;; @0090                               v12 = uextend.i64 v5
-;; @0090                               v13 = iconst.i64 1
-;; @0090                               v14 = imul v12, v13  ; v13 = 1
-;; @0090                               v15 = iadd v11, v14
-;; @0090                               v16 = icmp ugt v15, v10
-;; @0090                               trapnz v16, user6
-;; @0090                               v17 = load.i64 notrap aligned readonly can_move region2 v0+48
-;; @0090                               v18 = load.i64 notrap aligned region3 v17
-;; @0090                               v19 = uextend.i64 v3
-;; @0090                               v20 = iconst.i64 8
-;; @0090                               v21 = imul v19, v20  ; v20 = 8
-;; @0090                               v22 = iadd v18, v21
-;; @0090                               v23 = iconst.i32 6
-;; @0090                               v24 = uextend.i64 v23  ; v23 = 6
-;; @0090                               v25 = uextend.i64 v4
-;; @0090                               v26 = uextend.i64 v5
-;; @0090                               v27 = iconst.i64 1
-;; @0090                               v28 = imul v26, v27  ; v27 = 1
-;; @0090                               v29 = iadd v25, v28
-;; @0090                               v30 = icmp ugt v29, v24
-;; @0090                               trapnz v30, user6
-;; @0090                               v31 = load.i64 notrap aligned readonly can_move region3 v0+72
-;; @0090                               v32 = uextend.i64 v4
-;; @0090                               v33 = iconst.i64 8
-;; @0090                               v34 = imul v32, v33  ; v33 = 8
-;; @0090                               v35 = iadd v31, v34
-;; @0090                               v36 = uextend.i64 v5
-;; @0090                               v37 = iconst.i64 8
-;; @0090                               v38 = imul v36, v37  ; v37 = 8
-;; @0090                               v39 = iconst.i64 8
-;; @0090                               v40 = imul v36, v39  ; v39 = 8
-;; @0090                               brif v36, block2, block5
+;; @0090                               v6 = load.i64 notrap aligned readonly can_move region2 v0+48
+;; @0090                               v7 = load.i64 notrap aligned region4 v6+8
+;; @0090                               v8 = ireduce.i32 v7
+;; @0090                               v9 = uextend.i64 v8
+;; @0090                               v10 = uextend.i64 v3
+;; @0090                               v11 = uextend.i64 v5
+;; @0090                               v12 = iconst.i64 1
+;; @0090                               v13 = imul v11, v12  ; v12 = 1
+;; @0090                               v14 = iadd v10, v13
+;; @0090                               v15 = icmp ugt v14, v9
+;; @0090                               trapnz v15, user6
+;; @0090                               v16 = load.i64 notrap aligned readonly can_move region2 v0+48
+;; @0090                               v17 = load.i64 notrap aligned region3 v16
+;; @0090                               v18 = uextend.i64 v3
+;; @0090                               v19 = iconst.i64 8
+;; @0090                               v20 = imul v18, v19  ; v19 = 8
+;; @0090                               v21 = iadd v17, v20
+;; @0090                               v22 = iconst.i32 6
+;; @0090                               v23 = uextend.i64 v22  ; v22 = 6
+;; @0090                               v24 = uextend.i64 v4
+;; @0090                               v25 = uextend.i64 v5
+;; @0090                               v26 = iconst.i64 1
+;; @0090                               v27 = imul v25, v26  ; v26 = 1
+;; @0090                               v28 = iadd v24, v27
+;; @0090                               v29 = icmp ugt v28, v23
+;; @0090                               trapnz v29, user6
+;; @0090                               v30 = load.i64 notrap aligned readonly can_move region3 v0+72
+;; @0090                               v31 = uextend.i64 v4
+;; @0090                               v32 = iconst.i64 8
+;; @0090                               v33 = imul v31, v32  ; v32 = 8
+;; @0090                               v34 = iadd v30, v33
+;; @0090                               v35 = uextend.i64 v5
+;; @0090                               v36 = iconst.i64 8
+;; @0090                               v37 = imul v35, v36  ; v36 = 8
+;; @0090                               v38 = iconst.i64 8
+;; @0090                               v39 = imul v35, v38  ; v38 = 8
+;; @0090                               brif v35, block2, block5
 ;;
 ;;                                 block2:
-;; @0090                               v41 = icmp.i64 ult v22, v35
-;; @0090                               v42 = iconst.i64 8
-;; @0090                               v43 = imul.i64 v36, v42  ; v42 = 8
-;; @0090                               v44 = iconst.i64 8
-;; @0090                               v45 = imul.i64 v36, v44  ; v44 = 8
-;; @0090                               v46 = iadd.i64 v22, v43
-;; @0090                               v47 = iadd.i64 v35, v45
-;; @0090                               v48 = ireduce.i32 v36
-;; @0090                               v49 = iadd.i32 v4, v48
-;; @0090                               brif v41, block3(v22, v35, v4), block4(v46, v47, v49)
+;; @0090                               v40 = icmp.i64 ult v21, v34
+;; @0090                               v41 = iconst.i64 8
+;; @0090                               v42 = imul.i64 v35, v41  ; v41 = 8
+;; @0090                               v43 = iconst.i64 8
+;; @0090                               v44 = imul.i64 v35, v43  ; v43 = 8
+;; @0090                               v45 = iadd.i64 v21, v42
+;; @0090                               v46 = iadd.i64 v34, v44
+;; @0090                               v47 = ireduce.i32 v35
+;; @0090                               v48 = iadd.i32 v4, v47
+;; @0090                               brif v40, block3(v21, v34, v4), block4(v45, v46, v48)
 ;;
-;;                                 block3(v50: i64, v51: i64, v52: i32):
-;; @0090                               v53 = iconst.i32 6
-;; @0090                               v54 = icmp uge v52, v53  ; v53 = 6
-;; @0090                               v55 = uextend.i64 v52
-;; @0090                               v56 = load.i64 notrap aligned readonly can_move region3 v0+72
-;; @0090                               v57 = iconst.i64 3
-;; @0090                               v58 = ishl v55, v57  ; v57 = 3
-;; @0090                               v59 = iadd v56, v58
-;; @0090                               v60 = iconst.i64 0
-;; @0090                               v61 = select_spectre_guard v54, v60, v59  ; v60 = 0
-;; @0090                               v62 = load.i64 user6 aligned region5 v61
-;; @0090                               v63 = iconst.i64 -2
-;; @0090                               v64 = band v62, v63  ; v63 = -2
-;; @0090                               brif v62, block7(v64), block6
+;;                                 block3(v49: i64, v50: i64, v51: i32):
+;; @0090                               v52 = iconst.i32 6
+;; @0090                               v53 = icmp uge v51, v52  ; v52 = 6
+;; @0090                               v54 = uextend.i64 v51
+;; @0090                               v55 = load.i64 notrap aligned readonly can_move region3 v0+72
+;; @0090                               v56 = iconst.i64 3
+;; @0090                               v57 = ishl v54, v56  ; v56 = 3
+;; @0090                               v58 = iadd v55, v57
+;; @0090                               v59 = iconst.i64 0
+;; @0090                               v60 = select_spectre_guard v53, v59, v58  ; v59 = 0
+;; @0090                               v61 = load.i64 user6 aligned region5 v60
+;; @0090                               v62 = iconst.i64 -2
+;; @0090                               v63 = band v61, v62  ; v62 = -2
+;; @0090                               brif v61, block7(v63), block6
 ;;
-;;                                 block4(v78: i64, v79: i64, v80: i32):
-;; @0090                               v81 = iconst.i64 8
-;; @0090                               v82 = isub v78, v81  ; v81 = 8
-;; @0090                               v83 = iconst.i64 8
-;; @0090                               v84 = isub v79, v83  ; v83 = 8
-;; @0090                               v85 = iconst.i32 1
-;; @0090                               v86 = isub v80, v85  ; v85 = 1
-;; @0090                               v87 = iconst.i32 6
-;; @0090                               v88 = icmp uge v86, v87  ; v87 = 6
-;; @0090                               v89 = uextend.i64 v86
-;; @0090                               v90 = load.i64 notrap aligned readonly can_move region3 v0+72
-;; @0090                               v91 = iconst.i64 3
-;; @0090                               v92 = ishl v89, v91  ; v91 = 3
-;; @0090                               v93 = iadd v90, v92
-;; @0090                               v94 = iconst.i64 0
-;; @0090                               v95 = select_spectre_guard v88, v94, v93  ; v94 = 0
-;; @0090                               v96 = load.i64 user6 aligned region5 v95
-;; @0090                               v97 = iconst.i64 -2
-;; @0090                               v98 = band v96, v97  ; v97 = -2
-;; @0090                               brif v96, block9(v98), block8
+;;                                 block4(v77: i64, v78: i64, v79: i32):
+;; @0090                               v80 = iconst.i64 8
+;; @0090                               v81 = isub v77, v80  ; v80 = 8
+;; @0090                               v82 = iconst.i64 8
+;; @0090                               v83 = isub v78, v82  ; v82 = 8
+;; @0090                               v84 = iconst.i32 1
+;; @0090                               v85 = isub v79, v84  ; v84 = 1
+;; @0090                               v86 = iconst.i32 6
+;; @0090                               v87 = icmp uge v85, v86  ; v86 = 6
+;; @0090                               v88 = uextend.i64 v85
+;; @0090                               v89 = load.i64 notrap aligned readonly can_move region3 v0+72
+;; @0090                               v90 = iconst.i64 3
+;; @0090                               v91 = ishl v88, v90  ; v90 = 3
+;; @0090                               v92 = iadd v89, v91
+;; @0090                               v93 = iconst.i64 0
+;; @0090                               v94 = select_spectre_guard v87, v93, v92  ; v93 = 0
+;; @0090                               v95 = load.i64 user6 aligned region5 v94
+;; @0090                               v96 = iconst.i64 -2
+;; @0090                               v97 = band v95, v96  ; v96 = -2
+;; @0090                               brif v95, block9(v97), block8
 ;;
 ;;                                 block5:
 ;; @0094                               jump block1
 ;;
 ;;                                 block6 cold:
-;; @0090                               v66 = iconst.i32 1
-;; @0090                               v67 = uextend.i64 v52
-;; @0090                               v68 = call fn0(v0, v66, v67)  ; v66 = 1
-;; @0090                               jump block7(v68)
+;; @0090                               v65 = iconst.i32 1
+;; @0090                               v66 = uextend.i64 v51
+;; @0090                               v67 = call fn0(v0, v65, v66)  ; v65 = 1
+;; @0090                               jump block7(v67)
 ;;
-;;                                 block7(v65: i64):
-;; @0090                               v69 = iconst.i64 1
-;; @0090                               v70 = bor v65, v69  ; v69 = 1
-;; @0090                               store notrap aligned region5 v70, v50
-;; @0090                               v71 = iconst.i64 8
-;; @0090                               v72 = iadd.i64 v50, v71  ; v71 = 8
-;; @0090                               v73 = iconst.i64 8
-;; @0090                               v74 = iadd.i64 v51, v73  ; v73 = 8
-;; @0090                               v75 = iconst.i32 1
-;; @0090                               v76 = iadd.i32 v52, v75  ; v75 = 1
-;; @0090                               v77 = icmp eq v74, v47
-;; @0090                               brif v77, block5, block3(v72, v74, v76)
+;;                                 block7(v64: i64):
+;; @0090                               v68 = iconst.i64 1
+;; @0090                               v69 = bor v64, v68  ; v68 = 1
+;; @0090                               store notrap aligned region5 v69, v49
+;; @0090                               v70 = iconst.i64 8
+;; @0090                               v71 = iadd.i64 v49, v70  ; v70 = 8
+;; @0090                               v72 = iconst.i64 8
+;; @0090                               v73 = iadd.i64 v50, v72  ; v72 = 8
+;; @0090                               v74 = iconst.i32 1
+;; @0090                               v75 = iadd.i32 v51, v74  ; v74 = 1
+;; @0090                               v76 = icmp eq v73, v46
+;; @0090                               brif v76, block5, block3(v71, v73, v75)
 ;;
 ;;                                 block8 cold:
-;; @0090                               v100 = iconst.i32 1
-;; @0090                               v101 = uextend.i64 v86
-;; @0090                               v102 = call fn0(v0, v100, v101)  ; v100 = 1
-;; @0090                               jump block9(v102)
+;; @0090                               v99 = iconst.i32 1
+;; @0090                               v100 = uextend.i64 v85
+;; @0090                               v101 = call fn0(v0, v99, v100)  ; v99 = 1
+;; @0090                               jump block9(v101)
 ;;
-;;                                 block9(v99: i64):
-;; @0090                               v103 = iconst.i64 1
-;; @0090                               v104 = bor v99, v103  ; v103 = 1
-;; @0090                               store notrap aligned region5 v104, v82
-;; @0090                               v105 = icmp.i64 eq v84, v35
-;; @0090                               brif v105, block5, block4(v82, v84, v86)
+;;                                 block9(v98: i64):
+;; @0090                               v102 = iconst.i64 1
+;; @0090                               v103 = bor v98, v102  ; v102 = 1
+;; @0090                               store notrap aligned region5 v103, v81
+;; @0090                               v104 = icmp.i64 eq v83, v34
+;; @0090                               brif v104, block5, block4(v81, v83, v85)
 ;;
 ;;                                 block1:
 ;; @0094                               return v2
@@ -223,132 +223,132 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):
-;; @009f                               v7 = iconst.i32 6
-;; @009f                               v8 = uextend.i64 v7  ; v7 = 6
-;; @009f                               v9 = uextend.i64 v3
-;; @009f                               v10 = uextend.i64 v5
-;; @009f                               v11 = iconst.i64 1
-;; @009f                               v12 = imul v10, v11  ; v11 = 1
-;; @009f                               v13 = iadd v9, v12
-;; @009f                               v14 = icmp ugt v13, v8
-;; @009f                               trapnz v14, user6
-;; @009f                               v15 = load.i64 notrap aligned readonly can_move region2 v0+72
-;; @009f                               v16 = uextend.i64 v3
-;; @009f                               v17 = iconst.i64 8
-;; @009f                               v18 = imul v16, v17  ; v17 = 8
-;; @009f                               v19 = iadd v15, v18
-;; @009f                               v20 = load.i64 notrap aligned readonly can_move region3 v0+48
-;; @009f                               v21 = load.i64 notrap aligned region4 v20+8
-;; @009f                               v22 = ireduce.i32 v21
-;; @009f                               v23 = uextend.i64 v22
-;; @009f                               v24 = uextend.i64 v4
-;; @009f                               v25 = uextend.i64 v5
-;; @009f                               v26 = iconst.i64 1
-;; @009f                               v27 = imul v25, v26  ; v26 = 1
-;; @009f                               v28 = iadd v24, v27
-;; @009f                               v29 = icmp ugt v28, v23
-;; @009f                               trapnz v29, user6
-;; @009f                               v30 = load.i64 notrap aligned readonly can_move region3 v0+48
-;; @009f                               v31 = load.i64 notrap aligned region2 v30
-;; @009f                               v32 = uextend.i64 v4
-;; @009f                               v33 = iconst.i64 8
-;; @009f                               v34 = imul v32, v33  ; v33 = 8
-;; @009f                               v35 = iadd v31, v34
-;; @009f                               v36 = uextend.i64 v5
-;; @009f                               v37 = iconst.i64 8
-;; @009f                               v38 = imul v36, v37  ; v37 = 8
-;; @009f                               v39 = iconst.i64 8
-;; @009f                               v40 = imul v36, v39  ; v39 = 8
-;; @009f                               brif v36, block2, block5
+;; @009f                               v6 = iconst.i32 6
+;; @009f                               v7 = uextend.i64 v6  ; v6 = 6
+;; @009f                               v8 = uextend.i64 v3
+;; @009f                               v9 = uextend.i64 v5
+;; @009f                               v10 = iconst.i64 1
+;; @009f                               v11 = imul v9, v10  ; v10 = 1
+;; @009f                               v12 = iadd v8, v11
+;; @009f                               v13 = icmp ugt v12, v7
+;; @009f                               trapnz v13, user6
+;; @009f                               v14 = load.i64 notrap aligned readonly can_move region2 v0+72
+;; @009f                               v15 = uextend.i64 v3
+;; @009f                               v16 = iconst.i64 8
+;; @009f                               v17 = imul v15, v16  ; v16 = 8
+;; @009f                               v18 = iadd v14, v17
+;; @009f                               v19 = load.i64 notrap aligned readonly can_move region3 v0+48
+;; @009f                               v20 = load.i64 notrap aligned region4 v19+8
+;; @009f                               v21 = ireduce.i32 v20
+;; @009f                               v22 = uextend.i64 v21
+;; @009f                               v23 = uextend.i64 v4
+;; @009f                               v24 = uextend.i64 v5
+;; @009f                               v25 = iconst.i64 1
+;; @009f                               v26 = imul v24, v25  ; v25 = 1
+;; @009f                               v27 = iadd v23, v26
+;; @009f                               v28 = icmp ugt v27, v22
+;; @009f                               trapnz v28, user6
+;; @009f                               v29 = load.i64 notrap aligned readonly can_move region3 v0+48
+;; @009f                               v30 = load.i64 notrap aligned region2 v29
+;; @009f                               v31 = uextend.i64 v4
+;; @009f                               v32 = iconst.i64 8
+;; @009f                               v33 = imul v31, v32  ; v32 = 8
+;; @009f                               v34 = iadd v30, v33
+;; @009f                               v35 = uextend.i64 v5
+;; @009f                               v36 = iconst.i64 8
+;; @009f                               v37 = imul v35, v36  ; v36 = 8
+;; @009f                               v38 = iconst.i64 8
+;; @009f                               v39 = imul v35, v38  ; v38 = 8
+;; @009f                               brif v35, block2, block5
 ;;
 ;;                                 block2:
-;; @009f                               v41 = icmp.i64 ult v19, v35
-;; @009f                               v42 = iconst.i64 8
-;; @009f                               v43 = imul.i64 v36, v42  ; v42 = 8
-;; @009f                               v44 = iconst.i64 8
-;; @009f                               v45 = imul.i64 v36, v44  ; v44 = 8
-;; @009f                               v46 = iadd.i64 v19, v43
-;; @009f                               v47 = iadd.i64 v35, v45
-;; @009f                               v48 = ireduce.i32 v36
-;; @009f                               v49 = iadd.i32 v4, v48
-;; @009f                               brif v41, block3(v19, v35, v4), block4(v46, v47, v49)
+;; @009f                               v40 = icmp.i64 ult v18, v34
+;; @009f                               v41 = iconst.i64 8
+;; @009f                               v42 = imul.i64 v35, v41  ; v41 = 8
+;; @009f                               v43 = iconst.i64 8
+;; @009f                               v44 = imul.i64 v35, v43  ; v43 = 8
+;; @009f                               v45 = iadd.i64 v18, v42
+;; @009f                               v46 = iadd.i64 v34, v44
+;; @009f                               v47 = ireduce.i32 v35
+;; @009f                               v48 = iadd.i32 v4, v47
+;; @009f                               brif v40, block3(v18, v34, v4), block4(v45, v46, v48)
 ;;
-;;                                 block3(v50: i64, v51: i64, v52: i32):
-;; @009f                               v53 = load.i64 notrap aligned readonly can_move region3 v0+48
-;; @009f                               v54 = load.i64 notrap aligned region4 v53+8
-;; @009f                               v55 = ireduce.i32 v54
-;; @009f                               v56 = icmp uge v52, v55
-;; @009f                               v57 = uextend.i64 v52
-;; @009f                               v58 = load.i64 notrap aligned readonly can_move region3 v0+48
-;; @009f                               v59 = load.i64 notrap aligned region2 v58
-;; @009f                               v60 = iconst.i64 3
-;; @009f                               v61 = ishl v57, v60  ; v60 = 3
-;; @009f                               v62 = iadd v59, v61
-;; @009f                               v63 = iconst.i64 0
-;; @009f                               v64 = select_spectre_guard v56, v63, v62  ; v63 = 0
-;; @009f                               v65 = load.i64 user6 aligned region5 v64
-;; @009f                               v66 = iconst.i64 -2
-;; @009f                               v67 = band v65, v66  ; v66 = -2
-;; @009f                               brif v65, block7(v67), block6
+;;                                 block3(v49: i64, v50: i64, v51: i32):
+;; @009f                               v52 = load.i64 notrap aligned readonly can_move region3 v0+48
+;; @009f                               v53 = load.i64 notrap aligned region4 v52+8
+;; @009f                               v54 = ireduce.i32 v53
+;; @009f                               v55 = icmp uge v51, v54
+;; @009f                               v56 = uextend.i64 v51
+;; @009f                               v57 = load.i64 notrap aligned readonly can_move region3 v0+48
+;; @009f                               v58 = load.i64 notrap aligned region2 v57
+;; @009f                               v59 = iconst.i64 3
+;; @009f                               v60 = ishl v56, v59  ; v59 = 3
+;; @009f                               v61 = iadd v58, v60
+;; @009f                               v62 = iconst.i64 0
+;; @009f                               v63 = select_spectre_guard v55, v62, v61  ; v62 = 0
+;; @009f                               v64 = load.i64 user6 aligned region5 v63
+;; @009f                               v65 = iconst.i64 -2
+;; @009f                               v66 = band v64, v65  ; v65 = -2
+;; @009f                               brif v64, block7(v66), block6
 ;;
-;;                                 block4(v81: i64, v82: i64, v83: i32):
-;; @009f                               v84 = iconst.i64 8
-;; @009f                               v85 = isub v81, v84  ; v84 = 8
-;; @009f                               v86 = iconst.i64 8
-;; @009f                               v87 = isub v82, v86  ; v86 = 8
-;; @009f                               v88 = iconst.i32 1
-;; @009f                               v89 = isub v83, v88  ; v88 = 1
-;; @009f                               v90 = load.i64 notrap aligned readonly can_move region3 v0+48
-;; @009f                               v91 = load.i64 notrap aligned region4 v90+8
-;; @009f                               v92 = ireduce.i32 v91
-;; @009f                               v93 = icmp uge v89, v92
-;; @009f                               v94 = uextend.i64 v89
-;; @009f                               v95 = load.i64 notrap aligned readonly can_move region3 v0+48
-;; @009f                               v96 = load.i64 notrap aligned region2 v95
-;; @009f                               v97 = iconst.i64 3
-;; @009f                               v98 = ishl v94, v97  ; v97 = 3
-;; @009f                               v99 = iadd v96, v98
-;; @009f                               v100 = iconst.i64 0
-;; @009f                               v101 = select_spectre_guard v93, v100, v99  ; v100 = 0
-;; @009f                               v102 = load.i64 user6 aligned region5 v101
-;; @009f                               v103 = iconst.i64 -2
-;; @009f                               v104 = band v102, v103  ; v103 = -2
-;; @009f                               brif v102, block9(v104), block8
+;;                                 block4(v80: i64, v81: i64, v82: i32):
+;; @009f                               v83 = iconst.i64 8
+;; @009f                               v84 = isub v80, v83  ; v83 = 8
+;; @009f                               v85 = iconst.i64 8
+;; @009f                               v86 = isub v81, v85  ; v85 = 8
+;; @009f                               v87 = iconst.i32 1
+;; @009f                               v88 = isub v82, v87  ; v87 = 1
+;; @009f                               v89 = load.i64 notrap aligned readonly can_move region3 v0+48
+;; @009f                               v90 = load.i64 notrap aligned region4 v89+8
+;; @009f                               v91 = ireduce.i32 v90
+;; @009f                               v92 = icmp uge v88, v91
+;; @009f                               v93 = uextend.i64 v88
+;; @009f                               v94 = load.i64 notrap aligned readonly can_move region3 v0+48
+;; @009f                               v95 = load.i64 notrap aligned region2 v94
+;; @009f                               v96 = iconst.i64 3
+;; @009f                               v97 = ishl v93, v96  ; v96 = 3
+;; @009f                               v98 = iadd v95, v97
+;; @009f                               v99 = iconst.i64 0
+;; @009f                               v100 = select_spectre_guard v92, v99, v98  ; v99 = 0
+;; @009f                               v101 = load.i64 user6 aligned region5 v100
+;; @009f                               v102 = iconst.i64 -2
+;; @009f                               v103 = band v101, v102  ; v102 = -2
+;; @009f                               brif v101, block9(v103), block8
 ;;
 ;;                                 block5:
 ;; @00a3                               jump block1
 ;;
 ;;                                 block6 cold:
-;; @009f                               v69 = iconst.i32 0
-;; @009f                               v70 = uextend.i64 v52
-;; @009f                               v71 = call fn0(v0, v69, v70)  ; v69 = 0
-;; @009f                               jump block7(v71)
+;; @009f                               v68 = iconst.i32 0
+;; @009f                               v69 = uextend.i64 v51
+;; @009f                               v70 = call fn0(v0, v68, v69)  ; v68 = 0
+;; @009f                               jump block7(v70)
 ;;
-;;                                 block7(v68: i64):
-;; @009f                               v72 = iconst.i64 1
-;; @009f                               v73 = bor v68, v72  ; v72 = 1
-;; @009f                               store notrap aligned region5 v73, v50
-;; @009f                               v74 = iconst.i64 8
-;; @009f                               v75 = iadd.i64 v50, v74  ; v74 = 8
-;; @009f                               v76 = iconst.i64 8
-;; @009f                               v77 = iadd.i64 v51, v76  ; v76 = 8
-;; @009f                               v78 = iconst.i32 1
-;; @009f                               v79 = iadd.i32 v52, v78  ; v78 = 1
-;; @009f                               v80 = icmp eq v77, v47
-;; @009f                               brif v80, block5, block3(v75, v77, v79)
+;;                                 block7(v67: i64):
+;; @009f                               v71 = iconst.i64 1
+;; @009f                               v72 = bor v67, v71  ; v71 = 1
+;; @009f                               store notrap aligned region5 v72, v49
+;; @009f                               v73 = iconst.i64 8
+;; @009f                               v74 = iadd.i64 v49, v73  ; v73 = 8
+;; @009f                               v75 = iconst.i64 8
+;; @009f                               v76 = iadd.i64 v50, v75  ; v75 = 8
+;; @009f                               v77 = iconst.i32 1
+;; @009f                               v78 = iadd.i32 v51, v77  ; v77 = 1
+;; @009f                               v79 = icmp eq v76, v46
+;; @009f                               brif v79, block5, block3(v74, v76, v78)
 ;;
 ;;                                 block8 cold:
-;; @009f                               v106 = iconst.i32 0
-;; @009f                               v107 = uextend.i64 v89
-;; @009f                               v108 = call fn0(v0, v106, v107)  ; v106 = 0
-;; @009f                               jump block9(v108)
+;; @009f                               v105 = iconst.i32 0
+;; @009f                               v106 = uextend.i64 v88
+;; @009f                               v107 = call fn0(v0, v105, v106)  ; v105 = 0
+;; @009f                               jump block9(v107)
 ;;
-;;                                 block9(v105: i64):
-;; @009f                               v109 = iconst.i64 1
-;; @009f                               v110 = bor v105, v109  ; v109 = 1
-;; @009f                               store notrap aligned region5 v110, v85
-;; @009f                               v111 = icmp.i64 eq v87, v35
-;; @009f                               brif v111, block5, block4(v85, v87, v89)
+;;                                 block9(v104: i64):
+;; @009f                               v108 = iconst.i64 1
+;; @009f                               v109 = bor v104, v108  ; v108 = 1
+;; @009f                               store notrap aligned region5 v109, v84
+;; @009f                               v110 = icmp.i64 eq v86, v34
+;; @009f                               brif v110, block5, block4(v84, v86, v88)
 ;;
 ;;                                 block1:
 ;; @00a3                               return v2

--- a/tests/disas/table-get-fixed-size.wat
+++ b/tests/disas/table-get-fixed-size.wat
@@ -26,21 +26,21 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @0052                               v3 = iconst.i32 0
-;; @0054                               v4 = iconst.i32 7
-;; @0054                               v5 = icmp uge v3, v4  ; v3 = 0, v4 = 7
-;; @0054                               v6 = uextend.i64 v3  ; v3 = 0
-;; @0054                               v7 = load.i64 notrap aligned readonly can_move region2 v0+48
-;; @0054                               v8 = iconst.i64 2
-;; @0054                               v9 = ishl v6, v8  ; v8 = 2
-;; @0054                               v10 = iadd v7, v9
-;; @0054                               v11 = iconst.i64 0
-;; @0054                               v12 = select_spectre_guard v5, v11, v10  ; v11 = 0
-;; @0054                               v13 = load.i32 user6 aligned region3 v12
+;; @0052                               v2 = iconst.i32 0
+;; @0054                               v3 = iconst.i32 7
+;; @0054                               v4 = icmp uge v2, v3  ; v2 = 0, v3 = 7
+;; @0054                               v5 = uextend.i64 v2  ; v2 = 0
+;; @0054                               v6 = load.i64 notrap aligned readonly can_move region2 v0+48
+;; @0054                               v7 = iconst.i64 2
+;; @0054                               v8 = ishl v5, v7  ; v7 = 2
+;; @0054                               v9 = iadd v6, v8
+;; @0054                               v10 = iconst.i64 0
+;; @0054                               v11 = select_spectre_guard v4, v10, v9  ; v10 = 0
+;; @0054                               v12 = load.i32 user6 aligned region3 v11
 ;; @0056                               jump block1
 ;;
 ;;                                 block1:
-;; @0056                               return v13
+;; @0056                               return v12
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
@@ -54,18 +54,18 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @005b                               v4 = iconst.i32 7
-;; @005b                               v5 = icmp uge v2, v4  ; v4 = 7
-;; @005b                               v6 = uextend.i64 v2
-;; @005b                               v7 = load.i64 notrap aligned readonly can_move region2 v0+48
-;; @005b                               v8 = iconst.i64 2
-;; @005b                               v9 = ishl v6, v8  ; v8 = 2
-;; @005b                               v10 = iadd v7, v9
-;; @005b                               v11 = iconst.i64 0
-;; @005b                               v12 = select_spectre_guard v5, v11, v10  ; v11 = 0
-;; @005b                               v13 = load.i32 user6 aligned region3 v12
+;; @005b                               v3 = iconst.i32 7
+;; @005b                               v4 = icmp uge v2, v3  ; v3 = 7
+;; @005b                               v5 = uextend.i64 v2
+;; @005b                               v6 = load.i64 notrap aligned readonly can_move region2 v0+48
+;; @005b                               v7 = iconst.i64 2
+;; @005b                               v8 = ishl v5, v7  ; v7 = 2
+;; @005b                               v9 = iadd v6, v8
+;; @005b                               v10 = iconst.i64 0
+;; @005b                               v11 = select_spectre_guard v4, v10, v9  ; v10 = 0
+;; @005b                               v12 = load.i32 user6 aligned region3 v11
 ;; @005d                               jump block1
 ;;
 ;;                                 block1:
-;; @005d                               return v13
+;; @005d                               return v12
 ;; }

--- a/tests/disas/table-get.wat
+++ b/tests/disas/table-get.wat
@@ -26,22 +26,22 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @0051                               v3 = iconst.i32 0
-;; @0053                               v4 = load.i64 notrap aligned region3 v0+56
-;; @0053                               v5 = ireduce.i32 v4
-;; @0053                               v6 = icmp uge v3, v5  ; v3 = 0
-;; @0053                               v7 = uextend.i64 v3  ; v3 = 0
-;; @0053                               v8 = load.i64 notrap aligned region2 v0+48
-;; @0053                               v9 = iconst.i64 2
-;; @0053                               v10 = ishl v7, v9  ; v9 = 2
-;; @0053                               v11 = iadd v8, v10
-;; @0053                               v12 = iconst.i64 0
-;; @0053                               v13 = select_spectre_guard v6, v12, v11  ; v12 = 0
-;; @0053                               v14 = load.i32 user6 aligned region4 v13
+;; @0051                               v2 = iconst.i32 0
+;; @0053                               v3 = load.i64 notrap aligned region3 v0+56
+;; @0053                               v4 = ireduce.i32 v3
+;; @0053                               v5 = icmp uge v2, v4  ; v2 = 0
+;; @0053                               v6 = uextend.i64 v2  ; v2 = 0
+;; @0053                               v7 = load.i64 notrap aligned region2 v0+48
+;; @0053                               v8 = iconst.i64 2
+;; @0053                               v9 = ishl v6, v8  ; v8 = 2
+;; @0053                               v10 = iadd v7, v9
+;; @0053                               v11 = iconst.i64 0
+;; @0053                               v12 = select_spectre_guard v5, v11, v10  ; v11 = 0
+;; @0053                               v13 = load.i32 user6 aligned region4 v12
 ;; @0055                               jump block1
 ;;
 ;;                                 block1:
-;; @0055                               return v14
+;; @0055                               return v13
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
@@ -56,19 +56,19 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @005a                               v4 = load.i64 notrap aligned region3 v0+56
-;; @005a                               v5 = ireduce.i32 v4
-;; @005a                               v6 = icmp uge v2, v5
-;; @005a                               v7 = uextend.i64 v2
-;; @005a                               v8 = load.i64 notrap aligned region2 v0+48
-;; @005a                               v9 = iconst.i64 2
-;; @005a                               v10 = ishl v7, v9  ; v9 = 2
-;; @005a                               v11 = iadd v8, v10
-;; @005a                               v12 = iconst.i64 0
-;; @005a                               v13 = select_spectre_guard v6, v12, v11  ; v12 = 0
-;; @005a                               v14 = load.i32 user6 aligned region4 v13
+;; @005a                               v3 = load.i64 notrap aligned region3 v0+56
+;; @005a                               v4 = ireduce.i32 v3
+;; @005a                               v5 = icmp uge v2, v4
+;; @005a                               v6 = uextend.i64 v2
+;; @005a                               v7 = load.i64 notrap aligned region2 v0+48
+;; @005a                               v8 = iconst.i64 2
+;; @005a                               v9 = ishl v6, v8  ; v8 = 2
+;; @005a                               v10 = iadd v7, v9
+;; @005a                               v11 = iconst.i64 0
+;; @005a                               v12 = select_spectre_guard v5, v11, v10  ; v11 = 0
+;; @005a                               v13 = load.i32 user6 aligned region4 v12
 ;; @005c                               jump block1
 ;;
 ;;                                 block1:
-;; @005c                               return v14
+;; @005c                               return v13
 ;; }

--- a/tests/disas/typed-funcrefs-eager-init.wat
+++ b/tests/disas/typed-funcrefs-eager-init.wat
@@ -140,24 +140,24 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):
-;; @0048                               v12 = load.i64 notrap aligned readonly can_move region2 v0+48
-;;                                     v45 = iconst.i64 8
-;; @0048                               v15 = iadd v12, v45  ; v45 = 8
-;; @0048                               v18 = load.i64 user6 aligned region3 v15
-;; @004a                               v19 = load.i64 user16 aligned readonly v18+8
-;; @004a                               v20 = load.i64 notrap aligned readonly v18+24
-;; @004a                               v21 = call_indirect sig0, v19(v20, v0, v2, v3, v4, v5)
-;;                                     v52 = iconst.i64 16
-;; @005b                               v30 = iadd v12, v52  ; v52 = 16
-;; @005b                               v33 = load.i64 user6 aligned region3 v30
-;; @005d                               v34 = load.i64 user16 aligned readonly v33+8
-;; @005d                               v35 = load.i64 notrap aligned readonly v33+24
-;; @005d                               v36 = call_indirect sig0, v34(v35, v0, v2, v3, v4, v5)
+;; @0048                               v11 = load.i64 notrap aligned readonly can_move region2 v0+48
+;;                                     v44 = iconst.i64 8
+;; @0048                               v14 = iadd v11, v44  ; v44 = 8
+;; @0048                               v17 = load.i64 user6 aligned region3 v14
+;; @004a                               v18 = load.i64 user16 aligned readonly v17+8
+;; @004a                               v19 = load.i64 notrap aligned readonly v17+24
+;; @004a                               v20 = call_indirect sig0, v18(v19, v0, v2, v3, v4, v5)
+;;                                     v51 = iconst.i64 16
+;; @005b                               v29 = iadd v11, v51  ; v51 = 16
+;; @005b                               v32 = load.i64 user6 aligned region3 v29
+;; @005d                               v33 = load.i64 user16 aligned readonly v32+8
+;; @005d                               v34 = load.i64 notrap aligned readonly v32+24
+;; @005d                               v35 = call_indirect sig0, v33(v34, v0, v2, v3, v4, v5)
 ;; @0066                               jump block1
 ;;
 ;;                                 block1:
-;; @0061                               v37 = iadd.i32 v36, v21
-;; @0066                               return v37
+;; @0061                               v36 = iadd.i32 v35, v20
+;; @0066                               return v36
 ;; }
 ;;
 ;; function u0:2(i64 vmctx, i64, i32, i32, i32, i32) -> i32 tail {
@@ -172,24 +172,24 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):
-;; @0075                               v12 = load.i64 notrap aligned readonly can_move region2 v0+48
-;;                                     v45 = iconst.i64 8
-;; @0075                               v15 = iadd v12, v45  ; v45 = 8
-;; @0075                               v18 = load.i64 user6 aligned region3 v15
-;; @0075                               v19 = load.i64 user7 aligned readonly v18+8
-;; @0075                               v20 = load.i64 notrap aligned readonly v18+24
-;; @0075                               v21 = call_indirect sig0, v19(v20, v0, v2, v3, v4, v5)
-;;                                     v52 = iconst.i64 16
-;; @0087                               v30 = iadd v12, v52  ; v52 = 16
-;; @0087                               v33 = load.i64 user6 aligned region3 v30
-;; @0087                               v34 = load.i64 user7 aligned readonly v33+8
-;; @0087                               v35 = load.i64 notrap aligned readonly v33+24
-;; @0087                               v36 = call_indirect sig0, v34(v35, v0, v2, v3, v4, v5)
+;; @0075                               v11 = load.i64 notrap aligned readonly can_move region2 v0+48
+;;                                     v44 = iconst.i64 8
+;; @0075                               v14 = iadd v11, v44  ; v44 = 8
+;; @0075                               v17 = load.i64 user6 aligned region3 v14
+;; @0075                               v18 = load.i64 user7 aligned readonly v17+8
+;; @0075                               v19 = load.i64 notrap aligned readonly v17+24
+;; @0075                               v20 = call_indirect sig0, v18(v19, v0, v2, v3, v4, v5)
+;;                                     v51 = iconst.i64 16
+;; @0087                               v29 = iadd v11, v51  ; v51 = 16
+;; @0087                               v32 = load.i64 user6 aligned region3 v29
+;; @0087                               v33 = load.i64 user7 aligned readonly v32+8
+;; @0087                               v34 = load.i64 notrap aligned readonly v32+24
+;; @0087                               v35 = call_indirect sig0, v33(v34, v0, v2, v3, v4, v5)
 ;; @0091                               jump block1
 ;;
 ;;                                 block1:
-;; @008c                               v37 = iadd.i32 v36, v21
-;; @0091                               return v37
+;; @008c                               v36 = iadd.i32 v35, v20
+;; @0091                               return v36
 ;; }
 ;;
 ;; function u0:3(i64 vmctx, i64, i32, i32, i32, i32) -> i32 tail {
@@ -204,17 +204,17 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):
-;; @009e                               v8 = load.i64 notrap aligned region2 v0+64
-;; @00a0                               v9 = load.i64 user16 aligned readonly v8+8
-;; @00a0                               v10 = load.i64 notrap aligned readonly v8+24
-;; @00a0                               v11 = call_indirect sig0, v9(v10, v0, v2, v3, v4, v5)
-;; @00af                               v13 = load.i64 notrap aligned region3 v0+80
-;; @00b1                               v14 = load.i64 user16 aligned readonly v13+8
-;; @00b1                               v15 = load.i64 notrap aligned readonly v13+24
-;; @00b1                               v16 = call_indirect sig0, v14(v15, v0, v2, v3, v4, v5)
+;; @009e                               v7 = load.i64 notrap aligned region2 v0+64
+;; @00a0                               v8 = load.i64 user16 aligned readonly v7+8
+;; @00a0                               v9 = load.i64 notrap aligned readonly v7+24
+;; @00a0                               v10 = call_indirect sig0, v8(v9, v0, v2, v3, v4, v5)
+;; @00af                               v12 = load.i64 notrap aligned region3 v0+80
+;; @00b1                               v13 = load.i64 user16 aligned readonly v12+8
+;; @00b1                               v14 = load.i64 notrap aligned readonly v12+24
+;; @00b1                               v15 = call_indirect sig0, v13(v14, v0, v2, v3, v4, v5)
 ;; @00ba                               jump block1
 ;;
 ;;                                 block1:
-;; @00b5                               v17 = iadd.i32 v16, v11
-;; @00ba                               return v17
+;; @00b5                               v16 = iadd.i32 v15, v10
+;; @00ba                               return v16
 ;; }

--- a/tests/disas/typed-funcrefs.wat
+++ b/tests/disas/typed-funcrefs.wat
@@ -142,46 +142,46 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):
-;; @0048                               v12 = load.i64 notrap aligned readonly can_move region2 v0+48
-;;                                     v63 = iconst.i64 8
-;; @0048                               v15 = iadd v12, v63  ; v63 = 8
-;; @0048                               v18 = load.i64 user6 aligned region3 v15
-;; @0048                               v19 = iconst.i64 -2
-;; @0048                               v20 = band v18, v19  ; v19 = -2
-;; @0048                               brif v18, block3(v20), block2
+;; @0048                               v11 = load.i64 notrap aligned readonly can_move region2 v0+48
+;;                                     v62 = iconst.i64 8
+;; @0048                               v14 = iadd v11, v62  ; v62 = 8
+;; @0048                               v17 = load.i64 user6 aligned region3 v14
+;; @0048                               v18 = iconst.i64 -2
+;; @0048                               v19 = band v17, v18  ; v18 = -2
+;; @0048                               brif v17, block3(v19), block2
 ;;
 ;;                                 block2 cold:
-;; @003c                               v7 = iconst.i32 0
-;;                                     v62 = iconst.i64 1
-;; @0048                               v24 = call fn0(v0, v7, v62)  ; v7 = 0, v62 = 1
-;; @0048                               jump block3(v24)
+;; @003c                               v6 = iconst.i32 0
+;;                                     v61 = iconst.i64 1
+;; @0048                               v23 = call fn0(v0, v6, v61)  ; v6 = 0, v61 = 1
+;; @0048                               jump block3(v23)
 ;;
-;;                                 block3(v21: i64):
-;; @004a                               v25 = load.i64 user16 aligned readonly v21+8
-;; @004a                               v26 = load.i64 notrap aligned readonly v21+24
-;; @004a                               v27 = call_indirect sig1, v25(v26, v0, v2, v3, v4, v5)
-;;                                     v70 = iconst.i64 16
-;; @005b                               v41 = iadd.i64 v12, v70  ; v70 = 16
-;; @005b                               v44 = load.i64 user6 aligned region3 v41
-;;                                     v71 = iconst.i64 -2
-;;                                     v72 = band v44, v71  ; v71 = -2
-;; @005b                               brif v44, block5(v72), block4
+;;                                 block3(v20: i64):
+;; @004a                               v24 = load.i64 user16 aligned readonly v20+8
+;; @004a                               v25 = load.i64 notrap aligned readonly v20+24
+;; @004a                               v26 = call_indirect sig1, v24(v25, v0, v2, v3, v4, v5)
+;;                                     v69 = iconst.i64 16
+;; @005b                               v40 = iadd.i64 v11, v69  ; v69 = 16
+;; @005b                               v43 = load.i64 user6 aligned region3 v40
+;;                                     v70 = iconst.i64 -2
+;;                                     v71 = band v43, v70  ; v70 = -2
+;; @005b                               brif v43, block5(v71), block4
 ;;
 ;;                                 block4 cold:
-;;                                     v73 = iconst.i32 0
-;;                                     v69 = iconst.i64 2
-;; @005b                               v50 = call fn0(v0, v73, v69)  ; v73 = 0, v69 = 2
-;; @005b                               jump block5(v50)
+;;                                     v72 = iconst.i32 0
+;;                                     v68 = iconst.i64 2
+;; @005b                               v49 = call fn0(v0, v72, v68)  ; v72 = 0, v68 = 2
+;; @005b                               jump block5(v49)
 ;;
-;;                                 block5(v47: i64):
-;; @005d                               v51 = load.i64 user16 aligned readonly v47+8
-;; @005d                               v52 = load.i64 notrap aligned readonly v47+24
-;; @005d                               v53 = call_indirect sig1, v51(v52, v0, v2, v3, v4, v5)
+;;                                 block5(v46: i64):
+;; @005d                               v50 = load.i64 user16 aligned readonly v46+8
+;; @005d                               v51 = load.i64 notrap aligned readonly v46+24
+;; @005d                               v52 = call_indirect sig1, v50(v51, v0, v2, v3, v4, v5)
 ;; @0066                               jump block1
 ;;
 ;;                                 block1:
-;; @0061                               v55 = iadd.i32 v53, v27
-;; @0066                               return v55
+;; @0061                               v54 = iadd.i32 v52, v26
+;; @0066                               return v54
 ;; }
 ;;
 ;; function u0:2(i64 vmctx, i64, i32, i32, i32, i32) -> i32 tail {
@@ -198,46 +198,46 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):
-;; @0075                               v12 = load.i64 notrap aligned readonly can_move region2 v0+48
-;;                                     v63 = iconst.i64 8
-;; @0075                               v15 = iadd v12, v63  ; v63 = 8
-;; @0075                               v18 = load.i64 user6 aligned region3 v15
-;; @0075                               v19 = iconst.i64 -2
-;; @0075                               v20 = band v18, v19  ; v19 = -2
-;; @0075                               brif v18, block3(v20), block2
+;; @0075                               v11 = load.i64 notrap aligned readonly can_move region2 v0+48
+;;                                     v62 = iconst.i64 8
+;; @0075                               v14 = iadd v11, v62  ; v62 = 8
+;; @0075                               v17 = load.i64 user6 aligned region3 v14
+;; @0075                               v18 = iconst.i64 -2
+;; @0075                               v19 = band v17, v18  ; v18 = -2
+;; @0075                               brif v17, block3(v19), block2
 ;;
 ;;                                 block2 cold:
-;; @0069                               v7 = iconst.i32 0
-;;                                     v62 = iconst.i64 1
-;; @0075                               v24 = call fn0(v0, v7, v62)  ; v7 = 0, v62 = 1
-;; @0075                               jump block3(v24)
+;; @0069                               v6 = iconst.i32 0
+;;                                     v61 = iconst.i64 1
+;; @0075                               v23 = call fn0(v0, v6, v61)  ; v6 = 0, v61 = 1
+;; @0075                               jump block3(v23)
 ;;
-;;                                 block3(v21: i64):
-;; @0075                               v25 = load.i64 user7 aligned readonly v21+8
-;; @0075                               v26 = load.i64 notrap aligned readonly v21+24
-;; @0075                               v27 = call_indirect sig0, v25(v26, v0, v2, v3, v4, v5)
-;;                                     v70 = iconst.i64 16
-;; @0087                               v41 = iadd.i64 v12, v70  ; v70 = 16
-;; @0087                               v44 = load.i64 user6 aligned region3 v41
-;;                                     v71 = iconst.i64 -2
-;;                                     v72 = band v44, v71  ; v71 = -2
-;; @0087                               brif v44, block5(v72), block4
+;;                                 block3(v20: i64):
+;; @0075                               v24 = load.i64 user7 aligned readonly v20+8
+;; @0075                               v25 = load.i64 notrap aligned readonly v20+24
+;; @0075                               v26 = call_indirect sig0, v24(v25, v0, v2, v3, v4, v5)
+;;                                     v69 = iconst.i64 16
+;; @0087                               v40 = iadd.i64 v11, v69  ; v69 = 16
+;; @0087                               v43 = load.i64 user6 aligned region3 v40
+;;                                     v70 = iconst.i64 -2
+;;                                     v71 = band v43, v70  ; v70 = -2
+;; @0087                               brif v43, block5(v71), block4
 ;;
 ;;                                 block4 cold:
-;;                                     v73 = iconst.i32 0
-;;                                     v69 = iconst.i64 2
-;; @0087                               v50 = call fn0(v0, v73, v69)  ; v73 = 0, v69 = 2
-;; @0087                               jump block5(v50)
+;;                                     v72 = iconst.i32 0
+;;                                     v68 = iconst.i64 2
+;; @0087                               v49 = call fn0(v0, v72, v68)  ; v72 = 0, v68 = 2
+;; @0087                               jump block5(v49)
 ;;
-;;                                 block5(v47: i64):
-;; @0087                               v51 = load.i64 user7 aligned readonly v47+8
-;; @0087                               v52 = load.i64 notrap aligned readonly v47+24
-;; @0087                               v53 = call_indirect sig0, v51(v52, v0, v2, v3, v4, v5)
+;;                                 block5(v46: i64):
+;; @0087                               v50 = load.i64 user7 aligned readonly v46+8
+;; @0087                               v51 = load.i64 notrap aligned readonly v46+24
+;; @0087                               v52 = call_indirect sig0, v50(v51, v0, v2, v3, v4, v5)
 ;; @0091                               jump block1
 ;;
 ;;                                 block1:
-;; @008c                               v55 = iadd.i32 v53, v27
-;; @0091                               return v55
+;; @008c                               v54 = iadd.i32 v52, v26
+;; @0091                               return v54
 ;; }
 ;;
 ;; function u0:3(i64 vmctx, i64, i32, i32, i32, i32) -> i32 tail {
@@ -252,17 +252,17 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):
-;; @009e                               v8 = load.i64 notrap aligned region2 v0+64
-;; @00a0                               v9 = load.i64 user16 aligned readonly v8+8
-;; @00a0                               v10 = load.i64 notrap aligned readonly v8+24
-;; @00a0                               v11 = call_indirect sig0, v9(v10, v0, v2, v3, v4, v5)
-;; @00af                               v13 = load.i64 notrap aligned region3 v0+80
-;; @00b1                               v14 = load.i64 user16 aligned readonly v13+8
-;; @00b1                               v15 = load.i64 notrap aligned readonly v13+24
-;; @00b1                               v16 = call_indirect sig0, v14(v15, v0, v2, v3, v4, v5)
+;; @009e                               v7 = load.i64 notrap aligned region2 v0+64
+;; @00a0                               v8 = load.i64 user16 aligned readonly v7+8
+;; @00a0                               v9 = load.i64 notrap aligned readonly v7+24
+;; @00a0                               v10 = call_indirect sig0, v8(v9, v0, v2, v3, v4, v5)
+;; @00af                               v12 = load.i64 notrap aligned region3 v0+80
+;; @00b1                               v13 = load.i64 user16 aligned readonly v12+8
+;; @00b1                               v14 = load.i64 notrap aligned readonly v12+24
+;; @00b1                               v15 = call_indirect sig0, v13(v14, v0, v2, v3, v4, v5)
 ;; @00ba                               jump block1
 ;;
 ;;                                 block1:
-;; @00b5                               v17 = iadd.i32 v16, v11
-;; @00ba                               return v17
+;; @00b5                               v16 = iadd.i32 v15, v10
+;; @00ba                               return v16
 ;; }

--- a/tests/disas/unreachable_code.wat
+++ b/tests/disas/unreachable_code.wat
@@ -114,8 +114,8 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @0061                               v3 = iconst.i32 1
-;; @0063                               brif v3, block6, block13  ; v3 = 1
+;; @0061                               v2 = iconst.i32 1
+;; @0063                               brif v2, block6, block13  ; v2 = 1
 ;;
 ;;                                 block6:
 ;; @006a                               jump block9

--- a/tests/disas/unreachable_code.wat
+++ b/tests/disas/unreachable_code.wat
@@ -114,8 +114,8 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @0061                               v4 = iconst.i32 1
-;; @0063                               brif v4, block6, block13  ; v4 = 1
+;; @0061                               v3 = iconst.i32 1
+;; @0063                               brif v3, block6, block13  ; v3 = 1
 ;;
 ;;                                 block6:
 ;; @006a                               jump block9
@@ -148,7 +148,7 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @0095                               v4 = iconst.i32 1
+;; @0095                               v2 = iconst.i32 1
 ;; @0097                               jump block2
 ;;
 ;;                                 block2:

--- a/tests/disas/x64-simd-round-without-sse41.wat
+++ b/tests/disas/x64-simd-round-without-sse41.wat
@@ -23,25 +23,25 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
-;; @0023                               v4 = bitcast.f32x4 little v2
-;; @0023                               v5 = vconst.f32x4 const0
-;; @0023                               v6 = extractlane v4, 0
-;; @0023                               v7 = call fn0(v0, v6)
-;; @0023                               v8 = insertlane v5, v7, 0  ; v5 = const0
-;; @0023                               v9 = extractlane v4, 1
-;; @0023                               v10 = call fn0(v0, v9)
-;; @0023                               v11 = insertlane v8, v10, 1
-;; @0023                               v12 = extractlane v4, 2
-;; @0023                               v13 = call fn0(v0, v12)
-;; @0023                               v14 = insertlane v11, v13, 2
-;; @0023                               v15 = extractlane v4, 3
-;; @0023                               v16 = call fn0(v0, v15)
-;; @0023                               v17 = insertlane v14, v16, 3
-;; @0025                               v18 = bitcast.i8x16 little v17
+;; @0023                               v3 = bitcast.f32x4 little v2
+;; @0023                               v4 = vconst.f32x4 const0
+;; @0023                               v5 = extractlane v3, 0
+;; @0023                               v6 = call fn0(v0, v5)
+;; @0023                               v7 = insertlane v4, v6, 0  ; v4 = const0
+;; @0023                               v8 = extractlane v3, 1
+;; @0023                               v9 = call fn0(v0, v8)
+;; @0023                               v10 = insertlane v7, v9, 1
+;; @0023                               v11 = extractlane v3, 2
+;; @0023                               v12 = call fn0(v0, v11)
+;; @0023                               v13 = insertlane v10, v12, 2
+;; @0023                               v14 = extractlane v3, 3
+;; @0023                               v15 = call fn0(v0, v14)
+;; @0023                               v16 = insertlane v13, v15, 3
+;; @0025                               v17 = bitcast.i8x16 little v16
 ;; @0025                               jump block1
 ;;
 ;;                                 block1:
-;; @0025                               return v18
+;; @0025                               return v17
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i8x16) -> i8x16 tail {
@@ -56,25 +56,25 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
-;; @002a                               v4 = bitcast.f32x4 little v2
-;; @002a                               v5 = vconst.f32x4 const0
-;; @002a                               v6 = extractlane v4, 0
-;; @002a                               v7 = call fn0(v0, v6)
-;; @002a                               v8 = insertlane v5, v7, 0  ; v5 = const0
-;; @002a                               v9 = extractlane v4, 1
-;; @002a                               v10 = call fn0(v0, v9)
-;; @002a                               v11 = insertlane v8, v10, 1
-;; @002a                               v12 = extractlane v4, 2
-;; @002a                               v13 = call fn0(v0, v12)
-;; @002a                               v14 = insertlane v11, v13, 2
-;; @002a                               v15 = extractlane v4, 3
-;; @002a                               v16 = call fn0(v0, v15)
-;; @002a                               v17 = insertlane v14, v16, 3
-;; @002c                               v18 = bitcast.i8x16 little v17
+;; @002a                               v3 = bitcast.f32x4 little v2
+;; @002a                               v4 = vconst.f32x4 const0
+;; @002a                               v5 = extractlane v3, 0
+;; @002a                               v6 = call fn0(v0, v5)
+;; @002a                               v7 = insertlane v4, v6, 0  ; v4 = const0
+;; @002a                               v8 = extractlane v3, 1
+;; @002a                               v9 = call fn0(v0, v8)
+;; @002a                               v10 = insertlane v7, v9, 1
+;; @002a                               v11 = extractlane v3, 2
+;; @002a                               v12 = call fn0(v0, v11)
+;; @002a                               v13 = insertlane v10, v12, 2
+;; @002a                               v14 = extractlane v3, 3
+;; @002a                               v15 = call fn0(v0, v14)
+;; @002a                               v16 = insertlane v13, v15, 3
+;; @002c                               v17 = bitcast.i8x16 little v16
 ;; @002c                               jump block1
 ;;
 ;;                                 block1:
-;; @002c                               return v18
+;; @002c                               return v17
 ;; }
 ;;
 ;; function u0:2(i64 vmctx, i64, i8x16) -> i8x16 tail {
@@ -89,25 +89,25 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
-;; @0031                               v4 = bitcast.f32x4 little v2
-;; @0031                               v5 = vconst.f32x4 const0
-;; @0031                               v6 = extractlane v4, 0
-;; @0031                               v7 = call fn0(v0, v6)
-;; @0031                               v8 = insertlane v5, v7, 0  ; v5 = const0
-;; @0031                               v9 = extractlane v4, 1
-;; @0031                               v10 = call fn0(v0, v9)
-;; @0031                               v11 = insertlane v8, v10, 1
-;; @0031                               v12 = extractlane v4, 2
-;; @0031                               v13 = call fn0(v0, v12)
-;; @0031                               v14 = insertlane v11, v13, 2
-;; @0031                               v15 = extractlane v4, 3
-;; @0031                               v16 = call fn0(v0, v15)
-;; @0031                               v17 = insertlane v14, v16, 3
-;; @0033                               v18 = bitcast.i8x16 little v17
+;; @0031                               v3 = bitcast.f32x4 little v2
+;; @0031                               v4 = vconst.f32x4 const0
+;; @0031                               v5 = extractlane v3, 0
+;; @0031                               v6 = call fn0(v0, v5)
+;; @0031                               v7 = insertlane v4, v6, 0  ; v4 = const0
+;; @0031                               v8 = extractlane v3, 1
+;; @0031                               v9 = call fn0(v0, v8)
+;; @0031                               v10 = insertlane v7, v9, 1
+;; @0031                               v11 = extractlane v3, 2
+;; @0031                               v12 = call fn0(v0, v11)
+;; @0031                               v13 = insertlane v10, v12, 2
+;; @0031                               v14 = extractlane v3, 3
+;; @0031                               v15 = call fn0(v0, v14)
+;; @0031                               v16 = insertlane v13, v15, 3
+;; @0033                               v17 = bitcast.i8x16 little v16
 ;; @0033                               jump block1
 ;;
 ;;                                 block1:
-;; @0033                               return v18
+;; @0033                               return v17
 ;; }
 ;;
 ;; function u0:3(i64 vmctx, i64, i8x16) -> i8x16 tail {
@@ -122,25 +122,25 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
-;; @0038                               v4 = bitcast.f32x4 little v2
-;; @0038                               v5 = vconst.f32x4 const0
-;; @0038                               v6 = extractlane v4, 0
-;; @0038                               v7 = call fn0(v0, v6)
-;; @0038                               v8 = insertlane v5, v7, 0  ; v5 = const0
-;; @0038                               v9 = extractlane v4, 1
-;; @0038                               v10 = call fn0(v0, v9)
-;; @0038                               v11 = insertlane v8, v10, 1
-;; @0038                               v12 = extractlane v4, 2
-;; @0038                               v13 = call fn0(v0, v12)
-;; @0038                               v14 = insertlane v11, v13, 2
-;; @0038                               v15 = extractlane v4, 3
-;; @0038                               v16 = call fn0(v0, v15)
-;; @0038                               v17 = insertlane v14, v16, 3
-;; @003a                               v18 = bitcast.i8x16 little v17
+;; @0038                               v3 = bitcast.f32x4 little v2
+;; @0038                               v4 = vconst.f32x4 const0
+;; @0038                               v5 = extractlane v3, 0
+;; @0038                               v6 = call fn0(v0, v5)
+;; @0038                               v7 = insertlane v4, v6, 0  ; v4 = const0
+;; @0038                               v8 = extractlane v3, 1
+;; @0038                               v9 = call fn0(v0, v8)
+;; @0038                               v10 = insertlane v7, v9, 1
+;; @0038                               v11 = extractlane v3, 2
+;; @0038                               v12 = call fn0(v0, v11)
+;; @0038                               v13 = insertlane v10, v12, 2
+;; @0038                               v14 = extractlane v3, 3
+;; @0038                               v15 = call fn0(v0, v14)
+;; @0038                               v16 = insertlane v13, v15, 3
+;; @003a                               v17 = bitcast.i8x16 little v16
 ;; @003a                               jump block1
 ;;
 ;;                                 block1:
-;; @003a                               return v18
+;; @003a                               return v17
 ;; }
 ;;
 ;; function u0:4(i64 vmctx, i64, i8x16) -> i8x16 tail {
@@ -155,19 +155,19 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
-;; @003f                               v4 = bitcast.f64x2 little v2
-;; @003f                               v5 = vconst.f64x2 const0
-;; @003f                               v6 = extractlane v4, 0
-;; @003f                               v7 = call fn0(v0, v6)
-;; @003f                               v8 = insertlane v5, v7, 0  ; v5 = const0
-;; @003f                               v9 = extractlane v4, 1
-;; @003f                               v10 = call fn0(v0, v9)
-;; @003f                               v11 = insertlane v8, v10, 1
-;; @0041                               v12 = bitcast.i8x16 little v11
+;; @003f                               v3 = bitcast.f64x2 little v2
+;; @003f                               v4 = vconst.f64x2 const0
+;; @003f                               v5 = extractlane v3, 0
+;; @003f                               v6 = call fn0(v0, v5)
+;; @003f                               v7 = insertlane v4, v6, 0  ; v4 = const0
+;; @003f                               v8 = extractlane v3, 1
+;; @003f                               v9 = call fn0(v0, v8)
+;; @003f                               v10 = insertlane v7, v9, 1
+;; @0041                               v11 = bitcast.i8x16 little v10
 ;; @0041                               jump block1
 ;;
 ;;                                 block1:
-;; @0041                               return v12
+;; @0041                               return v11
 ;; }
 ;;
 ;; function u0:5(i64 vmctx, i64, i8x16) -> i8x16 tail {
@@ -182,19 +182,19 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
-;; @0046                               v4 = bitcast.f64x2 little v2
-;; @0046                               v5 = vconst.f64x2 const0
-;; @0046                               v6 = extractlane v4, 0
-;; @0046                               v7 = call fn0(v0, v6)
-;; @0046                               v8 = insertlane v5, v7, 0  ; v5 = const0
-;; @0046                               v9 = extractlane v4, 1
-;; @0046                               v10 = call fn0(v0, v9)
-;; @0046                               v11 = insertlane v8, v10, 1
-;; @0048                               v12 = bitcast.i8x16 little v11
+;; @0046                               v3 = bitcast.f64x2 little v2
+;; @0046                               v4 = vconst.f64x2 const0
+;; @0046                               v5 = extractlane v3, 0
+;; @0046                               v6 = call fn0(v0, v5)
+;; @0046                               v7 = insertlane v4, v6, 0  ; v4 = const0
+;; @0046                               v8 = extractlane v3, 1
+;; @0046                               v9 = call fn0(v0, v8)
+;; @0046                               v10 = insertlane v7, v9, 1
+;; @0048                               v11 = bitcast.i8x16 little v10
 ;; @0048                               jump block1
 ;;
 ;;                                 block1:
-;; @0048                               return v12
+;; @0048                               return v11
 ;; }
 ;;
 ;; function u0:6(i64 vmctx, i64, i8x16) -> i8x16 tail {
@@ -209,19 +209,19 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
-;; @004d                               v4 = bitcast.f64x2 little v2
-;; @004d                               v5 = vconst.f64x2 const0
-;; @004d                               v6 = extractlane v4, 0
-;; @004d                               v7 = call fn0(v0, v6)
-;; @004d                               v8 = insertlane v5, v7, 0  ; v5 = const0
-;; @004d                               v9 = extractlane v4, 1
-;; @004d                               v10 = call fn0(v0, v9)
-;; @004d                               v11 = insertlane v8, v10, 1
-;; @004f                               v12 = bitcast.i8x16 little v11
+;; @004d                               v3 = bitcast.f64x2 little v2
+;; @004d                               v4 = vconst.f64x2 const0
+;; @004d                               v5 = extractlane v3, 0
+;; @004d                               v6 = call fn0(v0, v5)
+;; @004d                               v7 = insertlane v4, v6, 0  ; v4 = const0
+;; @004d                               v8 = extractlane v3, 1
+;; @004d                               v9 = call fn0(v0, v8)
+;; @004d                               v10 = insertlane v7, v9, 1
+;; @004f                               v11 = bitcast.i8x16 little v10
 ;; @004f                               jump block1
 ;;
 ;;                                 block1:
-;; @004f                               return v12
+;; @004f                               return v11
 ;; }
 ;;
 ;; function u0:7(i64 vmctx, i64, i8x16) -> i8x16 tail {
@@ -236,19 +236,19 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
-;; @0054                               v4 = bitcast.f64x2 little v2
-;; @0054                               v5 = vconst.f64x2 const0
-;; @0054                               v6 = extractlane v4, 0
-;; @0054                               v7 = call fn0(v0, v6)
-;; @0054                               v8 = insertlane v5, v7, 0  ; v5 = const0
-;; @0054                               v9 = extractlane v4, 1
-;; @0054                               v10 = call fn0(v0, v9)
-;; @0054                               v11 = insertlane v8, v10, 1
-;; @0057                               v12 = bitcast.i8x16 little v11
+;; @0054                               v3 = bitcast.f64x2 little v2
+;; @0054                               v4 = vconst.f64x2 const0
+;; @0054                               v5 = extractlane v3, 0
+;; @0054                               v6 = call fn0(v0, v5)
+;; @0054                               v7 = insertlane v4, v6, 0  ; v4 = const0
+;; @0054                               v8 = extractlane v3, 1
+;; @0054                               v9 = call fn0(v0, v8)
+;; @0054                               v10 = insertlane v7, v9, 1
+;; @0057                               v11 = bitcast.i8x16 little v10
 ;; @0057                               jump block1
 ;;
 ;;                                 block1:
-;; @0057                               return v12
+;; @0057                               return v11
 ;; }
 ;;
 ;; function u0:8(i64 vmctx, i64, i8x16) -> i8x16 tail {
@@ -261,17 +261,17 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
-;; @005c                               v4 = bitcast.f64x2 little v2
-;; @005c                               v5 = extractlane v4, 0
-;; @005c                               v6 = extractlane v4, 1
+;; @005c                               v3 = bitcast.f64x2 little v2
+;; @005c                               v4 = extractlane v3, 0
+;; @005c                               v5 = extractlane v3, 1
+;; @005c                               v6 = fcvt_to_uint_sat.i32 v4
 ;; @005c                               v7 = fcvt_to_uint_sat.i32 v5
-;; @005c                               v8 = fcvt_to_uint_sat.i32 v6
-;; @005c                               v9 = vconst.i32x4 const0
-;; @005c                               v10 = insertlane v9, v7, 0  ; v9 = const0
-;; @005c                               v11 = insertlane v10, v8, 1
-;; @005f                               v12 = bitcast.i8x16 little v11
+;; @005c                               v8 = vconst.i32x4 const0
+;; @005c                               v9 = insertlane v8, v6, 0  ; v8 = const0
+;; @005c                               v10 = insertlane v9, v7, 1
+;; @005f                               v11 = bitcast.i8x16 little v10
 ;; @005f                               jump block1
 ;;
 ;;                                 block1:
-;; @005f                               return v12
+;; @005f                               return v11
 ;; }

--- a/tests/disas/x64-simd-test-and-branch.wat
+++ b/tests/disas/x64-simd-test-and-branch.wat
@@ -56,8 +56,8 @@
 ;; wasm[0]::function[0]::i8x16.all_true:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       pxor    %xmm7, %xmm7
-;;       pcmpeqb %xmm7, %xmm0
+;;       pxor    %xmm6, %xmm6
+;;       pcmpeqb %xmm6, %xmm0
 ;;       ptest   %xmm0, %xmm0
 ;;       je      0x21
 ;;   17: movl    $0xc8, %eax
@@ -70,8 +70,8 @@
 ;; wasm[0]::function[1]::i16x8.all_true:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       pxor    %xmm7, %xmm7
-;;       pcmpeqw %xmm7, %xmm0
+;;       pxor    %xmm6, %xmm6
+;;       pcmpeqw %xmm6, %xmm0
 ;;       ptest   %xmm0, %xmm0
 ;;       je      0x61
 ;;   57: movl    $0xc8, %eax
@@ -84,8 +84,8 @@
 ;; wasm[0]::function[2]::i32x4.all_true:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       pxor    %xmm7, %xmm7
-;;       pcmpeqd %xmm7, %xmm0
+;;       pxor    %xmm6, %xmm6
+;;       pcmpeqd %xmm6, %xmm0
 ;;       ptest   %xmm0, %xmm0
 ;;       je      0xa1
 ;;   97: movl    $0xc8, %eax
@@ -98,8 +98,8 @@
 ;; wasm[0]::function[3]::i64x2.all_true:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       pxor    %xmm7, %xmm7
-;;       pcmpeqq %xmm7, %xmm0
+;;       pxor    %xmm6, %xmm6
+;;       pcmpeqq %xmm6, %xmm0
 ;;       ptest   %xmm0, %xmm0
 ;;       je      0xe2
 ;;   d8: movl    $0xc8, %eax


### PR DESCRIPTION
This allows SSA construction to determine whether they need to actually become block params or not, and cuts down on the number of unnecessary block parameters we pessimistically introduce during Wasm-to-CLIF translation.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
