### PR TITLE
Cranelift modernize docs

### DIFF
--- a/cranelift/docs/add-clif-instruction.md
+++ b/cranelift/docs/add-clif-instruction.md
@@ -18,11 +18,12 @@ CLIF opcodes are defined using a meta-language in Rust:
 - `cranelift/codegen/meta/src/shared/immediates.rs` — immediate field types
 
 The meta code is compiled during the build (via `cranelift/codegen/build.rs`)
-to generate:
-- `cranelift/codegen/src/ir/instructions.rs` — the `Opcode` enum and
-  `InstructionData` enum
-- `cranelift/codegen/src/ir/builder.rs` — the `InstBuilder` trait with one
-  builder method per opcode
+to generate Rust source files in `OUT_DIR` (`target/`). These generated files
+are then `include!()`-ed by the handwritten source files in
+`cranelift/codegen/src/ir/`. Generated artifacts include:
+
+- `opcodes.rs` — opcode definitions and instruction metadata
+- `inst_builder.rs` — `InstBuilder` methods for each opcode
 - ISLE `extern` declarations so ISLE rules can reference CLIF opcodes
 
 ## Step 1: Choose or create an instruction format
@@ -49,9 +50,11 @@ example, many opcodes use the `Binary` format (two value inputs, one result).
 
 ## Step 2: Add the opcode definition
 
-In `cranelift/codegen/meta/src/shared/instructions.rs`, find the function that
-logically groups your instruction (e.g. `define_integer_ops`, `define_memory`,
-etc.) and add an entry:
+In `cranelift/codegen/meta/src/shared/instructions.rs`, add an entry in the
+`define()` function. If your instruction is SIMD-related, it may belong in one
+of the three sub-functions called by `define()`: `define_control_flow`,
+`define_simd_lane_access`, or `define_simd_arithmetic`. Otherwise add it
+directly in the body of `define()` alongside similar opcodes:
 
 ```rust
 ig.push(
@@ -108,14 +111,22 @@ with a descriptive error.
 The IR verifier (`cranelift/codegen/src/verifier/mod.rs`) checks semantic
 invariants. If your new instruction has any invariants beyond type correctness
 (e.g. alignment constraints, operand restrictions), add a case in the
-`verify_entity_references` function's match on `InstructionData`:
+`immediate_constraints` function's match on `InstructionData`:
 
 ```rust
-InstructionData::YourFormat { opcode: Opcode::MyNewOp, .. } => {
-    // example: check that an immediate satisfies a constraint
-    errors.report((inst, self.context(inst), "description of the error"));
+ir::InstructionData::YourFormat { opcode: ir::instructions::Opcode::MyNewOp, .. } => {
+    if /* constraint is violated */ {
+        errors.fatal((inst, self.context(inst), "description of the error"))
+    } else {
+        Ok(())
+    }
 }
 ```
+
+Use `errors.fatal` (returns `Err(())` and stops further checks on this
+instruction) or `errors.nonfatal` (returns `Ok(())` and continues) depending
+on severity. Do not use `errors.report` directly here — it returns `()` and
+the match arm must return `VerifierStepResult`.
 
 ## Step 5: Add interpreter support
 
@@ -128,9 +139,13 @@ Opcode::MyNewOp => {
     let x = arg(0);
     let y = arg(1);
     let result = /* compute semantics */;
-    Ok(ControlFlow::Assign(smallvec![result]))
+    Ok(assign(result))
 }
 ```
+
+The `assign` closure (defined near the top of `step`) wraps a single
+`DataValue` result into `ControlFlow::Assign`. Use `assign_multiple` for
+instructions that produce more than one result value.
 
 ## Step 6: Add lowering rules in each backend
 
@@ -149,8 +164,11 @@ constant folding), add ISLE rewrite rules in
 `my_new_op(c1, c2)` where both operands are constants:
 
 ```lisp
-(rule (simplify (my_new_op (iconst k1) (iconst k2)))
-      (subsume (iconst (my_new_op_const_fold k1 k2))))
+(rule (simplify
+       (my_new_op (fits_in_64 ty)
+                  (iconst ty k1)
+                  (iconst ty k2)))
+      (subsume (iconst ty (imm64_my_new_op ty k1 k2))))
 ```
 
 ## Step 8: Write tests
@@ -165,7 +183,14 @@ block0(v0: i32, v1: i32):
     v2 = my_new_op v0, v1
     return v2
 }
-; not: error
+```
+
+A `test verifier` function with no `; error:` annotations is expected to pass
+verification without errors. To assert that a specific instruction *causes* a
+verifier error, annotate it inline:
+
+```
+    v2 = my_new_op v0, v1  ; error: <expected error text>
 ```
 
 Add a `test run` filetest to verify semantics:

--- a/cranelift/docs/add-clif-instruction.md
+++ b/cranelift/docs/add-clif-instruction.md
@@ -29,16 +29,19 @@ to generate:
 
 An *instruction format* defines the structural shape of an instruction. Look
 at the existing formats in `cranelift/codegen/meta/src/shared/formats.rs`. If
-none fit, add a new one:
+none fit, add a new one by adding a field to the `Formats` struct and
+initializing it in `Formats::new()`:
 
 ```rust
-formats.add(
-    InstructionFormatBuilder::new("NewFormat")
-        .value_operand()     // one SSA value input
-        .value_operand()     // another SSA value input
-        .imm::<Imm64>()      // a 64-bit immediate
-        .build(),
-);
+// In the Formats struct:
+pub(crate) new_format: Rc<InstructionFormat>,
+
+// In Formats::new():
+new_format: Builder::new("NewFormat")
+    .value()          // one SSA value input
+    .value()          // another SSA value input
+    .imm(&imm.imm64)  // a 64-bit immediate
+    .build(),
 ```
 
 A format is shared by multiple opcodes that have the same structural shape. For
@@ -77,9 +80,9 @@ Where `iN` is a `TypeVar` describing which types this opcode is polymorphic
 over. Look at existing definitions for examples of how to construct `TypeVar`
 instances.
 
-If the instruction can trap, call `.can_trap(true)` on the builder.  
-If the instruction has side effects, call `.other_side_effects(true)`.  
-If it is a memory operation, use `.can_load(true)` or `.can_store(true)`.
+If the instruction can trap, call `.can_trap()` on the builder.  
+If the instruction has side effects, call `.other_side_effects()`.  
+If it is a memory operation, use `.can_load()` or `.can_store()`.
 
 ## Step 3: Rebuild the generated code
 
@@ -89,42 +92,41 @@ Run:
 cargo build -p cranelift-codegen
 ```
 
-This re-runs the meta build script and regenerates:
-- `cranelift/codegen/src/ir/instructions.rs`
-- `cranelift/codegen/src/ir/builder.rs`
-- Various ISLE `extern` files in `target/`
+This re-runs the meta build script and writes into `OUT_DIR` (`target/`):
+- `opcodes.rs` — `include!()`-ed by `cranelift/codegen/src/ir/instructions.rs`
+- `inst_builder.rs` — `include!()`-ed by `cranelift/codegen/src/ir/builder.rs`
+- ISLE `extern` declarations for opcodes and types
+
+The source files `instructions.rs` and `builder.rs` are not themselves
+regenerated; they `include!()` the generated content from `OUT_DIR`.
 
 If anything is structurally wrong with your definition, the build will fail
 with a descriptive error.
 
 ## Step 4: Add a verifier check (optional but recommended)
 
-The IR verifier (`cranelift/codegen/src/verify.rs`) checks semantic invariants.
-If your new instruction has any invariants beyond type correctness (e.g.
-alignment constraints, operand restrictions), add a case to the `verify_inst`
-function:
+The IR verifier (`cranelift/codegen/src/verifier/mod.rs`) checks semantic
+invariants. If your new instruction has any invariants beyond type correctness
+(e.g. alignment constraints, operand restrictions), add a case in the
+`verify_entity_references` function's match on `InstructionData`:
 
 ```rust
-Opcode::MyNewOp => {
-    // Check that the operand is aligned to a power of two
-    if let Some(imm) = dfg.inst_imms(inst).alignment {
-        if !imm.is_power_of_two() {
-            return Err(verifier.error(inst, "alignment must be a power of two"));
-        }
-    }
+InstructionData::YourFormat { opcode: Opcode::MyNewOp, .. } => {
+    // example: check that an immediate satisfies a constraint
+    errors.report((inst, self.context(inst), "description of the error"));
 }
 ```
 
 ## Step 5: Add interpreter support
 
 The Cranelift interpreter (`cranelift/interpreter/`) is used by the `test run`
