### PR TITLE
Tag stack map slots' loads/stores with alias regions

### DIFF
--- a/cranelift/codegen/src/ir/memflags.rs
+++ b/cranelift/codegen/src/ir/memflags.rs
@@ -547,6 +547,11 @@ impl AliasRegionSet {
         self.dedupe_map.contains_key(&user_id)
     }
 
+    /// Get the alias region with the given id, if any.
+    pub fn get(&self, user_id: u32) -> Option<AliasRegion> {
+        self.dedupe_map.get(&user_id).copied()
+    }
+
     /// Returns `true` if the given alias region reference is valid.
     pub fn is_valid(&self, ar: AliasRegion) -> bool {
         self.alias_regions.is_valid(ar)

--- a/crates/cranelift/src/alias_region.rs
+++ b/crates/cranelift/src/alias_region.rs
@@ -90,6 +90,12 @@ enum AliasRegionKey {
 
     /// A GC heap access.
     GcHeap,
+
+    /// A stack slot access.
+    Stack {
+        /// The stack slot being accessed.
+        slot: ir::StackSlot,
+    },
 }
 
 impl AliasRegionKey {
@@ -133,6 +139,7 @@ impl AliasRegionKey {
     const VM_TABLE_IMPORT_KIND: u32 = Self::new_kind(0b10100);
     const VM_TAG_IMPORT_KIND: u32 = Self::new_kind(0b10101);
     const VM_GLOBAL_IMPORT_KIND: u32 = Self::new_kind(0b10110);
+    const STACK_KIND: u32 = Self::new_kind(0b10111);
 
     /// Encode this key into a raw `u32` suitable for use as an
     /// `AliasRegionData::user_id`.
@@ -192,6 +199,10 @@ impl AliasRegionKey {
                     | index.as_u32()
             }
             AliasRegionKey::GcHeap => Self::GC_HEAP_KIND,
+            AliasRegionKey::Stack { slot } => {
+                debug_assert_eq!(slot.as_u32() & Self::KIND_MASK, 0);
+                Self::STACK_KIND | (slot.as_u32() & Self::OFFSET_MASK)
+            }
         }
     }
 }
@@ -213,6 +224,7 @@ impl fmt::Debug for AliasRegionKey {
                 write!(f, "DefinedGlobal({module:?}, {index:?})")
             }
             AliasRegionKey::GcHeap => write!(f, "GcHeap"),
+            AliasRegionKey::Stack { slot } => write!(f, "Stack({slot:?})"),
         }
     }
 }
@@ -236,6 +248,24 @@ pub struct AliasRegions<Offsets> {
     /// Avoids allocating a string for the debug formatting of `AliasRegionKey`
     /// as the `ir::AliasRegionData::description` string repeatedly.
     cache: std::collections::HashMap<AliasRegionKey, ir::AliasRegion>,
+}
+
+impl<Offsets> AliasRegions<Offsets> {
+    /// Make the alias region for a stack map.
+    pub fn stack_map_region(
+        regions: &mut ir::AliasRegionSet,
+        _ty: ir::Type,
+        slot: ir::StackSlot,
+        _offset: u32,
+    ) -> Option<ir::AliasRegion> {
+        let key = AliasRegionKey::Stack { slot };
+        let id = key.into_raw();
+        if let Some(region) = regions.get(id) {
+            Some(region)
+        } else {
+            Some(regions.insert(key.into()))
+        }
+    }
 }
 
 impl<Offsets> AliasRegions<Offsets>

--- a/crates/cranelift/src/compiler.rs
+++ b/crates/cranelift/src/compiler.rs
@@ -1564,6 +1564,7 @@ impl FunctionCompiler<'_> {
             &mut self.cx.codegen_context.func,
             self.cx.func_translator.context(),
         );
+        builder.make_stack_map_alias_region(Box::new(AliasRegions::<u8>::stack_map_region));
 
         let block0 = builder.create_block();
         builder.append_block_params_for_function_params(block0);

--- a/crates/cranelift/src/translate/func_translator.rs
+++ b/crates/cranelift/src/translate/func_translator.rs
@@ -4,6 +4,7 @@
 //! function to Cranelift IR guided by a `FuncEnvironment` which provides information about the
 //! WebAssembly module and the runtime environment.
 
+use crate::alias_region::AliasRegions;
 use crate::func_environ::FuncEnvironment;
 use crate::translate::TargetEnvironment;
 use crate::translate::code_translator::{bitcast_wasm_returns, translate_operator};
