### PR TITLE
wasmtime-fiber: support custom fiber stacks in no-std builds.

### DIFF
--- a/crates/fiber/src/lib.rs
+++ b/crates/fiber/src/lib.rs
@@ -454,6 +454,59 @@ mod tests {
     }
 
     #[test]
+    fn custom_stack() {
+        use super::RuntimeFiberStack;
+        use core::ops::Range;
+
+        struct CustomStack {
+            // `u128` to guarantee alignment.
+            buf: std::vec::Vec<u128>,
+        }
+        unsafe impl Send for CustomStack {}
+        unsafe impl Sync for CustomStack {}
+        unsafe impl RuntimeFiberStack for CustomStack {
+            fn top(&self) -> *mut u8 {
+                self.range().end as *mut u8
+            }
+            fn range(&self) -> Range<usize> {
+                let base = self.buf.as_ptr() as usize;
+                base..base + self.buf.len() * core::mem::size_of::<u128>()
+            }
+            fn guard_range(&self) -> Range<*mut u8> {
+                core::ptr::null_mut()..core::ptr::null_mut()
+            }
+        }
+
+        // A 1 MiB stack (65536 * 16 bytes).
+        let stack = FiberStack::from_custom(std::boxed::Box::new(CustomStack {
+            buf: std::vec![0u128; 1024 * 1024 / 16],
+        }))
+        .unwrap();
+        // A custom stack is not considered a `from_raw_parts` stack.
+        assert!(!stack.is_from_raw_parts());
+
+        let hit = Rc::new(Cell::new(false));
+        let hit2 = hit.clone();
+        let fiber = Fiber::<(), (), ()>::new(stack, move |_, s| {
+            hit2.set(true);
+            s.suspend(());
+            hit2.set(false);
+        })
+        .unwrap();
+        assert!(!hit.get());
+        // First resume runs up to the suspend point.
+        assert!(fiber.resume(()).is_err());
+        assert!(hit.get());
+        // Second resume runs to completion.
+        assert!(fiber.resume(()).is_ok());
+        assert!(!hit.get());
+
+        // The reclaimed stack still reports its range correctly.
+        let stack = fiber.into_stack();
+        assert!(stack.range().is_some());
+    }
+
+    #[test]
     fn cross_thread_fiber() {
         let fiber = Fiber::<(), (), ()>::new(fiber_stack(1024 * 1024), move |_, s| {
             s.suspend(());

--- a/crates/fiber/src/lib.rs
+++ b/crates/fiber/src/lib.rs
@@ -454,6 +454,8 @@ mod tests {
     }
 
     #[test]
+    // Don't run under `std` -- we assert that the stack is page-aligned there.
+    #[cfg(not(feature = "std"))]
     fn custom_stack() {
         use super::RuntimeFiberStack;
         use core::ops::Range;

--- a/crates/fiber/src/nostd.rs
+++ b/crates/fiber/src/nostd.rs
@@ -39,9 +39,19 @@ pub use wasmtime_environ::error::Error;
 pub struct FiberStack {
     base: BasePtr,
     len: usize,
+    storage: FiberStackStorage,
+}
+
+#[expect(
+    dead_code,
+    reason = "fields are held to own the backing storage until drop"
+)]
+enum FiberStackStorage {
     /// Backing storage, if owned. Allocated once at startup and then
     /// not reallocated afterward.
-    storage: TryVec<Align16>,
+    Owned(TryVec<Align16>),
+    Unmanaged,
+    Custom(Box<dyn RuntimeFiberStack>),
 }
 
 #[repr(align(16))]
@@ -70,24 +80,30 @@ impl FiberStack {
         Ok(FiberStack {
             base: BasePtr(storage.as_mut_ptr().cast()),
             len: storage.capacity() * 16,
-            storage,
+            storage: FiberStackStorage::Owned(storage),
         })
     }
 
     pub unsafe fn from_raw_parts(base: *mut u8, guard_size: usize, len: usize) -> Result<Self> {
         Ok(FiberStack {
-            storage: TryVec::default(),
+            storage: FiberStackStorage::Unmanaged,
             base: BasePtr(unsafe { base.offset(isize::try_from(guard_size).unwrap()) }),
             len,
         })
     }
 
     pub fn is_from_raw_parts(&self) -> bool {
-        self.storage.is_empty()
+        matches!(self.storage, FiberStackStorage::Unmanaged)
     }
 
-    pub fn from_custom(_custom: Box<dyn RuntimeFiberStack>) -> Result<Self> {
-        unimplemented!("Custom fiber stacks not supported in no_std fiber library")
+    pub fn from_custom(custom: Box<dyn RuntimeFiberStack>) -> Result<Self> {
+        let range = custom.range();
+        let start_ptr = range.start as *mut u8;
+        Ok(FiberStack {
+            base: BasePtr(start_ptr),
+            len: range.len(),
+            storage: FiberStackStorage::Custom(custom),
+        })
     }
 
     pub fn top(&self) -> Option<*mut u8> {


### PR DESCRIPTION
The ability to use the `StackCreator` API is useful, even (maybe especially?) for no-std targets where custom allocation schemes may be used. This allocation path was not wired all the way through in our no-std backend in the fiber library. This PR finishes that (mirroring the Unixlike implementation's storage-enum scheme to hold the boxed dyn trait alive) and adds a direct fiber-crate test to exercise it.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
