### PR TITLE
[Cranelift] remove redundant simplifictaion rule

### DIFF
--- a/cranelift/codegen/src/opts/arithmetic.isle
+++ b/cranelift/codegen/src/opts/arithmetic.isle
@@ -180,8 +180,6 @@
 ;; `iconst` of that type.
 (rule (simplify (imul ty x (iconst _ (imm64_power_of_two c))))
       (ishl ty x (iconst ty (imm64 c))))
-(rule (simplify (imul ty (iconst _ (imm64_power_of_two c)) x))
-      (ishl ty x (iconst ty (imm64 c))))
 
 ;; fneg(fneg(x)) == x.
 (rule (simplify (fneg ty (fneg ty x))) (subsume x))

--- a/cranelift/filetests/filetests/egraph/arithmetic.clif
+++ b/cranelift/filetests/filetests/egraph/arithmetic.clif
@@ -120,8 +120,8 @@ block0(v0: i32):
     v1 = iconst.i32 2
     v2 = imul v1, v0
     return v2
-    ; check: v6 = iadd v0, v0
-    ; check: return v6
+    ; check: v4 = iadd v0, v0
+    ; check: return v4
 }
 
 function %mul2_ne_add(i32, i32) -> i8 {

--- a/tests/disas/gc/copying/array-get.wat
+++ b/tests/disas/gc/copying/array-get.wat
@@ -31,20 +31,20 @@
 ;; @0022                               v11 = icmp ult v3, v10
 ;; @0022                               trapz v11, user17
 ;; @0022                               v13 = uextend.i64 v10
-;;                                     v32 = iconst.i64 3
-;;                                     v33 = ishl v13, v32  ; v32 = 3
+;;                                     v33 = iconst.i64 3
+;;                                     v34 = ishl v13, v33  ; v33 = 3
 ;; @0022                               v15 = iconst.i64 32
-;; @0022                               v16 = ushr v33, v15  ; v15 = 32
+;; @0022                               v16 = ushr v34, v15  ; v15 = 32
 ;; @0022                               trapnz v16, user2
-;;                                     v42 = iconst.i32 3
-;;                                     v43 = ishl v10, v42  ; v42 = 3
+;;                                     v41 = iconst.i32 3
+;;                                     v42 = ishl v10, v41  ; v41 = 3
 ;; @0022                               v18 = iconst.i32 24
-;; @0022                               v19 = uadd_overflow_trap v43, v18, user2  ; v18 = 24
+;; @0022                               v19 = uadd_overflow_trap v42, v18, user2  ; v18 = 24
 ;; @0022                               v23 = uadd_overflow_trap v2, v19, user2
 ;; @0022                               v24 = uextend.i64 v23
 ;; @0022                               v27 = iadd v6, v24
-;;                                     v49 = ishl v3, v42  ; v42 = 3
-;; @0022                               v22 = iadd v49, v18  ; v18 = 24
+;;                                     v47 = ishl v3, v41  ; v41 = 3
+;; @0022                               v22 = iadd v47, v18  ; v18 = 24
 ;; @0022                               v28 = isub v19, v22
 ;; @0022                               v29 = uextend.i64 v28
 ;; @0022                               v30 = isub v27, v29

--- a/tests/disas/gc/copying/array-new-fixed-of-gc-refs.wat
+++ b/tests/disas/gc/copying/array-new-fixed-of-gc-refs.wat
@@ -50,19 +50,19 @@
 ;; @0025                               brif v25, block2, block3
 ;;
 ;;                                 block2:
-;;                                     v259 = iconst.i32 32
-;;                                     v165 = iadd.i32 v15, v259  ; v259 = 32
+;;                                     v253 = iconst.i32 32
+;;                                     v165 = iadd.i32 v15, v253  ; v253 = 32
 ;; @0025                               store notrap aligned region3 v165, v14
-;;                                     v260 = iconst.i32 -1476394994
-;;                                     v261 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v262 = load.i64 notrap aligned readonly can_move region7 v261+32
-;; @0025                               v39 = iadd v262, v22
-;; @0025                               store user2 region8 v260, v39  ; v260 = -1476394994
-;;                                     v263 = load.i64 notrap aligned readonly can_move region5 v0+40
-;;                                     v264 = load.i32 notrap aligned readonly can_move region6 v263
-;; @0025                               store user2 region8 v264, v39+4
-;;                                     v265 = iconst.i64 32
-;; @0025                               istore32 user2 region8 v265, v39+8  ; v265 = 32
+;;                                     v254 = iconst.i32 -1476394994
+;;                                     v255 = load.i64 notrap aligned readonly can_move region0 v0+8
+;;                                     v256 = load.i64 notrap aligned readonly can_move region7 v255+32
+;; @0025                               v39 = iadd v256, v22
+;; @0025                               store user2 region8 v254, v39  ; v254 = -1476394994
+;;                                     v257 = load.i64 notrap aligned readonly can_move region5 v0+40
+;;                                     v258 = load.i32 notrap aligned readonly can_move region6 v257
+;; @0025                               store user2 region8 v258, v39+4
+;;                                     v259 = iconst.i64 32
+;; @0025                               istore32 user2 region8 v259, v39+8  ; v259 = 32
 ;; @0025                               jump block4(v15, v39)
 ;;
 ;;                                 block3 cold:
@@ -84,65 +84,65 @@
 ;; @0025                               v46 = iadd v44, v45  ; v45 = 16
 ;; @0025                               store user2 region8 v5, v46  ; v5 = 3
 ;; @0025                               trapz v43, user16
-;;                                     v266 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v267 = load.i64 notrap aligned readonly can_move region7 v266+32
+;;                                     v260 = load.i64 notrap aligned readonly can_move region0 v0+8
+;;                                     v261 = load.i64 notrap aligned readonly can_move region7 v260+32
 ;; @0025                               v48 = uextend.i64 v43
-;; @0025                               v51 = iadd v267, v48
+;; @0025                               v51 = iadd v261, v48
 ;; @0025                               v53 = iadd v51, v45  ; v45 = 16
 ;; @0025                               v54 = load.i32 user2 readonly region8 v53
 ;; @0025                               trapz v54, user17
 ;; @0025                               v57 = uextend.i64 v54
 ;;                                     v142 = iconst.i64 2
-;;                                     v171 = ishl v57, v142  ; v142 = 2
-;;                                     v268 = iconst.i64 32
-;;                                     v269 = ushr v171, v268  ; v268 = 32
-;; @0025                               trapnz v269, user2
-;;                                     v180 = iconst.i32 2
-;;                                     v181 = ishl v54, v180  ; v180 = 2
+;;                                     v172 = ishl v57, v142  ; v142 = 2
+;;                                     v262 = iconst.i64 32
+;;                                     v263 = ushr v172, v262  ; v262 = 32
+;; @0025                               trapnz v263, user2
+;;                                     v179 = iconst.i32 2
+;;                                     v180 = ishl v54, v179  ; v179 = 2
 ;; @0025                               v6 = iconst.i32 20
-;; @0025                               v63 = uadd_overflow_trap v181, v6, user2  ; v6 = 20
+;; @0025                               v63 = uadd_overflow_trap v180, v6, user2  ; v6 = 20
 ;; @0025                               v67 = uadd_overflow_trap v43, v63, user2
 ;;                                     v136 = load.i32 notrap aligned region12 v137
 ;; @0025                               v68 = uextend.i64 v67
-;; @0025                               v71 = iadd v267, v68
+;; @0025                               v71 = iadd v261, v68
 ;; @0025                               v72 = isub v63, v6  ; v6 = 20
 ;; @0025                               v73 = uextend.i64 v72
 ;; @0025                               v74 = isub v71, v73
 ;; @0025                               store user2 little region8 v136, v74
 ;; @0025                               v82 = load.i32 user2 readonly region8 v53
 ;; @0025                               v75 = iconst.i32 1
-;;                                     v198 = icmp ugt v82, v75  ; v75 = 1
-;; @0025                               trapz v198, user17
+;;                                     v196 = icmp ugt v82, v75  ; v75 = 1
+;; @0025                               trapz v196, user17
 ;; @0025                               v85 = uextend.i64 v82
-;;                                     v200 = ishl v85, v142  ; v142 = 2
-;;                                     v270 = ushr v200, v268  ; v268 = 32
-;; @0025                               trapnz v270, user2
-;;                                     v207 = ishl v82, v180  ; v180 = 2
-;; @0025                               v91 = uadd_overflow_trap v207, v6, user2  ; v6 = 20
+;;                                     v199 = ishl v85, v142  ; v142 = 2
+;;                                     v264 = ushr v199, v262  ; v262 = 32
+;; @0025                               trapnz v264, user2
+;;                                     v204 = ishl v82, v179  ; v179 = 2
+;; @0025                               v91 = uadd_overflow_trap v204, v6, user2  ; v6 = 20
 ;; @0025                               v95 = uadd_overflow_trap v43, v91, user2
 ;;                                     v134 = load.i32 notrap aligned region11 v138
 ;; @0025                               v96 = uextend.i64 v95
-;; @0025                               v99 = iadd v267, v96
-;;                                     v220 = iconst.i32 24
-;; @0025                               v100 = isub v91, v220  ; v220 = 24
+;; @0025                               v99 = iadd v261, v96
+;;                                     v216 = iconst.i32 24
+;; @0025                               v100 = isub v91, v216  ; v216 = 24
 ;; @0025                               v101 = uextend.i64 v100
 ;; @0025                               v102 = isub v99, v101
 ;; @0025                               store user2 little region8 v134, v102
 ;; @0025                               v110 = load.i32 user2 readonly region8 v53
-;;                                     v226 = icmp ugt v110, v180  ; v180 = 2
-;; @0025                               trapz v226, user17
+;;                                     v222 = icmp ugt v110, v179  ; v179 = 2
+;; @0025                               trapz v222, user17
 ;; @0025                               v113 = uextend.i64 v110
-;;                                     v228 = ishl v113, v142  ; v142 = 2
-;;                                     v271 = ushr v228, v268  ; v268 = 32
-;; @0025                               trapnz v271, user2
-;;                                     v235 = ishl v110, v180  ; v180 = 2
-;; @0025                               v119 = uadd_overflow_trap v235, v6, user2  ; v6 = 20
+;;                                     v225 = ishl v113, v142  ; v142 = 2
+;;                                     v265 = ushr v225, v262  ; v262 = 32
+;; @0025                               trapnz v265, user2
+;;                                     v230 = ishl v110, v179  ; v179 = 2
+;; @0025                               v119 = uadd_overflow_trap v230, v6, user2  ; v6 = 20
 ;; @0025                               v123 = uadd_overflow_trap v43, v119, user2
 ;;                                     v132 = load.i32 notrap aligned region10 v139
 ;; @0025                               v124 = uextend.i64 v123
-;; @0025                               v127 = iadd v267, v124
-;;                                     v253 = iconst.i32 28
-;; @0025                               v128 = isub v119, v253  ; v253 = 28
+;; @0025                               v127 = iadd v261, v124
+;;                                     v247 = iconst.i32 28
+;; @0025                               v128 = isub v119, v247  ; v247 = 28
 ;; @0025                               v129 = uextend.i64 v128
 ;; @0025                               v130 = isub v127, v129
 ;; @0025                               store user2 little region8 v132, v130

--- a/tests/disas/gc/copying/array-new-fixed.wat
+++ b/tests/disas/gc/copying/array-new-fixed.wat
@@ -38,19 +38,19 @@
 ;; @0025                               brif v25, block2, block3
 ;;
 ;;                                 block2:
-;;                                     v247 = iconst.i32 48
-;;                                     v155 = iadd.i32 v15, v247  ; v247 = 48
+;;                                     v241 = iconst.i32 48
+;;                                     v155 = iadd.i32 v15, v241  ; v241 = 48
 ;; @0025                               store notrap aligned region3 v155, v14
-;;                                     v248 = iconst.i32 -1476395002
-;;                                     v249 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v250 = load.i64 notrap aligned readonly can_move region7 v249+32
-;; @0025                               v39 = iadd v250, v22
-;; @0025                               store user2 region8 v248, v39  ; v248 = -1476395002
-;;                                     v251 = load.i64 notrap aligned readonly can_move region5 v0+40
-;;                                     v252 = load.i32 notrap aligned readonly can_move region6 v251
-;; @0025                               store user2 region8 v252, v39+4
-;;                                     v253 = iconst.i64 48
-;; @0025                               istore32 user2 region8 v253, v39+8  ; v253 = 48
+;;                                     v242 = iconst.i32 -1476395002
+;;                                     v243 = load.i64 notrap aligned readonly can_move region0 v0+8
+;;                                     v244 = load.i64 notrap aligned readonly can_move region7 v243+32
+;; @0025                               v39 = iadd v244, v22
+;; @0025                               store user2 region8 v242, v39  ; v242 = -1476395002
+;;                                     v245 = load.i64 notrap aligned readonly can_move region5 v0+40
+;;                                     v246 = load.i32 notrap aligned readonly can_move region6 v245
+;; @0025                               store user2 region8 v246, v39+4
+;;                                     v247 = iconst.i64 48
+;; @0025                               istore32 user2 region8 v247, v39+8  ; v247 = 48
 ;; @0025                               jump block4(v15, v39)
 ;;
 ;;                                 block3 cold:
@@ -72,62 +72,62 @@
 ;; @0025                               v46 = iadd v44, v45  ; v45 = 16
 ;; @0025                               store user2 region8 v5, v46  ; v5 = 3
 ;; @0025                               trapz v43, user16
-;;                                     v254 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v255 = load.i64 notrap aligned readonly can_move region7 v254+32
+;;                                     v248 = load.i64 notrap aligned readonly can_move region0 v0+8
+;;                                     v249 = load.i64 notrap aligned readonly can_move region7 v248+32
 ;; @0025                               v48 = uextend.i64 v43
-;; @0025                               v51 = iadd v255, v48
+;; @0025                               v51 = iadd v249, v48
 ;; @0025                               v53 = iadd v51, v45  ; v45 = 16
 ;; @0025                               v54 = load.i32 user2 readonly region8 v53
 ;; @0025                               trapz v54, user17
 ;; @0025                               v57 = uextend.i64 v54
 ;;                                     v131 = iconst.i64 3
-;;                                     v161 = ishl v57, v131  ; v131 = 3
+;;                                     v162 = ishl v57, v131  ; v131 = 3
 ;; @0025                               v10 = iconst.i64 32
-;; @0025                               v60 = ushr v161, v10  ; v10 = 32
+;; @0025                               v60 = ushr v162, v10  ; v10 = 32
 ;; @0025                               trapnz v60, user2
-;;                                     v170 = ishl v54, v5  ; v5 = 3
+;;                                     v169 = ishl v54, v5  ; v5 = 3
 ;; @0025                               v6 = iconst.i32 24
-;; @0025                               v63 = uadd_overflow_trap v170, v6, user2  ; v6 = 24
+;; @0025                               v63 = uadd_overflow_trap v169, v6, user2  ; v6 = 24
 ;; @0025                               v67 = uadd_overflow_trap v43, v63, user2
 ;; @0025                               v68 = uextend.i64 v67
-;; @0025                               v71 = iadd v255, v68
+;; @0025                               v71 = iadd v249, v68
 ;; @0025                               v72 = isub v63, v6  ; v6 = 24
 ;; @0025                               v73 = uextend.i64 v72
 ;; @0025                               v74 = isub v71, v73
 ;; @0025                               store.i64 user2 little region8 v2, v74
 ;; @0025                               v82 = load.i32 user2 readonly region8 v53
 ;; @0025                               v75 = iconst.i32 1
-;;                                     v187 = icmp ugt v82, v75  ; v75 = 1
-;; @0025                               trapz v187, user17
+;;                                     v185 = icmp ugt v82, v75  ; v75 = 1
+;; @0025                               trapz v185, user17
 ;; @0025                               v85 = uextend.i64 v82
-;;                                     v189 = ishl v85, v131  ; v131 = 3
-;; @0025                               v88 = ushr v189, v10  ; v10 = 32
+;;                                     v188 = ishl v85, v131  ; v131 = 3
+;; @0025                               v88 = ushr v188, v10  ; v10 = 32
 ;; @0025                               trapnz v88, user2
-;;                                     v196 = ishl v82, v5  ; v5 = 3
-;; @0025                               v91 = uadd_overflow_trap v196, v6, user2  ; v6 = 24
+;;                                     v193 = ishl v82, v5  ; v5 = 3
+;; @0025                               v91 = uadd_overflow_trap v193, v6, user2  ; v6 = 24
 ;; @0025                               v95 = uadd_overflow_trap v43, v91, user2
 ;; @0025                               v96 = uextend.i64 v95
-;; @0025                               v99 = iadd v255, v96
-;;                                     v209 = iconst.i32 32
-;; @0025                               v100 = isub v91, v209  ; v209 = 32
+;; @0025                               v99 = iadd v249, v96
+;;                                     v205 = iconst.i32 32
+;; @0025                               v100 = isub v91, v205  ; v205 = 32
 ;; @0025                               v101 = uextend.i64 v100
 ;; @0025                               v102 = isub v99, v101
 ;; @0025                               store.i64 user2 little region8 v3, v102
 ;; @0025                               v110 = load.i32 user2 readonly region8 v53
 ;; @0025                               v103 = iconst.i32 2
-;;                                     v215 = icmp ugt v110, v103  ; v103 = 2
-;; @0025                               trapz v215, user17
+;;                                     v211 = icmp ugt v110, v103  ; v103 = 2
+;; @0025                               trapz v211, user17
 ;; @0025                               v113 = uextend.i64 v110
-;;                                     v217 = ishl v113, v131  ; v131 = 3
-;; @0025                               v116 = ushr v217, v10  ; v10 = 32
+;;                                     v214 = ishl v113, v131  ; v131 = 3
+;; @0025                               v116 = ushr v214, v10  ; v10 = 32
 ;; @0025                               trapnz v116, user2
-;;                                     v224 = ishl v110, v5  ; v5 = 3
-;; @0025                               v119 = uadd_overflow_trap v224, v6, user2  ; v6 = 24
+;;                                     v219 = ishl v110, v5  ; v5 = 3
+;; @0025                               v119 = uadd_overflow_trap v219, v6, user2  ; v6 = 24
 ;; @0025                               v123 = uadd_overflow_trap v43, v119, user2
 ;; @0025                               v124 = uextend.i64 v123
-;; @0025                               v127 = iadd v255, v124
-;;                                     v241 = iconst.i32 40
-;; @0025                               v128 = isub v119, v241  ; v241 = 40
+;; @0025                               v127 = iadd v249, v124
+;;                                     v235 = iconst.i32 40
+;; @0025                               v128 = isub v119, v235  ; v235 = 40
 ;; @0025                               v129 = uextend.i64 v128
 ;; @0025                               v130 = isub v127, v129
 ;; @0025                               store.i64 user2 little region8 v4, v130

--- a/tests/disas/gc/copying/array-set.wat
+++ b/tests/disas/gc/copying/array-set.wat
@@ -31,20 +31,20 @@
 ;; @0024                               v12 = icmp ult v3, v11
 ;; @0024                               trapz v12, user17
 ;; @0024                               v14 = uextend.i64 v11
-;;                                     v32 = iconst.i64 3
-;;                                     v33 = ishl v14, v32  ; v32 = 3
+;;                                     v33 = iconst.i64 3
+;;                                     v34 = ishl v14, v33  ; v33 = 3
 ;; @0024                               v16 = iconst.i64 32
-;; @0024                               v17 = ushr v33, v16  ; v16 = 32
+;; @0024                               v17 = ushr v34, v16  ; v16 = 32
 ;; @0024                               trapnz v17, user2
-;;                                     v42 = iconst.i32 3
-;;                                     v43 = ishl v11, v42  ; v42 = 3
+;;                                     v41 = iconst.i32 3
+;;                                     v42 = ishl v11, v41  ; v41 = 3
 ;; @0024                               v19 = iconst.i32 24
-;; @0024                               v20 = uadd_overflow_trap v43, v19, user2  ; v19 = 24
+;; @0024                               v20 = uadd_overflow_trap v42, v19, user2  ; v19 = 24
 ;; @0024                               v24 = uadd_overflow_trap v2, v20, user2
 ;; @0024                               v25 = uextend.i64 v24
 ;; @0024                               v28 = iadd v7, v25
-;;                                     v49 = ishl v3, v42  ; v42 = 3
-;; @0024                               v23 = iadd v49, v19  ; v19 = 24
+;;                                     v47 = ishl v3, v41  ; v41 = 3
+;; @0024                               v23 = iadd v47, v19  ; v19 = 24
 ;; @0024                               v29 = isub v20, v23
 ;; @0024                               v30 = uextend.i64 v29
 ;; @0024                               v31 = isub v28, v30

--- a/tests/disas/gc/copying/multiple-array-get.wat
+++ b/tests/disas/gc/copying/multiple-array-get.wat
@@ -32,28 +32,28 @@
 ;; @0024                               v12 = icmp ult v3, v11
 ;; @0024                               trapz v12, user17
 ;; @0024                               v14 = uextend.i64 v11
-;;                                     v61 = iconst.i64 3
-;;                                     v62 = ishl v14, v61  ; v61 = 3
+;;                                     v62 = iconst.i64 3
+;;                                     v63 = ishl v14, v62  ; v62 = 3
 ;; @0024                               v16 = iconst.i64 32
-;; @0024                               v17 = ushr v62, v16  ; v16 = 32
+;; @0024                               v17 = ushr v63, v16  ; v16 = 32
 ;; @0024                               trapnz v17, user2
-;;                                     v71 = iconst.i32 3
-;;                                     v72 = ishl v11, v71  ; v71 = 3
+;;                                     v70 = iconst.i32 3
+;;                                     v71 = ishl v11, v70  ; v70 = 3
 ;; @0024                               v19 = iconst.i32 24
-;; @0024                               v20 = uadd_overflow_trap v72, v19, user2  ; v19 = 24
+;; @0024                               v20 = uadd_overflow_trap v71, v19, user2  ; v19 = 24
 ;; @0024                               v24 = uadd_overflow_trap v2, v20, user2
 ;; @0024                               v25 = uextend.i64 v24
 ;; @0024                               v28 = iadd v7, v25
-;;                                     v78 = ishl v3, v71  ; v71 = 3
-;; @0024                               v23 = iadd v78, v19  ; v19 = 24
+;;                                     v76 = ishl v3, v70  ; v70 = 3
+;; @0024                               v23 = iadd v76, v19  ; v19 = 24
 ;; @0024                               v29 = isub v20, v23
 ;; @0024                               v30 = uextend.i64 v29
 ;; @0024                               v31 = isub v28, v30
 ;; @0024                               v32 = load.i64 user2 little region4 v31
 ;; @002b                               v40 = icmp ult v4, v11
 ;; @002b                               trapz v40, user17
-;;                                     v80 = ishl v4, v71  ; v71 = 3
-;; @002b                               v51 = iadd v80, v19  ; v19 = 24
+;;                                     v78 = ishl v4, v70  ; v70 = 3
+;; @002b                               v51 = iadd v78, v19  ; v19 = 24
 ;; @002b                               v57 = isub v20, v51
 ;; @002b                               v58 = uextend.i64 v57
 ;; @002b                               v59 = isub v28, v58

--- a/tests/disas/gc/drc/array-get.wat
+++ b/tests/disas/gc/drc/array-get.wat
@@ -32,20 +32,20 @@
 ;; @0022                               v11 = icmp ult v3, v10
 ;; @0022                               trapz v11, user17
 ;; @0022                               v13 = uextend.i64 v10
-;;                                     v32 = iconst.i64 3
-;;                                     v33 = ishl v13, v32  ; v32 = 3
+;;                                     v33 = iconst.i64 3
+;;                                     v34 = ishl v13, v33  ; v33 = 3
 ;; @0022                               v15 = iconst.i64 32
-;; @0022                               v16 = ushr v33, v15  ; v15 = 32
+;; @0022                               v16 = ushr v34, v15  ; v15 = 32
 ;; @0022                               trapnz v16, user2
-;;                                     v42 = iconst.i32 3
-;;                                     v43 = ishl v10, v42  ; v42 = 3
+;;                                     v41 = iconst.i32 3
+;;                                     v42 = ishl v10, v41  ; v41 = 3
 ;; @0022                               v18 = iconst.i32 32
-;; @0022                               v19 = uadd_overflow_trap v43, v18, user2  ; v18 = 32
+;; @0022                               v19 = uadd_overflow_trap v42, v18, user2  ; v18 = 32
 ;; @0022                               v23 = uadd_overflow_trap v2, v19, user2
 ;; @0022                               v24 = uextend.i64 v23
 ;; @0022                               v27 = iadd v6, v24
-;;                                     v49 = ishl v3, v42  ; v42 = 3
-;; @0022                               v22 = iadd v49, v18  ; v18 = 32
+;;                                     v47 = ishl v3, v41  ; v41 = 3
+;; @0022                               v22 = iadd v47, v18  ; v18 = 32
 ;; @0022                               v28 = isub v19, v22
 ;; @0022                               v29 = uextend.i64 v28
 ;; @0022                               v30 = isub v27, v29

--- a/tests/disas/gc/drc/array-new-fixed-of-gc-refs.wat
+++ b/tests/disas/gc/drc/array-new-fixed-of-gc-refs.wat
@@ -81,39 +81,39 @@
 ;;                                     v206 = iconst.i64 12
 ;; @0025                               v52 = isub v49, v206  ; v206 = 12
 ;; @0025                               store user2 little region5 v193, v52
-;;                                     v309 = iadd.i64 v22, v23  ; v23 = 24
-;; @0025                               v81 = load.i32 user2 readonly region5 v309
-;;                                     v310 = iconst.i32 1
-;;                                     v311 = icmp ugt v81, v310  ; v310 = 1
-;; @0025                               trapz v311, user17
+;;                                     v305 = iadd.i64 v22, v23  ; v23 = 24
+;; @0025                               v81 = load.i32 user2 readonly region5 v305
+;;                                     v306 = iconst.i32 1
+;;                                     v307 = icmp ugt v81, v306  ; v306 = 1
+;; @0025                               trapz v307, user17
 ;; @0025                               v84 = uextend.i64 v81
 ;;                                     v207 = iconst.i64 2
-;;                                     v251 = ishl v84, v207  ; v207 = 2
+;;                                     v252 = ishl v84, v207  ; v207 = 2
 ;; @0025                               v10 = iconst.i64 32
-;; @0025                               v87 = ushr v251, v10  ; v10 = 32
+;; @0025                               v87 = ushr v252, v10  ; v10 = 32
 ;; @0025                               trapnz v87, user2
 ;;                                     v228 = iconst.i32 2
-;;                                     v258 = ishl v81, v228  ; v228 = 2
+;;                                     v257 = ishl v81, v228  ; v228 = 2
 ;; @0025                               v6 = iconst.i32 28
-;; @0025                               v90 = uadd_overflow_trap v258, v6, user2  ; v6 = 28
+;; @0025                               v90 = uadd_overflow_trap v257, v6, user2  ; v6 = 28
 ;; @0025                               v94 = uadd_overflow_trap.i32 v18, v90, user2
 ;;                                     v191 = load.i32 notrap aligned region8 v203
-;;                                     v312 = band v191, v310  ; v310 = 1
-;;                                     v313 = iconst.i32 0
-;;                                     v314 = icmp eq v191, v313  ; v313 = 0
-;; @0025                               v106 = uextend.i32 v314
-;; @0025                               v107 = bor v312, v106
+;;                                     v308 = band v191, v306  ; v306 = 1
+;;                                     v309 = iconst.i32 0
+;;                                     v310 = icmp eq v191, v309  ; v309 = 0
+;; @0025                               v106 = uextend.i32 v310
+;; @0025                               v107 = bor v308, v106
 ;; @0025                               brif v107, block5, block4
 ;;
 ;;                                 block4:
 ;;                                     v187 = load.i32 notrap aligned region8 v203
 ;; @0025                               v108 = uextend.i64 v187
 ;; @0025                               v111 = iadd.i64 v20, v108
-;;                                     v315 = iconst.i64 8
-;; @0025                               v113 = iadd v111, v315  ; v315 = 8
+;;                                     v311 = iconst.i64 8
+;; @0025                               v113 = iadd v111, v311  ; v311 = 8
 ;; @0025                               v114 = load.i64 user2 region5 v113
-;;                                     v316 = iconst.i64 1
-;; @0025                               v116 = iadd v114, v316  ; v316 = 1
+;;                                     v312 = iconst.i64 1
+;; @0025                               v116 = iadd v114, v312  ; v312 = 1
 ;; @0025                               store user2 region5 v116, v113
 ;; @0025                               jump block5
 ;;
@@ -121,44 +121,44 @@
 ;;                                     v183 = load.i32 notrap aligned region8 v203
 ;; @0025                               v95 = uextend.i64 v94
 ;; @0025                               v98 = iadd.i64 v20, v95
-;;                                     v271 = iconst.i32 32
-;; @0025                               v99 = isub.i32 v90, v271  ; v271 = 32
+;;                                     v269 = iconst.i32 32
+;; @0025                               v99 = isub.i32 v90, v269  ; v269 = 32
 ;; @0025                               v100 = uextend.i64 v99
 ;; @0025                               v101 = isub v98, v100
 ;; @0025                               store user2 little region5 v183, v101
-;;                                     v317 = iadd.i64 v22, v23  ; v23 = 24
-;; @0025                               v130 = load.i32 user2 readonly region5 v317
-;;                                     v318 = iconst.i32 2
-;;                                     v319 = icmp ugt v130, v318  ; v318 = 2
-;; @0025                               trapz v319, user17
+;;                                     v313 = iadd.i64 v22, v23  ; v23 = 24
+;; @0025                               v130 = load.i32 user2 readonly region5 v313
+;;                                     v314 = iconst.i32 2
+;;                                     v315 = icmp ugt v130, v314  ; v314 = 2
+;; @0025                               trapz v315, user17
 ;; @0025                               v133 = uextend.i64 v130
-;;                                     v320 = iconst.i64 2
-;;                                     v321 = ishl v133, v320  ; v320 = 2
-;;                                     v322 = iconst.i64 32
-;;                                     v323 = ushr v321, v322  ; v322 = 32
-;; @0025                               trapnz v323, user2
-;;                                     v324 = ishl v130, v318  ; v318 = 2
-;;                                     v325 = iconst.i32 28
-;; @0025                               v139 = uadd_overflow_trap v324, v325, user2  ; v325 = 28
+;;                                     v316 = iconst.i64 2
+;;                                     v317 = ishl v133, v316  ; v316 = 2
+;;                                     v318 = iconst.i64 32
+;;                                     v319 = ushr v317, v318  ; v318 = 32
+;; @0025                               trapnz v319, user2
+;;                                     v320 = ishl v130, v314  ; v314 = 2
+;;                                     v321 = iconst.i32 28
+;; @0025                               v139 = uadd_overflow_trap v320, v321, user2  ; v321 = 28
 ;; @0025                               v143 = uadd_overflow_trap.i32 v18, v139, user2
 ;;                                     v181 = load.i32 notrap aligned region7 v204
-;;                                     v326 = iconst.i32 1
-;;                                     v327 = band v181, v326  ; v326 = 1
-;;                                     v328 = iconst.i32 0
-;;                                     v329 = icmp eq v181, v328  ; v328 = 0
-;; @0025                               v155 = uextend.i32 v329
-;; @0025                               v156 = bor v327, v155
+;;                                     v322 = iconst.i32 1
+;;                                     v323 = band v181, v322  ; v322 = 1
+;;                                     v324 = iconst.i32 0
+;;                                     v325 = icmp eq v181, v324  ; v324 = 0
+;; @0025                               v155 = uextend.i32 v325
+;; @0025                               v156 = bor v323, v155
 ;; @0025                               brif v156, block7, block6
 ;;
 ;;                                 block6:
 ;;                                     v177 = load.i32 notrap aligned region7 v204
 ;; @0025                               v157 = uextend.i64 v177
 ;; @0025                               v160 = iadd.i64 v20, v157
-;;                                     v330 = iconst.i64 8
-;; @0025                               v162 = iadd v160, v330  ; v330 = 8
+;;                                     v326 = iconst.i64 8
+;; @0025                               v162 = iadd v160, v326  ; v326 = 8
 ;; @0025                               v163 = load.i64 user2 region5 v162
-;;                                     v331 = iconst.i64 1
-;; @0025                               v165 = iadd v163, v331  ; v331 = 1
+;;                                     v327 = iconst.i64 1
+;; @0025                               v165 = iadd v163, v327  ; v327 = 1
 ;; @0025                               store user2 region5 v165, v162
 ;; @0025                               jump block7
 ;;
@@ -166,8 +166,8 @@
 ;;                                     v173 = load.i32 notrap aligned region7 v204
 ;; @0025                               v144 = uextend.i64 v143
 ;; @0025                               v147 = iadd.i64 v20, v144
-;;                                     v303 = iconst.i32 36
-;; @0025                               v148 = isub.i32 v139, v303  ; v303 = 36
+;;                                     v299 = iconst.i32 36
+;; @0025                               v148 = isub.i32 v139, v299  ; v299 = 36
 ;; @0025                               v149 = uextend.i64 v148
 ;; @0025                               v150 = isub v147, v149
 ;; @0025                               store user2 little region5 v173, v150

--- a/tests/disas/gc/drc/array-new-fixed.wat
+++ b/tests/disas/gc/drc/array-new-fixed.wat
@@ -51,36 +51,36 @@
 ;; @0025                               trapz v150, user17
 ;; @0025                               v63 = uextend.i64 v60
 ;;                                     v109 = iconst.i64 3
-;;                                     v152 = ishl v63, v109  ; v109 = 3
+;;                                     v153 = ishl v63, v109  ; v109 = 3
 ;; @0025                               v10 = iconst.i64 32
-;; @0025                               v66 = ushr v152, v10  ; v10 = 32
+;; @0025                               v66 = ushr v153, v10  ; v10 = 32
 ;; @0025                               trapnz v66, user2
-;;                                     v159 = ishl v60, v5  ; v5 = 3
+;;                                     v158 = ishl v60, v5  ; v5 = 3
 ;; @0025                               v6 = iconst.i32 32
-;; @0025                               v69 = uadd_overflow_trap v159, v6, user2  ; v6 = 32
+;; @0025                               v69 = uadd_overflow_trap v158, v6, user2  ; v6 = 32
 ;; @0025                               v73 = uadd_overflow_trap v18, v69, user2
 ;; @0025                               v74 = uextend.i64 v73
 ;; @0025                               v77 = iadd v20, v74
-;;                                     v172 = iconst.i32 40
-;; @0025                               v78 = isub v69, v172  ; v172 = 40
+;;                                     v170 = iconst.i32 40
+;; @0025                               v78 = isub v69, v170  ; v170 = 40
 ;; @0025                               v79 = uextend.i64 v78
 ;; @0025                               v80 = isub v77, v79
 ;; @0025                               store user2 little region5 v3, v80
 ;; @0025                               v88 = load.i32 user2 readonly region5 v24
 ;; @0025                               v81 = iconst.i32 2
-;;                                     v178 = icmp ugt v88, v81  ; v81 = 2
-;; @0025                               trapz v178, user17
+;;                                     v176 = icmp ugt v88, v81  ; v81 = 2
+;; @0025                               trapz v176, user17
 ;; @0025                               v91 = uextend.i64 v88
-;;                                     v180 = ishl v91, v109  ; v109 = 3
-;; @0025                               v94 = ushr v180, v10  ; v10 = 32
+;;                                     v179 = ishl v91, v109  ; v109 = 3
+;; @0025                               v94 = ushr v179, v10  ; v10 = 32
 ;; @0025                               trapnz v94, user2
-;;                                     v187 = ishl v88, v5  ; v5 = 3
-;; @0025                               v97 = uadd_overflow_trap v187, v6, user2  ; v6 = 32
+;;                                     v184 = ishl v88, v5  ; v5 = 3
+;; @0025                               v97 = uadd_overflow_trap v184, v6, user2  ; v6 = 32
 ;; @0025                               v101 = uadd_overflow_trap v18, v97, user2
 ;; @0025                               v102 = uextend.i64 v101
 ;; @0025                               v105 = iadd v20, v102
-;;                                     v205 = iconst.i32 48
-;; @0025                               v106 = isub v97, v205  ; v205 = 48
+;;                                     v201 = iconst.i32 48
+;; @0025                               v106 = isub v97, v201  ; v201 = 48
 ;; @0025                               v107 = uextend.i64 v106
 ;; @0025                               v108 = isub v105, v107
 ;; @0025                               store user2 little region5 v4, v108

--- a/tests/disas/gc/drc/array-set.wat
+++ b/tests/disas/gc/drc/array-set.wat
@@ -32,20 +32,20 @@
 ;; @0024                               v12 = icmp ult v3, v11
 ;; @0024                               trapz v12, user17
 ;; @0024                               v14 = uextend.i64 v11
-;;                                     v32 = iconst.i64 3
-;;                                     v33 = ishl v14, v32  ; v32 = 3
+;;                                     v33 = iconst.i64 3
+;;                                     v34 = ishl v14, v33  ; v33 = 3
 ;; @0024                               v16 = iconst.i64 32
-;; @0024                               v17 = ushr v33, v16  ; v16 = 32
+;; @0024                               v17 = ushr v34, v16  ; v16 = 32
 ;; @0024                               trapnz v17, user2
-;;                                     v42 = iconst.i32 3
-;;                                     v43 = ishl v11, v42  ; v42 = 3
+;;                                     v41 = iconst.i32 3
+;;                                     v42 = ishl v11, v41  ; v41 = 3
 ;; @0024                               v19 = iconst.i32 32
-;; @0024                               v20 = uadd_overflow_trap v43, v19, user2  ; v19 = 32
+;; @0024                               v20 = uadd_overflow_trap v42, v19, user2  ; v19 = 32
 ;; @0024                               v24 = uadd_overflow_trap v2, v20, user2
 ;; @0024                               v25 = uextend.i64 v24
 ;; @0024                               v28 = iadd v7, v25
-;;                                     v49 = ishl v3, v42  ; v42 = 3
-;; @0024                               v23 = iadd v49, v19  ; v19 = 32
+;;                                     v47 = ishl v3, v41  ; v41 = 3
+;; @0024                               v23 = iadd v47, v19  ; v19 = 32
 ;; @0024                               v29 = isub v20, v23
 ;; @0024                               v30 = uextend.i64 v29
 ;; @0024                               v31 = isub v28, v30

--- a/tests/disas/gc/drc/multiple-array-get.wat
+++ b/tests/disas/gc/drc/multiple-array-get.wat
@@ -33,28 +33,28 @@
 ;; @0024                               v12 = icmp ult v3, v11
 ;; @0024                               trapz v12, user17
 ;; @0024                               v14 = uextend.i64 v11
-;;                                     v61 = iconst.i64 3
-;;                                     v62 = ishl v14, v61  ; v61 = 3
+;;                                     v62 = iconst.i64 3
+;;                                     v63 = ishl v14, v62  ; v62 = 3
 ;; @0024                               v16 = iconst.i64 32
-;; @0024                               v17 = ushr v62, v16  ; v16 = 32
+;; @0024                               v17 = ushr v63, v16  ; v16 = 32
 ;; @0024                               trapnz v17, user2
-;;                                     v71 = iconst.i32 3
-;;                                     v72 = ishl v11, v71  ; v71 = 3
+;;                                     v70 = iconst.i32 3
+;;                                     v71 = ishl v11, v70  ; v70 = 3
 ;; @0024                               v19 = iconst.i32 32
-;; @0024                               v20 = uadd_overflow_trap v72, v19, user2  ; v19 = 32
+;; @0024                               v20 = uadd_overflow_trap v71, v19, user2  ; v19 = 32
 ;; @0024                               v24 = uadd_overflow_trap v2, v20, user2
 ;; @0024                               v25 = uextend.i64 v24
 ;; @0024                               v28 = iadd v7, v25
-;;                                     v78 = ishl v3, v71  ; v71 = 3
-;; @0024                               v23 = iadd v78, v19  ; v19 = 32
+;;                                     v76 = ishl v3, v70  ; v70 = 3
+;; @0024                               v23 = iadd v76, v19  ; v19 = 32
 ;; @0024                               v29 = isub v20, v23
 ;; @0024                               v30 = uextend.i64 v29
 ;; @0024                               v31 = isub v28, v30
 ;; @0024                               v32 = load.i64 user2 little region4 v31
 ;; @002b                               v40 = icmp ult v4, v11
 ;; @002b                               trapz v40, user17
-;;                                     v80 = ishl v4, v71  ; v71 = 3
-;; @002b                               v51 = iadd v80, v19  ; v19 = 32
+;;                                     v78 = ishl v4, v70  ; v70 = 3
+;; @002b                               v51 = iadd v78, v19  ; v19 = 32
 ;; @002b                               v57 = isub v20, v51
 ;; @002b                               v58 = uextend.i64 v57
 ;; @002b                               v59 = isub v28, v58

--- a/tests/disas/gc/null/array-get.wat
+++ b/tests/disas/gc/null/array-get.wat
@@ -32,20 +32,20 @@
 ;; @0022                               v11 = icmp ult v3, v10
 ;; @0022                               trapz v11, user17
 ;; @0022                               v13 = uextend.i64 v10
-;;                                     v32 = iconst.i64 3
-;;                                     v33 = ishl v13, v32  ; v32 = 3
+;;                                     v33 = iconst.i64 3
+;;                                     v34 = ishl v13, v33  ; v33 = 3
 ;; @0022                               v15 = iconst.i64 32
-;; @0022                               v16 = ushr v33, v15  ; v15 = 32
+;; @0022                               v16 = ushr v34, v15  ; v15 = 32
 ;; @0022                               trapnz v16, user2
-;;                                     v42 = iconst.i32 3
-;;                                     v43 = ishl v10, v42  ; v42 = 3
+;;                                     v41 = iconst.i32 3
+;;                                     v42 = ishl v10, v41  ; v41 = 3
 ;; @0022                               v18 = iconst.i32 16
-;; @0022                               v19 = uadd_overflow_trap v43, v18, user2  ; v18 = 16
+;; @0022                               v19 = uadd_overflow_trap v42, v18, user2  ; v18 = 16
 ;; @0022                               v23 = uadd_overflow_trap v2, v19, user2
 ;; @0022                               v24 = uextend.i64 v23
 ;; @0022                               v27 = iadd v6, v24
-;;                                     v49 = ishl v3, v42  ; v42 = 3
-;; @0022                               v22 = iadd v49, v18  ; v18 = 16
+;;                                     v47 = ishl v3, v41  ; v41 = 3
+;; @0022                               v22 = iadd v47, v18  ; v18 = 16
 ;; @0022                               v28 = isub v19, v22
 ;; @0022                               v29 = uextend.i64 v28
 ;; @0022                               v30 = isub v27, v29

--- a/tests/disas/gc/null/array-new-fixed-of-gc-refs.wat
+++ b/tests/disas/gc/null/array-new-fixed-of-gc-refs.wat
@@ -56,9 +56,9 @@
 ;;                                 block2:
 ;;                                     v158 = iconst.i32 -1476394984
 ;; @0025                               v32 = load.i64 notrap aligned readonly can_move region5 v26+32
-;;                                     v256 = band.i32 v21, v157  ; v157 = -8
-;;                                     v257 = uextend.i64 v256
-;; @0025                               v34 = iadd v32, v257
+;;                                     v252 = band.i32 v21, v157  ; v157 = -8
+;;                                     v253 = uextend.i64 v252
+;; @0025                               v34 = iadd v32, v253
 ;; @0025                               store user2 region8 v158, v34  ; v158 = -1476394984
 ;; @0025                               v37 = load.i64 notrap aligned readonly can_move region6 v0+40
 ;; @0025                               v38 = load.i32 notrap aligned readonly can_move region7 v37
@@ -68,9 +68,9 @@
 ;; @0025                               v39 = iconst.i64 8
 ;; @0025                               v40 = iadd v34, v39  ; v39 = 8
 ;; @0025                               store user2 region8 v5, v40  ; v5 = 3
-;; @0025                               trapz v256, user16
-;;                                     v258 = iconst.i32 24
-;; @0025                               v61 = uadd_overflow_trap v256, v258, user2  ; v258 = 24
+;; @0025                               trapz v252, user16
+;;                                     v254 = iconst.i32 24
+;; @0025                               v61 = uadd_overflow_trap v252, v254, user2  ; v254 = 24
 ;;                                     v130 = load.i32 notrap aligned region11 v131
 ;; @0025                               v62 = uextend.i64 v61
 ;; @0025                               v65 = iadd v32, v62
@@ -83,38 +83,38 @@
 ;; @0025                               trapz v196, user17
 ;; @0025                               v79 = uextend.i64 v76
 ;;                                     v136 = iconst.i64 2
-;;                                     v198 = ishl v79, v136  ; v136 = 2
+;;                                     v199 = ishl v79, v136  ; v136 = 2
 ;; @0025                               v10 = iconst.i64 32
-;; @0025                               v82 = ushr v198, v10  ; v10 = 32
+;; @0025                               v82 = ushr v199, v10  ; v10 = 32
 ;; @0025                               trapnz v82, user2
 ;;                                     v175 = iconst.i32 2
-;;                                     v205 = ishl v76, v175  ; v175 = 2
+;;                                     v204 = ishl v76, v175  ; v175 = 2
 ;; @0025                               v6 = iconst.i32 12
-;; @0025                               v85 = uadd_overflow_trap v205, v6, user2  ; v6 = 12
-;; @0025                               v89 = uadd_overflow_trap v256, v85, user2
+;; @0025                               v85 = uadd_overflow_trap v204, v6, user2  ; v6 = 12
+;; @0025                               v89 = uadd_overflow_trap v252, v85, user2
 ;;                                     v128 = load.i32 notrap aligned region10 v132
 ;; @0025                               v90 = uextend.i64 v89
 ;; @0025                               v93 = iadd v32, v90
-;;                                     v218 = iconst.i32 16
-;; @0025                               v94 = isub v85, v218  ; v218 = 16
+;;                                     v216 = iconst.i32 16
+;; @0025                               v94 = isub v85, v216  ; v216 = 16
 ;; @0025                               v95 = uextend.i64 v94
 ;; @0025                               v96 = isub v93, v95
 ;; @0025                               store user2 little region8 v128, v96
 ;; @0025                               v104 = load.i32 user2 readonly region8 v40
-;;                                     v224 = icmp ugt v104, v175  ; v175 = 2
-;; @0025                               trapz v224, user17
+;;                                     v222 = icmp ugt v104, v175  ; v175 = 2
+;; @0025                               trapz v222, user17
 ;; @0025                               v107 = uextend.i64 v104
-;;                                     v226 = ishl v107, v136  ; v136 = 2
-;; @0025                               v110 = ushr v226, v10  ; v10 = 32
+;;                                     v225 = ishl v107, v136  ; v136 = 2
+;; @0025                               v110 = ushr v225, v10  ; v10 = 32
 ;; @0025                               trapnz v110, user2
-;;                                     v233 = ishl v104, v175  ; v175 = 2
-;; @0025                               v113 = uadd_overflow_trap v233, v6, user2  ; v6 = 12
-;; @0025                               v117 = uadd_overflow_trap v256, v113, user2
+;;                                     v230 = ishl v104, v175  ; v175 = 2
+;; @0025                               v113 = uadd_overflow_trap v230, v6, user2  ; v6 = 12
+;; @0025                               v117 = uadd_overflow_trap v252, v113, user2
 ;;                                     v126 = load.i32 notrap aligned region9 v133
 ;; @0025                               v118 = uextend.i64 v117
 ;; @0025                               v121 = iadd v32, v118
-;;                                     v250 = iconst.i32 20
-;; @0025                               v122 = isub v113, v250  ; v250 = 20
+;;                                     v246 = iconst.i32 20
+;; @0025                               v122 = isub v113, v246  ; v246 = 20
 ;; @0025                               v123 = uextend.i64 v122
 ;; @0025                               v124 = isub v121, v123
 ;; @0025                               store user2 little region8 v126, v124
@@ -126,6 +126,6 @@
 ;; @0025                               jump block2
 ;;
 ;;                                 block1:
-;;                                     v259 = band.i32 v21, v157  ; v157 = -8
-;; @0029                               return v259
+;;                                     v255 = band.i32 v21, v157  ; v157 = -8
+;; @0029                               return v255
 ;; }

