### PR TITLE
Tag GC-heap object writes with the GC-heap alias region

### DIFF
--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -3818,8 +3818,11 @@ impl FuncEnvironment<'_> {
             }
             CheckedEntity::Array { initialized, .. } => {
                 if is_pre_interned_funcref {
+                    let region = self.alias_regions.gc_heap_region(builder.func);
                     builder.ins().store(
-                        ir::MemFlagsData::trusted().with_endianness(Endianness::Little),
+                        ir::MemFlagsData::trusted()
+                            .with_endianness(Endianness::Little)
+                            .with_alias_region(Some(region)),
                         value,
                         elem_addr,
                         0,

--- a/crates/cranelift/src/func_environ/gc/copying.rs
+++ b/crates/cranelift/src/func_environ/gc/copying.rs
@@ -172,12 +172,16 @@ impl CopyingCompiler {
             let heap_offset = uextend_i32_to_pointer_type(builder, pointer_type, gc_ref);
             let obj_ptr = builder.ins().iadd(base, heap_offset);
 
+            // These header writes target the GC heap, so tag them with the
+            // GC-heap region (like the null collector does).
+            let header_flags = func_env.gc_memflags(&mut builder.func);
+
             // Write `VMGcHeader::kind` with inline trace info bits included.
             let kind_val = builder
                 .ins()
                 .iconst(ir::types::I32, i64::from(kind.as_u32() | reserved_bits));
             builder.ins().store(
-                ir::MemFlagsData::trusted(),
+                header_flags,
                 kind_val,
                 obj_ptr,
                 i32::try_from(wasmtime_environ::VM_GC_HEADER_KIND_OFFSET).unwrap(),
@@ -186,7 +190,7 @@ impl CopyingCompiler {
             // Write `VMGcHeader::type_index`.
             let shared_ty = func_env.module_interned_to_shared_ty(&mut builder.cursor(), ty);
             builder.ins().store(
-                ir::MemFlagsData::trusted(),
+                header_flags,
                 shared_ty,
                 obj_ptr,
                 i32::try_from(wasmtime_environ::VM_GC_HEADER_TYPE_INDEX_OFFSET).unwrap(),
@@ -194,7 +198,7 @@ impl CopyingCompiler {
 
             // Write `VMCopyingHeader::object_size`.
             builder.ins().istore32(
-                ir::MemFlagsData::trusted(),
+                header_flags,
                 aligned_size_64,
                 obj_ptr,
                 i32::try_from(wasmtime_environ::VM_GC_HEADER_SIZE).unwrap(),

--- a/tests/disas/array-fill-funcref.wat
+++ b/tests/disas/array-fill-funcref.wat
@@ -68,7 +68,7 @@
 ;; @003b                               brif v44, block3, block2(v29)
 ;;
 ;;                                 block2(v45: i64):
-;; @003b                               store.i32 notrap aligned little v41, v45
+;; @003b                               store.i32 notrap aligned little region4 v41, v45
 ;;                                     v56 = iconst.i64 4
 ;;                                     v57 = iadd v45, v56  ; v56 = 4
 ;; @003b                               v48 = icmp eq v57, v42
@@ -129,7 +129,7 @@
 ;; @0049                               brif v44, block3, block2(v29)
 ;;
 ;;                                 block2(v45: i64):
-;; @0049                               store.i32 notrap aligned little v41, v45
+;; @0049                               store.i32 notrap aligned little region4 v41, v45
 ;;                                     v55 = iconst.i64 4
 ;;                                     v56 = iadd v45, v55  ; v55 = 4
 ;; @0049                               v48 = icmp eq v56, v42
@@ -198,7 +198,7 @@
 ;; @0057                               brif v45, block3, block2(v30)
 ;;
 ;;                                 block2(v46: i64):
-;; @0057                               store.i32 notrap aligned little v42, v46
+;; @0057                               store.i32 notrap aligned little region4 v42, v46
 ;;                                     v64 = iconst.i64 4
 ;;                                     v65 = iadd v46, v64  ; v64 = 4
 ;; @0057                               v49 = icmp eq v65, v43

--- a/tests/disas/gc/array-new-data.wat
+++ b/tests/disas/gc/array-new-data.wat
@@ -134,12 +134,12 @@
 ;;                                     v142 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;;                                     v143 = load.i64 notrap aligned readonly can_move region6 v142+32
 ;; @0025                               v48 = iadd v143, v31
-;; @0025                               store notrap aligned v141, v48  ; v141 = -1476395002
+;; @0025                               store user2 region7 v141, v48  ; v141 = -1476395002
 ;;                                     v144 = load.i64 notrap aligned readonly can_move region5 v0+40
 ;;                                     v145 = load.i32 notrap aligned readonly can_move v144
-;; @0025                               store notrap aligned v145, v48+4
+;; @0025                               store user2 region7 v145, v48+4
 ;;                                     v146 = band.i64 v29, v28  ; v28 = -16
-;; @0025                               istore32 notrap aligned v146, v48+8
+;; @0025                               istore32 user2 region7 v146, v48+8
 ;; @0025                               jump block4(v24, v48)
 ;;
 ;;                                 block3 cold:

--- a/tests/disas/gc/array-new-default-anyref.wat
+++ b/tests/disas/gc/array-new-default-anyref.wat
@@ -60,12 +60,12 @@
 ;;                                     v127 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;;                                     v128 = load.i64 notrap aligned readonly can_move region4 v127+32
 ;; @001f                               v36 = iadd v128, v19
-;; @001f                               store notrap aligned v126, v36  ; v126 = -1476394994
+;; @001f                               store user2 region5 v126, v36  ; v126 = -1476394994
 ;;                                     v129 = load.i64 notrap aligned readonly can_move region3 v0+40
 ;;                                     v130 = load.i32 notrap aligned readonly can_move v129
-;; @001f                               store notrap aligned v130, v36+4
+;; @001f                               store user2 region5 v130, v36+4
 ;;                                     v131 = band.i64 v17, v16  ; v16 = -16
-;; @001f                               istore32 notrap aligned v131, v36+8
+;; @001f                               istore32 user2 region5 v131, v36+8
 ;; @001f                               jump block4(v12, v36)
 ;;
 ;;                                 block3 cold:

--- a/tests/disas/gc/array-new-default-exnref.wat
+++ b/tests/disas/gc/array-new-default-exnref.wat
@@ -60,12 +60,12 @@
 ;;                                     v127 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;;                                     v128 = load.i64 notrap aligned readonly can_move region4 v127+32
 ;; @001f                               v36 = iadd v128, v19
-;; @001f                               store notrap aligned v126, v36  ; v126 = -1476394994
+;; @001f                               store user2 region5 v126, v36  ; v126 = -1476394994
 ;;                                     v129 = load.i64 notrap aligned readonly can_move region3 v0+40
 ;;                                     v130 = load.i32 notrap aligned readonly can_move v129
-;; @001f                               store notrap aligned v130, v36+4
+;; @001f                               store user2 region5 v130, v36+4
 ;;                                     v131 = band.i64 v17, v16  ; v16 = -16
-;; @001f                               istore32 notrap aligned v131, v36+8
+;; @001f                               istore32 user2 region5 v131, v36+8
 ;; @001f                               jump block4(v12, v36)
 ;;
 ;;                                 block3 cold:

--- a/tests/disas/gc/array-new-default-externref.wat
+++ b/tests/disas/gc/array-new-default-externref.wat
@@ -60,12 +60,12 @@
 ;;                                     v127 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;;                                     v128 = load.i64 notrap aligned readonly can_move region4 v127+32
 ;; @001f                               v36 = iadd v128, v19
-;; @001f                               store notrap aligned v126, v36  ; v126 = -1476394994
+;; @001f                               store user2 region5 v126, v36  ; v126 = -1476394994
 ;;                                     v129 = load.i64 notrap aligned readonly can_move region3 v0+40
 ;;                                     v130 = load.i32 notrap aligned readonly can_move v129
-;; @001f                               store notrap aligned v130, v36+4
+;; @001f                               store user2 region5 v130, v36+4
 ;;                                     v131 = band.i64 v17, v16  ; v16 = -16
-;; @001f                               istore32 notrap aligned v131, v36+8
+;; @001f                               istore32 user2 region5 v131, v36+8
 ;; @001f                               jump block4(v12, v36)
 ;;
 ;;                                 block3 cold:

--- a/tests/disas/gc/array-new-default-f32.wat
+++ b/tests/disas/gc/array-new-default-f32.wat
@@ -63,12 +63,12 @@
 ;;                                     v130 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;;                                     v131 = load.i64 notrap aligned readonly can_move region4 v130+32
 ;; @001f                               v36 = iadd v131, v19
-;; @001f                               store notrap aligned v129, v36  ; v129 = -1476395002
+;; @001f                               store user2 region5 v129, v36  ; v129 = -1476395002
 ;;                                     v132 = load.i64 notrap aligned readonly can_move region3 v0+40
 ;;                                     v133 = load.i32 notrap aligned readonly can_move v132
-;; @001f                               store notrap aligned v133, v36+4
+;; @001f                               store user2 region5 v133, v36+4
 ;;                                     v134 = band.i64 v17, v16  ; v16 = -16
-;; @001f                               istore32 notrap aligned v134, v36+8
+;; @001f                               istore32 user2 region5 v134, v36+8
 ;; @001f                               jump block4(v12, v36)
 ;;
 ;;                                 block3 cold:

--- a/tests/disas/gc/array-new-default-f64.wat
+++ b/tests/disas/gc/array-new-default-f64.wat
@@ -63,12 +63,12 @@
 ;;                                     v130 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;;                                     v131 = load.i64 notrap aligned readonly can_move region4 v130+32
 ;; @001f                               v36 = iadd v131, v19
-;; @001f                               store notrap aligned v129, v36  ; v129 = -1476395002
+;; @001f                               store user2 region5 v129, v36  ; v129 = -1476395002
 ;;                                     v132 = load.i64 notrap aligned readonly can_move region3 v0+40
 ;;                                     v133 = load.i32 notrap aligned readonly can_move v132
-;; @001f                               store notrap aligned v133, v36+4
+;; @001f                               store user2 region5 v133, v36+4
 ;;                                     v134 = band.i64 v17, v16  ; v16 = -16
-;; @001f                               istore32 notrap aligned v134, v36+8
+;; @001f                               istore32 user2 region5 v134, v36+8
 ;; @001f                               jump block4(v12, v36)
 ;;
 ;;                                 block3 cold:

--- a/tests/disas/gc/array-new-default-funcref.wat
+++ b/tests/disas/gc/array-new-default-funcref.wat
@@ -63,12 +63,12 @@
 ;;                                     v137 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;;                                     v138 = load.i64 notrap aligned readonly can_move region4 v137+32
 ;; @001f                               v36 = iadd v138, v19
-;; @001f                               store notrap aligned v136, v36  ; v136 = -1476395002
+;; @001f                               store user2 region5 v136, v36  ; v136 = -1476395002
 ;;                                     v139 = load.i64 notrap aligned readonly can_move region3 v0+40
 ;;                                     v140 = load.i32 notrap aligned readonly can_move v139
-;; @001f                               store notrap aligned v140, v36+4
+;; @001f                               store user2 region5 v140, v36+4
 ;;                                     v141 = band.i64 v17, v16  ; v16 = -16
-;; @001f                               istore32 notrap aligned v141, v36+8
+;; @001f                               istore32 user2 region5 v141, v36+8
 ;; @001f                               jump block4(v12, v36)
 ;;
 ;;                                 block3 cold:
@@ -115,7 +115,7 @@
 ;; @001f                               brif v84, block6, block5(v65)
 ;;
 ;;                                 block5(v85: i64):
-;; @001f                               store.i32 notrap aligned little v81, v85
+;; @001f                               store.i32 notrap aligned little region5 v81, v85
 ;;                                     v144 = iconst.i64 4
 ;;                                     v145 = iadd v85, v144  ; v144 = 4
 ;; @001f                               v88 = icmp eq v145, v82

--- a/tests/disas/gc/array-new-default-i16.wat
+++ b/tests/disas/gc/array-new-default-i16.wat
@@ -62,12 +62,12 @@
 ;;                                     v140 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;;                                     v141 = load.i64 notrap aligned readonly can_move region4 v140+32
 ;; @001f                               v36 = iadd v141, v19
-;; @001f                               store notrap aligned v139, v36  ; v139 = -1476395002
+;; @001f                               store user2 region5 v139, v36  ; v139 = -1476395002
 ;;                                     v142 = load.i64 notrap aligned readonly can_move region3 v0+40
 ;;                                     v143 = load.i32 notrap aligned readonly can_move v142
-;; @001f                               store notrap aligned v143, v36+4
+;; @001f                               store user2 region5 v143, v36+4
 ;;                                     v144 = band.i64 v17, v16  ; v16 = -16
-;; @001f                               istore32 notrap aligned v144, v36+8
+;; @001f                               istore32 user2 region5 v144, v36+8
 ;; @001f                               jump block4(v12, v36)
 ;;
 ;;                                 block3 cold:

--- a/tests/disas/gc/array-new-default-i32.wat
+++ b/tests/disas/gc/array-new-default-i32.wat
@@ -63,12 +63,12 @@
 ;;                                     v130 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;;                                     v131 = load.i64 notrap aligned readonly can_move region4 v130+32
 ;; @001f                               v36 = iadd v131, v19
-;; @001f                               store notrap aligned v129, v36  ; v129 = -1476395002
+;; @001f                               store user2 region5 v129, v36  ; v129 = -1476395002
 ;;                                     v132 = load.i64 notrap aligned readonly can_move region3 v0+40
 ;;                                     v133 = load.i32 notrap aligned readonly can_move v132
-;; @001f                               store notrap aligned v133, v36+4
+;; @001f                               store user2 region5 v133, v36+4
 ;;                                     v134 = band.i64 v17, v16  ; v16 = -16
-;; @001f                               istore32 notrap aligned v134, v36+8
+;; @001f                               istore32 user2 region5 v134, v36+8
 ;; @001f                               jump block4(v12, v36)
 ;;
 ;;                                 block3 cold:

--- a/tests/disas/gc/array-new-default-i64.wat
+++ b/tests/disas/gc/array-new-default-i64.wat
@@ -63,12 +63,12 @@
 ;;                                     v129 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;;                                     v130 = load.i64 notrap aligned readonly can_move region4 v129+32
 ;; @001f                               v36 = iadd v130, v19
-;; @001f                               store notrap aligned v128, v36  ; v128 = -1476395002
+;; @001f                               store user2 region5 v128, v36  ; v128 = -1476395002
 ;;                                     v131 = load.i64 notrap aligned readonly can_move region3 v0+40
 ;;                                     v132 = load.i32 notrap aligned readonly can_move v131
-;; @001f                               store notrap aligned v132, v36+4
+;; @001f                               store user2 region5 v132, v36+4
 ;;                                     v133 = band.i64 v17, v16  ; v16 = -16
-;; @001f                               istore32 notrap aligned v133, v36+8
+;; @001f                               istore32 user2 region5 v133, v36+8
 ;; @001f                               jump block4(v12, v36)
 ;;
 ;;                                 block3 cold:

--- a/tests/disas/gc/array-new-default-i8.wat
+++ b/tests/disas/gc/array-new-default-i8.wat
@@ -59,12 +59,12 @@
 ;;                                     v118 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;;                                     v119 = load.i64 notrap aligned readonly can_move region4 v118+32
 ;; @001f                               v36 = iadd v119, v19
-;; @001f                               store notrap aligned v117, v36  ; v117 = -1476395002
+;; @001f                               store user2 region5 v117, v36  ; v117 = -1476395002
 ;;                                     v120 = load.i64 notrap aligned readonly can_move region3 v0+40
 ;;                                     v121 = load.i32 notrap aligned readonly can_move v120
-;; @001f                               store notrap aligned v121, v36+4
+;; @001f                               store user2 region5 v121, v36+4
 ;;                                     v122 = band.i64 v17, v16  ; v16 = -16
-;; @001f                               istore32 notrap aligned v122, v36+8
+;; @001f                               istore32 user2 region5 v122, v36+8
 ;; @001f                               jump block4(v12, v36)
 ;;
 ;;                                 block3 cold:

--- a/tests/disas/gc/copying/array-new-fixed-of-gc-refs.wat
+++ b/tests/disas/gc/copying/array-new-fixed-of-gc-refs.wat
@@ -51,12 +51,12 @@
 ;;                                     v261 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;;                                     v262 = load.i64 notrap aligned readonly can_move region4 v261+32
 ;; @0025                               v39 = iadd v262, v22
-;; @0025                               store notrap aligned v260, v39  ; v260 = -1476394994
+;; @0025                               store user2 region5 v260, v39  ; v260 = -1476394994
 ;;                                     v263 = load.i64 notrap aligned readonly can_move region3 v0+40
 ;;                                     v264 = load.i32 notrap aligned readonly can_move v263
-;; @0025                               store notrap aligned v264, v39+4
+;; @0025                               store user2 region5 v264, v39+4
 ;;                                     v265 = iconst.i64 32
-;; @0025                               istore32 notrap aligned v265, v39+8  ; v265 = 32
+;; @0025                               istore32 user2 region5 v265, v39+8  ; v265 = 32
 ;; @0025                               jump block4(v15, v39)
 ;;
 ;;                                 block3 cold:

--- a/tests/disas/gc/copying/array-new-fixed.wat
+++ b/tests/disas/gc/copying/array-new-fixed.wat
@@ -42,12 +42,12 @@
 ;;                                     v249 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;;                                     v250 = load.i64 notrap aligned readonly can_move region4 v249+32
 ;; @0025                               v39 = iadd v250, v22
-;; @0025                               store notrap aligned v248, v39  ; v248 = -1476395002
+;; @0025                               store user2 region5 v248, v39  ; v248 = -1476395002
 ;;                                     v251 = load.i64 notrap aligned readonly can_move region3 v0+40
 ;;                                     v252 = load.i32 notrap aligned readonly can_move v251
-;; @0025                               store notrap aligned v252, v39+4
+;; @0025                               store user2 region5 v252, v39+4
 ;;                                     v253 = iconst.i64 48
-;; @0025                               istore32 notrap aligned v253, v39+8  ; v253 = 48
+;; @0025                               istore32 user2 region5 v253, v39+8  ; v253 = 48
 ;; @0025                               jump block4(v15, v39)
 ;;
 ;;                                 block3 cold:

--- a/tests/disas/gc/copying/array-new.wat
+++ b/tests/disas/gc/copying/array-new.wat
@@ -59,12 +59,12 @@
 ;;                                     v127 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;;                                     v128 = load.i64 notrap aligned readonly can_move region4 v127+32
 ;; @0022                               v37 = iadd v128, v20
-;; @0022                               store notrap aligned v126, v37  ; v126 = -1476395002
+;; @0022                               store user2 region5 v126, v37  ; v126 = -1476395002
 ;;                                     v129 = load.i64 notrap aligned readonly can_move region3 v0+40
 ;;                                     v130 = load.i32 notrap aligned readonly can_move v129
-;; @0022                               store notrap aligned v130, v37+4
+;; @0022                               store user2 region5 v130, v37+4
 ;;                                     v131 = band.i64 v18, v17  ; v17 = -16
-;; @0022                               istore32 notrap aligned v131, v37+8
+;; @0022                               istore32 user2 region5 v131, v37+8
 ;; @0022                               jump block4(v13, v37)
 ;;
 ;;                                 block3 cold:

--- a/tests/disas/gc/copying/funcref-in-gc-heap-new.wat
+++ b/tests/disas/gc/copying/funcref-in-gc-heap-new.wat
@@ -44,12 +44,12 @@
 ;;                                     v60 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;;                                     v61 = load.i64 notrap aligned readonly can_move region4 v60+32
 ;; @0020                               v29 = iadd v61, v12
-;; @0020                               store notrap aligned v59, v29  ; v59 = -1342177278
+;; @0020                               store user2 region5 v59, v29  ; v59 = -1342177278
 ;;                                     v62 = load.i64 notrap aligned readonly can_move region3 v0+40
 ;;                                     v63 = load.i32 notrap aligned readonly can_move v62
-;; @0020                               store notrap aligned v63, v29+4
+;; @0020                               store user2 region5 v63, v29+4
 ;;                                     v64 = iconst.i64 32
-;; @0020                               istore32 notrap aligned v64, v29+8  ; v64 = 32
+;; @0020                               istore32 user2 region5 v64, v29+8  ; v64 = 32
 ;; @0020                               jump block4(v5, v29)
 ;;
 ;;                                 block3 cold:

--- a/tests/disas/gc/copying/struct-new-default.wat
+++ b/tests/disas/gc/copying/struct-new-default.wat
@@ -43,12 +43,12 @@
 ;;                                     v61 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;;                                     v62 = load.i64 notrap aligned readonly can_move region4 v61+32
 ;; @0021                               v31 = iadd v62, v14
-;; @0021                               store notrap aligned v60, v31  ; v60 = -1342177246
+;; @0021                               store user2 region5 v60, v31  ; v60 = -1342177246
 ;;                                     v63 = load.i64 notrap aligned readonly can_move region3 v0+40
 ;;                                     v64 = load.i32 notrap aligned readonly can_move v63
-;; @0021                               store notrap aligned v64, v31+4
+;; @0021                               store user2 region5 v64, v31+4
 ;;                                     v65 = iconst.i64 32
-;; @0021                               istore32 notrap aligned v65, v31+8  ; v65 = 32
+;; @0021                               istore32 user2 region5 v65, v31+8  ; v65 = 32
 ;; @0021                               jump block4(v7, v31)
 ;;
 ;;                                 block3 cold:

--- a/tests/disas/gc/copying/struct-new.wat
+++ b/tests/disas/gc/copying/struct-new.wat
@@ -46,12 +46,12 @@
 ;;                                     v64 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;;                                     v65 = load.i64 notrap aligned readonly can_move region4 v64+32
 ;; @002a                               v31 = iadd v65, v14
-;; @002a                               store notrap aligned v63, v31  ; v63 = -1342177246
+;; @002a                               store user2 region5 v63, v31  ; v63 = -1342177246
 ;;                                     v66 = load.i64 notrap aligned readonly can_move region3 v0+40
 ;;                                     v67 = load.i32 notrap aligned readonly can_move v66
-;; @002a                               store notrap aligned v67, v31+4
+;; @002a                               store user2 region5 v67, v31+4
 ;;                                     v68 = iconst.i64 32
-;; @002a                               istore32 notrap aligned v68, v31+8  ; v68 = 32
+;; @002a                               istore32 user2 region5 v68, v31+8  ; v68 = 32
 ;; @002a                               jump block4(v7, v31)
 ;;
 ;;                                 block3 cold:

--- a/tests/disas/gc/issue-11753.wat
+++ b/tests/disas/gc/issue-11753.wat
@@ -51,11 +51,14 @@
 ;;       movq    0x20(%rsi), %rdi
 ;;       leaq    (%rdi, %rcx), %rsi
 ;;       movl    $0xb0000002, (%rdi, %rcx)
+;;       ╰─╼ trap: GcHeapCorrupt
 ;;       movq    0x28(%r9), %r8
 ;;       movl    (%r8), %r8d
 ;;       movl    %r8d, 4(%rdi, %rcx)
+;;       ╰─╼ trap: GcHeapCorrupt
 ;;       movl    $0x20, %r8d
 ;;       movl    %r8d, 8(%rdi, %rcx)
+;;       ╰─╼ trap: GcHeapCorrupt
 ;;       movl    %eax, (%rsp)
 ;;       movl    $0x2a, 0x10(%rsi)
 ;;       ╰─╼ trap: GcHeapCorrupt

--- a/tests/disas/gc/struct-new-default.wat
+++ b/tests/disas/gc/struct-new-default.wat
@@ -46,12 +46,12 @@
 ;;                                     v64 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;;                                     v65 = load.i64 notrap aligned readonly can_move region4 v64+32
 ;; @0023                               v32 = iadd v65, v15
-;; @0023                               store notrap aligned v63, v32  ; v63 = -1342177246
+;; @0023                               store user2 region5 v63, v32  ; v63 = -1342177246
 ;;                                     v66 = load.i64 notrap aligned readonly can_move region3 v0+40
 ;;                                     v67 = load.i32 notrap aligned readonly can_move v66
-;; @0023                               store notrap aligned v67, v32+4
+;; @0023                               store user2 region5 v67, v32+4
 ;;                                     v68 = iconst.i64 48
-;; @0023                               istore32 notrap aligned v68, v32+8  ; v68 = 48
+;; @0023                               istore32 user2 region5 v68, v32+8  ; v68 = 48
 ;; @0023                               jump block4(v8, v32)
 ;;
 ;;                                 block3 cold:

--- a/tests/disas/gc/struct-new.wat
+++ b/tests/disas/gc/struct-new.wat
@@ -47,12 +47,12 @@
 ;;                                     v64 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;;                                     v65 = load.i64 notrap aligned readonly can_move region4 v64+32
 ;; @002a                               v31 = iadd v65, v14
-;; @002a                               store notrap aligned v63, v31  ; v63 = -1342177246
+;; @002a                               store user2 region5 v63, v31  ; v63 = -1342177246
 ;;                                     v66 = load.i64 notrap aligned readonly can_move region3 v0+40
 ;;                                     v67 = load.i32 notrap aligned readonly can_move v66
-;; @002a                               store notrap aligned v67, v31+4
+;; @002a                               store user2 region5 v67, v31+4
 ;;                                     v68 = iconst.i64 32
-;; @002a                               istore32 notrap aligned v68, v31+8  ; v68 = 32
+;; @002a                               istore32 user2 region5 v68, v31+8  ; v68 = 32
 ;; @002a                               jump block4(v7, v31)
 ;;
 ;;                                 block3 cold:


### PR DESCRIPTION
The copying collector's fresh-object header initialization writes now use the canonical GC memflags (like the null collector), and the pre-interned funcref array-element store gets the GC-heap region, matching how those locations are read elsewhere.

Note: these missing regions could not result in miscompiles previously because regionless stores are treated as memory fences by alias analysis.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
