### PR TITLE
Tag collector heap-data structs with alias regions

### DIFF
--- a/crates/cranelift/src/alias_region.rs
+++ b/crates/cranelift/src/alias_region.rs
@@ -21,6 +21,9 @@ enum VmType {
     VMMemoryDefinition,
     VMTableDefinition,
     VMComponentContext,
+    VMDrcHeapData,
+    VMCopyingHeapData,
+    VMNullHeapData,
 }
 
 /// A key that uniquely identifies an alias region across an entire compilation.
@@ -29,7 +32,7 @@ enum VmType {
 /// that alias regions can be deduplicated during inlining.
 ///
 /// The key encodes into a single `u32` with the following layout:
-/// `[ kind: 4 bits | data: 28 bits ]`
+/// `[ kind: 5 bits | data: 27 bits ]`
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
 enum AliasRegionKey {
     /// An access of a field within a VM data structure of type `ty`.
@@ -111,6 +114,9 @@ impl AliasRegionKey {
     const VM_MEMORY_DEFINITION_KIND: u32 = Self::new_kind(0b1001);
     const VM_TABLE_DEFINITION_KIND: u32 = Self::new_kind(0b1010);
     const VM_COMPONENT_CONTEXT_KIND: u32 = Self::new_kind(0b1011);
+    const VM_DRC_HEAP_DATA_KIND: u32 = Self::new_kind(0b1100);
+    const VM_COPYING_HEAP_DATA_KIND: u32 = Self::new_kind(0b1101);
+    const VM_NULL_HEAP_DATA_KIND: u32 = Self::new_kind(0b1110);
 
     /// Encode this key into a raw `u32` suitable for use as an
     /// `AliasRegionData::user_id`.
@@ -124,6 +130,9 @@ impl AliasRegionKey {
                     VmType::VMMemoryDefinition => Self::VM_MEMORY_DEFINITION_KIND,
                     VmType::VMTableDefinition => Self::VM_TABLE_DEFINITION_KIND,
                     VmType::VMComponentContext => Self::VM_COMPONENT_CONTEXT_KIND,
+                    VmType::VMDrcHeapData => Self::VM_DRC_HEAP_DATA_KIND,
+                    VmType::VMCopyingHeapData => Self::VM_COPYING_HEAP_DATA_KIND,
+                    VmType::VMNullHeapData => Self::VM_NULL_HEAP_DATA_KIND,
                 };
                 kind | (offset & Self::OFFSET_MASK)
             }
@@ -1645,5 +1654,235 @@ impl AliasRegions<VMComponentOffsets<u8>> {
             vmctx,
             self.offsets.may_leave(instance),
         )
+    }
+}
+
+/// Methods for the collectors' private heap-data structs.
+///
+/// Each struct is a separate allocation reached through a `*mut _` stored in the
+/// `VMContext`. Their fields are *not* GC heap locations, so they are tagged with
+/// the owning struct's own region (keyed on the field offset within the struct)
+/// rather than the `GcHeap` region. These helpers emit the field load/store.
+impl<Offsets> AliasRegions<Offsets>
+where
+    Offsets: GetPtrSize,
+{
+    fn vmdrc_heap_data_region(&mut self, func: &mut ir::Function, offset: u32) -> ir::AliasRegion {
+        self.region(
+            func,
+            AliasRegionKey::Vm {
+                ty: VmType::VMDrcHeapData,
+                offset,
+            },
+        )
+    }
+
+    /// Emit a load of the DRC over-approximated-stack-roots list head, given the
+    /// a `*mut VMDrcHeapData`.
+    pub fn vmdrc_heap_data_over_approximated_stack_roots(
+        &mut self,
+        cursor: &mut FuncCursor<'_>,
+        drc_heap_data: ir::Value,
+    ) -> ir::Value {
+        let offset = self
+            .offsets
+            .get_ptr_size()
+            .vmdrc_heap_data_over_approximated_stack_roots();
+        let region = self.vmdrc_heap_data_region(cursor.func, offset.into());
+        cursor.ins().load(
+            ir::types::I32,
+            ir::MemFlagsData::trusted().with_alias_region(Some(region)),
+            drc_heap_data,
+            i32::from(offset),
+        )
+    }
+
+    /// Emit a store to the DRC over-approximated-stack-roots list head.
+    pub fn store_vmdrc_heap_data_over_approximated_stack_roots(
+        &mut self,
+        cursor: &mut FuncCursor<'_>,
+        drc_heap_data: ir::Value,
+        val: ir::Value,
+    ) {
+        let offset = self
+            .offsets
+            .get_ptr_size()
+            .vmdrc_heap_data_over_approximated_stack_roots();
+        let region = self.vmdrc_heap_data_region(cursor.func, offset.into());
+        cursor.ins().store(
+            ir::MemFlagsData::trusted().with_alias_region(Some(region)),
+            val,
+            drc_heap_data,
+            i32::from(offset),
+        );
+    }
+
+    /// Emit a load of the current over-approximated-stack-roots list length.
+    pub fn vmdrc_heap_data_current_over_approximated_stack_roots_len(
+        &mut self,
+        cursor: &mut FuncCursor<'_>,
+        drc_heap_data: ir::Value,
+    ) -> ir::Value {
+        let offset = self
+            .offsets
+            .get_ptr_size()
+            .vmdrc_heap_data_current_over_approximated_stack_roots_len();
+        let region = self.vmdrc_heap_data_region(cursor.func, offset.into());
+        cursor.ins().load(
+            ir::types::I32,
+            ir::MemFlagsData::trusted().with_alias_region(Some(region)),
+            drc_heap_data,
+            i32::from(offset),
+        )
+    }
+
+    /// Emit a store to the current over-approximated-stack-roots list length.
+    pub fn store_vmdrc_heap_data_current_over_approximated_stack_roots_len(
+        &mut self,
+        cursor: &mut FuncCursor<'_>,
+        drc_heap_data: ir::Value,
+        len: ir::Value,
+    ) {
+        let offset = self
+            .offsets
+            .get_ptr_size()
+            .vmdrc_heap_data_current_over_approximated_stack_roots_len();
+        let region = self.vmdrc_heap_data_region(cursor.func, offset.into());
+        cursor.ins().store(
+            ir::MemFlagsData::trusted().with_alias_region(Some(region)),
+            len,
+            drc_heap_data,
+            i32::from(offset),
+        );
+    }
+
+    /// Emit a load of the over-approximated-stack-roots list length after the
+    /// last GC.
+    pub fn vmdrc_heap_data_over_approximated_stack_roots_len_after_last_gc(
+        &mut self,
+        cursor: &mut FuncCursor<'_>,
+        drc_heap_data: ir::Value,
+    ) -> ir::Value {
+        let offset = self
+            .offsets
+            .get_ptr_size()
+            .vmdrc_heap_data_over_approximated_stack_roots_len_after_last_gc();
+        let region = self.vmdrc_heap_data_region(cursor.func, offset.into());
+        cursor.ins().load(
+            ir::types::I32,
+            ir::MemFlagsData::trusted().with_alias_region(Some(region)),
+            drc_heap_data,
+            i32::from(offset),
+        )
+    }
+
+    fn vmcopying_heap_data_region(
+        &mut self,
+        func: &mut ir::Function,
+        offset: u32,
+    ) -> ir::AliasRegion {
+        self.region(
+            func,
+            AliasRegionKey::Vm {
+                ty: VmType::VMCopyingHeapData,
+                offset,
+            },
+        )
+    }
+
+    /// Emit a load of the copying collector's bump pointer.
+    pub fn vmcopying_heap_data_bump_ptr(
+        &mut self,
+        cursor: &mut FuncCursor<'_>,
+        copying_heap_data: ir::Value,
+    ) -> ir::Value {
+        let offset = self.offsets.get_ptr_size().vmcopying_heap_data_bump_ptr();
+        let region = self.vmcopying_heap_data_region(cursor.func, offset.into());
+        cursor.ins().load(
+            ir::types::I32,
+            ir::MemFlagsData::trusted().with_alias_region(Some(region)),
+            copying_heap_data,
+            i32::from(offset),
+        )
+    }
+
+    /// Emit a store to the copying collector's bump pointer.
+    pub fn store_vmcopying_heap_data_bump_ptr(
+        &mut self,
+        cursor: &mut FuncCursor<'_>,
+        copying_heap_data: ir::Value,
+        val: ir::Value,
+    ) {
+        let offset = self.offsets.get_ptr_size().vmcopying_heap_data_bump_ptr();
+        let region = self.vmcopying_heap_data_region(cursor.func, offset.into());
+        cursor.ins().store(
+            ir::MemFlagsData::trusted().with_alias_region(Some(region)),
+            val,
+            copying_heap_data,
+            i32::from(offset),
+        );
+    }
+
+    /// Emit a load of the copying collector's active-space-end pointer.
+    pub fn vmcopying_heap_data_active_space_end(
+        &mut self,
+        cursor: &mut FuncCursor<'_>,
+        copying_heap_data: ir::Value,
+    ) -> ir::Value {
+        let offset = self
+            .offsets
+            .get_ptr_size()
+            .vmcopying_heap_data_active_space_end();
+        let region = self.vmcopying_heap_data_region(cursor.func, offset.into());
+        cursor.ins().load(
+            ir::types::I32,
+            ir::MemFlagsData::trusted().with_alias_region(Some(region)),
+            copying_heap_data,
+            i32::from(offset),
+        )
+    }
+
+    /// Emit a load of the null collector's bump finger (the first and only field
+    /// of its heap data, at offset 0).
+    pub fn vmnull_heap_data_bump_finger(
+        &mut self,
+        cursor: &mut FuncCursor<'_>,
+        null_collector_heap_data: ir::Value,
+    ) -> ir::Value {
+        let region = self.region(
+            cursor.func,
+            AliasRegionKey::Vm {
+                ty: VmType::VMNullHeapData,
+                offset: 0,
+            },
+        );
+        cursor.ins().load(
+            ir::types::I32,
+            ir::MemFlagsData::trusted().with_alias_region(Some(region)),
+            null_collector_heap_data,
+            0,
+        )
+    }
+
+    /// Emit a store to the null collector's bump finger.
+    pub fn store_vmnull_heap_data_bump_finger(
+        &mut self,
+        cursor: &mut FuncCursor<'_>,
+        null_collector_heap_data: ir::Value,
+        val: ir::Value,
+    ) {
+        let region = self.region(
+            cursor.func,
+            AliasRegionKey::Vm {
+                ty: VmType::VMNullHeapData,
+                offset: 0,
+            },
+        );
+        cursor.ins().store(
+            ir::MemFlagsData::trusted().with_alias_region(Some(region)),
+            val,
+            null_collector_heap_data,
+            0,
+        );
     }
 }

--- a/crates/cranelift/src/func_environ/gc/copying.rs
+++ b/crates/cranelift/src/func_environ/gc/copying.rs
@@ -16,9 +16,8 @@ use wasmtime_environ::copying::{
     ALIGN, EXCEPTION_TAG_DEFINED_OFFSET, EXCEPTION_TAG_INSTANCE_OFFSET, InlineTraceInfo,
 };
 use wasmtime_environ::{
-    GcTypeLayouts, ModuleInternedTypeIndex, PtrSize, TypeIndex, VMGcKind, WasmHeapTopType,
-    WasmHeapType, WasmRefType, WasmResult, WasmStorageType, WasmValType,
-    copying::CopyingTypeLayouts,
+    GcTypeLayouts, ModuleInternedTypeIndex, TypeIndex, VMGcKind, WasmHeapTopType, WasmHeapType,
+    WasmRefType, WasmResult, WasmStorageType, WasmValType, copying::CopyingTypeLayouts,
 };
 
 #[derive(Default)]
@@ -47,18 +46,12 @@ impl CopyingCompiler {
         builder: &mut FunctionBuilder,
         ptr_to_heap_data: ir::Value,
     ) -> (ir::Value, ir::Value) {
-        let bump_ptr = builder.ins().load(
-            ir::types::I32,
-            ir::MemFlagsData::trusted(),
-            ptr_to_heap_data,
-            i32::from(func_env.offsets.ptr.vmcopying_heap_data_bump_ptr()),
-        );
-        let active_space_end = builder.ins().load(
-            ir::types::I32,
-            ir::MemFlagsData::trusted(),
-            ptr_to_heap_data,
-            i32::from(func_env.offsets.ptr.vmcopying_heap_data_active_space_end()),
-        );
+        let bump_ptr = func_env
+            .alias_regions
+            .vmcopying_heap_data_bump_ptr(&mut builder.cursor(), ptr_to_heap_data);
+        let active_space_end = func_env
+            .alias_regions
+            .vmcopying_heap_data_active_space_end(&mut builder.cursor(), ptr_to_heap_data);
         (bump_ptr, active_space_end)
     }
 
