### PR TITLE
VeriISLE: fix imul rule tagging, add basic (no solver) CI check

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1339,7 +1339,7 @@ jobs:
   isle_veri_basic_check:
     needs: determine
     if: needs.determine.outputs.run-full
-    name: ISLE verifier build
+    name: ISLE verifier basic check
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1335,6 +1335,20 @@ jobs:
     - run: ${{ matrix.script }}
       if: ${{ matrix.script }}
 
+  # Check the ISLE verifier builds/runs (without invoking the SMT solver, for now).
+  isle_veri_basic_check:
+    needs: determine
+    if: needs.determine.outputs.run-full
+    name: ISLE verifier build
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6
+      with:
+        submodules: true
+    - uses: ./.github/actions/install-rust
+    - run: cargo run -p cranelift-isle-veri --bin veri -- --config cranelift/isle/veri/configs/aarch64-fast.args --skip-solver
+    - run: cargo run -p cranelift-isle-veri --bin veri -- --name x64 --rule iadd_base_case_32_or_64_lea --skip-solver
+
   # Perform release builds of `wasmtime` and `libwasmtime.so`. Builds a variety
   # of platforms and architectures and then uploads the release artifacts to
   # this workflow run's list of artifacts.
@@ -1444,6 +1458,7 @@ jobs:
       - verify-publish
       - determine
       - miri
+      - isle_veri_basic_check
       - build-preview1-component-adapter
       - build-preview1-component-adapter-provider
       - test-min-platform-example

