### PR TITLE
Limit the size of constants in wasm-smith

### DIFF
--- a/crates/fuzzing/src/generators/module.rs
+++ b/crates/fuzzing/src/generators/module.rs
@@ -119,7 +119,12 @@ impl ModuleConfig {
             None
         };
 
-        let mut module = wasm_smith::Module::new(self.config.clone(), input)?;
+        let mut config = self.config.clone();
+        if default_fuel.is_some() {
+            config.limit_arrays_in_const_exprs = true;
+        }
+
+        let mut module = wasm_smith::Module::new(config, input)?;
 
         if let Some(before) = input_before {
             static GEN_CNT: AtomicUsize = AtomicUsize::new(0);
@@ -129,7 +134,7 @@ impl ModuleConfig {
             let config = format!("testcase{i}.json");
             log::debug!("writing `{dna}` and `{config}`");
             std::fs::write(&dna, &before[..used]).unwrap();
-            std::fs::write(&config, serde_json::to_string_pretty(&self.config).unwrap()).unwrap();
+            std::fs::write(&config, serde_json::to_string_pretty(&config).unwrap()).unwrap();
         }
 
         if let Some(default_fuel) = default_fuel {


### PR DESCRIPTION
When wasm-smith based fuel is enabled it needs extra configuration to limit the dynamic size of constants that are generated to limit the size of GC values, for example.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
