### PR TITLE
cranelift(aarch64): fold an i32x4 horizontal add into a single addv

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/lower.isle
+++ b/cranelift/codegen/src/isa/aarch64/lower.isle
@@ -2772,6 +2772,15 @@
                                     (u8_from_uimm8 lane)))
       (fpu_move_from_vec val lane (vector_size vty)))
 
+;; A full `i32x4` horizontal add — two (GVN-shared) `iadd_pairwise`es then a
+;; lane-0 extract — is a single `addv`, replacing `addp; addp; umov`.
+(rule 3 (lower (extractlane $I32
+                            (iadd_pairwise $I32X4
+                                (iadd_pairwise $I32X4 x x)
+                                (iadd_pairwise $I32X4 x x))
+                            (u8_from_uimm8 0)))
+      (mov_from_vec (addv x (vector_size $I32X4)) 0 (scalar_size $I32)))
+
 ;;; Rules for `insertlane` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (rule 1 (lower (insertlane _ vec @ (value_type vty)

--- a/cranelift/filetests/filetests/isa/aarch64/simd-addv-reduce.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/simd-addv-reduce.clif
@@ -1,0 +1,25 @@
+test compile precise-output
+set unwind_info=false
+target aarch64
+
+;; A complete `i32x4` horizontal-add reduction contracts to a single `addv`.
+function %hsum_i32x4(i32x4) -> i32 {
+block0(v0: i32x4):
+    v1 = iadd_pairwise v0, v0
+    v2 = iadd_pairwise v1, v1
+    v3 = extractlane v2, 0
+    return v3
+}
+
+; VCode:
+; block0:
+;   addv s2, v0.4s
+;   mov w0, v2.s[0]
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addv s2, v0.4s
+;   mov w0, v2.s[0]
+;   ret
+

--- a/cranelift/filetests/filetests/runtests/simd-addv-reduce.clif
+++ b/cranelift/filetests/filetests/runtests/simd-addv-reduce.clif
@@ -1,0 +1,19 @@
+test interpret
+test run
+target aarch64
+target x86_64 has_sse3 has_ssse3 has_sse41
+target s390x
+
+;; A complete `i32x4` horizontal-add reduction, expressed as two pairwise adds
+;; plus a lane-0 extract. On aarch64 this lowers to a single `addv`.
+function %hsum_i32x4(i32x4) -> i32 {
+block0(v0: i32x4):
+    v1 = iadd_pairwise v0, v0
+    v2 = iadd_pairwise v1, v1
+    v3 = extractlane v2, 0
+    return v3
+}
+; run: %hsum_i32x4([1 2 3 4]) == 10
+; run: %hsum_i32x4([10 -5 100 -1]) == 104
+; run: %hsum_i32x4([0 0 0 0]) == 0
+; run: %hsum_i32x4([-1 -1 -1 -1]) == -4


### PR DESCRIPTION
A complete `i32x4` horizontal-add reduction has no CLIF opcode, so it is
expressed as two `iadd_pairwise`es (which GVN shares) followed by a lane-0
`extractlane`. Currently that lowers to:

```asm
addp v.4s, v.4s, v.4s
addp v.4s, v.4s, v.4s
umov w0, v.s[0]
```

NEON `addv` reduces the whole vector in a single instruction, so this contracts
the tree to:

```asm
addv s0, v.4s
umov w0, v.s[0]
```

— one fewer instruction and, more importantly, no serial `addp` dependency chain.

The mid-end has no egraph rules touching `iadd_pairwise`, so the structured
reduction reaches isel intact, which keeps the match reliable (a plain `iadd`
tree would be reassociated).

### Follow-up

The cleaner long-term fix is a dedicated horizontal-reduce CLIF op (e.g.
`vreduce_iadd`) that completes the `vall_true` / `vany_true` / `vhigh_bits`
vector→scalar family and lowers to `addv` on aarch64 with portable fallbacks
elsewhere. Happy to do that as a follow-up if you'd prefer the IR-level
primitive; this is a minimal aarch64-only implementation for now.

### Tests

- `filetests/isa/aarch64/simd-addv-reduce.clif` — precise-output, asserts `addv; umov`.
- `filetests/runtests/simd-addv-reduce.clif` — `interpret` + `run` semantics on aarch64/x86_64/s390x.
- The existing `isa/aarch64` and `runtests` suites pass unchanged.