--- a/tests/disas/gc/null/array-new-fixed.wat
+++ b/tests/disas/gc/null/array-new-fixed.wat
@@ -44,9 +44,9 @@
 ;;                                 block2:
 ;;                                     v149 = iconst.i32 -1476394968
 ;; @0025                               v32 = load.i64 notrap aligned readonly can_move region5 v26+32
-;;                                     v244 = band.i32 v21, v148  ; v148 = -8
-;;                                     v245 = uextend.i64 v244
-;; @0025                               v34 = iadd v32, v245
+;;                                     v240 = band.i32 v21, v148  ; v148 = -8
+;;                                     v241 = uextend.i64 v240
+;; @0025                               v34 = iadd v32, v241
 ;; @0025                               store user2 region8 v149, v34  ; v149 = -1476394968
 ;; @0025                               v37 = load.i64 notrap aligned readonly can_move region6 v0+40
 ;; @0025                               v38 = load.i32 notrap aligned readonly can_move region7 v37
@@ -56,9 +56,9 @@
 ;; @0025                               v8 = iconst.i64 8
 ;; @0025                               v40 = iadd v34, v8  ; v8 = 8
 ;; @0025                               store user2 region8 v5, v40  ; v5 = 3
-;; @0025                               trapz v244, user16
-;;                                     v246 = iconst.i32 40
-;; @0025                               v61 = uadd_overflow_trap v244, v246, user2  ; v246 = 40
+;; @0025                               trapz v240, user16
+;;                                     v242 = iconst.i32 40
+;; @0025                               v61 = uadd_overflow_trap v240, v242, user2  ; v242 = 40
 ;; @0025                               v62 = uextend.i64 v61
 ;; @0025                               v65 = iadd v32, v62
 ;;                                     v126 = iconst.i64 24