@@ -68,6 +69,7 @@ impl FuncTranslator {
         debug_assert_eq!(func.dfg.num_insts(), 0, "Function must be empty");
 
         let mut builder = FunctionBuilder::new(func, &mut self.func_ctx);
+        builder.make_stack_map_alias_region(Box::new(AliasRegions::<u8>::stack_map_region));
         builder.set_srcloc(cur_srcloc(&reader));
         let entry_block = builder.create_block();
         builder.append_block_params_for_function_params(entry_block);
@@ -127,6 +129,7 @@ impl FuncTranslator {
         environ: &mut FuncEnvironment<'_>,
     ) -> WasmResult<()> {
         let mut builder = FunctionBuilder::new(func, &mut self.func_ctx);
+        builder.make_stack_map_alias_region(Box::new(AliasRegions::<u8>::stack_map_region));
         let entry_block = builder.create_block();
         builder.append_block_params_for_function_params(entry_block);
         builder.switch_to_block(entry_block);

--- a/tests/disas/array-fill-funcref.wat
+++ b/tests/disas/array-fill-funcref.wat
@@ -149,6 +149,7 @@
 ;;     region2 = 134217760 "VMStoreContext+0x20"
 ;;     region3 = 134217768 "VMStoreContext+0x28"
 ;;     region4 = 1073741824 "GcHeap"
+;;     region5 = 3087007744 "Stack(ss0)"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -160,10 +161,10 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
 ;;                                     v56 = stack_addr.i64 ss0
-;;                                     store notrap aligned v2, v56
+;;                                     store notrap aligned region5 v2, v56
 ;; @0053                               v5 = iconst.i32 3
 ;; @0053                               v6 = call fn0(v0, v5), stack_map=[i32 @ ss0+0]  ; v5 = 3
-;;                                     v55 = load.i32 notrap aligned v56
+;;                                     v55 = load.i32 notrap aligned region5 v56
 ;; @0057                               trapz v55, user16
 ;; @0057                               v8 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @0057                               v9 = load.i64 notrap aligned readonly can_move region2 v8+32

--- a/tests/disas/gc/array-copy-with-fuel.wat
+++ b/tests/disas/gc/array-copy-with-fuel.wat
@@ -18,6 +18,8 @@
 ;;     region3 = 134217760 "VMStoreContext+0x20"
 ;;     region4 = 134217768 "VMStoreContext+0x28"
 ;;     region5 = 1073741824 "GcHeap"
+;;     region6 = 3087007744 "Stack(ss0)"
+;;     region7 = 3087007745 "Stack(ss1)"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -27,9 +29,9 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32, v6: i32):
 ;;                                     v181 = stack_addr.i64 ss0
-;;                                     store notrap aligned v2, v181
+;;                                     store notrap aligned region6 v2, v181
 ;;                                     v182 = stack_addr.i64 ss1
-;;                                     store notrap aligned v4, v182
+;;                                     store notrap aligned region7 v4, v182
 ;; @0020                               v7 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @0020                               v8 = load.i64 notrap aligned region2 v7
 ;; @0020                               v9 = iconst.i64 1
@@ -46,7 +48,7 @@
 ;; @0020                               jump block3(v16)
 ;;
 ;;                                 block3(v89: i64):
-;;                                     v180 = load.i32 notrap aligned v181
+;;                                     v180 = load.i32 notrap aligned region6 v181
 ;; @002b                               trapz v180, user16
 ;; @002b                               v24 = load.i64 notrap aligned readonly can_move region3 v7+32
 ;; @002b                               v22 = uextend.i64 v180
@@ -60,7 +62,7 @@
 ;; @002b                               v29 = uextend.i64 v28
 ;; @002b                               v35 = icmp ugt v34, v29
 ;; @002b                               trapnz v35, user17
-;;                                     v174 = load.i32 notrap aligned v182
+;;                                     v174 = load.i32 notrap aligned region7 v182
 ;; @002b                               trapz v174, user16
 ;; @002b                               v46 = uextend.i64 v174
 ;; @002b                               v49 = iadd v24, v46
@@ -93,8 +95,8 @@
 ;; @002b                               brif.i32 v6, block4, block7(v91)
 ;;
 ;;                                 block4:
-;;                                     v162 = load.i32 notrap aligned v181
-;;                                     v164 = load.i32 notrap aligned v182
+;;                                     v162 = load.i32 notrap aligned region6 v181
+;;                                     v164 = load.i32 notrap aligned region7 v182
 ;; @002b                               v92 = icmp.i64 ult v45, v69
 ;;                                     v192 = iadd.i64 v89, v90  ; v90 = 6
 ;; @002b                               v97 = iadd.i64 v45, v189
@@ -105,8 +107,8 @@
 ;; @002b                               brif v92, block5(v45, v69, v5, v162, v164, v192), block6(v97, v98, v100, v162, v164, v192)
 ;;
 ;;                                 block5(v101: i64, v102: i64, v103: i32, v104: i32, v105: i32, v106: i64):
-;;                                     store notrap aligned v104, v181
-;;                                     store notrap aligned v105, v182
+;;                                     store notrap aligned region6 v104, v181
+;;                                     store notrap aligned region7 v105, v182
 ;;                                     v202 = iconst.i64 1
 ;;                                     v203 = iadd v106, v202  ; v202 = 1
 ;;                                     v204 = iconst.i64 0
@@ -114,8 +116,8 @@
 ;; @002b                               brif v205, block8, block9(v203)
 ;;
 ;;                                 block6(v123: i64, v124: i64, v125: i32, v126: i32, v127: i32, v128: i64):
-;;                                     store notrap aligned v126, v182
-;;                                     store notrap aligned v127, v181
+;;                                     store notrap aligned region7 v126, v182
+;;                                     store notrap aligned region6 v127, v181
 ;;                                     v193 = iconst.i64 1
 ;;                                     v194 = iadd v128, v193  ; v193 = 1
 ;;                                     v195 = iconst.i64 0
@@ -134,8 +136,8 @@
 ;;                                 block9(v145: i64):
 ;; @002b                               v115 = load.i32 user2 little region5 v102
 ;; @002b                               store user2 little region5 v115, v101
-;;                                     v150 = load.i32 notrap aligned v181
-;;                                     v152 = load.i32 notrap aligned v182
+;;                                     v150 = load.i32 notrap aligned region6 v181
+;;                                     v152 = load.i32 notrap aligned region7 v182
 ;;                                     v206 = iconst.i64 4
 ;;                                     v207 = iadd.i64 v102, v206  ; v206 = 4
 ;; @002b                               v122 = icmp eq v207, v98
@@ -156,8 +158,8 @@
 ;; @002b                               v143 = load.i32 user2 little region5 v198
 ;;                                     v199 = isub.i64 v123, v197  ; v197 = 4
 ;; @002b                               store user2 little region5 v143, v199
-;;                                     v156 = load.i32 notrap aligned v182
-;;                                     v158 = load.i32 notrap aligned v181
+;;                                     v156 = load.i32 notrap aligned region7 v182
+;;                                     v158 = load.i32 notrap aligned region6 v181
 ;; @002b                               v144 = icmp eq v198, v69
 ;;                                     v200 = iconst.i32 1
 ;;                                     v201 = isub.i32 v125, v200  ; v200 = 1

--- a/tests/disas/gc/array-new-data.wat
+++ b/tests/disas/gc/array-new-data.wat
@@ -88,6 +88,7 @@
 ;;     region8 = 134217760 "VMStoreContext+0x20"
 ;;     region9 = 1073741824 "GcHeap"
 ;;     region10 = 134217768 "VMStoreContext+0x28"
+;;     region11 = 3087007744 "Stack(ss0)"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -158,7 +159,7 @@
 ;;
 ;;                                 block4(v52: i32, v53: i64):
 ;;                                     v112 = stack_addr.i64 ss0
-;;                                     store notrap aligned v52, v112
+;;                                     store notrap aligned region11 v52, v112
 ;; @0025                               v54 = iconst.i64 16
 ;; @0025                               v55 = iadd v53, v54  ; v54 = 16
 ;; @0025                               store.i32 user2 region9 v3, v55
@@ -189,6 +190,6 @@
 ;; @0029                               jump block1
 ;;
 ;;                                 block1:
-;;                                     v105 = load.i32 notrap aligned v112
+;;                                     v105 = load.i32 notrap aligned region11 v112
 ;; @0029                               return v105
 ;; }