@@ -69,11 +62,10 @@ impl CopyingCompiler {
         heap_data_ptr: ir::Value,
         end_of_object: ir::Value,
     ) {
-        builder.ins().store(
-            ir::MemFlagsData::trusted(),
-            end_of_object,
+        func_env.alias_regions.store_vmcopying_heap_data_bump_ptr(
+            &mut builder.cursor(),
             heap_data_ptr,
-            i32::from(func_env.offsets.ptr.vmcopying_heap_data_bump_ptr()),
+            end_of_object,
         );
     }
 

--- a/crates/cranelift/src/func_environ/gc/drc.rs
+++ b/crates/cranelift/src/func_environ/gc/drc.rs
@@ -11,8 +11,8 @@ use cranelift_frontend::FunctionBuilder;
 use smallvec::SmallVec;
 use wasmtime_environ::drc::{EXCEPTION_TAG_DEFINED_OFFSET, EXCEPTION_TAG_INSTANCE_OFFSET};
 use wasmtime_environ::{
-    GcTypeLayouts, PtrSize, TypeIndex, VMGcKind, WasmHeapType, WasmRefType, WasmResult,
-    WasmStorageType, WasmValType, drc::DrcTypeLayouts,
+    GcTypeLayouts, TypeIndex, VMGcKind, WasmHeapType, WasmRefType, WasmResult, WasmStorageType,
+    WasmValType, drc::DrcTypeLayouts,
 };
 
 // The minimum over-approximated stack roots list size for which we will trigger
@@ -25,17 +25,6 @@ pub struct DrcCompiler {
 }
 
 impl DrcCompiler {
-    /// Load the pointer to the `VMDrcHeapData` from vmctx.
-    fn load_vmdrc_heap_data_ptr(
-        func_env: &mut FuncEnvironment<'_>,
-        builder: &mut FunctionBuilder,
-    ) -> ir::Value {
-        let vmctx = func_env.vmctx_val(&mut builder.cursor());
-        func_env
-            .alias_regions
-            .vmctx_gc_heap_data(&mut builder.cursor(), vmctx)
-    }
-
     /// Generate code to load the given GC reference's ref count.
     ///
     /// Assumes that the given `gc_ref` is a non-null, non-i31 GC reference.
@@ -117,13 +106,16 @@ impl DrcCompiler {
         debug_assert_eq!(builder.func.dfg.value_type(gc_ref), ir::types::I32);
         debug_assert_eq!(builder.func.dfg.value_type(reserved), ir::types::I32);
 
-        let head = self.load_over_approximated_stack_roots_head(func_env, builder);
-
-        let flags = func_env.gc_memflags(&mut builder.func);
+        let vmctx = func_env.vmctx_val(&mut builder.cursor());
+        let heap_data = func_env
+            .alias_regions
+            .vmctx_gc_heap_data(&mut builder.cursor(), vmctx);
 
         // Load the current first list element, which will be our new next list
         // element.
-        let next = builder.ins().load(ir::types::I32, flags, head, 0);
+        let next = func_env
+            .alias_regions
+            .vmdrc_heap_data_over_approximated_stack_roots(&mut builder.cursor(), heap_data);
 
         // Update our object's header to point to `next` and consider itself part of the list.
         self.set_next_over_approximated_stack_root(func_env, builder, gc_ref, next);
@@ -133,7 +125,13 @@ impl DrcCompiler {
         self.mutate_ref_count(func_env, builder, gc_ref, 1);
 
         // Commit this object as the new head of the list.
-        builder.ins().store(flags, gc_ref, head, 0);
+        func_env
+            .alias_regions
+            .store_vmdrc_heap_data_over_approximated_stack_roots(
+                &mut builder.cursor(),
+                heap_data,
+                gc_ref,
+            );
 
         // Increment the list's length.
         //
@@ -142,91 +140,21 @@ impl DrcCompiler {
         // smallest GC object has a `VMGcHeader` which is multiple bytes large,
         // meaning that there are always fewer objects in the GC heap than
         // `u32::MAX`.
-        let current_len = self.load_current_over_approximated_stack_roots_len(func_env, builder);
-        let new_current_len = builder.ins().iadd_imm_s(current_len, 1);
-        self.store_current_over_approximated_stack_roots_len(func_env, builder, new_current_len);
-    }
-
-    /// Load a pointer to the first element of the DRC heap's
-    /// over-approximated-stack-roots list.
-    fn load_over_approximated_stack_roots_head(
-        &mut self,
-        func_env: &mut FuncEnvironment<'_>,
-        builder: &mut FunctionBuilder,
-    ) -> ir::Value {
-        let ptr = Self::load_vmdrc_heap_data_ptr(func_env, builder);
-        let offset = i64::from(
-            func_env
-                .offsets
-                .ptr
-                .vmdrc_heap_data_over_approximated_stack_roots(),
-        );
-        if offset == 0 {
-            ptr
-        } else {
-            builder.ins().iadd_imm_s(ptr, offset)
-        }
-    }
-
-    /// Load the current size of the over-approximated-stack-roots list.
-    fn load_current_over_approximated_stack_roots_len(
-        &mut self,
-        func_env: &mut FuncEnvironment<'_>,
-        builder: &mut FunctionBuilder,
-    ) -> ir::Value {
-        let ptr = Self::load_vmdrc_heap_data_ptr(func_env, builder);
-        builder.ins().load(
-            ir::types::I32,
-            ir::MemFlagsData::trusted(),
-            ptr,
-            i32::from(
-                func_env
-                    .offsets
-                    .ptr
-                    .vmdrc_heap_data_current_over_approximated_stack_roots_len(),
-            ),
-        )
-    }
-
-    /// Load the over-approximated-stack-roots list size after the last GC.
-    fn load_over_approximated_stack_roots_len_after_last_gc(
-        &mut self,
-        func_env: &mut FuncEnvironment<'_>,
-        builder: &mut FunctionBuilder,
-    ) -> ir::Value {
-        let ptr = Self::load_vmdrc_heap_data_ptr(func_env, builder);
-        builder.ins().load(
-            ir::types::I32,
-            ir::MemFlagsData::trusted(),
-            ptr,
-            i32::from(
-                func_env
-                    .offsets
-                    .ptr
-                    .vmdrc_heap_data_over_approximated_stack_roots_len_after_last_gc(),
-            ),
-        )
-    }
-
-    /// Store the current size of the over-approximated-stack-roots list.
-    fn store_current_over_approximated_stack_roots_len(
-        &mut self,
-        func_env: &mut FuncEnvironment<'_>,
-        builder: &mut FunctionBuilder,
-        len: ir::Value,
-    ) {
-        let ptr = Self::load_vmdrc_heap_data_ptr(func_env, builder);
-        builder.ins().store(
-            ir::MemFlagsData::trusted(),
-            len,
-            ptr,
-            i32::from(
-                func_env
-                    .offsets
-                    .ptr
-                    .vmdrc_heap_data_current_over_approximated_stack_roots_len(),
-            ),
-        );
+        let current_len = func_env
+            .alias_regions
+            .vmdrc_heap_data_current_over_approximated_stack_roots_len(
+                &mut builder.cursor(),
+                heap_data,
+            );
+        let one = builder.ins().iconst(ir::types::I32, 1);
+        let new_current_len = builder.ins().iadd(current_len, one);
+        func_env
+            .alias_regions
+            .store_vmdrc_heap_data_current_over_approximated_stack_roots_len(
+                &mut builder.cursor(),
+                heap_data,
+                new_current_len,
+            );
     }
 
     /// Trigger a GC when the over-approximated-stack-roots list has doubled
@@ -244,13 +172,29 @@ impl DrcCompiler {
         builder.insert_block_after(gc_block, current_block);
         builder.insert_block_after(continue_block, gc_block);
 
-        let current_len = self.load_current_over_approximated_stack_roots_len(func_env, builder);
-        let last_len = self.load_over_approximated_stack_roots_len_after_last_gc(func_env, builder);
+        let vmctx = func_env.vmctx_val(&mut builder.cursor());
+        let heap_data = func_env
+            .alias_regions
+            .vmctx_gc_heap_data(&mut builder.cursor(), vmctx);
+        let current_len = func_env
+            .alias_regions
+            .vmdrc_heap_data_current_over_approximated_stack_roots_len(
+                &mut builder.cursor(),
+                heap_data,
+            );
+        let last_len = func_env
+            .alias_regions
+            .vmdrc_heap_data_over_approximated_stack_roots_len_after_last_gc(
+                &mut builder.cursor(),
+                heap_data,
+            );
+
         let doubled_last_len = builder.ins().iadd(last_len, last_len);
         let min_threshold = builder
             .ins()
             .iconst(ir::types::I32, MIN_OVER_APPROX_STACK_ROOTS_GC_THRESHOLD);
         let threshold = builder.ins().umax(doubled_last_len, min_threshold);
+
         let should_gc =
             builder
                 .ins()

--- a/crates/cranelift/src/func_environ/gc/null.rs
+++ b/crates/cranelift/src/func_environ/gc/null.rs
@@ -73,8 +73,9 @@ impl NullCompiler {
         let ptr_to_next = func_env
             .alias_regions
             .vmctx_gc_heap_data(&mut builder.cursor(), vmctx);
-        let flags = func_env.gc_memflags(&mut builder.func);
-        let next = builder.ins().load(ir::types::I32, flags, ptr_to_next, 0);
+        let next = func_env
+            .alias_regions
+            .vmnull_heap_data_bump_finger(&mut builder.cursor(), ptr_to_next);
 
         // Increment the bump "pointer" to the requested alignment:
         //
@@ -165,7 +166,11 @@ impl NullCompiler {
             ptr_to_object,
             i32::try_from(wasmtime_environ::VM_GC_HEADER_TYPE_INDEX_OFFSET).unwrap(),
         );
-        builder.ins().store(flags, end_of_object, ptr_to_next, 0);
+        func_env.alias_regions.store_vmnull_heap_data_bump_finger(
+            &mut builder.cursor(),
+            ptr_to_next,
+            end_of_object,
+        );
 
         log::trace!("emit_inline_alloc(..) -> ({aligned}, {ptr_to_object})");
         Ok((aligned, ptr_to_object))

--- a/tests/disas/gc/array-new-data.wat
+++ b/tests/disas/gc/array-new-data.wat
@@ -82,10 +82,12 @@
 ;;     region2 = 56 "VMContext+0x38"
 ;;     region3 = 48 "VMContext+0x30"
 ;;     region4 = 32 "VMContext+0x20"
-;;     region5 = 40 "VMContext+0x28"
-;;     region6 = 268435488 "VMStoreContext+0x20"
-;;     region7 = 2147483648 "GcHeap"
-;;     region8 = 268435496 "VMStoreContext+0x28"
+;;     region5 = 3489660928 "VMCopyingHeapData+0x0"
+;;     region6 = 3489660932 "VMCopyingHeapData+0x4"
+;;     region7 = 40 "VMContext+0x28"
+;;     region8 = 268435488 "VMStoreContext+0x20"
+;;     region9 = 2147483648 "GcHeap"
+;;     region10 = 268435496 "VMStoreContext+0x28"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -110,8 +112,8 @@
 ;; @0025                               v15 = iconst.i32 20
 ;; @0025                               v22 = uadd_overflow_trap v15, v3, user18  ; v15 = 20
 ;; @0025                               v23 = load.i64 notrap aligned readonly can_move region4 v0+32
-;; @0025                               v24 = load.i32 notrap aligned v23
-;; @0025                               v25 = load.i32 notrap aligned v23+4
+;; @0025                               v24 = load.i32 notrap aligned region5 v23
+;; @0025                               v25 = load.i32 notrap aligned region6 v23+4
 ;; @0025                               v31 = uextend.i64 v24
 ;; @0025                               v26 = uextend.i64 v22
 ;; @0025                               v27 = iconst.i64 15
@@ -129,27 +131,27 @@
 ;;                                     v124 = iconst.i32 -16
 ;;                                     v125 = band v121, v124  ; v124 = -16
 ;;                                     v127 = iadd.i32 v24, v125
-;; @0025                               store notrap aligned v127, v23
+;; @0025                               store notrap aligned region5 v127, v23
 ;;                                     v141 = iconst.i32 -1476395002
 ;;                                     v142 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v143 = load.i64 notrap aligned readonly can_move region6 v142+32
+;;                                     v143 = load.i64 notrap aligned readonly can_move region8 v142+32
 ;; @0025                               v48 = iadd v143, v31
-;; @0025                               store user2 region7 v141, v48  ; v141 = -1476395002
-;;                                     v144 = load.i64 notrap aligned readonly can_move region5 v0+40
+;; @0025                               store user2 region9 v141, v48  ; v141 = -1476395002
+;;                                     v144 = load.i64 notrap aligned readonly can_move region7 v0+40
 ;;                                     v145 = load.i32 notrap aligned readonly can_move v144
-;; @0025                               store user2 region7 v145, v48+4
+;; @0025                               store user2 region9 v145, v48+4
 ;;                                     v146 = band.i64 v29, v28  ; v28 = -16
-;; @0025                               istore32 user2 region7 v146, v48+8
+;; @0025                               istore32 user2 region9 v146, v48+8
 ;; @0025                               jump block4(v24, v48)
 ;;
 ;;                                 block3 cold:
 ;; @0025                               v35 = iconst.i32 -1476395002
-;; @0025                               v36 = load.i64 notrap aligned readonly can_move region5 v0+40
+;; @0025                               v36 = load.i64 notrap aligned readonly can_move region7 v0+40
 ;; @0025                               v37 = load.i32 notrap aligned readonly can_move v36
 ;; @0025                               v38 = iconst.i32 16
 ;; @0025                               v39 = call fn0(v0, v35, v37, v22, v38)  ; v35 = -1476395002, v38 = 16
 ;; @0025                               v40 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0025                               v41 = load.i64 notrap aligned readonly can_move region6 v40+32
+;; @0025                               v41 = load.i64 notrap aligned readonly can_move region8 v40+32
 ;; @0025                               v42 = uextend.i64 v39
 ;; @0025                               v43 = iadd v41, v42
 ;; @0025                               jump block4(v39, v43)
@@ -159,14 +161,14 @@
 ;;                                     store notrap v52, v112
 ;; @0025                               v54 = iconst.i64 16
 ;; @0025                               v55 = iadd v53, v54  ; v54 = 16
-;; @0025                               store.i32 user2 region7 v3, v55
+;; @0025                               store.i32 user2 region9 v3, v55
 ;; @0025                               trapz v52, user16
 ;;                                     v147 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v148 = load.i64 notrap aligned readonly can_move region6 v147+32
+;;                                     v148 = load.i64 notrap aligned readonly can_move region8 v147+32
 ;; @0025                               v57 = uextend.i64 v52
 ;; @0025                               v60 = iadd v148, v57
 ;; @0025                               v62 = iadd v60, v54  ; v54 = 16
-;; @0025                               v63 = load.i32 user2 readonly region7 v62
+;; @0025                               v63 = load.i32 user2 readonly region9 v62
 ;; @0025                               v64 = uextend.i64 v63
 ;; @0025                               v70 = icmp.i64 ugt v7, v64
 ;; @0025                               trapnz v70, user17
@@ -175,7 +177,7 @@
 ;; @0025                               v88 = icmp.i64 ugt v10, v82
 ;; @0025                               trapnz v88, heap_oob
 ;; @0025                               v89 = load.i64 notrap aligned region3 v0+48
-;; @0025                               v100 = load.i64 notrap aligned region8 v147+40
+;; @0025                               v100 = load.i64 notrap aligned region10 v147+40
 ;; @0025                               v75 = iconst.i64 20
 ;; @0025                               v76 = iadd v60, v75  ; v75 = 20
 ;; @0025                               v102 = uadd_overflow_trap v76, v7, user2

--- a/tests/disas/gc/array-new-default-anyref.wat
+++ b/tests/disas/gc/array-new-default-anyref.wat
@@ -13,10 +13,12 @@
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     region2 = 32 "VMContext+0x20"
-;;     region3 = 40 "VMContext+0x28"
-;;     region4 = 268435488 "VMStoreContext+0x20"
-;;     region5 = 2147483648 "GcHeap"
-;;     region6 = 268435496 "VMStoreContext+0x28"
+;;     region3 = 3489660928 "VMCopyingHeapData+0x0"
+;;     region4 = 3489660932 "VMCopyingHeapData+0x4"
+;;     region5 = 40 "VMContext+0x28"
+;;     region6 = 268435488 "VMStoreContext+0x20"
+;;     region7 = 2147483648 "GcHeap"
+;;     region8 = 268435496 "VMStoreContext+0x28"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -36,8 +38,8 @@
 ;;                                     v95 = ishl v2, v94  ; v94 = 2
 ;; @001f                               v10 = uadd_overflow_trap v3, v95, user18  ; v3 = 20
 ;; @001f                               v11 = load.i64 notrap aligned readonly can_move region2 v0+32
-;; @001f                               v12 = load.i32 notrap aligned v11
-;; @001f                               v13 = load.i32 notrap aligned v11+4
+;; @001f                               v12 = load.i32 notrap aligned region3 v11
+;; @001f                               v13 = load.i32 notrap aligned region4 v11+4
 ;; @001f                               v19 = uextend.i64 v12
 ;; @001f                               v14 = uextend.i64 v10
 ;; @001f                               v15 = iconst.i64 15
@@ -55,27 +57,27 @@
 ;;                                     v107 = iconst.i32 -16
 ;;                                     v108 = band v104, v107  ; v107 = -16
 ;;                                     v110 = iadd.i32 v12, v108
-;; @001f                               store notrap aligned v110, v11
+;; @001f                               store notrap aligned region3 v110, v11
 ;;                                     v126 = iconst.i32 -1476394994
 ;;                                     v127 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v128 = load.i64 notrap aligned readonly can_move region4 v127+32
+;;                                     v128 = load.i64 notrap aligned readonly can_move region6 v127+32
 ;; @001f                               v36 = iadd v128, v19
-;; @001f                               store user2 region5 v126, v36  ; v126 = -1476394994
-;;                                     v129 = load.i64 notrap aligned readonly can_move region3 v0+40
+;; @001f                               store user2 region7 v126, v36  ; v126 = -1476394994
+;;                                     v129 = load.i64 notrap aligned readonly can_move region5 v0+40
 ;;                                     v130 = load.i32 notrap aligned readonly can_move v129
-;; @001f                               store user2 region5 v130, v36+4
+;; @001f                               store user2 region7 v130, v36+4
 ;;                                     v131 = band.i64 v17, v16  ; v16 = -16
-;; @001f                               istore32 user2 region5 v131, v36+8
+;; @001f                               istore32 user2 region7 v131, v36+8
 ;; @001f                               jump block4(v12, v36)
 ;;
 ;;                                 block3 cold:
 ;; @001f                               v23 = iconst.i32 -1476394994
-;; @001f                               v24 = load.i64 notrap aligned readonly can_move region3 v0+40
+;; @001f                               v24 = load.i64 notrap aligned readonly can_move region5 v0+40
 ;; @001f                               v25 = load.i32 notrap aligned readonly can_move v24
 ;; @001f                               v26 = iconst.i32 16
 ;; @001f                               v27 = call fn0(v0, v23, v25, v10, v26)  ; v23 = -1476394994, v26 = 16
 ;; @001f                               v28 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @001f                               v29 = load.i64 notrap aligned readonly can_move region4 v28+32
+;; @001f                               v29 = load.i64 notrap aligned readonly can_move region6 v28+32
 ;; @001f                               v30 = uextend.i64 v27
 ;; @001f                               v31 = iadd v29, v30
 ;; @001f                               jump block4(v27, v31)
@@ -83,18 +85,18 @@
 ;;                                 block4(v40: i32, v41: i64):
 ;; @001f                               v42 = iconst.i64 16
 ;; @001f                               v43 = iadd v41, v42  ; v42 = 16
-;; @001f                               store.i32 user2 region5 v2, v43
+;; @001f                               store.i32 user2 region7 v2, v43
 ;; @001f                               trapz v40, user16
 ;;                                     v132 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v133 = load.i64 notrap aligned readonly can_move region4 v132+32
+;;                                     v133 = load.i64 notrap aligned readonly can_move region6 v132+32
 ;; @001f                               v46 = uextend.i64 v40
 ;; @001f                               v49 = iadd v133, v46
 ;; @001f                               v51 = iadd v49, v42  ; v42 = 16
-;; @001f                               v52 = load.i32 user2 readonly region5 v51
+;; @001f                               v52 = load.i32 user2 readonly region7 v51
 ;; @001f                               v53 = uextend.i64 v52
 ;; @001f                               v59 = icmp.i64 ugt v4, v53
 ;; @001f                               trapnz v59, user17
-;; @001f                               v76 = load.i64 notrap aligned region6 v132+40
+;; @001f                               v76 = load.i64 notrap aligned region8 v132+40
 ;; @001f                               v64 = iconst.i64 20
 ;; @001f                               v65 = iadd v49, v64  ; v64 = 20
 ;; @001f                               v78 = uadd_overflow_trap v65, v88, user2
@@ -110,7 +112,7 @@
 ;;
 ;;                                 block5(v83: i64):
 ;;                                     v134 = iconst.i32 0
-;; @001f                               store user2 little region5 v134, v83  ; v134 = 0
+;; @001f                               store user2 little region7 v134, v83  ; v134 = 0
 ;;                                     v135 = iconst.i64 4
 ;;                                     v136 = iadd v83, v135  ; v135 = 4
 ;; @001f                               v86 = icmp eq v136, v80

--- a/tests/disas/gc/array-new-default-exnref.wat
+++ b/tests/disas/gc/array-new-default-exnref.wat
@@ -13,10 +13,12 @@
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     region2 = 32 "VMContext+0x20"
-;;     region3 = 40 "VMContext+0x28"
-;;     region4 = 268435488 "VMStoreContext+0x20"
-;;     region5 = 2147483648 "GcHeap"
-;;     region6 = 268435496 "VMStoreContext+0x28"
+;;     region3 = 3489660928 "VMCopyingHeapData+0x0"
+;;     region4 = 3489660932 "VMCopyingHeapData+0x4"
+;;     region5 = 40 "VMContext+0x28"
+;;     region6 = 268435488 "VMStoreContext+0x20"
+;;     region7 = 2147483648 "GcHeap"
+;;     region8 = 268435496 "VMStoreContext+0x28"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -36,8 +38,8 @@
 ;;                                     v95 = ishl v2, v94  ; v94 = 2
 ;; @001f                               v10 = uadd_overflow_trap v3, v95, user18  ; v3 = 20
 ;; @001f                               v11 = load.i64 notrap aligned readonly can_move region2 v0+32
-;; @001f                               v12 = load.i32 notrap aligned v11
-;; @001f                               v13 = load.i32 notrap aligned v11+4
+;; @001f                               v12 = load.i32 notrap aligned region3 v11
+;; @001f                               v13 = load.i32 notrap aligned region4 v11+4
 ;; @001f                               v19 = uextend.i64 v12
 ;; @001f                               v14 = uextend.i64 v10
 ;; @001f                               v15 = iconst.i64 15
@@ -55,27 +57,27 @@
 ;;                                     v107 = iconst.i32 -16
 ;;                                     v108 = band v104, v107  ; v107 = -16
 ;;                                     v110 = iadd.i32 v12, v108
-;; @001f                               store notrap aligned v110, v11
+;; @001f                               store notrap aligned region3 v110, v11
 ;;                                     v126 = iconst.i32 -1476394994
 ;;                                     v127 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v128 = load.i64 notrap aligned readonly can_move region4 v127+32
+;;                                     v128 = load.i64 notrap aligned readonly can_move region6 v127+32
 ;; @001f                               v36 = iadd v128, v19
-;; @001f                               store user2 region5 v126, v36  ; v126 = -1476394994
-;;                                     v129 = load.i64 notrap aligned readonly can_move region3 v0+40
+;; @001f                               store user2 region7 v126, v36  ; v126 = -1476394994
+;;                                     v129 = load.i64 notrap aligned readonly can_move region5 v0+40
 ;;                                     v130 = load.i32 notrap aligned readonly can_move v129
-;; @001f                               store user2 region5 v130, v36+4
+;; @001f                               store user2 region7 v130, v36+4
 ;;                                     v131 = band.i64 v17, v16  ; v16 = -16
-;; @001f                               istore32 user2 region5 v131, v36+8
+;; @001f                               istore32 user2 region7 v131, v36+8
 ;; @001f                               jump block4(v12, v36)
 ;;
 ;;                                 block3 cold:
 ;; @001f                               v23 = iconst.i32 -1476394994
-;; @001f                               v24 = load.i64 notrap aligned readonly can_move region3 v0+40
+;; @001f                               v24 = load.i64 notrap aligned readonly can_move region5 v0+40
 ;; @001f                               v25 = load.i32 notrap aligned readonly can_move v24
 ;; @001f                               v26 = iconst.i32 16
 ;; @001f                               v27 = call fn0(v0, v23, v25, v10, v26)  ; v23 = -1476394994, v26 = 16
 ;; @001f                               v28 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @001f                               v29 = load.i64 notrap aligned readonly can_move region4 v28+32
+;; @001f                               v29 = load.i64 notrap aligned readonly can_move region6 v28+32
 ;; @001f                               v30 = uextend.i64 v27
 ;; @001f                               v31 = iadd v29, v30
 ;; @001f                               jump block4(v27, v31)
@@ -83,18 +85,18 @@
 ;;                                 block4(v40: i32, v41: i64):
 ;; @001f                               v42 = iconst.i64 16
 ;; @001f                               v43 = iadd v41, v42  ; v42 = 16
-;; @001f                               store.i32 user2 region5 v2, v43
+;; @001f                               store.i32 user2 region7 v2, v43
 ;; @001f                               trapz v40, user16
 ;;                                     v132 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v133 = load.i64 notrap aligned readonly can_move region4 v132+32
+;;                                     v133 = load.i64 notrap aligned readonly can_move region6 v132+32
 ;; @001f                               v46 = uextend.i64 v40
 ;; @001f                               v49 = iadd v133, v46
 ;; @001f                               v51 = iadd v49, v42  ; v42 = 16
-;; @001f                               v52 = load.i32 user2 readonly region5 v51
+;; @001f                               v52 = load.i32 user2 readonly region7 v51
 ;; @001f                               v53 = uextend.i64 v52
 ;; @001f                               v59 = icmp.i64 ugt v4, v53
 ;; @001f                               trapnz v59, user17
-;; @001f                               v76 = load.i64 notrap aligned region6 v132+40
+;; @001f                               v76 = load.i64 notrap aligned region8 v132+40
 ;; @001f                               v64 = iconst.i64 20
 ;; @001f                               v65 = iadd v49, v64  ; v64 = 20
 ;; @001f                               v78 = uadd_overflow_trap v65, v88, user2
@@ -110,7 +112,7 @@
 ;;
 ;;                                 block5(v83: i64):
 ;;                                     v134 = iconst.i32 0
-;; @001f                               store user2 little region5 v134, v83  ; v134 = 0
+;; @001f                               store user2 little region7 v134, v83  ; v134 = 0
 ;;                                     v135 = iconst.i64 4
 ;;                                     v136 = iadd v83, v135  ; v135 = 4
 ;; @001f                               v86 = icmp eq v136, v80

--- a/tests/disas/gc/array-new-default-externref.wat
+++ b/tests/disas/gc/array-new-default-externref.wat
@@ -13,10 +13,12 @@
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     region2 = 32 "VMContext+0x20"
-;;     region3 = 40 "VMContext+0x28"
-;;     region4 = 268435488 "VMStoreContext+0x20"
-;;     region5 = 2147483648 "GcHeap"
-;;     region6 = 268435496 "VMStoreContext+0x28"
+;;     region3 = 3489660928 "VMCopyingHeapData+0x0"
+;;     region4 = 3489660932 "VMCopyingHeapData+0x4"
+;;     region5 = 40 "VMContext+0x28"
+;;     region6 = 268435488 "VMStoreContext+0x20"
+;;     region7 = 2147483648 "GcHeap"
+;;     region8 = 268435496 "VMStoreContext+0x28"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -36,8 +38,8 @@
 ;;                                     v95 = ishl v2, v94  ; v94 = 2
 ;; @001f                               v10 = uadd_overflow_trap v3, v95, user18  ; v3 = 20
 ;; @001f                               v11 = load.i64 notrap aligned readonly can_move region2 v0+32
-;; @001f                               v12 = load.i32 notrap aligned v11
-;; @001f                               v13 = load.i32 notrap aligned v11+4
+;; @001f                               v12 = load.i32 notrap aligned region3 v11
+;; @001f                               v13 = load.i32 notrap aligned region4 v11+4
 ;; @001f                               v19 = uextend.i64 v12
 ;; @001f                               v14 = uextend.i64 v10
 ;; @001f                               v15 = iconst.i64 15
@@ -55,27 +57,27 @@
 ;;                                     v107 = iconst.i32 -16
 ;;                                     v108 = band v104, v107  ; v107 = -16
 ;;                                     v110 = iadd.i32 v12, v108
-;; @001f                               store notrap aligned v110, v11
+;; @001f                               store notrap aligned region3 v110, v11
 ;;                                     v126 = iconst.i32 -1476394994
 ;;                                     v127 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v128 = load.i64 notrap aligned readonly can_move region4 v127+32
+;;                                     v128 = load.i64 notrap aligned readonly can_move region6 v127+32
 ;; @001f                               v36 = iadd v128, v19
-;; @001f                               store user2 region5 v126, v36  ; v126 = -1476394994
-;;                                     v129 = load.i64 notrap aligned readonly can_move region3 v0+40
+;; @001f                               store user2 region7 v126, v36  ; v126 = -1476394994
+;;                                     v129 = load.i64 notrap aligned readonly can_move region5 v0+40
 ;;                                     v130 = load.i32 notrap aligned readonly can_move v129
-;; @001f                               store user2 region5 v130, v36+4
+;; @001f                               store user2 region7 v130, v36+4
 ;;                                     v131 = band.i64 v17, v16  ; v16 = -16
-;; @001f                               istore32 user2 region5 v131, v36+8
+;; @001f                               istore32 user2 region7 v131, v36+8
 ;; @001f                               jump block4(v12, v36)
 ;;
 ;;                                 block3 cold:
 ;; @001f                               v23 = iconst.i32 -1476394994
-;; @001f                               v24 = load.i64 notrap aligned readonly can_move region3 v0+40
+;; @001f                               v24 = load.i64 notrap aligned readonly can_move region5 v0+40
 ;; @001f                               v25 = load.i32 notrap aligned readonly can_move v24
 ;; @001f                               v26 = iconst.i32 16
 ;; @001f                               v27 = call fn0(v0, v23, v25, v10, v26)  ; v23 = -1476394994, v26 = 16
 ;; @001f                               v28 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @001f                               v29 = load.i64 notrap aligned readonly can_move region4 v28+32
+;; @001f                               v29 = load.i64 notrap aligned readonly can_move region6 v28+32
 ;; @001f                               v30 = uextend.i64 v27
 ;; @001f                               v31 = iadd v29, v30
 ;; @001f                               jump block4(v27, v31)
@@ -83,18 +85,18 @@
 ;;                                 block4(v40: i32, v41: i64):
 ;; @001f                               v42 = iconst.i64 16
 ;; @001f                               v43 = iadd v41, v42  ; v42 = 16
-;; @001f                               store.i32 user2 region5 v2, v43
+;; @001f                               store.i32 user2 region7 v2, v43
 ;; @001f                               trapz v40, user16
 ;;                                     v132 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v133 = load.i64 notrap aligned readonly can_move region4 v132+32
+;;                                     v133 = load.i64 notrap aligned readonly can_move region6 v132+32
 ;; @001f                               v46 = uextend.i64 v40
 ;; @001f                               v49 = iadd v133, v46
 ;; @001f                               v51 = iadd v49, v42  ; v42 = 16
-;; @001f                               v52 = load.i32 user2 readonly region5 v51
+;; @001f                               v52 = load.i32 user2 readonly region7 v51
 ;; @001f                               v53 = uextend.i64 v52
 ;; @001f                               v59 = icmp.i64 ugt v4, v53
 ;; @001f                               trapnz v59, user17
-;; @001f                               v76 = load.i64 notrap aligned region6 v132+40
+;; @001f                               v76 = load.i64 notrap aligned region8 v132+40
 ;; @001f                               v64 = iconst.i64 20
 ;; @001f                               v65 = iadd v49, v64  ; v64 = 20
 ;; @001f                               v78 = uadd_overflow_trap v65, v88, user2
@@ -110,7 +112,7 @@
 ;;
 ;;                                 block5(v83: i64):
 ;;                                     v134 = iconst.i32 0
-;; @001f                               store user2 little region5 v134, v83  ; v134 = 0
+;; @001f                               store user2 little region7 v134, v83  ; v134 = 0
 ;;                                     v135 = iconst.i64 4
 ;;                                     v136 = iadd v83, v135  ; v135 = 4
 ;; @001f                               v86 = icmp eq v136, v80

--- a/tests/disas/gc/array-new-default-f32.wat
+++ b/tests/disas/gc/array-new-default-f32.wat
@@ -14,10 +14,12 @@
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     region2 = 32 "VMContext+0x20"
-;;     region3 = 40 "VMContext+0x28"
-;;     region4 = 268435488 "VMStoreContext+0x20"
-;;     region5 = 2147483648 "GcHeap"
-;;     region6 = 268435496 "VMStoreContext+0x28"
+;;     region3 = 3489660928 "VMCopyingHeapData+0x0"
+;;     region4 = 3489660932 "VMCopyingHeapData+0x4"
+;;     region5 = 40 "VMContext+0x28"
+;;     region6 = 268435488 "VMStoreContext+0x20"
+;;     region7 = 2147483648 "GcHeap"
+;;     region8 = 268435496 "VMStoreContext+0x28"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -39,8 +41,8 @@
 ;;                                     v98 = ishl v2, v97  ; v97 = 2
 ;; @001f                               v10 = uadd_overflow_trap v3, v98, user18  ; v3 = 20
 ;; @001f                               v11 = load.i64 notrap aligned readonly can_move region2 v0+32
-;; @001f                               v12 = load.i32 notrap aligned v11
-;; @001f                               v13 = load.i32 notrap aligned v11+4
+;; @001f                               v12 = load.i32 notrap aligned region3 v11
+;; @001f                               v13 = load.i32 notrap aligned region4 v11+4
 ;; @001f                               v19 = uextend.i64 v12
 ;; @001f                               v14 = uextend.i64 v10
 ;; @001f                               v15 = iconst.i64 15
@@ -58,27 +60,27 @@
 ;;                                     v110 = iconst.i32 -16
 ;;                                     v111 = band v107, v110  ; v110 = -16
 ;;                                     v113 = iadd.i32 v12, v111
-;; @001f                               store notrap aligned v113, v11
+;; @001f                               store notrap aligned region3 v113, v11
 ;;                                     v129 = iconst.i32 -1476395002
 ;;                                     v130 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v131 = load.i64 notrap aligned readonly can_move region4 v130+32
+;;                                     v131 = load.i64 notrap aligned readonly can_move region6 v130+32
 ;; @001f                               v36 = iadd v131, v19
-;; @001f                               store user2 region5 v129, v36  ; v129 = -1476395002
-;;                                     v132 = load.i64 notrap aligned readonly can_move region3 v0+40
+;; @001f                               store user2 region7 v129, v36  ; v129 = -1476395002
+;;                                     v132 = load.i64 notrap aligned readonly can_move region5 v0+40
 ;;                                     v133 = load.i32 notrap aligned readonly can_move v132
-;; @001f                               store user2 region5 v133, v36+4
+;; @001f                               store user2 region7 v133, v36+4
 ;;                                     v134 = band.i64 v17, v16  ; v16 = -16
-;; @001f                               istore32 user2 region5 v134, v36+8
+;; @001f                               istore32 user2 region7 v134, v36+8
 ;; @001f                               jump block4(v12, v36)
 ;;
 ;;                                 block3 cold:
 ;; @001f                               v23 = iconst.i32 -1476395002
-;; @001f                               v24 = load.i64 notrap aligned readonly can_move region3 v0+40
+;; @001f                               v24 = load.i64 notrap aligned readonly can_move region5 v0+40
 ;; @001f                               v25 = load.i32 notrap aligned readonly can_move v24
 ;; @001f                               v26 = iconst.i32 16
 ;; @001f                               v27 = call fn0(v0, v23, v25, v10, v26)  ; v23 = -1476395002, v26 = 16
 ;; @001f                               v28 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @001f                               v29 = load.i64 notrap aligned readonly can_move region4 v28+32
+;; @001f                               v29 = load.i64 notrap aligned readonly can_move region6 v28+32
 ;; @001f                               v30 = uextend.i64 v27
 ;; @001f                               v31 = iadd v29, v30
 ;; @001f                               jump block4(v27, v31)
@@ -88,18 +90,18 @@
 ;;                                     store notrap v40, v89
 ;; @001f                               v42 = iconst.i64 16
 ;; @001f                               v43 = iadd v41, v42  ; v42 = 16
-;; @001f                               store.i32 user2 region5 v2, v43
+;; @001f                               store.i32 user2 region7 v2, v43
 ;; @001f                               trapz v40, user16
 ;;                                     v135 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v136 = load.i64 notrap aligned readonly can_move region4 v135+32
+;;                                     v136 = load.i64 notrap aligned readonly can_move region6 v135+32
 ;; @001f                               v46 = uextend.i64 v40
 ;; @001f                               v49 = iadd v136, v46
 ;; @001f                               v51 = iadd v49, v42  ; v42 = 16
-;; @001f                               v52 = load.i32 user2 readonly region5 v51
+;; @001f                               v52 = load.i32 user2 readonly region7 v51
 ;; @001f                               v53 = uextend.i64 v52
 ;; @001f                               v59 = icmp.i64 ugt v4, v53
 ;; @001f                               trapnz v59, user17
-;; @001f                               v76 = load.i64 notrap aligned region6 v135+40
+;; @001f                               v76 = load.i64 notrap aligned region8 v135+40
 ;; @001f                               v64 = iconst.i64 20
 ;; @001f                               v65 = iadd v49, v64  ; v64 = 20
 ;; @001f                               v78 = uadd_overflow_trap v65, v91, user2

--- a/tests/disas/gc/array-new-default-f64.wat
+++ b/tests/disas/gc/array-new-default-f64.wat
@@ -14,10 +14,12 @@
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     region2 = 32 "VMContext+0x20"
-;;     region3 = 40 "VMContext+0x28"
-;;     region4 = 268435488 "VMStoreContext+0x20"
-;;     region5 = 2147483648 "GcHeap"
-;;     region6 = 268435496 "VMStoreContext+0x28"
+;;     region3 = 3489660928 "VMCopyingHeapData+0x0"
+;;     region4 = 3489660932 "VMCopyingHeapData+0x4"
+;;     region5 = 40 "VMContext+0x28"
+;;     region6 = 268435488 "VMStoreContext+0x20"
+;;     region7 = 2147483648 "GcHeap"
+;;     region8 = 268435496 "VMStoreContext+0x28"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -39,8 +41,8 @@
 ;;                                     v98 = ishl v2, v97  ; v97 = 3
 ;; @001f                               v10 = uadd_overflow_trap v3, v98, user18  ; v3 = 24
 ;; @001f                               v11 = load.i64 notrap aligned readonly can_move region2 v0+32
-;; @001f                               v12 = load.i32 notrap aligned v11
-;; @001f                               v13 = load.i32 notrap aligned v11+4
+;; @001f                               v12 = load.i32 notrap aligned region3 v11
+;; @001f                               v13 = load.i32 notrap aligned region4 v11+4
 ;; @001f                               v19 = uextend.i64 v12
 ;; @001f                               v14 = uextend.i64 v10
 ;; @001f                               v15 = iconst.i64 15
@@ -58,27 +60,27 @@
 ;;                                     v110 = iconst.i32 -16
 ;;                                     v111 = band v107, v110  ; v110 = -16
 ;;                                     v113 = iadd.i32 v12, v111
-;; @001f                               store notrap aligned v113, v11
+;; @001f                               store notrap aligned region3 v113, v11
 ;;                                     v129 = iconst.i32 -1476395002
 ;;                                     v130 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v131 = load.i64 notrap aligned readonly can_move region4 v130+32
+;;                                     v131 = load.i64 notrap aligned readonly can_move region6 v130+32
 ;; @001f                               v36 = iadd v131, v19
-;; @001f                               store user2 region5 v129, v36  ; v129 = -1476395002
-;;                                     v132 = load.i64 notrap aligned readonly can_move region3 v0+40
+;; @001f                               store user2 region7 v129, v36  ; v129 = -1476395002
+;;                                     v132 = load.i64 notrap aligned readonly can_move region5 v0+40
 ;;                                     v133 = load.i32 notrap aligned readonly can_move v132
-;; @001f                               store user2 region5 v133, v36+4
+;; @001f                               store user2 region7 v133, v36+4
 ;;                                     v134 = band.i64 v17, v16  ; v16 = -16
-;; @001f                               istore32 user2 region5 v134, v36+8
+;; @001f                               istore32 user2 region7 v134, v36+8
 ;; @001f                               jump block4(v12, v36)
 ;;
 ;;                                 block3 cold:
 ;; @001f                               v23 = iconst.i32 -1476395002
-;; @001f                               v24 = load.i64 notrap aligned readonly can_move region3 v0+40
+;; @001f                               v24 = load.i64 notrap aligned readonly can_move region5 v0+40
 ;; @001f                               v25 = load.i32 notrap aligned readonly can_move v24
 ;; @001f                               v26 = iconst.i32 16
 ;; @001f                               v27 = call fn0(v0, v23, v25, v10, v26)  ; v23 = -1476395002, v26 = 16
 ;; @001f                               v28 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @001f                               v29 = load.i64 notrap aligned readonly can_move region4 v28+32
+;; @001f                               v29 = load.i64 notrap aligned readonly can_move region6 v28+32
 ;; @001f                               v30 = uextend.i64 v27
 ;; @001f                               v31 = iadd v29, v30
 ;; @001f                               jump block4(v27, v31)
@@ -88,18 +90,18 @@
 ;;                                     store notrap v40, v89
 ;; @001f                               v42 = iconst.i64 16
 ;; @001f                               v43 = iadd v41, v42  ; v42 = 16
-;; @001f                               store.i32 user2 region5 v2, v43
+;; @001f                               store.i32 user2 region7 v2, v43
 ;; @001f                               trapz v40, user16
 ;;                                     v135 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v136 = load.i64 notrap aligned readonly can_move region4 v135+32
+;;                                     v136 = load.i64 notrap aligned readonly can_move region6 v135+32
 ;; @001f                               v46 = uextend.i64 v40
 ;; @001f                               v49 = iadd v136, v46
 ;; @001f                               v51 = iadd v49, v42  ; v42 = 16
-;; @001f                               v52 = load.i32 user2 readonly region5 v51
+;; @001f                               v52 = load.i32 user2 readonly region7 v51
 ;; @001f                               v53 = uextend.i64 v52
 ;; @001f                               v59 = icmp.i64 ugt v4, v53
 ;; @001f                               trapnz v59, user17
-;; @001f                               v76 = load.i64 notrap aligned region6 v135+40
+;; @001f                               v76 = load.i64 notrap aligned region8 v135+40
 ;; @001f                               v64 = iconst.i64 24
 ;; @001f                               v65 = iadd v49, v64  ; v64 = 24
 ;; @001f                               v78 = uadd_overflow_trap v65, v91, user2

--- a/tests/disas/gc/array-new-default-funcref.wat
+++ b/tests/disas/gc/array-new-default-funcref.wat
@@ -14,10 +14,12 @@
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     region2 = 32 "VMContext+0x20"
-;;     region3 = 40 "VMContext+0x28"
-;;     region4 = 268435488 "VMStoreContext+0x20"
-;;     region5 = 2147483648 "GcHeap"
-;;     region6 = 268435496 "VMStoreContext+0x28"
+;;     region3 = 3489660928 "VMCopyingHeapData+0x0"
+;;     region4 = 3489660932 "VMCopyingHeapData+0x4"
+;;     region5 = 40 "VMContext+0x28"
+;;     region6 = 268435488 "VMStoreContext+0x20"
+;;     region7 = 2147483648 "GcHeap"
+;;     region8 = 268435496 "VMStoreContext+0x28"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -39,8 +41,8 @@
 ;;                                     v106 = ishl v2, v105  ; v105 = 2
 ;; @001f                               v10 = uadd_overflow_trap v3, v106, user18  ; v3 = 20
 ;; @001f                               v11 = load.i64 notrap aligned readonly can_move region2 v0+32
-;; @001f                               v12 = load.i32 notrap aligned v11
-;; @001f                               v13 = load.i32 notrap aligned v11+4
+;; @001f                               v12 = load.i32 notrap aligned region3 v11
+;; @001f                               v13 = load.i32 notrap aligned region4 v11+4
 ;; @001f                               v19 = uextend.i64 v12
 ;; @001f                               v14 = uextend.i64 v10
 ;; @001f                               v15 = iconst.i64 15
@@ -58,27 +60,27 @@
 ;;                                     v118 = iconst.i32 -16
 ;;                                     v119 = band v115, v118  ; v118 = -16
 ;;                                     v121 = iadd.i32 v12, v119
-;; @001f                               store notrap aligned v121, v11
+;; @001f                               store notrap aligned region3 v121, v11
 ;;                                     v136 = iconst.i32 -1476395002
 ;;                                     v137 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v138 = load.i64 notrap aligned readonly can_move region4 v137+32
+;;                                     v138 = load.i64 notrap aligned readonly can_move region6 v137+32
 ;; @001f                               v36 = iadd v138, v19
-;; @001f                               store user2 region5 v136, v36  ; v136 = -1476395002
-;;                                     v139 = load.i64 notrap aligned readonly can_move region3 v0+40
+;; @001f                               store user2 region7 v136, v36  ; v136 = -1476395002
+;;                                     v139 = load.i64 notrap aligned readonly can_move region5 v0+40
 ;;                                     v140 = load.i32 notrap aligned readonly can_move v139
-;; @001f                               store user2 region5 v140, v36+4
+;; @001f                               store user2 region7 v140, v36+4
 ;;                                     v141 = band.i64 v17, v16  ; v16 = -16
-;; @001f                               istore32 user2 region5 v141, v36+8
+;; @001f                               istore32 user2 region7 v141, v36+8
 ;; @001f                               jump block4(v12, v36)
 ;;
 ;;                                 block3 cold:
 ;; @001f                               v23 = iconst.i32 -1476395002
-;; @001f                               v24 = load.i64 notrap aligned readonly can_move region3 v0+40
+;; @001f                               v24 = load.i64 notrap aligned readonly can_move region5 v0+40
 ;; @001f                               v25 = load.i32 notrap aligned readonly can_move v24
 ;; @001f                               v26 = iconst.i32 16
 ;; @001f                               v27 = call fn0(v0, v23, v25, v10, v26)  ; v23 = -1476395002, v26 = 16
 ;; @001f                               v28 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @001f                               v29 = load.i64 notrap aligned readonly can_move region4 v28+32
+;; @001f                               v29 = load.i64 notrap aligned readonly can_move region6 v28+32
 ;; @001f                               v30 = uextend.i64 v27
 ;; @001f                               v31 = iadd v29, v30
 ;; @001f                               jump block4(v27, v31)
@@ -88,18 +90,18 @@
 ;;                                     store notrap v40, v97
 ;; @001f                               v42 = iconst.i64 16
 ;; @001f                               v43 = iadd v41, v42  ; v42 = 16
-;; @001f                               store.i32 user2 region5 v2, v43
+;; @001f                               store.i32 user2 region7 v2, v43
 ;; @001f                               trapz v40, user16
 ;;                                     v142 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v143 = load.i64 notrap aligned readonly can_move region4 v142+32
+;;                                     v143 = load.i64 notrap aligned readonly can_move region6 v142+32
 ;; @001f                               v46 = uextend.i64 v40
 ;; @001f                               v49 = iadd v143, v46
 ;; @001f                               v51 = iadd v49, v42  ; v42 = 16
-;; @001f                               v52 = load.i32 user2 readonly region5 v51
+;; @001f                               v52 = load.i32 user2 readonly region7 v51
 ;; @001f                               v53 = uextend.i64 v52
 ;; @001f                               v59 = icmp.i64 ugt v4, v53
 ;; @001f                               trapnz v59, user17
-;; @001f                               v76 = load.i64 notrap aligned region6 v142+40
+;; @001f                               v76 = load.i64 notrap aligned region8 v142+40
 ;; @001f                               v64 = iconst.i64 20
 ;; @001f                               v65 = iadd v49, v64  ; v64 = 20
 ;; @001f                               v78 = uadd_overflow_trap v65, v99, user2
@@ -115,7 +117,7 @@
 ;; @001f                               brif v84, block6, block5(v65)
 ;;
 ;;                                 block5(v85: i64):
-;; @001f                               store.i32 notrap aligned little region5 v81, v85
+;; @001f                               store.i32 notrap aligned little region7 v81, v85
 ;;                                     v144 = iconst.i64 4
 ;;                                     v145 = iadd v85, v144  ; v144 = 4
 ;; @001f                               v88 = icmp eq v145, v82

--- a/tests/disas/gc/array-new-default-i16.wat
+++ b/tests/disas/gc/array-new-default-i16.wat
@@ -14,10 +14,12 @@
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     region2 = 32 "VMContext+0x20"
-;;     region3 = 40 "VMContext+0x28"
-;;     region4 = 268435488 "VMStoreContext+0x20"
-;;     region5 = 2147483648 "GcHeap"
-;;     region6 = 268435496 "VMStoreContext+0x28"
+;;     region3 = 3489660928 "VMCopyingHeapData+0x0"
+;;     region4 = 3489660932 "VMCopyingHeapData+0x4"
+;;     region5 = 40 "VMContext+0x28"
+;;     region6 = 268435488 "VMStoreContext+0x20"
+;;     region7 = 2147483648 "GcHeap"
+;;     region8 = 268435496 "VMStoreContext+0x28"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -38,8 +40,8 @@
 ;;                                     v96 = iadd v2, v2
 ;; @001f                               v10 = uadd_overflow_trap v3, v96, user18  ; v3 = 20
 ;; @001f                               v11 = load.i64 notrap aligned readonly can_move region2 v0+32
-;; @001f                               v12 = load.i32 notrap aligned v11
-;; @001f                               v13 = load.i32 notrap aligned v11+4
+;; @001f                               v12 = load.i32 notrap aligned region3 v11
+;; @001f                               v13 = load.i32 notrap aligned region4 v11+4
 ;; @001f                               v19 = uextend.i64 v12
 ;; @001f                               v14 = uextend.i64 v10
 ;; @001f                               v15 = iconst.i64 15
@@ -57,27 +59,27 @@
 ;;                                     v115 = iconst.i32 -16
 ;;                                     v116 = band v112, v115  ; v115 = -16
 ;;                                     v118 = iadd.i32 v12, v116
-;; @001f                               store notrap aligned v118, v11
+;; @001f                               store notrap aligned region3 v118, v11
 ;;                                     v139 = iconst.i32 -1476395002
 ;;                                     v140 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v141 = load.i64 notrap aligned readonly can_move region4 v140+32
+;;                                     v141 = load.i64 notrap aligned readonly can_move region6 v140+32
 ;; @001f                               v36 = iadd v141, v19
-;; @001f                               store user2 region5 v139, v36  ; v139 = -1476395002
-;;                                     v142 = load.i64 notrap aligned readonly can_move region3 v0+40
+;; @001f                               store user2 region7 v139, v36  ; v139 = -1476395002
+;;                                     v142 = load.i64 notrap aligned readonly can_move region5 v0+40
 ;;                                     v143 = load.i32 notrap aligned readonly can_move v142
-;; @001f                               store user2 region5 v143, v36+4
+;; @001f                               store user2 region7 v143, v36+4
 ;;                                     v144 = band.i64 v17, v16  ; v16 = -16
-;; @001f                               istore32 user2 region5 v144, v36+8
+;; @001f                               istore32 user2 region7 v144, v36+8
 ;; @001f                               jump block4(v12, v36)
 ;;
 ;;                                 block3 cold:
 ;; @001f                               v23 = iconst.i32 -1476395002
-;; @001f                               v24 = load.i64 notrap aligned readonly can_move region3 v0+40
+;; @001f                               v24 = load.i64 notrap aligned readonly can_move region5 v0+40
 ;; @001f                               v25 = load.i32 notrap aligned readonly can_move v24
 ;; @001f                               v26 = iconst.i32 16
 ;; @001f                               v27 = call fn0(v0, v23, v25, v10, v26)  ; v23 = -1476395002, v26 = 16
 ;; @001f                               v28 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @001f                               v29 = load.i64 notrap aligned readonly can_move region4 v28+32
+;; @001f                               v29 = load.i64 notrap aligned readonly can_move region6 v28+32
 ;; @001f                               v30 = uextend.i64 v27
 ;; @001f                               v31 = iadd v29, v30
 ;; @001f                               jump block4(v27, v31)
@@ -87,18 +89,18 @@
 ;;                                     store notrap v40, v89
 ;; @001f                               v42 = iconst.i64 16
 ;; @001f                               v43 = iadd v41, v42  ; v42 = 16
-;; @001f                               store.i32 user2 region5 v2, v43
+;; @001f                               store.i32 user2 region7 v2, v43
 ;; @001f                               trapz v40, user16
 ;;                                     v145 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v146 = load.i64 notrap aligned readonly can_move region4 v145+32
+;;                                     v146 = load.i64 notrap aligned readonly can_move region6 v145+32
 ;; @001f                               v46 = uextend.i64 v40
 ;; @001f                               v49 = iadd v146, v46
 ;; @001f                               v51 = iadd v49, v42  ; v42 = 16
-;; @001f                               v52 = load.i32 user2 readonly region5 v51
+;; @001f                               v52 = load.i32 user2 readonly region7 v51
 ;; @001f                               v53 = uextend.i64 v52
 ;; @001f                               v59 = icmp.i64 ugt v4, v53
 ;; @001f                               trapnz v59, user17
-;; @001f                               v76 = load.i64 notrap aligned region6 v145+40
+;; @001f                               v76 = load.i64 notrap aligned region8 v145+40
 ;; @001f                               v64 = iconst.i64 20
 ;; @001f                               v65 = iadd v49, v64  ; v64 = 20
 ;; @001f                               v78 = uadd_overflow_trap v65, v92, user2

--- a/tests/disas/gc/array-new-default-i32.wat
+++ b/tests/disas/gc/array-new-default-i32.wat
@@ -14,10 +14,12 @@
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     region2 = 32 "VMContext+0x20"
-;;     region3 = 40 "VMContext+0x28"
-;;     region4 = 268435488 "VMStoreContext+0x20"
-;;     region5 = 2147483648 "GcHeap"
-;;     region6 = 268435496 "VMStoreContext+0x28"
+;;     region3 = 3489660928 "VMCopyingHeapData+0x0"
+;;     region4 = 3489660932 "VMCopyingHeapData+0x4"
+;;     region5 = 40 "VMContext+0x28"
+;;     region6 = 268435488 "VMStoreContext+0x20"
+;;     region7 = 2147483648 "GcHeap"
+;;     region8 = 268435496 "VMStoreContext+0x28"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -39,8 +41,8 @@
 ;;                                     v98 = ishl v2, v97  ; v97 = 2
 ;; @001f                               v10 = uadd_overflow_trap v3, v98, user18  ; v3 = 20
 ;; @001f                               v11 = load.i64 notrap aligned readonly can_move region2 v0+32
-;; @001f                               v12 = load.i32 notrap aligned v11
-;; @001f                               v13 = load.i32 notrap aligned v11+4
+;; @001f                               v12 = load.i32 notrap aligned region3 v11
+;; @001f                               v13 = load.i32 notrap aligned region4 v11+4
 ;; @001f                               v19 = uextend.i64 v12
 ;; @001f                               v14 = uextend.i64 v10
 ;; @001f                               v15 = iconst.i64 15
@@ -58,27 +60,27 @@
 ;;                                     v110 = iconst.i32 -16
 ;;                                     v111 = band v107, v110  ; v110 = -16
 ;;                                     v113 = iadd.i32 v12, v111
-;; @001f                               store notrap aligned v113, v11
+;; @001f                               store notrap aligned region3 v113, v11
 ;;                                     v129 = iconst.i32 -1476395002
 ;;                                     v130 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v131 = load.i64 notrap aligned readonly can_move region4 v130+32
+;;                                     v131 = load.i64 notrap aligned readonly can_move region6 v130+32
 ;; @001f                               v36 = iadd v131, v19
-;; @001f                               store user2 region5 v129, v36  ; v129 = -1476395002
-;;                                     v132 = load.i64 notrap aligned readonly can_move region3 v0+40
+;; @001f                               store user2 region7 v129, v36  ; v129 = -1476395002
+;;                                     v132 = load.i64 notrap aligned readonly can_move region5 v0+40
 ;;                                     v133 = load.i32 notrap aligned readonly can_move v132
-;; @001f                               store user2 region5 v133, v36+4
+;; @001f                               store user2 region7 v133, v36+4
 ;;                                     v134 = band.i64 v17, v16  ; v16 = -16
-;; @001f                               istore32 user2 region5 v134, v36+8
+;; @001f                               istore32 user2 region7 v134, v36+8
 ;; @001f                               jump block4(v12, v36)
 ;;
 ;;                                 block3 cold:
 ;; @001f                               v23 = iconst.i32 -1476395002
-;; @001f                               v24 = load.i64 notrap aligned readonly can_move region3 v0+40
+;; @001f                               v24 = load.i64 notrap aligned readonly can_move region5 v0+40
 ;; @001f                               v25 = load.i32 notrap aligned readonly can_move v24
 ;; @001f                               v26 = iconst.i32 16
 ;; @001f                               v27 = call fn0(v0, v23, v25, v10, v26)  ; v23 = -1476395002, v26 = 16
 ;; @001f                               v28 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @001f                               v29 = load.i64 notrap aligned readonly can_move region4 v28+32
+;; @001f                               v29 = load.i64 notrap aligned readonly can_move region6 v28+32
 ;; @001f                               v30 = uextend.i64 v27
 ;; @001f                               v31 = iadd v29, v30
 ;; @001f                               jump block4(v27, v31)
@@ -88,18 +90,18 @@
 ;;                                     store notrap v40, v89
 ;; @001f                               v42 = iconst.i64 16
 ;; @001f                               v43 = iadd v41, v42  ; v42 = 16
-;; @001f                               store.i32 user2 region5 v2, v43
+;; @001f                               store.i32 user2 region7 v2, v43
 ;; @001f                               trapz v40, user16
 ;;                                     v135 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v136 = load.i64 notrap aligned readonly can_move region4 v135+32
+;;                                     v136 = load.i64 notrap aligned readonly can_move region6 v135+32
 ;; @001f                               v46 = uextend.i64 v40
 ;; @001f                               v49 = iadd v136, v46
 ;; @001f                               v51 = iadd v49, v42  ; v42 = 16
-;; @001f                               v52 = load.i32 user2 readonly region5 v51
+;; @001f                               v52 = load.i32 user2 readonly region7 v51
 ;; @001f                               v53 = uextend.i64 v52
 ;; @001f                               v59 = icmp.i64 ugt v4, v53
 ;; @001f                               trapnz v59, user17
-;; @001f                               v76 = load.i64 notrap aligned region6 v135+40
+;; @001f                               v76 = load.i64 notrap aligned region8 v135+40
 ;; @001f                               v64 = iconst.i64 20
 ;; @001f                               v65 = iadd v49, v64  ; v64 = 20
 ;; @001f                               v78 = uadd_overflow_trap v65, v91, user2

--- a/tests/disas/gc/array-new-default-i64.wat
+++ b/tests/disas/gc/array-new-default-i64.wat
@@ -14,10 +14,12 @@
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     region2 = 32 "VMContext+0x20"
-;;     region3 = 40 "VMContext+0x28"
-;;     region4 = 268435488 "VMStoreContext+0x20"
-;;     region5 = 2147483648 "GcHeap"
-;;     region6 = 268435496 "VMStoreContext+0x28"
+;;     region3 = 3489660928 "VMCopyingHeapData+0x0"
+;;     region4 = 3489660932 "VMCopyingHeapData+0x4"
+;;     region5 = 40 "VMContext+0x28"
+;;     region6 = 268435488 "VMStoreContext+0x20"
+;;     region7 = 2147483648 "GcHeap"
+;;     region8 = 268435496 "VMStoreContext+0x28"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -39,8 +41,8 @@
 ;;                                     v98 = ishl v2, v97  ; v97 = 3
 ;; @001f                               v10 = uadd_overflow_trap v3, v98, user18  ; v3 = 24
 ;; @001f                               v11 = load.i64 notrap aligned readonly can_move region2 v0+32
-;; @001f                               v12 = load.i32 notrap aligned v11
-;; @001f                               v13 = load.i32 notrap aligned v11+4
+;; @001f                               v12 = load.i32 notrap aligned region3 v11
+;; @001f                               v13 = load.i32 notrap aligned region4 v11+4
 ;; @001f                               v19 = uextend.i64 v12
 ;; @001f                               v14 = uextend.i64 v10
 ;; @001f                               v15 = iconst.i64 15
@@ -58,27 +60,27 @@
 ;;                                     v110 = iconst.i32 -16
 ;;                                     v111 = band v107, v110  ; v110 = -16
 ;;                                     v113 = iadd.i32 v12, v111
-;; @001f                               store notrap aligned v113, v11
+;; @001f                               store notrap aligned region3 v113, v11
 ;;                                     v128 = iconst.i32 -1476395002
 ;;                                     v129 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v130 = load.i64 notrap aligned readonly can_move region4 v129+32
+;;                                     v130 = load.i64 notrap aligned readonly can_move region6 v129+32
 ;; @001f                               v36 = iadd v130, v19
-;; @001f                               store user2 region5 v128, v36  ; v128 = -1476395002
-;;                                     v131 = load.i64 notrap aligned readonly can_move region3 v0+40
+;; @001f                               store user2 region7 v128, v36  ; v128 = -1476395002
+;;                                     v131 = load.i64 notrap aligned readonly can_move region5 v0+40
 ;;                                     v132 = load.i32 notrap aligned readonly can_move v131
-;; @001f                               store user2 region5 v132, v36+4
+;; @001f                               store user2 region7 v132, v36+4
 ;;                                     v133 = band.i64 v17, v16  ; v16 = -16
-;; @001f                               istore32 user2 region5 v133, v36+8
+;; @001f                               istore32 user2 region7 v133, v36+8
 ;; @001f                               jump block4(v12, v36)
 ;;
 ;;                                 block3 cold:
 ;; @001f                               v23 = iconst.i32 -1476395002
-;; @001f                               v24 = load.i64 notrap aligned readonly can_move region3 v0+40
+;; @001f                               v24 = load.i64 notrap aligned readonly can_move region5 v0+40
 ;; @001f                               v25 = load.i32 notrap aligned readonly can_move v24
 ;; @001f                               v26 = iconst.i32 16
 ;; @001f                               v27 = call fn0(v0, v23, v25, v10, v26)  ; v23 = -1476395002, v26 = 16
 ;; @001f                               v28 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @001f                               v29 = load.i64 notrap aligned readonly can_move region4 v28+32
+;; @001f                               v29 = load.i64 notrap aligned readonly can_move region6 v28+32
 ;; @001f                               v30 = uextend.i64 v27
 ;; @001f                               v31 = iadd v29, v30
 ;; @001f                               jump block4(v27, v31)
@@ -88,18 +90,18 @@
 ;;                                     store notrap v40, v89
 ;; @001f                               v42 = iconst.i64 16
 ;; @001f                               v43 = iadd v41, v42  ; v42 = 16
-;; @001f                               store.i32 user2 region5 v2, v43
+;; @001f                               store.i32 user2 region7 v2, v43
 ;; @001f                               trapz v40, user16
 ;;                                     v134 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v135 = load.i64 notrap aligned readonly can_move region4 v134+32
+;;                                     v135 = load.i64 notrap aligned readonly can_move region6 v134+32
 ;; @001f                               v46 = uextend.i64 v40
 ;; @001f                               v49 = iadd v135, v46
 ;; @001f                               v51 = iadd v49, v42  ; v42 = 16
-;; @001f                               v52 = load.i32 user2 readonly region5 v51
+;; @001f                               v52 = load.i32 user2 readonly region7 v51
 ;; @001f                               v53 = uextend.i64 v52
 ;; @001f                               v59 = icmp.i64 ugt v4, v53
 ;; @001f                               trapnz v59, user17
-;; @001f                               v76 = load.i64 notrap aligned region6 v134+40
+;; @001f                               v76 = load.i64 notrap aligned region8 v134+40
 ;; @001f                               v64 = iconst.i64 24
 ;; @001f                               v65 = iadd v49, v64  ; v64 = 24
 ;; @001f                               v78 = uadd_overflow_trap v65, v91, user2

--- a/tests/disas/gc/array-new-default-i8.wat
+++ b/tests/disas/gc/array-new-default-i8.wat
@@ -14,10 +14,12 @@
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     region2 = 32 "VMContext+0x20"
-;;     region3 = 40 "VMContext+0x28"
-;;     region4 = 268435488 "VMStoreContext+0x20"
-;;     region5 = 2147483648 "GcHeap"
-;;     region6 = 268435496 "VMStoreContext+0x28"
+;;     region3 = 3489660928 "VMCopyingHeapData+0x0"
+;;     region4 = 3489660932 "VMCopyingHeapData+0x4"
+;;     region5 = 40 "VMContext+0x28"
+;;     region6 = 268435488 "VMStoreContext+0x20"
+;;     region7 = 2147483648 "GcHeap"
+;;     region8 = 268435496 "VMStoreContext+0x28"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -35,8 +37,8 @@
 ;; @001f                               v3 = iconst.i32 20
 ;; @001f                               v10 = uadd_overflow_trap v3, v2, user18  ; v3 = 20
 ;; @001f                               v11 = load.i64 notrap aligned readonly can_move region2 v0+32
-;; @001f                               v12 = load.i32 notrap aligned v11
-;; @001f                               v13 = load.i32 notrap aligned v11+4
+;; @001f                               v12 = load.i32 notrap aligned region3 v11
+;; @001f                               v13 = load.i32 notrap aligned region4 v11+4
 ;; @001f                               v19 = uextend.i64 v12
 ;; @001f                               v14 = uextend.i64 v10
 ;; @001f                               v15 = iconst.i64 15
@@ -54,27 +56,27 @@
 ;;                                     v100 = iconst.i32 -16
 ;;                                     v101 = band v97, v100  ; v100 = -16
 ;;                                     v103 = iadd.i32 v12, v101
-;; @001f                               store notrap aligned v103, v11
+;; @001f                               store notrap aligned region3 v103, v11
 ;;                                     v117 = iconst.i32 -1476395002
 ;;                                     v118 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v119 = load.i64 notrap aligned readonly can_move region4 v118+32
+;;                                     v119 = load.i64 notrap aligned readonly can_move region6 v118+32
 ;; @001f                               v36 = iadd v119, v19
-;; @001f                               store user2 region5 v117, v36  ; v117 = -1476395002
-;;                                     v120 = load.i64 notrap aligned readonly can_move region3 v0+40
+;; @001f                               store user2 region7 v117, v36  ; v117 = -1476395002
+;;                                     v120 = load.i64 notrap aligned readonly can_move region5 v0+40
 ;;                                     v121 = load.i32 notrap aligned readonly can_move v120
-;; @001f                               store user2 region5 v121, v36+4
+;; @001f                               store user2 region7 v121, v36+4
 ;;                                     v122 = band.i64 v17, v16  ; v16 = -16
-;; @001f                               istore32 user2 region5 v122, v36+8
+;; @001f                               istore32 user2 region7 v122, v36+8
 ;; @001f                               jump block4(v12, v36)
 ;;
 ;;                                 block3 cold:
 ;; @001f                               v23 = iconst.i32 -1476395002
-;; @001f                               v24 = load.i64 notrap aligned readonly can_move region3 v0+40
+;; @001f                               v24 = load.i64 notrap aligned readonly can_move region5 v0+40
 ;; @001f                               v25 = load.i32 notrap aligned readonly can_move v24
 ;; @001f                               v26 = iconst.i32 16
 ;; @001f                               v27 = call fn0(v0, v23, v25, v10, v26)  ; v23 = -1476395002, v26 = 16
 ;; @001f                               v28 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @001f                               v29 = load.i64 notrap aligned readonly can_move region4 v28+32
+;; @001f                               v29 = load.i64 notrap aligned readonly can_move region6 v28+32
 ;; @001f                               v30 = uextend.i64 v27
 ;; @001f                               v31 = iadd v29, v30
 ;; @001f                               jump block4(v27, v31)
@@ -84,18 +86,18 @@
 ;;                                     store notrap v40, v88
 ;; @001f                               v42 = iconst.i64 16
 ;; @001f                               v43 = iadd v41, v42  ; v42 = 16
-;; @001f                               store.i32 user2 region5 v2, v43
+;; @001f                               store.i32 user2 region7 v2, v43
 ;; @001f                               trapz v40, user16
 ;;                                     v123 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v124 = load.i64 notrap aligned readonly can_move region4 v123+32
+;;                                     v124 = load.i64 notrap aligned readonly can_move region6 v123+32
 ;; @001f                               v46 = uextend.i64 v40
 ;; @001f                               v49 = iadd v124, v46
 ;; @001f                               v51 = iadd v49, v42  ; v42 = 16
-;; @001f                               v52 = load.i32 user2 readonly region5 v51
+;; @001f                               v52 = load.i32 user2 readonly region7 v51
 ;; @001f                               v53 = uextend.i64 v52
 ;; @001f                               v59 = icmp.i64 ugt v4, v53
 ;; @001f                               trapnz v59, user17
-;; @001f                               v76 = load.i64 notrap aligned region6 v123+40
+;; @001f                               v76 = load.i64 notrap aligned region8 v123+40
 ;; @001f                               v64 = iconst.i64 20
 ;; @001f                               v65 = iadd v49, v64  ; v64 = 20
 ;; @001f                               v78 = uadd_overflow_trap v65, v4, user2

--- a/tests/disas/gc/copying/array-new-fixed-of-gc-refs.wat
+++ b/tests/disas/gc/copying/array-new-fixed-of-gc-refs.wat
@@ -15,10 +15,12 @@
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     region2 = 32 "VMContext+0x20"
-;;     region3 = 40 "VMContext+0x28"
-;;     region4 = 268435488 "VMStoreContext+0x20"
-;;     region5 = 2147483648 "GcHeap"
-;;     region6 = 268435496 "VMStoreContext+0x28"
+;;     region3 = 3489660928 "VMCopyingHeapData+0x0"
+;;     region4 = 3489660932 "VMCopyingHeapData+0x4"
+;;     region5 = 40 "VMContext+0x28"
+;;     region6 = 268435488 "VMStoreContext+0x20"
+;;     region7 = 2147483648 "GcHeap"
+;;     region8 = 268435496 "VMStoreContext+0x28"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -34,8 +36,8 @@
 ;;                                     v139 = stack_addr.i64 ss0
 ;;                                     store notrap v4, v139
 ;; @0025                               v14 = load.i64 notrap aligned readonly can_move region2 v0+32
-;; @0025                               v15 = load.i32 notrap aligned v14
-;; @0025                               v16 = load.i32 notrap aligned v14+4
+;; @0025                               v15 = load.i32 notrap aligned region3 v14
+;; @0025                               v16 = load.i32 notrap aligned region4 v14+4
 ;; @0025                               v22 = uextend.i64 v15
 ;; @0025                               v10 = iconst.i64 32
 ;; @0025                               v23 = iadd v22, v10  ; v10 = 32
@@ -46,28 +48,28 @@
 ;;                                 block2:
 ;;                                     v259 = iconst.i32 32
 ;;                                     v165 = iadd.i32 v15, v259  ; v259 = 32
-;; @0025                               store notrap aligned v165, v14
+;; @0025                               store notrap aligned region3 v165, v14
 ;;                                     v260 = iconst.i32 -1476394994
 ;;                                     v261 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v262 = load.i64 notrap aligned readonly can_move region4 v261+32
+;;                                     v262 = load.i64 notrap aligned readonly can_move region6 v261+32
 ;; @0025                               v39 = iadd v262, v22
-;; @0025                               store user2 region5 v260, v39  ; v260 = -1476394994
-;;                                     v263 = load.i64 notrap aligned readonly can_move region3 v0+40
+;; @0025                               store user2 region7 v260, v39  ; v260 = -1476394994
+;;                                     v263 = load.i64 notrap aligned readonly can_move region5 v0+40
 ;;                                     v264 = load.i32 notrap aligned readonly can_move v263
-;; @0025                               store user2 region5 v264, v39+4
+;; @0025                               store user2 region7 v264, v39+4
 ;;                                     v265 = iconst.i64 32
-;; @0025                               istore32 user2 region5 v265, v39+8  ; v265 = 32
+;; @0025                               istore32 user2 region7 v265, v39+8  ; v265 = 32
 ;; @0025                               jump block4(v15, v39)
 ;;
 ;;                                 block3 cold:
 ;; @0025                               v26 = iconst.i32 -1476394994
-;; @0025                               v27 = load.i64 notrap aligned readonly can_move region3 v0+40
+;; @0025                               v27 = load.i64 notrap aligned readonly can_move region5 v0+40
 ;; @0025                               v28 = load.i32 notrap aligned readonly can_move v27
 ;;                                     v151 = iconst.i32 32
 ;; @0025                               v29 = iconst.i32 16
 ;; @0025                               v30 = call fn0(v0, v26, v28, v151, v29), stack_map=[i32 @ ss2+0, i32 @ ss1+0, i32 @ ss0+0]  ; v26 = -1476394994, v151 = 32, v29 = 16
 ;; @0025                               v31 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0025                               v32 = load.i64 notrap aligned readonly can_move region4 v31+32
+;; @0025                               v32 = load.i64 notrap aligned readonly can_move region6 v31+32
 ;; @0025                               v33 = uextend.i64 v30
 ;; @0025                               v34 = iadd v32, v33
 ;; @0025                               jump block4(v30, v34)
@@ -76,14 +78,14 @@
 ;; @0025                               v5 = iconst.i32 3
 ;; @0025                               v45 = iconst.i64 16
 ;; @0025                               v46 = iadd v44, v45  ; v45 = 16
-;; @0025                               store user2 region5 v5, v46  ; v5 = 3
+;; @0025                               store user2 region7 v5, v46  ; v5 = 3
 ;; @0025                               trapz v43, user16
 ;;                                     v266 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v267 = load.i64 notrap aligned readonly can_move region4 v266+32
+;;                                     v267 = load.i64 notrap aligned readonly can_move region6 v266+32
 ;; @0025                               v48 = uextend.i64 v43
 ;; @0025                               v51 = iadd v267, v48
 ;; @0025                               v53 = iadd v51, v45  ; v45 = 16
-;; @0025                               v54 = load.i32 user2 readonly region5 v53
+;; @0025                               v54 = load.i32 user2 readonly region7 v53
 ;; @0025                               trapz v54, user17
 ;; @0025                               v57 = uextend.i64 v54
 ;;                                     v142 = iconst.i64 2
@@ -102,8 +104,8 @@
 ;; @0025                               v72 = isub v63, v6  ; v6 = 20
 ;; @0025                               v73 = uextend.i64 v72
 ;; @0025                               v74 = isub v71, v73
-;; @0025                               store user2 little region5 v136, v74
-;; @0025                               v82 = load.i32 user2 readonly region5 v53
+;; @0025                               store user2 little region7 v136, v74
+;; @0025                               v82 = load.i32 user2 readonly region7 v53
 ;; @0025                               v75 = iconst.i32 1
 ;;                                     v198 = icmp ugt v82, v75  ; v75 = 1
 ;; @0025                               trapz v198, user17
@@ -121,8 +123,8 @@
 ;; @0025                               v100 = isub v91, v220  ; v220 = 24
 ;; @0025                               v101 = uextend.i64 v100
 ;; @0025                               v102 = isub v99, v101
-;; @0025                               store user2 little region5 v134, v102
-;; @0025                               v110 = load.i32 user2 readonly region5 v53
+;; @0025                               store user2 little region7 v134, v102
+;; @0025                               v110 = load.i32 user2 readonly region7 v53
 ;;                                     v226 = icmp ugt v110, v180  ; v180 = 2
 ;; @0025                               trapz v226, user17
 ;; @0025                               v113 = uextend.i64 v110
@@ -139,7 +141,7 @@
 ;; @0025                               v128 = isub v119, v253  ; v253 = 28
 ;; @0025                               v129 = uextend.i64 v128
 ;; @0025                               v130 = isub v127, v129
-;; @0025                               store user2 little region5 v132, v130
+;; @0025                               store user2 little region7 v132, v130
 ;; @0029                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/copying/array-new-fixed.wat
+++ b/tests/disas/gc/copying/array-new-fixed.wat
@@ -12,10 +12,12 @@
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     region2 = 32 "VMContext+0x20"
-;;     region3 = 40 "VMContext+0x28"
-;;     region4 = 268435488 "VMStoreContext+0x20"
-;;     region5 = 2147483648 "GcHeap"
-;;     region6 = 268435496 "VMStoreContext+0x28"
+;;     region3 = 3489660928 "VMCopyingHeapData+0x0"
+;;     region4 = 3489660932 "VMCopyingHeapData+0x4"
+;;     region5 = 40 "VMContext+0x28"
+;;     region6 = 268435488 "VMStoreContext+0x20"
+;;     region7 = 2147483648 "GcHeap"
+;;     region8 = 268435496 "VMStoreContext+0x28"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -25,8 +27,8 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i64, v4: i64):
 ;; @0025                               v14 = load.i64 notrap aligned readonly can_move region2 v0+32
-;; @0025                               v15 = load.i32 notrap aligned v14
-;; @0025                               v16 = load.i32 notrap aligned v14+4
+;; @0025                               v15 = load.i32 notrap aligned region3 v14
+;; @0025                               v16 = load.i32 notrap aligned region4 v14+4
 ;; @0025                               v22 = uextend.i64 v15
 ;;                                     v141 = iconst.i64 48
 ;; @0025                               v23 = iadd v22, v141  ; v141 = 48
@@ -37,28 +39,28 @@
 ;;                                 block2:
 ;;                                     v247 = iconst.i32 48
 ;;                                     v155 = iadd.i32 v15, v247  ; v247 = 48
-;; @0025                               store notrap aligned v155, v14
+;; @0025                               store notrap aligned region3 v155, v14
 ;;                                     v248 = iconst.i32 -1476395002
 ;;                                     v249 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v250 = load.i64 notrap aligned readonly can_move region4 v249+32
+;;                                     v250 = load.i64 notrap aligned readonly can_move region6 v249+32
 ;; @0025                               v39 = iadd v250, v22
-;; @0025                               store user2 region5 v248, v39  ; v248 = -1476395002
-;;                                     v251 = load.i64 notrap aligned readonly can_move region3 v0+40
+;; @0025                               store user2 region7 v248, v39  ; v248 = -1476395002
+;;                                     v251 = load.i64 notrap aligned readonly can_move region5 v0+40
 ;;                                     v252 = load.i32 notrap aligned readonly can_move v251
-;; @0025                               store user2 region5 v252, v39+4
+;; @0025                               store user2 region7 v252, v39+4
 ;;                                     v253 = iconst.i64 48
-;; @0025                               istore32 user2 region5 v253, v39+8  ; v253 = 48
+;; @0025                               istore32 user2 region7 v253, v39+8  ; v253 = 48
 ;; @0025                               jump block4(v15, v39)
 ;;
 ;;                                 block3 cold:
 ;; @0025                               v26 = iconst.i32 -1476395002
-;; @0025                               v27 = load.i64 notrap aligned readonly can_move region3 v0+40
+;; @0025                               v27 = load.i64 notrap aligned readonly can_move region5 v0+40
 ;; @0025                               v28 = load.i32 notrap aligned readonly can_move v27
 ;;                                     v140 = iconst.i32 48
 ;; @0025                               v29 = iconst.i32 16
 ;; @0025                               v30 = call fn0(v0, v26, v28, v140, v29)  ; v26 = -1476395002, v140 = 48, v29 = 16
 ;; @0025                               v31 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0025                               v32 = load.i64 notrap aligned readonly can_move region4 v31+32
+;; @0025                               v32 = load.i64 notrap aligned readonly can_move region6 v31+32
 ;; @0025                               v33 = uextend.i64 v30
 ;; @0025                               v34 = iadd v32, v33
 ;; @0025                               jump block4(v30, v34)
@@ -67,14 +69,14 @@
 ;; @0025                               v5 = iconst.i32 3
 ;; @0025                               v45 = iconst.i64 16
 ;; @0025                               v46 = iadd v44, v45  ; v45 = 16
-;; @0025                               store user2 region5 v5, v46  ; v5 = 3
+;; @0025                               store user2 region7 v5, v46  ; v5 = 3
 ;; @0025                               trapz v43, user16
 ;;                                     v254 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v255 = load.i64 notrap aligned readonly can_move region4 v254+32
+;;                                     v255 = load.i64 notrap aligned readonly can_move region6 v254+32
 ;; @0025                               v48 = uextend.i64 v43
 ;; @0025                               v51 = iadd v255, v48
 ;; @0025                               v53 = iadd v51, v45  ; v45 = 16
-;; @0025                               v54 = load.i32 user2 readonly region5 v53
+;; @0025                               v54 = load.i32 user2 readonly region7 v53
 ;; @0025                               trapz v54, user17
 ;; @0025                               v57 = uextend.i64 v54
 ;;                                     v131 = iconst.i64 3
@@ -91,8 +93,8 @@
 ;; @0025                               v72 = isub v63, v6  ; v6 = 24
 ;; @0025                               v73 = uextend.i64 v72
 ;; @0025                               v74 = isub v71, v73
-;; @0025                               store.i64 user2 little region5 v2, v74
-;; @0025                               v82 = load.i32 user2 readonly region5 v53
+;; @0025                               store.i64 user2 little region7 v2, v74
+;; @0025                               v82 = load.i32 user2 readonly region7 v53
 ;; @0025                               v75 = iconst.i32 1
 ;;                                     v187 = icmp ugt v82, v75  ; v75 = 1
 ;; @0025                               trapz v187, user17
@@ -109,8 +111,8 @@
 ;; @0025                               v100 = isub v91, v209  ; v209 = 32
 ;; @0025                               v101 = uextend.i64 v100
 ;; @0025                               v102 = isub v99, v101
-;; @0025                               store.i64 user2 little region5 v3, v102
-;; @0025                               v110 = load.i32 user2 readonly region5 v53
+;; @0025                               store.i64 user2 little region7 v3, v102
+;; @0025                               v110 = load.i32 user2 readonly region7 v53
 ;; @0025                               v103 = iconst.i32 2
 ;;                                     v215 = icmp ugt v110, v103  ; v103 = 2
 ;; @0025                               trapz v215, user17
@@ -127,7 +129,7 @@
 ;; @0025                               v128 = isub v119, v241  ; v241 = 40
 ;; @0025                               v129 = uextend.i64 v128
 ;; @0025                               v130 = isub v127, v129
-;; @0025                               store.i64 user2 little region5 v4, v130
+;; @0025                               store.i64 user2 little region7 v4, v130
 ;; @0029                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/copying/array-new.wat
+++ b/tests/disas/gc/copying/array-new.wat
@@ -12,10 +12,12 @@
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     region2 = 32 "VMContext+0x20"
-;;     region3 = 40 "VMContext+0x28"
-;;     region4 = 268435488 "VMStoreContext+0x20"
-;;     region5 = 2147483648 "GcHeap"
-;;     region6 = 268435496 "VMStoreContext+0x28"
+;;     region3 = 3489660928 "VMCopyingHeapData+0x0"
+;;     region4 = 3489660932 "VMCopyingHeapData+0x4"
+;;     region5 = 40 "VMContext+0x28"
+;;     region6 = 268435488 "VMStoreContext+0x20"
+;;     region7 = 2147483648 "GcHeap"
+;;     region8 = 268435496 "VMStoreContext+0x28"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -35,8 +37,8 @@
 ;;                                     v95 = ishl v3, v94  ; v94 = 3
 ;; @0022                               v11 = uadd_overflow_trap v4, v95, user18  ; v4 = 24
 ;; @0022                               v12 = load.i64 notrap aligned readonly can_move region2 v0+32
-;; @0022                               v13 = load.i32 notrap aligned v12
-;; @0022                               v14 = load.i32 notrap aligned v12+4
+;; @0022                               v13 = load.i32 notrap aligned region3 v12
+;; @0022                               v14 = load.i32 notrap aligned region4 v12+4
 ;; @0022                               v20 = uextend.i64 v13
 ;; @0022                               v15 = uextend.i64 v11
 ;; @0022                               v16 = iconst.i64 15
@@ -54,27 +56,27 @@
 ;;                                     v107 = iconst.i32 -16
 ;;                                     v108 = band v104, v107  ; v107 = -16
 ;;                                     v110 = iadd.i32 v13, v108
-;; @0022                               store notrap aligned v110, v12
+;; @0022                               store notrap aligned region3 v110, v12
 ;;                                     v126 = iconst.i32 -1476395002
 ;;                                     v127 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v128 = load.i64 notrap aligned readonly can_move region4 v127+32
+;;                                     v128 = load.i64 notrap aligned readonly can_move region6 v127+32
 ;; @0022                               v37 = iadd v128, v20
-;; @0022                               store user2 region5 v126, v37  ; v126 = -1476395002
-;;                                     v129 = load.i64 notrap aligned readonly can_move region3 v0+40
+;; @0022                               store user2 region7 v126, v37  ; v126 = -1476395002
+;;                                     v129 = load.i64 notrap aligned readonly can_move region5 v0+40
 ;;                                     v130 = load.i32 notrap aligned readonly can_move v129
-;; @0022                               store user2 region5 v130, v37+4
+;; @0022                               store user2 region7 v130, v37+4
 ;;                                     v131 = band.i64 v18, v17  ; v17 = -16
-;; @0022                               istore32 user2 region5 v131, v37+8
+;; @0022                               istore32 user2 region7 v131, v37+8
 ;; @0022                               jump block4(v13, v37)
 ;;
 ;;                                 block3 cold:
 ;; @0022                               v24 = iconst.i32 -1476395002
-;; @0022                               v25 = load.i64 notrap aligned readonly can_move region3 v0+40
+;; @0022                               v25 = load.i64 notrap aligned readonly can_move region5 v0+40
 ;; @0022                               v26 = load.i32 notrap aligned readonly can_move v25
 ;; @0022                               v27 = iconst.i32 16
 ;; @0022                               v28 = call fn0(v0, v24, v26, v11, v27)  ; v24 = -1476395002, v27 = 16
 ;; @0022                               v29 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0022                               v30 = load.i64 notrap aligned readonly can_move region4 v29+32
+;; @0022                               v30 = load.i64 notrap aligned readonly can_move region6 v29+32
 ;; @0022                               v31 = uextend.i64 v28
 ;; @0022                               v32 = iadd v30, v31
 ;; @0022                               jump block4(v28, v32)
@@ -82,18 +84,18 @@
 ;;                                 block4(v41: i32, v42: i64):
 ;; @0022                               v43 = iconst.i64 16
 ;; @0022                               v44 = iadd v42, v43  ; v43 = 16
-;; @0022                               store.i32 user2 region5 v3, v44
+;; @0022                               store.i32 user2 region7 v3, v44
 ;; @0022                               trapz v41, user16
 ;;                                     v132 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v133 = load.i64 notrap aligned readonly can_move region4 v132+32
+;;                                     v133 = load.i64 notrap aligned readonly can_move region6 v132+32
 ;; @0022                               v46 = uextend.i64 v41
 ;; @0022                               v49 = iadd v133, v46
 ;; @0022                               v51 = iadd v49, v43  ; v43 = 16
-;; @0022                               v52 = load.i32 user2 readonly region5 v51
+;; @0022                               v52 = load.i32 user2 readonly region7 v51
 ;; @0022                               v53 = uextend.i64 v52
 ;; @0022                               v59 = icmp.i64 ugt v5, v53
 ;; @0022                               trapnz v59, user17
-;; @0022                               v76 = load.i64 notrap aligned region6 v132+40
+;; @0022                               v76 = load.i64 notrap aligned region8 v132+40
 ;; @0022                               v64 = iconst.i64 24
 ;; @0022                               v65 = iadd v49, v64  ; v64 = 24
 ;; @0022                               v78 = uadd_overflow_trap v65, v88, user2
@@ -107,7 +109,7 @@
 ;; @0022                               brif v82, block6, block5(v65)
 ;;
 ;;                                 block5(v83: i64):
-;; @0022                               store.i64 user2 little region5 v2, v83
+;; @0022                               store.i64 user2 little region7 v2, v83
 ;;                                     v134 = iconst.i64 8
 ;;                                     v135 = iadd v83, v134  ; v134 = 8
 ;; @0022                               v86 = icmp eq v135, v80

--- a/tests/disas/gc/copying/funcref-in-gc-heap-new.wat
+++ b/tests/disas/gc/copying/funcref-in-gc-heap-new.wat
@@ -13,9 +13,11 @@
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     region2 = 32 "VMContext+0x20"
-;;     region3 = 40 "VMContext+0x28"
-;;     region4 = 268435488 "VMStoreContext+0x20"
-;;     region5 = 2147483648 "GcHeap"
+;;     region3 = 3489660928 "VMCopyingHeapData+0x0"
+;;     region4 = 3489660932 "VMCopyingHeapData+0x4"
+;;     region5 = 40 "VMContext+0x28"
+;;     region6 = 268435488 "VMStoreContext+0x20"
+;;     region7 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -27,8 +29,8 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @0020                               v4 = load.i64 notrap aligned readonly can_move region2 v0+32
-;; @0020                               v5 = load.i32 notrap aligned v4
-;; @0020                               v6 = load.i32 notrap aligned v4+4
+;; @0020                               v5 = load.i32 notrap aligned region3 v4
+;; @0020                               v6 = load.i32 notrap aligned region4 v4+4
 ;; @0020                               v12 = uextend.i64 v5
 ;;                                     v42 = iconst.i64 32
 ;; @0020                               v13 = iadd v12, v42  ; v42 = 32
@@ -39,28 +41,28 @@
 ;;                                 block2:
 ;;                                     v58 = iconst.i32 32
 ;;                                     v56 = iadd.i32 v5, v58  ; v58 = 32
-;; @0020                               store notrap aligned v56, v4
+;; @0020                               store notrap aligned region3 v56, v4
 ;;                                     v59 = iconst.i32 -1342177278
 ;;                                     v60 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v61 = load.i64 notrap aligned readonly can_move region4 v60+32
+;;                                     v61 = load.i64 notrap aligned readonly can_move region6 v60+32
 ;; @0020                               v29 = iadd v61, v12
-;; @0020                               store user2 region5 v59, v29  ; v59 = -1342177278
-;;                                     v62 = load.i64 notrap aligned readonly can_move region3 v0+40
+;; @0020                               store user2 region7 v59, v29  ; v59 = -1342177278
+;;                                     v62 = load.i64 notrap aligned readonly can_move region5 v0+40
 ;;                                     v63 = load.i32 notrap aligned readonly can_move v62
-;; @0020                               store user2 region5 v63, v29+4
+;; @0020                               store user2 region7 v63, v29+4
 ;;                                     v64 = iconst.i64 32
-;; @0020                               istore32 user2 region5 v64, v29+8  ; v64 = 32
+;; @0020                               istore32 user2 region7 v64, v29+8  ; v64 = 32
 ;; @0020                               jump block4(v5, v29)
 ;;
 ;;                                 block3 cold:
 ;; @0020                               v16 = iconst.i32 -1342177278
-;; @0020                               v17 = load.i64 notrap aligned readonly can_move region3 v0+40
+;; @0020                               v17 = load.i64 notrap aligned readonly can_move region5 v0+40
 ;; @0020                               v18 = load.i32 notrap aligned readonly can_move v17
 ;; @0020                               v3 = iconst.i32 32
 ;; @0020                               v19 = iconst.i32 16
 ;; @0020                               v20 = call fn0(v0, v16, v18, v3, v19)  ; v16 = -1342177278, v3 = 32, v19 = 16
 ;; @0020                               v21 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0020                               v22 = load.i64 notrap aligned readonly can_move region4 v21+32
+;; @0020                               v22 = load.i64 notrap aligned readonly can_move region6 v21+32
 ;; @0020                               v23 = uextend.i64 v20
 ;; @0020                               v24 = iadd v22, v23
 ;; @0020                               jump block4(v20, v24)
@@ -72,7 +74,7 @@
 ;; @0020                               v38 = ireduce.i32 v37
 ;; @0020                               v35 = iconst.i64 16
 ;; @0020                               v36 = iadd v34, v35  ; v35 = 16
-;; @0020                               store user2 little region5 v38, v36
+;; @0020                               store user2 little region7 v38, v36
 ;; @0023                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/copying/struct-new-default.wat
+++ b/tests/disas/gc/copying/struct-new-default.wat
@@ -14,9 +14,11 @@
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     region2 = 32 "VMContext+0x20"
-;;     region3 = 40 "VMContext+0x28"
-;;     region4 = 268435488 "VMStoreContext+0x20"
-;;     region5 = 2147483648 "GcHeap"
+;;     region3 = 3489660928 "VMCopyingHeapData+0x0"
+;;     region4 = 3489660932 "VMCopyingHeapData+0x4"
+;;     region5 = 40 "VMContext+0x28"
+;;     region6 = 268435488 "VMStoreContext+0x20"
+;;     region7 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -26,8 +28,8 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64):
 ;; @0021                               v6 = load.i64 notrap aligned readonly can_move region2 v0+32
-;; @0021                               v7 = load.i32 notrap aligned v6
-;; @0021                               v8 = load.i32 notrap aligned v6+4
+;; @0021                               v7 = load.i32 notrap aligned region3 v6
+;; @0021                               v8 = load.i32 notrap aligned region4 v6+4
 ;; @0021                               v14 = uextend.i64 v7
 ;;                                     v43 = iconst.i64 32
 ;; @0021                               v15 = iadd v14, v43  ; v43 = 32
@@ -38,28 +40,28 @@
 ;;                                 block2:
 ;;                                     v59 = iconst.i32 32
 ;;                                     v57 = iadd.i32 v7, v59  ; v59 = 32
-;; @0021                               store notrap aligned v57, v6
+;; @0021                               store notrap aligned region3 v57, v6
 ;;                                     v60 = iconst.i32 -1342177246
 ;;                                     v61 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v62 = load.i64 notrap aligned readonly can_move region4 v61+32
+;;                                     v62 = load.i64 notrap aligned readonly can_move region6 v61+32
 ;; @0021                               v31 = iadd v62, v14
-;; @0021                               store user2 region5 v60, v31  ; v60 = -1342177246
-;;                                     v63 = load.i64 notrap aligned readonly can_move region3 v0+40
+;; @0021                               store user2 region7 v60, v31  ; v60 = -1342177246
+;;                                     v63 = load.i64 notrap aligned readonly can_move region5 v0+40
 ;;                                     v64 = load.i32 notrap aligned readonly can_move v63
-;; @0021                               store user2 region5 v64, v31+4
+;; @0021                               store user2 region7 v64, v31+4
 ;;                                     v65 = iconst.i64 32
-;; @0021                               istore32 user2 region5 v65, v31+8  ; v65 = 32
+;; @0021                               istore32 user2 region7 v65, v31+8  ; v65 = 32
 ;; @0021                               jump block4(v7, v31)
 ;;
 ;;                                 block3 cold:
 ;; @0021                               v18 = iconst.i32 -1342177246
-;; @0021                               v19 = load.i64 notrap aligned readonly can_move region3 v0+40
+;; @0021                               v19 = load.i64 notrap aligned readonly can_move region5 v0+40
 ;; @0021                               v20 = load.i32 notrap aligned readonly can_move v19
 ;; @0021                               v5 = iconst.i32 32
 ;; @0021                               v21 = iconst.i32 16
 ;; @0021                               v22 = call fn0(v0, v18, v20, v5, v21)  ; v18 = -1342177246, v5 = 32, v21 = 16
 ;; @0021                               v23 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0021                               v24 = load.i64 notrap aligned readonly can_move region4 v23+32
+;; @0021                               v24 = load.i64 notrap aligned readonly can_move region6 v23+32
 ;; @0021                               v25 = uextend.i64 v22
 ;; @0021                               v26 = iadd v24, v25
 ;; @0021                               jump block4(v22, v26)
@@ -68,14 +70,14 @@
 ;; @0021                               v2 = f32const 0.0
 ;; @0021                               v37 = iconst.i64 16
 ;; @0021                               v38 = iadd v36, v37  ; v37 = 16
-;; @0021                               store user2 little region5 v2, v38  ; v2 = 0.0
+;; @0021                               store user2 little region7 v2, v38  ; v2 = 0.0
 ;; @0021                               v3 = iconst.i32 0
 ;; @0021                               v39 = iconst.i64 20
 ;; @0021                               v40 = iadd v36, v39  ; v39 = 20
-;; @0021                               istore8 user2 little region5 v3, v40  ; v3 = 0
+;; @0021                               istore8 user2 little region7 v3, v40  ; v3 = 0
 ;; @0021                               v41 = iconst.i64 24
 ;; @0021                               v42 = iadd v36, v41  ; v41 = 24
-;; @0021                               store user2 little region5 v3, v42  ; v3 = 0
+;; @0021                               store user2 little region7 v3, v42  ; v3 = 0
 ;; @0024                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/copying/struct-new.wat
+++ b/tests/disas/gc/copying/struct-new.wat
@@ -15,9 +15,11 @@
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     region2 = 32 "VMContext+0x20"
-;;     region3 = 40 "VMContext+0x28"
-;;     region4 = 268435488 "VMStoreContext+0x20"
-;;     region5 = 2147483648 "GcHeap"
+;;     region3 = 3489660928 "VMCopyingHeapData+0x0"
+;;     region4 = 3489660932 "VMCopyingHeapData+0x4"
+;;     region5 = 40 "VMContext+0x28"
+;;     region6 = 268435488 "VMStoreContext+0x20"
+;;     region7 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -29,8 +31,8 @@
 ;;                                     v45 = stack_addr.i64 ss0
 ;;                                     store notrap v4, v45
 ;; @002a                               v6 = load.i64 notrap aligned readonly can_move region2 v0+32
-;; @002a                               v7 = load.i32 notrap aligned v6
-;; @002a                               v8 = load.i32 notrap aligned v6+4
+;; @002a                               v7 = load.i32 notrap aligned region3 v6
+;; @002a                               v8 = load.i32 notrap aligned region4 v6+4
 ;; @002a                               v14 = uextend.i64 v7
 ;;                                     v46 = iconst.i64 32
 ;; @002a                               v15 = iadd v14, v46  ; v46 = 32
@@ -41,28 +43,28 @@
 ;;                                 block2:
 ;;                                     v62 = iconst.i32 32
 ;;                                     v60 = iadd.i32 v7, v62  ; v62 = 32
-;; @002a                               store notrap aligned v60, v6
+;; @002a                               store notrap aligned region3 v60, v6
 ;;                                     v63 = iconst.i32 -1342177246
 ;;                                     v64 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v65 = load.i64 notrap aligned readonly can_move region4 v64+32
+;;                                     v65 = load.i64 notrap aligned readonly can_move region6 v64+32
 ;; @002a                               v31 = iadd v65, v14
-;; @002a                               store user2 region5 v63, v31  ; v63 = -1342177246
-;;                                     v66 = load.i64 notrap aligned readonly can_move region3 v0+40
+;; @002a                               store user2 region7 v63, v31  ; v63 = -1342177246
+;;                                     v66 = load.i64 notrap aligned readonly can_move region5 v0+40
 ;;                                     v67 = load.i32 notrap aligned readonly can_move v66
-;; @002a                               store user2 region5 v67, v31+4
+;; @002a                               store user2 region7 v67, v31+4
 ;;                                     v68 = iconst.i64 32
-;; @002a                               istore32 user2 region5 v68, v31+8  ; v68 = 32
+;; @002a                               istore32 user2 region7 v68, v31+8  ; v68 = 32
 ;; @002a                               jump block4(v7, v31)
 ;;
 ;;                                 block3 cold:
 ;; @002a                               v18 = iconst.i32 -1342177246
-;; @002a                               v19 = load.i64 notrap aligned readonly can_move region3 v0+40
+;; @002a                               v19 = load.i64 notrap aligned readonly can_move region5 v0+40
 ;; @002a                               v20 = load.i32 notrap aligned readonly can_move v19
 ;; @002a                               v5 = iconst.i32 32
 ;; @002a                               v21 = iconst.i32 16
 ;; @002a                               v22 = call fn0(v0, v18, v20, v5, v21), stack_map=[i32 @ ss0+0]  ; v18 = -1342177246, v5 = 32, v21 = 16
 ;; @002a                               v23 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @002a                               v24 = load.i64 notrap aligned readonly can_move region4 v23+32
+;; @002a                               v24 = load.i64 notrap aligned readonly can_move region6 v23+32
 ;; @002a                               v25 = uextend.i64 v22
 ;; @002a                               v26 = iadd v24, v25
 ;; @002a                               jump block4(v22, v26)
@@ -70,14 +72,14 @@
 ;;                                 block4(v35: i32, v36: i64):
 ;; @002a                               v37 = iconst.i64 16
 ;; @002a                               v38 = iadd v36, v37  ; v37 = 16
-;; @002a                               store.f32 user2 little region5 v2, v38
+;; @002a                               store.f32 user2 little region7 v2, v38
 ;; @002a                               v39 = iconst.i64 20
 ;; @002a                               v40 = iadd v36, v39  ; v39 = 20
-;; @002a                               istore8.i32 user2 little region5 v3, v40
+;; @002a                               istore8.i32 user2 little region7 v3, v40
 ;;                                     v44 = load.i32 notrap v45
 ;; @002a                               v41 = iconst.i64 24
 ;; @002a                               v42 = iadd v36, v41  ; v41 = 24
-;; @002a                               store user2 little region5 v44, v42
+;; @002a                               store user2 little region7 v44, v42
 ;; @002d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/drc/externref-globals.wat
+++ b/tests/disas/gc/drc/externref-globals.wat
@@ -21,6 +21,9 @@
 ;;     region4 = 268435496 "VMStoreContext+0x28"
 ;;     region5 = 2147483648 "GcHeap"
 ;;     region6 = 32 "VMContext+0x20"
+;;     region7 = 3221225472 "VMDrcHeapData+0x0"
+;;     region8 = 3221225476 "VMDrcHeapData+0x4"
+;;     region9 = 3221225480 "VMDrcHeapData+0x8"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -32,8 +35,8 @@
 ;; @0034                               v2 = iconst.i64 48
 ;; @0034                               v3 = iadd v0, v2  ; v2 = 48
 ;; @0034                               v4 = load.i32 notrap aligned region2 v3
-;;                                     v79 = stack_addr.i64 ss0
-;;                                     store notrap v4, v79
+;;                                     v76 = stack_addr.i64 ss0
+;;                                     store notrap v4, v76
 ;; @0034                               v5 = iconst.i32 1
 ;; @0034                               v6 = band v4, v5  ; v5 = 1
 ;; @0034                               v7 = iconst.i32 0
@@ -54,33 +57,33 @@
 ;;
 ;;                                 block3:
 ;; @0034                               v18 = load.i64 notrap aligned readonly can_move region6 v0+32
-;; @0034                               v19 = load.i32 user2 region5 v18
+;; @0034                               v19 = load.i32 notrap aligned region7 v18
 ;; @0034                               v24 = iconst.i64 16
 ;; @0034                               v25 = iadd.i64 v14, v24  ; v24 = 16
 ;; @0034                               store user2 region5 v19, v25
-;;                                     v80 = iconst.i32 2
-;;                                     v81 = bor.i32 v15, v80  ; v80 = 2
-;; @0034                               store user2 region5 v81, v14
+;;                                     v77 = iconst.i32 2
+;;                                     v78 = bor.i32 v15, v77  ; v77 = 2
+;; @0034                               store user2 region5 v78, v14
 ;; @0034                               v36 = iconst.i64 8
 ;; @0034                               v37 = iadd.i64 v14, v36  ; v36 = 8
 ;; @0034                               v38 = load.i64 user2 region5 v37
 ;; @0034                               v39 = iconst.i64 1
 ;; @0034                               v40 = iadd v38, v39  ; v39 = 1
 ;; @0034                               store user2 region5 v40, v37
-;; @0034                               store.i32 user2 region5 v4, v18
-;; @0034                               v48 = load.i32 notrap aligned v18+4
-;;                                     v82 = iconst.i32 1
-;;                                     v83 = iadd v48, v82  ; v82 = 1
-;; @0034                               store notrap aligned v83, v18+4
-;; @0034                               v55 = load.i32 notrap aligned v18+8
-;; @0034                               v56 = iadd v55, v55
-;; @0034                               v57 = iconst.i32 1024
-;; @0034                               v58 = umax v56, v57  ; v57 = 1024
-;; @0034                               v59 = icmp uge v83, v58
-;; @0034                               brif v59, block5, block6
+;; @0034                               store.i32 notrap aligned region7 v4, v18
+;; @0034                               v47 = load.i32 notrap aligned region8 v18+4
+;;                                     v79 = iconst.i32 1
+;;                                     v80 = iadd v47, v79  ; v79 = 1
+;; @0034                               store notrap aligned region8 v80, v18+4
+;; @0034                               v52 = load.i32 notrap aligned region9 v18+8
+;; @0034                               v53 = iadd v52, v52
+;; @0034                               v54 = iconst.i32 1024
+;; @0034                               v55 = umax v53, v54  ; v54 = 1024
+;; @0034                               v56 = icmp uge v80, v55
+;; @0034                               brif v56, block5, block6
 ;;
 ;;                                 block5 cold:
-;; @0034                               v60 = call fn0(v0), stack_map=[i32 @ ss0+0]
+;; @0034                               v57 = call fn0(v0), stack_map=[i32 @ ss0+0]
 ;; @0034                               jump block6
 ;;
 ;;                                 block6:
@@ -90,8 +93,8 @@
 ;; @0036                               jump block1
 ;;
 ;;                                 block1:
-;;                                     v62 = load.i32 notrap v79
-;; @0036                               return v62
+;;                                     v59 = load.i32 notrap v76
+;; @0036                               return v59
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) tail {

--- a/tests/disas/gc/drc/struct-get.wat
+++ b/tests/disas/gc/drc/struct-get.wat
@@ -111,6 +111,9 @@
 ;;     region3 = 268435496 "VMStoreContext+0x28"
 ;;     region4 = 2147483648 "GcHeap"
 ;;     region5 = 32 "VMContext+0x20"
+;;     region6 = 3221225472 "VMDrcHeapData+0x0"
+;;     region7 = 3221225476 "VMDrcHeapData+0x4"
+;;     region8 = 3221225480 "VMDrcHeapData+0x8"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -127,8 +130,8 @@
 ;; @004e                               v7 = iconst.i64 32
 ;; @004e                               v8 = iadd v6, v7  ; v7 = 32
 ;; @004e                               v9 = load.i32 user2 little region4 v8
-;;                                     v84 = stack_addr.i64 ss0
-;;                                     store notrap v9, v84
+;;                                     v81 = stack_addr.i64 ss0
+;;                                     store notrap v9, v81
 ;; @004e                               v10 = iconst.i32 1
 ;; @004e                               v11 = band v9, v10  ; v10 = 1
 ;; @004e                               v12 = iconst.i32 0
@@ -147,33 +150,33 @@
 ;;
 ;;                                 block3:
 ;; @004e                               v23 = load.i64 notrap aligned readonly can_move region5 v0+32
-;; @004e                               v24 = load.i32 user2 region4 v23
+;; @004e                               v24 = load.i32 notrap aligned region6 v23
 ;; @004e                               v29 = iconst.i64 16
 ;; @004e                               v30 = iadd.i64 v19, v29  ; v29 = 16
 ;; @004e                               store user2 region4 v24, v30
-;;                                     v85 = iconst.i32 2
-;;                                     v86 = bor.i32 v20, v85  ; v85 = 2
-;; @004e                               store user2 region4 v86, v19
+;;                                     v82 = iconst.i32 2
+;;                                     v83 = bor.i32 v20, v82  ; v82 = 2
+;; @004e                               store user2 region4 v83, v19
 ;; @004e                               v41 = iconst.i64 8
 ;; @004e                               v42 = iadd.i64 v19, v41  ; v41 = 8
 ;; @004e                               v43 = load.i64 user2 region4 v42
 ;; @004e                               v44 = iconst.i64 1
 ;; @004e                               v45 = iadd v43, v44  ; v44 = 1
 ;; @004e                               store user2 region4 v45, v42
-;; @004e                               store.i32 user2 region4 v9, v23
-;; @004e                               v53 = load.i32 notrap aligned v23+4
-;;                                     v87 = iconst.i32 1
-;;                                     v88 = iadd v53, v87  ; v87 = 1
-;; @004e                               store notrap aligned v88, v23+4
-;; @004e                               v60 = load.i32 notrap aligned v23+8
-;; @004e                               v61 = iadd v60, v60
-;; @004e                               v62 = iconst.i32 1024
-;; @004e                               v63 = umax v61, v62  ; v62 = 1024
-;; @004e                               v64 = icmp uge v88, v63
-;; @004e                               brif v64, block5, block6
+;; @004e                               store.i32 notrap aligned region6 v9, v23
+;; @004e                               v52 = load.i32 notrap aligned region7 v23+4
+;;                                     v84 = iconst.i32 1
+;;                                     v85 = iadd v52, v84  ; v84 = 1
+;; @004e                               store notrap aligned region7 v85, v23+4
+;; @004e                               v57 = load.i32 notrap aligned region8 v23+8
+;; @004e                               v58 = iadd v57, v57
+;; @004e                               v59 = iconst.i32 1024
+;; @004e                               v60 = umax v58, v59  ; v59 = 1024
+;; @004e                               v61 = icmp uge v85, v60
+;; @004e                               brif v61, block5, block6
 ;;
 ;;                                 block5 cold:
-;; @004e                               v65 = call fn0(v0), stack_map=[i32 @ ss0+0]
+;; @004e                               v62 = call fn0(v0), stack_map=[i32 @ ss0+0]
 ;; @004e                               jump block6
 ;;
 ;;                                 block6:
@@ -183,6 +186,6 @@
 ;; @0052                               jump block1
 ;;
 ;;                                 block1:
-;;                                     v67 = load.i32 notrap v84
-;; @0052                               return v67
+;;                                     v64 = load.i32 notrap v81
+;; @0052                               return v64
 ;; }

--- a/tests/disas/gc/null/array-new-fixed-of-gc-refs.wat
+++ b/tests/disas/gc/null/array-new-fixed-of-gc-refs.wat
@@ -16,10 +16,11 @@
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     region2 = 32 "VMContext+0x20"
-;;     region3 = 2147483648 "GcHeap"
+;;     region3 = 3758096384 "VMNullHeapData+0x0"
 ;;     region4 = 268435496 "VMStoreContext+0x28"
 ;;     region5 = 268435488 "VMStoreContext+0x20"
 ;;     region6 = 40 "VMContext+0x28"
+;;     region7 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -35,7 +36,7 @@
 ;;                                     v133 = stack_addr.i64 ss0
 ;;                                     store notrap v4, v133
 ;; @0025                               v17 = load.i64 notrap aligned readonly can_move region2 v0+32
-;; @0025                               v18 = load.i32 user2 region3 v17
+;; @0025                               v18 = load.i32 notrap aligned region3 v17
 ;;                                     v151 = iconst.i32 7
 ;; @0025                               v21 = uadd_overflow_trap v18, v151, user18  ; v151 = 7
 ;;                                     v157 = iconst.i32 -8
@@ -54,15 +55,15 @@
 ;;                                     v256 = band.i32 v21, v157  ; v157 = -8
 ;;                                     v257 = uextend.i64 v256
 ;; @0025                               v34 = iadd v32, v257
-;; @0025                               store user2 region3 v158, v34  ; v158 = -1476394984
+;; @0025                               store user2 region7 v158, v34  ; v158 = -1476394984
 ;; @0025                               v37 = load.i64 notrap aligned readonly can_move region6 v0+40
 ;; @0025                               v38 = load.i32 notrap aligned readonly can_move v37
-;; @0025                               store user2 region3 v38, v34+4
-;; @0025                               store.i32 user2 region3 v24, v17
+;; @0025                               store user2 region7 v38, v34+4
+;; @0025                               store.i32 notrap aligned region3 v24, v17
 ;; @0025                               v5 = iconst.i32 3
 ;; @0025                               v39 = iconst.i64 8
 ;; @0025                               v40 = iadd v34, v39  ; v39 = 8
-;; @0025                               store user2 region3 v5, v40  ; v5 = 3
+;; @0025                               store user2 region7 v5, v40  ; v5 = 3
 ;; @0025                               trapz v256, user16
 ;;                                     v258 = iconst.i32 24
 ;; @0025                               v61 = uadd_overflow_trap v256, v258, user2  ; v258 = 24
@@ -71,8 +72,8 @@
 ;; @0025                               v65 = iadd v32, v62
 ;;                                     v135 = iconst.i64 12
 ;; @0025                               v68 = isub v65, v135  ; v135 = 12
-;; @0025                               store user2 little region3 v130, v68
-;; @0025                               v76 = load.i32 user2 readonly region3 v40
+;; @0025                               store user2 little region7 v130, v68
+;; @0025                               v76 = load.i32 user2 readonly region7 v40
 ;; @0025                               v69 = iconst.i32 1
 ;;                                     v196 = icmp ugt v76, v69  ; v69 = 1
 ;; @0025                               trapz v196, user17
@@ -94,8 +95,8 @@
 ;; @0025                               v94 = isub v85, v218  ; v218 = 16
 ;; @0025                               v95 = uextend.i64 v94
 ;; @0025                               v96 = isub v93, v95
-;; @0025                               store user2 little region3 v128, v96
-;; @0025                               v104 = load.i32 user2 readonly region3 v40
+;; @0025                               store user2 little region7 v128, v96
+;; @0025                               v104 = load.i32 user2 readonly region7 v40
 ;;                                     v224 = icmp ugt v104, v175  ; v175 = 2
 ;; @0025                               trapz v224, user17
 ;; @0025                               v107 = uextend.i64 v104
@@ -112,7 +113,7 @@
 ;; @0025                               v122 = isub v113, v250  ; v250 = 20
 ;; @0025                               v123 = uextend.i64 v122
 ;; @0025                               v124 = isub v121, v123
-;; @0025                               store user2 little region3 v126, v124
+;; @0025                               store user2 little region7 v126, v124
 ;; @0029                               jump block1
 ;;
 ;;                                 block3 cold:

--- a/tests/disas/gc/null/array-new-fixed.wat
+++ b/tests/disas/gc/null/array-new-fixed.wat
@@ -13,10 +13,11 @@
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     region2 = 32 "VMContext+0x20"
-;;     region3 = 2147483648 "GcHeap"
+;;     region3 = 3758096384 "VMNullHeapData+0x0"
 ;;     region4 = 268435496 "VMStoreContext+0x28"
 ;;     region5 = 268435488 "VMStoreContext+0x20"
 ;;     region6 = 40 "VMContext+0x28"
+;;     region7 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -26,7 +27,7 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i64, v4: i64):
 ;; @0025                               v17 = load.i64 notrap aligned readonly can_move region2 v0+32
-;; @0025                               v18 = load.i32 user2 region3 v17
+;; @0025                               v18 = load.i32 notrap aligned region3 v17
 ;;                                     v142 = iconst.i32 7
 ;; @0025                               v21 = uadd_overflow_trap v18, v142, user18  ; v142 = 7
 ;;                                     v148 = iconst.i32 -8
@@ -45,15 +46,15 @@
 ;;                                     v244 = band.i32 v21, v148  ; v148 = -8
 ;;                                     v245 = uextend.i64 v244
 ;; @0025                               v34 = iadd v32, v245
-;; @0025                               store user2 region3 v149, v34  ; v149 = -1476394968
+;; @0025                               store user2 region7 v149, v34  ; v149 = -1476394968
 ;; @0025                               v37 = load.i64 notrap aligned readonly can_move region6 v0+40
 ;; @0025                               v38 = load.i32 notrap aligned readonly can_move v37
-;; @0025                               store user2 region3 v38, v34+4
-;; @0025                               store.i32 user2 region3 v24, v17
+;; @0025                               store user2 region7 v38, v34+4
+;; @0025                               store.i32 notrap aligned region3 v24, v17
 ;; @0025                               v5 = iconst.i32 3
 ;; @0025                               v8 = iconst.i64 8
 ;; @0025                               v40 = iadd v34, v8  ; v8 = 8
-;; @0025                               store user2 region3 v5, v40  ; v5 = 3
+;; @0025                               store user2 region7 v5, v40  ; v5 = 3
 ;; @0025                               trapz v244, user16
 ;;                                     v246 = iconst.i32 40
 ;; @0025                               v61 = uadd_overflow_trap v244, v246, user2  ; v246 = 40
@@ -61,8 +62,8 @@
 ;; @0025                               v65 = iadd v32, v62
 ;;                                     v126 = iconst.i64 24
 ;; @0025                               v68 = isub v65, v126  ; v126 = 24
-;; @0025                               store.i64 user2 little region3 v2, v68
-;; @0025                               v76 = load.i32 user2 readonly region3 v40
+;; @0025                               store.i64 user2 little region7 v2, v68
+;; @0025                               v76 = load.i32 user2 readonly region7 v40
 ;; @0025                               v69 = iconst.i32 1
 ;;                                     v185 = icmp ugt v76, v69  ; v69 = 1
 ;; @0025                               trapz v185, user17
@@ -82,8 +83,8 @@
 ;; @0025                               v94 = isub v85, v134  ; v134 = 24
 ;; @0025                               v95 = uextend.i64 v94
 ;; @0025                               v96 = isub v93, v95
-;; @0025                               store.i64 user2 little region3 v3, v96
-;; @0025                               v104 = load.i32 user2 readonly region3 v40
+;; @0025                               store.i64 user2 little region7 v3, v96
+;; @0025                               v104 = load.i32 user2 readonly region7 v40
 ;; @0025                               v97 = iconst.i32 2
 ;;                                     v212 = icmp ugt v104, v97  ; v97 = 2
 ;; @0025                               trapz v212, user17
@@ -100,7 +101,7 @@
 ;; @0025                               v122 = isub v113, v238  ; v238 = 32
 ;; @0025                               v123 = uextend.i64 v122
 ;; @0025                               v124 = isub v121, v123
-;; @0025                               store.i64 user2 little region3 v4, v124
+;; @0025                               store.i64 user2 little region7 v4, v124
 ;; @0029                               jump block1
 ;;
 ;;                                 block3 cold:

--- a/tests/disas/gc/null/array-new.wat
+++ b/tests/disas/gc/null/array-new.wat
@@ -13,10 +13,11 @@
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     region2 = 32 "VMContext+0x20"
-;;     region3 = 2147483648 "GcHeap"
+;;     region3 = 3758096384 "VMNullHeapData+0x0"
 ;;     region4 = 268435496 "VMStoreContext+0x28"
 ;;     region5 = 268435488 "VMStoreContext+0x20"
 ;;     region6 = 40 "VMContext+0x28"
+;;     region7 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -39,7 +40,7 @@
 ;; @0022                               v14 = band v11, v13  ; v13 = -67108864
 ;; @0022                               trapnz v14, user18
 ;; @0022                               v15 = load.i64 notrap aligned readonly can_move region2 v0+32
-;; @0022                               v16 = load.i32 user2 region3 v15
+;; @0022                               v16 = load.i32 notrap aligned region3 v15
 ;;                                     v92 = iconst.i32 7
 ;; @0022                               v19 = uadd_overflow_trap v16, v92, user18  ; v92 = 7
 ;;                                     v98 = iconst.i32 -8
@@ -58,14 +59,14 @@
 ;;                                     v116 = band.i32 v19, v98  ; v98 = -8
 ;;                                     v117 = uextend.i64 v116
 ;; @0022                               v32 = iadd v30, v117
-;; @0022                               store user2 region3 v99, v32
+;; @0022                               store user2 region7 v99, v32
 ;; @0022                               v35 = load.i64 notrap aligned readonly can_move region6 v0+40
 ;; @0022                               v36 = load.i32 notrap aligned readonly can_move v35
-;; @0022                               store user2 region3 v36, v32+4
-;; @0022                               store.i32 user2 region3 v22, v15
+;; @0022                               store user2 region7 v36, v32+4
+;; @0022                               store.i32 notrap aligned region3 v22, v15
 ;; @0022                               v6 = iconst.i64 8
 ;; @0022                               v38 = iadd v32, v6  ; v6 = 8
-;; @0022                               store.i32 user2 region3 v3, v38
+;; @0022                               store.i32 user2 region7 v3, v38
 ;; @0022                               trapz v116, user16
 ;; @0022                               v70 = load.i64 notrap aligned region4 v24+40
 ;; @0022                               v58 = iconst.i64 16
@@ -80,7 +81,7 @@
 ;; @0022                               brif v76, block5, block4(v59)
 ;;
 ;;                                 block4(v77: i64):
-;; @0022                               store.i64 user2 little region3 v2, v77
+;; @0022                               store.i64 user2 little region7 v2, v77
 ;;                                     v118 = iconst.i64 8
 ;;                                     v119 = iadd v77, v118  ; v118 = 8
 ;; @0022                               v80 = icmp eq v119, v74

--- a/tests/disas/gc/null/funcref-in-gc-heap-new.wat
+++ b/tests/disas/gc/null/funcref-in-gc-heap-new.wat
@@ -13,10 +13,11 @@
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     region2 = 32 "VMContext+0x20"
-;;     region3 = 2147483648 "GcHeap"
+;;     region3 = 3758096384 "VMNullHeapData+0x0"
 ;;     region4 = 268435496 "VMStoreContext+0x28"
 ;;     region5 = 268435488 "VMStoreContext+0x20"
 ;;     region6 = 40 "VMContext+0x28"
+;;     region7 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -28,7 +29,7 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @0020                               v7 = load.i64 notrap aligned readonly can_move region2 v0+32
-;; @0020                               v8 = load.i32 user2 region3 v7
+;; @0020                               v8 = load.i32 notrap aligned region3 v7
 ;;                                     v39 = iconst.i32 7
 ;; @0020                               v11 = uadd_overflow_trap v8, v39, user18  ; v39 = 7
 ;;                                     v45 = iconst.i32 -8
@@ -47,16 +48,16 @@
 ;;                                     v52 = band.i32 v11, v45  ; v45 = -8
 ;;                                     v53 = uextend.i64 v52
 ;; @0020                               v24 = iadd v22, v53
-;; @0020                               store user2 region3 v46, v24  ; v46 = -1342177264
+;; @0020                               store user2 region7 v46, v24  ; v46 = -1342177264
 ;; @0020                               v27 = load.i64 notrap aligned readonly can_move region6 v0+40
 ;; @0020                               v28 = load.i32 notrap aligned readonly can_move v27
-;; @0020                               store user2 region3 v28, v24+4
-;; @0020                               store.i32 user2 region3 v14, v7
+;; @0020                               store user2 region7 v28, v24+4
+;; @0020                               store.i32 notrap aligned region3 v14, v7
 ;; @0020                               v31 = call fn1(v0, v2)
 ;; @0020                               v32 = ireduce.i32 v31
 ;; @0020                               v29 = iconst.i64 8
 ;; @0020                               v30 = iadd v24, v29  ; v29 = 8
-;; @0020                               store user2 little region3 v32, v30
+;; @0020                               store user2 little region7 v32, v30
 ;; @0023                               jump block1
 ;;
 ;;                                 block3 cold:

--- a/tests/disas/gc/null/struct-new-default.wat
+++ b/tests/disas/gc/null/struct-new-default.wat
@@ -15,10 +15,11 @@
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     region2 = 32 "VMContext+0x20"
-;;     region3 = 2147483648 "GcHeap"
+;;     region3 = 3758096384 "VMNullHeapData+0x0"
 ;;     region4 = 268435496 "VMStoreContext+0x28"
 ;;     region5 = 268435488 "VMStoreContext+0x20"
 ;;     region6 = 40 "VMContext+0x28"
+;;     region7 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -28,7 +29,7 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64):
 ;; @0021                               v9 = load.i64 notrap aligned readonly can_move region2 v0+32
-;; @0021                               v10 = load.i32 user2 region3 v9
+;; @0021                               v10 = load.i32 notrap aligned region3 v9
 ;;                                     v42 = iconst.i32 7
 ;; @0021                               v13 = uadd_overflow_trap v10, v42, user18  ; v42 = 7
 ;;                                     v48 = iconst.i32 -8
@@ -47,22 +48,22 @@
 ;;                                     v55 = band.i32 v13, v48  ; v48 = -8
 ;;                                     v56 = uextend.i64 v55
 ;; @0021                               v26 = iadd v24, v56
-;; @0021                               store user2 region3 v49, v26  ; v49 = -1342177256
+;; @0021                               store user2 region7 v49, v26  ; v49 = -1342177256
 ;; @0021                               v29 = load.i64 notrap aligned readonly can_move region6 v0+40
 ;; @0021                               v30 = load.i32 notrap aligned readonly can_move v29
-;; @0021                               store user2 region3 v30, v26+4
-;; @0021                               store.i32 user2 region3 v16, v9
+;; @0021                               store user2 region7 v30, v26+4
+;; @0021                               store.i32 notrap aligned region3 v16, v9
 ;; @0021                               v2 = f32const 0.0
 ;; @0021                               v31 = iconst.i64 8
 ;; @0021                               v32 = iadd v26, v31  ; v31 = 8
-;; @0021                               store user2 little region3 v2, v32  ; v2 = 0.0
+;; @0021                               store user2 little region7 v2, v32  ; v2 = 0.0
 ;; @0021                               v3 = iconst.i32 0
 ;; @0021                               v33 = iconst.i64 12
 ;; @0021                               v34 = iadd v26, v33  ; v33 = 12
-;; @0021                               istore8 user2 little region3 v3, v34  ; v3 = 0
+;; @0021                               istore8 user2 little region7 v3, v34  ; v3 = 0
 ;; @0021                               v35 = iconst.i64 16
 ;; @0021                               v36 = iadd v26, v35  ; v35 = 16
-;; @0021                               store user2 little region3 v3, v36  ; v3 = 0
+;; @0021                               store user2 little region7 v3, v36  ; v3 = 0
 ;; @0024                               jump block1
 ;;
 ;;                                 block3 cold:

--- a/tests/disas/gc/null/struct-new.wat
+++ b/tests/disas/gc/null/struct-new.wat
@@ -16,10 +16,11 @@
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     region2 = 32 "VMContext+0x20"
-;;     region3 = 2147483648 "GcHeap"
+;;     region3 = 3758096384 "VMNullHeapData+0x0"
 ;;     region4 = 268435496 "VMStoreContext+0x28"
 ;;     region5 = 268435488 "VMStoreContext+0x20"
 ;;     region6 = 40 "VMContext+0x28"
+;;     region7 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -31,7 +32,7 @@
 ;;                                     v39 = stack_addr.i64 ss0
 ;;                                     store notrap v4, v39
 ;; @002a                               v9 = load.i64 notrap aligned readonly can_move region2 v0+32
-;; @002a                               v10 = load.i32 user2 region3 v9
+;; @002a                               v10 = load.i32 notrap aligned region3 v9
 ;;                                     v46 = iconst.i32 7
 ;; @002a                               v13 = uadd_overflow_trap v10, v46, user18  ; v46 = 7
 ;;                                     v52 = iconst.i32 -8
@@ -50,21 +51,21 @@
 ;;                                     v59 = band.i32 v13, v52  ; v52 = -8
 ;;                                     v60 = uextend.i64 v59
 ;; @002a                               v26 = iadd v24, v60
-;; @002a                               store user2 region3 v53, v26  ; v53 = -1342177256
+;; @002a                               store user2 region7 v53, v26  ; v53 = -1342177256
 ;; @002a                               v29 = load.i64 notrap aligned readonly can_move region6 v0+40
 ;; @002a                               v30 = load.i32 notrap aligned readonly can_move v29
-;; @002a                               store user2 region3 v30, v26+4
-;; @002a                               store.i32 user2 region3 v16, v9
+;; @002a                               store user2 region7 v30, v26+4
+;; @002a                               store.i32 notrap aligned region3 v16, v9
 ;; @002a                               v31 = iconst.i64 8
 ;; @002a                               v32 = iadd v26, v31  ; v31 = 8
-;; @002a                               store.f32 user2 little region3 v2, v32
+;; @002a                               store.f32 user2 little region7 v2, v32
 ;; @002a                               v33 = iconst.i64 12
 ;; @002a                               v34 = iadd v26, v33  ; v33 = 12
-;; @002a                               istore8.i32 user2 little region3 v3, v34
+;; @002a                               istore8.i32 user2 little region7 v3, v34
 ;;                                     v38 = load.i32 notrap v39
 ;; @002a                               v35 = iconst.i64 16
 ;; @002a                               v36 = iadd v26, v35  ; v35 = 16
-;; @002a                               store user2 little region3 v38, v36
+;; @002a                               store user2 little region7 v38, v36
 ;; @002d                               jump block1
 ;;
 ;;                                 block3 cold:

--- a/tests/disas/gc/struct-new-default.wat
+++ b/tests/disas/gc/struct-new-default.wat
@@ -16,9 +16,11 @@
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     region2 = 32 "VMContext+0x20"
-;;     region3 = 40 "VMContext+0x28"
-;;     region4 = 268435488 "VMStoreContext+0x20"
-;;     region5 = 2147483648 "GcHeap"
+;;     region3 = 3489660928 "VMCopyingHeapData+0x0"
+;;     region4 = 3489660932 "VMCopyingHeapData+0x4"
+;;     region5 = 40 "VMContext+0x28"
+;;     region6 = 268435488 "VMStoreContext+0x20"
+;;     region7 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -29,8 +31,8 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64):
 ;; @0023                               v7 = load.i64 notrap aligned readonly can_move region2 v0+32
