### PR TITLE
Tag inlined `VM*Import` types with alias regions

### DIFF
--- a/crates/cranelift/src/alias_region.rs
+++ b/crates/cranelift/src/alias_region.rs
@@ -27,6 +27,11 @@ enum VmType {
     VMDeferredThread,
     VMContRef,
     ContinuationStackMemory,
+    VMFunctionImport,
+    VMMemoryImport,
+    VMTableImport,
+    VMTagImport,
+    VMGlobalImport,
 }
 
 /// A key that uniquely identifies an alias region across an entire compilation.
@@ -123,6 +128,11 @@ impl AliasRegionKey {
     const VM_DEFERRED_THREAD_KIND: u32 = Self::new_kind(0b01111);
     const VM_CONTREF_KIND: u32 = Self::new_kind(0b10000);
     const CONTINUATION_STACK_MEMORY_KIND: u32 = Self::new_kind(0b10001);
+    const VM_FUNCTION_IMPORT_KIND: u32 = Self::new_kind(0b10010);
+    const VM_MEMORY_IMPORT_KIND: u32 = Self::new_kind(0b10011);
+    const VM_TABLE_IMPORT_KIND: u32 = Self::new_kind(0b10100);
+    const VM_TAG_IMPORT_KIND: u32 = Self::new_kind(0b10101);
+    const VM_GLOBAL_IMPORT_KIND: u32 = Self::new_kind(0b10110);
 
     /// Encode this key into a raw `u32` suitable for use as an
     /// `AliasRegionData::user_id`.
@@ -142,6 +152,11 @@ impl AliasRegionKey {
                     VmType::VMDeferredThread => Self::VM_DEFERRED_THREAD_KIND,
                     VmType::VMContRef => Self::VM_CONTREF_KIND,
                     VmType::ContinuationStackMemory => Self::CONTINUATION_STACK_MEMORY_KIND,
+                    VmType::VMFunctionImport => Self::VM_FUNCTION_IMPORT_KIND,
+                    VmType::VMMemoryImport => Self::VM_MEMORY_IMPORT_KIND,
+                    VmType::VMTableImport => Self::VM_TABLE_IMPORT_KIND,
+                    VmType::VMTagImport => Self::VM_TAG_IMPORT_KIND,
+                    VmType::VMGlobalImport => Self::VM_GLOBAL_IMPORT_KIND,
                 };
                 kind | (offset & Self::OFFSET_MASK)
             }
