### PR TITLE
Tag the epoch counter dereference with an alias region

### DIFF
--- a/crates/cranelift/src/alias_region.rs
+++ b/crates/cranelift/src/alias_region.rs
@@ -34,6 +34,7 @@ enum VmType {
     VMGlobalImport,
     VMFuncRef,
     TypeIdsArray,
+    EpochCounter,
 }
 
 /// A key that uniquely identifies an alias region across an entire compilation.
@@ -144,6 +145,7 @@ impl AliasRegionKey {
     const STACK_KIND: u32 = Self::new_kind(0b10111);
     const VM_FUNC_REF_KIND: u32 = Self::new_kind(0b11000);
     const TYPE_IDS_ARRAY_KIND: u32 = Self::new_kind(0b11001);
+    const EPOCH_COUNTER_KIND: u32 = Self::new_kind(0b11010);
 
     /// Encode this key into a raw `u32` suitable for use as an
     /// `AliasRegionData::user_id`.
@@ -170,6 +172,7 @@ impl AliasRegionKey {
                     VmType::VMGlobalImport => Self::VM_GLOBAL_IMPORT_KIND,
                     VmType::VMFuncRef => Self::VM_FUNC_REF_KIND,
                     VmType::TypeIdsArray => Self::TYPE_IDS_ARRAY_KIND,
+                    VmType::EpochCounter => Self::EPOCH_COUNTER_KIND,
                 };
                 kind | (offset & Self::OFFSET_MASK)
             }
@@ -1908,6 +1911,34 @@ where
                 .with_alias_region(Some(region)),
             array,
             i32::try_from(offset).unwrap(),
+        )
+    }
+}
+
+/// Epoch counter-related methods.
+impl<Offsets> AliasRegions<Offsets>
+where
+    Offsets: GetPtrSize,
+{
+    /// Dereference the epoch pointer (an `*const AtomicU64` previously loaded
+    /// out of the vmctx's `epoch_ptr` field) to read the current epoch counter.
+    pub fn epoch_counter(
+        &mut self,
+        cursor: &mut FuncCursor<'_>,
+        epoch_ptr: ir::Value,
+    ) -> ir::Value {
+        let region = self.region(
+            cursor.func,
+            AliasRegionKey::Vm {
+                ty: VmType::EpochCounter,
+                offset: 0,
+            },
+        );
+        cursor.ins().load(
+            ir::types::I64,
+            ir::MemFlagsData::trusted().with_alias_region(Some(region)),
+            epoch_ptr,
+            0,
         )
     }
 }