-;; @0023                               v8 = load.i32 notrap aligned v7
-;; @0023                               v9 = load.i32 notrap aligned v7+4
+;; @0023                               v8 = load.i32 notrap aligned region3 v7
+;; @0023                               v9 = load.i32 notrap aligned region4 v7+4
 ;; @0023                               v15 = uextend.i64 v8
 ;;                                     v46 = iconst.i64 48
 ;; @0023                               v16 = iadd v15, v46  ; v46 = 48
@@ -41,28 +43,28 @@
 ;;                                 block2:
 ;;                                     v62 = iconst.i32 48
 ;;                                     v60 = iadd.i32 v8, v62  ; v62 = 48
-;; @0023                               store notrap aligned v60, v7
+;; @0023                               store notrap aligned region3 v60, v7
 ;;                                     v63 = iconst.i32 -1342177246
 ;;                                     v64 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v65 = load.i64 notrap aligned readonly can_move region4 v64+32
+;;                                     v65 = load.i64 notrap aligned readonly can_move region6 v64+32
 ;; @0023                               v32 = iadd v65, v15
-;; @0023                               store user2 region5 v63, v32  ; v63 = -1342177246
-;;                                     v66 = load.i64 notrap aligned readonly can_move region3 v0+40
+;; @0023                               store user2 region7 v63, v32  ; v63 = -1342177246
+;;                                     v66 = load.i64 notrap aligned readonly can_move region5 v0+40
 ;;                                     v67 = load.i32 notrap aligned readonly can_move v66
