### PR TITLE
fix: use unaligned reads for debug state slot values

### DIFF
--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -1158,7 +1158,7 @@ impl<'module_environment> FuncEnvironment<'module_environment> {
         // universally supported, while native or
         // big-endian formats may not be in all cases
         // (e.g. Pulley on s390x).
-        let mut flags = MemFlagsData::trusted();
+        let mut flags = MemFlagsData::new().with_notrap();
         if ty == WasmValType::V128 {
             flags.set_endianness(Endianness::Little);
         }
@@ -1166,7 +1166,7 @@ impl<'module_environment> FuncEnvironment<'module_environment> {
     }
 
     fn memflags_for_debug_slot_value_clif_ty(&self, ty: ir::Type) -> MemFlagsData {
-        let mut flags = MemFlagsData::trusted();
+        let mut flags = MemFlagsData::new().with_notrap();
         if ty.is_vector() {
             flags.set_endianness(Endianness::Little);
         }

--- a/crates/wasmtime/src/runtime/debug.rs
+++ b/crates/wasmtime/src/runtime/debug.rs
@@ -772,50 +772,52 @@ unsafe fn read_value(
 ) -> Val {
     let address = unsafe { slot_base.offset(isize::try_from(offset.offset()).unwrap()) };
 
-    // SAFETY: each case reads a value from memory that should be
-    // valid according to our safety condition.
+    // SAFETY: each case reads a value from memory that should be valid
+    // according to our safety condition. State-slot values are packed without
+    // alignment padding, so these loads must accept unaligned addresses.
     match ty {
         FrameValType::I32 => {
-            let value = unsafe { *(address as *const i32) };
+            let value = unsafe { (address as *const i32).read_unaligned() };
             Val::I32(value)
         }
         FrameValType::I64 => {
-            let value = unsafe { *(address as *const i64) };
+            let value = unsafe { (address as *const i64).read_unaligned() };
             Val::I64(value)
         }
         FrameValType::F32 => {
-            let value = unsafe { *(address as *const u32) };
+            let value = unsafe { (address as *const u32).read_unaligned() };
             Val::F32(value)
         }
         FrameValType::F64 => {
-            let value = unsafe { *(address as *const u64) };
+            let value = unsafe { (address as *const u64).read_unaligned() };
             Val::F64(value)
         }
         FrameValType::V128 => {
             // Vectors are always stored as little-endian.
-            let value = unsafe { u128::from_le_bytes(*(address as *const [u8; 16])) };
+            let value =
+                unsafe { u128::from_le_bytes((address as *const [u8; 16]).read_unaligned()) };
             Val::V128(value.into())
         }
         FrameValType::AnyRef => {
             let mut nogc = AutoAssertNoGc::new(store);
-            let value = unsafe { *(address as *const u32) };
+            let value = unsafe { (address as *const u32).read_unaligned() };
             let value = AnyRef::_from_raw(&mut nogc, value);
             Val::AnyRef(value)
         }
         FrameValType::ExnRef => {
             let mut nogc = AutoAssertNoGc::new(store);
-            let value = unsafe { *(address as *const u32) };
+            let value = unsafe { (address as *const u32).read_unaligned() };
             let value = ExnRef::_from_raw(&mut nogc, value);
             Val::ExnRef(value)
         }
         FrameValType::ExternRef => {
             let mut nogc = AutoAssertNoGc::new(store);
-            let value = unsafe { *(address as *const u32) };
+            let value = unsafe { (address as *const u32).read_unaligned() };
             let value = ExternRef::_from_raw(&mut nogc, value);
             Val::ExternRef(value)
         }
         FrameValType::FuncRef => {
-            let value = unsafe { *(address as *const *mut c_void) };
+            let value = unsafe { (address as *const *mut c_void).read_unaligned() };
             let value = unsafe { Func::_from_raw(store, value) };
             Val::FuncRef(value)
         }

--- a/tests/all/debug.rs
+++ b/tests/all/debug.rs
@@ -146,6 +146,38 @@ fn stack_values_two_frames() -> wasmtime::Result<()> {
     Ok(())
 }
 
+/// Regression test: state-slot values are byte-packed, so an `i64` value can
+/// land at an offset that is not aligned for `i64` after an `i32`.
+#[test]
+#[cfg_attr(miri, ignore)]
+fn stack_values_unaligned_i64() -> wasmtime::Result<()> {
+    let _ = env_logger::try_init();
+
+    test_stack_values(
+        r#"
+    (module
+      (import "" "host" (func))
+      (func (export "main")
+        i32.const 1
+        i64.const 0x1122334455667788
+        call 2)
+      (func (param i32 i64)
+        call 0))
+    "#,
+        |_config| {},
+        |mut caller: Caller<'_, ()>| {
+            let stack = caller.debug_exit_frames().next().unwrap();
+            assert_eq!(stack.num_locals(&mut caller)?, 2);
+            assert_eq!(stack.local(&mut caller, 0)?.unwrap_i32(), 1);
+            assert_eq!(
+                stack.local(&mut caller, 1)?.unwrap_i64(),
+                0x1122334455667788
+            );
+            Ok(())
+        },
+    )
+}
+
 #[test]
 #[cfg_attr(miri, ignore)]
 fn stack_values_exceptions() -> wasmtime::Result<()> {


### PR DESCRIPTION
I randomly ran into: `misaligned pointer dereference: address must be a multiple of 0x8 but is ...` when using the guest debugging api to inspect the frame. I couldn't find an issue for it, but the change is so small that I decided to just open a PR directly.

The issue seems to be that debug frames are packed without any padding, but on the read side it's assuming natural alignment. Then an i64 can end up in a 4-byte-aligned address if there is an i32 before it, for example.

I think the 4-byte types don't necessarily need this change, and is unlikely it will change, but I just switched all of them for consistency.