### PR TITLE
Adjust alignment assertions in C headers

### DIFF
--- a/crates/c-api/include/wasmtime/val.h
+++ b/crates/c-api/include/wasmtime/val.h
@@ -350,10 +350,11 @@ static inline void __wasmtime_val_assertions() {
                     sizeof(wasmtime_valunion_t) <= 24,
                 "should be 16 bytes plus a pointer large (plus alignment on "
                 "some platforms)");
-  static_assert(__alignof(wasmtime_valunion_t) == 8,
-                "should be 8-byte aligned");
+  static_assert(__alignof(wasmtime_valunion_t) == __alignof(uint64_t),
+                "should be aligned to u64");
   static_assert(sizeof(wasmtime_val_raw_t) == 16, "should be 16 bytes large");
-  static_assert(__alignof(wasmtime_val_raw_t) == 8, "should be 8-byte aligned");
+  static_assert(__alignof(wasmtime_val_raw_t) == __alignof(uint64_t),
+                "should be aligned to u64");
 }
 
 /**


### PR DESCRIPTION
This was adjusted in #9039 in the source but forgot to update the headers at the time.

cc #13733

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
