### PR TITLE
Tag passive element segment `ValRaw` accesses with an alias region

### DIFF
--- a/crates/cranelift/src/alias_region.rs
+++ b/crates/cranelift/src/alias_region.rs
@@ -112,6 +112,9 @@ enum AliasRegionKey {
     /// aliasing of the embedder's data structures that the unsafe intrinsics do
     /// access, so all their accesses are lumped together into the same region.
     UnsafeIntrinsicMemory,
+
+    /// An access of a `ValRaw` inside a passive element segment.
+    ElementSegment,
 }
 
 impl AliasRegionKey {
@@ -163,6 +166,7 @@ impl AliasRegionKey {
     const COMPONENT_BUILTIN_FUNCTIONS_KIND: u32 = Self::new_kind(0b11100);
     const UNSAFE_INTRINSIC_MEMORY_KIND: u32 = Self::new_kind(0b11101);
     const HOST_VAL_RAW_KIND: u32 = Self::new_kind(0b11110);
+    const ELEMENT_SEGMENT_KIND: u32 = Self::new_kind(0b11111);
 
     /// Encode this key into a raw `u32` suitable for use as an
     /// `AliasRegionData::user_id`.
@@ -235,6 +239,7 @@ impl AliasRegionKey {
                 Self::STACK_KIND | (slot.as_u32() & Self::OFFSET_MASK)
             }
             AliasRegionKey::UnsafeIntrinsicMemory => Self::UNSAFE_INTRINSIC_MEMORY_KIND,
+            AliasRegionKey::ElementSegment => Self::ELEMENT_SEGMENT_KIND,
         }
     }
 }
@@ -258,6 +263,7 @@ impl fmt::Debug for AliasRegionKey {
             AliasRegionKey::GcHeap => write!(f, "GcHeap"),
             AliasRegionKey::Stack { slot } => write!(f, "Stack({slot:?})"),
             AliasRegionKey::UnsafeIntrinsicMemory => write!(f, "UnsafeIntrinsicMemory"),
+            AliasRegionKey::ElementSegment => write!(f, "ElementSegment"),
         }
     }
 }
@@ -2083,6 +2089,19 @@ where
                 offset: 0,
             },
         )
+    }
+}
+
+/// Passive element-related methods.
+impl<Offsets> AliasRegions<Offsets>
+where
+    Offsets: GetPtrSize,
+{
+    /// Get the alias region for the runtime `ValRaw` storage of passive element
+    /// segments (written by passive-element initialization and read by
+    /// `table.init` and `array.{new,init}_elem`).
+    pub fn element_segment_region(&mut self, func: &mut ir::Function) -> ir::AliasRegion {
+        self.region(func, AliasRegionKey::ElementSegment)
     }
 }
 

--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -419,10 +419,18 @@ impl<'module_environment> FuncEnvironment<'module_environment> {
             CheckedEntity::Memory(index) => Some(self.memory_alias_region(func, index)),
             CheckedEntity::Table { table, .. } => Some(self.table_alias_region(func, table)),
             CheckedEntity::Array { .. } => Some(self.alias_regions.gc_heap_region(func)),
-            CheckedEntity::Data { .. } | CheckedEntity::RuntimeData(_) | CheckedEntity::Elem(_) => {
-                None
-            }
+            CheckedEntity::Elem(_) => Some(self.alias_regions.element_segment_region(func)),
+            CheckedEntity::Data { .. } | CheckedEntity::RuntimeData(_) => None,
         }