--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -747,12 +747,8 @@ impl<'module_environment> FuncEnvironment<'module_environment> {
 
     fn epoch_load_current(&mut self, builder: &mut FunctionBuilder<'_>) -> ir::Value {
         let addr = builder.use_var(self.epoch_ptr_var);
-        builder.ins().load(
-            ir::types::I64,
-            ir::MemFlagsData::trusted(),
-            addr,
-            ir::immediates::Offset32::new(0),
-        )
+        self.alias_regions
+            .epoch_counter(&mut builder.cursor(), addr)
     }
 
     fn epoch_check(&mut self, builder: &mut FunctionBuilder<'_>) {

--- a/tests/disas/epoch-interruption.wat
+++ b/tests/disas/epoch-interruption.wat
@@ -8,7 +8,8 @@
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 134217752 "VMStoreContext+0x18"
 ;;     region2 = 24 "VMContext+0x18"
-;;     region3 = 134217736 "VMStoreContext+0x8"
+;;     region3 = 3489660928 "EpochCounter+0x0"
+;;     region4 = 134217736 "VMStoreContext+0x8"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -18,9 +19,9 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64):
 ;; @0016                               v2 = load.i64 notrap aligned region2 v0+24
-;; @0016                               v3 = load.i64 notrap aligned v2
+;; @0016                               v3 = load.i64 notrap aligned region3 v2
 ;; @0016                               v4 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0016                               v5 = load.i64 notrap aligned region3 v4+8
+;; @0016                               v5 = load.i64 notrap aligned region4 v4+8
 ;; @0016                               v6 = icmp uge v3, v5
 ;; @0016                               brif v6, block3, block2(v5)
 ;;
@@ -32,12 +33,12 @@
 ;; @0017                               jump block4(v18)
 ;;
 ;;                                 block4(v10: i64):
-;; @0017                               v9 = load.i64 notrap aligned v2
+;; @0017                               v9 = load.i64 notrap aligned region3 v2
 ;; @0017                               v11 = icmp uge v9, v10
 ;; @0017                               brif v11, block7, block6(v10)
 ;;
 ;;                                 block7 cold:
-;; @0017                               v13 = load.i64 notrap aligned region3 v4+8
+;; @0017                               v13 = load.i64 notrap aligned region4 v4+8
 ;; @0017                               v14 = icmp.i64 uge v9, v13
 ;; @0017                               brif v14, block8, block6(v13)
 ;;

--- a/tests/disas/memory-copy-epochs.wat
+++ b/tests/disas/memory-copy-epochs.wat
@@ -12,9 +12,10 @@
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 134217752 "VMStoreContext+0x18"
 ;;     region2 = 24 "VMContext+0x18"
-;;     region3 = 134217736 "VMStoreContext+0x8"
-;;     region4 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region5 = 1207959560 "VMMemoryDefinition+0x8"
+;;     region3 = 3489660928 "EpochCounter+0x0"
+;;     region4 = 134217736 "VMStoreContext+0x8"
+;;     region5 = 1207959552 "VMMemoryDefinition+0x0"
+;;     region6 = 1207959560 "VMMemoryDefinition+0x8"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -26,9 +27,9 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
 ;; @001e                               v5 = load.i64 notrap aligned region2 v0+24
-;; @001e                               v6 = load.i64 notrap aligned v5
+;; @001e                               v6 = load.i64 notrap aligned region3 v5
 ;; @001e                               v7 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @001e                               v8 = load.i64 notrap aligned region3 v7+8
+;; @001e                               v8 = load.i64 notrap aligned region4 v7+8
 ;; @001e                               v9 = icmp uge v6, v8
 ;; @001e                               brif v9, block3, block2(v8)
 ;;
@@ -37,7 +38,7 @@
 ;; @001e                               jump block2(v10)
 ;;
 ;;                                 block2(v59: i64):
-;; @0025                               v14 = load.i64 notrap aligned region5 v0+64
+;; @0025                               v14 = load.i64 notrap aligned region6 v0+64
 ;; @0025                               v15 = uextend.i64 v2
 ;; @0025                               v16 = uextend.i64 v4
 ;; @0025                               v19 = iadd v15, v16
@@ -47,19 +48,19 @@
 ;; @0025                               v31 = iadd v27, v16
 ;; @0025                               v32 = icmp ugt v31, v14
 ;; @0025                               trapnz v32, heap_oob
-;; @0025                               v21 = load.i64 notrap aligned readonly can_move region4 v0+56
+;; @0025                               v21 = load.i64 notrap aligned readonly can_move region5 v0+56
 ;; @0025                               v37 = iadd v21, v27
 ;; @0025                               v25 = iadd v21, v15
 ;; @0025                               v40 = icmp ugt v37, v25
 ;; @0025                               brif v40, block6, block7
 ;;
 ;;                                 block4(v42: i64, v43: i64, v44: i64, v47: i64):
-;; @0025                               v46 = load.i64 notrap aligned v5
+;; @0025                               v46 = load.i64 notrap aligned region3 v5
 ;; @0025                               v48 = icmp uge v46, v47
 ;; @0025                               brif v48, block9, block8(v47)
 ;;
 ;;                                 block5(v86: i64, v87: i64, v88: i64, v92: i64):
-;; @0025                               v91 = load.i64 notrap aligned v5
+;; @0025                               v91 = load.i64 notrap aligned region3 v5
 ;; @0025                               v94 = icmp uge v91, v92
 ;; @0025                               brif v94, block17, block16
 ;;
@@ -69,7 +70,7 @@
 ;; @0025                               brif v109, block4(v25, v37, v16, v59), block5(v25, v37, v16, v59)
 ;;
 ;;                                 block9 cold:
-;; @0025                               v50 = load.i64 notrap aligned region3 v7+8
+;; @0025                               v50 = load.i64 notrap aligned region4 v7+8
 ;; @0025                               v51 = icmp.i64 uge v46, v50
 ;; @0025                               brif v51, block10, block8(v50)
 ;;
@@ -93,12 +94,12 @@
 ;; @0025                               brif v63, block11(v61, v62, v16, v59), block12(v61, v62, v16, v59)
 ;;
 ;;                                 block11(v64: i64, v65: i64, v66: i64, v71: i64):
-;; @0025                               v70 = load.i64 notrap aligned v5
+;; @0025                               v70 = load.i64 notrap aligned region3 v5
 ;; @0025                               v72 = icmp uge v70, v71
 ;; @0025                               brif v72, block14, block13(v71)
 ;;
 ;;                                 block14 cold:
-;; @0025                               v74 = load.i64 notrap aligned region3 v7+8
+;; @0025                               v74 = load.i64 notrap aligned region4 v7+8
 ;; @0025                               v75 = icmp.i64 uge v70, v74
 ;; @0025                               brif v75, block15, block13(v74)
 ;;
@@ -121,7 +122,7 @@
 ;; @0025                               jump block5(v84, v85, v83, v93)
 ;;
 ;;                                 block17 cold:
-;; @0025                               v96 = load.i64 notrap aligned region3 v7+8
+;; @0025                               v96 = load.i64 notrap aligned region4 v7+8
 ;; @0025                               v97 = icmp.i64 uge v91, v96
 ;; @0025                               brif v97, block18, block16
 ;;


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
