### PR TITLE
Use `OnceLock` in the C API instead of `OnceCell`

### DIFF
--- a/crates/c-api/src/trap.rs
+++ b/crates/c-api/src/trap.rs
@@ -1,5 +1,5 @@
 use crate::{wasm_frame_vec_t, wasm_instance_t, wasm_name_t, wasm_store_t};
-use std::cell::OnceCell;
+use std::sync::OnceLock;
 use wasmtime::{Error, Trap, WasmBacktrace, format_err};
 
 // Help ensure the Rust enum matches the C one.  If any of these assertions
@@ -88,8 +88,8 @@ impl wasm_trap_t {
 pub struct wasm_frame_t<'a> {
     trace: &'a WasmBacktrace,
     idx: usize,
-    func_name: OnceCell<Option<wasm_name_t>>,
-    module_name: OnceCell<Option<wasm_name_t>>,
+    func_name: OnceLock<Option<wasm_name_t>>,
+    module_name: OnceLock<Option<wasm_name_t>>,
 }
 
 wasmtime_c_api_macros::declare_own!(wasm_frame_t);
@@ -147,8 +147,8 @@ pub extern "C" fn wasm_trap_origin(raw: &wasm_trap_t) -> Option<Box<wasm_frame_t
         Some(Box::new(wasm_frame_t {
             trace,
             idx: 0,
-            func_name: OnceCell::new(),
-            module_name: OnceCell::new(),
+            func_name: OnceLock::new(),
+            module_name: OnceLock::new(),
         }))
     } else {
         None
@@ -170,8 +170,8 @@ pub(crate) fn error_trace<'a>(error: &'a Error, out: &mut wasm_frame_vec_t<'a>) 
             Some(Box::new(wasm_frame_t {
                 trace,
                 idx,
-                func_name: OnceCell::new(),
-                module_name: OnceCell::new(),
+                func_name: OnceLock::new(),
+                module_name: OnceLock::new(),
             }))
         })
         .collect();

--- a/crates/c-api/src/types/export.rs
+++ b/crates/c-api/src/types/export.rs
@@ -1,13 +1,13 @@
 use crate::{CExternType, wasm_externtype_t, wasm_name_t};
-use std::cell::OnceCell;
+use std::sync::OnceLock;
 
 #[repr(C)]
 #[derive(Clone)]
 pub struct wasm_exporttype_t {
     name: String,
     ty: CExternType,
-    name_cache: OnceCell<wasm_name_t>,
-    type_cache: OnceCell<wasm_externtype_t>,
+    name_cache: OnceLock<wasm_name_t>,
+    type_cache: OnceLock<wasm_externtype_t>,
 }
 
 wasmtime_c_api_macros::declare_ty!(wasm_exporttype_t);
@@ -17,8 +17,8 @@ impl wasm_exporttype_t {
         wasm_exporttype_t {
             name,
             ty,
-            name_cache: OnceCell::new(),
-            type_cache: OnceCell::new(),
+            name_cache: OnceLock::new(),
+            type_cache: OnceLock::new(),
         }
     }
 }

--- a/crates/c-api/src/types/func.rs
+++ b/crates/c-api/src/types/func.rs
@@ -1,5 +1,5 @@
 use crate::{CExternType, wasm_externtype_t, wasm_valtype_vec_t};