-;; @0023                               store user2 region5 v67, v32+4
+;; @0023                               store user2 region7 v67, v32+4
 ;;                                     v68 = iconst.i64 48
-;; @0023                               istore32 user2 region5 v68, v32+8  ; v68 = 48
+;; @0023                               istore32 user2 region7 v68, v32+8  ; v68 = 48
 ;; @0023                               jump block4(v8, v32)
 ;;
 ;;                                 block3 cold:
 ;; @0023                               v19 = iconst.i32 -1342177246
-;; @0023                               v20 = load.i64 notrap aligned readonly can_move region3 v0+40
+;; @0023                               v20 = load.i64 notrap aligned readonly can_move region5 v0+40
 ;; @0023                               v21 = load.i32 notrap aligned readonly can_move v20
 ;; @0023                               v6 = iconst.i32 48
 ;; @0023                               v22 = iconst.i32 16
 ;; @0023                               v23 = call fn0(v0, v19, v21, v6, v22)  ; v19 = -1342177246, v6 = 48, v22 = 16
 ;; @0023                               v24 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0023                               v25 = load.i64 notrap aligned readonly can_move region4 v24+32
+;; @0023                               v25 = load.i64 notrap aligned readonly can_move region6 v24+32
 ;; @0023                               v26 = uextend.i64 v23
 ;; @0023                               v27 = iadd v25, v26
 ;; @0023                               jump block4(v23, v27)