--- a/tests/disas/gc/array-new-default-f32.wat
+++ b/tests/disas/gc/array-new-default-f32.wat
@@ -20,6 +20,7 @@
 ;;     region6 = 134217760 "VMStoreContext+0x20"
 ;;     region7 = 1073741824 "GcHeap"
 ;;     region8 = 134217768 "VMStoreContext+0x28"
+;;     region9 = 3087007744 "Stack(ss0)"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -87,7 +88,7 @@
 ;;
 ;;                                 block4(v40: i32, v41: i64):
 ;;                                     v89 = stack_addr.i64 ss0
-;;                                     store notrap aligned v40, v89
+;;                                     store notrap aligned region9 v40, v89
 ;; @001f                               v42 = iconst.i64 16
 ;; @001f                               v43 = iadd v41, v42  ; v42 = 16
 ;; @001f                               store.i32 user2 region7 v2, v43
@@ -113,6 +114,6 @@
 ;; @0022                               jump block1
 ;;
 ;;                                 block1:
-;;                                     v82 = load.i32 notrap aligned v89
+;;                                     v82 = load.i32 notrap aligned region9 v89
 ;; @0022                               return v82
 ;; }

--- a/tests/disas/gc/array-new-default-f64.wat
+++ b/tests/disas/gc/array-new-default-f64.wat
@@ -20,6 +20,7 @@
 ;;     region6 = 134217760 "VMStoreContext+0x20"
 ;;     region7 = 1073741824 "GcHeap"
 ;;     region8 = 134217768 "VMStoreContext+0x28"
+;;     region9 = 3087007744 "Stack(ss0)"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -87,7 +88,7 @@
 ;;
 ;;                                 block4(v40: i32, v41: i64):
 ;;                                     v89 = stack_addr.i64 ss0
-;;                                     store notrap aligned v40, v89
+;;                                     store notrap aligned region9 v40, v89
 ;; @001f                               v42 = iconst.i64 16
 ;; @001f                               v43 = iadd v41, v42  ; v42 = 16
 ;; @001f                               store.i32 user2 region7 v2, v43
@@ -113,6 +114,6 @@
 ;; @0022                               jump block1
 ;;
 ;;                                 block1:
-;;                                     v82 = load.i32 notrap aligned v89
+;;                                     v82 = load.i32 notrap aligned region9 v89
 ;; @0022                               return v82
 ;; }

--- a/tests/disas/gc/array-new-default-funcref.wat
+++ b/tests/disas/gc/array-new-default-funcref.wat
@@ -20,6 +20,7 @@
 ;;     region6 = 134217760 "VMStoreContext+0x20"
 ;;     region7 = 1073741824 "GcHeap"
 ;;     region8 = 134217768 "VMStoreContext+0x28"
+;;     region9 = 3087007744 "Stack(ss0)"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -87,7 +88,7 @@
 ;;
 ;;                                 block4(v40: i32, v41: i64):
 ;;                                     v97 = stack_addr.i64 ss0
-;;                                     store notrap aligned v40, v97
+;;                                     store notrap aligned region9 v40, v97
 ;; @001f                               v42 = iconst.i64 16
 ;; @001f                               v43 = iadd v41, v42  ; v42 = 16
 ;; @001f                               store.i32 user2 region7 v2, v43
@@ -127,6 +128,6 @@
 ;; @0022                               jump block1
 ;;
 ;;                                 block1:
-;;                                     v90 = load.i32 notrap aligned v97
+;;                                     v90 = load.i32 notrap aligned region9 v97
 ;; @0022                               return v90
 ;; }

--- a/tests/disas/gc/array-new-default-i16.wat
+++ b/tests/disas/gc/array-new-default-i16.wat
@@ -20,6 +20,7 @@
 ;;     region6 = 134217760 "VMStoreContext+0x20"
 ;;     region7 = 1073741824 "GcHeap"
 ;;     region8 = 134217768 "VMStoreContext+0x28"
+;;     region9 = 3087007744 "Stack(ss0)"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -86,7 +87,7 @@
 ;;
 ;;                                 block4(v40: i32, v41: i64):
 ;;                                     v89 = stack_addr.i64 ss0
