### PR TITLE
fix p3 request.set-authority rejecting ipv6 literal authorities

### DIFF
--- a/crates/wasi-http/src/p3/host/types.rs
+++ b/crates/wasi-http/src/p3/host/types.rs
@@ -123,6 +123,25 @@ fn delete_request_options(
         .context("failed to delete request options from table")
 }
 
+/// Parse an outgoing request `authority`, rejecting a malformed value.
+///
+/// `http::uri::Authority` accepts an authority whose port section is empty or
+/// non-numeric (for example `example.com:` or `example.com:abc`), so the port
+/// is validated here as well. A `:` inside an IPv6 literal host such as `[::1]`
+/// is part of the host rather than a port delimiter, so the port is only looked
+/// for after any closing bracket.
+fn parse_authority(authority: String) -> Result<http::uri::Authority, ()> {
+    let has_port = match authority.rfind(']') {
+        Some(i) => authority[i..].contains(':'),
+        None => authority.contains(':'),
+    };
+    let authority = http::uri::Authority::try_from(authority).map_err(|_| ())?;
+    if has_port && authority.port_u16().is_none() {
+        return Err(());
+    }
+    Ok(authority)
+}
+
 fn parse_header_value(
     name: &http::HeaderName,
     value: impl AsRef<[u8]>,
@@ -468,13 +487,9 @@ impl HostRequest for WasiHttpCtxView<'_> {
             req.authority = None;
             return Ok(Ok(()));
         };
-        let has_port = authority.contains(':');
-        let Ok(authority) = http::uri::Authority::try_from(authority) else {
+        let Ok(authority) = parse_authority(authority) else {
             return Ok(Err(()));
         };
-        if has_port && authority.port_u16().is_none() {
-            return Ok(Err(()));
-        }
         req.authority = Some(authority);
         Ok(Ok(()))
     }
@@ -730,5 +745,25 @@ mod tests {
 
         // other header names are unaffected
         assert!(parse_header_value(&CONTENT_TYPE, "text/plain").is_ok());
+    }
+
+    #[test]
+    fn authority_accepts_ipv6_and_validates_ports() {
+        use super::parse_authority;
+
+        // Host names and IPv4 literals, with and without an explicit port.
+        assert!(parse_authority("example.com".into()).is_ok());
+        assert!(parse_authority("example.com:443".into()).is_ok());
+        assert!(parse_authority("127.0.0.1:80".into()).is_ok());
+
+        // Bracketed IPv6 literals: the colons belong to the host, so a missing
+        // port must still be accepted and not mistaken for an empty port.
+        assert!(parse_authority("[::1]".into()).is_ok());
+        assert!(parse_authority("[2001:db8::1]".into()).is_ok());
+        assert!(parse_authority("[::1]:443".into()).is_ok());
+
+        // When a port section is present it must be a valid number.
+        assert!(parse_authority("example.com:".into()).is_err());
+        assert!(parse_authority("example.com:abc".into()).is_err());
     }
 }


### PR DESCRIPTION
Repro: in WASIp3, call `request.set-authority` with a bracketed IPv6 literal that has no explicit port, for example `[::1]` or `[2001:db8::1]`. The call returns an error and the authority is never set.

Cause: the validation detects whether a port was supplied with `authority.contains(':')` before checking that the port parses. That is also true for the colons inside an IPv6 literal host, so the later "port present but not a valid number" guard fires and a perfectly valid IPv6 authority is rejected unless a port is also appended.

Fix: look for the port only after any closing `]`, so colons inside the IPv6 host are not mistaken for a port. A genuinely malformed port such as `example.com:` or `example.com:abc` is still rejected. The check moved into a small `parse_authority` helper with unit tests for the host-name, IPv4, and bracketed IPv6 forms.