@@ -70,14 +70,14 @@
 ;; @0025                               trapz v185, user17
 ;; @0025                               v79 = uextend.i64 v76
 ;;                                     v125 = iconst.i64 3
-;;                                     v187 = ishl v79, v125  ; v125 = 3
+;;                                     v188 = ishl v79, v125  ; v125 = 3
 ;; @0025                               v10 = iconst.i64 32
-;; @0025                               v82 = ushr v187, v10  ; v10 = 32
+;; @0025                               v82 = ushr v188, v10  ; v10 = 32
 ;; @0025                               trapnz v82, user2
-;;                                     v194 = ishl v76, v5  ; v5 = 3
+;;                                     v193 = ishl v76, v5  ; v5 = 3
 ;; @0025                               v6 = iconst.i32 16
-;; @0025                               v85 = uadd_overflow_trap v194, v6, user2  ; v6 = 16
-;; @0025                               v89 = uadd_overflow_trap v244, v85, user2
+;; @0025                               v85 = uadd_overflow_trap v193, v6, user2  ; v6 = 16
+;; @0025                               v89 = uadd_overflow_trap v240, v85, user2
 ;; @0025                               v90 = uextend.i64 v89
 ;; @0025                               v93 = iadd v32, v90
 ;;                                     v134 = iconst.i32 24