-;;                                     store notrap aligned v40, v89
+;;                                     store notrap aligned region9 v40, v89
 ;; @001f                               v42 = iconst.i64 16
 ;; @001f                               v43 = iadd v41, v42  ; v42 = 16
 ;; @001f                               store.i32 user2 region7 v2, v43
@@ -112,6 +113,6 @@
 ;; @0022                               jump block1
 ;;
 ;;                                 block1:
-;;                                     v82 = load.i32 notrap aligned v89
+;;                                     v82 = load.i32 notrap aligned region9 v89
 ;; @0022                               return v82
 ;; }

--- a/tests/disas/gc/array-new-default-i32.wat
+++ b/tests/disas/gc/array-new-default-i32.wat
@@ -20,6 +20,7 @@
 ;;     region6 = 134217760 "VMStoreContext+0x20"
 ;;     region7 = 1073741824 "GcHeap"
 ;;     region8 = 134217768 "VMStoreContext+0x28"
+;;     region9 = 3087007744 "Stack(ss0)"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -87,7 +88,7 @@
 ;;
 ;;                                 block4(v40: i32, v41: i64):
 ;;                                     v89 = stack_addr.i64 ss0
-;;                                     store notrap aligned v40, v89
+;;                                     store notrap aligned region9 v40, v89
 ;; @001f                               v42 = iconst.i64 16
 ;; @001f                               v43 = iadd v41, v42  ; v42 = 16
 ;; @001f                               store.i32 user2 region7 v2, v43
@@ -113,6 +114,6 @@
 ;; @0022                               jump block1
 ;;
 ;;                                 block1:
-;;                                     v82 = load.i32 notrap aligned v89
+;;                                     v82 = load.i32 notrap aligned region9 v89
 ;; @0022                               return v82
 ;; }

--- a/tests/disas/gc/array-new-default-i64.wat
+++ b/tests/disas/gc/array-new-default-i64.wat
@@ -20,6 +20,7 @@
 ;;     region6 = 134217760 "VMStoreContext+0x20"
 ;;     region7 = 1073741824 "GcHeap"
 ;;     region8 = 134217768 "VMStoreContext+0x28"
+;;     region9 = 3087007744 "Stack(ss0)"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -87,7 +88,7 @@
 ;;
 ;;                                 block4(v40: i32, v41: i64):
 ;;                                     v89 = stack_addr.i64 ss0
-;;                                     store notrap aligned v40, v89
+;;                                     store notrap aligned region9 v40, v89
 ;; @001f                               v42 = iconst.i64 16
 ;; @001f                               v43 = iadd v41, v42  ; v42 = 16
 ;; @001f                               store.i32 user2 region7 v2, v43
@@ -113,6 +114,6 @@
 ;; @0022                               jump block1
 ;;
 ;;                                 block1:
-;;                                     v82 = load.i32 notrap aligned v89
+;;                                     v82 = load.i32 notrap aligned region9 v89
 ;; @0022                               return v82
 ;; }

--- a/tests/disas/gc/array-new-default-i8.wat
+++ b/tests/disas/gc/array-new-default-i8.wat
@@ -20,6 +20,7 @@
 ;;     region6 = 134217760 "VMStoreContext+0x20"
 ;;     region7 = 1073741824 "GcHeap"
 ;;     region8 = 134217768 "VMStoreContext+0x28"
+;;     region9 = 3087007744 "Stack(ss0)"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -83,7 +84,7 @@
 ;;
 ;;                                 block4(v40: i32, v41: i64):
 ;;                                     v88 = stack_addr.i64 ss0
-;;                                     store notrap aligned v40, v88
+;;                                     store notrap aligned region9 v40, v88
 ;; @001f                               v42 = iconst.i64 16
 ;; @001f                               v43 = iadd v41, v42  ; v42 = 16
 ;; @001f                               store.i32 user2 region7 v2, v43
@@ -109,6 +110,6 @@
 ;; @0022                               jump block1
 ;;
 ;;                                 block1:
-;;                                     v81 = load.i32 notrap aligned v88
+;;                                     v81 = load.i32 notrap aligned region9 v88
 ;; @0022                               return v81
 ;; }

--- a/tests/disas/gc/copying/array-new-fixed-of-gc-refs.wat
+++ b/tests/disas/gc/copying/array-new-fixed-of-gc-refs.wat
@@ -21,6 +21,9 @@
 ;;     region6 = 134217760 "VMStoreContext+0x20"
 ;;     region7 = 1073741824 "GcHeap"
 ;;     region8 = 134217768 "VMStoreContext+0x28"
+;;     region9 = 3087007744 "Stack(ss0)"
+;;     region10 = 3087007745 "Stack(ss1)"
+;;     region11 = 3087007746 "Stack(ss2)"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -30,11 +33,11 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
 ;;                                     v137 = stack_addr.i64 ss2
-;;                                     store notrap aligned v2, v137
+;;                                     store notrap aligned region11 v2, v137
 ;;                                     v138 = stack_addr.i64 ss1
-;;                                     store notrap aligned v3, v138
+;;                                     store notrap aligned region10 v3, v138
 ;;                                     v139 = stack_addr.i64 ss0
-;;                                     store notrap aligned v4, v139
+;;                                     store notrap aligned region9 v4, v139
 ;; @0025                               v14 = load.i64 notrap aligned readonly can_move region2 v0+32
 ;; @0025                               v15 = load.i32 notrap aligned region3 v14
 ;; @0025                               v16 = load.i32 notrap aligned region4 v14+4
@@ -98,7 +101,7 @@
 ;; @0025                               v6 = iconst.i32 20
 ;; @0025                               v63 = uadd_overflow_trap v181, v6, user2  ; v6 = 20
 ;; @0025                               v67 = uadd_overflow_trap v43, v63, user2
