### PR TITLE
Remove `component_task_state_mut` accessor

### DIFF
--- a/crates/wasmtime/src/runtime/component/concurrent_disabled.rs
+++ b/crates/wasmtime/src/runtime/component/concurrent_disabled.rs
@@ -2,23 +2,10 @@ use crate::component::func::{LiftContext, LowerContext};
 use crate::component::matching::InstanceType;
 use crate::component::{ComponentType, Lift, Lower, RuntimeInstance, Val};
 use crate::store::StoreOpaque;
-use crate::vm::component::CallContext;
 use crate::{Result, bail, error::format_err};
 use core::convert::Infallible;
 use core::mem::MaybeUninit;
 use wasmtime_environ::component::{CanonicalAbiInfo, InterfaceType};
-
-pub enum ConcurrentState {}
-
-impl ConcurrentState {
-    pub fn call_context(&mut self, _: u32) -> Result<&mut CallContext> {
-        match *self {}
-    }
-
-    pub fn current_call_context_scope_id(&self) -> Result<u32> {
-        match *self {}
-    }
-}
 
 fn should_have_failed_validation<T>(what: &str) -> Result<T> {
     // This should be unreachable; if we trap here, it indicates a

--- a/crates/wasmtime/src/runtime/component/store.rs
+++ b/crates/wasmtime/src/runtime/component/store.rs
@@ -5,7 +5,7 @@ use crate::runtime::vm::component::{
     CallContext, ComponentInstance, HandleTable, OwnedComponentInstance,
 };
 use crate::store::{StoreData, StoreId, StoreOpaque};
-use crate::{AsContext, AsContextMut, Engine, Store, StoreContextMut, bail_bug};
+use crate::{AsContext, AsContextMut, Engine, Store, StoreContextMut};
 use core::pin::Pin;
 use wasmtime_environ::component::RuntimeComponentInstanceIndex;
 use wasmtime_environ::prelude::TryPrimaryMap;
@@ -466,7 +466,7 @@ impl StoreOpaque {
                 None => Ok(None),
             },
             #[cfg(feature = "component-model-async")]
-            ComponentTaskState::Concurrent(_) => bail_bug!("should not be reachable"),
+            ComponentTaskState::Concurrent(_) => crate::bail_bug!("should not be reachable"),
         }
     }
 }

--- a/crates/wasmtime/src/runtime/component/store.rs
+++ b/crates/wasmtime/src/runtime/component/store.rs
@@ -1,5 +1,4 @@
 use crate::prelude::*;
-use crate::runtime::component::concurrent::ConcurrentState;
 use crate::runtime::component::{HostResourceData, Instance};
 use crate::runtime::vm;
 use crate::runtime::vm::component::{
@@ -14,6 +13,7 @@ use wasmtime_environ::prelude::TryPrimaryMap;
 #[cfg(feature = "component-model-async")]
 use crate::{
     component::ResourceTable,
+    component::concurrent::ConcurrentState,
     runtime::vm::{VMStore, component::InstanceState},
 };
 
@@ -66,6 +66,7 @@ pub enum ComponentTaskState {
 
     /// Used when `Config::concurrency_support` is enabled and has
     /// full state for all async tasks.
+    #[cfg(feature = "component-model-async")]
     Concurrent(ConcurrentState),
 }
 
@@ -297,15 +298,6 @@ impl StoreOpaque {
         &mut self.store_data_mut().components
     }
 
-    pub(crate) fn component_task_state_mut(&mut self) -> Result<&mut ComponentTaskState> {
-        // NB: Force the deferred lazy thread, if any, before handing out task
-        // state.
-        #[cfg(feature = "component-model-async")]
-        let _ = self.current_thread()?;
-
-        Ok(&mut self.component_data_mut().task_state)
-    }
-
     pub(crate) fn push_component_instance(&mut self, instance: Instance) {
         // We don't actually need the instance itself right now, but it seems
         // like something we will almost certainly eventually want to keep
@@ -431,6 +423,7 @@ impl StoreOpaque {
     pub(crate) fn enter_call_not_concurrent(&mut self) -> Result<()> {
         let state = match &mut self.component_data_mut().task_state {
             ComponentTaskState::NotConcurrent(state) => state,
+            #[cfg(feature = "component-model-async")]
             ComponentTaskState::Concurrent(_) => unreachable!(),
         };
         state.scopes.push(CallContext::default())?;
@@ -440,6 +433,7 @@ impl StoreOpaque {
     pub(crate) fn exit_call_not_concurrent(&mut self) {
         let state = match &mut self.component_data_mut().task_state {
             ComponentTaskState::NotConcurrent(state) => state,
+            #[cfg(feature = "component-model-async")]
             ComponentTaskState::Concurrent(_) => unreachable!(),
         };
         state.scopes.pop();
@@ -471,6 +465,7 @@ impl StoreOpaque {
                 Some(i) => Ok(Some(u32::try_from(i)?)),
                 None => Ok(None),
             },
+            #[cfg(feature = "component-model-async")]
             ComponentTaskState::Concurrent(_) => bail_bug!("should not be reachable"),
         }
     }
@@ -554,10 +549,12 @@ impl ComponentTaskState {
     pub fn call_context(&mut self, id: u32) -> Result<&mut CallContext> {
         match self {
             ComponentTaskState::NotConcurrent(state) => Ok(&mut state.scopes[id as usize]),
+            #[cfg(feature = "component-model-async")]
             ComponentTaskState::Concurrent(state) => state.call_context(id),
         }
     }
 
+    #[cfg(feature = "component-model-async")]
     pub fn concurrent_state_mut(&mut self) -> &mut ConcurrentState {
         match self {
             ComponentTaskState::Concurrent(state) => state,

--- a/crates/wasmtime/src/runtime/store.rs
+++ b/crates/wasmtime/src/runtime/store.rs
@@ -2471,13 +2471,6 @@ unsafe impl<T> VMStore for StoreInner<T> {
         self
     }
 
-    #[cfg(feature = "component-model")]
-    fn component_task_state_mut(
-        &mut self,
-    ) -> Result<&mut crate::component::store::ComponentTaskState> {
-        StoreOpaque::component_task_state_mut(self)
-    }
-
     fn store_opaque(&self) -> &StoreOpaque {
         &self.inner
     }

--- a/crates/wasmtime/src/runtime/vm.rs
+++ b/crates/wasmtime/src/runtime/vm.rs
@@ -219,12 +219,6 @@ pub unsafe trait VMStore: 'static {
     #[cfg(target_has_atomic = "64")]
     fn new_epoch_updated_deadline(&mut self) -> Result<crate::UpdateDeadline>;
 
-    /// Metadata required for resources for the component model.
-    #[cfg(feature = "component-model")]
-    fn component_task_state_mut(
-        &mut self,
-    ) -> Result<&mut crate::component::store::ComponentTaskState>;
-
     #[cfg(feature = "component-model-async")]
     fn component_async_store(
         &mut self,


### PR DESCRIPTION
Turns out this is dead code

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
