### PR TITLE
cranelift(aarch64): share base+index across offset loads via uimm12 amode

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/inst.isle
+++ b/cranelift/codegen/src/isa/aarch64/inst.isle
@@ -4037,6 +4037,32 @@
         (if-let true (u64_eq (ty_bytes ty) (u64_wrapping_shl 1 (shift_masked_imm shift_ty n))))
         (amode_reg_scaled (amode_add x offset) y))
 
+;; `base + (extended index)` plus a non-zero scaled-uimm12 offset: fold the
+;; offset into the load and keep `base + index` as one CSE-able value, so loads
+;; sharing `base + index` reuse a single `add` instead of one add per offset.
+(rule 8 (amode_no_more_iconst ty val @ (iadd _ _ (uextend _ (value_type $I32))) offset)
+        (if-let uimm12 (uimm12_scaled_from_i64 offset ty))
+        (AMode.UnsignedOffset val uimm12))
+(rule 8 (amode_no_more_iconst ty val @ (iadd _ _ (sextend _ (value_type $I32))) offset)
+        (if-let uimm12 (uimm12_scaled_from_i64 offset ty))
+        (AMode.UnsignedOffset val uimm12))
+(rule 9 (amode_no_more_iconst ty val @ (iadd _ (uextend _ (value_type $I32)) _) offset)
+        (if-let uimm12 (uimm12_scaled_from_i64 offset ty))
+        (AMode.UnsignedOffset val uimm12))
+(rule 9 (amode_no_more_iconst ty val @ (iadd _ (sextend _ (value_type $I32)) _) offset)
+        (if-let uimm12 (uimm12_scaled_from_i64 offset ty))
+        (AMode.UnsignedOffset val uimm12))
+
+;; offset == 0: keep rules 4/5's single-instruction `RegExtended` form.
+(rule 10 (amode_no_more_iconst ty (iadd _ x (uextend _ y @ (value_type $I32))) 0)
+        (AMode.RegExtended x y (ExtendOp.UXTW)))
+(rule 10 (amode_no_more_iconst ty (iadd _ x (sextend _ y @ (value_type $I32))) 0)
+        (AMode.RegExtended x y (ExtendOp.SXTW)))
+(rule 11 (amode_no_more_iconst ty (iadd _ (uextend _ x @ (value_type $I32)) y) 0)
+        (AMode.RegExtended y x (ExtendOp.UXTW)))
+(rule 11 (amode_no_more_iconst ty (iadd _ (sextend _ x @ (value_type $I32)) y) 0)
+        (AMode.RegExtended y x (ExtendOp.SXTW)))
+
 (attr amode_reg_scaled (veri chain))
 (decl amode_reg_scaled (Reg Value) AMode)
 (rule 0 (amode_reg_scaled base index)

--- a/cranelift/codegen/src/isa/aarch64/inst.isle
+++ b/cranelift/codegen/src/isa/aarch64/inst.isle
@@ -4037,31 +4037,12 @@
         (if-let true (u64_eq (ty_bytes ty) (u64_wrapping_shl 1 (shift_masked_imm shift_ty n))))
         (amode_reg_scaled (amode_add x offset) y))
 
-;; `base + (extended index)` plus a non-zero scaled-uimm12 offset: fold the
-;; offset into the load and keep `base + index` as one CSE-able value, so loads
-;; sharing `base + index` reuse a single `add` instead of one add per offset.
-(rule 8 (amode_no_more_iconst ty val @ (iadd _ _ (uextend _ (value_type $I32))) offset)
-        (if-let uimm12 (uimm12_scaled_from_i64 offset ty))
+;; Highest priority: a non-zero uimm12 offset folds into the load's immediate,
+;; keeping `val` (e.g. a shared `base + index`) CSE-able across offsets instead
+;; of folding into an operand per-load. Zero falls through to rules 3-7.
+(rule 8 (amode_no_more_iconst ty val offset)
+        (if-let uimm12 (uimm12_scaled_nonzero_from_i64 offset ty))
         (AMode.UnsignedOffset val uimm12))
-(rule 8 (amode_no_more_iconst ty val @ (iadd _ _ (sextend _ (value_type $I32))) offset)
-        (if-let uimm12 (uimm12_scaled_from_i64 offset ty))
-        (AMode.UnsignedOffset val uimm12))
-(rule 9 (amode_no_more_iconst ty val @ (iadd _ (uextend _ (value_type $I32)) _) offset)
-        (if-let uimm12 (uimm12_scaled_from_i64 offset ty))
-        (AMode.UnsignedOffset val uimm12))
-(rule 9 (amode_no_more_iconst ty val @ (iadd _ (sextend _ (value_type $I32)) _) offset)
-        (if-let uimm12 (uimm12_scaled_from_i64 offset ty))
-        (AMode.UnsignedOffset val uimm12))
-
-;; offset == 0: keep rules 4/5's single-instruction `RegExtended` form.
-(rule 10 (amode_no_more_iconst ty (iadd _ x (uextend _ y @ (value_type $I32))) 0)
-        (AMode.RegExtended x y (ExtendOp.UXTW)))
-(rule 10 (amode_no_more_iconst ty (iadd _ x (sextend _ y @ (value_type $I32))) 0)
-        (AMode.RegExtended x y (ExtendOp.SXTW)))
-(rule 11 (amode_no_more_iconst ty (iadd _ (uextend _ x @ (value_type $I32)) y) 0)
-        (AMode.RegExtended y x (ExtendOp.UXTW)))
-(rule 11 (amode_no_more_iconst ty (iadd _ (sextend _ x @ (value_type $I32)) y) 0)
-        (AMode.RegExtended y x (ExtendOp.SXTW)))
 
 (attr amode_reg_scaled (veri chain))
 (decl amode_reg_scaled (Reg Value) AMode)
@@ -4121,6 +4102,29 @@
 )
 (decl pure partial uimm12_scaled_from_i64 (i64 Type) UImm12Scaled)
 (extern constructor uimm12_scaled_from_i64 uimm12_scaled_from_i64)
