### PR TITLE
Tag `VMFuncRef` field loads with alias regions

### DIFF
--- a/crates/cranelift/src/alias_region.rs
+++ b/crates/cranelift/src/alias_region.rs
@@ -32,6 +32,7 @@ enum VmType {
     VMTableImport,
     VMTagImport,
     VMGlobalImport,
+    VMFuncRef,
 }
 
 /// A key that uniquely identifies an alias region across an entire compilation.
@@ -140,6 +141,7 @@ impl AliasRegionKey {
     const VM_TAG_IMPORT_KIND: u32 = Self::new_kind(0b10101);
     const VM_GLOBAL_IMPORT_KIND: u32 = Self::new_kind(0b10110);
     const STACK_KIND: u32 = Self::new_kind(0b10111);
+    const VM_FUNC_REF_KIND: u32 = Self::new_kind(0b11000);
 
     /// Encode this key into a raw `u32` suitable for use as an
     /// `AliasRegionData::user_id`.
@@ -164,6 +166,7 @@ impl AliasRegionKey {
                     VmType::VMTableImport => Self::VM_TABLE_IMPORT_KIND,
                     VmType::VMTagImport => Self::VM_TAG_IMPORT_KIND,
                     VmType::VMGlobalImport => Self::VM_GLOBAL_IMPORT_KIND,
+                    VmType::VMFuncRef => Self::VM_FUNC_REF_KIND,
                 };
                 kind | (offset & Self::OFFSET_MASK)
             }
@@ -1783,6 +1786,83 @@ where
             self.pointer_type,
             ir::MemFlagsData::trusted().with_alias_region(Some(region)),
             ptr,
+        )
+    }
+}
+
+/// `VMFuncRef`-related methods.
+impl<Offsets> AliasRegions<Offsets>
+where
+    Offsets: GetPtrSize,
+{
+    fn vmfuncref_region(&mut self, func: &mut ir::Function, offset: u32) -> ir::AliasRegion {
+        self.region(
+            func,
+            AliasRegionKey::Vm {
+                ty: VmType::VMFuncRef,
+                offset,
+            },
+        )
+    }
+
+    /// Load the `VMFuncRef::type_index` field out of a `*const VMFuncRef`.
+    pub fn vmfuncref_type_index(
+        &mut self,
+        cursor: &mut FuncCursor<'_>,
+        base_flags: ir::MemFlagsData,
+        funcref: ir::Value,
+    ) -> ir::Value {
+        let offset = self.offsets.get_ptr_size().vm_func_ref_type_index();
+        let region = self.vmfuncref_region(cursor.func, offset.into());
+        let ty = ir::Type::int_with_byte_size(
+            self.offsets
+                .get_ptr_size()
+                .size_of_vmshared_type_index()
+                .into(),
+        )
+        .unwrap();
+        cursor.ins().load(
+            ty,
+            base_flags.with_alias_region(Some(region)),
+            funcref,
+            i32::from(offset),
+        )
+    }
+
+    /// Load the `VMFuncRef::wasm_call` field out of a `*const VMFuncRef`.
+    ///
+    /// The caller supplies the base flags because this load may carry an
+    /// optional trap code for the null-funcref case.
+    pub fn vmfuncref_wasm_call(
+        &mut self,
+        cursor: &mut FuncCursor<'_>,
+        base_flags: ir::MemFlagsData,
+        funcref: ir::Value,
+    ) -> ir::Value {
+        let offset = self.offsets.get_ptr_size().vm_func_ref_wasm_call();
+        let region = self.vmfuncref_region(cursor.func, offset.into());
+        cursor.ins().load(
+            self.pointer_type,
+            base_flags.with_alias_region(Some(region)),
+            funcref,
+            i32::from(offset),
+        )
+    }
+
+    /// Load the `VMFuncRef::vmctx` field out of a `*const VMFuncRef`.
+    pub fn vmfuncref_vmctx(
+        &mut self,
+        cursor: &mut FuncCursor<'_>,
+        base_flags: ir::MemFlagsData,
+        funcref: ir::Value,
+    ) -> ir::Value {
+        let offset = self.offsets.get_ptr_size().vm_func_ref_vmctx();
+        let region = self.vmfuncref_region(cursor.func, offset.into());
+        cursor.ins().load(
+            self.pointer_type,
+            base_flags.with_alias_region(Some(region)),
+            funcref,
+            i32::from(offset),
         )
     }
 }