-;;                                     v136 = load.i32 notrap aligned v137
+;;                                     v136 = load.i32 notrap aligned region11 v137
 ;; @0025                               v68 = uextend.i64 v67
 ;; @0025                               v71 = iadd v267, v68
 ;; @0025                               v72 = isub v63, v6  ; v6 = 20
@@ -116,7 +119,7 @@
 ;;                                     v207 = ishl v82, v180  ; v180 = 2
 ;; @0025                               v91 = uadd_overflow_trap v207, v6, user2  ; v6 = 20
 ;; @0025                               v95 = uadd_overflow_trap v43, v91, user2
-;;                                     v134 = load.i32 notrap aligned v138
+;;                                     v134 = load.i32 notrap aligned region10 v138
 ;; @0025                               v96 = uextend.i64 v95
 ;; @0025                               v99 = iadd v267, v96
 ;;                                     v220 = iconst.i32 24
@@ -134,7 +137,7 @@
 ;;                                     v235 = ishl v110, v180  ; v180 = 2
 ;; @0025                               v119 = uadd_overflow_trap v235, v6, user2  ; v6 = 20
 ;; @0025                               v123 = uadd_overflow_trap v43, v119, user2
-;;                                     v132 = load.i32 notrap aligned v139
+;;                                     v132 = load.i32 notrap aligned region9 v139
 ;; @0025                               v124 = uextend.i64 v123
 ;; @0025                               v127 = iadd v267, v124
 ;;                                     v253 = iconst.i32 28

--- a/tests/disas/gc/copying/funcref-in-gc-heap-new.wat
+++ b/tests/disas/gc/copying/funcref-in-gc-heap-new.wat
@@ -18,6 +18,7 @@
 ;;     region5 = 40 "VMContext+0x28"
 ;;     region6 = 134217760 "VMStoreContext+0x20"
 ;;     region7 = 1073741824 "GcHeap"
+;;     region8 = 3087007744 "Stack(ss0)"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -69,7 +70,7 @@
 ;;
 ;;                                 block4(v33: i32, v34: i64):
 ;;                                     v41 = stack_addr.i64 ss0
-;;                                     store notrap aligned v33, v41
+;;                                     store notrap aligned region8 v33, v41
 ;; @0020                               v37 = call fn1(v0, v2), stack_map=[i32 @ ss0+0]
 ;; @0020                               v38 = ireduce.i32 v37
 ;; @0020                               v35 = iconst.i64 16
@@ -78,6 +79,6 @@
 ;; @0023                               jump block1
 ;;
 ;;                                 block1:
-;;                                     v40 = load.i32 notrap aligned v41
+;;                                     v40 = load.i32 notrap aligned region8 v41
 ;; @0023                               return v40
 ;; }

--- a/tests/disas/gc/copying/struct-new.wat
+++ b/tests/disas/gc/copying/struct-new.wat
@@ -20,6 +20,7 @@
 ;;     region5 = 40 "VMContext+0x28"
 ;;     region6 = 134217760 "VMStoreContext+0x20"
 ;;     region7 = 1073741824 "GcHeap"
+;;     region8 = 3087007744 "Stack(ss0)"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -29,7 +30,7 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: f32, v3: i32, v4: i32):
 ;;                                     v45 = stack_addr.i64 ss0
-;;                                     store notrap aligned v4, v45
+;;                                     store notrap aligned region8 v4, v45
 ;; @002a                               v6 = load.i64 notrap aligned readonly can_move region2 v0+32
 ;; @002a                               v7 = load.i32 notrap aligned region3 v6
 ;; @002a                               v8 = load.i32 notrap aligned region4 v6+4
@@ -76,7 +77,7 @@
 ;; @002a                               v39 = iconst.i64 20
 ;; @002a                               v40 = iadd v36, v39  ; v39 = 20
 ;; @002a                               istore8.i32 user2 little region7 v3, v40
-;;                                     v44 = load.i32 notrap aligned v45
+;;                                     v44 = load.i32 notrap aligned region8 v45
 ;; @002a                               v41 = iconst.i64 24
 ;; @002a                               v42 = iadd v36, v41  ; v41 = 24
 ;; @002a                               store user2 little region7 v44, v42

--- a/tests/disas/gc/drc/array-new-fixed-of-gc-refs.wat
+++ b/tests/disas/gc/drc/array-new-fixed-of-gc-refs.wat
@@ -19,6 +19,9 @@
 ;;     region3 = 134217760 "VMStoreContext+0x20"
 ;;     region4 = 1073741824 "GcHeap"
 ;;     region5 = 134217768 "VMStoreContext+0x28"
+;;     region6 = 3087007744 "Stack(ss0)"
+;;     region7 = 3087007745 "Stack(ss1)"
+;;     region8 = 3087007746 "Stack(ss2)"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -28,11 +31,11 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
 ;;                                     v202 = stack_addr.i64 ss2
-;;                                     store notrap aligned v2, v202
+;;                                     store notrap aligned region8 v2, v202
 ;;                                     v203 = stack_addr.i64 ss1
-;;                                     store notrap aligned v3, v203
+;;                                     store notrap aligned region7 v3, v203
 ;;                                     v204 = stack_addr.i64 ss0
-;;                                     store notrap aligned v4, v204
+;;                                     store notrap aligned region6 v4, v204
 ;; @0025                               v14 = iconst.i32 -1476395008
 ;; @0025                               v15 = load.i64 notrap aligned readonly can_move region2 v0+40
 ;; @0025                               v16 = load.i32 notrap aligned readonly can_move v15