@@ -71,18 +73,18 @@
 ;; @0023                               v2 = f32const 0.0
 ;; @0023                               v38 = iconst.i64 16
 ;; @0023                               v39 = iadd v37, v38  ; v38 = 16
-;; @0023                               store user2 little region5 v2, v39  ; v2 = 0.0
+;; @0023                               store user2 little region7 v2, v39  ; v2 = 0.0
 ;; @0023                               v3 = iconst.i32 0
 ;; @0023                               v40 = iconst.i64 20
 ;; @0023                               v41 = iadd v37, v40  ; v40 = 20
-;; @0023                               istore8 user2 little region5 v3, v41  ; v3 = 0
+;; @0023                               istore8 user2 little region7 v3, v41  ; v3 = 0
 ;; @0023                               v42 = iconst.i64 24
 ;; @0023                               v43 = iadd v37, v42  ; v42 = 24
-;; @0023                               store user2 little region5 v3, v43  ; v3 = 0
+;; @0023                               store user2 little region7 v3, v43  ; v3 = 0
 ;; @0023                               v5 = vconst.i8x16 const0
 ;; @0023                               v44 = iconst.i64 32
 ;; @0023                               v45 = iadd v37, v44  ; v44 = 32
-;; @0023                               store user2 little region5 v5, v45  ; v5 = const0
+;; @0023                               store user2 little region7 v5, v45  ; v5 = const0
 ;; @0026                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/struct-new.wat