--- a/crates/cranelift/src/compiler/component.rs
+++ b/crates/cranelift/src/compiler/component.rs
@@ -1058,7 +1058,6 @@ impl<'a> TrampolineCompiler<'a> {
         let args = self.abi_load_params();
         let vmctx = args[0];
         let caller_vmctx = args[1];
-        let pointer_type = self.isa.pointer_type();
 
         // The arguments this shim passes along to the libcall are:
         //
@@ -1245,17 +1244,15 @@ impl<'a> TrampolineCompiler<'a> {
                     .ins()
                     .trapz(dtor_func_ref, TRAP_INTERNAL_ASSERT);
             }
-            let func_addr = self.builder.ins().load(
-                pointer_type,
+            let func_addr = self.alias_regions.vmfuncref_wasm_call(
+                &mut self.builder.cursor(),
                 trusted,
                 dtor_func_ref,
-                i32::from(self.offsets.ptr.vm_func_ref_wasm_call()),
             );
-            let callee_vmctx = self.builder.ins().load(
-                pointer_type,
+            let callee_vmctx = self.alias_regions.vmfuncref_vmctx(
+                &mut self.builder.cursor(),
                 trusted,
                 dtor_func_ref,
-                i32::from(self.offsets.ptr.vm_func_ref_vmctx()),
             );
 
             let sig = crate::wasm_call_signature(self.isa, self.signature, &self.compiler.tunables);

--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -1122,25 +1122,6 @@ impl<'module_environment> FuncEnvironment<'module_environment> {
         )
     }
 
-    /// Load the associated `VMSharedTypeIndex` from inside a `*const VMFuncRef`.
-    ///
-    /// Does not check for null; just assumes that the `funcref` is a valid
-    /// pointer.
-    pub(crate) fn load_funcref_type_index(
-        &mut self,
-        pos: &mut FuncCursor,
-        mem_flags: ir::MemFlagsData,
-        funcref: ir::Value,
-    ) -> ir::Value {
-        let ty = self.vmshared_type_index_ty();
-        pos.ins().load(
-            ty,
-            mem_flags,
-            funcref,
-            i32::from(self.offsets.ptr.vm_func_ref_type_index()),
-        )
-    }
-
     /// Does this function need a GC heap?
     pub fn needs_gc_heap(&self) -> bool {
         self.needs_gc_heap
@@ -2305,9 +2286,11 @@ impl<'a, 'func, 'module_env> Call<'a, 'func, 'module_env> {
             self.env
                 .trapz(self.builder, funcref_ptr, crate::TRAP_INDIRECT_CALL_TO_NULL);
         }
-        let callee_sig_id =
-            self.env
-                .load_funcref_type_index(&mut self.builder.cursor(), mem_flags, funcref_ptr);
+        let callee_sig_id = self.env.alias_regions.vmfuncref_type_index(
+            &mut self.builder.cursor(),
+            mem_flags,
+            funcref_ptr,
+        );
 
         // Check that they match: in the case of Wasm GC, this means doing a
         // full subtype check. Otherwise, we do a simple equality check.
@@ -2358,8 +2341,6 @@ impl<'a, 'func, 'module_env> Call<'a, 'func, 'module_env> {
         callee: ir::Value,
         callee_load_trap_code: Option<ir::TrapCode>,
     ) -> (ir::Value, ir::Value) {
-        let pointer_type = self.env.pointer_type();
-
         // Dereference callee pointer to get the function address.
         //
         // Note that this may trap if `callee` hasn't previously been verified
@@ -2376,18 +2357,15 @@ impl<'a, 'func, 'module_env> Call<'a, 'func, 'module_env> {
                 self.env.trapz(self.builder, callee, trap);
             }
         }
-        let func_addr = self.builder.ins().load(
-            pointer_type,
+        let func_addr = self.env.alias_regions.vmfuncref_wasm_call(
+            &mut self.builder.cursor(),
             callee_flags,
             callee,
-            i32::from(self.env.offsets.ptr.vm_func_ref_wasm_call()),
         );
-        let callee_vmctx = self.builder.ins().load(
-            pointer_type,
-            mem_flags,
-            callee,
-            i32::from(self.env.offsets.ptr.vm_func_ref_vmctx()),
-        );
+        let callee_vmctx =
+            self.env
+                .alias_regions
+                .vmfuncref_vmctx(&mut self.builder.cursor(), mem_flags, callee);
 
         (func_addr, callee_vmctx)
     }

--- a/crates/cranelift/src/func_environ/gc.rs
+++ b/crates/cranelift/src/func_environ/gc.rs
@@ -1263,10 +1263,9 @@ pub fn translate_ref_test(
             let expected_shared_ty =
                 func_env.module_interned_to_shared_ty(&mut builder.cursor(), expected_interned_ty);
 
-            let gc_memflags = func_env.gc_memflags(&mut builder.func);
-            let actual_shared_ty = func_env.load_funcref_type_index(
+            let actual_shared_ty = func_env.alias_regions.vmfuncref_type_index(
                 &mut builder.cursor(),
-                gc_memflags.with_readonly(),
+                ir::MemFlagsData::trusted().with_readonly(),
                 val,
             );
 

--- a/crates/environ/src/vmoffsets.rs
+++ b/crates/environ/src/vmoffsets.rs
@@ -163,6 +163,12 @@ pub trait PtrSize {
         4 * self.size()
     }
 
+    /// Return the size of `VMSharedTypeIndex`.
+    #[inline]
+    fn size_of_vmshared_type_index(&self) -> u8 {
+        4
+    }
+
     /// Return the size of `VMGlobalDefinition`; this is the size of the largest value type (i.e. a
     /// V128).
     #[inline]
@@ -1037,7 +1043,7 @@ impl<P: PtrSize> VMOffsets<P> {
     /// Return the size of `VMSharedTypeIndex`.
     #[inline]
     pub fn size_of_vmshared_type_index(&self) -> u8 {
-        4
+        self.ptr.size_of_vmshared_type_index()
     }
 }
 

--- a/tests/disas/alias-region-tables.wat
+++ b/tests/disas/alias-region-tables.wat
@@ -24,6 +24,9 @@
 ;;     region5 = 536870912 "PublicTable"
 ;;     region6 = 671088640 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
 ;;     region7 = 40 "VMContext+0x28"
+;;     region8 = 3221225488 "VMFuncRef+0x10"
+;;     region9 = 3221225480 "VMFuncRef+0x8"
+;;     region10 = 3221225496 "VMFuncRef+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -64,13 +67,13 @@
 ;; @004d                               jump block3(v48)
 ;;
 ;;                                 block3(v45: i64):
-;; @004d                               v51 = load.i32 user7 aligned readonly v45+16
+;; @004d                               v51 = load.i32 user7 aligned readonly region8 v45+16
 ;; @004d                               v49 = load.i64 notrap aligned readonly can_move region7 v0+40
 ;; @004d                               v50 = load.i32 notrap aligned readonly can_move v49
 ;; @004d                               v52 = icmp eq v51, v50
 ;; @004d                               trapz v52, user8
-;; @004d                               v54 = load.i64 notrap aligned readonly v45+8
-;; @004d                               v55 = load.i64 notrap aligned readonly v45+24
+;; @004d                               v54 = load.i64 notrap aligned readonly region9 v45+8
+;; @004d                               v55 = load.i64 notrap aligned readonly region10 v45+24
 ;; @004d                               v56 = call_indirect sig0, v54(v55, v0)
 ;; @0050                               jump block1
 ;;

--- a/tests/disas/call-indirect-with-gc.wat
+++ b/tests/disas/call-indirect-with-gc.wat
@@ -16,6 +16,9 @@
 ;;     region3 = 1342177288 "VMTableDefinition+0x8"
 ;;     region4 = 536870912 "PublicTable"
 ;;     region5 = 40 "VMContext+0x28"
+;;     region6 = 3221225488 "VMFuncRef+0x10"
+;;     region7 = 3221225480 "VMFuncRef+0x8"
+;;     region8 = 3221225496 "VMFuncRef+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -46,13 +49,13 @@
 ;; @0035                               jump block3(v20)
 ;;
 ;;                                 block3(v17: i64):
-;; @0035                               v23 = load.i32 user7 aligned readonly v17+16
+;; @0035                               v23 = load.i32 user7 aligned readonly region6 v17+16
 ;; @0035                               v21 = load.i64 notrap aligned readonly can_move region5 v0+40
 ;; @0035                               v22 = load.i32 notrap aligned readonly can_move v21+4
 ;; @0035                               v24 = icmp eq v23, v22
 ;; @0035                               trapz v24, user8
-;; @0035                               v26 = load.i64 notrap aligned readonly v17+8
-;; @0035                               v27 = load.i64 notrap aligned readonly v17+24
+;; @0035                               v26 = load.i64 notrap aligned readonly region7 v17+8
+;; @0035                               v27 = load.i64 notrap aligned readonly region8 v17+24
 ;; @0035                               v28 = call_indirect sig0, v26(v27, v0, v2)
 ;; @0038                               jump block1
 ;;

--- a/tests/disas/call-indirect-without-gc.wat
+++ b/tests/disas/call-indirect-without-gc.wat
@@ -16,6 +16,9 @@
 ;;     region3 = 1342177288 "VMTableDefinition+0x8"
 ;;     region4 = 536870912 "PublicTable"
 ;;     region5 = 40 "VMContext+0x28"
+;;     region6 = 3221225488 "VMFuncRef+0x10"
+;;     region7 = 3221225480 "VMFuncRef+0x8"
+;;     region8 = 3221225496 "VMFuncRef+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -46,13 +49,13 @@
 ;; @0035                               jump block3(v20)
 ;;
 ;;                                 block3(v17: i64):
-;; @0035                               v23 = load.i32 user7 aligned readonly v17+16
+;; @0035                               v23 = load.i32 user7 aligned readonly region6 v17+16
 ;; @0035                               v21 = load.i64 notrap aligned readonly can_move region5 v0+40
 ;; @0035                               v22 = load.i32 notrap aligned readonly can_move v21+4
 ;; @0035                               v24 = icmp eq v23, v22
 ;; @0035                               trapz v24, user8
-;; @0035                               v26 = load.i64 notrap aligned readonly v17+8
-;; @0035                               v27 = load.i64 notrap aligned readonly v17+24
+;; @0035                               v26 = load.i64 notrap aligned readonly region7 v17+8
+;; @0035                               v27 = load.i64 notrap aligned readonly region8 v17+24
 ;; @0035                               v28 = call_indirect sig0, v26(v27, v0, v2)
 ;; @0038                               jump block1
 ;;

--- a/tests/disas/call-indirect.wat
+++ b/tests/disas/call-indirect.wat
@@ -14,6 +14,9 @@
 ;;     region3 = 1342177288 "VMTableDefinition+0x8"
 ;;     region4 = 536870912 "PublicTable"
 ;;     region5 = 40 "VMContext+0x28"
+;;     region6 = 3221225488 "VMFuncRef+0x10"
+;;     region7 = 3221225480 "VMFuncRef+0x8"
+;;     region8 = 3221225496 "VMFuncRef+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -47,12 +50,12 @@
 ;;                                 block3(v17: i64):
 ;; @0035                               v21 = load.i64 notrap aligned readonly can_move region5 v0+40
 ;; @0035                               v22 = load.i32 notrap aligned readonly can_move v21+4
-;; @0035                               v23 = load.i32 user7 aligned readonly v17+16
+;; @0035                               v23 = load.i32 user7 aligned readonly region6 v17+16
 ;; @0035                               v24 = icmp eq v23, v22
 ;; @0035                               v25 = uextend.i32 v24
 ;; @0035                               trapz v25, user8
-;; @0035                               v26 = load.i64 notrap aligned readonly v17+8
-;; @0035                               v27 = load.i64 notrap aligned readonly v17+24
+;; @0035                               v26 = load.i64 notrap aligned readonly region7 v17+8
+;; @0035                               v27 = load.i64 notrap aligned readonly region8 v17+24
 ;; @0035                               v28 = call_indirect sig0, v26(v27, v0, v2)
 ;; @0038                               jump block1
 ;;

--- a/tests/disas/duplicate-function-types.wat
+++ b/tests/disas/duplicate-function-types.wat
@@ -24,6 +24,9 @@
 ;;     region4 = 1342177288 "VMTableDefinition+0x8"
 ;;     region5 = 536870912 "PublicTable"
 ;;     region6 = 40 "VMContext+0x28"
+;;     region7 = 3221225488 "VMFuncRef+0x10"
+;;     region8 = 3221225480 "VMFuncRef+0x8"
+;;     region9 = 3221225496 "VMFuncRef+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -59,12 +62,12 @@
 ;;                                 block3(v18: i64):
 ;; @002d                               v22 = load.i64 notrap aligned readonly can_move region6 v0+40
 ;; @002d                               v23 = load.i32 notrap aligned readonly can_move v22
-;; @002d                               v24 = load.i32 user7 aligned readonly v18+16
+;; @002d                               v24 = load.i32 user7 aligned readonly region7 v18+16
 ;; @002d                               v25 = icmp eq v24, v23
 ;; @002d                               v26 = uextend.i32 v25
 ;; @002d                               trapz v26, user8
-;; @002d                               v27 = load.i64 notrap aligned readonly v18+8
-;; @002d                               v28 = load.i64 notrap aligned readonly v18+24
+;; @002d                               v27 = load.i64 notrap aligned readonly region8 v18+8
+;; @002d                               v28 = load.i64 notrap aligned readonly region9 v18+24
 ;; @002d                               v29 = call_indirect sig0, v27(v28, v0)
 ;; @0032                               v31 = load.i64 notrap aligned readonly can_move region2 v0+48
 ;; @0032                               v32 = load.i64 notrap aligned region4 v31+8
@@ -92,12 +95,12 @@
 ;;                                 block5(v46: i64):
 ;; @0032                               v50 = load.i64 notrap aligned readonly can_move region6 v0+40
 ;; @0032                               v51 = load.i32 notrap aligned readonly can_move v50
-;; @0032                               v52 = load.i32 user7 aligned readonly v46+16
+;; @0032                               v52 = load.i32 user7 aligned readonly region7 v46+16
 ;; @0032                               v53 = icmp eq v52, v51
 ;; @0032                               v54 = uextend.i32 v53
 ;; @0032                               trapz v54, user8
-;; @0032                               v55 = load.i64 notrap aligned readonly v46+8
-;; @0032                               v56 = load.i64 notrap aligned readonly v46+24
+;; @0032                               v55 = load.i64 notrap aligned readonly region8 v46+8
+;; @0032                               v56 = load.i64 notrap aligned readonly region9 v46+24
 ;; @0032                               v57 = call_indirect sig0, v55(v56, v0)
 ;; @0035                               jump block1
 ;;

--- a/tests/disas/foo.wat
+++ b/tests/disas/foo.wat
@@ -25,6 +25,9 @@
 ;;     region7 = 1342177288 "VMTableDefinition+0x8"
 ;;     region8 = 536870912 "PublicTable"
 ;;     region9 = 40 "VMContext+0x28"
+;;     region10 = 3221225488 "VMFuncRef+0x10"
+;;     region11 = 3221225480 "VMFuncRef+0x8"
+;;     region12 = 3221225496 "VMFuncRef+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -60,13 +63,13 @@
 ;; @0043                               jump block3(v26)
 ;;
 ;;                                 block3(v23: i64):
-;; @0043                               v29 = load.i32 user7 aligned readonly v23+16
+;; @0043                               v29 = load.i32 user7 aligned readonly region10 v23+16
 ;; @0043                               v27 = load.i64 notrap aligned readonly can_move region9 v0+40
 ;; @0043                               v28 = load.i32 notrap aligned readonly can_move v27+4
 ;; @0043                               v30 = icmp eq v29, v28
 ;; @0043                               trapz v30, user8
-;; @0043                               v32 = load.i64 notrap aligned readonly v23+8
-;; @0043                               v33 = load.i64 notrap aligned readonly v23+24
+;; @0043                               v32 = load.i64 notrap aligned readonly region11 v23+8
+;; @0043                               v33 = load.i64 notrap aligned readonly region12 v23+24
 ;; @0043                               v34 = call_indirect sig0, v32(v33, v0, v2)
 ;; @004a                               v40 = load.i32 little region4 v6
 ;; @004d                               v42 = load.i64 notrap aligned region7 v8+8
@@ -90,11 +93,11 @@
 ;; @004d                               jump block5(v59)
 ;;
 ;;                                 block5(v56: i64):
-;; @004d                               v62 = load.i32 user7 aligned readonly v56+16
+;; @004d                               v62 = load.i32 user7 aligned readonly region10 v56+16
 ;; @004d                               v63 = icmp eq v62, v28
 ;; @004d                               trapz v63, user8
-;; @004d                               v65 = load.i64 notrap aligned readonly v56+8
-;; @004d                               v66 = load.i64 notrap aligned readonly v56+24
+;; @004d                               v65 = load.i64 notrap aligned readonly region11 v56+8
+;; @004d                               v66 = load.i64 notrap aligned readonly region12 v56+24
 ;; @004d                               v67 = call_indirect sig0, v65(v66, v0, v2)
 ;; @0050                               jump block1
 ;;

--- a/tests/disas/gc/call-indirect-final-type.wat
+++ b/tests/disas/gc/call-indirect-final-type.wat
@@ -22,6 +22,9 @@
 ;;     region3 = 1342177288 "VMTableDefinition+0x8"
 ;;     region4 = 671088640 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
 ;;     region5 = 40 "VMContext+0x28"
+;;     region6 = 3221225488 "VMFuncRef+0x10"
+;;     region7 = 3221225480 "VMFuncRef+0x8"
+;;     region8 = 3221225496 "VMFuncRef+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -52,13 +55,13 @@
 ;; @002b                               jump block3(v20)
 ;;
 ;;                                 block3(v17: i64):
-;; @002b                               v23 = load.i32 user7 aligned readonly v17+16
+;; @002b                               v23 = load.i32 user7 aligned readonly region6 v17+16
 ;; @002b                               v21 = load.i64 notrap aligned readonly can_move region5 v0+40
 ;; @002b                               v22 = load.i32 notrap aligned readonly can_move v21
 ;; @002b                               v24 = icmp eq v23, v22
 ;; @002b                               trapz v24, user8
-;; @002b                               v26 = load.i64 notrap aligned readonly v17+8
-;; @002b                               v27 = load.i64 notrap aligned readonly v17+24
+;; @002b                               v26 = load.i64 notrap aligned readonly region7 v17+8
+;; @002b                               v27 = load.i64 notrap aligned readonly region8 v17+24
 ;; @002b                               v28 = call_indirect sig0, v26(v27, v0, v2)
 ;; @002e                               jump block1
 ;;
@@ -73,6 +76,9 @@
 ;;     region3 = 1342177288 "VMTableDefinition+0x8"
 ;;     region4 = 671088640 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
 ;;     region5 = 40 "VMContext+0x28"
+;;     region6 = 3221225488 "VMFuncRef+0x10"
+;;     region7 = 3221225480 "VMFuncRef+0x8"
+;;     region8 = 3221225496 "VMFuncRef+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -103,12 +109,12 @@
 ;; @0035                               jump block3(v20)
 ;;
 ;;                                 block3(v17: i64):
-;; @0035                               v23 = load.i32 user7 aligned readonly v17+16
+;; @0035                               v23 = load.i32 user7 aligned readonly region6 v17+16
 ;; @0035                               v21 = load.i64 notrap aligned readonly can_move region5 v0+40
 ;; @0035                               v22 = load.i32 notrap aligned readonly can_move v21
 ;; @0035                               v24 = icmp eq v23, v22
 ;; @0035                               trapz v24, user8
-;; @0035                               v26 = load.i64 notrap aligned readonly v17+8
-;; @0035                               v27 = load.i64 notrap aligned readonly v17+24
+;; @0035                               v26 = load.i64 notrap aligned readonly region7 v17+8
+;; @0035                               v27 = load.i64 notrap aligned readonly region8 v17+24
 ;; @0035                               return_call_indirect sig0, v26(v27, v0, v2)
 ;; }

--- a/tests/disas/gc/copying/call-indirect-and-subtyping.wat
+++ b/tests/disas/gc/copying/call-indirect-and-subtyping.wat
@@ -21,6 +21,9 @@
 ;;     region2 = 1342177280 "VMTableDefinition+0x0"
 ;;     region3 = 671088640 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
 ;;     region4 = 40 "VMContext+0x28"
+;;     region5 = 3221225488 "VMFuncRef+0x10"
+;;     region6 = 3221225480 "VMFuncRef+0x8"
+;;     region7 = 3221225496 "VMFuncRef+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -52,7 +55,7 @@
 ;; @005c                               jump block3(v18)
 ;;
 ;;                                 block3(v15: i64):
-;; @005c                               v21 = load.i32 user7 aligned readonly v15+16
+;; @005c                               v21 = load.i32 user7 aligned readonly region5 v15+16
 ;; @005c                               v19 = load.i64 notrap aligned readonly can_move region4 v0+40
 ;; @005c                               v20 = load.i32 notrap aligned readonly can_move v19
 ;; @005c                               v22 = icmp eq v21, v20
@@ -65,8 +68,8 @@
 ;;
 ;;                                 block5(v25: i32):
 ;; @005c                               trapz v25, user8
-;; @005c                               v26 = load.i64 notrap aligned readonly v15+8
-;; @005c                               v27 = load.i64 notrap aligned readonly v15+24
+;; @005c                               v26 = load.i64 notrap aligned readonly region6 v15+8
+;; @005c                               v27 = load.i64 notrap aligned readonly region7 v15+24
 ;; @005c                               call_indirect sig0, v26(v27, v0)
 ;; @005f                               jump block1
 ;;

--- a/tests/disas/gc/copying/ref-test-concrete-func-type.wat
+++ b/tests/disas/gc/copying/ref-test-concrete-func-type.wat
@@ -11,7 +11,7 @@
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 134217752 "VMStoreContext+0x18"
 ;;     region2 = 40 "VMContext+0x28"
-;;     region3 = 1073741824 "GcHeap"
+;;     region3 = 3221225488 "VMFuncRef+0x10"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -27,7 +27,7 @@
 ;; @0020                               jump block3
 ;;
 ;;                                 block3:
-;; @0020                               v9 = load.i32 user2 readonly region3 v2+16
+;; @0020                               v9 = load.i32 notrap aligned readonly region3 v2+16
 ;; @0020                               v7 = load.i64 notrap aligned readonly can_move region2 v0+40
 ;; @0020                               v8 = load.i32 notrap aligned readonly can_move v7
 ;; @0020                               v10 = icmp eq v9, v8

--- a/tests/disas/gc/drc/call-indirect-and-subtyping.wat
+++ b/tests/disas/gc/drc/call-indirect-and-subtyping.wat
@@ -22,6 +22,9 @@
 ;;     region2 = 1342177280 "VMTableDefinition+0x0"
 ;;     region3 = 671088640 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
 ;;     region4 = 40 "VMContext+0x28"
+;;     region5 = 3221225488 "VMFuncRef+0x10"
+;;     region6 = 3221225480 "VMFuncRef+0x8"
+;;     region7 = 3221225496 "VMFuncRef+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -53,7 +56,7 @@
 ;; @005c                               jump block3(v18)
 ;;
 ;;                                 block3(v15: i64):
-;; @005c                               v21 = load.i32 user7 aligned readonly v15+16
+;; @005c                               v21 = load.i32 user7 aligned readonly region5 v15+16
 ;; @005c                               v19 = load.i64 notrap aligned readonly can_move region4 v0+40
 ;; @005c                               v20 = load.i32 notrap aligned readonly can_move v19
 ;; @005c                               v22 = icmp eq v21, v20
@@ -66,8 +69,8 @@
 ;;
 ;;                                 block5(v25: i32):
 ;; @005c                               trapz v25, user8
-;; @005c                               v26 = load.i64 notrap aligned readonly v15+8
-;; @005c                               v27 = load.i64 notrap aligned readonly v15+24
+;; @005c                               v26 = load.i64 notrap aligned readonly region6 v15+8
+;; @005c                               v27 = load.i64 notrap aligned readonly region7 v15+24
 ;; @005c                               call_indirect sig0, v26(v27, v0)
 ;; @005f                               jump block1
 ;;

--- a/tests/disas/gc/drc/ref-test-concrete-func-type.wat
+++ b/tests/disas/gc/drc/ref-test-concrete-func-type.wat
@@ -12,7 +12,7 @@
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 134217752 "VMStoreContext+0x18"
 ;;     region2 = 40 "VMContext+0x28"
-;;     region3 = 1073741824 "GcHeap"
+;;     region3 = 3221225488 "VMFuncRef+0x10"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -28,7 +28,7 @@
 ;; @0020                               jump block3
 ;;
 ;;                                 block3:
-;; @0020                               v9 = load.i32 user2 readonly region3 v2+16
+;; @0020                               v9 = load.i32 notrap aligned readonly region3 v2+16
 ;; @0020                               v7 = load.i64 notrap aligned readonly can_move region2 v0+40
 ;; @0020                               v8 = load.i32 notrap aligned readonly can_move v7
 ;; @0020                               v10 = icmp eq v9, v8

--- a/tests/disas/gc/null/call-indirect-and-subtyping.wat
+++ b/tests/disas/gc/null/call-indirect-and-subtyping.wat
@@ -22,6 +22,9 @@
 ;;     region2 = 1342177280 "VMTableDefinition+0x0"
 ;;     region3 = 671088640 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
 ;;     region4 = 40 "VMContext+0x28"
+;;     region5 = 3221225488 "VMFuncRef+0x10"
+;;     region6 = 3221225480 "VMFuncRef+0x8"
+;;     region7 = 3221225496 "VMFuncRef+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -53,7 +56,7 @@
 ;; @005c                               jump block3(v18)
 ;;
 ;;                                 block3(v15: i64):
-;; @005c                               v21 = load.i32 user7 aligned readonly v15+16
+;; @005c                               v21 = load.i32 user7 aligned readonly region5 v15+16
 ;; @005c                               v19 = load.i64 notrap aligned readonly can_move region4 v0+40
 ;; @005c                               v20 = load.i32 notrap aligned readonly can_move v19
 ;; @005c                               v22 = icmp eq v21, v20
@@ -66,8 +69,8 @@
 ;;
 ;;                                 block5(v25: i32):
 ;; @005c                               trapz v25, user8
-;; @005c                               v26 = load.i64 notrap aligned readonly v15+8
-;; @005c                               v27 = load.i64 notrap aligned readonly v15+24
+;; @005c                               v26 = load.i64 notrap aligned readonly region6 v15+8
+;; @005c                               v27 = load.i64 notrap aligned readonly region7 v15+24
 ;; @005c                               call_indirect sig0, v26(v27, v0)
 ;; @005f                               jump block1
 ;;

--- a/tests/disas/gc/null/ref-test-concrete-func-type.wat
+++ b/tests/disas/gc/null/ref-test-concrete-func-type.wat
@@ -12,7 +12,7 @@
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 134217752 "VMStoreContext+0x18"
 ;;     region2 = 40 "VMContext+0x28"
-;;     region3 = 1073741824 "GcHeap"
+;;     region3 = 3221225488 "VMFuncRef+0x10"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -28,7 +28,7 @@
 ;; @0020                               jump block3
 ;;
 ;;                                 block3:
-;; @0020                               v9 = load.i32 user2 readonly region3 v2+16
+;; @0020                               v9 = load.i32 notrap aligned readonly region3 v2+16
 ;; @0020                               v7 = load.i64 notrap aligned readonly can_move region2 v0+40
 ;; @0020                               v8 = load.i32 notrap aligned readonly can_move v7
 ;; @0020                               v10 = icmp eq v9, v8

--- a/tests/disas/icall-loop.wat
+++ b/tests/disas/icall-loop.wat
@@ -28,6 +28,9 @@
 ;;     region2 = 1342177280 "VMTableDefinition+0x0"
 ;;     region3 = 671088640 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
 ;;     region4 = 40 "VMContext+0x28"
+;;     region5 = 3221225488 "VMFuncRef+0x10"
+;;     region6 = 3221225480 "VMFuncRef+0x8"
+;;     region7 = 3221225496 "VMFuncRef+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -64,11 +67,11 @@
 ;; @002b                               jump block5(v19)
 ;;
 ;;                                 block5(v16: i64):
-;; @002b                               v22 = load.i32 user7 aligned readonly v16+16
+;; @002b                               v22 = load.i32 user7 aligned readonly region5 v16+16
 ;; @002b                               v23 = icmp eq v22, v21
 ;; @002b                               trapz v23, user8
-;; @002b                               v25 = load.i64 notrap aligned readonly v16+8
-;; @002b                               v26 = load.i64 notrap aligned readonly v16+24
+;; @002b                               v25 = load.i64 notrap aligned readonly region6 v16+8
+;; @002b                               v26 = load.i64 notrap aligned readonly region7 v16+24
 ;; @002b                               v27 = call_indirect sig0, v25(v26, v0)
 ;; @002e                               jump block2
 ;; }
@@ -79,6 +82,9 @@
 ;;     region2 = 1342177280 "VMTableDefinition+0x0"
 ;;     region3 = 671088640 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
 ;;     region4 = 40 "VMContext+0x28"
+;;     region5 = 3221225488 "VMFuncRef+0x10"
+;;     region6 = 3221225480 "VMFuncRef+0x8"
+;;     region7 = 3221225496 "VMFuncRef+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -112,11 +118,11 @@
 ;; @0038                               jump block5(v18)
 ;;
 ;;                                 block5(v15: i64):
-;; @0038                               v21 = load.i32 user7 aligned readonly v15+16
+;; @0038                               v21 = load.i32 user7 aligned readonly region5 v15+16
 ;; @0038                               v22 = icmp eq v21, v20
 ;; @0038                               trapz v22, user8
-;; @0038                               v24 = load.i64 notrap aligned readonly v15+8
-;; @0038                               v25 = load.i64 notrap aligned readonly v15+24
+;; @0038                               v24 = load.i64 notrap aligned readonly region6 v15+8
+;; @0038                               v25 = load.i64 notrap aligned readonly region7 v15+24
 ;; @0038                               v26 = call_indirect sig0, v24(v25, v0)
 ;; @003b                               jump block2
 ;; }

--- a/tests/disas/icall-simd.wat
+++ b/tests/disas/icall-simd.wat
@@ -14,6 +14,9 @@
 ;;     region2 = 1342177280 "VMTableDefinition+0x0"
 ;;     region3 = 671088640 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
 ;;     region4 = 40 "VMContext+0x28"
+;;     region5 = 3221225488 "VMFuncRef+0x10"
+;;     region6 = 3221225480 "VMFuncRef+0x8"
+;;     region7 = 3221225496 "VMFuncRef+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -46,12 +49,12 @@
 ;;                                 block3(v16: i64):
 ;; @0033                               v20 = load.i64 notrap aligned readonly can_move region4 v0+40
 ;; @0033                               v21 = load.i32 notrap aligned readonly can_move v20
-;; @0033                               v22 = load.i32 user7 aligned readonly v16+16
+;; @0033                               v22 = load.i32 user7 aligned readonly region5 v16+16
 ;; @0033                               v23 = icmp eq v22, v21
 ;; @0033                               v24 = uextend.i32 v23
 ;; @0033                               trapz v24, user8
-;; @0033                               v25 = load.i64 notrap aligned readonly v16+8
-;; @0033                               v26 = load.i64 notrap aligned readonly v16+24
+;; @0033                               v25 = load.i64 notrap aligned readonly region6 v16+8
+;; @0033                               v26 = load.i64 notrap aligned readonly region7 v16+24
 ;; @0033                               v27 = call_indirect sig0, v25(v26, v0, v3)
 ;; @0036                               jump block1
 ;;

--- a/tests/disas/icall.wat
+++ b/tests/disas/icall.wat
@@ -14,6 +14,9 @@
 ;;     region2 = 1342177280 "VMTableDefinition+0x0"
 ;;     region3 = 671088640 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
 ;;     region4 = 40 "VMContext+0x28"
+;;     region5 = 3221225488 "VMFuncRef+0x10"
+;;     region6 = 3221225480 "VMFuncRef+0x8"
+;;     region7 = 3221225496 "VMFuncRef+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -46,12 +49,12 @@
 ;;                                 block3(v16: i64):
 ;; @0033                               v20 = load.i64 notrap aligned readonly can_move region4 v0+40
 ;; @0033                               v21 = load.i32 notrap aligned readonly can_move v20
-;; @0033                               v22 = load.i32 user7 aligned readonly v16+16
+;; @0033                               v22 = load.i32 user7 aligned readonly region5 v16+16
 ;; @0033                               v23 = icmp eq v22, v21
 ;; @0033                               v24 = uextend.i32 v23
 ;; @0033                               trapz v24, user8
-;; @0033                               v25 = load.i64 notrap aligned readonly v16+8
-;; @0033                               v26 = load.i64 notrap aligned readonly v16+24
+;; @0033                               v25 = load.i64 notrap aligned readonly region6 v16+8
+;; @0033                               v26 = load.i64 notrap aligned readonly region7 v16+24
 ;; @0033                               v27 = call_indirect sig0, v25(v26, v0, v3)
 ;; @0036                               jump block1
 ;;

--- a/tests/disas/indirect-call-no-caching.wat
+++ b/tests/disas/indirect-call-no-caching.wat
@@ -74,6 +74,9 @@
 ;;     region2 = 1342177280 "VMTableDefinition+0x0"
 ;;     region3 = 671088640 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
 ;;     region4 = 40 "VMContext+0x28"
+;;     region5 = 3221225488 "VMFuncRef+0x10"
+;;     region6 = 3221225480 "VMFuncRef+0x8"
+;;     region7 = 3221225496 "VMFuncRef+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -106,12 +109,12 @@
 ;;                                 block3(v15: i64):
 ;; @0050                               v19 = load.i64 notrap aligned readonly can_move region4 v0+40
 ;; @0050                               v20 = load.i32 notrap aligned readonly can_move v19
-;; @0050                               v21 = load.i32 user7 aligned readonly v15+16
+;; @0050                               v21 = load.i32 user7 aligned readonly region5 v15+16
 ;; @0050                               v22 = icmp eq v21, v20
 ;; @0050                               v23 = uextend.i32 v22
 ;; @0050                               trapz v23, user8
-;; @0050                               v24 = load.i64 notrap aligned readonly v15+8
-;; @0050                               v25 = load.i64 notrap aligned readonly v15+24
+;; @0050                               v24 = load.i64 notrap aligned readonly region6 v15+8
+;; @0050                               v25 = load.i64 notrap aligned readonly region7 v15+24
 ;; @0050                               v26 = call_indirect sig0, v24(v25, v0)
 ;; @0053                               jump block1
 ;;

--- a/tests/disas/readonly-funcrefs.wat
+++ b/tests/disas/readonly-funcrefs.wat
@@ -39,6 +39,9 @@
 ;;     region2 = 1342177280 "VMTableDefinition+0x0"
 ;;     region3 = 671088640 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
 ;;     region4 = 40 "VMContext+0x28"
+;;     region5 = 3221225488 "VMFuncRef+0x10"
+;;     region6 = 3221225480 "VMFuncRef+0x8"
+;;     region7 = 3221225496 "VMFuncRef+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -68,13 +71,13 @@
 ;; @0031                               jump block3(v18)
 ;;
 ;;                                 block3(v15: i64):
-;; @0031                               v21 = load.i32 user7 aligned readonly v15+16
+;; @0031                               v21 = load.i32 user7 aligned readonly region5 v15+16
 ;; @0031                               v19 = load.i64 notrap aligned readonly can_move region4 v0+40
 ;; @0031                               v20 = load.i32 notrap aligned readonly can_move v19
 ;; @0031                               v22 = icmp eq v21, v20
 ;; @0031                               trapz v22, user8
-;; @0031                               v24 = load.i64 notrap aligned readonly v15+8
-;; @0031                               v25 = load.i64 notrap aligned readonly v15+24
+;; @0031                               v24 = load.i64 notrap aligned readonly region6 v15+8
+;; @0031                               v25 = load.i64 notrap aligned readonly region7 v15+24
 ;; @0031                               call_indirect sig0, v24(v25, v0)
 ;; @0034                               jump block1
 ;;

--- a/tests/disas/typed-funcrefs-eager-init.wat
+++ b/tests/disas/typed-funcrefs-eager-init.wat
@@ -133,6 +133,8 @@
 ;;     region1 = 134217752 "VMStoreContext+0x18"
 ;;     region2 = 1342177280 "VMTableDefinition+0x0"
 ;;     region3 = 671088640 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
+;;     region4 = 3221225480 "VMFuncRef+0x8"
+;;     region5 = 3221225496 "VMFuncRef+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -144,14 +146,14 @@
 ;;                                     v44 = iconst.i64 8
 ;; @0048                               v14 = iadd v11, v44  ; v44 = 8
 ;; @0048                               v17 = load.i64 user6 aligned region3 v14
-;; @004a                               v18 = load.i64 user16 aligned readonly v17+8
-;; @004a                               v19 = load.i64 notrap aligned readonly v17+24
+;; @004a                               v18 = load.i64 user16 aligned readonly region4 v17+8
+;; @004a                               v19 = load.i64 notrap aligned readonly region5 v17+24
 ;; @004a                               v20 = call_indirect sig0, v18(v19, v0, v2, v3, v4, v5)
 ;;                                     v51 = iconst.i64 16
 ;; @005b                               v29 = iadd v11, v51  ; v51 = 16
 ;; @005b                               v32 = load.i64 user6 aligned region3 v29
-;; @005d                               v33 = load.i64 user16 aligned readonly v32+8
-;; @005d                               v34 = load.i64 notrap aligned readonly v32+24
+;; @005d                               v33 = load.i64 user16 aligned readonly region4 v32+8
+;; @005d                               v34 = load.i64 notrap aligned readonly region5 v32+24
 ;; @005d                               v35 = call_indirect sig0, v33(v34, v0, v2, v3, v4, v5)
 ;; @0066                               jump block1
 ;;
@@ -165,6 +167,8 @@
 ;;     region1 = 134217752 "VMStoreContext+0x18"
 ;;     region2 = 1342177280 "VMTableDefinition+0x0"
 ;;     region3 = 671088640 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
+;;     region4 = 3221225480 "VMFuncRef+0x8"
+;;     region5 = 3221225496 "VMFuncRef+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -176,14 +180,14 @@
 ;;                                     v44 = iconst.i64 8
 ;; @0075                               v14 = iadd v11, v44  ; v44 = 8
 ;; @0075                               v17 = load.i64 user6 aligned region3 v14
-;; @0075                               v18 = load.i64 user7 aligned readonly v17+8
-;; @0075                               v19 = load.i64 notrap aligned readonly v17+24
+;; @0075                               v18 = load.i64 user7 aligned readonly region4 v17+8
+;; @0075                               v19 = load.i64 notrap aligned readonly region5 v17+24
 ;; @0075                               v20 = call_indirect sig0, v18(v19, v0, v2, v3, v4, v5)
 ;;                                     v51 = iconst.i64 16
 ;; @0087                               v29 = iadd v11, v51  ; v51 = 16
 ;; @0087                               v32 = load.i64 user6 aligned region3 v29
-;; @0087                               v33 = load.i64 user7 aligned readonly v32+8
-;; @0087                               v34 = load.i64 notrap aligned readonly v32+24
+;; @0087                               v33 = load.i64 user7 aligned readonly region4 v32+8
+;; @0087                               v34 = load.i64 notrap aligned readonly region5 v32+24
 ;; @0087                               v35 = call_indirect sig0, v33(v34, v0, v2, v3, v4, v5)
 ;; @0091                               jump block1
 ;;
@@ -196,7 +200,9 @@
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 134217752 "VMStoreContext+0x18"
 ;;     region2 = 939524096 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(0))"
-;;     region3 = 939524097 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(1))"
+;;     region3 = 3221225480 "VMFuncRef+0x8"
+;;     region4 = 3221225496 "VMFuncRef+0x18"
+;;     region5 = 939524097 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(1))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -205,12 +211,12 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):
 ;; @009e                               v7 = load.i64 notrap aligned region2 v0+64