@@ -87,19 +87,19 @@
 ;; @0025                               store.i64 user2 little region8 v3, v96
 ;; @0025                               v104 = load.i32 user2 readonly region8 v40
 ;; @0025                               v97 = iconst.i32 2
-;;                                     v212 = icmp ugt v104, v97  ; v97 = 2
-;; @0025                               trapz v212, user17
+;;                                     v210 = icmp ugt v104, v97  ; v97 = 2
+;; @0025                               trapz v210, user17
 ;; @0025                               v107 = uextend.i64 v104
-;;                                     v214 = ishl v107, v125  ; v125 = 3
-;; @0025                               v110 = ushr v214, v10  ; v10 = 32
+;;                                     v213 = ishl v107, v125  ; v125 = 3
+;; @0025                               v110 = ushr v213, v10  ; v10 = 32
 ;; @0025                               trapnz v110, user2
-;;                                     v221 = ishl v104, v5  ; v5 = 3
-;; @0025                               v113 = uadd_overflow_trap v221, v6, user2  ; v6 = 16
-;; @0025                               v117 = uadd_overflow_trap v244, v113, user2
+;;                                     v218 = ishl v104, v5  ; v5 = 3
+;; @0025                               v113 = uadd_overflow_trap v218, v6, user2  ; v6 = 16
+;; @0025                               v117 = uadd_overflow_trap v240, v113, user2
 ;; @0025                               v118 = uextend.i64 v117
 ;; @0025                               v121 = iadd v32, v118
