### PR TITLE
x64: report an error instead of panicking on stack frames larger than i32::MAX

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/mod.rs
+++ b/cranelift/codegen/src/isa/aarch64/mod.rs
@@ -74,7 +74,7 @@ impl TargetIsa for AArch64Backend {
     ) -> CodegenResult<CompiledCodeStencil> {
         let (vcode, regalloc_result) = self.compile_vcode(func, domtree, ctrl_plane)?;
 
-        let emit_result = vcode.emit(&regalloc_result, want_disasm, &self.flags, ctrl_plane);
+        let emit_result = vcode.emit(&regalloc_result, want_disasm, &self.flags, ctrl_plane)?;
         let value_labels_ranges = emit_result.value_labels_ranges;
         let buffer = emit_result.buffer;
 

--- a/cranelift/codegen/src/isa/pulley_shared/mod.rs
+++ b/cranelift/codegen/src/isa/pulley_shared/mod.rs
@@ -179,7 +179,7 @@ where
 
         let want_disasm =
             want_disasm || (cfg!(feature = "trace-log") && log::log_enabled!(log::Level::Debug));
-        let emit_result = vcode.emit(&regalloc_result, want_disasm, &self.flags, ctrl_plane);
+        let emit_result = vcode.emit(&regalloc_result, want_disasm, &self.flags, ctrl_plane)?;
         let value_labels_ranges = emit_result.value_labels_ranges;
         let buffer = emit_result.buffer;
 

--- a/cranelift/codegen/src/isa/riscv64/mod.rs
+++ b/cranelift/codegen/src/isa/riscv64/mod.rs
@@ -76,7 +76,7 @@ impl TargetIsa for Riscv64Backend {
         let (vcode, regalloc_result) = self.compile_vcode(func, domtree, ctrl_plane)?;
 
         let want_disasm = want_disasm || log::log_enabled!(log::Level::Debug);
-        let emit_result = vcode.emit(&regalloc_result, want_disasm, &self.flags, ctrl_plane);
+        let emit_result = vcode.emit(&regalloc_result, want_disasm, &self.flags, ctrl_plane)?;
         let value_labels_ranges = emit_result.value_labels_ranges;
         let buffer = emit_result.buffer;
 

--- a/cranelift/codegen/src/isa/s390x/mod.rs
+++ b/cranelift/codegen/src/isa/s390x/mod.rs
@@ -73,7 +73,7 @@ impl TargetIsa for S390xBackend {
         let flags = self.flags();
         let (vcode, regalloc_result) = self.compile_vcode(func, domtree, ctrl_plane)?;
 
-        let emit_result = vcode.emit(&regalloc_result, want_disasm, flags, ctrl_plane);
+        let emit_result = vcode.emit(&regalloc_result, want_disasm, flags, ctrl_plane)?;
         let value_labels_ranges = emit_result.value_labels_ranges;
         let buffer = emit_result.buffer;
 

--- a/cranelift/codegen/src/isa/x64/abi.rs
+++ b/cranelift/codegen/src/isa/x64/abi.rs
@@ -1343,3 +1343,51 @@ const fn create_reg_env_systemv(enable_pinned_reg: bool) -> MachineEnv {
 
     env
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::machinst::abi::Callee;
+    use alloc::vec::Vec;
+
+    fn make_frame_layout(total_relevant_fields_sum: u32) -> FrameLayout {
+        FrameLayout {
+            word_bytes: 8,
+            incoming_args_size: 0,
+            tail_args_size: 0,
+            setup_area_size: 0,
+            clobber_size: 0,
+            fixed_frame_storage_size: total_relevant_fields_sum,
+            stackslots_size: 0,
+            outgoing_args_size: 0,
+            clobbered_callee_saves: Vec::new(),
+            function_calls: crate::machinst::FunctionCalls::None,
+        }
+    }
+
+    const ONE_GIB: u32 = 1 << 30;
+
+    #[test]
+    fn frame_layout_under_limit_is_accepted() {
+        let layout = make_frame_layout(ONE_GIB - 1);
+        assert!(!Callee::<X64ABIMachineSpec>::frame_layout_exceeds_limit(
+            &layout, ONE_GIB
+        ));
+    }
+
+    #[test]
+    fn frame_layout_at_exact_limit_is_accepted() {
+        let layout = make_frame_layout(ONE_GIB);
+        assert!(!Callee::<X64ABIMachineSpec>::frame_layout_exceeds_limit(
+            &layout, ONE_GIB
+        ));
+    }
+
+    #[test]
+    fn frame_layout_over_limit_is_rejected() {
+        let layout = make_frame_layout(ONE_GIB + 1);
+        assert!(Callee::<X64ABIMachineSpec>::frame_layout_exceeds_limit(
+            &layout, ONE_GIB
+        ));
+    }
+}

--- a/cranelift/codegen/src/isa/x64/mod.rs
+++ b/cranelift/codegen/src/isa/x64/mod.rs
@@ -82,7 +82,7 @@ impl TargetIsa for X64Backend {
     ) -> CodegenResult<CompiledCodeStencil> {
         let (vcode, regalloc_result) = self.compile_vcode(func, domtree, ctrl_plane)?;
 
-        let emit_result = vcode.emit(&regalloc_result, want_disasm, &self.flags, ctrl_plane);
+        let emit_result = vcode.emit(&regalloc_result, want_disasm, &self.flags, ctrl_plane)?;
         let value_labels_ranges = emit_result.value_labels_ranges;
         let buffer = emit_result.buffer;
 

--- a/cranelift/codegen/src/machinst/abi.rs
+++ b/cranelift/codegen/src/machinst/abi.rs
@@ -498,6 +498,12 @@ pub trait ABIMachineSpec {
         outgoing_args_size: u32,
     ) -> FrameLayout;
 
+    /// Defaults to a conservative 1GiB
+    /// across all backends.
+    fn maximum_frame_size() -> u32 {
+        1 << 30 // 1 GiB
+    }
+
     /// Generate the usual frame-setup sequence for this architecture: e.g.,
     /// `push rbp / mov rbp, rsp` on x86-64, or `stp fp, lr, [sp, #-16]!` on
     /// AArch64.
@@ -2204,12 +2210,12 @@ impl<M: ABIMachineSpec> Callee<M> {
         spillslots: usize,
         clobbered: Vec<Writable<RealReg>>,
         function_calls: FunctionCalls,
-    ) {
+    ) -> CodegenResult<()> {
         let bytes = M::word_bytes();
         let total_stacksize = self.stackslots_size + bytes * spillslots as u32;
         let mask = M::stack_align(self.call_conv) - 1;
         let total_stacksize = (total_stacksize + mask) & !mask; // 16-align the stack.
-        self.frame_layout = Some(M::compute_frame_layout(
+        let frame_layout = M::compute_frame_layout(
             self.call_conv,
             &self.flags,
             self.signature(),
@@ -2220,7 +2226,28 @@ impl<M: ABIMachineSpec> Callee<M> {
             self.stackslots_size,
             total_stacksize,
             self.outgoing_args_size,
-        ));
+        );
+
+        if Self::frame_layout_exceeds_limit(&frame_layout, M::maximum_frame_size()) {
+            return Err(CodegenError::ImplLimitExceeded);
+        }
+
+        self.frame_layout = Some(frame_layout);
+        Ok(())
+    }
+
+    /// Pulled out so that it can be used directly in tests without constructing a full `Callee`.
+    pub(crate) fn frame_layout_exceeds_limit(
+        frame_layout: &FrameLayout,
+        max_frame_size: u32,
+    ) -> bool {
+        let total: u64 = frame_layout.incoming_args_size as u64
+            + frame_layout.tail_args_size as u64
+            + frame_layout.setup_area_size as u64
+            + frame_layout.clobber_size as u64
+            + frame_layout.fixed_frame_storage_size as u64
+            + frame_layout.outgoing_args_size as u64;
+        total > max_frame_size as u64
     }
 
     /// Generate a prologue, post-regalloc.

--- a/cranelift/codegen/src/machinst/vcode.rs
+++ b/cranelift/codegen/src/machinst/vcode.rs
@@ -739,7 +739,7 @@ impl<I: VCodeInst> VCode<I> {
         want_disasm: bool,
         flags: &settings::Flags,
         ctrl_plane: &mut ControlPlane,
-    ) -> EmitResult
+    ) -> CodegenResult<EmitResult>
     where
         I: VCodeInst,
     {
@@ -783,7 +783,7 @@ impl<I: VCodeInst> VCode<I> {
             regalloc.num_spillslots,
             clobbers,
             function_calls,
-        );
+        )?;
 
         // Emit blocks.
         let mut cur_srcloc = None;
@@ -1164,13 +1164,13 @@ impl<I: VCodeInst> VCode<I> {
         // Store metadata about frame layout in the MachBuffer.
         buffer.set_frame_layout(self.abi.frame_slot_metadata());
 
-        EmitResult {
+        Ok(EmitResult {
             buffer: buffer.finish(&self.constants, ctrl_plane),
             bb_offsets,
             bb_edges,
             disasm: if want_disasm { Some(disasm) } else { None },
             value_labels_ranges,
-        }
+        })
     }
 
     fn monotonize_inst_offsets(&self, inst_offsets: &mut [CodeOffset], func_body_len: u32) {


### PR DESCRIPTION
## Summary

x64 codegen panics with `TryFromIntError` when a function's stack frame
is large enough that offsets relative to it no longer fit in a 32-bit
immediate. This affects three places: the inline stack-probe loop
(`guard_size * probe_count`), clobber save/restore (RSP-relative
offsets), and incoming-argument access (RBP-relative offsets via
`SyntheticAmode::IncomingArg::finalize`).

This was reported downstream in
rust-lang/rustc_codegen_cranelift#1656, where a ~2GB stack allocation
(`[0; 536870787_usize]`, a `[i32; N]` array) triggers an ICE:
thread 'optimize module ...' panicked at cranelift/codegen/src/isa/x64/inst/emit.rs:373:18:
guard_size * probe_count is too large to fit in a 32-bit immediate: TryFromIntError(PosOverflow)


## What this does

Adds `ABIMachineSpec::validate_frame_layout`, a new trait method with a
no-op default, overridden for x64. It's called from `VCode::emit` right
after `compute_frame_layout`, before any offset encoding takes place,
and checks:

On overflow, this returns `CodegenError::Unsupported` instead of
panicking. Only x64 overrides the new trait method; other backends are
unaffected (`aarch64`/`riscv64`/`s390x`/`pulley` needed a one-line `?`
each to propagate `emit`'s now-fallible return type, no behavior
change).

## Testing

- Added unit tests in `isa/x64/abi.rs` covering: a normal frame
  (accepted), an oversized `fixed_frame_storage_size` (rejected), an
  oversized `tail_args_size` via the RBP-relative path (rejected), and
  a frame that's under `i32::MAX` on its own but pushed over by the
  guard-page rounding margin (rejected) — this last case specifically
  reproduces the original bug.

## Known follow-up (not included here)

`bjorn3`'s comment mentions "all stack load/store instruction
lowerings" more broadly. I traced and covered the two offset-encoding
paths that are actually reachable from the repro (`gen_clobber_save`/
`gen_clobber_restore` and `SyntheticAmode::IncomingArg::finalize`), but
I have not exhaustively audited every stack-relative offset computation
in the x64 backend for the same class of narrowing. Happy to widen this
if there's a specific path you'd like checked.

Separately, `rustc_codegen_cranelift` currently panics when it receives
*any* `Err` from `Context::compile` at
[`src/base.rs:224`](https://github.com/rust-lang/rustc_codegen_cranelift/blob/main/src/base.rs#L224)
rather than converting it to a rustc diagnostic. I have open a  PR rust-lang/rustc_codegen_cranelift/pull/1669 there to handle `CodegenError::Unsupported` the same way
the existing `CodegenError::Verifier` arm already does.