-and `test interpret` filetest commands. Add a case for your opcode in
-`cranelift/interpreter/src/interpreter.rs` under the `step` function:
+and `test interpret` filetest commands. Add a case for your opcode in the
+`step` function in `cranelift/interpreter/src/step.rs`:
 
 ```rust
 Opcode::MyNewOp => {
-    let x = self.frame.get(inst_args[0]);
-    let y = self.frame.get(inst_args[1]);
+    let x = arg(0);
+    let y = arg(1);
     let result = /* compute semantics */;
     Ok(ControlFlow::Assign(smallvec![result]))
 }

--- a/cranelift/docs/add-clif-instruction.md
+++ b/cranelift/docs/add-clif-instruction.md
@@ -1,0 +1,183 @@
+# How to Add a New Instruction to CLIF
+
+This guide walks through adding a new opcode to the Cranelift Intermediate
+Representation (CLIF). Most contributors will not need to do this — CLIF's
+opcode set is intentionally stable. If you just need to teach a backend how to
+handle an existing opcode, see
+[How to Add a Machine Instruction and Lowering](add-machine-instruction.md)
+instead.
+
+## Where CLIF opcodes are defined
+
+CLIF opcodes are defined using a meta-language in Rust:
+
+- `cranelift/codegen/meta/src/shared/instructions.rs` — almost all opcodes
+- `cranelift/codegen/meta/src/shared/formats.rs` — instruction formats
+  (the structural shape of each instruction: how many value inputs, how many
+  immediate fields, etc.)
+- `cranelift/codegen/meta/src/shared/immediates.rs` — immediate field types
+
+The meta code is compiled during the build (via `cranelift/codegen/build.rs`)
+to generate:
+- `cranelift/codegen/src/ir/instructions.rs` — the `Opcode` enum and
+  `InstructionData` enum
+- `cranelift/codegen/src/ir/builder.rs` — the `InstBuilder` trait with one
+  builder method per opcode
+- ISLE `extern` declarations so ISLE rules can reference CLIF opcodes
+
+## Step 1: Choose or create an instruction format
+
+An *instruction format* defines the structural shape of an instruction. Look
+at the existing formats in `cranelift/codegen/meta/src/shared/formats.rs`. If
+none fit, add a new one:
+
+```rust
+formats.add(
+    InstructionFormatBuilder::new("NewFormat")
+        .value_operand()     // one SSA value input
+        .value_operand()     // another SSA value input
+        .imm::<Imm64>()      // a 64-bit immediate
+        .build(),
+);
+```
+
+A format is shared by multiple opcodes that have the same structural shape. For
+example, many opcodes use the `Binary` format (two value inputs, one result).
+
+## Step 2: Add the opcode definition
+
+In `cranelift/codegen/meta/src/shared/instructions.rs`, find the function that
+logically groups your instruction (e.g. `define_integer_ops`, `define_memory`,
+etc.) and add an entry:
+
+```rust
+ig.push(
+    Inst::new(
+        "my_new_op",
+        r#"
+    My new operation.
+
+    Detailed description of semantics: what the instruction does, any
+    special cases (overflow behavior, NaN handling, alignment
+    requirements, etc.).
+    "#,
+        &formats.binary,   // use the appropriate format
+    )
+    .operands_in(vec![
+        Operand::new("x", iN).with_doc("Left operand"),
+        Operand::new("y", iN).with_doc("Right operand"),
+    ])
+    .operands_out(vec![
+        Operand::new("a", iN).with_doc("Result"),
+    ]),
+);
+```
+
+Where `iN` is a `TypeVar` describing which types this opcode is polymorphic
+over. Look at existing definitions for examples of how to construct `TypeVar`
+instances.
+
+If the instruction can trap, call `.can_trap(true)` on the builder.  
+If the instruction has side effects, call `.other_side_effects(true)`.  
+If it is a memory operation, use `.can_load(true)` or `.can_store(true)`.
+
+## Step 3: Rebuild the generated code
+
+Run:
+
+```
+cargo build -p cranelift-codegen
+```
+
+This re-runs the meta build script and regenerates:
+- `cranelift/codegen/src/ir/instructions.rs`
+- `cranelift/codegen/src/ir/builder.rs`
+- Various ISLE `extern` files in `target/`
+
+If anything is structurally wrong with your definition, the build will fail
+with a descriptive error.
+
+## Step 4: Add a verifier check (optional but recommended)
+
+The IR verifier (`cranelift/codegen/src/verify.rs`) checks semantic invariants.
+If your new instruction has any invariants beyond type correctness (e.g.
+alignment constraints, operand restrictions), add a case to the `verify_inst`
+function:
+
+```rust
+Opcode::MyNewOp => {
+    // Check that the operand is aligned to a power of two
+    if let Some(imm) = dfg.inst_imms(inst).alignment {
+        if !imm.is_power_of_two() {
+            return Err(verifier.error(inst, "alignment must be a power of two"));
+        }
+    }
+}
+```
+
+## Step 5: Add interpreter support
+
+The Cranelift interpreter (`cranelift/interpreter/`) is used by the `test run`
+and `test interpret` filetest commands. Add a case for your opcode in
+`cranelift/interpreter/src/interpreter.rs` under the `step` function:
+
+```rust
+Opcode::MyNewOp => {
+    let x = self.frame.get(inst_args[0]);
+    let y = self.frame.get(inst_args[1]);
+    let result = /* compute semantics */;
+    Ok(ControlFlow::Assign(smallvec![result]))
+}
+```
+
+## Step 6: Add lowering rules in each backend
+
+For every backend that should support your new opcode, add an ISLE lowering
+rule. See [How to Add a Machine Instruction and Lowering](add-machine-instruction.md)
+for details.
+
+If a backend does not implement a rule for an opcode, attempting to compile a
+function using that opcode on that backend will produce a compile-time error.
+
+## Step 7: Add optimization rules (optional)
+
+If your new opcode can be simplified algebraically (e.g. identity elements,
+constant folding), add ISLE rewrite rules in
+`cranelift/codegen/src/opts/`. For example, to constant-fold
+`my_new_op(c1, c2)` where both operands are constants:
+
+```lisp
+(rule (simplify (my_new_op (iconst k1) (iconst k2)))
+      (subsume (iconst (my_new_op_const_fold k1 k2))))
+```
+
+## Step 8: Write tests
+
+Add a filetest in `cranelift/filetests/filetests/`:
+
+```
+test verifier
+
+function %test_my_new_op(i32, i32) -> i32 {
+block0(v0: i32, v1: i32):
+    v2 = my_new_op v0, v1
+    return v2
+}
+; not: error
+```
+
+Add a `test run` filetest to verify semantics:
+
+```
+test run
+target x86_64
+
+function %my_new_op_test() -> i32 {
+block0:
+    v0 = iconst.i32 3
+    v1 = iconst.i32 4
+    v2 = my_new_op v0, v1
+    return v2
+}
+; run: %my_new_op_test() == 7
+```

--- a/cranelift/docs/add-machine-instruction.md
+++ b/cranelift/docs/add-machine-instruction.md
@@ -1,0 +1,217 @@
+# How to Add a Machine Instruction and Lowering
+
+This guide covers two related tasks:
+
+1. Adding a new machine instruction variant to a backend's `Inst` enum.
+2. Adding a CLIF-to-machine-instruction lowering rule in ISLE.
+
+These often go together: a new lowering may need a new instruction form, and a
+new instruction form is only useful if it can be selected by the lowering.
+
+For background on how the backend and ISLE work, read
+[Backend Architecture](backend-architecture.md).
+
+## Part 1: Adding a new machine instruction
+
+### Step 1: Add the instruction variant
+
+Open `cranelift/codegen/src/isa/<arch>/inst/mod.rs` and add a variant to
+the `Inst` enum:
+
+```rust
+/// A fused multiply-add: rd = rn * rm + ra
+FMAdd {
+    rd: Writable<Reg>,
+    rn: Reg,
+    rm: Reg,
+    ra: Reg,
+    ty: Type,
+},
+```
+
+Add it to the `Display` / `Debug` implementation too, so that `VCode` can be
+pretty-printed for debugging.
+
+### Step 2: Implement `get_operands`
+
+In the `MachInst::get_operands` implementation, add a case for the new
+variant. This tells the register allocator about all register uses and
+definitions:
+
+```rust
+Inst::FMAdd { rd, rn, rm, ra, .. } => {
+    collector.reg_def(rd);
+    collector.reg_use(rn);
+    collector.reg_use(rm);
+    collector.reg_use(ra);
+}
+```
+
+Use `reg_def` for registers written, `reg_use` for registers read, and
+`reg_mod` for registers both read and written (e.g., x86 two-operand instructions).
+
+### Step 3: Implement `worst_case_size`
+
+If the new instruction might be larger than the current `worst_case_size()`,
+update it. This is used by `MachBuffer` for constant island spacing.
+
+### Step 4: Implement binary emission
+
+In `cranelift/codegen/src/isa/<arch>/inst/emit.rs`, add an arm in the
+`emit` match:
+
+```rust
+Inst::FMAdd { rd, rn, rm, ra, ty } => {
+    // Resolve virtual registers to physical registers from the allocation.
+    let rd = allocs.next_writable().to_real_reg().unwrap().hw_enc();
+    let rn = allocs.next().to_real_reg().unwrap().hw_enc();
+    let rm = allocs.next().to_real_reg().unwrap().hw_enc();
+    let ra = allocs.next().to_real_reg().unwrap().hw_enc();
+
+    // Emit the encoding. AArch64 FMADD (scalar):
+    // 0001_1111 | ftype | 0 | rm | ra | rn | rd
+    let ftype = match ty { F32 => 0b00, F64 => 0b01, _ => panic!() };
+    let enc = (0b0001_1111 << 24)
+        | (ftype << 22)
+        | ((rm as u32) << 16)
+        | ((ra as u32) << 10)
+        | ((rn as u32) << 5)
+        | (rd as u32);
+    sink.put4(enc);
+}
+```
+
+The registers must be consumed in the same order they were yielded in
+`get_operands` (defs first, then uses, or whatever order `regalloc2` expects —
+check how other instructions in the same backend do it).
+
+### Step 5: Add ISLE declarations
+
+The new machine instruction needs to be declared in ISLE so that lowering rules
+can produce it. In the backend's ISLE instruction definition file
+(`cranelift/codegen/src/isa/<arch>/inst/<arch>.isle` or similar), add:
+
+```lisp
+;; Declare the constructor that the lowering rules will call.
+(decl fmadd (Type Value Value Value) InstOutput)
+(extern constructor fmadd fmadd)
+```
+
+Then implement the Rust constructor in `lower/isle.rs`:
+
+```rust
+pub fn fmadd(&mut self, ty: Type, rn: Value, rm: Value, ra: Value) -> InstOutput {
+    let rn = self.put_in_reg(rn);
+    let rm = self.put_in_reg(rm);
+    let ra = self.put_in_reg(ra);
+    let rd = self.alloc_tmp(ty);
+    self.emit(Inst::FMAdd { rd, rn, rm, ra, ty });
+    output_reg(rd.to_reg(), ty)
+}
+```
+
+## Part 2: Adding a CLIF lowering rule
+
+### Step 1: Write the rule in ISLE
+
+Open the backend's lowering ISLE file
+(`cranelift/codegen/src/isa/<arch>/lower.isle`) and add a rule:
+
+```lisp
+;; Lower fma (fused multiply-add) to FMAdd on our ISA.
+(rule (lower (has_type (ty_scalar_float ty)
+                       (fma x y z)))
+      (fmadd ty x y z))
+```
+
+Breaking down the rule:
+- `(lower ...)` — top-level lowering term; the argument is a CLIF instruction
+- `(has_type ty ...)` — constrains the instruction to have type `ty`
+- `(ty_scalar_float ty)` — extractor that succeeds only for `f32`/`f64`
+- `(fma x y z)` — matches the `fma` CLIF opcode with three value operands
+- `(fmadd ty x y z)` — calls the `fmadd` constructor we defined above
+
+### Step 2: Use ISLE pattern extractors
+
+ISLE provides many built-in extractors for common patterns. Some useful ones:
+
+- `(iconst k)` — matches an `iconst` instruction and binds `k` to the constant value
+- `(fits_in_64 ty)` — succeeds if `ty` has ≤ 64 bits
+- `(ty_int ty)` — succeeds if `ty` is an integer type
+- `(ty_scalar_float ty)` — succeeds if `ty` is `f32` or `f64`
+- `(value_type ty x)` — binds `ty` to the type of SSA value `x`
+- `(put_in_reg x)` — materializes an SSA value into a register (used in constructors)
+- `(put_in_regs x)` — same, for multi-register values (e.g. `i128`)
+
+### Step 3: Handle type polymorphism
+
+If the same lowering applies to multiple types, use a type variable:
+
+```lisp
+(rule (lower (has_type (fits_in_64 ty) (iadd x y)))
+      (alu_rrr (ALUOp.Add) ty x y))
+```
+
+If you need different instructions for different types, add multiple rules with
+different type constraints. ISLE picks the most specific matching rule.
+
+### Step 4: Sink producer instructions
+
+Sometimes it is beneficial to fold a producer into its consumer (instruction
+selection). For example, an `iadd` followed by an `icmp` might be expressible
+as a single compare-and-add. ISLE lets you match through the SSA def:
+
+```lisp
+;; cmp r, r  combined with  add r, r  ->  cmpadd r, r, r
+(rule (lower (has_type (fits_in_64 ty)
+                       (icmp cc (iadd x y) z)))
+      (cmp_and_add ty cc x y z))
+```
+
+When a pattern matches a producer instruction like `(iadd x y)`, ISLE's
+lowering framework automatically calls `sink_inst` to mark that instruction as
+absorbed.
+
+### Step 5: Build and test
+
+Rebuild to regenerate ISLE output:
+
+```
+cargo build -p cranelift-codegen
+```
+
+If the ISLE compiler catches a type mismatch or missing rule, it will print an
+error. For a detailed multi-line error, rebuild with:
+
+```
+cargo build -p cranelift-codegen --features isle-errors
+```
+
+To inspect the generated Rust code:
+
+```
+ISLE_SOURCE_DIR=$(pwd)/isle-generated cargo check -p cranelift-codegen
+```
+
+Then add a filetest:
+
+```
+test compile
+target aarch64
+
+function %test_fma(f32, f32, f32) -> f32 {
+block0(v0: f32, v1: f32, v2: f32):
+    v3 = fma v0, v1, v2
+    return v3
+}
+; check: fmadd
+```
+
+The `; check: fmadd` filecheck directive asserts that the compiled output
+contains an `fmadd` instruction.
+
+Run the test:
+
+```
+cargo run -p cranelift-codegen --example clif-util -- test path/to/test.clif
+```

--- a/cranelift/docs/add-machine-instruction.md
+++ b/cranelift/docs/add-machine-instruction.md
@@ -62,11 +62,12 @@ In `cranelift/codegen/src/isa/<arch>/inst/emit.rs`, add an arm in the
 
 ```rust
 Inst::FMAdd { rd, rn, rm, ra, ty } => {
-    // Resolve virtual registers to physical registers from the allocation.
-    let rd = allocs.next_writable().to_real_reg().unwrap().hw_enc();
-    let rn = allocs.next().to_real_reg().unwrap().hw_enc();
-    let rm = allocs.next().to_real_reg().unwrap().hw_enc();
-    let ra = allocs.next().to_real_reg().unwrap().hw_enc();
+    // By the time emit() is called, regalloc has already resolved all
+    // virtual registers to physical registers in the instruction struct.
+    let rd = rd.to_reg().to_real_reg().unwrap().hw_enc();
+    let rn = rn.to_real_reg().unwrap().hw_enc();
+    let rm = rm.to_real_reg().unwrap().hw_enc();
+    let ra = ra.to_real_reg().unwrap().hw_enc();
 
     // Emit the encoding. AArch64 FMADD (scalar):
     // 0001_1111 | ftype | 0 | rm | ra | rn | rd
@@ -81,15 +82,11 @@ Inst::FMAdd { rd, rn, rm, ra, ty } => {
 }
 ```
 
-The registers must be consumed in the same order they were yielded in
-`get_operands` (defs first, then uses, or whatever order `regalloc2` expects —
-check how other instructions in the same backend do it).
-
 ### Step 5: Add ISLE declarations
 
 The new machine instruction needs to be declared in ISLE so that lowering rules
 can produce it. In the backend's ISLE instruction definition file
-(`cranelift/codegen/src/isa/<arch>/inst/<arch>.isle` or similar), add:
+(`cranelift/codegen/src/isa/<arch>/inst.isle`), add:
 
 ```lisp
 ;; Declare the constructor that the lowering rules will call.
@@ -213,5 +210,5 @@ contains an `fmadd` instruction.
 Run the test:
 
 ```
-cargo run -p cranelift-codegen --example clif-util -- test path/to/test.clif
+cargo run -p cranelift-tools -- test path/to/test.clif
 ```

--- a/cranelift/docs/add-machine-instruction.md
+++ b/cranelift/docs/add-machine-instruction.md
@@ -47,8 +47,11 @@ Inst::FMAdd { rd, rn, rm, ra, .. } => {
 }
 ```
 
-Use `reg_def` for registers written, `reg_use` for registers read, and
-`reg_mod` for registers both read and written (e.g., x86 two-operand instructions).
+Use `reg_def` for registers written and `reg_use` for registers read. For
+x86-style two-operand instructions where the output reuses an input register,
+use `reg_reuse_def(rd, idx)` where `idx` is the index of the `reg_use` call
+that this def reuses; or use `reg_early_def` when the def may be written before
+all uses are read and the regalloc must keep it in a different register.
 
 ### Step 3: Implement `worst_case_size`
 
@@ -132,7 +135,7 @@ Breaking down the rule:
 
 ISLE provides many built-in extractors for common patterns. Some useful ones:
 
-- `(iconst k)` — matches an `iconst` instruction and binds `k` to the constant value
+- `(u64_from_iconst k)` — matches an `iconst` and binds `k` to its value as a `u64`; typed variants `u32_from_iconst`, `i64_from_iconst`, etc. are also available
 - `(fits_in_64 ty)` — succeeds if `ty` has ≤ 64 bits
 - `(ty_int ty)` — succeeds if `ty` is an integer type
 - `(ty_scalar_float ty)` — succeeds if `ty` is `f32` or `f64`
@@ -190,10 +193,12 @@ To inspect the generated Rust code:
 ISLE_SOURCE_DIR=$(pwd)/isle-generated cargo check -p cranelift-codegen
 ```
 
-Then add a filetest:
+Then add a filetest. Compile tests use `test compile precise-output`, which
+compares the full VCode and disassembly output exactly. Add the expected output
+as a comment block after the function:
 
 ```
-test compile
+test compile precise-output
 target aarch64
 
 function %test_fma(f32, f32, f32) -> f32 {
@@ -201,11 +206,17 @@ block0(v0: f32, v1: f32, v2: f32):
     v3 = fma v0, v1, v2
     return v3
 }
-; check: fmadd
-```
 
-The `; check: fmadd` filecheck directive asserts that the compiled output
-contains an `fmadd` instruction.
+; VCode:
+; block0:
+;   fmadd s0, s0, s1, s2
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   fmadd s0, s0, s1, s2
+;   ret
+```
 
 Run the test:
 

--- a/cranelift/docs/add-new-backend.md
+++ b/cranelift/docs/add-new-backend.md
@@ -46,20 +46,31 @@ And add it to the default features if appropriate.
 
 ## Step 3: Define ISA-specific settings
 
-Create `cranelift/codegen/meta/src/isa/<arch>/mod.rs` (or `settings.rs`)
-defining ISA-specific settings using the meta DSL:
+Create `cranelift/codegen/meta/src/isa/<arch>.rs` (a single file alongside
+the other ISA files in that directory) defining ISA-specific settings using
+the meta DSL:
 
 ```rust
-pub fn define() -> SettingGroup {
-    let mut setting = SettingGroupBuilder::new("newarch");
-    // add flags/enums as needed
-    setting.build()
+use crate::cdsl::isa::TargetIsa;
+use crate::cdsl::settings::SettingGroupBuilder;
+
+pub(crate) fn define() -> TargetIsa {
+    let mut settings = SettingGroupBuilder::new("newarch");
+    // add flags/enums as needed, e.g.:
+    // settings.add_bool("has_feature_x", "Has feature X.", "", false);
+    TargetIsa::new("newarch", settings.build())
 }
 ```
 
-Run `cargo build -p cranelift-codegen` once to generate
-`cranelift/codegen/src/isa/<arch>/settings.rs` from the meta definition.
-This generated file defines `Flags` and `Builder` types for your ISA settings.
+The meta build will generate a `settings-<arch>.rs` file into `OUT_DIR`. You
+must create `cranelift/codegen/src/isa/<arch>/settings.rs` as a stub that
+`include!()`s it — exactly like the existing backends:
+
+```rust
+include!(concat!(env!("OUT_DIR"), "/settings-<arch>.rs"));
+```
+
+This file defines `Flags` and `Builder` types for your ISA settings.
 
 Register your settings in `cranelift/codegen/meta/src/isa/mod.rs` and in
 `cranelift/codegen/meta/src/lib.rs`.
@@ -83,14 +94,26 @@ pub fn f_reg(enc: usize) -> Reg { ... }
 pub fn create_machine_env() -> MachineEnv {
     MachineEnv {
         preferred_regs_by_class: [
-            // integer registers
-            vec![x_reg(0), x_reg(1), /* ... */],
-            // float registers
-            vec![f_reg(0), f_reg(1), /* ... */],
-            // vector registers (if any)
-            vec![],
+            // integer registers (caller-saved / not callee-saved)
+            PRegSet::empty()
+                .with(PReg::new(0, RegClass::Int))
+                .with(PReg::new(1, RegClass::Int)),
+                /* ... */
+            // float/vector registers
+            PRegSet::empty()
+                .with(PReg::new(0, RegClass::Float))
+                /* ... */,
+            // second vector class (unused on most ISAs)
+            PRegSet::empty(),
         ],
-        non_preferred_regs_by_class: [vec![], vec![], vec![]],
+        non_preferred_regs_by_class: [
+            // callee-saved integer registers
+            PRegSet::empty()
+                .with(PReg::new(8, RegClass::Int))
+                /* ... */,
+            PRegSet::empty(),
+            PRegSet::empty(),
+        ],
         fixed_stack_slots: vec![],
         scratch_by_class: [None, None, None],
     }
@@ -102,27 +125,42 @@ pub fn create_machine_env() -> MachineEnv {
 In `inst/mod.rs`, define an enum `Inst` for all machine instructions. Each
 variant holds the operands and addressing modes for that instruction.
 
-`Inst` must implement the `MachInst` trait:
+`Inst` must implement the `MachInst` trait. The key required methods are:
 
 ```rust
 impl MachInst for Inst {
     type ABIMachineSpec = NewArchABIMachineSpec;
-    type LabelUse = LabelUse;
+    type LabelUse = LabelUse;  // your label-use kind enum
 
-    fn get_operands(&self, collector: &mut impl OperandVisitor) { ... }
-    fn is_term(&self) -> MachTerminator { ... }
-    fn branch_destination<'a>(&'a self, targets: &'a [MachLabel]) -> ... { ... }
-    fn is_included_in_clobbers(&self) -> bool { ... }
+    const TRAP_OPCODE: &'static [u8] = &[/* ISA-specific trap encoding */];
+
+    fn get_operands(&mut self, collector: &mut impl OperandVisitor) { ... }
     fn is_move(&self) -> Option<(Writable<Reg>, Reg)> { ... }
-    fn gen_move(to: Writable<Reg>, from: Reg, ty: Type) -> Inst { ... }
-    fn gen_nop(preferred_size: usize) -> Inst { ... }
+    fn is_term(&self) -> MachTerminator { ... }
+    fn is_trap(&self) -> bool { ... }
+    fn is_args(&self) -> bool { ... }
+    fn call_type(&self) -> CallType { ... }
+    fn is_included_in_clobbers(&self) -> bool { ... }
+    fn is_mem_access(&self) -> bool { ... }
+    fn gen_move(to_reg: Writable<Reg>, from_reg: Reg, ty: Type) -> Self { ... }
+    fn gen_dummy_use(reg: Reg) -> Self { ... }
     fn rc_for_type(ty: Type) -> CodegenResult<(&'static [RegClass], &'static [Type])> { ... }
     fn canonical_type_for_rc(rc: RegClass) -> Type { ... }
-    fn gen_jump(target: MachLabel) -> Inst { ... }
+    fn gen_jump(target: MachLabel) -> Self { ... }
+    fn gen_nop(preferred_size: usize) -> Self { ... }
+    fn gen_nop_units() -> Vec<Vec<u8>> { ... }
     fn worst_case_size() -> CodeOffset { ... }
-    fn ref_type_regclass(_: &settings::Flags) -> RegClass { ... }
+    fn worst_case_island_growth() -> CodeOffset { ... }
+    fn ref_type_regclass(_flags: &Flags) -> RegClass { ... }
+    fn is_safepoint(&self) -> bool { ... }
+    fn function_alignment() -> FunctionAlignment { ... }
 }
 ```
+
+Several methods have default implementations and can be omitted — check the
+trait definition in `cranelift/codegen/src/machinst/mod.rs` to see which ones.
+`type LabelUse`, `const TRAP_OPCODE`, and `fn function_alignment` are required
+with no default.
 
 ## Step 6: Implement binary emission
 
@@ -133,12 +171,13 @@ impl MachInstEmit for Inst {
     type State = EmitState;
     type Info = EmitInfo;
 
-    fn emit(&self, allocs: &[regalloc2::Allocation], sink: &mut MachBuffer<Inst>, info: &EmitInfo, state: &mut EmitState) {
+    fn emit(&self, sink: &mut MachBuffer<Inst>, info: &EmitInfo, state: &mut EmitState) {
         match self {
             Inst::Add { rd, rn, rm } => {
-                let rd = allocs[0].as_reg().unwrap();
-                let rn = allocs[1].as_reg().unwrap();
-                let rm = allocs[2].as_reg().unwrap();
+                // Registers are already physical by the time emit() is called.
+                let rd = rd.to_reg().to_real_reg().unwrap().hw_enc();
+                let rn = rn.to_real_reg().unwrap().hw_enc();
+                let rm = rm.to_real_reg().unwrap().hw_enc();
                 // encode and write bytes to sink
                 sink.put4(encode_add(rd, rn, rm));
             }
@@ -165,12 +204,11 @@ impl ABIMachineSpec for NewArchABIMachineSpec {
     fn word_bits() -> u32 { 64 }
     fn stack_align(_call_conv: isa::CallConv) -> u32 { 16 }
     fn compute_arg_locs(...) -> ... { ... }
-    fn gen_load_stack(mem: StackAMode, into_reg: Writable<Reg>, ty: Type, flags: MemFlags) -> Inst { ... }
-    fn gen_store_stack(mem: StackAMode, from_reg: Reg, ty: Type, flags: MemFlags) -> Inst { ... }
-    fn gen_move(to: Writable<Reg>, from: Reg, ty: Type) -> Inst { ... }
-    fn gen_extend(to: Writable<Reg>, from: Reg, signed: bool, from_bits: u8, to_bits: u8) -> Inst { ... }
-    fn gen_ret(setup_frame: bool, isa_flags: &Self::F, rets: &[Reg]) -> Inst { ... }
-    fn gen_add_imm(rd: Writable<Reg>, rn: Reg, imm: u32) -> SmallVec<[Inst; 4]> { ... }
+    fn gen_load_stack(mem: StackAMode, into_reg: Writable<Reg>, ty: Type) -> Self::I { ... }
+    fn gen_store_stack(mem: StackAMode, from_reg: Reg, ty: Type) -> Self::I { ... }
+    fn gen_move(to_reg: Writable<Reg>, from_reg: Reg, ty: Type) -> Self::I { ... }
+    fn gen_rets(rets: Vec<RetPair>) -> Self::I { ... }
+    fn gen_add_imm(into_reg: Writable<Reg>, from_reg: Reg, imm: u32) -> SmallVec<[Self::I; 4]> { ... }
     // ... many more
 }
 ```
@@ -259,5 +297,5 @@ cargo test -p cranelift-filetests
 or for a specific file:
 
 ```
-cargo run -p cranelift-codegen --example clif-util -- test path/to/test.clif
+cargo run -p cranelift-tools -- test path/to/test.clif
 ```

--- a/cranelift/docs/add-new-backend.md
+++ b/cranelift/docs/add-new-backend.md
@@ -16,15 +16,20 @@ cranelift/codegen/src/isa/<arch>/
     mod.rs
     abi.rs
     settings.rs     (usually generated — see Step 3)
+    lower.rs        (wires up the ISLE-based lowering)
+    inst.isle       (machine instruction ISLE declarations)
+    lower.isle      (CLIF-to-machine lowering rules)
     inst/
         mod.rs
         args.rs
         emit.rs
         regs.rs
     lower/
-        isle.rs
-        *.isle
+        isle.rs     (Rust constructors backing ISLE extern declarations)
 ```
+
+Additional `.isle` files (e.g. `inst_neon.isle`, `lower_vector.isle`) live
+at the same top-level arch directory alongside `inst.isle` and `lower.isle`.
 
 ## Step 2: Register the backend
 
@@ -77,21 +82,25 @@ Register your settings in `cranelift/codegen/meta/src/isa/mod.rs` and in
 
 ## Step 4: Define machine registers
 
-In `inst/regs.rs`, define:
-
-- Constants for physical registers (e.g. `pub const X0: PReg = PReg::new(0, RegClass::Int);`)
-- A `create_machine_env()` function that returns a `regalloc2::MachineEnv`
-  listing allocatable registers, callee-saved registers, etc.
-
-Example:
+In `inst/regs.rs`, define helper functions and constants for physical registers,
+for example:
 
 ```rust
-use regalloc2::{MachineEnv, PReg, PRegSet, RegClass};
+use regalloc2::PReg;
+use crate::machinst::{Reg, RegClass};
 
-pub fn x_reg(enc: usize) -> Reg { ... }
-pub fn f_reg(enc: usize) -> Reg { ... }
+pub const fn x_reg(enc: usize) -> Reg { ... }
+pub const fn f_reg(enc: usize) -> Reg { ... }
+```
 
-pub fn create_machine_env() -> MachineEnv {
+The `regalloc2::MachineEnv` (which lists allocatable, caller-saved, and
+callee-saved registers) is constructed in `abi.rs` inside the
+`ABIMachineSpec::get_machine_env()` implementation. A typical pattern:
+
+```rust
+use regalloc2::{MachineEnv, PRegSet};
+
+const fn create_reg_environment() -> MachineEnv {
     MachineEnv {
         preferred_regs_by_class: [
             // integer registers (caller-saved / not callee-saved)
@@ -116,6 +125,14 @@ pub fn create_machine_env() -> MachineEnv {
         ],
         fixed_stack_slots: vec![],
         scratch_by_class: [None, None, None],
+    }
+}
+
+impl ABIMachineSpec for NewArchABIMachineSpec {
+    // ...
+    fn get_machine_env(_flags: &settings::Flags, _call_conv: isa::CallConv) -> &MachineEnv {
+        static MACHINE_ENV: MachineEnv = create_reg_environment();
+        &MACHINE_ENV
     }
 }
 ```
@@ -283,8 +300,9 @@ impl TargetIsa for NewArchBackend {
 
 1. Add filetest `.clif` files in `cranelift/filetests/filetests/` under a
    subdirectory for your ISA.
-2. Use `test compile` to verify end-to-end compilation, and `test run` if your
-   ISA can be run via an interpreter (or natively on CI).
+2. Use `test compile precise-output` to verify end-to-end compilation (the test
+   compares the full VCode and disassembly output exactly), and `test run` /
+   `test interpret` if your ISA can be run via an interpreter or natively on CI.
 3. Add `test verifier` tests to verify that your backend correctly rejects
    invalid IR.
 

--- a/cranelift/docs/add-new-backend.md
+++ b/cranelift/docs/add-new-backend.md
@@ -1,0 +1,263 @@
+# How to Add a New Cranelift Backend
+
+This guide walks through the steps to add a new ISA backend to Cranelift.
+Before starting, read [Backend Architecture](backend-architecture.md) for an
+overview of the components you will be implementing.
+
+The existing backends (`aarch64`, `riscv64`, `s390x`, `x64`, `pulley`) are
+good references throughout this process.
+
+## Step 1: Create the backend directory
+
+Create `cranelift/codegen/src/isa/<arch>/` with the following modules:
+
+```
+cranelift/codegen/src/isa/<arch>/
+    mod.rs
+    abi.rs
+    settings.rs     (usually generated — see Step 3)
+    inst/
+        mod.rs
+        args.rs
+        emit.rs
+        regs.rs
+    lower/
+        isle.rs
+        *.isle
+```
+
+## Step 2: Register the backend
+
+In `cranelift/codegen/src/isa/mod.rs`:
+
+1. Add a feature flag for the new backend (e.g. `#[cfg(feature = "newarch")]`)
+   and `pub mod newarch;`.
+2. In `isa::lookup()`, add a match arm that maps your triple's architecture to
+   a new `Builder` for your backend.
+
+In `Cargo.toml` for `cranelift-codegen`, add a feature like:
+
+```toml
+[features]
+newarch = []
+```
+
+And add it to the default features if appropriate.
+
+## Step 3: Define ISA-specific settings
+
+Create `cranelift/codegen/meta/src/isa/<arch>/mod.rs` (or `settings.rs`)
+defining ISA-specific settings using the meta DSL:
+
+```rust
+pub fn define() -> SettingGroup {
+    let mut setting = SettingGroupBuilder::new("newarch");
+    // add flags/enums as needed
+    setting.build()
+}
+```
+
+Run `cargo build -p cranelift-codegen` once to generate
+`cranelift/codegen/src/isa/<arch>/settings.rs` from the meta definition.
+This generated file defines `Flags` and `Builder` types for your ISA settings.
+
+Register your settings in `cranelift/codegen/meta/src/isa/mod.rs` and in
+`cranelift/codegen/meta/src/lib.rs`.
+
+## Step 4: Define machine registers
+
+In `inst/regs.rs`, define:
+
+- Constants for physical registers (e.g. `pub const X0: PReg = PReg::new(0, RegClass::Int);`)
+- A `create_machine_env()` function that returns a `regalloc2::MachineEnv`
+  listing allocatable registers, callee-saved registers, etc.
+
+Example:
+
+```rust
+use regalloc2::{MachineEnv, PReg, PRegSet, RegClass};
+
+pub fn x_reg(enc: usize) -> Reg { ... }
+pub fn f_reg(enc: usize) -> Reg { ... }
+
+pub fn create_machine_env() -> MachineEnv {
+    MachineEnv {
+        preferred_regs_by_class: [
+            // integer registers
+            vec![x_reg(0), x_reg(1), /* ... */],
+            // float registers
+            vec![f_reg(0), f_reg(1), /* ... */],
+            // vector registers (if any)
+            vec![],
+        ],
+        non_preferred_regs_by_class: [vec![], vec![], vec![]],
+        fixed_stack_slots: vec![],
+        scratch_by_class: [None, None, None],
+    }
+}
+```
+
+## Step 5: Define machine instructions
+
+In `inst/mod.rs`, define an enum `Inst` for all machine instructions. Each
+variant holds the operands and addressing modes for that instruction.
+
+`Inst` must implement the `MachInst` trait:
+
+```rust
+impl MachInst for Inst {
+    type ABIMachineSpec = NewArchABIMachineSpec;
+    type LabelUse = LabelUse;
+
+    fn get_operands(&self, collector: &mut impl OperandVisitor) { ... }
+    fn is_term(&self) -> MachTerminator { ... }
+    fn branch_destination<'a>(&'a self, targets: &'a [MachLabel]) -> ... { ... }
+    fn is_included_in_clobbers(&self) -> bool { ... }
+    fn is_move(&self) -> Option<(Writable<Reg>, Reg)> { ... }
+    fn gen_move(to: Writable<Reg>, from: Reg, ty: Type) -> Inst { ... }
+    fn gen_nop(preferred_size: usize) -> Inst { ... }
+    fn rc_for_type(ty: Type) -> CodegenResult<(&'static [RegClass], &'static [Type])> { ... }
+    fn canonical_type_for_rc(rc: RegClass) -> Type { ... }
+    fn gen_jump(target: MachLabel) -> Inst { ... }
+    fn worst_case_size() -> CodeOffset { ... }
+    fn ref_type_regclass(_: &settings::Flags) -> RegClass { ... }
+}
+```
+
+## Step 6: Implement binary emission
+
+In `inst/emit.rs`, implement `MachInstEmit` for `Inst`:
+
+```rust
+impl MachInstEmit for Inst {
+    type State = EmitState;
+    type Info = EmitInfo;
+
+    fn emit(&self, allocs: &[regalloc2::Allocation], sink: &mut MachBuffer<Inst>, info: &EmitInfo, state: &mut EmitState) {
+        match self {
+            Inst::Add { rd, rn, rm } => {
+                let rd = allocs[0].as_reg().unwrap();
+                let rn = allocs[1].as_reg().unwrap();
+                let rm = allocs[2].as_reg().unwrap();
+                // encode and write bytes to sink
+                sink.put4(encode_add(rd, rn, rm));
+            }
+            // ...
+        }
+    }
+}
+```
+
+`EmitState` tracks per-function state during emission (stack frame size, etc.).
+`EmitInfo` carries settings that are constant for the entire function.
+
+## Step 7: Implement the ABI
+
+In `abi.rs`, implement `ABIMachineSpec`:
+
+```rust
+pub struct NewArchABIMachineSpec;
+
+impl ABIMachineSpec for NewArchABIMachineSpec {
+    type I = Inst;
+    type F = settings::Flags;
+
+    fn word_bits() -> u32 { 64 }
+    fn stack_align(_call_conv: isa::CallConv) -> u32 { 16 }
+    fn compute_arg_locs(...) -> ... { ... }
+    fn gen_load_stack(mem: StackAMode, into_reg: Writable<Reg>, ty: Type, flags: MemFlags) -> Inst { ... }
+    fn gen_store_stack(mem: StackAMode, from_reg: Reg, ty: Type, flags: MemFlags) -> Inst { ... }
+    fn gen_move(to: Writable<Reg>, from: Reg, ty: Type) -> Inst { ... }
+    fn gen_extend(to: Writable<Reg>, from: Reg, signed: bool, from_bits: u8, to_bits: u8) -> Inst { ... }
+    fn gen_ret(setup_frame: bool, isa_flags: &Self::F, rets: &[Reg]) -> Inst { ... }
+    fn gen_add_imm(rd: Writable<Reg>, rn: Reg, imm: u32) -> SmallVec<[Inst; 4]> { ... }
+    // ... many more
+}
+```
+
+The full list of required methods is in `cranelift/codegen/src/machinst/abi.rs`.
+The existing backends are the best reference for what each method should do.
+
+## Step 8: Write ISLE lowering rules
+
+Create `lower/<arch>.isle` (you can name it as you like) with lowering rules.
+At minimum you need to provide a rule for every CLIF opcode your backend
+supports.
+
+A rule looks like:
+
+```lisp
+;; Lower iadd
+(rule (lower (has_type (fits_in_64 ty) (iadd x y)))
+      (alu_rrr (ALUOp.Add) ty x y))
+```
+
+You also need to define your machine instruction constructors as ISLE
+*constructors* that emit instructions, e.g.:
+
+```lisp
+(decl alu_rrr (ALUOp Type Value Value) InstOutput)
+(extern constructor alu_rrr alu_rrr)
+```
+
+where `alu_rrr` is implemented as a Rust function in `lower/isle.rs`:
+
+```rust
+pub fn alu_rrr(&mut self, op: ALUOp, ty: Type, rn: Value, rm: Value) -> InstOutput {
+    let rn = self.put_in_reg(rn);
+    let rm = self.put_in_reg(rm);
+    let rd = self.alloc_tmp(ty);
+    self.emit(Inst::AluRRR { op, rd, rn, rm });
+    output_reg(rd.to_reg(), ty)
+}
+```
+
+Refer to [How to Add a Machine Instruction and Lowering](add-machine-instruction.md)
+for a detailed walkthrough.
+
+## Step 9: Wire up the backend
+
+In `mod.rs`, implement `TargetIsa` for your backend struct:
+
+```rust
+pub struct NewArchBackend {
+    triple: Triple,
+    flags: settings::Flags,
+    isa_flags: newarch_settings::Flags,
+}
+
+impl TargetIsa for NewArchBackend {
+    fn name(&self) -> &'static str { "newarch" }
+    fn triple(&self) -> &Triple { &self.triple }
+    fn flags(&self) -> &settings::Flags { &self.flags }
+    fn isa_flags(&self) -> Vec<settings::Value> { self.isa_flags.iter().collect() }
+
+    fn compile_function(&self, func: &Function, domtree: &DominatorTree, ...) -> CodegenResult<CompiledCodeStencil> {
+        let (vcode, regalloc_result) = self.compile_vcode(func, domtree, ctrl_plane)?;
+        let emit_result = vcode.emit(&regalloc_result, ...)?;
+        Ok(emit_result.into())
+    }
+    // ...
+}
+```
+
+## Step 10: Add tests
+
+1. Add filetest `.clif` files in `cranelift/filetests/filetests/` under a
+   subdirectory for your ISA.
+2. Use `test compile` to verify end-to-end compilation, and `test run` if your
+   ISA can be run via an interpreter (or natively on CI).
+3. Add `test verifier` tests to verify that your backend correctly rejects
+   invalid IR.
+
+Run with:
+
+```
+cargo test -p cranelift-filetests
+```
+
+or for a specific file:
+
+```
+cargo run -p cranelift-codegen --example clif-util -- test path/to/test.clif
+```

--- a/cranelift/docs/backend-architecture.md
+++ b/cranelift/docs/backend-architecture.md
@@ -47,9 +47,15 @@ Every ISA backend defines a type that implements `MachInst`. This trait
 provides:
 
 - `get_operands`: enumerate register uses and definitions (for regalloc)
-- `is_term`: whether this is a block terminator
-- `branch_destination`: return target blocks for branch instructions
-- `emit`: encode the instruction into bytes in a `MachBuffer`
+- `is_term`: whether this is a block terminator; returns a `MachTerminator`
+  that carries branch target block indices for conditional and unconditional
+  branches
+- `gen_move`, `gen_jump`, `gen_nop`, etc.: generate specific instruction forms
+  needed by the backend framework
+
+Binary encoding is handled by the separate `MachInstEmit` trait (also
+implemented on the same `Inst` type), whose `emit` method writes bytes into a
+`MachBuffer`.
 
 ### `MachBuffer`
 
@@ -81,10 +87,19 @@ Engine), a domain-specific language for writing pattern-matching lowering rules.
 ### ISLE compilation model
 
 ISLE source files (`.isle`) are compiled at build time by the ISLE compiler
-(in `cranelift/isle`) into Rust code. The generated Rust is checked in at
-`cranelift/codegen/src/isa/<arch>/lower/isle/generated_code.rs` to allow
-building Cranelift without running the ISLE compiler (though it is
-automatically re-run when any `.isle` file changes).
+(in `cranelift/isle`) into Rust code. The build script (`build.rs`) runs the
+ISLE compiler automatically whenever a `.isle` file changes — no manual step
+is required. The generated Rust code is placed in Cargo's output directory
+(`target/`).
+
+Each backend has a thin `generated_code.rs` file in the source tree that does
+nothing but `include!()` the actual generated file from `target/`. The actual
+generated code is never checked in. To inspect the generated code, set the
+`ISLE_SOURCE_DIR` environment variable to redirect it to a readable path:
+
+```shell
+$ ISLE_SOURCE_DIR=$(pwd)/isle-sources cargo check -p cranelift-codegen
+```
 
 ### How lowering works
 
@@ -101,8 +116,8 @@ instructions into the `VCodeBuilder`.
 
 For a given backend (e.g. `aarch64`):
 
-- `cranelift/codegen/src/isa/aarch64/inst/*.isle`: machine instruction
-  definitions (the `MInstruction` term and its variants)
+- `cranelift/codegen/src/isa/aarch64/inst.isle` (and `inst_neon.isle`):
+  machine instruction definitions (the `MInstruction` term and its variants)
 - `cranelift/codegen/src/isa/aarch64/lower.isle`: lowering rules (patterns
   matching CLIF and emitting machine instructions)
 - `cranelift/codegen/src/prelude.isle`: shared declarations available to all
@@ -147,8 +162,8 @@ inst/
 lower/
     isle.rs     - Glue between the Rust lowering entry point and ISLE
     isle/
-        generated_code.rs  - ISLE compiler output (checked in)
-*.isle          - ISLE source files
+        generated_code.rs  - include!() wrapper for ISLE output in target/
+*.isle          - ISLE source files (compiled to Rust by build.rs)
 ```
 
 ## Optimization pipeline context

--- a/cranelift/docs/backend-architecture.md
+++ b/cranelift/docs/backend-architecture.md
@@ -1,0 +1,166 @@
+# Cranelift Backend Architecture
+
+This document describes the architecture of Cranelift's code generation
+backend — the pipeline that takes optimized CLIF IR and produces binary
+machine code.
+
+## Overview
+
+After machine-independent optimization passes run on CLIF IR, the backend
+pipeline takes over. The pipeline consists of the following stages:
+
+```
+ir::Function            (optimized CLIF IR)
+    |
+    | [instruction selection / lowering via ISLE]
+    |
+VCode<arch::Inst>       (virtual-register machine instructions)
+    |
+    | [register allocation via regalloc2]
+    |
+    | [branch resolution and binary emission via MachBuffer]
+    |
+Vec<u8>                 (binary machine code)
+```
+
+## Key Data Structures
+
+### `VCode<I>`
+
+`VCode` (virtual-register code) is the central container for machine
+instructions in the backend. It holds:
+
+- A list of machine instructions of type `I` (the ISA-specific instruction
+  type, e.g. `aarch64::inst::Inst`).
+- A mapping from machine instruction indices to basic block indices.
+- ABI/calling-convention state (the `Callee` struct).
+- A table of embedded constants referenced by instructions.
+
+`VCode` implements the `regalloc2::Function` trait so that the register
+allocator can operate on it directly. The ISA-specific `Inst` type implements
+the `MachInst` trait which provides information about register uses/defs,
+branch targets, and instruction emission.
+
+### `MachInst` trait
+
+Every ISA backend defines a type that implements `MachInst`. This trait
+provides:
+
+- `get_operands`: enumerate register uses and definitions (for regalloc)
+- `is_term`: whether this is a block terminator
+- `branch_destination`: return target blocks for branch instructions
+- `emit`: encode the instruction into bytes in a `MachBuffer`
+
+### `MachBuffer`
+
+`MachBuffer` is a streaming encoder that accumulates binary code and handles:
+
+- Branch-target patching and relaxation (short vs. long branches)
+- Constant pool islands inserted between blocks for out-of-range constants
+- Relocation records
+
+### `Callee` and the ABI Layer
+
+`Callee` (from `machinst::abi`) manages the calling convention and stack frame
+for a function. It is responsible for:
+
+- Allocating stack slots and spill slots
+- Emitting prologue (register saves, stack pointer adjustment) and epilogue
+- Handling argument passing and return values according to the calling
+  convention (System V, Windows x64, etc.)
+
+Each ISA implements the `ABIMachineSpec` trait to specialize the generic
+`Callee` logic for the particular register file and calling conventions of
+that ISA.
+
+## Instruction Selection via ISLE
+
+Instruction selection is performed by ISLE (Instruction Selection and Lowering
+Engine), a domain-specific language for writing pattern-matching lowering rules.
+
+### ISLE compilation model
+
+ISLE source files (`.isle`) are compiled at build time by the ISLE compiler
+(in `cranelift/isle`) into Rust code. The generated Rust is checked in at
+`cranelift/codegen/src/isa/<arch>/lower/isle/generated_code.rs` to allow
+building Cranelift without running the ISLE compiler (though it is
+automatically re-run when any `.isle` file changes).
+
+### How lowering works
+
+The entry point is `Lower::lower()` in `cranelift/codegen/src/machinst/lower.rs`.
+It iterates over CLIF basic blocks in reverse post-order and for each
+instruction calls the ISLE-generated `lower()` function.
+
+The ISLE generated code operates as a term-rewriting system over CLIF
+instruction patterns. A CLIF `Opcode` (plus optional type and immediates) is
+matched against patterns, and the matching rule emits one or more machine
+instructions into the `VCodeBuilder`.
+
+### ISLE file organization
+
+For a given backend (e.g. `aarch64`):
+
+- `cranelift/codegen/src/isa/aarch64/inst/*.isle`: machine instruction
+  definitions (the `MInstruction` term and its variants)
+- `cranelift/codegen/src/isa/aarch64/lower.isle`: lowering rules (patterns
+  matching CLIF and emitting machine instructions)
+- `cranelift/codegen/src/prelude.isle`: shared declarations available to all
+  backends
+- `cranelift/codegen/src/prelude_lower.isle`: helpers for lowering shared
+  across all backends
+- `cranelift/codegen/src/opts/*.isle`: mid-end CLIF-to-CLIF optimization rules
+
+Auto-generated ISLE files (from `cranelift/codegen/build.rs`) provide `extern`
+declarations for CLIF opcodes and types so that ISLE rules can reference them
+by name.
+
+## Register Allocation
+
+Register allocation is performed by [regalloc2], an external crate. After
+lowering, `VCode` is passed to regalloc2 which returns an `Output` containing
+the allocation decisions. The allocation is applied during binary emission:
+each instruction's `emit` method receives the `regalloc2::Output` and looks
+up the physical registers assigned to each virtual register.
+
+Cranelift supports two regalloc algorithms, selectable via the
+`regalloc_algorithm` setting:
+- `backtracking` (default): the Ion backtracking allocator, good quality
+- `single_pass`: a fast single-pass allocator, lower quality but faster
+
+[regalloc2]: https://github.com/bytecodealliance/regalloc2
+
+## Backend module layout
+
+Each ISA backend lives in `cranelift/codegen/src/isa/<arch>/` and contains:
+
+```
+mod.rs          - TargetIsa implementation, compile_vcode()
+settings.rs     - ISA-specific settings (generated from meta)
+abi.rs          - ABIMachineSpec implementation
+inst/
+    mod.rs      - MachInst implementation and instruction enum
+    args.rs     - Operand types (register kinds, addressing modes, immediates)
+    emit.rs     - Binary encoding (MachInstEmit impl)
+    regs.rs     - Register definitions
+    imms.rs     - Immediate helper types
+lower/
+    isle.rs     - Glue between the Rust lowering entry point and ISLE
+    isle/
+        generated_code.rs  - ISLE compiler output (checked in)
+*.isle          - ISLE source files
+```
+
+## Optimization pipeline context
+
+The backend receives an already-optimized `ir::Function`. The optimization
+pipeline that runs before backend lowering includes:
+
+1. **E-graph optimization** (`cranelift/codegen/src/egraph/`): GVN, algebraic
+   simplifications, and rewrites expressed as ISLE rules in
+   `cranelift/codegen/src/opts/*.isle`.
+2. **Alias analysis** (`cranelift/codegen/src/alias_analysis.rs`): redundant
+   load elimination.
+
+These passes are ISA-independent and run on CLIF IR before any ISA-specific
+code is invoked.

--- a/cranelift/docs/compare-llvm.md
+++ b/cranelift/docs/compare-llvm.md
@@ -76,22 +76,25 @@ representation. Some target ISAs have a fast instruction selector that can
 translate simple code directly to MachineInstrs, bypassing SelectionDAG when
 possible.
 
-[Cranelift IR](ir.md) uses a single intermediate representation to cover
-these levels of abstraction. This is possible in part because of Cranelift's
-smaller scope.
+[Cranelift IR](ir.md) is an ISA-agnostic SSA IR that serves as the input to
+the code generator. Cranelift uses a two-phase approach:
 
-- Cranelift does not provide assemblers and disassemblers, so it is not
-  necessary to be able to represent every weird instruction in an ISA. Only
-  those instructions that the code generator emits have a representation.
-- Cranelift's opcodes are ISA-agnostic, but after legalization / instruction
-  selection, each instruction is annotated with an ISA-specific encoding which
-  represents a native instruction.
-- SSA form is preserved throughout. After register allocation, each SSA value
-  is annotated with an assigned ISA register or stack slot.
+1. **Mid-end optimizations**: CLIF IR is first optimized by machine-independent
+   passes (e-graph-based GVN, alias analysis, etc.) that work entirely on CLIF
+   opcodes.
+
+2. **Backend lowering**: The optimized CLIF is then lowered to machine
+   instructions by an ISA-specific backend, using ISLE (Instruction Selection
+   and Lowering Engine) rewrite rules. The result is a `VCode` container of
+   virtual-register machine instructions. Register allocation then assigns
+   physical registers, after which the instructions are emitted as binary code.
+
+Cranelift does not provide assemblers or disassemblers, so only those
+instructions that the code generator emits need a representation.
 
 The Cranelift intermediate representation is similar to LLVM IR, but at a slightly
 lower level of abstraction, to allow it to be used all the way through the
-codegen process.
+optimization phase of the codegen process.
 
 This design tradeoff does mean that Cranelift IR is less friendly for mid-level
 optimizations. Cranelift doesn't currently perform mid-level optimizations,
@@ -166,12 +169,10 @@ instead models this by returning a single value of an aggregate type.
 
 LLVM has a small well-defined basic instruction set and a large number of
 intrinsics, some of which are ISA-specific. Cranelift has a larger instruction
-set and no intrinsics. Some Cranelift instructions are ISA-specific.
+set and no intrinsics.
 
-Since Cranelift instructions are used all the way until the binary machine code
-is emitted, there are opcodes for every native instruction that can be
-generated. There is a lot of overlap between different ISAs, so for example the
-`iadd_imm` instruction is used by every ISA that can add an
-immediate integer to a register. A simple RISC ISA like RISC-V can be defined
-with only shared instructions, while x86 needs a number of specific
-instructions to model addressing modes.
+Cranelift's CLIF opcodes are ISA-agnostic and are used for both optimization
+and as the input to instruction selection. ISA-specific machine instructions
+are defined separately in each backend (in ISLE) and are never exposed at the
+CLIF IR level. Lowering rules in ISLE match patterns of CLIF opcodes and emit
+the corresponding sequences of machine instructions into `VCode`.

--- a/cranelift/docs/debugging-codegen.md
+++ b/cranelift/docs/debugging-codegen.md
@@ -8,14 +8,17 @@ allocation failures.
 
 ### Print CLIF input
 
-To see the CLIF IR that a function starts with, use `clif-util print`:
+To see the CLIF IR that a function starts with, use `clif-util cat`:
 
 ```
-cargo run -p cranelift-codegen --example clif-util -- print path/to/function.clif
+cargo run -p cranelift-tools -- cat path/to/function.clif
 ```
 
-Or use the `CRANELIFT_VERBOSE` environment variable to make `cranelift-codegen`
-print CLIF at key stages during normal compilation.
+To print CLIF at key stages during normal compilation, enable trace logging:
+
+```
+RUST_LOG=cranelift_codegen=trace cargo test ...
+```
 
 ### Print optimized CLIF
 
@@ -35,13 +38,13 @@ function %my_func(i32, i32) -> i32 {
 Run with:
 
 ```
-cargo run -p cranelift-codegen --example clif-util -- test path/to/test.clif
+cargo run -p cranelift-tools -- test path/to/test.clif
 ```
 
 ### Print VCode (machine instructions before regalloc)
 
-Set `CRANELIFT_VERBOSE=1` or enable the `trace` log level for
-`cranelift_codegen::machinst`. With `RUST_LOG=cranelift_codegen::machinst=trace`:
+Enable the `trace` log level for `cranelift_codegen::machinst`:
+
 
 ```
 RUST_LOG=cranelift_codegen::machinst=trace cargo test ...
@@ -80,7 +83,7 @@ helps enormously to reduce the input to a small `.clif` file.
 
 2. Save the function to a `.clif` file and run:
    ```
-   cargo run -p cranelift-codegen --example clif-util -- test path/to/test.clif
+   cargo run -p cranelift-tools -- test path/to/test.clif
    ```
 
 3. Manually simplify the function: remove instructions, replace values with
@@ -126,10 +129,10 @@ Use `test run` with different `target` lines to run the same function on
 different ISAs and compare results. The interpreter (`test interpret`) provides
 a reference implementation that does not go through native code generation.
 
-### Using `clif-util disasm`
+### Using `clif-util compile --disasm`
 
 ```
-cargo run -p cranelift-codegen --example clif-util -- compile --disasm -t aarch64 path/to/test.clif
+cargo run -p cranelift-tools -- compile --disasm --target aarch64 path/to/test.clif
 ```
 
 This prints the generated machine code as both hex and disassembly.
@@ -167,14 +170,15 @@ Cranelift supports a `ControlPlane` mechanism that can randomize certain
 compilation decisions (such as block layout). This is useful for finding
 latent bugs that only manifest with a particular ordering.
 
-Pass `--chaos` to `clif-util` to enable chaos mode:
+Chaos mode is enabled via a Cargo feature. Build with the `chaos` feature to
+activate it:
 
 ```
-cargo run -p cranelift-codegen --example clif-util -- test --chaos path/to/test.clif
+cargo test -p cranelift-filetests --features cranelift-control/chaos
 ```
 
-When a test fails under chaos mode, bisect which random seed triggers the
-failure by setting `CRANELIFT_SEED=<N>`.
+When a miscompilation only appears under chaos mode, run tests repeatedly or
+use a fuzzer seed to reproduce the specific ordering that triggers the bug.
 
 ## Debugging ISLE rule selection
 

--- a/cranelift/docs/debugging-codegen.md
+++ b/cranelift/docs/debugging-codegen.md
@@ -1,0 +1,222 @@
+# Debugging Cranelift Code Generation
+
+This guide describes strategies for debugging issues in Cranelift's code
+generation — wrong output, compiler panics, miscompilations, and register
+allocation failures.
+
+## Printing IR at various pipeline stages
+
+### Print CLIF input
+
+To see the CLIF IR that a function starts with, use `clif-util print`:
+
+```
+cargo run -p cranelift-codegen --example clif-util -- print path/to/function.clif
+```
+
+Or use the `CRANELIFT_VERBOSE` environment variable to make `cranelift-codegen`
+print CLIF at key stages during normal compilation.
+
+### Print optimized CLIF
+
+Use a `test optimize` filetest (see [Testing Cranelift](testing.md)) to observe
+the IR after mid-end optimization passes:
+
+```
+test optimize
+target x86_64
+
+function %my_func(i32, i32) -> i32 {
+...
+}
+; check: ...
+```
+
+Run with:
+
+```
+cargo run -p cranelift-codegen --example clif-util -- test path/to/test.clif
+```
+
+### Print VCode (machine instructions before regalloc)
+
+Set `CRANELIFT_VERBOSE=1` or enable the `trace` log level for
+`cranelift_codegen::machinst`. With `RUST_LOG=cranelift_codegen::machinst=trace`:
+
+```
+RUST_LOG=cranelift_codegen::machinst=trace cargo test ...
+```
+
+This prints the VCode (virtual-register machine instructions) after lowering
+but before register allocation.
+
+### Print the final compiled output
+
+Use a `test compile` filetest with filecheck directives to inspect the
+instruction sequence after register allocation:
+
+```
+test compile
+target aarch64
+
+function %add(i32, i32) -> i32 {
+block0(v0: i32, v1: i32):
+    v2 = iadd v0, v1
+    return v2
+}
+; check: add w0, w0, w1
+```
+
+## Minimizing a failing test case
+
+When a miscompilation or panic occurs in Wasmtime or another consumer, it
+helps enormously to reduce the input to a small `.clif` file.
+
+### Manual minimization
+
+1. Dump the CLIF IR of the failing function. In Wasmtime, set
+   `WASMTIME_LOG=cranelift_codegen=trace` and look for the function's CLIF
+   output in stderr.
+
+2. Save the function to a `.clif` file and run:
+   ```
+   cargo run -p cranelift-codegen --example clif-util -- test path/to/test.clif
+   ```
+
+3. Manually simplify the function: remove instructions, replace values with
+   constants, shrink the number of blocks, etc. After each change, confirm the
+   bug is still reproducible.
+
+### Fuzzer-assisted minimization
+
+If the bug was found via fuzzing (`cranelift/fuzzgen`), the fuzzer's corpus
+entry can be minimized using `cargo-fuzz tmin`. See the
+[fuzzgen README](../fuzzgen/README.md) for details.
+
+## Diffing output against a reference
+
+When debugging a miscompilation (the code compiles but produces wrong results),
+it can be useful to compare the output of two different configurations.
+
+### Compare optimized vs. unoptimized
+
+Compile with `opt_level=none` and `opt_level=speed` and compare the outputs:
+
+```
+test run
+set opt_level=none
+target x86_64
+
+function %foo(i32) -> i32 { ... }
+; run: %foo(42) == 42
+```
+
+```
+test run
+set opt_level=speed
+target x86_64
+
+function %foo(i32) -> i32 { ... }
+; run: %foo(42) == 42
+```
+
+### Compare two backends
+
+Use `test run` with different `target` lines to run the same function on
+different ISAs and compare results. The interpreter (`test interpret`) provides
+a reference implementation that does not go through native code generation.
+
+### Using `clif-util disasm`
+
+```
+cargo run -p cranelift-codegen --example clif-util -- compile --disasm -t aarch64 path/to/test.clif
+```
+
+This prints the generated machine code as both hex and disassembly.
+
+## Debugging register allocation issues
+
+Register allocation errors from regalloc2 are reported with a dump of the
+VCode. Key things to check:
+
+- Is `get_operands` correct? Every register read by an instruction must be
+  listed as a `reg_use`, every register written must be listed as `reg_def`.
+  A missing `reg_use` can cause a use-before-def error; a missing `reg_def`
+  can cause wrong-register assignment.
+- Are block parameters (`block_params_succ` / `block_params`) correct?
+- Does the terminator instruction list its target blocks correctly?
+
+Enable the regalloc checker for additional verification:
+
+```
+set regalloc_checker=true
+```
+
+This adds a post-allocation correctness check that verifies every register
+use is preceded by a definition or block-parameter assignment.
+
+Enable verbose regalloc logs:
+
+```
+RUST_LOG=regalloc2=debug cargo test ...
+```
+
+## Using "optimization fuel" / chaos mode
+
+Cranelift supports a `ControlPlane` mechanism that can randomize certain
+compilation decisions (such as block layout). This is useful for finding
+latent bugs that only manifest with a particular ordering.
+
+Pass `--chaos` to `clif-util` to enable chaos mode:
+
+```
+cargo run -p cranelift-codegen --example clif-util -- test --chaos path/to/test.clif
+```
+
+When a test fails under chaos mode, bisect which random seed triggers the
+failure by setting `CRANELIFT_SEED=<N>`.
+
+## Debugging ISLE rule selection
+
+### See which rule fired
+
+Set `RUST_LOG=cranelift_codegen::machinst::isle=trace` to see which ISLE rules
+are selected during lowering.
+
+### Inspect generated ISLE code
+
+To see the Rust code that ISLE generated:
+
+```
+ISLE_SOURCE_DIR=$(pwd)/isle-out cargo check -p cranelift-codegen
+```
+
+The generated code is placed in `./isle-out/`. You can set breakpoints in it or
+add `eprintln!` statements to trace rule execution.
+
+### ISLE error reporting
+
+For pretty-printed ISLE type errors with source context, build with:
+
+```
+cargo build -p cranelift-codegen --features isle-errors
+```
+
+## Common panics and their causes
+
+| Panic message | Likely cause |
+|---|---|
+| `no rule for opcode X in lower` | Backend missing a lowering rule for that CLIF opcode. Add an ISLE rule or return a more helpful error. |
+| `register class mismatch` | `get_operands` returned a wrong `RegClass` for a register, or the instruction is being given a register of the wrong class. |
+| `assertion failed: is_term` | A basic block's last instruction is not a terminator (branch or return). |
+| `MachBuffer: island required` | An instruction's branch or constant reference is out of range and the `MachBuffer` island logic did not insert an island. Increase island frequency or check `worst_case_size`. |
+| `regalloc2: live range crosses call without clobber` | A value is live across a call but the register assigned to it is not callee-saved. Check that the ABI's callee-saved register list is correct. |
+
+## Useful environment variables
+
+| Variable | Effect |
+|---|---|
+| `RUST_LOG=cranelift_codegen=debug` | Enable debug-level tracing in cranelift-codegen |
+| `RUST_LOG=regalloc2=debug` | Enable regalloc2 verbose logging |
+| `CRANELIFT_FILETESTS_THREADS=1` | Run filetests single-threaded (for cleaner output) |
+| `ISLE_SOURCE_DIR=<path>` | Write ISLE-generated Rust to `<path>` instead of `target/` |

--- a/cranelift/docs/index.md
+++ b/cranelift/docs/index.md
@@ -1,51 +1,75 @@
 # Cranelift Documentation
 
-## Miscellaneous documentation pages:
+## Reference
 
  - [Cranelift IR](ir.md)
-   Cranelift IR is the data structure that most of the compiler operates on.
+   The data structure that most of the compiler operates on: opcodes, types,
+   basic blocks, function signatures, and the textual `.clif` format.
 
  - [Testing Cranelift](testing.md)
-   This page documents Cranelift's testing frameworks.
+   Cranelift's testing frameworks: Rust unit tests, filecheck-based `.clif`
+   file tests, and the available `test` commands.
 
  - [Cranelift compared to LLVM](compare-llvm.md)
-   LLVM and Cranelift have similarities and differences.
+   Similarities and differences between Cranelift and LLVM in terms of IR
+   design, optimization model, and code generation approach.
 
-## Cranelift crate documentation:
+ - [How ISLE is Integrated with Cranelift](isle-integration.md)
+   How the ISLE DSL fits into Cranelift's build system and lowering pipeline.
+
+## Architecture
+
+ - [Backend Architecture](backend-architecture.md)
+   How the backend pipeline works: CLIF → VCode → binary. Covers ISLE
+   instruction selection, the `MachInst` trait, `VCode`, register allocation
+   via regalloc2, and `MachBuffer` emission.
+
+## Contributor Guides
+
+ - [How to Add a New Backend](add-new-backend.md)
+   Step-by-step guide to creating a new ISA backend: directory layout,
+   register definitions, machine instruction enum, ABI, ISLE lowering rules,
+   and binary emission.
+
+ - [How to Add a New Instruction to CLIF](add-clif-instruction.md)
+   Adding a new opcode to the Cranelift IR: format definitions, the meta
+   DSL, verifier checks, interpreter support, and testing.
+
+ - [How to Add a Machine Instruction and Lowering](add-machine-instruction.md)
+   Adding a new machine instruction variant to a backend and writing ISLE
+   rules to lower CLIF opcodes to it.
+
+ - [Debugging Code Generation](debugging-codegen.md)
+   Strategies for debugging miscompilations, panics, and register allocation
+   failures: printing IR, minimizing test cases, diffing output, chaos mode,
+   and common error patterns.
+
+## Cranelift crate documentation
 
  - [cranelift](https://docs.rs/cranelift)
-    This is an umbrella crate that re-exports the codegen and frontend crates,
-    to make them easier to use.
+    Umbrella crate that re-exports `cranelift-codegen` and `cranelift-frontend`.
 
  - [cranelift-codegen](https://docs.rs/cranelift-codegen)
-    This is the core code generator crate. It takes Cranelift IR as input
-    and emits encoded machine instructions, along with symbolic relocations,
-    as output.
-
- - [cranelift-codegen-meta](https://docs.rs/cranelift-codegen-meta)
-    This crate contains the meta-language utilities and descriptions used by the
-    code generator.
+    Core code generator crate. Takes Cranelift IR as input and emits encoded
+    machine instructions with symbolic relocations.
 
  - [cranelift-frontend](https://docs.rs/cranelift-frontend)
-    This crate provides utilities for translating code into Cranelift IR.
+    Utilities for translating code into Cranelift IR, including SSA construction.
 
  - [cranelift-native](https://docs.rs/cranelift-native)
-    This crate performs auto-detection of the host, allowing Cranelift to
-    generate code optimized for the machine it's running on.
+    Auto-detection of the host ISA and feature flags.
 
  - [cranelift-reader](https://docs.rs/cranelift-reader)
-    This crate translates from Cranelift IR's text format into Cranelift IR
-    in in-memory data structures.
+    Parses the textual `.clif` format into in-memory IR data structures.
 
  - [cranelift-module](https://docs.rs/cranelift-module)
-    This crate manages compiling multiple functions and data objects
-    together.
+    Manages compiling multiple functions and data objects together and linking
+    them into a module.
 
  - [cranelift-object](https://docs.rs/cranelift-object)
-    This crate provides a object-based backend for `cranelift-module`, which
-    emits native object files using the
-    [object](https://github.com/gimli-rs/object) library.
+    Object-file backend for `cranelift-module`, emitting native object files
+    via the [object](https://github.com/gimli-rs/object) library.
 
  - [cranelift-jit](https://docs.rs/cranelift-jit)
-    This crate provides a JIT backend for `cranelift-module`, which
-    emits code and data into memory.
+    JIT backend for `cranelift-module`, emitting code and data directly into
+    executable memory.

--- a/cranelift/docs/ir.md
+++ b/cranelift/docs/ir.md
@@ -351,13 +351,13 @@ retlist      : paramlist
 param        : type [paramext] [paramspecial]
 paramext     : "uext" | "sext"
 paramspecial : "sarg" ( num ) | "sret" | "vmctx" | "stack_limit"
-callconv     : "fast" | "cold" | "system_v" | "windows_fastcall"
-             | "apple_aarch64" | "probestack" | "winch"
+callconv     : "fast" | "tail" | "system_v" | "windows_fastcall"
+             | "apple_aarch64" | "probestack" | "winch" | "preserve_all"
 ```
 
 A function's calling convention determines exactly how arguments and return
 values are passed, and how stack frames are managed. Since all of these details
-depend on both the instruction set /// architecture and possibly the operating
+depend on both the instruction set architecture and possibly the operating
 system, a function's calling convention is only fully determined by a
 `(TargetIsa, CallConv)` tuple.
 
@@ -370,15 +370,17 @@ system, a function's calling convention is only fully determined by a
 
 | Name      | Description |
 | --------- | ----------- |
-| fast      |  not-ABI-stable convention for best performance |
-| cold      |  not-ABI-stable convention for infrequently executed code |
-| system_v  |  System V-style convention used on many platforms |
-| fastcall  |  Windows "fastcall" convention, also used for x64 and ARM |
+| fast             |  not-ABI-stable convention for best performance |
+| tail             |  not-ABI-stable convention supporting tail calls |
+| system_v         |  System V-style convention used on many platforms |
+| windows_fastcall |  Windows x64 calling convention |
+| apple_aarch64    |  Apple AArch64 calling convention |
+| probestack       |  Convention for stack-probe helper functions |
+| winch            |  Convention used by the Winch baseline compiler |
+| preserve_all     |  Preserves all registers; used for signal handlers and similar |
 
-The "not-ABI-stable" conventions do not follow an external specification and
-may change between versions of Cranelift.
-
-The "fastcall" convention is not yet implemented.
+The "not-ABI-stable" conventions (`fast`, `tail`) do not follow an external
+specification and may change between versions of Cranelift.
 
 Parameters and return values have flags whose meaning is mostly target
 dependent. These flags support interfacing with code produced by other

--- a/cranelift/docs/testing.md
+++ b/cranelift/docs/testing.md
@@ -55,19 +55,19 @@ option   ::= flag | setting "=" value
 The `set` lines apply settings cumulatively:
 
 ```
-test legalizer
+test compile
 set opt_level=best
 set is_pic=1
 target riscv64
 set is_pic=0
-target riscv32 supports_m=false
+target riscv64 has_m=false
 
 function %foo() {}
 ```
 
-This example will run the legalizer test twice. Both runs will have
-`opt_level=best`, but they will have different `is_pic` settings. The 32-bit
-run will also have the RISC-V specific flag `supports_m` disabled.
+This example will run the compile test twice. Both runs will have
+`opt_level=best`, but they will have different `is_pic` settings. The second
+run will also have the RISC-V specific flag `has_m` disabled.
 
 The filetests are run automatically as part of `cargo test`, and they can
 also be run manually with the `clif-util test` command.
@@ -221,7 +221,7 @@ Requires a target ISA.
 Supports the `precise-output` option, which requires the filecheck directives
 to be a complete and exact description of the optimized output. This is useful
 for tests that need to verify the exact form of the optimized IR and can be
-auto-updated with `clif-util test --update-comments`.
+auto-updated by setting `CRANELIFT_TEST_BLESS=1` when running the tests.
 
 Example:
 

--- a/cranelift/docs/testing.md
+++ b/cranelift/docs/testing.md
@@ -20,16 +20,16 @@ Compilers work with large data structures representing programs, and it quickly
 gets unwieldy to generate test data programmatically. File-level tests make it
 easier to provide substantial input functions for the compiler tests.
 
-File tests are `*.clif` files in the `filetests/` directory
-hierarchy. Each file has a header describing what to test followed by a number
-of input functions in the :doc:`Cranelift textual intermediate representation
-<ir>`:
+File tests are `*.clif` files in the `filetests/` directory hierarchy. Each
+file has a header describing what to test followed by a number of input
+functions in the [Cranelift textual intermediate representation](ir.md):
 
-.. productionlist::
-    test_file     : test_header `function_list`
-    test_header   : test_commands (`isa_specs` | `settings`)
-    test_commands : test_command { test_command }
-    test_command  : "test" test_name { option } "\n"
+```
+test_file     ::= test_header function_list
+test_header   ::= test_commands (isa_specs | settings)
+test_commands ::= test_command { test_command }
+test_command  ::= "test" test_name { option } "\n"
+```
 
 The available test commands are described below.
 
@@ -37,34 +37,32 @@ Many test commands only make sense in the context of a target instruction set
 architecture. These tests require one or more ISA specifications in the test
 header:
 
-.. productionlist::
-    isa_specs     : { [`settings`] isa_spec }
-    isa_spec      : "isa" isa_name { `option` } "\n"
+```
+isa_specs ::= { [settings] isa_spec }
+isa_spec  ::= "isa" isa_name { option } "\n"
+```
 
-The options given on the `isa` line modify the ISA-specific settings defined in
-`cranelift-codegen/meta-python/isa/*/settings.py`.
+The options given on the `isa` line modify ISA-specific settings.
 
 All types of tests allow shared Cranelift settings to be modified:
 
-.. productionlist::
-    settings      : { setting }
-    setting       : "set" { option } "\n"
-    option        : flag | setting "=" value
-
-The shared settings available for all target ISAs are defined in
-`cranelift-codegen/meta-python/base/settings.py`.
+```
+settings ::= { setting }
+setting  ::= "set" { option } "\n"
+option   ::= flag | setting "=" value
+```
 
 The `set` lines apply settings cumulatively:
 
 ```
-    test legalizer
-    set opt_level=best
-    set is_pic=1
-    target riscv64
-    set is_pic=0
-    target riscv32 supports_m=false
+test legalizer
+set opt_level=best
+set is_pic=1
+target riscv64
+set is_pic=0
+target riscv32 supports_m=false
 
-    function %foo() {}
+function %foo() {}
 ```
 
 This example will run the legalizer test twice. Both runs will have
@@ -87,7 +85,8 @@ $ CRANELIFT_FILETESTS_THREADS=1 clif-util test path/to/file.clif
 
 Many of the test commands described below use *filecheck* to verify their
 output. Filecheck is a Rust implementation of the LLVM tool of the same name.
-See the `documentation <https://docs.rs/filecheck/>`_ for details of its syntax.
+See the [filecheck documentation](https://docs.rs/filecheck/) for details of
+its syntax.
 
 Comments in `.clif` files are associated with the entity they follow.
 This typically means an instruction or the whole function. Those tests that
@@ -101,9 +100,9 @@ This is useful for defining common regular expression variables with the
 
 Note that LLVM's file tests don't separate filecheck directives by their
 associated function. It verifies the concatenated output against all filecheck
-directives in the test file. LLVM's :command:`FileCheck` command has a
-`CHECK-LABEL:` directive to help separate the output from different functions.
-Cranelift's tests don't need this.
+directives in the test file. LLVM's `FileCheck` command has a `CHECK-LABEL:`
+directive to help separate the output from different functions. Cranelift's
+tests don't need this.
 
 ### `test cat`
 
@@ -115,18 +114,18 @@ against the associated filecheck directives.
 Example:
 
 ```
-    function %r1() -> i32, f32 {
-    block1:
-        v10 = iconst.i32 3
-        v20 = f32const 0.0
-        return v10, v20
-    }
-    ; sameln: function %r1() -> i32, f32 {
-    ; nextln: block0:
-    ; nextln:     v10 = iconst.i32 3
-    ; nextln:     v20 = f32const 0.0
-    ; nextln:     return v10, v20
-    ; nextln: }
+function %r1() -> i32, f32 {
+block1:
+    v10 = iconst.i32 3
+    v20 = f32const 0.0
+    return v10, v20
+}
+; sameln: function %r1() -> i32, f32 {
+; nextln: block0:
+; nextln:     v10 = iconst.i32 3
+; nextln:     v20 = f32const 0.0
+; nextln:     return v10, v20
+; nextln: }
 ```
 
 ### `test verifier`
@@ -139,13 +138,13 @@ instruction that produces the verifier error*. Both the error message and
 reported location of the error is verified:
 
 ```
-    test verifier
+test verifier
 
-    function %test(i32) {
-        block0(v0: i32):
-            jump block1       ; error: terminator
-            return
-    }
+function %test(i32) {
+    block0(v0: i32):
+        jump block1       ; error: terminator
+        return
+}
 ```
 
 This example test passes if the verifier fails with an error message containing
@@ -158,51 +157,50 @@ function verifies correctly.
 ### `test print-cfg`
 
 Print the control flow graph of each function as a Graphviz graph, and run
-filecheck over the result. See also the :command:`clif-util print-cfg`
-command:
+filecheck over the result. See also the `clif-util print-cfg` command:
 
 ```
-    ; For testing cfg generation. This code is nonsense.
-    test print-cfg
-    test verifier
+; For testing cfg generation. This code is nonsense.
+test print-cfg
+test verifier
 
-    function %nonsense(i32, i32) -> f32 {
-    ; check: digraph %nonsense {
-    ; regex: I=\binst\d+\b
-    ; check: label="{block0 | <$(BRIF=$I)>brif v1, block1(v2), block2 }"]
+function %nonsense(i32, i32) -> f32 {
+; check: digraph %nonsense {
+; regex: I=\binst\d+\b
+; check: label="{block0 | <$(BRIF=$I)>brif v1, block1(v2), block2 }"]
 
-    block0(v0: i32, v1: i32):
-        v2 = iconst.i32 0
-        brif v1, block1(v2), block2  ; unordered: block0:$BRIF -> block1
-                                     ; unordered: block0:$BRIF -> block2
+block0(v0: i32, v1: i32):
+    v2 = iconst.i32 0
+    brif v1, block1(v2), block2  ; unordered: block0:$BRIF -> block1
+                                 ; unordered: block0:$BRIF -> block2
 
-    block1(v5: i32):
-        return v0
+block1(v5: i32):
+    return v0
 
-    block2:
-        v100 = f32const 0.0
-        return v100
-    }
+block2:
+    v100 = f32const 0.0
+    return v100
+}
 ```
 
 ### `test domtree`
 
 Compute the dominator tree of each function and validate it against the
-`dominates:` annotations::
+`dominates:` annotations:
 
 ```
-    test domtree
+test domtree
 
-    function %test(i32) {
-        block0(v0: i32):
-            jump block1              ; dominates: block1
-        block1:
-            brif v0, block2, block3  ; dominates: block2, block3
-        block2:
-            jump block3
-        block3:
-            return
-    }
+function %test(i32) {
+    block0(v0: i32):
+        jump block1              ; dominates: block1
+    block1:
+        brif v0, block2, block3  ; dominates: block2, block3
+    block2:
+        jump block3
+    block3:
+        return
+}
 ```
 
 Every reachable basic block except for the entry block has an
@@ -212,71 +210,50 @@ both correct and complete.
 
 This test also sends the computed CFG post-order through filecheck.
 
-### `test legalizer`
+### `test optimize`
 
-Legalize each function for the specified target ISA and run the resulting
-function through filecheck. This test command can be used to validate the
-encodings selected for legal instructions as well as the instruction
-transformations performed by the legalizer.
+Run each function through the optimization passes (e-graph based GVN and
+rewrites, alias analysis, etc.) but not lowering or register allocation. The
+resulting CLIF IR is sent to filecheck.
 
-### `test regalloc`
+Requires a target ISA.
 
-Test the register allocator.
+Supports the `precise-output` option, which requires the filecheck directives
+to be a complete and exact description of the optimized output. This is useful
+for tests that need to verify the exact form of the optimized IR and can be
+auto-updated with `clif-util test --update-comments`.
 
-First, each function is legalized for the specified target ISA. This is
-required for register allocation since the instruction encodings provide
-register class constraints to the register allocator.
+Example:
 
-Second, the register allocator is run on the function, inserting spill code and
-assigning registers and stack slots to all values.
+```
+test optimize
+target x86_64
 
-The resulting function is then run through filecheck.
+function %foo(i32, i32) -> i32 {
+block0(v0: i32, v1: i32):
+    v2 = iadd v0, v1
+    v3 = iadd v2, v0
+    return v3
+}
+; check: v4 = iadd v0, v0
+; check: v5 = iadd v4, v1
+; check: return v5
+```
 
+### `test alias-analysis`
 
-### `test simple-gvn`
-
-Test the simple GVN pass.
-
-The simple GVN pass is run on each function, and then results are run
-through filecheck.
-
-### `test licm`
-
-Test the LICM pass.
-
-The LICM pass is run on each function, and then results are run
-through filecheck.
-
-### `test dce`
-
-Test the DCE pass.
-
-The DCE pass is run on each function, and then results are run
-through filecheck.
-
-### `test shrink`
-
-Test the instruction shrinking pass.
-
-The shrink pass is run on each function, and then results are run
-through filecheck.
-
-### `test simple_preopt`
-
-Test the preopt pass.
-
-The preopt pass is run on each function, and then results are run
-through filecheck.
+Run each function through the GVN and alias analysis passes (redundant load
+elimination), then send the resulting CLIF to filecheck. Does not perform
+lowering or register allocation.
 
 ### `test compile`
 
 Test the whole code generation pipeline.
 
 Each function is passed through the full `Context::compile()` function
-which is normally used to compile code. This type of test often depends
-on assertions or verifier errors, but it is also possible to use
-filecheck directives which will be matched against the final form of the
-Cranelift IR right before binary machine code emission.
+which is normally used to compile code. Filecheck directives are matched
+against the final form of the Cranelift IR right before binary machine code
+emission.
 
 ### `test run`
 
@@ -284,48 +261,76 @@ Compile and execute a function.
 
 This test command allows several directives:
  - to print the result of running a function to stdout, add a `print`
- directive and call the preceding function with arguments (see `%foo` in
- the example below); remember to enable `--nocapture` if running these
- tests through Cargo
+   directive and call the preceding function with arguments (see `%foo` in
+   the example below); remember to enable `--nocapture` if running these
+   tests through Cargo
  - to check the result of a function, add a `run` directive and call the
- preceding function with a comparison (`==` or `!=`) (see `%bar` below)
+   preceding function with a comparison (`==` or `!=`) (see `%bar` below)
  - for backwards compatibility, to check the result of a function with a
- `() -> i*` signature, only the `run` directive is required, with no
- invocation or comparison (see `%baz` below);  a non zero value is
- interpreted as a successful test execution, whereas a zero value is
- interpreted as a failed test.
+   `() -> i*` signature, only the `run` directive is required, with no
+   invocation or comparison (see `%baz` below); a non-zero value is
+   interpreted as a successful test execution, whereas a zero value is
+   interpreted as a failed test.
 
 Currently a `target` is required but is only used to indicate whether the host
-platform can run the test and currently only the architecture is filtered. The
-host platform's native target will be used to actually compile the test.
+platform can run the test; only the architecture is filtered. The host
+platform's native target will be used to actually compile the test.
 
 Example:
 
 ```
-    test run
-    target x86_64
+test run
+target x86_64
 
-    ; how to print the results of a function
-    function %foo() -> i32 {
-    block0:
-        v0 = iconst.i32 42
-        return v0
-    }
-    ; print: %foo()
+; how to print the results of a function
+function %foo() -> i32 {
+block0:
+    v0 = iconst.i32 42
+    return v0
+}
+; print: %foo()
 
-    ; how to check the results of a function
-    function %bar(i32) -> i32 {
-    block0(v0:i32):
-        v1 = iadd_imm v0, 1
-        return v1
-    }
-    ; run: %bar(1) == 2
+; how to check the results of a function
+function %bar(i32) -> i32 {
+block0(v0:i32):
+    v1 = iadd_imm v0, 1
+    return v1
+}
+; run: %bar(1) == 2
 
-    ; legacy method of checking the results of a function
-    function %baz() -> i8 {
-    block0:
-        v0 = iconst.i8 1
-        return v0
-    }
-    ; run
+; legacy method of checking the results of a function
+function %baz() -> i8 {
+block0:
+    v0 = iconst.i8 1
+    return v0
+}
+; run
 ```
+
+### `test interpret`
+
+Interpret each function using Cranelift's interpreter rather than compiling it.
+Use `run:` and `print:` directives the same way as in `test run`. This does not
+require a target ISA and runs platform-independently.
+
+### `test inline`
+
+Inline all calls in each function, optionally followed by optimization passes,
+and send the resulting CLIF to filecheck. Does not perform lowering or register
+allocation.
+
+Supports the following options:
+ - `precise-output`: require filecheck directives to be a complete and exact
+   description of the output
+ - `optimize`: run optimization passes after inlining
+
+### `test safepoint`
+
+Run CFG and dominator tree computation for each function, then send the CLIF
+to filecheck. Useful for verifying safepoint/stackmap-related IR.
+
+### `test unwind`
+
+Run each function through the full code generation pipeline and verify the
+generated unwind information (DWARF `.eh_frame` entries or Windows x64 unwind
+data) against filecheck directives. Requires a target ISA.


### PR DESCRIPTION
While reviewing the Cranelift documentation I found several guides that
no longer matched the current codebase.
Addresses #4135 issue
## New pages added:

- **`backend-architecture.md`**: Documents the CLIF-to-VCode-to-binary
  pipeline and the current roles of ISLE, regalloc2, and `MachInst`.
- **`add-new-backend.md`**: Step-by-step guide for creating a new ISA
  backend: directory layout, registration, settings, `MachInst` trait,
  `PRegSet` usage, ABI, ISLE lowering rules, and tests.
- **`add-clif-instruction.md`**: Guide for adding a new CLIF opcode:
  instruction format API, builder methods, generated file names,
  verifier checks, and interpreter support.
- **`add-machine-instruction.md`**: Guide for adding a machine
  instruction variant: register access in `emit()`, ISLE file paths,
  and testing commands.
- **`debugging-codegen.md`**: Guide for debugging the code generator
  using `RUST_LOG`, `clif-util`, and chaos mode.

## Updates to existing pages:
- **`testing.md`**: Replaced the deprecated `test legalizer` command
  with `test compile`, updated the RISC-V feature flag name, and
  corrected the `CRANELIFT_TEST_BLESS` environment variable.
- **`index.md`**: Refreshed guide descriptions and restored the missing
  link to `isle-integration.md`.
- **`compare-llvm.md`**: Updated the description of the current
  compilation pipeline.