-;;                                     v238 = iconst.i32 32
-;; @0025                               v122 = isub v113, v238  ; v238 = 32
+;;                                     v234 = iconst.i32 32
+;; @0025                               v122 = isub v113, v234  ; v234 = 32
 ;; @0025                               v123 = uextend.i64 v122
 ;; @0025                               v124 = isub v121, v123
 ;; @0025                               store.i64 user2 little region8 v4, v124
@@ -111,6 +111,6 @@
 ;; @0025                               jump block2
 ;;
 ;;                                 block1:
-;;                                     v247 = band.i32 v21, v148  ; v148 = -8
-;; @0029                               return v247
+;;                                     v243 = band.i32 v21, v148  ; v148 = -8
+;; @0029                               return v243
 ;; }

--- a/tests/disas/gc/null/array-set.wat
+++ b/tests/disas/gc/null/array-set.wat
@@ -32,20 +32,20 @@
 ;; @0024                               v12 = icmp ult v3, v11
 ;; @0024                               trapz v12, user17
 ;; @0024                               v14 = uextend.i64 v11
-;;                                     v32 = iconst.i64 3
-;;                                     v33 = ishl v14, v32  ; v32 = 3
+;;                                     v33 = iconst.i64 3
+;;                                     v34 = ishl v14, v33  ; v33 = 3
 ;; @0024                               v16 = iconst.i64 32