-;; @00a0                               v8 = load.i64 user16 aligned readonly v7+8
-;; @00a0                               v9 = load.i64 notrap aligned readonly v7+24
+;; @00a0                               v8 = load.i64 user16 aligned readonly region3 v7+8
+;; @00a0                               v9 = load.i64 notrap aligned readonly region4 v7+24
 ;; @00a0                               v10 = call_indirect sig0, v8(v9, v0, v2, v3, v4, v5)
-;; @00af                               v12 = load.i64 notrap aligned region3 v0+80
-;; @00b1                               v13 = load.i64 user16 aligned readonly v12+8
-;; @00b1                               v14 = load.i64 notrap aligned readonly v12+24
+;; @00af                               v12 = load.i64 notrap aligned region5 v0+80
+;; @00b1                               v13 = load.i64 user16 aligned readonly region3 v12+8
+;; @00b1                               v14 = load.i64 notrap aligned readonly region4 v12+24
 ;; @00b1                               v15 = call_indirect sig0, v13(v14, v0, v2, v3, v4, v5)
 ;; @00ba                               jump block1
 ;;

--- a/tests/disas/typed-funcrefs.wat
+++ b/tests/disas/typed-funcrefs.wat
@@ -133,6 +133,8 @@
 ;;     region1 = 134217752 "VMStoreContext+0x18"
 ;;     region2 = 1342177280 "VMTableDefinition+0x0"
 ;;     region3 = 671088640 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
