### PR TITLE
Cranelift: Avoid a clone of `LastStores` in the alias analysis

### DIFF
--- a/cranelift/codegen/src/alias_analysis.rs
+++ b/cranelift/codegen/src/alias_analysis.rs
@@ -146,15 +146,16 @@ impl LastStores {
     /// Returns `true` if `self` changed, `false` otherwise.
     fn meet_from(&mut self, other: &LastStores, loc: Inst) -> bool {
         let meet = |a: &mut PackedOption<Inst>, b: PackedOption<Inst>| -> bool {
-            let (inst, changed) = match (a.expand(), b.expand()) {
-                (None, None) => (None, false),
-                (Some(a), None) => (Some(a), true),
-                (None, Some(b)) => (Some(b), true),
-                (Some(a), Some(b)) if a == b => (Some(a), false),
-                (Some(a), Some(_)) => (Some(loc), a != loc),
+            let old = a.expand();
+            let new = match (old, b.expand()) {
+                (None, None) => None,
+                (Some(a), None) => Some(a),
+                (None, Some(b)) => Some(b),
+                (Some(a), Some(b)) if a == b => Some(a),
+                (Some(_), Some(_)) => Some(loc),
             };
-            *a = inst.into();
-            changed
+            *a = new.into();
+            old != new
         };
 
         // Meet all region slots.

--- a/cranelift/codegen/src/alias_analysis.rs
+++ b/cranelift/codegen/src/alias_analysis.rs
@@ -141,25 +141,32 @@ impl LastStores {
         }
     }
 
-    fn meet_from(&mut self, other: &LastStores, loc: Inst) {
-        let meet = |a: PackedOption<Inst>, b: PackedOption<Inst>| -> PackedOption<Inst> {
-            match (a.into(), b.into()) {
-                (None, None) => None.into(),
-                (Some(a), None) => a,
-                (None, Some(b)) => b,
-                (Some(a), Some(b)) if a == b => a,
-                _ => loc.into(),
-            }
+    /// Meet `self` with `other` and place the result in `self`.
+    ///
+    /// Returns `true` if `self` changed, `false` otherwise.
+    fn meet_from(&mut self, other: &LastStores, loc: Inst) -> bool {
+        let meet = |a: &mut PackedOption<Inst>, b: PackedOption<Inst>| -> bool {
+            let (inst, changed) = match (a.expand(), b.expand()) {
+                (None, None) => (None.into(), false),
+                (Some(a), None) => (Some(a), true),
+                (None, Some(b)) => (Some(b), true),
+                (Some(a), Some(b)) if a == b => (Some(a), false),
+                (Some(a), Some(_)) => (Some(loc), a != loc),
+            };
+            *a = inst.into();
+            changed
         };
 
         // Meet all region slots.
+        let mut changed = false;
         let max_len = core::cmp::max(self.regions.keys().len(), other.regions.keys().len());
         for i in 0..max_len {
             let ar = AliasRegion::new(i);
-            self.regions[ar] = meet(self.regions[ar], other.regions[ar]);
+            changed |= meet(&mut self.regions[ar], other.regions[ar]);
         }
-        self.other = meet(self.other, other.other);
-        self.last_fence = meet(self.last_fence, other.last_fence);
+        changed |= meet(&mut self.other, other.other);
+        changed |= meet(&mut self.last_fence, other.last_fence);
+        changed
     }
 }
 
@@ -262,11 +269,7 @@ impl<'a> AliasAnalysis<'a> {
             visit_block_succs(func, block, |_inst, succ, _from_table| {
                 let succ_first_inst = func.layout.block_insts(succ).next().unwrap();
                 let updated = match self.block_input.get_mut(&succ) {
-                    Some(succ_state) => {
-                        let old = succ_state.clone();
-                        succ_state.meet_from(&state, succ_first_inst);
-                        *succ_state != old
-                    }
+                    Some(succ_state) => succ_state.meet_from(&state, succ_first_inst),
                     None => {
                         self.block_input.insert(succ, state.clone());
                         true

--- a/cranelift/codegen/src/alias_analysis.rs
+++ b/cranelift/codegen/src/alias_analysis.rs
@@ -147,7 +147,7 @@ impl LastStores {
     fn meet_from(&mut self, other: &LastStores, loc: Inst) -> bool {
         let meet = |a: &mut PackedOption<Inst>, b: PackedOption<Inst>| -> bool {
             let (inst, changed) = match (a.expand(), b.expand()) {
-                (None, None) => (None.into(), false),
+                (None, None) => (None, false),
                 (Some(a), None) => (Some(a), true),
                 (None, Some(b)) => (Some(b), true),
                 (Some(a), Some(b)) if a == b => (Some(a), false),

--- a/cranelift/codegen/src/alias_analysis.rs
+++ b/cranelift/codegen/src/alias_analysis.rs
@@ -149,10 +149,8 @@ impl LastStores {
             let old = a.expand();
             let new = match (old, b.expand()) {
                 (None, None) => None,
-                (Some(a), None) => Some(a),
-                (None, Some(b)) => Some(b),
                 (Some(a), Some(b)) if a == b => Some(a),
-                (Some(_), Some(_)) => Some(loc),
+                _ => Some(loc),
             };
             *a = new.into();
             old != new

--- a/cranelift/filetests/filetests/alias/control-flow-join-lossy.clif
+++ b/cranelift/filetests/filetests/alias/control-flow-join-lossy.clif
@@ -1,0 +1,49 @@
+test optimize precise-output
+set opt_level=speed
+target aarch64
+
+function %f(i64) -> i32 {
+    region0 = 0 "R"
+    fn0 = colocated %g()
+
+block0(v0: i64):
+    v1 = iconst.i32 42
+    store.i32 region0 v1, v0
+    brif v0, block1, block2
+
+block1:
+    call fn0()
+    jump block3
+
+block2:
+    jump block3
+
+block3:
+    ;; Because the the call (which acts as a memory fence) we must forget the
+    ;; current value at memory location `v0+0` at the control-flow join point
+    ;; and we cannot do store-to-load forwarding here.
+    v2 = load.i32 region0 v0
+    return v2
+}
+
+; function %f(i64) -> i32 fast {
+;     region0 = 0 "R"
+;     sig0 = () fast
+;     fn0 = colocated %g sig0
+;
+; block0(v0: i64):
+;     v1 = iconst.i32 42
+;     store region0 v1, v0  ; v1 = 42
+;     brif v0, block1, block2
+;
+; block1:
+;     call fn0()
+;     jump block3
+;
+; block2:
+;     jump block3
+;
+; block3:
+;     v2 = load.i32 region0 v0
+;     return v2
+; }


### PR DESCRIPTION
The `LastStores` struct contains an owned heap allocation (via `SecondaryMap`) so best to avoid cloning it when we can.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