-;; @0024                               v17 = ushr v33, v16  ; v16 = 32
+;; @0024                               v17 = ushr v34, v16  ; v16 = 32
 ;; @0024                               trapnz v17, user2
-;;                                     v42 = iconst.i32 3
-;;                                     v43 = ishl v11, v42  ; v42 = 3
+;;                                     v41 = iconst.i32 3
+;;                                     v42 = ishl v11, v41  ; v41 = 3
 ;; @0024                               v19 = iconst.i32 16
-;; @0024                               v20 = uadd_overflow_trap v43, v19, user2  ; v19 = 16
+;; @0024                               v20 = uadd_overflow_trap v42, v19, user2  ; v19 = 16
 ;; @0024                               v24 = uadd_overflow_trap v2, v20, user2
 ;; @0024                               v25 = uextend.i64 v24
 ;; @0024                               v28 = iadd v7, v25
-;;                                     v49 = ishl v3, v42  ; v42 = 3
-;; @0024                               v23 = iadd v49, v19  ; v19 = 16
+;;                                     v47 = ishl v3, v41  ; v41 = 3
+;; @0024                               v23 = iadd v47, v19  ; v19 = 16
 ;; @0024                               v29 = isub v20, v23
 ;; @0024                               v30 = uextend.i64 v29
 ;; @0024                               v31 = isub v28, v30