+
+;; As `uimm12_scaled_from_i64`, but additionally requires a non-zero value.
+(spec (uimm12_scaled_nonzero_from_i64 value ty)
+      (match
+            (let
+                  (
+                        (scale (bits2bytes! (int2bv 64 (:bits ty))))
+                        (limit (bvmul (int2bv 64 4095) scale))
+                  )
+                  (and
+                        (not (bv_is_zero! value))
+                        (bvsge value (bvzero! 64))
+                        (bvsle value limit)
+                        (bv_is_zero! (bvand value (bvsub scale (bvone! 64))))
+                  )
+            )
+      )
+      (provide
+            (= result (extract 11 0 (bvudiv value (bits2bytes! (int2bv 64 (:bits ty))))))
+      )
+)
+(decl pure partial uimm12_scaled_nonzero_from_i64 (i64 Type) UImm12Scaled)
+(extern constructor uimm12_scaled_nonzero_from_i64 uimm12_scaled_nonzero_from_i64)
 
 (spec (simm9_from_i64 value)
       (provide (= value (sign_ext 64 result)))

--- a/cranelift/codegen/src/isa/aarch64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/aarch64/lower/isle.rs
@@ -827,6 +827,15 @@ impl Context for IsleContext<'_, '_, MInst, AArch64Backend> {
         UImm12Scaled::maybe_from_i64(val, ty)
     }
 
+    /// Like `uimm12_scaled_from_i64`, but rejects a zero value so `base + index
+    /// + 0` keeps its single-instruction `RegExtended` amode.
+    fn uimm12_scaled_nonzero_from_i64(&mut self, val: i64, ty: Type) -> Option<UImm12Scaled> {
+        if val == 0 {
+            return None;
+        }
+        UImm12Scaled::maybe_from_i64(val, ty)
+    }
+
     fn test_and_compare_bit_const(&mut self, ty: Type, n: u64) -> Option<u8> {
         if n.count_ones() != 1 {
             return None;

--- a/cranelift/filetests/filetests/isa/aarch64/amode-shared-base.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/amode-shared-base.clif
@@ -1,0 +1,125 @@
+test compile precise-output
+set unwind_info=false
+target aarch64
+
+;; Multiple loads sharing `base + uextend(index)` with distinct constant
+;; offsets: the `base + index` add is materialized once and reused, with each
+;; offset folded into the load's immediate. Previously each load emitted its own
+;; `add base, #offset` (defeating CSE of the shared `base + index`).
+function %shared_base_uext(i64, i32) -> i32 {
+block0(v0: i64, v1: i32):
+    v2 = uextend.i64 v1
+    v3 = iadd v0, v2
+    v4 = load.i16 v3+260
+    v5 = load.i16 v3+262
+    v6 = load.i16 v3+264
+    v7 = load.i16 v3+266
+    v8 = sextend.i32 v4
+    v9 = sextend.i32 v5
+    v10 = sextend.i32 v6
+    v11 = sextend.i32 v7
+    v12 = iadd v8, v9
+    v13 = iadd v10, v11
+    v14 = iadd v12, v13
+    return v14
+}
+
+; VCode:
+; block0:
+;   add x11, x0, x1, UXTW
+;   ldrh w12, [x11, #260]
+;   ldrh w14, [x11, #262]
+;   ldrh w13, [x11, #264]
+;   sxth w14, w14
+;   ldrsh x11, [x11, #266]
+;   add w12, w14, w12, SXTH
+;   add w11, w11, w13, SXTH
+;   add w0, w12, w11
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   add x11, x0, w1, uxtw
+;   ldrh w12, [x11, #0x104] ; trap: heap_oob
+;   ldrh w14, [x11, #0x106] ; trap: heap_oob
+;   ldrh w13, [x11, #0x108] ; trap: heap_oob
+;   sxth w14, w14
+;   ldrsh x11, [x11, #0x10a] ; trap: heap_oob
+;   add w12, w14, w12, sxth
+;   add w11, w11, w13, sxth
+;   add w0, w12, w11
+;   ret
+
+;; Same with a sign-extended index.
+function %shared_base_sext(i64, i32) -> i32 {
+block0(v0: i64, v1: i32):
+    v2 = sextend.i64 v1
+    v3 = iadd v0, v2
+    v4 = load.i16 v3+260
+    v5 = load.i16 v3+262
+    v8 = sextend.i32 v4
+    v9 = sextend.i32 v5
+    v12 = iadd v8, v9
+    return v12
+}
+
+; VCode:
+; block0:
+;   add x6, x0, x1, SXTW
+;   ldrh w7, [x6, #260]
+;   ldrsh x6, [x6, #262]
+;   add w0, w6, w7, SXTH
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   add x6, x0, w1, sxtw
+;   ldrh w7, [x6, #0x104] ; trap: heap_oob
+;   ldrsh x6, [x6, #0x106] ; trap: heap_oob
+;   add w0, w6, w7, sxth
+;   ret
+
+;; A single load with a non-zero offset: both forms are two instructions, so
+;; this is neutral (folds the offset into the load immediate).
+function %single_use_uext(i64, i32) -> i32 {
+block0(v0: i64, v1: i32):
+    v2 = uextend.i64 v1
+    v3 = iadd v0, v2
+    v4 = load.i16 v3+128
+    v5 = sextend.i32 v4
+    return v5
+}
+
+; VCode:
+; block0:
+;   add x4, x0, x1, UXTW
+;   ldrsh x0, [x4, #128]
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   add x4, x0, w1, uxtw
+;   ldrsh x0, [x4, #0x80] ; trap: heap_oob
+;   ret
+
+;; Zero offset: must stay a single `ldrh [base, index, uxtw]` (the non-zero
+;; guard keeps `RegExtended` here rather than splitting into add + load).
+function %offset_zero_uext(i64, i32) -> i32 {
+block0(v0: i64, v1: i32):
+    v2 = uextend.i64 v1
+    v3 = iadd v0, v2
+    v4 = load.i16 v3
+    v5 = sextend.i32 v4
+    return v5
+}
+
+; VCode:
+; block0:
+;   ldrsh x0, [x0, w1, UXTW]
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   ldrsh x0, [x0, w1, uxtw] ; trap: heap_oob
+;   ret
+

--- a/cranelift/filetests/filetests/isa/aarch64/amodes.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/amodes.clif
@@ -75,8 +75,8 @@ block0(v0: i64, v1: i32):
 ;   sxtw x7, w1
 ;   add x7, x7, #32
 ;   add x7, x7, x0
-;   add x6, x7, #4
-;   ldr w0, [x6, x7]
+;   add x7, x7, x7
+;   ldr w0, [x7, #4]
 ;   ret
 ;
 ; Disassembled:
@@ -84,8 +84,8 @@ block0(v0: i64, v1: i32):
 ;   sxtw x7, w1
 ;   add x7, x7, #0x20
 ;   add x7, x7, x0
-;   add x6, x7, #4
-;   ldr w0, [x6, x7] ; trap: heap_oob
+;   add x7, x7, x7
+;   ldr w0, [x7, #4] ; trap: heap_oob
 ;   ret
 
 function %f9(i64, i64, i64) -> i32 {
@@ -101,15 +101,15 @@ block0(v0: i64, v1: i64, v2: i64):
 ; VCode:
 ; block0:
 ;   add x6, x0, x1
-;   add x5, x6, #48
-;   ldr w0, [x5, x2]
+;   add x6, x6, x2
+;   ldr w0, [x6, #48]
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   add x6, x0, x1
-;   add x5, x6, #0x30
-;   ldr w0, [x5, x2] ; trap: heap_oob
+;   add x6, x6, x2
+;   ldr w0, [x6, #0x30] ; trap: heap_oob
 ;   ret
 
 function %f10(i64, i64, i64) -> i32 {
@@ -124,18 +124,16 @@ block0(v0: i64, v1: i64, v2: i64):
 
 ; VCode:
 ; block0:
-;   add x7, x0, x1
-;   movz x5, #4100
-;   add x7, x7, x5
-;   ldr w0, [x7, x2]
+;   add x6, x0, x1
+;   add x6, x6, x2
+;   ldr w0, [x6, #4100]
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   add x7, x0, x1
-;   mov x5, #0x1004
-;   add x7, x7, x5
-;   ldr w0, [x7, x2] ; trap: heap_oob
+;   add x6, x0, x1
+;   add x6, x6, x2
+;   ldr w0, [x6, #0x1004] ; trap: heap_oob
 ;   ret
 
 function %f10() -> i32 {

--- a/cranelift/filetests/filetests/runtests/amode-shared-base.clif
+++ b/cranelift/filetests/filetests/runtests/amode-shared-base.clif
@@ -1,0 +1,48 @@
+test interpret
+test run
+target aarch64
+target x86_64 has_sse3 has_ssse3 has_sse41
+target s390x
+
+;; Store at a fixed slot offset, then load it back through
+;; `base + (extended index) + offset`, so the computed addressing mode must
+;; resolve to the same byte. Catches a wrong base/offset in the amode.
+function %amode_uext(i32) -> i16 {
+    ss0 = explicit_slot 32
+block0(v0: i32):
+    v1 = iconst.i16 0x1234
+    v2 = stack_addr.i64 ss0
+    store.i16 v1, v2+10
+    v3 = uextend.i64 v0
+    v4 = iadd v2, v3
+    v5 = load.i16 v4+8
+    return v5
+}
+; run: %amode_uext(2) == 0x1234
+
+function %amode_sext(i32) -> i16 {
+    ss0 = explicit_slot 32
+block0(v0: i32):
+    v1 = iconst.i16 0x5678
+    v2 = stack_addr.i64 ss0
+    store.i16 v1, v2+12
+    v3 = sextend.i64 v0
+    v4 = iadd v2, v3
+    v5 = load.i16 v4+8
+    return v5
+}
+; run: %amode_sext(4) == 0x5678
+
+;; Zero offset: exercises the RegExtended guard path.
+function %amode_zero(i32) -> i16 {
+    ss0 = explicit_slot 32
+block0(v0: i32):
+    v1 = iconst.i16 0x4321
+    v2 = stack_addr.i64 ss0
+    store.i16 v1, v2+6
+    v3 = uextend.i64 v0
+    v4 = iadd v2, v3
+    v5 = load.i16 v4
+    return v5
+}
+; run: %amode_zero(6) == 0x4321

--- a/tests/disas/debug-exceptions.wat
+++ b/tests/disas/debug-exceptions.wat
@@ -31,84 +31,82 @@
 ;;       stur    x0, [sp, #0x18]
 ;;       mov     x0, sp
 ;;       cmp     x0, x1
-;;       b.lo    #0x220
+;;       b.lo    #0x218
 ;;   48: stur    x2, [sp]
 ;;       mov     x0, x2
 ;;       stur    x2, [sp, #0x10]
 ;;       nop
 ;;       ├─╼ debug frame state (after previous inst): func key DefinedWasmFunction(StaticModuleIndex(0), DefinedFuncIndex(0)), wasm PC 0x35, slot at FP-0xb0, locals , stack 
-;;       ╰─╼ breakpoint patch: wasm PC 0x35, patch bytes [69, 1, 0, 148]
+;;       ╰─╼ breakpoint patch: wasm PC 0x35, patch bytes [67, 1, 0, 148]
 ;;       ldur    x0, [sp, #0x10]
 ;;       nop
 ;;       ├─╼ debug frame state (after previous inst): func key DefinedWasmFunction(StaticModuleIndex(0), DefinedFuncIndex(0)), wasm PC 0x37, slot at FP-0xb0, locals , stack 
-;;       ╰─╼ breakpoint patch: wasm PC 0x37, patch bytes [67, 1, 0, 148]
+;;       ╰─╼ breakpoint patch: wasm PC 0x37, patch bytes [65, 1, 0, 148]
 ;;       ldur    x0, [sp, #0x10]
 ;;       nop
 ;;       ├─╼ debug frame state (after previous inst): func key DefinedWasmFunction(StaticModuleIndex(0), DefinedFuncIndex(0)), wasm PC 0x3d, slot at FP-0xb0, locals , stack 
-;;       ╰─╼ breakpoint patch: wasm PC 0x3d, patch bytes [65, 1, 0, 148]
+;;       ╰─╼ breakpoint patch: wasm PC 0x3d, patch bytes [63, 1, 0, 148]
 ;;       mov     w1, #0x2a
 ;;       stur    w1, [sp, #8]
 ;;       nop
 ;;       ├─╼ debug frame state (after previous inst): func key DefinedWasmFunction(StaticModuleIndex(0), DefinedFuncIndex(0)), wasm PC 0x3f, slot at FP-0xb0, locals , stack I32 @ slot+0x8
-;;       ╰─╼ breakpoint patch: wasm PC 0x3f, patch bytes [62, 1, 0, 148]
+;;       ╰─╼ breakpoint patch: wasm PC 0x3f, patch bytes [60, 1, 0, 148]
 ;;       nop
 ;;       ├─╼ debug frame state (after previous inst): func key DefinedWasmFunction(StaticModuleIndex(0), DefinedFuncIndex(0)), wasm PC 0x40, slot at FP-0xb0, locals , stack 
-;;       ╰─╼ breakpoint patch: wasm PC 0x40, patch bytes [61, 1, 0, 148]
+;;       ╰─╼ breakpoint patch: wasm PC 0x40, patch bytes [59, 1, 0, 148]
 ;;       stur    w1, [sp, #8]
 ;;       nop
 ;;       ├─╼ debug frame state (after previous inst): func key DefinedWasmFunction(StaticModuleIndex(0), DefinedFuncIndex(0)), wasm PC 0x42, slot at FP-0xb0, locals , stack I32 @ slot+0x8
-;;       ╰─╼ breakpoint patch: wasm PC 0x42, patch bytes [59, 1, 0, 148]
+;;       ╰─╼ breakpoint patch: wasm PC 0x42, patch bytes [57, 1, 0, 148]
 ;;       ldur    x2, [sp, #0x10]
-;;       bl      #0x4d0
+;;       bl      #0x4c8
 ;;   88: ldur    x0, [sp, #0x10]
 ;;       mov     x19, x2
-;;       ldr     x1, [x0, #0x20]
-;;       ldr     w3, [x1]
-;;       mov     w2, w3
-;;       add     x2, x2, #0x20
-;;       ldr     w4, [x1, #4]
-;;       cmp     x2, x4
-;;       b.hi    #0x1a0
-;;   ac: ldur    x0, [sp, #0x18]
-;;       add     w4, w3, #0x20
-;;       str     w4, [x1]
-;;       mov     w6, #2
-;;       movk    w6, #0x400, lsl #16
-;;       ldr     x5, [x0, #0x20]
-;;       add     x1, x5, w3, uxtw
-;;       str     w6, [x5, w3, uxtw]
+;;       ldr     x0, [x0, #0x20]
+;;       ldr     w3, [x0]
+;;       mov     w1, w3
+;;       add     x1, x1, #0x20
+;;       ldr     w2, [x0, #4]
+;;       cmp     x1, x2
+;;       b.hi    #0x198
+;;   ac: ldur    x4, [sp, #0x18]
+;;       add     w2, w3, #0x20
+;;       str     w2, [x0]
+;;       mov     w5, #2
+;;       movk    w5, #0x400, lsl #16
+;;       ldr     x6, [x4, #0x20]
+;;       add     x1, x6, w3, uxtw
+;;       str     w5, [x6, w3, uxtw]
 ;;       ldur    x0, [sp, #0x10]
-;;       ldr     x6, [x0, #0x28]
-;;       ldr     w6, [x6, #8]
-;;       add     x7, x5, #4
-;;       str     w6, [x7, w3, uxtw]
-;;       mov     x7, #0x20
-;;       add     x8, x5, #8
-;;       str     w7, [x8, w3, uxtw]
-;;       mov     w9, #0x2a
-;;       str     w9, [x1, #0x18]
+;;       ldr     x4, [x0, #0x28]
+;;       ldr     w4, [x4, #8]
+;;       str     w4, [x1, #4]
+;;       mov     x5, #0x20
+;;       str     w5, [x1, #8]
+;;       mov     w7, #0x2a
+;;       str     w7, [x1, #0x18]
 ;;       mov     x2, x19
 ;;       str     w2, [x1, #0x10]
-;;       mov     w11, #0
-;;       str     w11, [x1, #0x14]
+;;       mov     w9, #0
+;;       str     w9, [x1, #0x14]
 ;;       ldur    x2, [sp, #0x10]
-;;       bl      #0x508
+;;       bl      #0x500
 ;;       ├─╼ exception frame offset: SP = FP - 0xb0
-;;       ╰─╼ exception handler: tag=0, context at [SP+0x10], handler=0x110
-;;       b       #0x1d8
-;;  110: mov     w1, w0
-;;       mov     x2, #0x20
-;;       adds    x15, x1, x2
-;;       cset    x1, hs
-;;       tst     w1, #0xff
-;;       b.ne    #0x208
-;;  128: ldur    x2, [sp, #0x18]
+;;       ╰─╼ exception handler: tag=0, context at [SP+0x10], handler=0x108
+;;       b       #0x1d0
+;;  108: mov     w14, w0
+;;       mov     x15, #0x20
+;;       adds    x13, x14, x15
+;;       cset    x15, hs
+;;       tst     w15, #0xff
+;;       b.ne    #0x200
+;;  120: ldur    x2, [sp, #0x18]
 ;;       ldr     x1, [x2, #0x28]
-;;       cmp     x15, x1
-;;       b.hi    #0x1f0
-;;  138: ldr     x1, [x2, #0x20]
-;;       add     x1, x1, #0x18
-;;       ldr     w0, [x1, w0, uxtw]
+;;       cmp     x13, x1
+;;       b.hi    #0x1e8
+;;  130: ldr     x1, [x2, #0x20]
+;;       add     x0, x1, w0, uxtw
+;;       ldr     w0, [x0, #0x18]
 ;;       stur    w0, [sp, #8]
 ;;       ldur    x0, [sp, #0x10]
 ;;       nop
@@ -120,7 +118,7 @@
 ;;       ldur    x3, [sp, #0x10]
 ;;       blr     x0
 ;;       ╰─╼ debug frame state (after previous inst): func key DefinedWasmFunction(StaticModuleIndex(0), DefinedFuncIndex(0)), wasm PC 0x4a, slot at FP-0xb0, locals , stack I32 @ slot+0x8
-;;  164: ldur    x0, [sp, #0x10]
+;;  15c: ldur    x0, [sp, #0x10]
 ;;       nop
 ;;       ├─╼ debug frame state (after previous inst): func key DefinedWasmFunction(StaticModuleIndex(0), DefinedFuncIndex(0)), wasm PC 0x4a, slot at FP-0xb0, locals , stack I32 @ slot+0x8
 ;;       ╰─╼ breakpoint patch: wasm PC 0x4a, patch bytes [0, 1, 0, 148]
@@ -139,45 +137,45 @@
 ;;       ldp     x27, x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;  1a0: mov     w3, #2
-;;  1a4: movk    w3, #0x400, lsl #16
-;;  1a8: ldur    x0, [sp, #0x10]
-;;  1ac: ldr     x4, [x0, #0x28]
-;;  1b0: ldr     w4, [x4, #8]
-;;  1b4: mov     w5, #0x20
-;;  1b8: mov     w6, #0x10
-;;  1bc: ldur    x2, [sp, #0x10]
-;;  1c0: bl      #0x3fc
-;;  1c4: ldur    x0, [sp, #0x18]
-;;  1c8: ldr     x3, [x0, #0x20]
-;;  1cc: add     x1, x3, w2, uxtw
-;;  1d0: mov     x3, x2
-;;  1d4: b       #0xec
-;;  1d8: mov     w3, #9
+;;  198: mov     w3, #2
+;;  19c: movk    w3, #0x400, lsl #16
+;;  1a0: ldur    x0, [sp, #0x10]
+;;  1a4: ldr     x1, [x0, #0x28]
+;;  1a8: ldr     w4, [x1, #8]
+;;  1ac: mov     w5, #0x20
+;;  1b0: mov     w6, #0x10
+;;  1b4: ldur    x2, [sp, #0x10]
+;;  1b8: bl      #0x3f4
+;;  1bc: ldur    x4, [sp, #0x18]
+;;  1c0: ldr     x1, [x4, #0x20]
+;;  1c4: add     x1, x1, w2, uxtw
+;;  1c8: mov     x3, x2
+;;  1cc: b       #0xe4
+;;  1d0: mov     w3, #9
+;;  1d4: ldur    x2, [sp, #0x10]
+;;  1d8: bl      #0x45c
 ;;  1dc: ldur    x2, [sp, #0x10]
-;;  1e0: bl      #0x464
-;;  1e4: ldur    x2, [sp, #0x10]
-;;  1e8: bl      #0x49c
+;;  1e0: bl      #0x494
 ;;       ╰─╼ debug frame state (after previous inst): func key DefinedWasmFunction(StaticModuleIndex(0), DefinedFuncIndex(0)), wasm PC 0x42, slot at FP-0xb0, locals , stack I32 @ slot+0x8
-;;  1ec: udf     #0xc11f
-;;  1f0: mov     w3, #0xfe
+;;  1e4: udf     #0xc11f
+;;  1e8: mov     w3, #0xfe
+;;  1ec: ldur    x2, [sp, #0x10]
+;;  1f0: bl      #0x45c
 ;;  1f4: ldur    x2, [sp, #0x10]
-;;  1f8: bl      #0x464
-;;  1fc: ldur    x2, [sp, #0x10]
-;;  200: bl      #0x49c
+;;  1f8: bl      #0x494
 ;;       ╰─╼ debug frame state (after previous inst): func key DefinedWasmFunction(StaticModuleIndex(0), DefinedFuncIndex(0)), wasm PC 0x37, slot at FP-0xb0, locals , stack 
-;;  204: udf     #0xc11f
-;;  208: mov     w3, #0xfe
+;;  1fc: udf     #0xc11f
+;;  200: mov     w3, #0xfe
+;;  204: ldur    x2, [sp, #0x10]
+;;  208: bl      #0x45c
 ;;  20c: ldur    x2, [sp, #0x10]
-;;  210: bl      #0x464
-;;  214: ldur    x2, [sp, #0x10]
-;;  218: bl      #0x49c
+;;  210: bl      #0x494
 ;;       ╰─╼ debug frame state (after previous inst): func key DefinedWasmFunction(StaticModuleIndex(0), DefinedFuncIndex(0)), wasm PC 0x37, slot at FP-0xb0, locals , stack 
-;;  21c: udf     #0xc11f
-;;  220: stur    x2, [sp, #0x10]
-;;  224: mov     w3, #0
-;;  228: bl      #0x464
-;;  22c: ldur    x2, [sp, #0x10]
-;;  230: bl      #0x49c
+;;  214: udf     #0xc11f
+;;  218: stur    x2, [sp, #0x10]
+;;  21c: mov     w3, #0
+;;  220: bl      #0x45c
+;;  224: ldur    x2, [sp, #0x10]
+;;  228: bl      #0x494
 ;;       ╰─╼ debug frame state (after previous inst): func key DefinedWasmFunction(StaticModuleIndex(0), DefinedFuncIndex(0)), wasm PC 0x34, slot at FP-0xb0, locals , stack 
-;;  234: udf     #0xc11f
+;;  22c: udf     #0xc11f

--- a/tests/disas/load-store/aarch64/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -28,8 +28,8 @@
 ;;       cmp     x10, x9
 ;;       b.hi    #0x34
 ;;   20: ldr     x11, [x2, #0x38]
-;;       add     x11, x11, #1, lsl #12
-;;       str     w5, [x11, w4, uxtw]
+;;       add     x11, x11, w4, uxtw
+;;       str     w5, [x11, #0x1000]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   34: udf     #0xc11f
@@ -44,8 +44,8 @@
 ;;       cmp     x10, x9
 ;;       b.hi    #0x74
 ;;   60: ldr     x11, [x2, #0x38]
-;;       add     x10, x11, #1, lsl #12
-;;       ldr     w2, [x10, w4, uxtw]
+;;       add     x11, x11, w4, uxtw
+;;       ldr     w2, [x11, #0x1000]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   74: udf     #0xc11f

--- a/tests/disas/load-store/aarch64/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -26,8 +26,8 @@
 ;;       cmp     x8, x7
 ;;       b.hi    #0x2c
 ;;   18: ldr     x9, [x2, #0x38]
-;;       add     x9, x9, #1, lsl #12
-;;       str     w5, [x9, w4, uxtw]
+;;       add     x9, x9, w4, uxtw
+;;       str     w5, [x9, #0x1000]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   2c: udf     #0xc11f
@@ -40,8 +40,8 @@
 ;;       cmp     x8, x7
 ;;       b.hi    #0x6c
 ;;   58: ldr     x9, [x2, #0x38]
-;;       add     x8, x9, #1, lsl #12
-;;       ldr     w2, [x8, w4, uxtw]
+;;       add     x9, x9, w4, uxtw
+;;       ldr     w2, [x9, #0x1000]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   6c: udf     #0xc11f

--- a/tests/disas/load-store/aarch64/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -27,8 +27,8 @@
 ;;       cmp     x4, x8
 ;;       b.hi    #0x30
 ;;   1c: ldr     x10, [x2, #0x38]
-;;       add     x10, x10, #1, lsl #12
-;;       str     w5, [x10, x4]
+;;       add     x10, x10, x4
+;;       str     w5, [x10, #0x1000]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   30: udf     #0xc11f
@@ -42,8 +42,8 @@
 ;;       cmp     x4, x8
 ;;       b.hi    #0x70
 ;;   5c: ldr     x10, [x2, #0x38]
-;;       add     x9, x10, #1, lsl #12
-;;       ldr     w2, [x9, x4]
+;;       add     x10, x10, x4
+;;       ldr     w2, [x10, #0x1000]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   70: udf     #0xc11f

--- a/tests/disas/load-store/aarch64/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -25,8 +25,8 @@
 ;;       cmp     x4, x6
 ;;       b.hi    #0x28
 ;;   14: ldr     x8, [x2, #0x38]
-;;       add     x8, x8, #1, lsl #12
-;;       str     w5, [x8, x4]
+;;       add     x8, x8, x4
+;;       str     w5, [x8, #0x1000]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   28: udf     #0xc11f
@@ -38,8 +38,8 @@
 ;;       cmp     x4, x6
 ;;       b.hi    #0x68
 ;;   54: ldr     x8, [x2, #0x38]
-;;       add     x7, x8, #1, lsl #12
-;;       ldr     w2, [x7, x4]
+;;       add     x8, x8, x4
+;;       ldr     w2, [x8, #0x1000]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   68: udf     #0xc11f

--- a/tests/disas/load-store/aarch64/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -26,8 +26,8 @@
 ;;       cmp     x7, x8
 ;;       b.hi    #0x2c
 ;;   18: ldr     x9, [x2, #0x38]
-;;       add     x9, x9, #1, lsl #12
-;;       str     w5, [x9, w4, uxtw]
+;;       add     x9, x9, w4, uxtw
+;;       str     w5, [x9, #0x1000]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   2c: udf     #0xc11f
@@ -40,8 +40,8 @@
 ;;       cmp     x7, x8
 ;;       b.hi    #0x6c
 ;;   58: ldr     x9, [x2, #0x38]
-;;       add     x8, x9, #1, lsl #12
-;;       ldr     w2, [x8, w4, uxtw]
+;;       add     x9, x9, w4, uxtw
+;;       ldr     w2, [x9, #0x1000]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   6c: udf     #0xc11f

--- a/tests/disas/load-store/aarch64/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -22,8 +22,8 @@
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
 ;;       ldr     x6, [x2, #0x38]
-;;       add     x6, x6, #1, lsl #12
-;;       str     w5, [x6, w4, uxtw]
+;;       add     x6, x6, w4, uxtw
+;;       str     w5, [x6, #0x1000]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;
@@ -31,7 +31,7 @@
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
 ;;       ldr     x5, [x2, #0x38]
-;;       add     x5, x5, #1, lsl #12
-;;       ldr     w2, [x5, w4, uxtw]
+;;       add     x5, x5, w4, uxtw
+;;       ldr     w2, [x5, #0x1000]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/load-store/aarch64/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -22,8 +22,8 @@
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
 ;;       ldr     x6, [x2, #0x38]
-;;       add     x6, x6, #1, lsl #12
-;;       str     w5, [x6, w4, uxtw]
+;;       add     x6, x6, w4, uxtw
+;;       str     w5, [x6, #0x1000]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;
@@ -31,7 +31,7 @@
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
 ;;       ldr     x5, [x2, #0x38]
-;;       add     x5, x5, #1, lsl #12
-;;       ldr     w2, [x5, w4, uxtw]
+;;       add     x5, x5, w4, uxtw
+;;       ldr     w2, [x5, #0x1000]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/load-store/aarch64/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -25,8 +25,8 @@
 ;;       cmp     x4, x6
 ;;       b.hi    #0x28
 ;;   14: ldr     x8, [x2, #0x38]
-;;       add     x8, x8, #1, lsl #12
-;;       str     w5, [x8, x4]
+;;       add     x8, x8, x4
+;;       str     w5, [x8, #0x1000]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   28: udf     #0xc11f
@@ -38,8 +38,8 @@
 ;;       cmp     x4, x6
 ;;       b.hi    #0x68
 ;;   54: ldr     x8, [x2, #0x38]
-;;       add     x7, x8, #1, lsl #12
-;;       ldr     w2, [x7, x4]
+;;       add     x8, x8, x4
+;;       ldr     w2, [x8, #0x1000]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   68: udf     #0xc11f

--- a/tests/disas/load-store/aarch64/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -25,8 +25,8 @@
 ;;       cmp     x4, x6
 ;;       b.hi    #0x28
 ;;   14: ldr     x8, [x2, #0x38]
-;;       add     x8, x8, #1, lsl #12
-;;       str     w5, [x8, x4]
+;;       add     x8, x8, x4
+;;       str     w5, [x8, #0x1000]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   28: udf     #0xc11f
@@ -38,8 +38,8 @@
 ;;       cmp     x4, x6
 ;;       b.hi    #0x68
 ;;   54: ldr     x8, [x2, #0x38]
-;;       add     x7, x8, #1, lsl #12
-;;       ldr     w2, [x7, x4]
+;;       add     x8, x8, x4
+;;       ldr     w2, [x8, #0x1000]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   68: udf     #0xc11f


### PR DESCRIPTION
When several loads share `base + (extended index)` and differ only by a
uimm12-scaled offset (e.g. fields read through a computed index), AArch64 amode
selection emitted a separate `add base, #offset` per load, defeating CSE of the
shared `base + index`.

This folds the offset into the load's immediate and keeps `base + index` as one
value, so a single `add base, index, uxtw` is materialized and reused. A zero
offset keeps the single-instruction `RegExtended` form, so it is
neutral-or-better: a cluster of N such loads drops N address-adds to 1, a lone
load is unchanged.

Tested: new aarch64 precise-output filetest + a stack round-trip runtest
(aarch64/x86_64/s390x); the full aarch64 filetest and runtest suites pass.