### PR TITLE
Cranelift: Fix unused warning on some builds

### DIFF
--- a/cranelift/codegen/src/machinst/lower.rs
+++ b/cranelift/codegen/src/machinst/lower.rs
@@ -1623,6 +1623,13 @@ impl<'func, I: VCodeInst> Lower<'func, I> {
     }
 
     /// Increment the reference count for the Value, ensuring that it gets lowered.
+    #[cfg(any(
+        feature = "x86",
+        feature = "arm64",
+        feature = "riscv64",
+        feature = "s390x",
+        feature = "pulley"
+    ))]
     pub fn increment_lowered_uses(&mut self, val: Value) {
         self.value_lowered_uses[val] += 1
     }


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
