### PR TITLE
release-46.0.0: backport flaky test fix, amend release notes

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,15 @@
+
+## 46.0.1
+
+Released 2026-06-24.
+
+### Fixed
+
+* Explicit hint for generic call in wasmtime wit-bindgen.
+  [#13719](https://github.com/bytecodealliance/wasmtime/pull/13719)
+
+--------------------------------------------------------------------------------
+
 ## 46.0.0
 
 Released 2026-06-22.

--- a/tests/all/cli_tests.rs
+++ b/tests/all/cli_tests.rs
@@ -2979,7 +2979,7 @@ start a print 1234
             let _ = tx.send(res);
         });
 
-        let buf = match rx.recv_timeout(std::time::Duration::from_secs(10)) {
+        let buf = match rx.recv_timeout(std::time::Duration::from_secs(100)) {
             Ok(Ok(buf)) => buf,
             Ok(Err(e)) => {
                 let _ = child.kill();


### PR DESCRIPTION
Closes https://github.com/bytecodealliance/wasmtime/issues/13720