+++ b/tests/disas/gc/struct-new.wat
@@ -16,9 +16,11 @@
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 268435480 "VMStoreContext+0x18"
 ;;     region2 = 32 "VMContext+0x20"
-;;     region3 = 40 "VMContext+0x28"
-;;     region4 = 268435488 "VMStoreContext+0x20"
-;;     region5 = 2147483648 "GcHeap"
+;;     region3 = 3489660928 "VMCopyingHeapData+0x0"
+;;     region4 = 3489660932 "VMCopyingHeapData+0x4"
+;;     region5 = 40 "VMContext+0x28"
+;;     region6 = 268435488 "VMStoreContext+0x20"
+;;     region7 = 2147483648 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -30,8 +32,8 @@
 ;;                                     v45 = stack_addr.i64 ss0
 ;;                                     store notrap v4, v45
 ;; @002a                               v6 = load.i64 notrap aligned readonly can_move region2 v0+32
-;; @002a                               v7 = load.i32 notrap aligned v6
-;; @002a                               v8 = load.i32 notrap aligned v6+4
+;; @002a                               v7 = load.i32 notrap aligned region3 v6
+;; @002a                               v8 = load.i32 notrap aligned region4 v6+4
 ;; @002a                               v14 = uextend.i64 v7
 ;;                                     v46 = iconst.i64 32
 ;; @002a                               v15 = iadd v14, v46  ; v46 = 32
