### PR TITLE
Adjust handling null references in the C API

### DIFF
--- a/crates/c-api/src/arrayref.rs
+++ b/crates/c-api/src/arrayref.rs
@@ -74,16 +74,15 @@ pub unsafe extern "C" fn wasmtime_arrayref_len(
     arrayref: Option<&wasmtime_arrayref_t>,
     out: &mut MaybeUninit<u32>,
 ) -> Option<Box<crate::wasmtime_error_t>> {
-    let arrayref = arrayref
-        .and_then(|a| a.as_wasmtime())
-        .expect("non-null arrayref required");
-    match arrayref.len(&cx) {
-        Ok(len) => {
-            out.write(len);
-            None
-        }
-        Err(e) => Some(Box::new(e.into())),
-    }
+    let result = (|| {
+        let arrayref = arrayref
+            .and_then(|a| a.as_wasmtime())
+            .ok_or_else(|| wasmtime::format_err!("non-null arrayref required"))?;
+        arrayref.len(&cx)
+    })();
+    crate::handle_result(result, |len| {
+        out.write(len);
+    })
 }
 
 #[unsafe(no_mangle)]
@@ -93,19 +92,18 @@ pub unsafe extern "C" fn wasmtime_arrayref_get(
     index: u32,
     out: &mut MaybeUninit<crate::wasmtime_val_t>,
 ) -> Option<Box<crate::wasmtime_error_t>> {
-    let arrayref = arrayref
-        .and_then(|a| a.as_wasmtime())
-        .expect("non-null arrayref required");
-    let mut scope = RootScope::new(&mut cx);
-    let rooted = arrayref.to_rooted(&mut scope);
-    match rooted.get(&mut scope, index) {
-        Ok(val) => {
-            let c_val = crate::wasmtime_val_t::from_val(&mut scope, val);
-            out.write(c_val);
-            None
-        }
-        Err(e) => Some(Box::new(e.into())),
-    }
+    let result = (|| {
+        let arrayref = arrayref
+            .and_then(|a| a.as_wasmtime())
+            .ok_or_else(|| wasmtime::format_err!("non-null arrayref required"))?;
+        let mut scope = RootScope::new(&mut cx);
+        let rooted = arrayref.to_rooted(&mut scope);
+        let val = rooted.get(&mut scope, index)?;
+        Ok(crate::wasmtime_val_t::from_val(&mut scope, val))
+    })();
+    crate::handle_result(result, |val| {
+        out.write(val);
+    })
 }
 
 #[unsafe(no_mangle)]
@@ -115,16 +113,16 @@ pub unsafe extern "C" fn wasmtime_arrayref_set(
     index: u32,
     val: &crate::wasmtime_val_t,
 ) -> Option<Box<crate::wasmtime_error_t>> {
-    let arrayref = arrayref
-        .and_then(|a| a.as_wasmtime())
-        .expect("non-null arrayref required");
-    let mut scope = RootScope::new(&mut cx);
-    let rooted = arrayref.to_rooted(&mut scope);
-    let rust_val = val.to_val(&mut scope);
-    match rooted.set(&mut scope, index, rust_val) {
-        Ok(()) => None,
-        Err(e) => Some(Box::new(e.into())),
-    }
+    let result = (|| {
+        let arrayref = arrayref
+            .and_then(|a| a.as_wasmtime())
+            .ok_or_else(|| wasmtime::format_err!("non-null arrayref required"))?;
+        let mut scope = RootScope::new(&mut cx);
+        let rooted = arrayref.to_rooted(&mut scope);
+        let rust_val = val.to_val(&mut scope);
+        rooted.set(&mut scope, index, rust_val)
+    })();
+    crate::handle_result(result, |_| {})
 }
 
 #[unsafe(no_mangle)]

--- a/crates/c-api/src/exnref.rs
+++ b/crates/c-api/src/exnref.rs
@@ -105,7 +105,7 @@ pub unsafe extern "C" fn wasmtime_context_set_exception(
             let Err(thrown) = scope
                 .as_context_mut()
                 .throw::<std::convert::Infallible>(rooted);
-            thrown.into()
+            thrown
         }
         None => wasmtime::format_err!("exnref is null"),
     };