+;;     region4 = 3221225480 "VMFuncRef+0x8"
+;;     region5 = 3221225496 "VMFuncRef+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -157,8 +159,8 @@
 ;; @0048                               jump block3(v23)
 ;;
 ;;                                 block3(v20: i64):
-;; @004a                               v24 = load.i64 user16 aligned readonly v20+8
-;; @004a                               v25 = load.i64 notrap aligned readonly v20+24
+;; @004a                               v24 = load.i64 user16 aligned readonly region4 v20+8
+;; @004a                               v25 = load.i64 notrap aligned readonly region5 v20+24
 ;; @004a                               v26 = call_indirect sig1, v24(v25, v0, v2, v3, v4, v5)
 ;;                                     v69 = iconst.i64 16
 ;; @005b                               v40 = iadd.i64 v11, v69  ; v69 = 16
@@ -174,8 +176,8 @@
 ;; @005b                               jump block5(v49)
 ;;
 ;;                                 block5(v46: i64):
-;; @005d                               v50 = load.i64 user16 aligned readonly v46+8
-;; @005d                               v51 = load.i64 notrap aligned readonly v46+24
+;; @005d                               v50 = load.i64 user16 aligned readonly region4 v46+8
+;; @005d                               v51 = load.i64 notrap aligned readonly region5 v46+24
 ;; @005d                               v52 = call_indirect sig1, v50(v51, v0, v2, v3, v4, v5)
 ;; @0066                               jump block1
 ;;