@@ -42,28 +44,28 @@
 ;;                                 block2:
 ;;                                     v62 = iconst.i32 32
 ;;                                     v60 = iadd.i32 v7, v62  ; v62 = 32
-;; @002a                               store notrap aligned v60, v6
+;; @002a                               store notrap aligned region3 v60, v6
 ;;                                     v63 = iconst.i32 -1342177246
 ;;                                     v64 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v65 = load.i64 notrap aligned readonly can_move region4 v64+32
+;;                                     v65 = load.i64 notrap aligned readonly can_move region6 v64+32
 ;; @002a                               v31 = iadd v65, v14
-;; @002a                               store user2 region5 v63, v31  ; v63 = -1342177246
-;;                                     v66 = load.i64 notrap aligned readonly can_move region3 v0+40
+;; @002a                               store user2 region7 v63, v31  ; v63 = -1342177246
+;;                                     v66 = load.i64 notrap aligned readonly can_move region5 v0+40
 ;;                                     v67 = load.i32 notrap aligned readonly can_move v66
-;; @002a                               store user2 region5 v67, v31+4
+;; @002a                               store user2 region7 v67, v31+4
 ;;                                     v68 = iconst.i64 32
-;; @002a                               istore32 user2 region5 v68, v31+8  ; v68 = 32
+;; @002a                               istore32 user2 region7 v68, v31+8  ; v68 = 32
 ;; @002a                               jump block4(v7, v31)
 ;;
 ;;                                 block3 cold:
 ;; @002a                               v18 = iconst.i32 -1342177246