@@ -49,7 +52,7 @@
 ;; @0025                               store user2 region4 v5, v24  ; v5 = 3
 ;; @0025                               trapz v18, user16
 ;; @0025                               v45 = uadd_overflow_trap v18, v216, user2  ; v216 = 40
-;;                                     v201 = load.i32 notrap aligned v202
+;;                                     v201 = load.i32 notrap aligned region8 v202
 ;; @0025                               v53 = iconst.i32 1
 ;; @0025                               v54 = band v201, v53  ; v53 = 1
 ;; @0025                               v25 = iconst.i32 0
@@ -59,7 +62,7 @@
 ;; @0025                               brif v58, block3, block2
 ;;
 ;;                                 block2:
-;;                                     v197 = load.i32 notrap aligned v202
+;;                                     v197 = load.i32 notrap aligned region8 v202
 ;; @0025                               v59 = uextend.i64 v197
 ;; @0025                               v62 = iadd.i64 v20, v59
 ;; @0025                               v63 = iconst.i64 8
@@ -71,7 +74,7 @@
 ;; @0025                               jump block3
 ;;
 ;;                                 block3:
-;;                                     v193 = load.i32 notrap aligned v202
+;;                                     v193 = load.i32 notrap aligned region8 v202
 ;; @0025                               v46 = uextend.i64 v45
 ;; @0025                               v49 = iadd.i64 v20, v46
 ;;                                     v206 = iconst.i64 12
@@ -93,7 +96,7 @@
 ;; @0025                               v6 = iconst.i32 28
 ;; @0025                               v90 = uadd_overflow_trap v258, v6, user2  ; v6 = 28
 ;; @0025                               v94 = uadd_overflow_trap.i32 v18, v90, user2
-;;                                     v191 = load.i32 notrap aligned v203
+;;                                     v191 = load.i32 notrap aligned region7 v203
 ;;                                     v312 = band v191, v310  ; v310 = 1
 ;;                                     v313 = iconst.i32 0
 ;;                                     v314 = icmp eq v191, v313  ; v313 = 0
@@ -102,7 +105,7 @@
 ;; @0025                               brif v107, block5, block4
 ;;
 ;;                                 block4:
-;;                                     v187 = load.i32 notrap aligned v203
+;;                                     v187 = load.i32 notrap aligned region7 v203
 ;; @0025                               v108 = uextend.i64 v187
 ;; @0025                               v111 = iadd.i64 v20, v108
 ;;                                     v315 = iconst.i64 8
@@ -114,7 +117,7 @@
 ;; @0025                               jump block5
 ;;
 ;;                                 block5:
-;;                                     v183 = load.i32 notrap aligned v203
+;;                                     v183 = load.i32 notrap aligned region7 v203
 ;; @0025                               v95 = uextend.i64 v94
 ;; @0025                               v98 = iadd.i64 v20, v95
 ;;                                     v271 = iconst.i32 32
@@ -137,7 +140,7 @@
 ;;                                     v325 = iconst.i32 28
 ;; @0025                               v139 = uadd_overflow_trap v324, v325, user2  ; v325 = 28
 ;; @0025                               v143 = uadd_overflow_trap.i32 v18, v139, user2
-;;                                     v181 = load.i32 notrap aligned v204
+;;                                     v181 = load.i32 notrap aligned region6 v204
 ;;                                     v326 = iconst.i32 1
 ;;                                     v327 = band v181, v326  ; v326 = 1
 ;;                                     v328 = iconst.i32 0
@@ -147,7 +150,7 @@
 ;; @0025                               brif v156, block7, block6
 ;;
 ;;                                 block6:
-;;                                     v177 = load.i32 notrap aligned v204
+;;                                     v177 = load.i32 notrap aligned region6 v204
 ;; @0025                               v157 = uextend.i64 v177
 ;; @0025                               v160 = iadd.i64 v20, v157
 ;;                                     v330 = iconst.i64 8
@@ -159,7 +162,7 @@
 ;; @0025                               jump block7
 ;;
 ;;                                 block7:
-;;                                     v173 = load.i32 notrap aligned v204
+;;                                     v173 = load.i32 notrap aligned region6 v204
 ;; @0025                               v144 = uextend.i64 v143
 ;; @0025                               v147 = iadd.i64 v20, v144
 ;;                                     v303 = iconst.i32 36

--- a/tests/disas/gc/drc/externref-globals.wat
+++ b/tests/disas/gc/drc/externref-globals.wat
@@ -24,6 +24,7 @@
 ;;     region7 = 1610612736 "VMDrcHeapData+0x0"
 ;;     region8 = 1610612740 "VMDrcHeapData+0x4"
 ;;     region9 = 1610612744 "VMDrcHeapData+0x8"
+;;     region10 = 3087007744 "Stack(ss0)"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -36,7 +37,7 @@
 ;; @0034                               v3 = iadd v0, v2  ; v2 = 48
 ;; @0034                               v4 = load.i32 notrap aligned region2 v3
 ;;                                     v76 = stack_addr.i64 ss0
-;;                                     store notrap aligned v4, v76
+;;                                     store notrap aligned region10 v4, v76
 ;; @0034                               v5 = iconst.i32 1
 ;; @0034                               v6 = band v4, v5  ; v5 = 1
 ;; @0034                               v7 = iconst.i32 0
@@ -93,7 +94,7 @@
 ;; @0036                               jump block1
 ;;
 ;;                                 block1:
-;;                                     v59 = load.i32 notrap aligned v76
+;;                                     v59 = load.i32 notrap aligned region10 v76
 ;; @0036                               return v59
 ;; }
 ;;