--- a/crates/c-api/src/exnref.rs
+++ b/crates/c-api/src/exnref.rs
@@ -46,9 +46,14 @@ pub extern "C" fn wasmtime_exnref_tag(
     exn: &wasmtime_exnref_t,
     tag_ret: &mut Tag,
 ) -> Option<Box<wasmtime_error_t>> {
-    let mut scope = RootScope::new(&mut store);
-    let rooted = unsafe { exn.as_wasmtime()?.to_rooted(&mut scope) };
-    handle_result(rooted.tag(&mut scope), |tag| {
+    let result = (|| {
+        let exn = unsafe {
+            exn.as_wasmtime()
+                .ok_or_else(|| wasmtime::format_err!("exnref is null"))?
+        };
+        exn.tag(&mut store)
+    })();
+    handle_result(result, |tag| {
         *tag_ret = tag;
     })
 }
@@ -74,10 +79,17 @@ pub unsafe extern "C" fn wasmtime_exnref_field(
     index: usize,
     val_ret: &mut MaybeUninit<wasmtime_val_t>,
 ) -> Option<Box<wasmtime_error_t>> {
-    let mut scope = RootScope::new(&mut store);
-    let rooted = exn.as_wasmtime()?.to_rooted(&mut scope);
-    handle_result(rooted.field(&mut scope, index), |val| {
-        val_ret.write(wasmtime_val_t::from_val(&mut scope, val));
+    let result = (|| {
+        let mut scope = RootScope::new(&mut store);
+        let exn = unsafe {
+            exn.as_wasmtime()
+                .ok_or_else(|| wasmtime::format_err!("exnref is null"))?
+        };
+        let field = exn.field(&mut scope, index)?;
+        Ok(wasmtime_val_t::from_val(&mut scope, field))
+    })();
+    handle_result(result, |val| {
+        val_ret.write(val);
     })
 }
 
@@ -87,11 +99,17 @@ pub unsafe extern "C" fn wasmtime_context_set_exception(
     exn: &wasmtime_exnref_t,
 ) -> Option<Box<wasm_trap_t>> {
     let mut scope = RootScope::new(&mut store);
-    let rooted = exn.as_wasmtime()?.to_rooted(&mut scope);
-    let Err(thrown) = scope
-        .as_context_mut()
-        .throw::<std::convert::Infallible>(rooted);
-    Some(Box::new(wasm_trap_t::new(thrown)))
+    let err = match exn.as_wasmtime() {
+        Some(e) => {
+            let rooted = e.to_rooted(&mut scope);
+            let Err(thrown) = scope
+                .as_context_mut()
+                .throw::<std::convert::Infallible>(rooted);
+            thrown.into()
+        }
+        None => wasmtime::format_err!("exnref is null"),
+    };
+    Some(Box::new(wasm_trap_t::new(err)))
 }
 
 #[unsafe(no_mangle)]

--- a/crates/c-api/src/structref.rs
+++ b/crates/c-api/src/structref.rs
@@ -78,19 +78,18 @@ pub unsafe extern "C" fn wasmtime_structref_field(
     index: usize,
     out: &mut MaybeUninit<crate::wasmtime_val_t>,
 ) -> Option<Box<crate::wasmtime_error_t>> {
-    let structref = structref
-        .and_then(|s| s.as_wasmtime())
-        .expect("non-null structref required");
-    let mut scope = RootScope::new(&mut cx);
-    let rooted = structref.to_rooted(&mut scope);
-    match rooted.field(&mut scope, index) {
-        Ok(val) => {
-            let c_val = crate::wasmtime_val_t::from_val(&mut scope, val);
-            out.write(c_val);
-            None
-        }
-        Err(e) => Some(Box::new(e.into())),
-    }
+    let result = (|| {
+        let structref = structref
+            .and_then(|s| s.as_wasmtime())
+            .ok_or_else(|| wasmtime::format_err!("non-null structref required"))?;
+        let mut scope = RootScope::new(&mut cx);
+        let rooted = structref.to_rooted(&mut scope);
+        let val = rooted.field(&mut scope, index)?;
+        Ok(crate::wasmtime_val_t::from_val(&mut scope, val))
+    })();
+    crate::handle_result(result, |val| {
+        out.write(val);
+    })
 }
 
 #[unsafe(no_mangle)]
@@ -100,16 +99,15 @@ pub unsafe extern "C" fn wasmtime_structref_set_field(
     index: usize,
     val: &crate::wasmtime_val_t,
 ) -> Option<Box<crate::wasmtime_error_t>> {
-    let structref = structref
-        .and_then(|s| s.as_wasmtime())
-        .expect("non-null structref required");
-    let mut scope = RootScope::new(&mut cx);
-    let rooted = structref.to_rooted(&mut scope);
-    let rust_val = val.to_val(&mut scope);
-    match rooted.set_field(&mut scope, index, rust_val) {
-        Ok(()) => None,
-        Err(e) => Some(Box::new(e.into())),
-    }
+    let result = (|| {
+        let structref = structref
+            .and_then(|s| s.as_wasmtime())
+            .ok_or_else(|| wasmtime::format_err!("non-null structref required"))?;
+        let mut scope = RootScope::new(&mut cx);
+        let rust_val = val.to_val(&mut scope);
+        structref.set_field(&mut scope, index, rust_val)
+    })();
+    crate::handle_result(result, |()| {})
 }
 
 #[unsafe(no_mangle)]

--- a/crates/c-api/tests/exception.cc
+++ b/crates/c-api/tests/exception.cc
@@ -228,3 +228,19 @@ TEST(Exception, WasmThrowHostCatch) {
   auto f0 = exn->field(cx, 0).unwrap();
   EXPECT_EQ(f0.i32(), 77);
 }
+
+TEST(ExnRef, NullAndMethods) {
+  Config config;
+  config.wasm_gc(true);
+  Engine engine(std::move(config));
+  Store store(engine);
+
+  wasmtime_exnref_t null_raw;
+  wasmtime_exnref_set_null(&null_raw);
+  ExnRef null(null_raw);
+  EXPECT_FALSE(null.tag(store));
+  EXPECT_EQ(null.field_count(store), 0);
+  EXPECT_FALSE(null.field(store, 0));
+
+  store.context().throw_exception(null);
+}

--- a/crates/c-api/tests/gc.cc
+++ b/crates/c-api/tests/gc.cc
@@ -263,6 +263,20 @@ TEST(ArrayRef, UpcastAndDowncast) {
   EXPECT_FALSE(aty->element_type().is_mutable());
 }
 
+TEST(ArrayRef, NullAndMethods) {
+  Config config;
+  config.wasm_gc(true);
+  Engine engine(std::move(config));
+  Store store(engine);
+
+  wasmtime_arrayref_t null_raw;
+  wasmtime_arrayref_set_null(&null_raw);
+  ArrayRef null(null_raw);
+  EXPECT_FALSE(null.len(store));
+  EXPECT_FALSE(null.get(store, 0));
+  EXPECT_FALSE(null.set(store, 0, 0));
+}
+
 TEST(AnyRef, DowncastI31) {
   Config config;
   config.wasm_gc(true);
@@ -342,4 +356,18 @@ TEST(AnyRef, DowncastArray) {
   auto len = arr2.len(cx);
   ASSERT_TRUE(len);
   EXPECT_EQ(len.ok(), 2u);
+}
+
+TEST(StructRef, NullAndMethods) {
+  Config config;
+  config.wasm_gc(true);
+  Engine engine(std::move(config));
+  Store store(engine);
+
+  wasmtime_structref_t null_raw;
+  wasmtime_structref_set_null(&null_raw);
+  StructRef null(null_raw);
+  // EXPECT_FALSE(null.len(store));
+  EXPECT_FALSE(null.field(store, 0));
+  EXPECT_FALSE(null.set_field(store, 0, 0));
 }


### PR DESCRIPTION
Translate panics to errors and don't use `?` to return a null error without returning anything as well.

Closes #13785

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