-;; @002a                               v19 = load.i64 notrap aligned readonly can_move region3 v0+40
+;; @002a                               v19 = load.i64 notrap aligned readonly can_move region5 v0+40
 ;; @002a                               v20 = load.i32 notrap aligned readonly can_move v19
 ;; @002a                               v5 = iconst.i32 32
 ;; @002a                               v21 = iconst.i32 16
 ;; @002a                               v22 = call fn0(v0, v18, v20, v5, v21), stack_map=[i32 @ ss0+0]  ; v18 = -1342177246, v5 = 32, v21 = 16
 ;; @002a                               v23 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @002a                               v24 = load.i64 notrap aligned readonly can_move region4 v23+32
+;; @002a                               v24 = load.i64 notrap aligned readonly can_move region6 v23+32
 ;; @002a                               v25 = uextend.i64 v22
 ;; @002a                               v26 = iadd v24, v25
 ;; @002a                               jump block4(v22, v26)
@@ -71,14 +73,14 @@
 ;;                                 block4(v35: i32, v36: i64):
 ;; @002a                               v37 = iconst.i64 16
 ;; @002a                               v38 = iadd v36, v37  ; v37 = 16
-;; @002a                               store.f32 user2 little region5 v2, v38
+;; @002a                               store.f32 user2 little region7 v2, v38
 ;; @002a                               v39 = iconst.i64 20
 ;; @002a                               v40 = iadd v36, v39  ; v39 = 20
-;; @002a                               istore8.i32 user2 little region5 v3, v40
+;; @002a                               istore8.i32 user2 little region7 v3, v40
 ;;                                     v44 = load.i32 notrap v45
 ;; @002a                               v41 = iconst.i64 24
 ;; @002a                               v42 = iadd v36, v41  ; v41 = 24
-;; @002a                               store user2 little region5 v44, v42
+;; @002a                               store user2 little region7 v44, v42
 ;; @002d                               jump block1
 ;;
 ;;                                 block1:


### PR DESCRIPTION
Add `VMDrcHeapData`, `VMCopyingHeapData`, and `VMNullHeapData` variants of `VmType` and `AliasRegions` helpers that emit their field loads/stores. Tag the DRC over-approximated-stack-roots list head/length fields, the copying collector's bump_ptr/active_space_end, and the null collector's bump finger with their owning struct's region instead of `gc_memflags()`.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