--- a/tests/disas/gc/drc/funcref-in-gc-heap-new.wat
+++ b/tests/disas/gc/drc/funcref-in-gc-heap-new.wat
@@ -16,6 +16,7 @@
 ;;     region2 = 40 "VMContext+0x28"
 ;;     region3 = 134217760 "VMStoreContext+0x20"
 ;;     region4 = 1073741824 "GcHeap"
+;;     region5 = 3087007744 "Stack(ss0)"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -33,7 +34,7 @@
 ;; @0020                               v7 = iconst.i32 8
 ;; @0020                               v8 = call fn0(v0, v4, v6, v3, v7)  ; v4 = -1342177280, v3 = 32, v7 = 8
 ;;                                     v21 = stack_addr.i64 ss0
-;;                                     store notrap aligned v8, v21
+;;                                     store notrap aligned region5 v8, v21
 ;; @0020                               v15 = call fn1(v0, v2), stack_map=[i32 @ ss0+0]
 ;; @0020                               v16 = ireduce.i32 v15
 ;; @0020                               v9 = load.i64 notrap aligned readonly can_move region0 v0+8
@@ -46,6 +47,6 @@
 ;; @0023                               jump block1
 ;;
 ;;                                 block1:
-;;                                     v18 = load.i32 notrap aligned v21
+;;                                     v18 = load.i32 notrap aligned region5 v21
 ;; @0023                               return v18
 ;; }

--- a/tests/disas/gc/drc/struct-get.wat
+++ b/tests/disas/gc/drc/struct-get.wat
@@ -114,6 +114,7 @@
 ;;     region6 = 1610612736 "VMDrcHeapData+0x0"
 ;;     region7 = 1610612740 "VMDrcHeapData+0x4"
 ;;     region8 = 1610612744 "VMDrcHeapData+0x8"
+;;     region9 = 3087007744 "Stack(ss0)"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -131,7 +132,7 @@
 ;; @004e                               v8 = iadd v6, v7  ; v7 = 32
 ;; @004e                               v9 = load.i32 user2 little region4 v8
 ;;                                     v81 = stack_addr.i64 ss0
-;;                                     store notrap aligned v9, v81
+;;                                     store notrap aligned region9 v9, v81
 ;; @004e                               v10 = iconst.i32 1
 ;; @004e                               v11 = band v9, v10  ; v10 = 1
 ;; @004e                               v12 = iconst.i32 0
@@ -186,6 +187,6 @@
 ;; @0052                               jump block1
 ;;
 ;;                                 block1:
-;;                                     v64 = load.i32 notrap aligned v81
+;;                                     v64 = load.i32 notrap aligned region9 v81
 ;; @0052                               return v64
 ;; }

--- a/tests/disas/gc/drc/struct-new.wat
+++ b/tests/disas/gc/drc/struct-new.wat
@@ -19,6 +19,7 @@
 ;;     region3 = 134217760 "VMStoreContext+0x20"
 ;;     region4 = 1073741824 "GcHeap"
 ;;     region5 = 134217768 "VMStoreContext+0x28"
+;;     region6 = 3087007744 "Stack(ss0)"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -28,7 +29,7 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: f32, v3: i32, v4: i32):
 ;;                                     v52 = stack_addr.i64 ss0
-;;                                     store notrap aligned v4, v52
+;;                                     store notrap aligned region6 v4, v52
 ;; @002a                               v6 = iconst.i32 -1342177280
 ;; @002a                               v7 = load.i64 notrap aligned readonly can_move region2 v0+40
 ;; @002a                               v8 = load.i32 notrap aligned readonly can_move v7
@@ -45,7 +46,7 @@
 ;; @002a                               v17 = iconst.i64 28
 ;; @002a                               v18 = iadd v14, v17  ; v17 = 28
 ;; @002a                               istore8 user2 little region4 v3, v18
-;;                                     v51 = load.i32 notrap aligned v52
+;;                                     v51 = load.i32 notrap aligned region6 v52
 ;; @002a                               v21 = iconst.i32 1
 ;; @002a                               v22 = band v51, v21  ; v21 = 1
 ;; @002a                               v23 = iconst.i32 0

--- a/tests/disas/gc/null/array-new-fixed-of-gc-refs.wat
+++ b/tests/disas/gc/null/array-new-fixed-of-gc-refs.wat
@@ -21,6 +21,9 @@
 ;;     region5 = 134217760 "VMStoreContext+0x20"
 ;;     region6 = 40 "VMContext+0x28"
 ;;     region7 = 1073741824 "GcHeap"
+;;     region8 = 3087007744 "Stack(ss0)"
+;;     region9 = 3087007745 "Stack(ss1)"
+;;     region10 = 3087007746 "Stack(ss2)"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -30,11 +33,11 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
 ;;                                     v131 = stack_addr.i64 ss2
-;;                                     store notrap aligned v2, v131
+;;                                     store notrap aligned region10 v2, v131
 ;;                                     v132 = stack_addr.i64 ss1
-;;                                     store notrap aligned v3, v132
+;;                                     store notrap aligned region9 v3, v132
 ;;                                     v133 = stack_addr.i64 ss0
-;;                                     store notrap aligned v4, v133
+;;                                     store notrap aligned region8 v4, v133
 ;; @0025                               v17 = load.i64 notrap aligned readonly can_move region2 v0+32
 ;; @0025                               v18 = load.i32 notrap aligned region3 v17
 ;;                                     v151 = iconst.i32 7
@@ -67,7 +70,7 @@
 ;; @0025                               trapz v256, user16
 ;;                                     v258 = iconst.i32 24
 ;; @0025                               v61 = uadd_overflow_trap v256, v258, user2  ; v258 = 24