@@ -189,6 +191,8 @@
 ;;     region1 = 134217752 "VMStoreContext+0x18"
 ;;     region2 = 1342177280 "VMTableDefinition+0x0"
 ;;     region3 = 671088640 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
+;;     region4 = 3221225480 "VMFuncRef+0x8"
+;;     region5 = 3221225496 "VMFuncRef+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -213,8 +217,8 @@
 ;; @0075                               jump block3(v23)
 ;;
 ;;                                 block3(v20: i64):
-;; @0075                               v24 = load.i64 user7 aligned readonly v20+8
-;; @0075                               v25 = load.i64 notrap aligned readonly v20+24
+;; @0075                               v24 = load.i64 user7 aligned readonly region4 v20+8
+;; @0075                               v25 = load.i64 notrap aligned readonly region5 v20+24
 ;; @0075                               v26 = call_indirect sig0, v24(v25, v0, v2, v3, v4, v5)
 ;;                                     v69 = iconst.i64 16
 ;; @0087                               v40 = iadd.i64 v11, v69  ; v69 = 16
@@ -230,8 +234,8 @@
 ;; @0087                               jump block5(v49)
 ;;
 ;;                                 block5(v46: i64):
-;; @0087                               v50 = load.i64 user7 aligned readonly v46+8
-;; @0087                               v51 = load.i64 notrap aligned readonly v46+24
+;; @0087                               v50 = load.i64 user7 aligned readonly region4 v46+8
+;; @0087                               v51 = load.i64 notrap aligned readonly region5 v46+24
 ;; @0087                               v52 = call_indirect sig0, v50(v51, v0, v2, v3, v4, v5)
 ;; @0091                               jump block1
 ;;