-use std::cell::OnceCell;
+use std::sync::OnceLock;
 use std::{
     mem,
     sync::{Arc, Mutex},
@@ -83,8 +83,8 @@ impl<'a, T> ExactSizeIterator for LazyFuncTypeIter<'a, T> where T: ExactSizeIter
 #[derive(Clone)]
 pub(crate) struct CFuncType {
     ty: Arc<Mutex<LazyFuncType>>,
-    params_cache: OnceCell<wasm_valtype_vec_t>,
-    returns_cache: OnceCell<wasm_valtype_vec_t>,
+    params_cache: OnceLock<wasm_valtype_vec_t>,
+    returns_cache: OnceLock<wasm_valtype_vec_t>,
 }
 
 impl wasm_functype_t {
@@ -121,16 +121,16 @@ impl CFuncType {
     pub(crate) fn new(ty: FuncType) -> CFuncType {
         CFuncType {
             ty: Arc::new(Mutex::new(LazyFuncType::FuncType(ty))),
-            params_cache: OnceCell::new(),
-            returns_cache: OnceCell::new(),
+            params_cache: OnceLock::new(),
+            returns_cache: OnceLock::new(),
         }
     }
 
     pub(crate) fn lazy(params: Vec<ValType>, results: Vec<ValType>) -> CFuncType {
         CFuncType {
             ty: Arc::new(Mutex::new(LazyFuncType::Lazy { params, results })),
-            params_cache: OnceCell::new(),
-            returns_cache: OnceCell::new(),
+            params_cache: OnceLock::new(),
+            returns_cache: OnceLock::new(),
         }
     }
 

--- a/crates/c-api/src/types/import.rs
+++ b/crates/c-api/src/types/import.rs
@@ -1,5 +1,5 @@
 use crate::{CExternType, wasm_externtype_t, wasm_name_t};
-use std::cell::OnceCell;
+use std::sync::OnceLock;
 
 #[repr(C)]
 #[derive(Clone)]
@@ -7,9 +7,9 @@ pub struct wasm_importtype_t {
     pub(crate) module: String,
     pub(crate) name: String,
     pub(crate) ty: CExternType,
-    module_cache: OnceCell<wasm_name_t>,
-    name_cache: OnceCell<wasm_name_t>,
-    type_cache: OnceCell<wasm_externtype_t>,
+    module_cache: OnceLock<wasm_name_t>,
+    name_cache: OnceLock<wasm_name_t>,
+    type_cache: OnceLock<wasm_externtype_t>,
 }
 
 wasmtime_c_api_macros::declare_ty!(wasm_importtype_t);
@@ -20,9 +20,9 @@ impl wasm_importtype_t {
             module,
             name,
             ty,
-            module_cache: OnceCell::new(),
-            name_cache: OnceCell::new(),
-            type_cache: OnceCell::new(),
+            module_cache: OnceLock::new(),
+            name_cache: OnceLock::new(),
+            type_cache: OnceLock::new(),
         }
     }
 }

--- a/crates/c-api/src/types/memory.rs
+++ b/crates/c-api/src/types/memory.rs
@@ -1,6 +1,6 @@
 use crate::{CExternType, handle_result, wasm_externtype_t, wasm_limits_t, wasmtime_error_t};
 use std::convert::TryFrom;
-use std::{cell::OnceCell, mem::MaybeUninit};
+use std::{mem::MaybeUninit, sync::OnceLock};
 use wasmtime::{MemoryType, MemoryTypeBuilder};
 
 #[repr(transparent)]
@@ -14,7 +14,7 @@ wasmtime_c_api_macros::declare_ty!(wasm_memorytype_t);
 #[derive(Clone)]
 pub(crate) struct CMemoryType {
     pub(crate) ty: MemoryType,
-    limits_cache: OnceCell<wasm_limits_t>,
+    limits_cache: OnceLock<wasm_limits_t>,
 }
 
 impl wasm_memorytype_t {
@@ -43,7 +43,7 @@ impl CMemoryType {
     pub(crate) fn new(ty: MemoryType) -> CMemoryType {
         CMemoryType {
             ty,
-            limits_cache: OnceCell::new(),
+            limits_cache: OnceLock::new(),
         }
     }
 }

--- a/crates/c-api/src/types/table.rs
+++ b/crates/c-api/src/types/table.rs
@@ -1,5 +1,5 @@
 use crate::{CExternType, wasm_externtype_t, wasm_limits_t, wasm_valtype_t};
-use std::cell::OnceCell;
+use std::sync::OnceLock;
 use wasmtime::{TableType, ValType};
 
 #[repr(transparent)]
@@ -13,8 +13,8 @@ wasmtime_c_api_macros::declare_ty!(wasm_tabletype_t);
 #[derive(Clone)]
 pub(crate) struct CTableType {
     pub(crate) ty: TableType,
-    element_cache: OnceCell<wasm_valtype_t>,
-    limits_cache: OnceCell<wasm_limits_t>,
+    element_cache: OnceLock<wasm_valtype_t>,
+    limits_cache: OnceLock<wasm_limits_t>,
 }
 
 impl wasm_tabletype_t {
@@ -43,8 +43,8 @@ impl CTableType {
     pub(crate) fn new(ty: TableType) -> CTableType {
         CTableType {
             ty,
-            element_cache: OnceCell::new(),
-            limits_cache: OnceCell::new(),
+            element_cache: OnceLock::new(),
+            limits_cache: OnceLock::new(),
         }
     }
 }

--- a/crates/c-api/src/types/tag.rs
+++ b/crates/c-api/src/types/tag.rs
@@ -1,5 +1,5 @@
 use crate::{CExternType, wasm_externtype_t, wasm_functype_t};
-use std::cell::OnceCell;
+use std::sync::OnceLock;
 use wasmtime::{Engine, TagType};
 
 #[repr(transparent)]
@@ -13,8 +13,8 @@ wasmtime_c_api_macros::declare_ty!(wasm_tagtype_t);
 #[derive(Clone)]
 pub(crate) struct CTagType {
     ty: LazyTagType,
-    tagtype_cache: OnceCell<TagType>,
-    functype_cache: OnceCell<Box<wasm_functype_t>>,
+    tagtype_cache: OnceLock<TagType>,
+    functype_cache: OnceLock<Box<wasm_functype_t>>,
 }
 
 #[derive(Clone)]
@@ -27,16 +27,16 @@ impl CTagType {
     pub(crate) fn new(ty: TagType) -> CTagType {
         CTagType {
             ty: LazyTagType::TagType(ty),
-            tagtype_cache: OnceCell::new(),
-            functype_cache: OnceCell::new(),
+            tagtype_cache: OnceLock::new(),
+            functype_cache: OnceLock::new(),
         }
     }
 
     fn lazy(functype: Box<wasm_functype_t>) -> CTagType {
         CTagType {
             ty: LazyTagType::Lazy(functype),
-            tagtype_cache: OnceCell::new(),
-            functype_cache: OnceCell::new(),
+            tagtype_cache: OnceLock::new(),
+            functype_cache: OnceLock::new(),
         }
     }
 }


### PR DESCRIPTION
This is a bit more robust for the expected type signature and shouldn't come at too much extra cost.

Closes #13751

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