-;;                                     v130 = load.i32 notrap aligned v131
+;;                                     v130 = load.i32 notrap aligned region10 v131
 ;; @0025                               v62 = uextend.i64 v61
 ;; @0025                               v65 = iadd v32, v62
 ;;                                     v135 = iconst.i64 12
@@ -88,7 +91,7 @@
 ;; @0025                               v6 = iconst.i32 12
 ;; @0025                               v85 = uadd_overflow_trap v205, v6, user2  ; v6 = 12
 ;; @0025                               v89 = uadd_overflow_trap v256, v85, user2
-;;                                     v128 = load.i32 notrap aligned v132
+;;                                     v128 = load.i32 notrap aligned region9 v132
 ;; @0025                               v90 = uextend.i64 v89
 ;; @0025                               v93 = iadd v32, v90
 ;;                                     v218 = iconst.i32 16
@@ -106,7 +109,7 @@
 ;;                                     v233 = ishl v104, v175  ; v175 = 2
 ;; @0025                               v113 = uadd_overflow_trap v233, v6, user2  ; v6 = 12
 ;; @0025                               v117 = uadd_overflow_trap v256, v113, user2
-;;                                     v126 = load.i32 notrap aligned v133
+;;                                     v126 = load.i32 notrap aligned region8 v133
 ;; @0025                               v118 = uextend.i64 v117
 ;; @0025                               v121 = iadd v32, v118
 ;;                                     v250 = iconst.i32 20

--- a/tests/disas/gc/null/struct-new.wat
+++ b/tests/disas/gc/null/struct-new.wat
@@ -21,6 +21,7 @@
 ;;     region5 = 134217760 "VMStoreContext+0x20"
 ;;     region6 = 40 "VMContext+0x28"
 ;;     region7 = 1073741824 "GcHeap"
+;;     region8 = 3087007744 "Stack(ss0)"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -30,7 +31,7 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: f32, v3: i32, v4: i32):
 ;;                                     v39 = stack_addr.i64 ss0
-;;                                     store notrap aligned v4, v39
+;;                                     store notrap aligned region8 v4, v39
 ;; @002a                               v9 = load.i64 notrap aligned readonly can_move region2 v0+32
 ;; @002a                               v10 = load.i32 notrap aligned region3 v9
 ;;                                     v46 = iconst.i32 7
@@ -62,7 +63,7 @@
 ;; @002a                               v33 = iconst.i64 12
 ;; @002a                               v34 = iadd v26, v33  ; v33 = 12
 ;; @002a                               istore8.i32 user2 little region7 v3, v34
-;;                                     v38 = load.i32 notrap aligned v39
+;;                                     v38 = load.i32 notrap aligned region8 v39
 ;; @002a                               v35 = iconst.i64 16
 ;; @002a                               v36 = iadd v26, v35  ; v35 = 16
 ;; @002a                               store user2 little region7 v38, v36

--- a/tests/disas/gc/struct-new.wat
+++ b/tests/disas/gc/struct-new.wat
@@ -21,6 +21,7 @@
 ;;     region5 = 40 "VMContext+0x28"
 ;;     region6 = 134217760 "VMStoreContext+0x20"
 ;;     region7 = 1073741824 "GcHeap"
+;;     region8 = 3087007744 "Stack(ss0)"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -30,7 +31,7 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: f32, v3: i32, v4: i32):
 ;;                                     v45 = stack_addr.i64 ss0
-;;                                     store notrap aligned v4, v45
+;;                                     store notrap aligned region8 v4, v45
 ;; @002a                               v6 = load.i64 notrap aligned readonly can_move region2 v0+32
 ;; @002a                               v7 = load.i32 notrap aligned region3 v6
 ;; @002a                               v8 = load.i32 notrap aligned region4 v6+4
@@ -77,7 +78,7 @@
 ;; @002a                               v39 = iconst.i64 20
 ;; @002a                               v40 = iadd v36, v39  ; v39 = 20
 ;; @002a                               istore8.i32 user2 little region7 v3, v40
-;;                                     v44 = load.i32 notrap aligned v45
+;;                                     v44 = load.i32 notrap aligned region8 v45
 ;; @002a                               v41 = iconst.i64 24
 ;; @002a                               v42 = iadd v36, v41  ; v41 = 24
 ;; @002a                               store user2 little region7 v44, v42

--- a/tests/disas/gc/typed-select-and-stack-maps.wat
+++ b/tests/disas/gc/typed-select-and-stack-maps.wat
@@ -45,6 +45,7 @@
 ;;     region1 = 134217752 "VMStoreContext+0x18"
 ;;     region2 = 2415919128 "VMFunctionImport+0x18"
 ;;     region3 = 2415919112 "VMFunctionImport+0x8"
+;;     region4 = 3087007744 "Stack(ss0)"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -55,11 +56,11 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
 ;; @0049                               v5 = select v4, v2, v3
 ;;                                     v12 = stack_addr.i64 ss0
-;;                                     store notrap aligned v5, v12
+;;                                     store notrap aligned region4 v5, v12
 ;; @004c                               v7 = load.i64 notrap aligned readonly can_move region3 v0+88
 ;; @004c                               v6 = load.i64 notrap aligned readonly can_move region2 v0+104
 ;; @004c                               call_indirect sig0, v7(v6, v0), stack_map=[i32 @ ss0+0]
-;;                                     v11 = load.i32 notrap aligned v12
+;;                                     v11 = load.i32 notrap aligned region4 v12
 ;; @004e                               v9 = load.i64 notrap aligned readonly can_move region3 v0+56
 ;; @004e                               v8 = load.i64 notrap aligned readonly can_move region2 v0+72
 ;; @004e                               call_indirect sig1, v9(v8, v0, v11)


### PR DESCRIPTION
Using the new `FunctionBuilder::make_stack_map_alias_region` hook.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