@@ -244,7 +248,9 @@
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 134217752 "VMStoreContext+0x18"
 ;;     region2 = 939524096 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(0))"
-;;     region3 = 939524097 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(1))"
+;;     region3 = 3221225480 "VMFuncRef+0x8"
+;;     region4 = 3221225496 "VMFuncRef+0x18"
+;;     region5 = 939524097 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(1))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -253,12 +259,12 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):
 ;; @009e                               v7 = load.i64 notrap aligned region2 v0+64
-;; @00a0                               v8 = load.i64 user16 aligned readonly v7+8
-;; @00a0                               v9 = load.i64 notrap aligned readonly v7+24
+;; @00a0                               v8 = load.i64 user16 aligned readonly region3 v7+8
+;; @00a0                               v9 = load.i64 notrap aligned readonly region4 v7+24
 ;; @00a0                               v10 = call_indirect sig0, v8(v9, v0, v2, v3, v4, v5)
-;; @00af                               v12 = load.i64 notrap aligned region3 v0+80
-;; @00b1                               v13 = load.i64 user16 aligned readonly v12+8
-;; @00b1                               v14 = load.i64 notrap aligned readonly v12+24
+;; @00af                               v12 = load.i64 notrap aligned region5 v0+80
+;; @00b1                               v13 = load.i64 user16 aligned readonly region3 v12+8
+;; @00b1                               v14 = load.i64 notrap aligned readonly region4 v12+24
 ;; @00b1                               v15 = call_indirect sig0, v13(v14, v0, v2, v3, v4, v5)
 ;; @00ba                               jump block1
 ;;


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