+    }
+
+    /// Build the `MemFlags` for accessing a passive element segment's runtime
+    /// `ValRaw` storage: little-endian, tagged with the `ElementSegment` region.
+    fn element_segment_memflags(&mut self, func: &mut Function) -> ir::MemFlagsData {
+        let region = self.alias_regions.element_segment_region(func);
+        ir::MemFlagsData::trusted()
+            .with_endianness(Endianness::Little)
+            .with_alias_region(Some(region))
     }
 
     fn get_memory_atomic_wait(&mut self, func: &mut Function, ty: ir::Type) -> ir::FuncRef {
@@ -4630,9 +4638,7 @@ impl FuncEnvironment<'_> {
                         let WasmStorageType::Val(WasmValType::Ref(ty)) = write_ty else {
                             unreachable!();
                         };
-                        // `ValRaw` is always stored as little-endian
-                        let mut flags = ir::MemFlagsData::trusted();
-                        flags.set_endianness(Endianness::Little);
+                        let flags = this.element_segment_memflags(builder.func);
 
                         match ty.heap_type.top() {
                             WasmHeapTopType::Func => {
@@ -5896,13 +5902,11 @@ impl FuncEnvironment<'_> {
         let call = builder.ins().call(libcall, &[vmctx, idx]);
         let base = builder.func.dfg.first_result(call);
 
-        // Values in `ValRaw` are always stored in little-endian.
-        let flags = ir::MemFlagsData::trusted().with_endianness(Endianness::Little);
-
         match exprs {
             TableSegmentElements::Functions(indices) => {
                 for (i, func) in indices.iter().enumerate() {
                     let func = self.translate_ref_func(builder.cursor(), *func)?;
+                    let flags = self.element_segment_memflags(builder.func);
                     builder.ins().store(
                         flags,
                         func,
@@ -5924,6 +5928,7 @@ impl FuncEnvironment<'_> {
                             gc::init_field_at_addr(self, builder, ty, dst, val)?;
                         }
                         WasmHeapTopType::Func | WasmHeapTopType::Cont => {
+                            let flags = self.element_segment_memflags(builder.func);
                             builder.ins().store(
                                 flags,
                                 val,

--- a/tests/disas/elem-segment.wat
+++ b/tests/disas/elem-segment.wat
@@ -1,0 +1,63 @@
+;;! target = "x86_64"
+;;! test = "optimize"
+;;! filter = "module_start"
+
+;; Passive funcref element segments store their `ref.func` values into the
+;; runtime `ValRaw` storage of the segment during instantiation. Those stores
+;; should carry the `ElementSegment` alias region.
+
+(module
+  (func $f)
+  (elem func $f $f $f)
+)
+;; function u2415919104:1(i64 vmctx, i64, i64, i64) -> i8 system_v {
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 134217800 "VMStoreContext+0x48"
+;;     region2 = 134217792 "VMStoreContext+0x40"
+;;     region3 = 134217808 "VMStoreContext+0x50"
+;;     region4 = 134217864 "VMStoreContext+0x88"
+;;     sig0 = (i64 vmctx, i64) tail
+;;     fn0 = colocated u2415919104:0 sig0
+;;
+;; block0(v0: i64, v1: i64, v2: i64, v3: i64):
+;;     jump block1
+;;
+;; block1:
+;;     v5 = get_frame_pointer.i64 
+;;     v4 = load.i64 notrap aligned readonly can_move region0 v0+8
+;;     store notrap aligned region1 v5, v4+72
+;;     v6 = get_stack_pointer.i64 
+;;     store notrap aligned region2 v6, v4+64
+;;     v7 = get_exception_handler_address.i64 block1, 0
+;;     store notrap aligned region3 v7, v4+80
+;;     try_call fn0(v0, v1), sig0, block2, [ default: block3 ]
+;;
+;; block2:
+;;     v8 = iconst.i8 1
+;;     return v8  ; v8 = 1
+;;
+;; block3:
+;;     v9 = iconst.i64 1
+;;     store notrap aligned region4 v9, v4+136  ; v9 = 1
+;;     v10 = iconst.i8 0
+;;     return v10  ; v10 = 0
+;; }
+;;
+;; function u2415919104:0(i64 vmctx, i64) tail {
+;;     region0 = 4160749568 "ElementSegment"
+;;     sig0 = (i64 vmctx, i32) -> i64 tail
+;;     sig1 = (i64 vmctx, i32) -> i64 tail
+;;     fn0 = colocated u805306368:4 sig0
+;;     fn1 = colocated u805306368:6 sig1
+;;
+;; block0(v0: i64, v1: i64):
+;;     v2 = iconst.i32 0
+;;     v3 = call fn0(v0, v2)  ; v2 = 0
+;;     v5 = call fn1(v0, v2)  ; v2 = 0
+;;     store notrap aligned little region0 v5, v3
+;;     v7 = call fn1(v0, v2)  ; v2 = 0
+;;     store notrap aligned little region0 v7, v3+16
+;;     v9 = call fn1(v0, v2)  ; v2 = 0
+;;     store notrap aligned little region0 v9, v3+32
+;;     return
+;; }


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