--- a/tests/disas/gc/null/multiple-array-get.wat
+++ b/tests/disas/gc/null/multiple-array-get.wat
@@ -33,28 +33,28 @@
 ;; @0024                               v12 = icmp ult v3, v11
 ;; @0024                               trapz v12, user17
 ;; @0024                               v14 = uextend.i64 v11
-;;                                     v61 = iconst.i64 3
-;;                                     v62 = ishl v14, v61  ; v61 = 3
+;;                                     v62 = iconst.i64 3
+;;                                     v63 = ishl v14, v62  ; v62 = 3
 ;; @0024                               v16 = iconst.i64 32
-;; @0024                               v17 = ushr v62, v16  ; v16 = 32
+;; @0024                               v17 = ushr v63, v16  ; v16 = 32
 ;; @0024                               trapnz v17, user2
-;;                                     v71 = iconst.i32 3
-;;                                     v72 = ishl v11, v71  ; v71 = 3
+;;                                     v70 = iconst.i32 3
+;;                                     v71 = ishl v11, v70  ; v70 = 3
 ;; @0024                               v19 = iconst.i32 16
-;; @0024                               v20 = uadd_overflow_trap v72, v19, user2  ; v19 = 16
+;; @0024                               v20 = uadd_overflow_trap v71, v19, user2  ; v19 = 16
 ;; @0024                               v24 = uadd_overflow_trap v2, v20, user2
 ;; @0024                               v25 = uextend.i64 v24
 ;; @0024                               v28 = iadd v7, v25
