### PR TITLE
Tag `table.fill`/`table.copy` element stores with table alias regions

### DIFF
--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -3806,11 +3806,12 @@ impl FuncEnvironment<'_> {
         match entity {
             CheckedEntity::Table { table, initialized } => {
                 assert!(!is_pre_interned_funcref);
+                let region = self.table_alias_region(builder.func, table);
                 self.emit_table_set(
                     builder,
                     table,
                     elem_addr,
-                    ir::MemFlagsData::trusted(),
+                    ir::MemFlagsData::trusted().with_alias_region(Some(region)),
                     value,
                     initialized,
                 )?
@@ -4464,11 +4465,12 @@ impl FuncEnvironment<'_> {
                 };
                 match dst_entity {
                     CheckedEntity::Table { table, initialized } => {
+                        let region = this.table_alias_region(builder.func, table);
                         this.emit_table_set(
                             builder,
                             table,
                             dst,
-                            ir::MemFlagsData::trusted(),
+                            ir::MemFlagsData::trusted().with_alias_region(Some(region)),
                             val,
                             initialized,
                         )?;

--- a/tests/disas/startup-table-initial-value.wat
+++ b/tests/disas/startup-table-initial-value.wat
@@ -39,6 +39,7 @@
 ;; function u2415919104:0(i64 vmctx, i64) tail {
 ;;     region0 = 2684354560 "VMTableDefinition+0x0"
 ;;     region1 = 2684354568 "VMTableDefinition+0x8"
+;;     region2 = 1342177280 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
 ;;
 ;; block0(v0: i64, v1: i64):
 ;;     v9 = load.i64 notrap aligned region1 v0+56
@@ -56,7 +57,7 @@
 ;;
 ;; block1(v29: i64):
 ;;     v86 = iconst.i32 1
-;;     store notrap aligned v86, v29  ; v86 = 1
+;;     store notrap aligned region2 v86, v29  ; v86 = 1
 ;;     v87 = iadd.i64 v18, v81  ; v81 = 36
 ;;     v88 = icmp eq v29, v87
 ;;     v89 = iconst.i64 4

--- a/tests/disas/table-copy.wat
+++ b/tests/disas/table-copy.wat
@@ -181,7 +181,7 @@
 ;;                                 block7(v65: i64):
 ;; @0090                               v69 = iconst.i64 1
 ;; @0090                               v70 = bor v65, v69  ; v69 = 1
-;; @0090                               store notrap aligned v70, v50
+;; @0090                               store notrap aligned region5 v70, v50
 ;; @0090                               v71 = iconst.i64 8
 ;; @0090                               v72 = iadd.i64 v50, v71  ; v71 = 8
 ;; @0090                               v73 = iconst.i64 8
@@ -200,7 +200,7 @@
 ;;                                 block9(v99: i64):
 ;; @0090                               v103 = iconst.i64 1
 ;; @0090                               v104 = bor v99, v103  ; v103 = 1
-;; @0090                               store notrap aligned v104, v82
+;; @0090                               store notrap aligned region5 v104, v82
 ;; @0090                               v105 = icmp.i64 eq v84, v35
 ;; @0090                               brif v105, block5, block4(v82, v84, v86)
 ;;
@@ -327,7 +327,7 @@
 ;;                                 block7(v68: i64):
 ;; @009f                               v72 = iconst.i64 1
 ;; @009f                               v73 = bor v68, v72  ; v72 = 1
-;; @009f                               store notrap aligned v73, v50
+;; @009f                               store notrap aligned region5 v73, v50
 ;; @009f                               v74 = iconst.i64 8
 ;; @009f                               v75 = iadd.i64 v50, v74  ; v74 = 8
 ;; @009f                               v76 = iconst.i64 8
@@ -346,7 +346,7 @@
 ;;                                 block9(v105: i64):
 ;; @009f                               v109 = iconst.i64 1
 ;; @009f                               v110 = bor v105, v109  ; v109 = 1
-;; @009f                               store notrap aligned v110, v85
+;; @009f                               store notrap aligned region5 v110, v85
 ;; @009f                               v111 = icmp.i64 eq v87, v35
 ;; @009f                               brif v111, block5, block4(v85, v87, v89)
 ;;


### PR DESCRIPTION
The bulk `table.fill` and `table.copy` paths fed region-less flags into emit_table_set; pass the proper table alias regions so their element stores match the `table.get`/`table.set` path.

Note that this omission could not have triggered any miscompiles because region-less stores act as fences.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