--- a/cranelift/codegen/src/isa/aarch64/lower.isle
+++ b/cranelift/codegen/src/isa/aarch64/lower.isle
@@ -1036,10 +1036,10 @@
 
 ;;;; Rules for `smulhi` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(rule 1 (lower (smulhi $I64 x y))
+(rule smulhi_64 1 (lower (smulhi $I64 x y))
       (smulh $I64 x y))
 
-(rule (lower (smulhi (fits_in_32 ty) x y))
+(rule smulhi_fits_in_32 (lower (smulhi (fits_in_32 ty) x y))
       (let ((x64 Reg (put_in_reg_sext64 x))
             (y64 Reg (put_in_reg_sext64 y))
             (mul Reg (madd $I64 x64 y64 (zero_reg)))
@@ -1048,10 +1048,10 @@
 
 ;;;; Rules for `umulhi` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(rule 1 (lower (umulhi $I64 x y))
+(rule umulhi_64 1 (lower (umulhi $I64 x y))
       (umulh $I64 x y))
 
-(rule (lower (umulhi (fits_in_32 ty) x y))
+(rule umulhi_fits_in_32 (lower (umulhi (fits_in_32 ty) x y))
       (let (
           (x64 Reg (put_in_reg_zext64 x))
           (y64 Reg (put_in_reg_zext64 y))
@@ -1096,7 +1096,7 @@
 ;; Note that aarch64's `udiv` doesn't trap so to respect the semantics of
 ;; CLIF's `udiv` the check for zero needs to be manually performed.
 
-(rule udiv_54 1 (lower (udiv $I64 x y))
+(rule udiv_64 1 (lower (udiv $I64 x y))
       (a64_udiv $I64 (put_in_reg x) (put_nonzero_in_reg y (ExtType.Unsigned) $I64)))
 
 (rule udiv_fits_in_32 (lower (udiv (fits_in_32 ty) x y))
@@ -3216,3 +3216,29 @@
 
 (attr load_ext_name (tag TODO))
 (attr get_exception_handler_address (tag TODO))
+
+;; Multiplication, division, and remainder are slow for bitvector reasoning
+(attr rule imul_base_case (tag slow))
+(attr rule iadd_imul_right (tag slow))
+(attr rule iadd_imul_left (tag slow))
+(attr rule isub_imul (tag slow))
+(attr rule umulhi_64 (tag slow))
+(attr rule umulhi_fits_in_32 (tag slow))
+(attr rule smulhi_64 (tag slow))
+(attr rule smulhi_fits_in_32 (tag slow))
+(attr rule udiv_64 (tag slow))
+(attr rule udiv_fits_in_32 (tag slow))
+(attr rule sdiv_safe_divisor_i64 (tag slow))
+(attr rule sdiv_safe_divisor_fits_in_32 (tag slow))
+(attr rule urem_64 (tag slow))
+(attr rule urem_fits_in_32 (tag slow))
+(attr rule srem_64 (tag slow))
+(attr rule srem_fits_in_32 (tag slow))
+
+(attr rule iadd_imul_left (tag solver_z3))
+(attr rule iadd_imul_right (tag solver_z3))
+(attr rule isub_imul (tag solver_z3))
+(attr rule imul_base_case (tag solver_z3))
+(attr rule sdiv_safe_divisor_fits_in_32 (tag solver_z3))
+(attr rule sdiv_safe_divisor_i64 (tag solver_z3))
+(attr fsub (tag solver_z3))

--- a/cranelift/codegen/src/spec/inst_specs.isle
+++ b/cranelift/codegen/src/spec/inst_specs.isle
@@ -203,23 +203,6 @@
                 (= result (bvsrem x y))))))
 (instantiate srem bv_binary_8_to_64)
 
-
-;; multiplication, division, and remainder are slow for bitvector reasoning
-(attr imul_base_case (tag slow))
-(attr iadd_imul_right (tag slow))
-(attr iadd_imul_left (tag slow))
-(attr isub_imul (tag slow))
-(attr umulhi_64 (tag slow))
-(attr umulhi_fits_in_32 (tag slow))
-(attr udiv_64 (tag slow))
-(attr udiv_fits_in_32 (tag slow))
-(attr sdiv_safe_divisor_i64 (tag slow))
-(attr sdiv_safe_divisor_fits_in_32 (tag slow))
-(attr urem_64 (tag slow))
-(attr urem_fits_in_32 (tag slow))
-(attr srem_64 (tag slow))
-(attr srem_fits_in_32 (tag slow))
-
 ;; "Unsigned addition of x and y, trapping if the result overflows."
 ;; "Accepts 32 or 64-bit integers, and does not support vector types."
 (spec (uadd_overflow_trap ty x y trap_code)
@@ -1299,7 +1282,7 @@
 (attr select_spectre_guard (tag spectre))
 (attr fence (tag TODO))
 
-; Use Z3 solver for the following instructions/rules.
+; Use Z3 solver for the following instructions.
 (attr fadd (tag solver_z3))
 (attr fmul (tag solver_z3))
 (attr fdiv (tag solver_z3))
@@ -1309,10 +1292,8 @@
 (attr clz (tag solver_z3))
 (attr ctz (tag solver_z3))
 (attr popcnt (tag solver_z3))
-(attr iadd_imul_left (tag solver_z3))
-(attr iadd_imul_right (tag solver_z3))
-(attr isub_imul (tag solver_z3))
-(attr imul_base_case (tag solver_z3))
-(attr sdiv_safe_divisor_fits_in_32 (tag solver_z3))
-(attr sdiv_safe_divisor_i64 (tag solver_z3))
-(attr fsub (tag solver_z3))
+(attr imul (tag solver_z3))
+(attr udiv (tag solver_z3))
+(attr sdiv (tag solver_z3))
+(attr urem (tag solver_z3))
+(attr srem (tag solver_z3))

--- a/cranelift/isle/veri/README.md
+++ b/cranelift/isle/veri/README.md
@@ -74,7 +74,7 @@ and expensive division operations.
 
 The verification bin will default to running on a number of threads
 based on the number of logical CPUs on your current machine, pass `--num-threads=n` to
-override this. On a 12-core M2 MacBook, the command above takes about 6 minutes.
+override this. On a 12-core M2 MacBook, the command above takes about 3 minutes.
 
 By default the verifier attempts every expansion it can reach. It seeds an
 expansion at every term that has rules and a constructor, and verifies all rule


### PR DESCRIPTION
For the ISLE verifier:

- Fix the `imul` rule tagging logic, fixes #13773
- Add basic verifier check (build and enumerate applicable rules/tags; skips invoking either solver) to CI to avoid accidental issues like this in the future. This runs in about 55 seconds on my machine. 

CC @fitzgen, @cfallin 