### PR TITLE
Tag the stack switching control context temp slot with an alias region

### DIFF
--- a/crates/cranelift/src/func_environ/stack_switching/instructions.rs
+++ b/crates/cranelift/src/func_environ/stack_switching/instructions.rs
@@ -1921,13 +1921,15 @@ pub(crate) fn translate_switch<'a>(
         let tmp_control_context = builder.ins().stack_addr(env.pointer_type(), slot, 0);
 
         // The `*_last_ancestor_cc` control contexts live on continuation
-        // stacks, but the temporary lives in a current-frame stack slot, so
-        // only the former get the continuation-stack-memory region.
+        // stacks, but the temporary lives in a current-frame stack slot, so the
+        // former get the continuation-stack-memory region while the latter gets
+        // its own stack-slot region.
         let region = env
             .alias_regions
             .continuation_stack_memory_region(builder.func);
         let cc_flags = MemFlagsData::trusted().with_alias_region(Some(region));
-        let tmp_flags = MemFlagsData::trusted();
+        let tmp_region = env.alias_regions.stack_slot_region(builder.func, slot);
+        let tmp_flags = MemFlagsData::trusted().with_alias_region(Some(tmp_region));
         let mut offset: i32 = 0;
         while offset < i32::from(cctx_size) {
             // switchee_last_ancestor_cc -> tmp control context

--- a/tests/disas/stack-switching/symmetric-switch.wat
+++ b/tests/disas/stack-switching/symmetric-switch.wat
@@ -33,6 +33,7 @@
 ;;     region3 = 134217816 "VMStoreContext+0x58"
 ;;     region4 = 2281701376 "ContinuationStackMemory+0x0"
 ;;     region5 = 134217800 "VMStoreContext+0x48"
+;;     region6 = 3087007744 "Stack(ss0)"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -204,15 +205,15 @@
 ;; @003e                               v118 = iadd v116, v117  ; v117 = -24
 ;; @003e                               v119 = stack_addr.i64 ss0
 ;; @003e                               v120 = load.i64 notrap aligned region4 v118
-;; @003e                               store notrap aligned v120, v119
+;; @003e                               store notrap aligned region6 v120, v119
 ;; @003e                               v121 = load.i64 notrap aligned region4 v113
 ;; @003e                               store notrap aligned region4 v121, v118
 ;; @003e                               v122 = load.i64 notrap aligned region4 v118+8
-;; @003e                               store notrap aligned v122, v119+8
+;; @003e                               store notrap aligned region6 v122, v119+8
 ;; @003e                               v123 = load.i64 notrap aligned region4 v113+8
 ;; @003e                               store notrap aligned region4 v123, v118+8
 ;; @003e                               v124 = load.i64 notrap aligned region4 v118+16
-;; @003e                               store notrap aligned v124, v119+16
+;; @003e                               store notrap aligned region6 v124, v119+16
 ;; @003e                               v125 = load.i64 notrap aligned region4 v113+16
 ;; @003e                               store notrap aligned region4 v125, v118+16
 ;; @003e                               v126 = iconst.i64 3


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