@@ -453,6 +468,34 @@ where
 /// `VMContext`-related methods that are specific to a particular Wasm module's
 /// `VMOffsets`.
 impl AliasRegions<VMOffsets<u8>> {
+    /// Like `vmctx_load`, but tags the load with a per-import alias region
+    /// rather than the coarse `VMContext` region. Used for fields of the
+    /// `VM*Import` structs inlined into the `VMContext`.
+    fn vmimport_load(
+        &mut self,
+        cursor: &mut FuncCursor<'_>,
+        ty: ir::Type,
+        base_flags: ir::MemFlagsData,
+        vmctx: ir::Value,
+        vmctx_offset: u32,
+        field_offset: u32,
+        vm_type: VmType,
+    ) -> ir::Value {
+        let region = self.region(
+            cursor.func,
+            AliasRegionKey::Vm {
+                ty: vm_type,
+                offset: field_offset,
+            },
+        );
+        cursor.ins().load(
+            ty,
+            base_flags.with_alias_region(Some(region)),
+            vmctx,
+            i32::try_from(vmctx_offset).unwrap(),
+        )
+    }
+
     /// Load the imported tag's `VMTagImport::vmctx` field from the `*mut
     /// VMContext`.
     pub fn vmctx_vmtag_import_vmctx(
@@ -461,12 +504,14 @@ impl AliasRegions<VMOffsets<u8>> {
         vmctx: ir::Value,
         tag: TagIndex,
     ) -> ir::Value {
-        self.vmctx_load(
+        self.vmimport_load(
             cursor,
             self.pointer_type,
             ir::MemFlagsData::trusted().with_readonly().with_can_move(),
             vmctx,
             self.offsets.vmctx_vmtag_import_vmctx(tag),
+            self.offsets.vmtag_import_vmctx().into(),
+            VmType::VMTagImport,
         )
     }
 
@@ -478,12 +523,14 @@ impl AliasRegions<VMOffsets<u8>> {
         vmctx: ir::Value,
         tag: TagIndex,
     ) -> ir::Value {
-        self.vmctx_load(
+        self.vmimport_load(
             cursor,
             ir::types::I32,
             ir::MemFlagsData::trusted().with_readonly().with_can_move(),
             vmctx,
             self.offsets.vmctx_vmtag_import_index(tag),
+            self.offsets.vmtag_import_index().into(),
+            VmType::VMTagImport,
         )
     }
 
@@ -495,12 +542,14 @@ impl AliasRegions<VMOffsets<u8>> {
         vmctx: ir::Value,
         tag: TagIndex,
     ) -> ir::Value {
-        self.vmctx_load(
+        self.vmimport_load(
             cursor,
             self.pointer_type,
             ir::MemFlagsData::trusted().with_readonly().with_can_move(),
             vmctx,
             self.offsets.vmctx_vmtag_import_from(tag),
+            self.offsets.vmtag_import_from().into(),
+            VmType::VMTagImport,
         )
     }
 
@@ -512,12 +561,14 @@ impl AliasRegions<VMOffsets<u8>> {
         vmctx: ir::Value,
         func: FuncIndex,
     ) -> ir::Value {
-        self.vmctx_load(
+        self.vmimport_load(
             cursor,
             self.pointer_type,
             ir::MemFlagsData::trusted().with_readonly().with_can_move(),
             vmctx,
             self.offsets.vmctx_vmfunction_import_vmctx(func),
+            self.offsets.vmfunction_import_vmctx().into(),
+            VmType::VMFunctionImport,
         )
     }
 
@@ -529,12 +580,14 @@ impl AliasRegions<VMOffsets<u8>> {
         vmctx: ir::Value,
         func: FuncIndex,
     ) -> ir::Value {
-        self.vmctx_load(
+        self.vmimport_load(
             cursor,
             self.pointer_type,
             ir::MemFlagsData::trusted().with_readonly().with_can_move(),
             vmctx,
             self.offsets.vmctx_vmfunction_import_wasm_call(func),
+            self.offsets.vmfunction_import_wasm_call().into(),
+            VmType::VMFunctionImport,
         )
     }
 
@@ -548,12 +601,14 @@ impl AliasRegions<VMOffsets<u8>> {
     ) -> ir::Value {
         let mem_offset = self.offsets.vmctx_vmmemory_import(memory);
         let mem_vmctx_offset = mem_offset + u32::from(self.offsets.vmmemory_import_vmctx());
-        self.vmctx_load(
+        self.vmimport_load(
             cursor,
             self.pointer_type,
             ir::MemFlagsData::trusted().with_readonly().with_can_move(),
             vmctx,
             mem_vmctx_offset,
+            self.offsets.vmmemory_import_vmctx().into(),
+            VmType::VMMemoryImport,
         )
     }
 
@@ -567,12 +622,14 @@ impl AliasRegions<VMOffsets<u8>> {
     ) -> ir::Value {
         let mem_offset = self.offsets.vmctx_vmmemory_import(memory);
         let mem_index_offset = mem_offset + u32::from(self.offsets.vmmemory_import_index());
-        self.vmctx_load(
+        self.vmimport_load(
             cursor,
             ir::types::I32,
             ir::MemFlagsData::trusted().with_readonly().with_can_move(),
             vmctx,
             mem_index_offset,
+            self.offsets.vmmemory_import_index().into(),
+            VmType::VMMemoryImport,
         )
     }
 
@@ -597,7 +654,13 @@ impl AliasRegions<VMOffsets<u8>> {
     ) -> Load {
         let mem_offset = self.offsets.vmctx_vmmemory_import(memory);
         let offset = mem_offset + u32::from(self.offsets.vmmemory_import_from());
-        let region = self.vmctx_region(func, offset);
+        let region = self.region(
+            func,
+            AliasRegionKey::Vm {
+                ty: VmType::VMMemoryImport,
+                offset: self.offsets.vmmemory_import_from().into(),
+            },
+        );
         Load {
             offset,
             flags: ir::MemFlagsData::trusted()
@@ -618,12 +681,14 @@ impl AliasRegions<VMOffsets<u8>> {
     ) -> ir::Value {
         let table_offset = self.offsets.vmctx_vmtable_import(table);
         let table_vmctx_offset = table_offset + u32::from(self.offsets.vmtable_import_vmctx());
-        self.vmctx_load(
+        self.vmimport_load(
             cursor,
             self.pointer_type,
             ir::MemFlagsData::trusted().with_readonly().with_can_move(),
             vmctx,
             table_vmctx_offset,
+            self.offsets.vmtable_import_vmctx().into(),
+            VmType::VMTableImport,
         )
     }
 
@@ -637,12 +702,14 @@ impl AliasRegions<VMOffsets<u8>> {
     ) -> ir::Value {
         let table_offset = self.offsets.vmctx_vmtable_import(table);
         let table_index_offset = table_offset + u32::from(self.offsets.vmtable_import_index());
-        self.vmctx_load(
+        self.vmimport_load(
             cursor,
             ir::types::I32,
             ir::MemFlagsData::trusted().with_readonly().with_can_move(),
             vmctx,
             table_index_offset,
+            self.offsets.vmtable_import_index().into(),
+            VmType::VMTableImport,
         )
     }
 
@@ -650,7 +717,13 @@ impl AliasRegions<VMOffsets<u8>> {
     /// `*mut VMTableDefinition`) out of a `*mut VMContext`.
     pub fn vmctx_vmtable_from_load(&mut self, func: &mut ir::Function, table: TableIndex) -> Load {
         let offset = self.offsets.vmctx_vmtable_from(table);
-        let region = self.vmctx_region(func, offset);
+        let region = self.region(
+            func,
+            AliasRegionKey::Vm {
+                ty: VmType::VMTableImport,
+                offset: self.offsets.vmtable_import_from().into(),
+            },
+        );
         Load {
             offset,
             flags: ir::MemFlagsData::trusted()
@@ -670,12 +743,14 @@ impl AliasRegions<VMOffsets<u8>> {
         global: GlobalIndex,
     ) -> ir::Value {
         let from_offset = self.offsets.vmctx_vmglobal_import_from(global);
-        self.vmctx_load(
+        self.vmimport_load(
             cursor,
             self.pointer_type,
             ir::MemFlagsData::trusted().with_readonly().with_can_move(),
             vmctx,
             from_offset,
+            self.offsets.vmglobal_import_from().into(),
+            VmType::VMGlobalImport,
         )
     }
 

--- a/tests/disas/alias-region-globals.wat
+++ b/tests/disas/alias-region-globals.wat
@@ -17,7 +17,7 @@
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 48 "VMContext+0x30"
+;;     region2 = 2952790016 "VMGlobalImport+0x0"
 ;;     region3 = 805306368 "PublicGlobal"
 ;;     region4 = 939524096 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(0))"
 ;;     gv0 = vmctx

--- a/tests/disas/alias-region-memories.wat
+++ b/tests/disas/alias-region-memories.wat
@@ -17,7 +17,7 @@
 ;; function u0:0(i64 vmctx, i64, i32, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 48 "VMContext+0x30"
+;;     region2 = 2550136832 "VMMemoryImport+0x0"
 ;;     region3 = 1207959552 "VMMemoryDefinition+0x0"
 ;;     region4 = 1207959560 "VMMemoryDefinition+0x8"
 ;;     region5 = 268435456 "PublicMemory"

--- a/tests/disas/alias-region-tables.wat
+++ b/tests/disas/alias-region-tables.wat
@@ -18,7 +18,7 @@
 ;; function u0:0(i64 vmctx, i64, i32, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 48 "VMContext+0x30"
+;;     region2 = 2684354560 "VMTableImport+0x0"
 ;;     region3 = 1342177280 "VMTableDefinition+0x0"
 ;;     region4 = 1342177288 "VMTableDefinition+0x8"
 ;;     region5 = 536870912 "PublicTable"

--- a/tests/disas/block-params-br_if-single-pred.wat
+++ b/tests/disas/block-params-br_if-single-pred.wat
@@ -23,12 +23,8 @@
 ;; function u0:0(i64 vmctx, i64) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 72 "VMContext+0x48"
-;;     region3 = 56 "VMContext+0x38"
-;;     region4 = 104 "VMContext+0x68"
-;;     region5 = 88 "VMContext+0x58"
-;;     region6 = 136 "VMContext+0x88"
-;;     region7 = 120 "VMContext+0x78"
+;;     region2 = 2415919128 "VMFunctionImport+0x18"
+;;     region3 = 2415919112 "VMFunctionImport+0x8"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -45,14 +41,14 @@
 ;; @003f                               brif v6, block2, block3
 ;;
 ;;                                 block3:
-;; @0041                               v7 = load.i64 notrap aligned readonly can_move region4 v0+104
-;; @0041                               v8 = load.i64 notrap aligned readonly can_move region5 v0+88
+;; @0041                               v7 = load.i64 notrap aligned readonly can_move region2 v0+104
+;; @0041                               v8 = load.i64 notrap aligned readonly can_move region3 v0+88
 ;; @0041                               call_indirect sig1, v8(v7, v0, v2, v3)  ; v2 = 1, v3 = 2
 ;; @0043                               trap user12
 ;;
 ;;                                 block2:
-;; @0045                               v9 = load.i64 notrap aligned readonly can_move region6 v0+136
-;; @0045                               v10 = load.i64 notrap aligned readonly can_move region7 v0+120
+;; @0045                               v9 = load.i64 notrap aligned readonly can_move region2 v0+136
+;; @0045                               v10 = load.i64 notrap aligned readonly can_move region3 v0+120
 ;; @0045                               call_indirect sig1, v10(v9, v0, v2, v3)  ; v2 = 1, v3 = 2
 ;; @0047                               jump block1
 ;;

--- a/tests/disas/block-params-if-else-same-values.wat
+++ b/tests/disas/block-params-if-else-same-values.wat
@@ -23,10 +23,8 @@
 ;; function u0:0(i64 vmctx, i64, i32, i32, i32) -> i32, i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 72 "VMContext+0x48"
-;;     region3 = 56 "VMContext+0x38"
-;;     region4 = 104 "VMContext+0x68"
-;;     region5 = 88 "VMContext+0x58"
+;;     region2 = 2415919128 "VMFunctionImport+0x18"
+;;     region3 = 2415919112 "VMFunctionImport+0x8"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -43,8 +41,8 @@
 ;; @003b                               jump block3
 ;;
 ;;                                 block4:
-;; @003c                               v7 = load.i64 notrap aligned readonly can_move region4 v0+104
-;; @003c                               v8 = load.i64 notrap aligned readonly can_move region5 v0+88
+;; @003c                               v7 = load.i64 notrap aligned readonly can_move region2 v0+104
+;; @003c                               v8 = load.i64 notrap aligned readonly can_move region3 v0+88
 ;; @003c                               call_indirect sig0, v8(v7, v0)
 ;; @0042                               jump block3
 ;;

--- a/tests/disas/component-model/checked-intrinsics-inlined-no-spectre.wat
+++ b/tests/disas/component-model/checked-intrinsics-inlined-no-spectre.wat
@@ -50,10 +50,8 @@
 ;; function u0:0(i64 vmctx, i64, i64, i64) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 72 "VMContext+0x48"
+;;     region2 = 2415919128 "VMFunctionImport+0x18"
 ;;     region3 = 134217832 "VMStoreContext+0x68"
-;;     region4 = 104 "VMContext+0x68"
-;;     region5 = 136 "VMContext+0x88"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/component-model/checked-intrinsics-inlined.wat
+++ b/tests/disas/component-model/checked-intrinsics-inlined.wat
@@ -51,10 +51,8 @@
 ;; function u0:0(i64 vmctx, i64, i64, i64) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 72 "VMContext+0x48"
+;;     region2 = 2415919128 "VMFunctionImport+0x18"
 ;;     region3 = 134217832 "VMStoreContext+0x68"
-;;     region4 = 104 "VMContext+0x68"
-;;     region5 = 136 "VMContext+0x88"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/component-model/direct-adapter-calls-inlining.wat
+++ b/tests/disas/component-model/direct-adapter-calls-inlining.wat
@@ -57,12 +57,10 @@
 ;; function u1:0(i64 vmctx, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 72 "VMContext+0x48"
-;;     region3 = 136 "VMContext+0x88"
+;;     region2 = 2415919128 "VMFunctionImport+0x18"
+;;     region3 = 2952790016 "VMGlobalImport+0x0"
 ;;     region4 = 805306368 "PublicGlobal"
-;;     region5 = 112 "VMContext+0x70"
-;;     region6 = 104 "VMContext+0x68"
-;;     region7 = 88 "VMContext+0x58"
+;;     region5 = 2415919112 "VMFunctionImport+0x8"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -95,8 +93,8 @@
 ;;                                     brif v10, block9, block10
 ;;
 ;;                                 block10:
-;;                                     v24 = load.i64 notrap aligned readonly can_move region7 v3+88
-;;                                     v23 = load.i64 notrap aligned readonly can_move region6 v3+104
+;;                                     v24 = load.i64 notrap aligned readonly can_move region5 v3+88
+;;                                     v23 = load.i64 notrap aligned readonly can_move region2 v3+104
 ;;                                     v22 = iconst.i32 23
 ;;                                     try_call_indirect v24(v23, v3, v22), sig1, block11, [ context v3, default: block8(exn0) ]  ; v22 = 23
 ;;
@@ -104,7 +102,7 @@
 ;;                                     trap user12
 ;;
 ;;                                 block9:
-;;                                     v11 = load.i64 notrap aligned readonly can_move region5 v3+112
+;;                                     v11 = load.i64 notrap aligned readonly can_move region3 v3+112
 ;;                                     v12 = load.i32 notrap aligned region4 v11
 ;;                                     v8 = iconst.i32 0
 ;;                                     store notrap aligned region4 v8, v11  ; v8 = 0

--- a/tests/disas/component-model/direct-adapter-calls.wat
+++ b/tests/disas/component-model/direct-adapter-calls.wat
@@ -77,7 +77,7 @@
 ;; function u1:0(i64 vmctx, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 72 "VMContext+0x48"
+;;     region2 = 2415919128 "VMFunctionImport+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -98,12 +98,10 @@
 ;; function u2:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 136 "VMContext+0x88"
+;;     region2 = 2952790016 "VMGlobalImport+0x0"
 ;;     region3 = 805306368 "PublicGlobal"
-;;     region4 = 104 "VMContext+0x68"
-;;     region5 = 88 "VMContext+0x58"
-;;     region6 = 112 "VMContext+0x70"
-;;     region7 = 72 "VMContext+0x48"
+;;     region4 = 2415919128 "VMFunctionImport+0x18"
+;;     region5 = 2415919112 "VMFunctionImport+0x8"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -133,12 +131,12 @@
 ;; @008c                               trap user12
 ;;
 ;;                                 block7:
-;; @008e                               v11 = load.i64 notrap aligned readonly can_move region6 v0+112
+;; @008e                               v11 = load.i64 notrap aligned readonly can_move region2 v0+112
 ;; @008e                               v12 = load.i32 notrap aligned region3 v11
 ;; @0075                               v3 = iconst.i32 0
 ;; @0094                               store notrap aligned region3 v3, v11  ; v3 = 0
 ;; @009a                               store notrap aligned region3 v12, v11
-;; @009c                               v16 = load.i64 notrap aligned readonly can_move region7 v0+72
+;; @009c                               v16 = load.i64 notrap aligned readonly can_move region4 v0+72
 ;; @009c                               try_call fn0(v16, v0, v2), sig1, block10(ret0), [ context v0, default: block6(exn0) ]
 ;;
 ;;                                 block10(v17: i32):

--- a/tests/disas/component-model/exported-module-makes-adapters-indirect.wat
+++ b/tests/disas/component-model/exported-module-makes-adapters-indirect.wat
@@ -61,8 +61,8 @@
 ;; function u1:0(i64 vmctx, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 72 "VMContext+0x48"
-;;     region3 = 56 "VMContext+0x38"
+;;     region2 = 2415919128 "VMFunctionImport+0x18"
+;;     region3 = 2415919112 "VMFunctionImport+0x8"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/component-model/inlining-and-unsafe-intrinsics.wat
+++ b/tests/disas/component-model/inlining-and-unsafe-intrinsics.wat
@@ -45,10 +45,8 @@
 ;; function u0:0(i64 vmctx, i64) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 72 "VMContext+0x48"
+;;     region2 = 2415919128 "VMFunctionImport+0x18"
 ;;     region3 = 134217832 "VMStoreContext+0x68"
-;;     region4 = 104 "VMContext+0x68"
-;;     region5 = 136 "VMContext+0x88"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/component-model/inlining-bug.wat
+++ b/tests/disas/component-model/inlining-bug.wat
@@ -37,8 +37,7 @@
 ;; function u2:0(i64 vmctx, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 72 "VMContext+0x48"
-;;     region3 = 104 "VMContext+0x68"
+;;     region2 = 2415919128 "VMFunctionImport+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -64,7 +63,7 @@
 ;;
 ;;                                 block4:
 ;; @00d4                               v2 = load.i64 notrap aligned readonly can_move region2 v0+72
-;;                                     v6 = load.i64 notrap aligned readonly can_move region3 v2+104
+;;                                     v6 = load.i64 notrap aligned readonly can_move region2 v2+104
 ;;                                     call fn2(v6, v6)
 ;;                                     jump block5
 ;;

--- a/tests/disas/component-model/inlining-fuzz-bug.wat
+++ b/tests/disas/component-model/inlining-fuzz-bug.wat
@@ -40,8 +40,7 @@
 ;; function u2:0(i64 vmctx, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 72 "VMContext+0x48"
-;;     region3 = 104 "VMContext+0x68"
+;;     region2 = 2415919128 "VMFunctionImport+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/component-model/issue-11458.wat
+++ b/tests/disas/component-model/issue-11458.wat
@@ -22,7 +22,7 @@
 ;; function u1:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 72 "VMContext+0x48"
+;;     region2 = 2415919128 "VMFunctionImport+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/component-model/multiple-instantiations-makes-adapters-indirect.wat
+++ b/tests/disas/component-model/multiple-instantiations-makes-adapters-indirect.wat
@@ -67,8 +67,8 @@
 ;; function u1:0(i64 vmctx, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 72 "VMContext+0x48"
-;;     region3 = 56 "VMContext+0x38"
+;;     region2 = 2415919128 "VMFunctionImport+0x18"
+;;     region3 = 2415919112 "VMFunctionImport+0x8"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/component-model/sync-adapter-calls.wat
+++ b/tests/disas/component-model/sync-adapter-calls.wat
@@ -71,25 +71,19 @@
 ;;     ss0 = explicit_slot 32, align = 8
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 72 "VMContext+0x48"
-;;     region3 = 200 "VMContext+0xc8"
+;;     region2 = 2415919128 "VMFunctionImport+0x18"
+;;     region3 = 2952790016 "VMGlobalImport+0x0"
 ;;     region4 = 805306368 "PublicGlobal"
-;;     region5 = 224 "VMContext+0xe0"
-;;     region6 = 136 "VMContext+0x88"
-;;     region7 = 134217864 "VMStoreContext+0x88"
-;;     region8 = 2013265920 "VMDeferredThread+0x0"
-;;     region9 = 2013265928 "VMDeferredThread+0x8"
-;;     region10 = 2013265932 "VMDeferredThread+0xc"
-;;     region11 = 2013265936 "VMDeferredThread+0x10"
-;;     region12 = 134217856 "VMStoreContext+0x80"
-;;     region13 = 2013265940 "VMDeferredThread+0x14"
-;;     region14 = 134217860 "VMStoreContext+0x84"
-;;     region15 = 2013265944 "VMDeferredThread+0x18"
-;;     region16 = 176 "VMContext+0xb0"
-;;     region17 = 168 "VMContext+0xa8"
-;;     region18 = 152 "VMContext+0x98"
-;;     region19 = 104 "VMContext+0x68"
-;;     region20 = 88 "VMContext+0x58"
+;;     region5 = 134217864 "VMStoreContext+0x88"
+;;     region6 = 2013265920 "VMDeferredThread+0x0"
+;;     region7 = 2013265928 "VMDeferredThread+0x8"
+;;     region8 = 2013265932 "VMDeferredThread+0xc"
+;;     region9 = 2013265936 "VMDeferredThread+0x10"
+;;     region10 = 134217856 "VMStoreContext+0x80"
+;;     region11 = 2013265940 "VMDeferredThread+0x14"
+;;     region12 = 134217860 "VMStoreContext+0x84"
+;;     region13 = 2013265944 "VMDeferredThread+0x18"
+;;     region14 = 2415919112 "VMFunctionImport+0x8"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -124,8 +118,8 @@
 ;;                                     brif v10, block9, block10
 ;;
 ;;                                 block10:
-;;                                     v53 = load.i64 notrap aligned readonly can_move region20 v3+88
-;;                                     v52 = load.i64 notrap aligned readonly can_move region19 v3+104
+;;                                     v53 = load.i64 notrap aligned readonly can_move region14 v3+88
+;;                                     v52 = load.i64 notrap aligned readonly can_move region2 v3+104
 ;;                                     v51 = iconst.i32 23
 ;;                                     try_call_indirect v53(v52, v3, v51), sig1, block11, [ context v3, default: block8(exn0) ]  ; v51 = 23
 ;;
@@ -133,27 +127,27 @@
 ;;                                     trap user12
 ;;
 ;;                                 block9:
-;;                                     v11 = load.i64 notrap aligned readonly can_move region5 v3+224
+;;                                     v11 = load.i64 notrap aligned readonly can_move region3 v3+224
 ;;                                     v12 = load.i32 notrap aligned region4 v11
 ;;                                     v8 = iconst.i32 0
 ;;                                     store notrap aligned region4 v8, v11  ; v8 = 0
 ;;                                     v20 = load.i64 notrap aligned readonly can_move region0 v3+8
-;;                                     v21 = load.i64 notrap aligned region7 v20+136
+;;                                     v21 = load.i64 notrap aligned region5 v20+136
 ;;                                     v19 = stack_addr.i64 ss0
-;;                                     store notrap aligned region8 v21, v19
+;;                                     store notrap aligned region6 v21, v19
 ;;                                     v15 = iconst.i32 2
-;;                                     store notrap aligned region9 v15, v19+8  ; v15 = 2
-;;                                     store notrap aligned region10 v8, v19+12  ; v8 = 0
+;;                                     store notrap aligned region7 v15, v19+8  ; v15 = 2
+;;                                     store notrap aligned region8 v8, v19+12  ; v8 = 0
 ;;                                     v17 = iconst.i32 1
-;;                                     store notrap aligned region11 v17, v19+16  ; v17 = 1
-;;                                     v22 = load.i32 notrap aligned region12 v20+128
-;;                                     store notrap aligned region13 v22, v19+20
-;;                                     store notrap aligned region12 v8, v20+128  ; v8 = 0
-;;                                     v24 = load.i32 notrap aligned region14 v20+132
-;;                                     store notrap aligned region15 v24, v19+24
-;;                                     store notrap aligned region14 v8, v20+132  ; v8 = 0
-;;                                     store notrap aligned region7 v19, v20+136
-;;                                     v26 = load.i64 notrap aligned readonly can_move region16 v3+176
+;;                                     store notrap aligned region9 v17, v19+16  ; v17 = 1
+;;                                     v22 = load.i32 notrap aligned region10 v20+128
+;;                                     store notrap aligned region11 v22, v19+20
+;;                                     store notrap aligned region10 v8, v20+128  ; v8 = 0
+;;                                     v24 = load.i32 notrap aligned region12 v20+132
+;;                                     store notrap aligned region13 v24, v19+24
+;;                                     store notrap aligned region12 v8, v20+132  ; v8 = 0
+;;                                     store notrap aligned region5 v19, v20+136
+;;                                     v26 = load.i64 notrap aligned readonly can_move region3 v3+176
 ;;                                     v27 = load.i32 notrap aligned region4 v26
 ;;                                     store notrap aligned region4 v8, v26  ; v8 = 0
 ;;                                     store notrap aligned region4 v27, v26
@@ -169,9 +163,9 @@
 ;;                                     jump block13
 ;;
 ;;                                 block13:
-;;                                     store.i64 notrap aligned region7 v21, v20+136
-;;                                     store.i32 notrap aligned region12 v22, v20+128
-;;                                     store.i32 notrap aligned region14 v24, v20+132
+;;                                     store.i64 notrap aligned region5 v21, v20+136
+;;                                     store.i32 notrap aligned region10 v22, v20+128
+;;                                     store.i32 notrap aligned region12 v24, v20+132
 ;;                                     jump block15
 ;;
 ;;                                 block15:
@@ -185,8 +179,8 @@
 ;;                                     jump block4
 ;;
 ;;                                 block5:
-;;                                     v62 = load.i64 notrap aligned readonly can_move region20 v3+88
-;;                                     v63 = load.i64 notrap aligned readonly can_move region19 v3+104
+;;                                     v62 = load.i64 notrap aligned readonly can_move region14 v3+88
+;;                                     v63 = load.i64 notrap aligned readonly can_move region2 v3+104
 ;;                                     v48 = iconst.i32 49
 ;;                                     call_indirect sig1, v62(v63, v3, v48)  ; v48 = 49
 ;;                                     trap user12
@@ -209,25 +203,19 @@
 ;;     ss0 = explicit_slot 32, align = 8
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 200 "VMContext+0xc8"
+;;     region2 = 2952790016 "VMGlobalImport+0x0"
 ;;     region3 = 805306368 "PublicGlobal"
-;;     region4 = 104 "VMContext+0x68"
-;;     region5 = 88 "VMContext+0x58"
-;;     region6 = 224 "VMContext+0xe0"
-;;     region7 = 136 "VMContext+0x88"
-;;     region8 = 134217864 "VMStoreContext+0x88"
-;;     region9 = 2013265920 "VMDeferredThread+0x0"
-;;     region10 = 2013265928 "VMDeferredThread+0x8"
-;;     region11 = 2013265932 "VMDeferredThread+0xc"
-;;     region12 = 2013265936 "VMDeferredThread+0x10"
-;;     region13 = 134217856 "VMStoreContext+0x80"
-;;     region14 = 2013265940 "VMDeferredThread+0x14"
-;;     region15 = 134217860 "VMStoreContext+0x84"
-;;     region16 = 2013265944 "VMDeferredThread+0x18"
-;;     region17 = 176 "VMContext+0xb0"
-;;     region18 = 72 "VMContext+0x48"
-;;     region19 = 168 "VMContext+0xa8"
-;;     region20 = 152 "VMContext+0x98"
+;;     region4 = 2415919128 "VMFunctionImport+0x18"
+;;     region5 = 2415919112 "VMFunctionImport+0x8"
+;;     region6 = 134217864 "VMStoreContext+0x88"
+;;     region7 = 2013265920 "VMDeferredThread+0x0"
+;;     region8 = 2013265928 "VMDeferredThread+0x8"
+;;     region9 = 2013265932 "VMDeferredThread+0xc"
+;;     region10 = 2013265936 "VMDeferredThread+0x10"
+;;     region11 = 134217856 "VMStoreContext+0x80"
+;;     region12 = 2013265940 "VMDeferredThread+0x14"
+;;     region13 = 134217860 "VMStoreContext+0x84"
+;;     region14 = 2013265944 "VMDeferredThread+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -262,27 +250,27 @@
 ;; @00e0                               trap user12
 ;;
 ;;                                 block7:
-;; @00e2                               v11 = load.i64 notrap aligned readonly can_move region6 v0+224
+;; @00e2                               v11 = load.i64 notrap aligned readonly can_move region2 v0+224
 ;; @00e2                               v12 = load.i32 notrap aligned region3 v11
 ;; @00c9                               v3 = iconst.i32 0
 ;; @00e8                               store notrap aligned region3 v3, v11  ; v3 = 0
 ;; @00f0                               v20 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @00f0                               v21 = load.i64 notrap aligned region8 v20+136
+;; @00f0                               v21 = load.i64 notrap aligned region6 v20+136
 ;; @00f0                               v19 = stack_addr.i64 ss0
-;; @00f0                               store notrap aligned region9 v21, v19
+;; @00f0                               store notrap aligned region7 v21, v19
 ;; @00ea                               v15 = iconst.i32 2
-;; @00f0                               store notrap aligned region10 v15, v19+8  ; v15 = 2
-;; @00f0                               store notrap aligned region11 v3, v19+12  ; v3 = 0
+;; @00f0                               store notrap aligned region8 v15, v19+8  ; v15 = 2
+;; @00f0                               store notrap aligned region9 v3, v19+12  ; v3 = 0
 ;; @00ee                               v17 = iconst.i32 1
-;; @00f0                               store notrap aligned region12 v17, v19+16  ; v17 = 1
-;; @00f0                               v22 = load.i32 notrap aligned region13 v20+128
-;; @00f0                               store notrap aligned region14 v22, v19+20
-;; @00f0                               store notrap aligned region13 v3, v20+128  ; v3 = 0
-;; @00f0                               v24 = load.i32 notrap aligned region15 v20+132
-;; @00f0                               store notrap aligned region16 v24, v19+24
-;; @00f0                               store notrap aligned region15 v3, v20+132  ; v3 = 0
-;; @00f0                               store notrap aligned region8 v19, v20+136
-;; @00f2                               v26 = load.i64 notrap aligned readonly can_move region17 v0+176
+;; @00f0                               store notrap aligned region10 v17, v19+16  ; v17 = 1
+;; @00f0                               v22 = load.i32 notrap aligned region11 v20+128
+;; @00f0                               store notrap aligned region12 v22, v19+20
+;; @00f0                               store notrap aligned region11 v3, v20+128  ; v3 = 0
+;; @00f0                               v24 = load.i32 notrap aligned region13 v20+132
+;; @00f0                               store notrap aligned region14 v24, v19+24
+;; @00f0                               store notrap aligned region13 v3, v20+132  ; v3 = 0
+;; @00f0                               store notrap aligned region6 v19, v20+136
+;; @00f2                               v26 = load.i64 notrap aligned readonly can_move region2 v0+176
 ;; @00f2                               v27 = load.i32 notrap aligned region3 v26
 ;; @00f8                               store notrap aligned region3 v3, v26  ; v3 = 0
 ;; @00fe                               store notrap aligned region3 v27, v26
@@ -298,9 +286,9 @@
 ;; @0104                               jump block11
 ;;
 ;;                                 block11:
-;; @0104                               store.i64 notrap aligned region8 v21, v20+136
-;; @0104                               store.i32 notrap aligned region13 v22, v20+128
-;; @0104                               store.i32 notrap aligned region15 v24, v20+132
+;; @0104                               store.i64 notrap aligned region6 v21, v20+136
+;; @0104                               store.i32 notrap aligned region11 v22, v20+128
+;; @0104                               store.i32 notrap aligned region13 v24, v20+132
 ;; @0104                               jump block13
 ;;
 ;;                                 block13:

--- a/tests/disas/duplicate-function-types.wat
+++ b/tests/disas/duplicate-function-types.wat
@@ -19,7 +19,7 @@
 ;; function u0:0(i64 vmctx, i64, i32) -> i32, i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 48 "VMContext+0x30"
+;;     region2 = 2684354560 "VMTableImport+0x0"
 ;;     region3 = 1342177280 "VMTableDefinition+0x0"
 ;;     region4 = 1342177288 "VMTableDefinition+0x8"
 ;;     region5 = 536870912 "PublicTable"

--- a/tests/disas/foo.wat
+++ b/tests/disas/foo.wat
@@ -20,7 +20,7 @@
 ;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
 ;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
 ;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
-;;     region5 = 72 "VMContext+0x48"
+;;     region5 = 2684354560 "VMTableImport+0x0"
 ;;     region6 = 1342177280 "VMTableDefinition+0x0"
 ;;     region7 = 1342177288 "VMTableDefinition+0x8"
 ;;     region8 = 536870912 "PublicTable"

--- a/tests/disas/gc/copying/br-on-cast-fail.wat
+++ b/tests/disas/gc/copying/br-on-cast-fail.wat
@@ -22,10 +22,8 @@
 ;;     region3 = 134217760 "VMStoreContext+0x20"
 ;;     region4 = 134217768 "VMStoreContext+0x28"
 ;;     region5 = 1073741824 "GcHeap"
-;;     region6 = 72 "VMContext+0x48"
-;;     region7 = 56 "VMContext+0x38"
-;;     region8 = 104 "VMContext+0x68"
-;;     region9 = 88 "VMContext+0x58"
+;;     region6 = 2415919128 "VMFunctionImport+0x18"
+;;     region7 = 2415919112 "VMFunctionImport+0x8"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -67,8 +65,8 @@
 ;; @0036                               return
 ;;
 ;;                                 block2:
-;; @0038                               v25 = load.i64 notrap aligned readonly can_move region9 v0+88
-;; @0038                               v24 = load.i64 notrap aligned readonly can_move region8 v0+104
+;; @0038                               v25 = load.i64 notrap aligned readonly can_move region7 v0+88
+;; @0038                               v24 = load.i64 notrap aligned readonly can_move region6 v0+104
 ;; @0038                               call_indirect sig0, v25(v24, v0)
 ;; @003a                               return
 ;; }

--- a/tests/disas/gc/copying/br-on-cast.wat
+++ b/tests/disas/gc/copying/br-on-cast.wat
@@ -22,10 +22,8 @@
 ;;     region3 = 134217760 "VMStoreContext+0x20"
 ;;     region4 = 134217768 "VMStoreContext+0x28"
 ;;     region5 = 1073741824 "GcHeap"
-;;     region6 = 72 "VMContext+0x48"
-;;     region7 = 56 "VMContext+0x38"
-;;     region8 = 104 "VMContext+0x68"
-;;     region9 = 88 "VMContext+0x58"
+;;     region6 = 2415919128 "VMFunctionImport+0x18"
+;;     region7 = 2415919112 "VMFunctionImport+0x8"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -67,8 +65,8 @@
 ;; @0037                               return
 ;;
 ;;                                 block2:
-;; @0039                               v25 = load.i64 notrap aligned readonly can_move region9 v0+88
-;; @0039                               v24 = load.i64 notrap aligned readonly can_move region8 v0+104
+;; @0039                               v25 = load.i64 notrap aligned readonly can_move region7 v0+88
+;; @0039                               v24 = load.i64 notrap aligned readonly can_move region6 v0+104
 ;; @0039                               call_indirect sig0, v25(v24, v0)
 ;; @003b                               return
 ;; }

--- a/tests/disas/gc/drc/br-on-cast-fail.wat
+++ b/tests/disas/gc/drc/br-on-cast-fail.wat
@@ -23,10 +23,8 @@
 ;;     region3 = 134217760 "VMStoreContext+0x20"
 ;;     region4 = 134217768 "VMStoreContext+0x28"
 ;;     region5 = 1073741824 "GcHeap"
-;;     region6 = 72 "VMContext+0x48"
-;;     region7 = 56 "VMContext+0x38"
-;;     region8 = 104 "VMContext+0x68"
-;;     region9 = 88 "VMContext+0x58"
+;;     region6 = 2415919128 "VMFunctionImport+0x18"
+;;     region7 = 2415919112 "VMFunctionImport+0x8"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -68,8 +66,8 @@
 ;; @0036                               return
 ;;
 ;;                                 block2:
-;; @0038                               v25 = load.i64 notrap aligned readonly can_move region9 v0+88
-;; @0038                               v24 = load.i64 notrap aligned readonly can_move region8 v0+104
+;; @0038                               v25 = load.i64 notrap aligned readonly can_move region7 v0+88
+;; @0038                               v24 = load.i64 notrap aligned readonly can_move region6 v0+104
 ;; @0038                               call_indirect sig0, v25(v24, v0)
 ;; @003a                               return
 ;; }

--- a/tests/disas/gc/drc/br-on-cast.wat
+++ b/tests/disas/gc/drc/br-on-cast.wat
@@ -23,10 +23,8 @@
 ;;     region3 = 134217760 "VMStoreContext+0x20"
 ;;     region4 = 134217768 "VMStoreContext+0x28"
 ;;     region5 = 1073741824 "GcHeap"
-;;     region6 = 72 "VMContext+0x48"
-;;     region7 = 56 "VMContext+0x38"
-;;     region8 = 104 "VMContext+0x68"
-;;     region9 = 88 "VMContext+0x58"
+;;     region6 = 2415919128 "VMFunctionImport+0x18"
+;;     region7 = 2415919112 "VMFunctionImport+0x8"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -68,8 +66,8 @@
 ;; @0037                               return
 ;;
 ;;                                 block2:
-;; @0039                               v25 = load.i64 notrap aligned readonly can_move region9 v0+88
-;; @0039                               v24 = load.i64 notrap aligned readonly can_move region8 v0+104
+;; @0039                               v25 = load.i64 notrap aligned readonly can_move region7 v0+88
+;; @0039                               v24 = load.i64 notrap aligned readonly can_move region6 v0+104
 ;; @0039                               call_indirect sig0, v25(v24, v0)
 ;; @003b                               return
 ;; }

--- a/tests/disas/gc/null/br-on-cast-fail.wat
+++ b/tests/disas/gc/null/br-on-cast-fail.wat
@@ -23,10 +23,8 @@
 ;;     region3 = 134217760 "VMStoreContext+0x20"
 ;;     region4 = 134217768 "VMStoreContext+0x28"
 ;;     region5 = 1073741824 "GcHeap"
-;;     region6 = 72 "VMContext+0x48"
-;;     region7 = 56 "VMContext+0x38"
-;;     region8 = 104 "VMContext+0x68"
-;;     region9 = 88 "VMContext+0x58"
+;;     region6 = 2415919128 "VMFunctionImport+0x18"
+;;     region7 = 2415919112 "VMFunctionImport+0x8"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -68,8 +66,8 @@
 ;; @0036                               return
 ;;
 ;;                                 block2:
-;; @0038                               v25 = load.i64 notrap aligned readonly can_move region9 v0+88
-;; @0038                               v24 = load.i64 notrap aligned readonly can_move region8 v0+104
+;; @0038                               v25 = load.i64 notrap aligned readonly can_move region7 v0+88
+;; @0038                               v24 = load.i64 notrap aligned readonly can_move region6 v0+104
 ;; @0038                               call_indirect sig0, v25(v24, v0)
 ;; @003a                               return
 ;; }

--- a/tests/disas/gc/null/br-on-cast.wat
+++ b/tests/disas/gc/null/br-on-cast.wat
@@ -23,10 +23,8 @@
 ;;     region3 = 134217760 "VMStoreContext+0x20"
 ;;     region4 = 134217768 "VMStoreContext+0x28"
 ;;     region5 = 1073741824 "GcHeap"
-;;     region6 = 72 "VMContext+0x48"
-;;     region7 = 56 "VMContext+0x38"
-;;     region8 = 104 "VMContext+0x68"
-;;     region9 = 88 "VMContext+0x58"
+;;     region6 = 2415919128 "VMFunctionImport+0x18"
+;;     region7 = 2415919112 "VMFunctionImport+0x8"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -68,8 +66,8 @@
 ;; @0037                               return
 ;;
 ;;                                 block2:
-;; @0039                               v25 = load.i64 notrap aligned readonly can_move region9 v0+88
-;; @0039                               v24 = load.i64 notrap aligned readonly can_move region8 v0+104
+;; @0039                               v25 = load.i64 notrap aligned readonly can_move region7 v0+88
+;; @0039                               v24 = load.i64 notrap aligned readonly can_move region6 v0+104
 ;; @0039                               call_indirect sig0, v25(v24, v0)
 ;; @003b                               return
 ;; }

--- a/tests/disas/gc/typed-select-and-stack-maps.wat
+++ b/tests/disas/gc/typed-select-and-stack-maps.wat
@@ -43,10 +43,8 @@
 ;;     ss0 = explicit_slot 4, align = 4
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 104 "VMContext+0x68"
-;;     region3 = 88 "VMContext+0x58"
-;;     region4 = 72 "VMContext+0x48"
-;;     region5 = 56 "VMContext+0x38"
+;;     region2 = 2415919128 "VMFunctionImport+0x18"
+;;     region3 = 2415919112 "VMFunctionImport+0x8"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -62,8 +60,8 @@
 ;; @004c                               v6 = load.i64 notrap aligned readonly can_move region2 v0+104
 ;; @004c                               call_indirect sig0, v7(v6, v0), stack_map=[i32 @ ss0+0]
 ;;                                     v11 = load.i32 notrap v12
-;; @004e                               v9 = load.i64 notrap aligned readonly can_move region5 v0+56
-;; @004e                               v8 = load.i64 notrap aligned readonly can_move region4 v0+72
+;; @004e                               v9 = load.i64 notrap aligned readonly can_move region3 v0+56
+;; @004e                               v8 = load.i64 notrap aligned readonly can_move region2 v0+72
 ;; @004e                               call_indirect sig1, v9(v8, v0, v11)
 ;; @0050                               jump block1
 ;;
@@ -74,10 +72,8 @@
 ;; function u0:1(i64 vmctx, i64, i32, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 104 "VMContext+0x68"
-;;     region3 = 88 "VMContext+0x58"
-;;     region4 = 72 "VMContext+0x48"
-;;     region5 = 56 "VMContext+0x38"
+;;     region2 = 2415919128 "VMFunctionImport+0x18"
+;;     region3 = 2415919112 "VMFunctionImport+0x8"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -89,8 +85,8 @@
 ;; @005c                               v7 = load.i64 notrap aligned readonly can_move region3 v0+88
 ;; @005c                               v6 = load.i64 notrap aligned readonly can_move region2 v0+104
 ;; @005c                               call_indirect sig0, v7(v6, v0)
-;; @005e                               v9 = load.i64 notrap aligned readonly can_move region5 v0+56
-;; @005e                               v8 = load.i64 notrap aligned readonly can_move region4 v0+72
+;; @005e                               v9 = load.i64 notrap aligned readonly can_move region3 v0+56
+;; @005e                               v8 = load.i64 notrap aligned readonly can_move region2 v0+72
 ;; @0059                               v5 = select v4, v2, v3
 ;; @005e                               call_indirect sig1, v9(v8, v0, v5)
 ;; @0060                               jump block1

--- a/tests/disas/global-get.wat
+++ b/tests/disas/global-get.wat
@@ -33,7 +33,7 @@
 ;; function u0:0(i64 vmctx, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 48 "VMContext+0x30"
+;;     region2 = 2952790016 "VMGlobalImport+0x0"
 ;;     region3 = 805306368 "PublicGlobal"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
@@ -52,7 +52,7 @@
 ;; function u0:1(i64 vmctx, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 72 "VMContext+0x48"
+;;     region2 = 2952790016 "VMGlobalImport+0x0"
 ;;     region3 = 805306368 "PublicGlobal"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8

--- a/tests/disas/memory-min-max-same.wat
+++ b/tests/disas/memory-min-max-same.wat
@@ -36,8 +36,8 @@
 ;; function u0:0(i64 vmctx, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 96 "VMContext+0x60"
-;;     region3 = 80 "VMContext+0x50"
+;;     region2 = 2415919128 "VMFunctionImport+0x18"
+;;     region3 = 2415919112 "VMFunctionImport+0x8"
 ;;     region4 = 1207959552 "VMMemoryDefinition+0x0"
 ;;     region5 = 1207959560 "VMMemoryDefinition+0x8"
 ;;     region6 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"

--- a/tests/disas/pic.wat
+++ b/tests/disas/pic.wat
@@ -76,8 +76,8 @@
 ;;     region3 = 1207959552 "VMMemoryDefinition+0x0"
 ;;     region4 = 1207959560 "VMMemoryDefinition+0x8"
 ;;     region5 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
-;;     region6 = 96 "VMContext+0x60"
-;;     region7 = 80 "VMContext+0x50"
+;;     region6 = 2415919128 "VMFunctionImport+0x18"
+;;     region7 = 2415919112 "VMFunctionImport+0x8"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/table-copy.wat
+++ b/tests/disas/table-copy.wat
@@ -71,7 +71,7 @@
 ;; function u0:3(i64 vmctx, i64, i32, i32, i32, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 48 "VMContext+0x30"
+;;     region2 = 2684354560 "VMTableImport+0x0"
 ;;     region3 = 1342177280 "VMTableDefinition+0x0"
 ;;     region4 = 1342177288 "VMTableDefinition+0x8"
 ;;     region5 = 536870912 "PublicTable"
@@ -212,7 +212,7 @@
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 134217752 "VMStoreContext+0x18"
 ;;     region2 = 1342177280 "VMTableDefinition+0x0"
-;;     region3 = 48 "VMContext+0x30"
+;;     region3 = 2684354560 "VMTableImport+0x0"
 ;;     region4 = 1342177288 "VMTableDefinition+0x8"
 ;;     region5 = 536870912 "PublicTable"
 ;;     gv0 = vmctx


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