-;;                                     v78 = ishl v3, v71  ; v71 = 3
-;; @0024                               v23 = iadd v78, v19  ; v19 = 16
+;;                                     v76 = ishl v3, v70  ; v70 = 3
+;; @0024                               v23 = iadd v76, v19  ; v19 = 16
 ;; @0024                               v29 = isub v20, v23
 ;; @0024                               v30 = uextend.i64 v29
 ;; @0024                               v31 = isub v28, v30
 ;; @0024                               v32 = load.i64 user2 little region4 v31
 ;; @002b                               v40 = icmp ult v4, v11
 ;; @002b                               trapz v40, user17
-;;                                     v80 = ishl v4, v71  ; v71 = 3
-;; @002b                               v51 = iadd v80, v19  ; v19 = 16
+;;                                     v78 = ishl v4, v70  ; v70 = 3
+;; @002b                               v51 = iadd v78, v19  ; v19 = 16
 ;; @002b                               v57 = isub v20, v51
 ;; @002b                               v58 = uextend.i64 v57
 ;; @002b                               v59 = isub v28, v58


### PR DESCRIPTION
This PR removes a redundant simplification rule that is already covered by constant canonicalization in `cprop.isle`.

The rule `(2^n) * x --> x << n` is redundant because it can be derived by first canonicalizing the constant operand:
```
(2^n) * x --> x * (2^n) --> x << n
```
So only `x * (2^n) --> (x << n)` rule is needed.

