### PR TITLE
Cranelift: extend alias analysis to eliminate dead stores

### DIFF
--- a/cranelift/codegen/src/alias_analysis.rs
+++ b/cranelift/codegen/src/alias_analysis.rs
@@ -62,17 +62,74 @@
 //! must be correct likely reduce the potential benefit, we don't yet
 //! do this.
 
+use crate::cursor::CursorPosition;
 use crate::{FxHashMap, FxHashSet};
 use crate::{
     cursor::{Cursor, FuncCursor},
     dominator_tree::DominatorTree,
-    inst_predicates::{
-        has_memory_fence_semantics, inst_addr_offset_type, inst_store_data, visit_block_succs,
-    },
+    inst_predicates::{inst_addr_offset_type, inst_store_data, visit_block_succs},
     ir::{AliasRegion, Block, Function, Inst, Opcode, Type, Value, immediates::Offset32},
+    post_dominator_tree::PostDominatorTree,
     trace,
 };
+use cranelift_entity::EntitySet;
 use cranelift_entity::{EntityRef, SecondaryMap, packed_option::PackedOption};
+
+/// Determine whether this opcode behaves as a memory fence, i.e.,
+/// prohibits any moving of memory accesses across it.
+fn has_memory_fence_semantics(op: Opcode) -> bool {
+    match op {
+        Opcode::AtomicRmw
+        | Opcode::AtomicCas
+        | Opcode::AtomicLoad
+        | Opcode::AtomicStore
+        | Opcode::Fence
+        | Opcode::Debugtrap
+        | Opcode::SequencePoint => true,
+        Opcode::Call | Opcode::CallIndirect | Opcode::TryCall | Opcode::TryCallIndirect => true,
+        _ => false,
+    }
+}
+
+/// A description of which alias region(s) can an instruction observe.
+enum AliasRegionsObserved {
+    /// All alias regions.
+    All,
+    /// Just the given alias region.
+    Just(AliasRegion),
+    /// Just the "other" / missing alias region.
+    Other,
+    /// No alias regions observed.
+    None,
+}
+
+/// Which alias region(s) can an instruction observe?
+fn alias_regions_observed(func: &Function, inst: Inst) -> AliasRegionsObserved {
+    let opcode = func.dfg.insts[inst].opcode();
+    if opcode.is_return()
+        || opcode.is_call()
+        || opcode.can_trap()
+        // NB: the `opcode.can_trap()` check above only covers explicitly
+        // trapping instructions (like `trap` and `trapz`), not loads/stores
+        // that can implicitly trap; we check those via their memflags.
+        || func.dfg.insts[inst]
+            .memflags_data(&func.dfg)
+            .and_then(|flags| flags.trap_code())
+            .is_some()
+    {
+        return AliasRegionsObserved::All;
+    }
+
+    if opcode.can_load() {
+        if let Some(region) = func.dfg.insts[inst].alias_region(&func.dfg) {
+            AliasRegionsObserved::Just(region)
+        } else {
+            AliasRegionsObserved::Other
+        }
+    } else {
+        AliasRegionsObserved::None
+    }
+}
 
 /// For a given program point, the vector of last-store instruction
 /// indices for each disjoint category of abstract state.
@@ -80,71 +137,209 @@ use cranelift_entity::{EntityRef, SecondaryMap, packed_option::PackedOption};
 pub struct LastStores {
     /// Last store for each named alias region.
     regions: SecondaryMap<AliasRegion, PackedOption<Inst>>,
+
+    /// Whether each region has been observed or not since it was last stored
+    /// to.
+    observed_regions: EntitySet<AliasRegion>,
+
     /// Last store for memory accesses with no alias region.
     other: PackedOption<Inst>,
+
+    /// Whether the other/missing alias region has been observed since it was
+    /// last stored to.
+    observed_other: bool,
+
     /// Last instruction with fence semantics. This applies to ALL regions,
     /// including ones not yet in the `regions` map.
     last_fence: PackedOption<Inst>,
+
+    /// Whether all alias regions have been observed since they were last stored
+    /// to (e.g. via a memory fence or a call).
+    observed_all: bool,
 }
 
 impl LastStores {
-    fn update(&mut self, func: &Function, inst: Inst) {
+    pub(crate) fn update(&mut self, func: &Function, inst: Inst) {
         let opcode = func.dfg.insts[inst].opcode();
+
         if has_memory_fence_semantics(opcode) {
-            self.regions.clear();
-            self.last_fence = inst.into();
-            self.other = inst.into();
-        } else if opcode.can_store() {
+            self.fence(inst);
+        }
+        // Explicitly trapping instructions (`trap`, `trapz`, `udiv`,
+        // `uadd_overflow_trap`, etc... but not loads/stores that can implicitly
+        // trap): allow store-to-load forwarding across these instructions, but
+        // do not eliminate dead stores across them, as that would change the
+        // state of memory on trap. We do this by marking every region with a
+        // last-store as observed, but not clearing its last-store information.
+        else if opcode.can_trap() {
+            self.observe_others(None);
+        }
+        // Store instructions: update the last-store information for this
+        // instruction's alias region, or, if it has no alias region, treat it
+        // as a fence.
+        else if opcode.can_store() {
             if let Some(memflags) = func.dfg.insts[inst].memflags() {
                 match func.dfg.mem_flags[memflags].alias_region() {
-                    Some(region) => self.regions[region] = inst.into(),
+                    Some(region) => {
+                        self.regions[region] = inst.into();
+                        self.observed_regions.remove(region);
+
+                        // And if this store can trap, then we need to observe
+                        // all other alias regions, to ensure that their state
+                        // is preserved in the case that this store traps
+                        // (similar to the `can_trap()` handling above).
+                        //
+                        // This prevents removing the first store in the
+                        // following snippet, for example:
+                        //
+                        //     store notrap region0 v0, v3+8
+                        //     store user42 region1 v1, v4+16
+                        //     store notrap region0 v2, v3+8
+                        //
+                        // Removing it would be invalid because it drops a
+                        // memory store to `v3+8` that would otherwise have been
+                        // performed when writing to `v4+16` traps.
+                        //
+                        // On the other hand, if it cannot trap, then we need to
+                        // observe all the regions whose last-store *can* trap
+                        // so that we don't allow a non-trapping store to
+                        // effectively be moved ahead of a trapping store:
+                        //
+                        //     store user42 region0 v0, v3+8
+                        //     store notrap region1 v1, v4+16
+                        //     store user42 region0 v2, v3+8
+                        //
+                        // In this case, removing the first store would mean
+                        // that when writing to `v3+8` traps, we would
+                        // incorrectly store to `v4+16`, when we otherwise
+                        // wouldn't have.
+                        if func.dfg.mem_flags[memflags].trap_code().is_some() {
+                            self.observe_others(Some(region));
+                        } else {
+                            self.observe_trapping_others(region, func);
+                        }
+                    }
                     None => {
                         // A store with no alias region may alias any region, so
-                        // treat it like a fence: clear all regions and update
-                        // `last_fence` so that subsequent region-tagged loads don't
-                        // forward stale values past this store.
-                        self.regions.clear();
-                        self.last_fence = inst.into();
-                        self.other = inst.into();
+                        // treat it like a fence.
+                        self.fence(inst);
                     }
                 }
             } else {
-                // Store with no memflags: must clobber everything.
-                self.regions.clear();
-                self.last_fence = inst.into();
-                self.other = inst.into();
+                // Store with no memflags (and therefore no region):
+                // treat it like a fence.
+                self.fence(inst);
+            }
+        }
+        // Everything else: determine which, if any, alias regions this
+        // instruction observes.
+        else {
+            match alias_regions_observed(func, inst) {
+                AliasRegionsObserved::All => {
+                    self.observed_all = true;
+                }
+                AliasRegionsObserved::Just(region) => {
+                    self.observed_regions.insert(region);
+                    // NB: Because stores without regions may alias any other
+                    // region, we have also observed the last-store in
+                    // `self.other`.
+                    self.observed_other = true;
+                }
+                AliasRegionsObserved::Other => {
+                    self.observed_other = true;
+                }
+                AliasRegionsObserved::None => {}
             }
         }
     }
 
-    fn get_last_store(&self, func: &Function, inst: Inst) -> PackedOption<Inst> {
+    /// Mark all regions except for `excluding` (if given) as observed.
+    fn observe_others(&mut self, excluding: Option<AliasRegion>) {
+        for (region, last_store) in self.regions.iter() {
+            if last_store.is_some() && excluding.is_none_or(|r| r != region) {
+                self.observed_regions.insert(region);
+            }
+        }
+        self.observed_other = true;
+    }
+
+    /// Mark all regions whose last-store can trap as observed, except for
+    /// `excluding`.
+    fn observe_trapping_others(&mut self, excluding: AliasRegion, func: &Function) {
+        for (region, last_store) in self.regions.iter() {
+            if region != excluding
+                && last_store
+                    .expand()
+                    .is_some_and(|s| func.dfg.insts[s].memflags_trap_code(&func.dfg).is_some())
+            {
+                self.observed_regions.insert(region);
+            }
+        }
+
+        self.observed_other |= self
+            .other
+            .expand()
+            .is_some_and(|s| func.dfg.insts[s].memflags_trap_code(&func.dfg).is_some());
+    }
+
+    /// Handle memory fence-like instructions by clearing all analysis data.
+    fn fence(&mut self, inst: Inst) {
+        self.regions.clear();
+        self.observed_regions.clear();
+        self.other = inst.into();
+        self.observed_other = false;
+        self.last_fence = inst.into();
+        self.observed_all = false;
+    }
+
+    /// Get the last-store instruction for the given `inst`'s alias region, if
+    /// any, and whether that alias region has been observed or not.
+    fn get_last_store(&self, func: &Function, inst: Inst) -> (PackedOption<Inst>, bool) {
         if let Some(memflags) = func.dfg.insts[inst].memflags() {
             match func.dfg.mem_flags[memflags].alias_region() {
-                None => self.other,
+                None => return (self.other, self.observed_all || self.observed_other),
                 Some(region) => {
                     let region_store = self.regions[region];
                     // If the region has never been explicitly stored to,
                     // fall back to the last fence (which affects all regions).
                     if region_store.is_none() {
-                        self.last_fence
+                        return (self.last_fence, self.observed_all);
                     } else {
-                        region_store
+                        return (
+                            region_store,
+                            self.observed_all || self.observed_regions.contains(region),
+                        );
                     }
                 }
             }
-        } else if func.dfg.insts[inst].opcode().can_load()
-            || func.dfg.insts[inst].opcode().can_store()
-        {
-            inst.into()
+        }
+
+        let opcode = func.dfg.insts[inst].opcode();
+        if opcode.can_load() || opcode.can_store() {
+            (
+                inst.into(),
+                opcode.can_load() || self.observed_all || self.observed_other,
+            )
         } else {
-            PackedOption::default()
+            (None.into(), true)
         }
     }
 
-    /// Meet `self` with `other` and place the result in `self`.
+    /// Meet `self` with `rhs`, placing the result in `self`.
     ///
     /// Returns `true` if `self` changed, `false` otherwise.
-    fn meet_from(&mut self, other: &LastStores, loc: Inst) -> bool {
+    fn meet_from(&mut self, rhs: &LastStores, loc: Inst) -> bool {
+        // NB: Destructure to make sure we don't accidentally forget a
+        // field.
+        let LastStores {
+            regions,
+            observed_regions,
+            other,
+            observed_other,
+            last_fence,
+            observed_all,
+        } = self;
+
         let meet = |a: &mut PackedOption<Inst>, b: PackedOption<Inst>| -> bool {
             let old = a.expand();
             let new = match (old, b.expand()) {
@@ -156,15 +351,38 @@ impl LastStores {
             old != new
         };
 
-        // Meet all region slots.
+        let union_set_entry = |a: &mut EntitySet<AliasRegion>,
+                               b: &EntitySet<AliasRegion>,
+                               region: AliasRegion|
+         -> bool {
+            if b.contains(region) {
+                a.insert(region)
+            } else {
+                false
+            }
+        };
+
+        let union_bool = |a: &mut bool, b: bool| -> bool {
+            let old = *a;
+            *a = *a || b;
+            *a != old
+        };
+
         let mut changed = false;
-        let max_len = core::cmp::max(self.regions.keys().len(), other.regions.keys().len());
+
+        let max_len = core::cmp::max(regions.keys().len(), rhs.regions.keys().len());
         for i in 0..max_len {
-            let ar = AliasRegion::new(i);
-            changed |= meet(&mut self.regions[ar], other.regions[ar]);
+            let region = AliasRegion::new(i);
+            changed |= meet(&mut regions[region], rhs.regions[region]);
+            changed |= union_set_entry(observed_regions, &rhs.observed_regions, region);
         }
-        changed |= meet(&mut self.other, other.other);
-        changed |= meet(&mut self.last_fence, other.last_fence);
+
+        changed |= meet(other, rhs.other);
+        changed |= union_bool(observed_other, rhs.observed_other);
+
+        changed |= meet(last_fence, rhs.last_fence);
+        changed |= union_bool(observed_all, rhs.observed_all);
+
         changed
     }
 }
@@ -207,12 +425,24 @@ pub enum OptResult {
     AliasedLoad(Value),
     /// An idempotent store; remove it.
     IdempotentStore,
+    /// We determined that an instruction is a dead store and its memory write
+    /// cannot be observed.
+    DeadStore {
+        /// The store instruction that is dead.
+        dead: Inst,
+        /// The other store instruction that makes the previous instruction
+        /// dead.
+        killer: Inst,
+    },
 }
 
 /// An alias-analysis pass.
 pub struct AliasAnalysis<'a> {
     /// The domtree for the function.
     domtree: &'a DominatorTree,
+
+    /// The post-dominator tree for the function.
+    post_dom_tree: &'a PostDominatorTree,
 
     /// Input state to a basic block.
     block_input: FxHashMap<Block, LastStores>,
@@ -227,10 +457,17 @@ pub struct AliasAnalysis<'a> {
 
 impl<'a> AliasAnalysis<'a> {
     /// Perform an alias analysis pass.
-    pub fn new(func: &Function, domtree: &'a DominatorTree) -> AliasAnalysis<'a> {
+    pub fn new(
+        func: &Function,
+        domtree: &'a DominatorTree,
+        post_dom_tree: &'a PostDominatorTree,
+    ) -> AliasAnalysis<'a> {
         trace!("alias analysis: input is:\n{:?}", func);
+        assert!(domtree.is_valid());
+        assert!(post_dom_tree.is_valid());
         let mut analysis = AliasAnalysis {
             domtree,
+            post_dom_tree,
             block_input: FxHashMap::default(),
             mem_values: FxHashMap::default(),
         };
@@ -300,10 +537,9 @@ impl<'a> AliasAnalysis<'a> {
         inst: Inst,
     ) -> OptResult {
         trace!(
-            "alias analysis: scanning at inst{} with state {:?} ({:?})",
-            inst.index(),
-            state,
-            func.dfg.insts[inst],
+            "process_inst: {inst}: {}\n\twith last stores: {state:?}\n\twith mem values = {:?}",
+            func.dfg.display_inst(inst),
+            self.mem_values,
         );
 
         let result = if let Some((address, offset, ty)) = inst_addr_offset_type(func, inst) {
@@ -314,9 +550,48 @@ impl<'a> AliasAnalysis<'a> {
                 let store_data = inst_store_data(func, inst).unwrap();
                 let store_data = func.dfg.resolve_aliases(store_data);
 
-                // Check for idempotent stores, where we are storing the exact
-                // same value back to a location that already has that value.
-                let last_store = state.get_last_store(func, inst);
+                let (last_store, observed_last_store) = state.get_last_store(func, inst);
+
+                // Check whether this store makes the last store dead.
+                if let Some(last_store) = last_store.expand() {
+                    // A store can only be dead if we haven't observed
+                    // its alias region yet.
+                    if !observed_last_store
+                        // This instruction doesn't make the last
+                        // store dead if it itself is the last store.
+                        && inst != last_store
+                        // The last store isn't dead if this
+                        // instruction is a fetch-add or something
+                        // like that.
+                        && !func.dfg.insts[inst].opcode().can_load()
+                        // `last_store` must really be a store that
+                        // writes exactly the bytes this store
+                        // overwrites (same region, address, offset,
+                        // type, and width).
+                        && killer_fully_overwrites(func, last_store, inst, address, offset, ty)
+                        // We can't remove dead stores if they've
+                        // already been removed, and `post_dominates`
+                        // requires that `last_store` is in the
+                        // layout.
+                        && func.layout.inst_block(last_store).is_some()
+                        // The last store is only dead if all paths
+                        // out of the function from it go through this
+                        // instruction.
+                        && self
+                            .post_dom_tree
+                            .post_dominates(inst, last_store, &func.layout)
+                    {
+                        trace!(
+                            "  --> discovered dead store at {last_store}: {}",
+                            func.dfg.display_inst(last_store)
+                        );
+                        return OptResult::DeadStore {
+                            dead: last_store,
+                            killer: inst,
+                        };
+                    }
+                }
+
                 let check_loc = MemoryLoc {
                     last_store,
                     address,
@@ -325,15 +600,20 @@ impl<'a> AliasAnalysis<'a> {
                     extending_opcode: get_ext_opcode(opcode),
                 };
                 if let Some((def_inst, known_value)) = self.mem_values.get(&check_loc).cloned() {
+                    // Check for idempotent stores, where we are
+                    // storing the exact same value back to a location
+                    // that already has that value.
                     if known_value == store_data
+                        // We cannot remove an idempotent store if we already
+                        // removed the original store instruction (perhaps
+                        // because this instruction made it dead).
+                        && func.layout.inst_block(def_inst).is_some()
+                        // We cannot remove this store unless all control-flow
+                        // paths leading to it go through the original store
+                        // instruction.
                         && self.domtree.dominates(def_inst, inst, &func.layout)
                     {
-                        trace!(
-                            "alias analysis: at inst{}: idempotent store of v{} to loc {:?}",
-                            inst.index(),
-                            store_data.index(),
-                            check_loc
-                        );
+                        trace!("  --> idempotent store of {store_data} to loc {check_loc:?}");
                         return OptResult::IdempotentStore;
                     }
                 }
@@ -346,17 +626,12 @@ impl<'a> AliasAnalysis<'a> {
                     ty,
                     extending_opcode: get_ext_opcode(opcode),
                 };
-                trace!(
-                    "alias analysis: at inst{}: store with data v{} at loc {:?}",
-                    inst.index(),
-                    store_data.index(),
-                    mem_loc
-                );
+                trace!("  --> updating known values in memory: {mem_loc:?} = {store_data}");
                 self.mem_values.insert(mem_loc, (inst, store_data));
 
                 OptResult::None
             } else if opcode.can_load() {
-                let last_store = state.get_last_store(func, inst);
+                let (last_store, _observed_last_store) = state.get_last_store(func, inst);
                 let load_result = func.dfg.inst_results(inst)[0];
                 let mem_loc = MemoryLoc {
                     last_store,
@@ -365,12 +640,7 @@ impl<'a> AliasAnalysis<'a> {
                     ty,
                     extending_opcode: get_ext_opcode(opcode),
                 };
-                trace!(
-                    "alias analysis: at inst{}: load with last_store inst{} at loc {:?}",
-                    inst.index(),
-                    last_store.map(|inst| inst.index()).unwrap_or(usize::MAX),
-                    mem_loc
-                );
+                trace!("  load with last_store at loc {mem_loc:?}");
 
                 // Is there a Value already known to be stored
                 // at this specific memory location?  If so,
@@ -382,40 +652,37 @@ impl<'a> AliasAnalysis<'a> {
                 // load (stores will always dominate though if
                 // their `last_store` survives through
                 // meet-points to this use-site).
-                let aliased =
-                    if let Some((def_inst, value)) = self.mem_values.get(&mem_loc).cloned() {
+                let aliased = if let Some((def_inst, value)) =
+                    self.mem_values.get(&mem_loc).cloned()
+                {
+                    trace!("  see known value {value} from {def_inst}");
+                    if self.domtree.dominates(def_inst, inst, &func.layout) {
                         trace!(
-                            " -> sees known value v{} from inst{}",
-                            value.index(),
-                            def_inst.index()
+                            "  --> dominates; inserting value equivalence from {load_result} to {value}",
                         );
-                        if self.domtree.dominates(def_inst, inst, &func.layout) {
-                            trace!(
-                                " -> dominates; value equiv from v{} to v{} inserted",
-                                load_result.index(),
-                                value.index()
-                            );
-                            Some(value)
-                        } else {
-                            None
-                        }
+                        Some(value)
                     } else {
                         None
-                    };
+                    }
+                } else {
+                    None
+                };
 
                 // Otherwise, we can keep *this* load around
                 // as a new equivalent value.
                 if aliased.is_none() {
-                    trace!(
-                        " -> inserting load result v{} at loc {:?}",
-                        load_result.index(),
-                        mem_loc
-                    );
+                    trace!("  --> inserting load result {load_result} at loc {mem_loc:?}");
                     self.mem_values.insert(mem_loc, (inst, load_result));
                 }
 
                 match aliased {
-                    Some(value) => OptResult::AliasedLoad(value),
+                    Some(value) => {
+                        // NB: Early return to skip the `state.update` below --
+                        // store-to-load forwarding does not observe the store
+                        // and its region and should not prevent the store from
+                        // being dead-store eliminated.
+                        return OptResult::AliasedLoad(value);
+                    }
                     None => OptResult::None,
                 }
             } else {
@@ -452,6 +719,24 @@ impl<'a> AliasAnalysis<'a> {
                     OptResult::IdempotentStore => {
                         pos.remove_inst_and_step_back();
                     }
+                    OptResult::DeadStore { dead, killer } => {
+                        assert!(
+                            !matches!(pos.position(), CursorPosition::At(other) if dead == other)
+                        );
+                        // Copy the trap code (if any) from the dead store to
+                        // its killer.
+                        if let Some(flags) = pos.func.dfg.insts[dead].memflags_data(&pos.func.dfg) {
+                            if let Some(code) = flags.trap_code() {
+                                let flags = pos.func.dfg.insts[killer]
+                                    .memflags_data(&pos.func.dfg)
+                                    .unwrap();
+                                let flags = flags.with_trap_code(Some(code));
+                                let flags = pos.func.dfg.mem_flags.insert(flags).unwrap();
+                                *pos.func.dfg.insts[killer].memflags_mut().unwrap() = flags;
+                            }
+                        }
+                        pos.func.layout.remove_inst(dead);
+                    }
                 }
             }
         }
@@ -463,5 +748,59 @@ fn get_ext_opcode(op: Opcode) -> Option<Opcode> {
     match op {
         Opcode::Load | Opcode::Store => None,
         _ => Some(op),
+    }
+}
+
+/// Can `killer` make `dead` a dead store?
+///
+/// Only if `dead` is itself a store that writes exactly the bytes
+/// `killer` overwrites: the same alias region, address, offset, type,
+/// and store width (i.e. extending/truncating opcode). Otherwise some
+/// (or all) of `dead`'s bytes may remain observable after `killer`
+/// runs, and removing `dead` would change the program's behavior.
+///
+/// `killer_addr` must already have had its value-aliases resolved (as
+/// the caller does for the killer's address).
+fn killer_fully_overwrites(
+    func: &Function,
+    dead: Inst,
+    killer: Inst,
+    killer_addr: Value,
+    killer_offset: Offset32,
+    killer_ty: Type,
+) -> bool {
+    debug_assert!(!func.dfg.value_is_alias(killer_addr));
+
+    let dead_opcode = func.dfg.insts[dead].opcode();
+
+    // `dead` must really be a store (this rejects the `last_fence` and merge
+    // fallbacks that point at calls/fences/atomics or unrelated instructions).
+    if !dead_opcode.can_store() {
+        return false;
+    }
+
+    // Both must write the same number of bytes: e.g. `istore8` and `store`
+    // write different widths even when their value types are equal.
+    let killer_opcode = func.dfg.insts[killer].opcode();
+    if get_ext_opcode(dead_opcode) != get_ext_opcode(killer_opcode) {
+        return false;
+    }
+
+    // Both must target the same alias region; a store to one region cannot make
+    // a store to a disjoint region dead.
+    if func.dfg.insts[dead].alias_region(&func.dfg)
+        != func.dfg.insts[killer].alias_region(&func.dfg)
+    {
+        return false;
+    }
+
+    // Both must write the same address, offset, and type.
+    match inst_addr_offset_type(func, dead) {
+        Some((addr, offset, ty)) => {
+            func.dfg.resolve_aliases(addr) == killer_addr
+                && offset == killer_offset
+                && ty == killer_ty
+        }
+        None => false,
     }
 }

--- a/cranelift/codegen/src/alias_analysis.rs
+++ b/cranelift/codegen/src/alias_analysis.rs
@@ -726,22 +726,13 @@ impl<'a> AliasAnalysis<'a> {
                     OptResult::IdempotentStore => {
                         pos.remove_inst_and_step_back();
                     }
-                    OptResult::DeadStore { dead, overwriter } => {
+                    OptResult::DeadStore {
+                        dead,
+                        overwriter: _,
+                    } => {
                         assert!(
                             !matches!(pos.position(), CursorPosition::At(other) if dead == other)
                         );
-                        // Copy the trap code (if any) from the dead store to
-                        // its overwriter.
-                        if let Some(flags) = pos.func.dfg.insts[dead].memflags_data(&pos.func.dfg) {
-                            if let Some(code) = flags.trap_code() {
-                                let flags = pos.func.dfg.insts[overwriter]
-                                    .memflags_data(&pos.func.dfg)
-                                    .unwrap();
-                                let flags = flags.with_trap_code(Some(code));
-                                let flags = pos.func.dfg.mem_flags.insert(flags).unwrap();
-                                *pos.func.dfg.insts[overwriter].memflags_mut().unwrap() = flags;
-                            }
-                        }
                         pos.func.layout.remove_inst(dead);
                     }
                 }
@@ -798,6 +789,18 @@ fn fully_overwrites(
     // a store to a disjoint region dead.
     if func.dfg.insts[maybe_dead].alias_region(&func.dfg)
         != func.dfg.insts[overwriter].alias_region(&func.dfg)
+    {
+        return false;
+    }
+
+    // Both must have the same trap code, if any. Otherwise, removing
+    // `maybe_dead` could change which code an execution traps with.
+    if func.dfg.insts[maybe_dead]
+        .memflags()
+        .and_then(|f| func.dfg.mem_flags[f].trap_code())
+        != func.dfg.insts[overwriter]
+            .memflags()
+            .and_then(|f| func.dfg.mem_flags[f].trap_code())
     {
         return false;
     }

--- a/cranelift/codegen/src/alias_analysis.rs
+++ b/cranelift/codegen/src/alias_analysis.rs
@@ -43,24 +43,29 @@
 //! load, we can also insert, if we don't already have a value (from
 //! the store that produced the load's value).
 //!
-//! Then we can do two optimizations at once given this table. If a
-//! load accesses a location identified by a (last store, address,
-//! type) key already in the table, we replace it with the SSA value
-//! for that memory location. This is usually known as "redundant load
-//! elimination" if the value came from an earlier load of the same
-//! location, or "store-to-load forwarding" if the value came from an
-//! earlier store to the same location.
+//! Then we do a few optimizations at once given this table:
 //!
-//! In theory we could also do *dead-store elimination*, where if a
-//! store overwrites a key in the table, *and* if no other load/store
-//! to the abstract region occurred, *and* no other trapping
-//! instruction occurred (at which point we need an up-to-date memory
-//! state because post-trap-termination memory state can be observed),
-//! *and* we can prove the original store could not have trapped, then
-//! we can eliminate the original store. Because this is so complex,
-//! and the conditions for doing it correctly when post-trap state
-//! must be correct likely reduce the potential benefit, we don't yet
-//! do this.
+//! * If a load accesses a location identified by a (last store,
+//!   address, type) key already in the table, we replace it with the
+//!   SSA value for that memory location. This is usually known as
+//!   "redundant load elimination" if the value came from an earlier
+//!   load of the same location, or "store-to-load forwarding" if the
+//!   value came from an earlier store to the same location.
+//!
+//! * If a store writes the same value that is already in the table
+//!   for its memory location, then we can elide this store because it
+//!   doesn't actually modify memory. We call this "idempotent-store
+//!   elimination".
+//!
+//! * If a store overwrites a key in the table, *and* if this
+//!   overwriting store always executes after the original store
+//!   (i.e. this store post-dominates the original), *and* if no other
+//!   instruction has "observed" the associated alias region in
+//!   between, then we can eliminate the original store. This is
+//!   called "dead-store elimination". Note that observing an alias
+//!   region is not just loading from it, all potentially-trapping
+//!   instructions must be treated as observing all regions because we
+//!   must preserve post-trap memory state.
 
 use crate::cursor::CursorPosition;
 use crate::{FxHashMap, FxHashSet};
@@ -432,7 +437,7 @@ pub enum OptResult {
         dead: Inst,
         /// The other store instruction that makes the previous instruction
         /// dead.
-        killer: Inst,
+        overwriter: Inst,
     },
 }
 
@@ -562,13 +567,15 @@ impl<'a> AliasAnalysis<'a> {
                         && inst != last_store
                         // The last store isn't dead if this
                         // instruction is a fetch-add or something
-                        // like that.
+                        // like that, as these instructions first load
+                        // from (and therefore observe) memory before
+                        // storing to it.
                         && !func.dfg.insts[inst].opcode().can_load()
                         // `last_store` must really be a store that
                         // writes exactly the bytes this store
                         // overwrites (same region, address, offset,
                         // type, and width).
-                        && killer_fully_overwrites(func, last_store, inst, address, offset, ty)
+                        && fully_overwrites(func, last_store, inst, address, offset, ty)
                         // We can't remove dead stores if they've
                         // already been removed, and `post_dominates`
                         // requires that `last_store` is in the
@@ -587,7 +594,7 @@ impl<'a> AliasAnalysis<'a> {
                         );
                         return OptResult::DeadStore {
                             dead: last_store,
-                            killer: inst,
+                            overwriter: inst,
                         };
                     }
                 }
@@ -719,20 +726,20 @@ impl<'a> AliasAnalysis<'a> {
                     OptResult::IdempotentStore => {
                         pos.remove_inst_and_step_back();
                     }
-                    OptResult::DeadStore { dead, killer } => {
+                    OptResult::DeadStore { dead, overwriter } => {
                         assert!(
                             !matches!(pos.position(), CursorPosition::At(other) if dead == other)
                         );
                         // Copy the trap code (if any) from the dead store to
-                        // its killer.
+                        // its overwriter.
                         if let Some(flags) = pos.func.dfg.insts[dead].memflags_data(&pos.func.dfg) {
                             if let Some(code) = flags.trap_code() {
-                                let flags = pos.func.dfg.insts[killer]
+                                let flags = pos.func.dfg.insts[overwriter]
                                     .memflags_data(&pos.func.dfg)
                                     .unwrap();
                                 let flags = flags.with_trap_code(Some(code));
                                 let flags = pos.func.dfg.mem_flags.insert(flags).unwrap();
-                                *pos.func.dfg.insts[killer].memflags_mut().unwrap() = flags;
+                                *pos.func.dfg.insts[overwriter].memflags_mut().unwrap() = flags;
                             }
                         }
                         pos.func.layout.remove_inst(dead);
@@ -751,55 +758,56 @@ fn get_ext_opcode(op: Opcode) -> Option<Opcode> {
     }
 }
 
-/// Can `killer` make `dead` a dead store?
+/// Can `overwriter` make `maybe_dead` a dead store?
 ///
-/// Only if `dead` is itself a store that writes exactly the bytes
-/// `killer` overwrites: the same alias region, address, offset, type,
-/// and store width (i.e. extending/truncating opcode). Otherwise some
-/// (or all) of `dead`'s bytes may remain observable after `killer`
-/// runs, and removing `dead` would change the program's behavior.
+/// Only if `maybe_dead` is itself a store that writes exactly the
+/// bytes `overwriter` overwrites: the same alias region, address,
+/// offset, type, and store width (i.e. extending/truncating
+/// opcode). Otherwise some (or all) of `maybe_dead`'s bytes may
+/// remain observable after `overwriter` runs, and removing
+/// `maybe_dead` would change the program's behavior.
 ///
-/// `killer_addr` must already have had its value-aliases resolved (as
-/// the caller does for the killer's address).
-fn killer_fully_overwrites(
+/// `overwriter_addr` must already have had its value-aliases resolved
+/// (as the caller does for the overwriter's address).
+fn fully_overwrites(
     func: &Function,
-    dead: Inst,
-    killer: Inst,
-    killer_addr: Value,
-    killer_offset: Offset32,
-    killer_ty: Type,
+    maybe_dead: Inst,
+    overwriter: Inst,
+    overwriter_addr: Value,
+    overwriter_offset: Offset32,
+    overwriter_ty: Type,
 ) -> bool {
-    debug_assert!(!func.dfg.value_is_alias(killer_addr));
+    debug_assert!(!func.dfg.value_is_alias(overwriter_addr));
 
-    let dead_opcode = func.dfg.insts[dead].opcode();
+    let maybe_dead_opcode = func.dfg.insts[maybe_dead].opcode();
 
-    // `dead` must really be a store (this rejects the `last_fence` and merge
+    // `maybe_dead` must really be a store (this rejects the `last_fence` and merge
     // fallbacks that point at calls/fences/atomics or unrelated instructions).
-    if !dead_opcode.can_store() {
+    if !maybe_dead_opcode.can_store() {
         return false;
     }
 
     // Both must write the same number of bytes: e.g. `istore8` and `store`
     // write different widths even when their value types are equal.
-    let killer_opcode = func.dfg.insts[killer].opcode();
-    if get_ext_opcode(dead_opcode) != get_ext_opcode(killer_opcode) {
+    let overwriter_opcode = func.dfg.insts[overwriter].opcode();
+    if get_ext_opcode(maybe_dead_opcode) != get_ext_opcode(overwriter_opcode) {
         return false;
     }
 
     // Both must target the same alias region; a store to one region cannot make
     // a store to a disjoint region dead.
-    if func.dfg.insts[dead].alias_region(&func.dfg)
-        != func.dfg.insts[killer].alias_region(&func.dfg)
+    if func.dfg.insts[maybe_dead].alias_region(&func.dfg)
+        != func.dfg.insts[overwriter].alias_region(&func.dfg)
     {
         return false;
     }
 
     // Both must write the same address, offset, and type.
-    match inst_addr_offset_type(func, dead) {
+    match inst_addr_offset_type(func, maybe_dead) {
         Some((addr, offset, ty)) => {
-            func.dfg.resolve_aliases(addr) == killer_addr
-                && offset == killer_offset
-                && ty == killer_ty
+            func.dfg.resolve_aliases(addr) == overwriter_addr
+                && offset == overwriter_offset
+                && ty == overwriter_ty
         }
         None => false,
     }

--- a/cranelift/codegen/src/context.rs
+++ b/cranelift/codegen/src/context.rs
@@ -19,6 +19,7 @@ use crate::isa::TargetIsa;
 use crate::loop_analysis::LoopAnalysis;
 use crate::machinst::{CompiledCode, CompiledCodeStencil};
 use crate::nan_canonicalization::do_nan_canonicalization;
+use crate::post_dominator_tree::PostDominatorTree;
 use crate::remove_constant_phis::do_remove_constant_phis;
 use crate::result::{CodegenResult, CompileResult};
 use crate::settings::{FlagsOrIsa, OptLevel};
@@ -45,6 +46,9 @@ pub struct Context {
 
     /// Dominator tree for `func`.
     pub domtree: DominatorTree,
+
+    /// Post-dominator tree for `func`.
+    pub post_dom_tree: PostDominatorTree,
 
     /// Loop analysis of `func`.
     pub loop_analysis: LoopAnalysis,
@@ -77,6 +81,7 @@ impl Context {
             func,
             cfg: ControlFlowGraph::new(),
             domtree: DominatorTree::new(),
+            post_dom_tree: PostDominatorTree::new(),
             loop_analysis: LoopAnalysis::new(),
             compiled_code: None,
             want_disasm: false,
@@ -192,6 +197,7 @@ impl Context {
         self.func.dfg.resolve_all_aliases();
 
         if opt_level != OptLevel::None {
+            self.compute_post_dom_tree();
             self.egraph_pass(isa, ctrl_plane)?;
         }
 
@@ -312,6 +318,11 @@ impl Context {
         self.domtree.compute(&self.func, &self.cfg);
     }
 
+    /// Compute the post-dominator tree.
+    pub fn compute_post_dom_tree(&mut self) {
+        self.post_dom_tree.compute(&self.func, &self.cfg);
+    }
+
     /// Compute the loop analysis.
     pub fn compute_loop_analysis(&mut self) {
         self.loop_analysis
@@ -342,7 +353,7 @@ impl Context {
     /// by a store instruction to the same instruction (so-called
     /// "store-to-load forwarding").
     pub fn replace_redundant_loads(&mut self) -> CodegenResult<()> {
-        let mut analysis = AliasAnalysis::new(&self.func, &self.domtree);
+        let mut analysis = AliasAnalysis::new(&self.func, &self.domtree, &self.post_dom_tree);
         analysis.compute_and_update_aliases(&mut self.func);
         Ok(())
     }
@@ -374,7 +385,7 @@ impl Context {
         );
         let fisa = fisa.into();
         self.compute_loop_analysis();
-        let mut alias_analysis = AliasAnalysis::new(&self.func, &self.domtree);
+        let mut alias_analysis = AliasAnalysis::new(&self.func, &self.domtree, &self.post_dom_tree);
         let mut pass = EgraphPass::new(
             &mut self.func,
             &self.domtree,

--- a/cranelift/codegen/src/egraph/mod.rs
+++ b/cranelift/codegen/src/egraph/mod.rs
@@ -567,10 +567,7 @@ where
             }
             OptResult::DeadStore { dead, overwriter } => {
                 self.stats.alias_analysis_removed_dead_store += 1;
-                Some(SkeletonInstSimplification::RemoveDeadStore {
-                    dead,
-                    killer: overwriter,
-                })
+                Some(SkeletonInstSimplification::RemoveDeadStore { dead, overwriter })
             }
             OptResult::None => {
                 // Generic side-effecting op -- always keep it, and
@@ -675,12 +672,12 @@ where
                     return Some(SkeletonInstSimplification::ReplaceWithTwo { first, second });
                 }
 
-                SkeletonInstSimplification::RemoveDeadStore { dead, killer } => {
+                SkeletonInstSimplification::RemoveDeadStore { dead, overwriter } => {
                     log::trace!(
                         " -> simplify_skeleton: remove other: {dead}: {}",
                         ctx.func.dfg.display_inst(dead)
                     );
-                    return Some(SkeletonInstSimplification::RemoveDeadStore { dead, killer });
+                    return Some(SkeletonInstSimplification::RemoveDeadStore { dead, overwriter });
                 }
 
                 // For instruction replacement simplification, we want to check
@@ -1168,22 +1165,10 @@ impl<'a> EgraphPass<'a> {
                 reprocess_from(cursor, first);
                 return;
             }
-            SkeletonInstSimplification::RemoveDeadStore { dead, killer } => {
+            SkeletonInstSimplification::RemoveDeadStore { dead, overwriter } => {
                 assert!(!matches!(cursor.position(), CursorPosition::At(inst) if inst == dead));
-                // Copy the trap code (if any) from the dead store to its
-                // killer.
-                if let Some(flags) = cursor.func.dfg.insts[dead].memflags_data(&cursor.func.dfg) {
-                    if let Some(code) = flags.trap_code() {
-                        let flags = cursor.func.dfg.insts[killer]
-                            .memflags_data(&cursor.func.dfg)
-                            .unwrap();
-                        let flags = flags.with_trap_code(Some(code));
-                        let flags = cursor.func.dfg.mem_flags.insert(flags).unwrap();
-                        *cursor.func.dfg.insts[killer].memflags_mut().unwrap() = flags;
-                    }
-                }
                 cursor.func.layout.remove_inst(dead);
-                self_map_operands(&cursor.func.dfg, value_to_opt_value, killer);
+                self_map_operands(&cursor.func.dfg, value_to_opt_value, overwriter);
                 cursor.prev_inst();
                 return;
             }

--- a/cranelift/codegen/src/egraph/mod.rs
+++ b/cranelift/codegen/src/egraph/mod.rs
@@ -529,7 +529,7 @@ where
                         }
                         (_, _) => unreachable!(),
                     }
-                    Some(SkeletonInstSimplification::Remove)
+                    return Some(SkeletonInstSimplification::Remove);
                 }
                 ScopedEntry::Vacant(v) => {
                     // Otherwise, insert it into the value-map.
@@ -539,42 +539,44 @@ where
                     }
                     v.insert(result);
                     trace!(" -> inserts as new (no GVN)");
-                    None
                 }
             }
         }
-        // Otherwise, if a load or store, process it with the alias
-        // analysis to see if we can optimize it (rewrite in terms of
-        // an earlier load or stored value, or remove an idempotent store).
-        else {
-            match self
-                .alias_analysis
-                .process_inst(self.func, self.alias_analysis_state, inst)
-            {
-                OptResult::AliasedLoad(new_result) => {
-                    self.stats.alias_analysis_removed_load += 1;
-                    let result = self.func.dfg.first_result(inst);
-                    trace!(
-                        " -> inst {} has result {} replaced with {}",
-                        inst, result, new_result
-                    );
-                    self.value_to_opt_value[result] = new_result;
-                    self.available_block[result] = self.available_block[new_result];
-                    Some(SkeletonInstSimplification::Remove)
+
+        // Otherwise, if a load or store, process it with the alias analysis to
+        // see if we can optimize it (rewrite in terms of an earlier load or
+        // stored value, or remove an idempotent store).
+        match self
+            .alias_analysis
+            .process_inst(self.func, self.alias_analysis_state, inst)
+        {
+            OptResult::AliasedLoad(new_result) => {
+                self.stats.alias_analysis_removed_load += 1;
+                let result = self.func.dfg.first_result(inst);
+                trace!(
+                    " -> inst {} has result {} replaced with {}",
+                    inst, result, new_result
+                );
+                self.value_to_opt_value[result] = new_result;
+                self.available_block[result] = self.available_block[new_result];
+                Some(SkeletonInstSimplification::Remove)
+            }
+            OptResult::IdempotentStore => {
+                self.stats.alias_analysis_removed_idempotent_store += 1;
+                Some(SkeletonInstSimplification::Remove)
+            }
+            OptResult::DeadStore { dead, killer } => {
+                self.stats.alias_analysis_removed_dead_store += 1;
+                Some(SkeletonInstSimplification::RemoveDeadStore { dead, killer })
+            }
+            OptResult::None => {
+                // Generic side-effecting op -- always keep it, and
+                // set its results to identity-map to original values.
+                for &result in self.func.dfg.inst_results(inst) {
+                    self.value_to_opt_value[result] = result;
+                    self.available_block[result] = block;
                 }
-                OptResult::IdempotentStore => {
-                    self.stats.alias_analysis_removed_store += 1;
-                    Some(SkeletonInstSimplification::Remove)
-                }
-                OptResult::None => {
-                    // Generic side-effecting op -- always keep it, and
-                    // set its results to identity-map to original values.
-                    for &result in self.func.dfg.inst_results(inst) {
-                        self.value_to_opt_value[result] = result;
-                        self.available_block[result] = block;
-                    }
-                    None
-                }
+                None
             }
         }
     }
@@ -668,6 +670,14 @@ where
                         ctx.func.dfg.display_inst(second),
                     );
                     return Some(SkeletonInstSimplification::ReplaceWithTwo { first, second });
+                }
+
+                SkeletonInstSimplification::RemoveDeadStore { dead, killer } => {
+                    log::trace!(
+                        " -> simplify_skeleton: remove other: {dead}: {}",
+                        ctx.func.dfg.display_inst(dead)
+                    );
+                    return Some(SkeletonInstSimplification::RemoveDeadStore { dead, killer });
                 }
 
                 // For instruction replacement simplification, we want to check
@@ -1154,6 +1164,25 @@ impl<'a> EgraphPass<'a> {
                 reprocess_from(cursor, first);
                 return;
             }
+            SkeletonInstSimplification::RemoveDeadStore { dead, killer } => {
+                assert!(!matches!(cursor.position(), CursorPosition::At(inst) if inst == dead));
+                // Copy the trap code (if any) from the dead store to its
+                // killer.
+                if let Some(flags) = cursor.func.dfg.insts[dead].memflags_data(&cursor.func.dfg) {
+                    if let Some(code) = flags.trap_code() {
+                        let flags = cursor.func.dfg.insts[killer]
+                            .memflags_data(&cursor.func.dfg)
+                            .unwrap();
+                        let flags = flags.with_trap_code(Some(code));
+                        let flags = cursor.func.dfg.mem_flags.insert(flags).unwrap();
+                        *cursor.func.dfg.insts[killer].memflags_mut().unwrap() = flags;
+                    }
+                }
+                cursor.func.layout.remove_inst(dead);
+                self_map_operands(&cursor.func.dfg, value_to_opt_value, killer);
+                cursor.prev_inst();
+                return;
+            }
 
             SkeletonInstSimplification::Replace { inst } => (inst, None),
             SkeletonInstSimplification::ReplaceWithVal { inst, val } => (inst, Some(val)),
@@ -1296,7 +1325,8 @@ pub(crate) struct Stats {
     pub(crate) skeleton_inst_simplified: u64,
     pub(crate) skeleton_inst_gvn: u64,
     pub(crate) alias_analysis_removed_load: u64,
-    pub(crate) alias_analysis_removed_store: u64,
+    pub(crate) alias_analysis_removed_idempotent_store: u64,
+    pub(crate) alias_analysis_removed_dead_store: u64,
     pub(crate) new_inst: u64,
     pub(crate) union: u64,
     pub(crate) subsume: u64,

--- a/cranelift/codegen/src/egraph/mod.rs
+++ b/cranelift/codegen/src/egraph/mod.rs
@@ -567,7 +567,10 @@ where
             }
             OptResult::DeadStore { dead, overwriter } => {
                 self.stats.alias_analysis_removed_dead_store += 1;
-                Some(SkeletonInstSimplification::RemoveDeadStore { dead, killer: overwriter })
+                Some(SkeletonInstSimplification::RemoveDeadStore {
+                    dead,
+                    killer: overwriter,
+                })
             }
             OptResult::None => {
                 // Generic side-effecting op -- always keep it, and
@@ -750,7 +753,8 @@ impl SkeletonInstSimplification {
             // Removing an instruction never rewrites a terminator: a block's
             // terminator cannot be removed or the block would become invalid.
             SkeletonInstSimplification::Remove
-            | SkeletonInstSimplification::RemoveWithVal { .. } => false,
+            | SkeletonInstSimplification::RemoveWithVal { .. }
+            | SkeletonInstSimplification::RemoveDeadStore { .. } => false,
 
             // Swapping a conditional branch/trap's condition operand leaves the
             // opcode and successors in place, so the CFG is preserved.

--- a/cranelift/codegen/src/egraph/mod.rs
+++ b/cranelift/codegen/src/egraph/mod.rs
@@ -565,9 +565,9 @@ where
                 self.stats.alias_analysis_removed_idempotent_store += 1;
                 Some(SkeletonInstSimplification::Remove)
             }
-            OptResult::DeadStore { dead, killer } => {
+            OptResult::DeadStore { dead, overwriter } => {
                 self.stats.alias_analysis_removed_dead_store += 1;
-                Some(SkeletonInstSimplification::RemoveDeadStore { dead, killer })
+                Some(SkeletonInstSimplification::RemoveDeadStore { dead, killer: overwriter })
             }
             OptResult::None => {
                 // Generic side-effecting op -- always keep it, and

--- a/cranelift/codegen/src/inst_predicates.rs
+++ b/cranelift/codegen/src/inst_predicates.rs
@@ -144,23 +144,6 @@ pub fn inst_store_data(func: &Function, inst: Inst) -> Option<Value> {
     }
 }
 
-/// Determine whether this opcode behaves as a memory fence, i.e.,
-/// prohibits any moving of memory accesses across it.
-pub fn has_memory_fence_semantics(op: Opcode) -> bool {
-    match op {
-        Opcode::AtomicRmw
-        | Opcode::AtomicCas
-        | Opcode::AtomicLoad
-        | Opcode::AtomicStore
-        | Opcode::Fence
-        | Opcode::Debugtrap
-        | Opcode::SequencePoint => true,
-        Opcode::Call | Opcode::CallIndirect | Opcode::TryCall | Opcode::TryCallIndirect => true,
-        op if op.can_trap() => true,
-        _ => false,
-    }
-}
-
 /// Visit all successors of a block with a given visitor closure. The closure
 /// arguments are the branch instruction that is used to reach the successor,
 /// the successor block itself, and a flag indicating whether the block is

--- a/cranelift/codegen/src/ir/instructions.rs
+++ b/cranelift/codegen/src/ir/instructions.rs
@@ -567,10 +567,37 @@ impl InstructionData {
         }
     }
 
+    /// If this is a load/store instruction, return its memory flags.
+    pub fn memflags_mut(&mut self) -> Option<&mut MemFlags> {
+        match self {
+            InstructionData::Load { flags, .. }
+            | InstructionData::LoadNoOffset { flags, .. }
+            | InstructionData::Store { flags, .. }
+            | InstructionData::StoreNoOffset { flags, .. }
+            | InstructionData::AtomicCas { flags, .. }
+            | InstructionData::AtomicRmw { flags, .. } => Some(flags),
+            _ => None,
+        }
+    }
+
     /// If this is a load/store instruction, resolve its memory flags to data
     /// through the DFG.
     pub fn memflags_data(&self, dfg: &super::dfg::DataFlowGraph) -> Option<super::MemFlagsData> {
         self.memflags().map(|f| dfg.mem_flags[f])
+    }
+
+    /// Get this load/store instruction's trap code, if any.
+    ///
+    /// Returns `None` when this is not a load/store instruction, or if it is a
+    /// load/store instruction but does not have a trap code.
+    pub fn memflags_trap_code(&self, dfg: &super::dfg::DataFlowGraph) -> Option<TrapCode> {
+        self.memflags_data(dfg)?.trap_code()
+    }
+
+    /// If this is a load/store instruction, get its alias region.
+    pub fn alias_region(&self, dfg: &super::dfg::DataFlowGraph) -> Option<super::AliasRegion> {
+        let flags = self.memflags_data(dfg)?;
+        flags.alias_region()
     }
 
     /// If this instruction references a stack slot, return it

--- a/cranelift/codegen/src/prelude_opt.isle
+++ b/cranelift/codegen/src/prelude_opt.isle
@@ -121,7 +121,12 @@
         ;; Neither instruction may define any results, and if the instruction
         ;; being replaced is a block terminator then `second` must also be a
         ;; block terminator.
-        (ReplaceWithTwo (first Inst) (second Inst))))
+        (ReplaceWithTwo (first Inst) (second Inst))
+
+        ;; Remove a dead store.
+        ;;
+        ;; The trap code from `dead` (if any) is copied to `killer`.
+        (RemoveDeadStore (dead Inst) (killer Inst))))
 
 (decl pure inst_to_skeleton_inst_simplification (Inst) SkeletonInstSimplification)
 (rule (inst_to_skeleton_inst_simplification inst)

--- a/cranelift/codegen/src/prelude_opt.isle
+++ b/cranelift/codegen/src/prelude_opt.isle
@@ -124,9 +124,7 @@
         (ReplaceWithTwo (first Inst) (second Inst))
 
         ;; Remove a dead store.
-        ;;
-        ;; The trap code from `dead` (if any) is copied to `killer`.
-        (RemoveDeadStore (dead Inst) (killer Inst))))
+        (RemoveDeadStore (dead Inst) (overwriter Inst))))
 
 (decl pure inst_to_skeleton_inst_simplification (Inst) SkeletonInstSimplification)
 (rule (inst_to_skeleton_inst_simplification inst)

--- a/cranelift/filetests/filetests/alias/check-unset-reset-flag.clif
+++ b/cranelift/filetests/filetests/alias/check-unset-reset-flag.clif
@@ -1,0 +1,27 @@
+test optimize precise-output
+set opt_level=speed
+target aarch64
+
+function u1:0(i64 vmctx, i32) -> i32 tail {
+    region0 = 0 "flag"
+
+block0(v0: i64, v1: i32):
+    v2 = load.i64 notrap aligned region0 v0
+    trapz v2, user42
+    v3 = iconst.i64 0
+    store notrap aligned region0 v3, v0
+    v4 = iadd v1, v1
+    store notrap aligned region0 v2, v0
+    return v4
+}
+
+; function u1:0(i64 vmctx, i32) -> i32 tail {
+;     region0 = 0 "flag"
+;
+; block0(v0: i64, v1: i32):
+;     v2 = load.i64 notrap aligned region0 v0
+;     trapz v2, user42
+;     store notrap aligned region0 v2, v0
+;     v4 = iadd v1, v1
+;     return v4
+; }

--- a/cranelift/filetests/filetests/alias/dead-store-chain.clif
+++ b/cranelift/filetests/filetests/alias/dead-store-chain.clif
@@ -1,0 +1,23 @@
+test optimize precise-output
+set opt_level=speed
+target aarch64
+
+;; A chain of stores to the same location collapses to only the last store.
+function %chain(i64, i32, i32, i32, i32) {
+    region0 = 0 "R"
+block0(v0: i64, v1: i32, v2: i32, v3: i32, v4: i32):
+    store notrap aligned region0 v1, v0
+    store notrap aligned region0 v2, v0
+    store notrap aligned region0 v3, v0
+    store notrap aligned region0 v4, v0
+    return
+}
+
+; function %chain(i64, i32, i32, i32, i32) fast {
+;     region0 = 0 "R"
+;
+; block0(v0: i64, v1: i32, v2: i32, v3: i32, v4: i32):
+;     store notrap aligned region0 v4, v0
+;     return
+; }
+

--- a/cranelift/filetests/filetests/alias/dead-store-cross-block.clif
+++ b/cranelift/filetests/filetests/alias/dead-store-cross-block.clif
@@ -1,0 +1,59 @@
+test optimize precise-output
+set opt_level=speed
+target aarch64
+
+function %straight_line(i64, i32, i32) {
+    region0 = 0 "R0"
+block0(v0: i64, v1: i32, v2: i32):
+    store notrap aligned region0 v1, v0
+    jump block1
+
+block1:
+    store notrap aligned region0 v2, v0
+    return
+}
+
+; function %straight_line(i64, i32, i32) fast {
+;     region0 = 0 "R0"
+;
+; block0(v0: i64, v1: i32, v2: i32):
+;     jump block1
+;
+; block1:
+;     store.i32 notrap aligned region0 v2, v0
+;     return
+; }
+
+function %diamond(i64, i32, i32, i32) {
+    region0 = 0 "R0"
+block0(v0: i64, v1: i32, v2: i32, v3: i32):
+    store notrap aligned region0 v1, v0
+    brif v1, block1, block2
+
+block1:
+    jump block3(v2)
+
+block2:
+    jump block3(v3)
+
+block3(v4: i32):
+    store notrap aligned region0 v4, v0
+    return
+}
+
+; function %diamond(i64, i32, i32, i32) fast {
+;     region0 = 0 "R0"
+;
+; block0(v0: i64, v1: i32, v2: i32, v3: i32):
+;     brif v1, block1, block2
+;
+; block1:
+;     jump block3(v2)
+;
+; block2:
+;     jump block3(v3)
+;
+; block3(v4: i32):
+;     store notrap aligned region0 v4, v0
+;     return
+; }

--- a/cranelift/filetests/filetests/alias/dead-store-no-region.clif
+++ b/cranelift/filetests/filetests/alias/dead-store-no-region.clif
@@ -1,0 +1,35 @@
+test optimize precise-output
+set opt_level=speed
+target aarch64
+
+;; Stores without an alias region are also subject to dead store elimination.
+function %no_region_dead_store(i64, i32, i32) {
+block0(v0: i64, v1: i32, v2: i32):
+    store notrap aligned v1, v0
+    store notrap aligned v2, v0
+    return
+}
+
+; function %no_region_dead_store(i64, i32, i32) fast {
+; block0(v0: i64, v1: i32, v2: i32):
+;     store notrap aligned v2, v0
+;     return
+; }
+
+;; A load without an alias region observes the unregioned store and keeps it.
+function %no_region_load_observes(i64, i32, i32) -> i32 {
+block0(v0: i64, v1: i32, v2: i32):
+    store notrap aligned v1, v0
+    v3 = load.i32 notrap v0+1
+    store notrap aligned v2, v0
+    return v3
+}
+
+; function %no_region_load_observes(i64, i32, i32) -> i32 fast {
+; block0(v0: i64, v1: i32, v2: i32):
+;     store notrap aligned v1, v0
+;     v3 = load.i32 notrap v0+1
+;     store notrap aligned v2, v0
+;     return v3
+; }
+

--- a/cranelift/filetests/filetests/alias/dead-store-other-region.clif
+++ b/cranelift/filetests/filetests/alias/dead-store-other-region.clif
@@ -1,0 +1,68 @@
+test optimize precise-output
+set opt_level=speed
+target aarch64
+
+;; A store to a different region in between does not save the dead store.
+function %store_to_other_region_between(i64, i64, i32, i32, i32) {
+    region0 = 0 "R0"
+    region1 = 1 "R1"
+block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
+    store notrap aligned region0 v2, v0
+    store notrap aligned region1 v4, v1
+    store notrap aligned region0 v3, v0
+    return
+}
+
+; function %store_to_other_region_between(i64, i64, i32, i32, i32) fast {
+;     region0 = 0 "R0"
+;     region1 = 1 "R1"
+;
+; block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
+;     store notrap aligned region1 v4, v1
+;     store notrap aligned region0 v3, v0
+;     return
+; }
+
+;; A trapping load from a different region in between does not save the dead
+;; notrap store.
+function %load_from_other_region_between(i64, i64, i32, i32) -> i32 {
+    region0 = 0 "R0"
+    region1 = 1 "R1"
+block0(v0: i64, v1: i64, v2: i32, v3: i32):
+    store notrap aligned region0 v2, v0
+    v4 = load.i32 notrap aligned region1 v1
+    store notrap aligned region0 v3, v0
+    return v4
+}
+
+; function %load_from_other_region_between(i64, i64, i32, i32) -> i32 fast {
+;     region0 = 0 "R0"
+;     region1 = 1 "R1"
+;
+; block0(v0: i64, v1: i64, v2: i32, v3: i32):
+;     v4 = load.i32 notrap aligned region1 v1
+;     store notrap aligned region0 v3, v0
+;     return v4
+; }
+
+;; A notrap load from a different region in between does not save the dead
+;; trapping store.
+function %notrap_load_between_trapping_stores(i64, i64, i32, i32) -> i32 {
+    region0 = 0 "R0"
+    region1 = 1 "R1"
+block0(v0: i64, v1: i64, v2: i32, v3: i32):
+    store aligned region0 user10 v2, v0
+    v4 = load.i32 notrap aligned region1 v1
+    store aligned region0 user10 v3, v0
+    return v4
+}
+
+; function %notrap_load_between_trapping_stores(i64, i64, i32, i32) -> i32 fast {
+;     region0 = 0 "R0"
+;     region1 = 1 "R1"
+;
+; block0(v0: i64, v1: i64, v2: i32, v3: i32):
+;     v4 = load.i32 notrap aligned region1 v1
+;     store user10 aligned region0 v3, v0
+;     return v4
+; }

--- a/cranelift/filetests/filetests/alias/dead-store-trap-codes.clif
+++ b/cranelift/filetests/filetests/alias/dead-store-trap-codes.clif
@@ -1,0 +1,77 @@
+test optimize precise-output
+set opt_level=speed
+target aarch64
+
+;; The killer inherits the dead store's trap code, replacing its own.
+function %different_trap_codes(i64, i32, i32) {
+    region0 = 0 "R"
+block0(v0: i64, v1: i32, v2: i32):
+    store aligned region0 user10 v1, v0
+    store aligned region0 user20 v2, v0
+    return
+}
+
+; function %different_trap_codes(i64, i32, i32) fast {
+;     region0 = 0 "R"
+;
+; block0(v0: i64, v1: i32, v2: i32):
+;     store user10 aligned region0 v2, v0
+;     return
+; }
+
+;; The previously untrapping killer inherits the dead store's trap code.
+function %dead_traps_killer_does_not(i64, i32, i32) {
+    region0 = 0 "R"
+block0(v0: i64, v1: i32, v2: i32):
+    store aligned region0 user10 v1, v0
+    store notrap aligned region0 v2, v0
+    return
+}
+
+; function %dead_traps_killer_does_not(i64, i32, i32) fast {
+;     region0 = 0 "R"
+;
+; block0(v0: i64, v1: i32, v2: i32):
+;     store user10 aligned region0 v2, v0
+;     return
+; }
+
+;; The killer keeps its own trap code because the dead store had none.
+function %dead_does_not_trap_killer_does(i64, i32, i32) {
+    region0 = 0 "R"
+block0(v0: i64, v1: i32, v2: i32):
+    store notrap aligned region0 v1, v0
+    store aligned region0 user20 v2, v0
+    return
+}
+
+; function %dead_does_not_trap_killer_does(i64, i32, i32) fast {
+;     region0 = 0 "R"
+;
+; block0(v0: i64, v1: i32, v2: i32):
+;     store user20 aligned region0 v2, v0
+;     return
+; }
+
+;; Different trap codes across blocks.
+function %f(i64, i32, i32) {
+    region0 = 0 "R0"
+block0(v0: i64, v1: i32, v2: i32):
+    store aligned region0 user10 v1, v0
+    jump block1
+
+block1:
+    store aligned region0 user20 v2, v0
+    return
+}
+
+; function %f(i64, i32, i32) fast {
+;     region0 = 0 "R0"
+;
+; block0(v0: i64, v1: i32, v2: i32):
+;     jump block1
+;
+; block1:
+;     store.i32 user10 aligned region0 v2, v0
+;     return
+; }

--- a/cranelift/filetests/filetests/alias/dead-store-trap-codes.clif
+++ b/cranelift/filetests/filetests/alias/dead-store-trap-codes.clif
@@ -2,7 +2,9 @@ test optimize precise-output
 set opt_level=speed
 target aarch64
 
-;; The killer inherits the dead store's trap code, replacing its own.
+;; We do not eliminate dead stores when the overwriting store has a different
+;; trap code: this risks changing the observed trap code of an execution.
+
 function %different_trap_codes(i64, i32, i32) {
     region0 = 0 "R"
 block0(v0: i64, v1: i32, v2: i32):
@@ -15,12 +17,12 @@ block0(v0: i64, v1: i32, v2: i32):
 ;     region0 = 0 "R"
 ;
 ; block0(v0: i64, v1: i32, v2: i32):
-;     store user10 aligned region0 v2, v0
+;     store user10 aligned region0 v1, v0
+;     store user20 aligned region0 v2, v0
 ;     return
 ; }
 
-;; The previously untrapping killer inherits the dead store's trap code.
-function %dead_traps_killer_does_not(i64, i32, i32) {
+function %dead_traps_overwriter_does_not(i64, i32, i32) {
     region0 = 0 "R"
 block0(v0: i64, v1: i32, v2: i32):
     store aligned region0 user10 v1, v0
@@ -28,16 +30,16 @@ block0(v0: i64, v1: i32, v2: i32):
     return
 }
 
-; function %dead_traps_killer_does_not(i64, i32, i32) fast {
+; function %dead_traps_overwriter_does_not(i64, i32, i32) fast {
 ;     region0 = 0 "R"
 ;
 ; block0(v0: i64, v1: i32, v2: i32):
-;     store user10 aligned region0 v2, v0
+;     store user10 aligned region0 v1, v0
+;     store notrap aligned region0 v2, v0
 ;     return
 ; }
 
-;; The killer keeps its own trap code because the dead store had none.
-function %dead_does_not_trap_killer_does(i64, i32, i32) {
+function %dead_does_not_trap_overwriter_does(i64, i32, i32) {
     region0 = 0 "R"
 block0(v0: i64, v1: i32, v2: i32):
     store notrap aligned region0 v1, v0
@@ -45,16 +47,16 @@ block0(v0: i64, v1: i32, v2: i32):
     return
 }
 
-; function %dead_does_not_trap_killer_does(i64, i32, i32) fast {
+; function %dead_does_not_trap_overwriter_does(i64, i32, i32) fast {
 ;     region0 = 0 "R"
 ;
 ; block0(v0: i64, v1: i32, v2: i32):
+;     store notrap aligned region0 v1, v0
 ;     store user20 aligned region0 v2, v0
 ;     return
 ; }
 
-;; Different trap codes across blocks.
-function %f(i64, i32, i32) {
+function %different_trap_codes_across_blocks(i64, i32, i32) {
     region0 = 0 "R0"
 block0(v0: i64, v1: i32, v2: i32):
     store aligned region0 user10 v1, v0
@@ -65,13 +67,14 @@ block1:
     return
 }
 
-; function %f(i64, i32, i32) fast {
+; function %different_trap_codes_across_blocks(i64, i32, i32) fast {
 ;     region0 = 0 "R0"
 ;
 ; block0(v0: i64, v1: i32, v2: i32):
+;     store user10 aligned region0 v1, v0
 ;     jump block1
 ;
 ; block1:
-;     store.i32 user10 aligned region0 v2, v0
+;     store.i32 user20 aligned region0 v2, v0
 ;     return
 ; }

--- a/cranelift/filetests/filetests/alias/forward-across-trap.clif
+++ b/cranelift/filetests/filetests/alias/forward-across-trap.clif
@@ -1,0 +1,42 @@
+test optimize precise-output
+set opt_level=speed
+target aarch64
+
+;; A pure trap does not modify memory, so a redundant load after it can still be
+;; forwarded from an identical load before it.
+function %forward_load_across_trap(i64, i32) -> i64, i64 {
+    region0 = 0 "R"
+block0(v0: i64, v1: i32):
+    v2 = load.i64 notrap aligned region0 v0
+    trapz v1, user42
+    v3 = load.i64 notrap aligned region0 v0
+    return v2, v3
+}
+
+; function %forward_load_across_trap(i64, i32) -> i64, i64 fast {
+;     region0 = 0 "R"
+;
+; block0(v0: i64, v1: i32):
+;     v2 = load.i64 notrap aligned region0 v0
+;     trapz v1, user42
+;     return v2, v2
+; }
+
+;; A stored value can likewise be forwarded to a later load across a pure trap.
+function %forward_store_across_trap(i64, i32, i64) -> i64 {
+    region0 = 0 "R"
+block0(v0: i64, v1: i32, v2: i64):
+    store notrap aligned region0 v2, v0
+    trapz v1, user42
+    v3 = load.i64 notrap aligned region0 v0
+    return v3
+}
+
+; function %forward_store_across_trap(i64, i32, i64) -> i64 fast {
+;     region0 = 0 "R"
+;
+; block0(v0: i64, v1: i32, v2: i64):
+;     store notrap aligned region0 v2, v0
+;     trapz v1, user42
+;     return v2
+; }

--- a/cranelift/filetests/filetests/alias/idempotent-store.clif
+++ b/cranelift/filetests/filetests/alias/idempotent-store.clif
@@ -36,7 +36,8 @@ block0(v0: i64, v1: i32):
 ;     return
 ; }
 
-;; Same block: non-idempotent store (different value) should NOT be removed.
+;; Same block: a store of a different value to the same location overwrites the
+;; first, which is a dead store and is removed (dead-store elimination).
 function %non_idempotent_store(i64, i32, i32) {
     region0 = 0 "heap"
 block0(v0: i64, v1: i32, v2: i32):
@@ -49,7 +50,6 @@ block0(v0: i64, v1: i32, v2: i32):
 ;     region0 = 0 "heap"
 ;
 ; block0(v0: i64, v1: i32, v2: i32):
-;     store region0 v1, v0+8
 ;     store region0 v2, v0+8
 ;     return
 ; }

--- a/cranelift/filetests/filetests/alias/no-region.clif
+++ b/cranelift/filetests/filetests/alias/no-region.clif
@@ -1,0 +1,89 @@
+test optimize precise-output
+set opt_level=speed
+target aarch64
+
+;; Stores without a region may alias any region. On the other hand, loads
+;; without an alias region are confined to only the "other" / missing
+;; region. Therefore, removing the first store here is sound.
+function %f(i64, i64) -> i32 {
+    region0 = 0 "R0"
+block0(v0: i64, v1: i64):
+    v2 = iconst.i32 0x1234
+    store notrap aligned region0 v2, v0
+
+    v3 = load.i32 notrap aligned v1
+
+    v4 = iconst.i32 0x5678
+    store notrap aligned region0 v4, v0
+
+    return v3
+}
+
+; function %f(i64, i64) -> i32 fast {
+;     region0 = 0 "R0"
+;
+; block0(v0: i64, v1: i64):
+;     v3 = load.i32 notrap aligned v1
+;     v4 = iconst.i32 0x5678
+;     store notrap aligned region0 v4, v0  ; v4 = 0x5678
+;     return v3
+; }
+
+;; But removing the first store here is NOT sound.
+function %f(i64, i64) -> i32 {
+    region0 = 0 "R0"
+block0(v0: i64, v1: i64):
+    v2 = iconst.i32 0x1234
+    store notrap aligned v2, v0
+
+    v3 = load.i32 notrap aligned region0 v1
+
+    v4 = iconst.i32 0x5678
+    store notrap aligned v4, v0
+
+    return v3
+}
+
+; function %f(i64, i64) -> i32 fast {
+;     region0 = 0 "R0"
+;
+; block0(v0: i64, v1: i64):
+;     v2 = iconst.i32 4660
+;     store notrap aligned v2, v0  ; v2 = 4660
+;     v3 = load.i32 notrap aligned region0 v1
+;     v4 = iconst.i32 0x5678
+;     store notrap aligned v4, v0  ; v4 = 0x5678
+;     return v3
+; }
+
+;; Cross-block version.
+function %f(i64, i64, i32, i32) -> i32 {
+    region0 = 0 "R0"
+block0(v0: i64, v1: i64, v2: i32, v3: i32):
+    store notrap aligned v2, v0
+    jump block1
+
+block1:
+    v4 = load.i32 notrap aligned region0 v1
+    jump block2
+
+block2:
+    store notrap aligned v3, v0
+    return v4
+}
+
+; function %f(i64, i64, i32, i32) -> i32 fast {
+;     region0 = 0 "R0"
+;
+; block0(v0: i64, v1: i64, v2: i32, v3: i32):
+;     store notrap aligned v2, v0
+;     jump block1
+;
+; block1:
+;     v4 = load.i32 notrap aligned region0 v1
+;     jump block2
+;
+; block2:
+;     store.i32 notrap aligned v3, v0
+;     return v4
+; }

--- a/cranelift/filetests/filetests/alias/not-dead-all-regions-observed.clif
+++ b/cranelift/filetests/filetests/alias/not-dead-all-regions-observed.clif
@@ -1,0 +1,121 @@
+test optimize precise-output
+set opt_level=speed
+target aarch64
+
+;; A call on one path clobbers all regions, so the store is kept.
+function %call_on_path(i64, i32, i32) {
+    region0 = 0 "R"
+    fn0 = colocated %g()
+block0(v0: i64, v1: i32, v2: i32):
+    store notrap aligned region0 v1, v0
+    brif v1, block1, block2
+
+block1:
+    call fn0()
+    jump block3
+
+block2:
+    jump block3
+
+block3:
+    store notrap aligned region0 v2, v0
+    return
+}
+
+; function %call_on_path(i64, i32, i32) fast {
+;     region0 = 0 "R"
+;     sig0 = () fast
+;     fn0 = colocated %g sig0
+;
+; block0(v0: i64, v1: i32, v2: i32):
+;     store notrap aligned region0 v1, v0
+;     brif v1, block1, block2
+;
+; block1:
+;     call fn0()
+;     jump block3
+;
+; block2:
+;     jump block3
+;
+; block3:
+;     store.i32 notrap aligned region0 v2, v0
+;     return
+; }
+
+;; A trapping instruction on one path keeps the store.
+function %trap_on_path(i64, i32, i32, i32) {
+    region0 = 0 "R"
+block0(v0: i64, v1: i32, v2: i32, v3: i32):
+    store notrap aligned region0 v1, v0
+    brif v1, block1, block2
+
+block1:
+    trapz v3, user42
+    jump block3
+
+block2:
+    jump block3
+
+block3:
+    store notrap aligned region0 v2, v0
+    return
+}
+
+; function %trap_on_path(i64, i32, i32, i32) fast {
+;     region0 = 0 "R"
+;
+; block0(v0: i64, v1: i32, v2: i32, v3: i32):
+;     store notrap aligned region0 v1, v0
+;     brif v1, block1, block2
+;
+; block1:
+;     trapz.i32 v3, user42
+;     jump block3
+;
+; block2:
+;     jump block3
+;
+; block3:
+;     store.i32 notrap aligned region0 v2, v0
+;     return
+; }
+
+;; A fence on one path keeps the store.
+function %fence_on_path(i64, i32, i32) {
+    region0 = 0 "R"
+block0(v0: i64, v1: i32, v2: i32):
+    store notrap aligned region0 v1, v0
+    brif v1, block1, block2
+
+block1:
+    fence
+    jump block3
+
+block2:
+    jump block3
+
+block3:
+    store notrap aligned region0 v2, v0
+    return
+}
+
+; function %fence_on_path(i64, i32, i32) fast {
+;     region0 = 0 "R"
+;
+; block0(v0: i64, v1: i32, v2: i32):
+;     store notrap aligned region0 v1, v0
+;     brif v1, block1, block2
+;
+; block1:
+;     fence 
+;     jump block3
+;
+; block2:
+;     jump block3
+;
+; block3:
+;     store.i32 notrap aligned region0 v2, v0
+;     return
+; }
+

--- a/cranelift/filetests/filetests/alias/not-dead-cross-region.clif
+++ b/cranelift/filetests/filetests/alias/not-dead-cross-region.clif
@@ -1,0 +1,53 @@
+test optimize precise-output
+set opt_level=speed
+target aarch64
+
+;; At a control-flow merge, a region's last store can be collapsed to the join
+;; block's first instruction. A store to `region1` must not be treated as the
+;; killer of a store to `region0`: they touch disjoint regions, so neither is
+;; dead. Both stores in `block3` must be kept.
+function %cross_region_kill(i64, i64, i32, i32, i32, i32) {
+    region0 = 0 "R0"
+    region1 = 1 "R1"
+    fn0 = colocated %g()
+block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):
+    store notrap aligned region0 v2, v0
+    store notrap aligned region1 v3, v1
+    brif v2, block1, block2
+
+block1:
+    call fn0()
+    jump block3
+
+block2:
+    jump block3
+
+block3:
+    store notrap aligned region0 v4, v0
+    store notrap aligned region1 v5, v1
+    return
+}
+
+; function %cross_region_kill(i64, i64, i32, i32, i32, i32) fast {
+;     region0 = 0 "R0"
+;     region1 = 1 "R1"
+;     sig0 = () fast
+;     fn0 = colocated %g sig0
+;
+; block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):
+;     store notrap aligned region0 v2, v0
+;     store notrap aligned region1 v3, v1
+;     brif v2, block1, block2
+;
+; block1:
+;     call fn0()
+;     jump block3
+;
+; block2:
+;     jump block3
+;
+; block3:
+;     store.i32 notrap aligned region0 v4, v0
+;     store.i32 notrap aligned region1 v5, v1
+;     return
+; }

--- a/cranelift/filetests/filetests/alias/not-dead-different-location.clif
+++ b/cranelift/filetests/filetests/alias/not-dead-different-location.clif
@@ -1,0 +1,60 @@
+test optimize precise-output
+set opt_level=speed
+target aarch64
+
+;; The killer writes a different offset in the same region, so the first store
+;; is not dead: its bytes are never overwritten and must be kept.
+function %killer_writes_different_offset(i64, i32, i32) {
+    region0 = 0 "R"
+block0(v0: i64, v1: i32, v2: i32):
+    store notrap aligned region0 v1, v0
+    store notrap aligned region0 v2, v0+8
+    return
+}
+
+; function %killer_writes_different_offset(i64, i32, i32) fast {
+;     region0 = 0 "R"
+;
+; block0(v0: i64, v1: i32, v2: i32):
+;     store notrap aligned region0 v1, v0
+;     store notrap aligned region0 v2, v0+8
+;     return
+; }
+
+;; The killer writes a different address value in the same region, so the first
+;; store is not dead (the addresses may differ at runtime).
+function %killer_writes_different_address(i64, i64, i32, i32) {
+    region0 = 0 "R"
+block0(v0: i64, v1: i64, v2: i32, v3: i32):
+    store notrap aligned region0 v2, v0
+    store notrap aligned region0 v3, v1
+    return
+}
+
+; function %killer_writes_different_address(i64, i64, i32, i32) fast {
+;     region0 = 0 "R"
+;
+; block0(v0: i64, v1: i64, v2: i32, v3: i32):
+;     store notrap aligned region0 v2, v0
+;     store notrap aligned region0 v3, v1
+;     return
+; }
+
+;; The killer is narrower than the dead store, so it only partially overwrites
+;; it; the upper bytes of the wide store are still observable and it is kept.
+function %killer_narrower_than_dead(i64, i64, i32) {
+    region0 = 0 "R"
+block0(v0: i64, v1: i64, v2: i32):
+    store notrap aligned region0 v1, v0
+    store notrap aligned region0 v2, v0
+    return
+}
+
+; function %killer_narrower_than_dead(i64, i64, i32) fast {
+;     region0 = 0 "R"
+;
+; block0(v0: i64, v1: i64, v2: i32):
+;     store notrap aligned region0 v1, v0
+;     store notrap aligned region0 v2, v0
+;     return
+; }

--- a/cranelift/filetests/filetests/alias/not-dead-fence-between.clif
+++ b/cranelift/filetests/filetests/alias/not-dead-fence-between.clif
@@ -1,0 +1,207 @@
+test optimize precise-output
+set opt_level=speed
+target aarch64
+
+;; A call between two stores to the same region is a fence; it must not be
+;; treated as a dead store and removed, and the first store must be kept.
+function %call_between(i64, i32, i32) {
+    region0 = 0 "R"
+    fn0 = colocated %g()
+block0(v0: i64, v1: i32, v2: i32):
+    store notrap aligned region0 v1, v0
+    call fn0()
+    store notrap aligned region0 v2, v0
+    return
+}
+
+; function %call_between(i64, i32, i32) fast {
+;     region0 = 0 "R"
+;     sig0 = () fast
+;     fn0 = colocated %g sig0
+;
+; block0(v0: i64, v1: i32, v2: i32):
+;     store notrap aligned region0 v1, v0
+;     call fn0()
+;     store notrap aligned region0 v2, v0
+;     return
+; }
+
+;; Same as above, but the call produces a result.
+function %call_result_between(i64, i32) -> i32 {
+    region0 = 0 "R"
+    fn0 = colocated %g(i64) -> i32
+block0(v0: i64, v1: i32):
+    store notrap aligned region0 v1, v0
+    v2 = call fn0(v0)
+    store notrap aligned region0 v2, v0
+    return v2
+}
+
+; function %call_result_between(i64, i32) -> i32 fast {
+;     region0 = 0 "R"
+;     sig0 = (i64) -> i32 fast
+;     fn0 = colocated %g sig0
+;
+; block0(v0: i64, v1: i32):
+;     store notrap aligned region0 v1, v0
+;     v2 = call fn0(v0)
+;     store notrap aligned region0 v2, v0
+;     return v2
+; }
+
+;; A `fence` between two stores must be kept.
+function %fence_between(i64, i32, i32) {
+    region0 = 0 "R"
+block0(v0: i64, v1: i32, v2: i32):
+    store notrap aligned region0 v1, v0
+    fence
+    store notrap aligned region0 v2, v0
+    return
+}
+
+; function %fence_between(i64, i32, i32) fast {
+;     region0 = 0 "R"
+;
+; block0(v0: i64, v1: i32, v2: i32):
+;     store notrap aligned region0 v1, v0
+;     fence 
+;     store notrap aligned region0 v2, v0
+;     return
+; }
+
+;; An `atomic_cas` between two stores is a fence and must be kept.
+function %atomic_cas_between(i64, i32, i32, i32) {
+    region0 = 0 "R"
+block0(v0: i64, v1: i32, v2: i32, v3: i32):
+    store notrap aligned region0 v1, v0
+    v4 = atomic_cas.i32 v0, v2, v3
+    store notrap aligned region0 v2, v0
+    return
+}
+
+; function %atomic_cas_between(i64, i32, i32, i32) fast {
+;     region0 = 0 "R"
+;
+; block0(v0: i64, v1: i32, v2: i32, v3: i32):
+;     store notrap aligned region0 v1, v0
+;     v4 = atomic_cas v0, v2, v3
+;     store notrap aligned region0 v2, v0
+;     return
+; }
+
+;; A `trapz` between two stores: post-trap memory must reflect the first store,
+;; so the first store cannot be eliminated across the trap.
+function %trapz_between(i64, i32, i32, i32) {
+    region0 = 0 "R"
+block0(v0: i64, v1: i32, v2: i32, v3: i32):
+    store notrap aligned region0 v1, v0
+    trapz v3, user42
+    store notrap aligned region0 v2, v0
+    return
+}
+
+; function %trapz_between(i64, i32, i32, i32) fast {
+;     region0 = 0 "R"
+;
+; block0(v0: i64, v1: i32, v2: i32, v3: i32):
+;     store notrap aligned region0 v1, v0
+;     trapz v3, user42
+;     store notrap aligned region0 v2, v0
+;     return
+; }
+
+function %atomic_rmw_between(i64, i32, i32) {
+    region0 = 0 "R0"
+block0(v0: i64, v1: i32, v2: i32):
+    store notrap aligned region0 v1, v0
+    v3 = atomic_rmw.i32 add v0, v1
+    store notrap aligned region0 v2, v0
+    return
+}
+
+; function %atomic_rmw_between(i64, i32, i32) fast {
+;     region0 = 0 "R0"
+;
+; block0(v0: i64, v1: i32, v2: i32):
+;     store notrap aligned region0 v1, v0
+;     v3 = atomic_rmw.i32 add v0, v1
+;     store notrap aligned region0 v2, v0
+;     return
+; }
+
+function %atomic_load_between(i64, i32, i32) {
+    region0 = 0 "R0"
+block0(v0: i64, v1: i32, v2: i32):
+    store notrap aligned region0 v1, v0
+    v3 = atomic_load.i32 v0
+    store notrap aligned region0 v2, v0
+    return
+}
+
+; function %atomic_load_between(i64, i32, i32) fast {
+;     region0 = 0 "R0"
+;
+; block0(v0: i64, v1: i32, v2: i32):
+;     store notrap aligned region0 v1, v0
+;     v3 = atomic_load.i32 v0
+;     store notrap aligned region0 v2, v0
+;     return
+; }
+
+function %atomic_store_between(i64, i32, i32, i32) {
+    region0 = 0 "R0"
+block0(v0: i64, v1: i32, v2: i32, v3: i32):
+    store notrap aligned region0 v1, v0
+    atomic_store.i32 v3, v0
+    store notrap aligned region0 v2, v0
+    return
+}
+
+; function %atomic_store_between(i64, i32, i32, i32) fast {
+;     region0 = 0 "R0"
+;
+; block0(v0: i64, v1: i32, v2: i32, v3: i32):
+;     store notrap aligned region0 v1, v0
+;     atomic_store v3, v0
+;     store notrap aligned region0 v2, v0
+;     return
+; }
+
+function %debugtrap_between(i64, i32, i32) {
+    region0 = 0 "R0"
+block0(v0: i64, v1: i32, v2: i32):
+    store notrap aligned region0 v1, v0
+    debugtrap
+    store notrap aligned region0 v2, v0
+    return
+}
+
+; function %debugtrap_between(i64, i32, i32) fast {
+;     region0 = 0 "R0"
+;
+; block0(v0: i64, v1: i32, v2: i32):
+;     store notrap aligned region0 v1, v0
+;     debugtrap 
+;     store notrap aligned region0 v2, v0
+;     return
+; }
+
+function %sequence_point_between(i64, i32, i32) {
+    region0 = 0 "R0"
+block0(v0: i64, v1: i32, v2: i32):
+    store notrap aligned region0 v1, v0
+    sequence_point
+    store notrap aligned region0 v2, v0
+    return
+}
+
+; function %sequence_point_between(i64, i32, i32) fast {
+;     region0 = 0 "R0"
+;
+; block0(v0: i64, v1: i32, v2: i32):
+;     store notrap aligned region0 v1, v0
+;     sequence_point 
+;     store notrap aligned region0 v2, v0
+;     return
+; }
+

--- a/cranelift/filetests/filetests/alias/not-dead-not-post-dominated.clif
+++ b/cranelift/filetests/filetests/alias/not-dead-not-post-dominated.clif
@@ -1,0 +1,40 @@
+test optimize precise-output
+set opt_level=speed
+target aarch64
+
+;; The killer runs on only one path and does not post-dominate the store.
+function %killer_in_one_arm(i64, i32, i32) {
+    region0 = 0 "R"
+block0(v0: i64, v1: i32, v2: i32):
+    store notrap aligned region0 v1, v0
+    brif v1, block1, block2
+
+block1:
+    store notrap aligned region0 v2, v0
+    jump block3
+
+block2:
+    jump block3
+
+block3:
+    return
+}
+
+; function %killer_in_one_arm(i64, i32, i32) fast {
+;     region0 = 0 "R"
+;
+; block0(v0: i64, v1: i32, v2: i32):
+;     store notrap aligned region0 v1, v0
+;     brif v1, block1, block2
+;
+; block1:
+;     store.i32 notrap aligned region0 v2, v0
+;     jump block3
+;
+; block2:
+;     jump block3
+;
+; block3:
+;     return
+; }
+

--- a/cranelift/filetests/filetests/alias/not-dead-region-observed.clif
+++ b/cranelift/filetests/filetests/alias/not-dead-region-observed.clif
@@ -1,0 +1,61 @@
+test optimize precise-output
+set opt_level=speed
+target aarch64
+
+;; A load observes the store's region before the killer, so the store is kept.
+function %load_observes_region(i64, i32, i32) -> i32 {
+    region0 = 0 "R"
+block0(v0: i64, v1: i32, v2: i32):
+    store notrap aligned region0 v1, v0
+    v3 = load.i32 notrap aligned region0 v0+8
+    store notrap aligned region0 v2, v0
+    return v3
+}
+
+; function %load_observes_region(i64, i32, i32) -> i32 fast {
+;     region0 = 0 "R"
+;
+; block0(v0: i64, v1: i32, v2: i32):
+;     store notrap aligned region0 v1, v0
+;     v3 = load.i32 notrap aligned region0 v0+8
+;     store notrap aligned region0 v2, v0
+;     return v3
+; }
+
+;; Observing the region on only one path of a merge is enough to keep the store.
+function %load_observes_region_on_one_path(i64, i32, i32) -> i32 {
+    region0 = 0 "R"
+block0(v0: i64, v1: i32, v2: i32):
+    store notrap aligned region0 v1, v0
+    brif v1, block1, block2
+
+block1:
+    v3 = load.i32 notrap aligned region0 v0
+    jump block3(v3)
+
+block2:
+    jump block3(v2)
+
+block3(v4: i32):
+    store notrap aligned region0 v2, v0
+    return v4
+}
+
+; function %load_observes_region_on_one_path(i64, i32, i32) -> i32 fast {
+;     region0 = 0 "R"
+;
+; block0(v0: i64, v1: i32, v2: i32):
+;     store notrap aligned region0 v1, v0
+;     brif v1, block1, block2
+;
+; block1:
+;     jump block3(v1)
+;
+; block2:
+;     jump block3(v2)
+;
+; block3(v4: i32):
+;     store.i32 notrap aligned region0 v2, v0
+;     return v4
+; }
+

--- a/cranelift/filetests/filetests/alias/not-dead-trapping-load.clif
+++ b/cranelift/filetests/filetests/alias/not-dead-trapping-load.clif
@@ -1,0 +1,26 @@
+test optimize precise-output
+set opt_level=speed
+target aarch64
+
+;; A trapping load to region1 sits between two region0 stores. The load can
+;; observe region0 via its trap, so the first store is not dead.
+function %trapping_load_between(i64, i64, i32, i32) -> i32 {
+    region0 = 0 "R0"
+    region1 = 1 "R1"
+block0(v0: i64, v1: i64, v2: i32, v3: i32):
+    store aligned region0 user10 v2, v0
+    v4 = load.i32 aligned region1 user11 v1
+    store aligned region0 user10 v3, v0
+    return v4
+}
+
+; function %trapping_load_between(i64, i64, i32, i32) -> i32 fast {
+;     region0 = 0 "R0"
+;     region1 = 1 "R1"
+;
+; block0(v0: i64, v1: i64, v2: i32, v3: i32):
+;     store user10 aligned region0 v2, v0
+;     v4 = load.i32 user11 aligned region1 v1
+;     store user10 aligned region0 v3, v0
+;     return v4
+; }

--- a/cranelift/filetests/filetests/alias/not-dead-would-change-trap.clif
+++ b/cranelift/filetests/filetests/alias/not-dead-would-change-trap.clif
@@ -1,0 +1,38 @@
+test optimize precise-output
+set opt_level=speed
+target aarch64
+
+;; The first store is not dead because removing it would not preserve the set of
+;; memory stores made when writing to `v0` and `v1` traps:
+;;
+;; * Before: trap with `user1`
+;;
+;; * After, if we treated the first store as dead: trap with `user2`
+function %f(i64, i64) {
+    ss0 = explicit_slot 8
+    region0 = 0 "R0"
+    region1 = 1 "R1"
+block0(v0: i64, v1: i64):
+    v2 = iconst.i32 11
+    store aligned region0 user1 v2, v0
+    v3 = iconst.i32 22
+    store aligned region1 user2 v3, v1
+    v4 = iconst.i32 33
+    store aligned region0 user1 v4, v0
+    return
+}
+
+; function %f(i64, i64) fast {
+;     ss0 = explicit_slot 8
+;     region0 = 0 "R0"
+;     region1 = 1 "R1"
+;
+; block0(v0: i64, v1: i64):
+;     v2 = iconst.i32 11
+;     store user1 aligned region0 v2, v0  ; v2 = 11
+;     v3 = iconst.i32 22
+;     store user2 aligned region1 v3, v1  ; v3 = 22
+;     v4 = iconst.i32 33
+;     store user1 aligned region0 v4, v0  ; v4 = 33
+;     return
+; }

--- a/cranelift/filetests/filetests/alias/not-dead-would-drop-store-before-trap.clif
+++ b/cranelift/filetests/filetests/alias/not-dead-would-drop-store-before-trap.clif
@@ -1,0 +1,70 @@
+test optimize precise-output
+set opt_level=speed
+target aarch64
+
+;; The first store must NOT be removed, because when writing to `v0` traps:
+;;
+;; * Now: no writes, just trap
+;;
+;; * If the first store was treated as dead asn removed: write to `v1`, then
+;;   trap
+function %f(i64, i64) {
+    region0 = 0 "R0"
+    region1 = 1 "R1"
+block0(v0: i64, v1: i64):
+    v2 = iconst.i32 11
+    store aligned region0 user1 v2, v0
+    v3 = iconst.i32 22
+    store aligned region1 user1 v3, v1
+    v4 = iconst.i32 33
+    store aligned region0 user1 v4, v0
+    return
+}
+
+; function %f(i64, i64) fast {
+;     region0 = 0 "R0"
+;     region1 = 1 "R1"
+;
+; block0(v0: i64, v1: i64):
+;     v2 = iconst.i32 11
+;     store user1 aligned region0 v2, v0  ; v2 = 11
+;     v3 = iconst.i32 22
+;     store user1 aligned region1 v3, v1  ; v3 = 22
+;     v4 = iconst.i32 33
+;     store user1 aligned region0 v4, v0  ; v4 = 33
+;     return
+; }
+
+;; Same as above, but with the almost-dead stores being non-trapping. In the
+;; case that writing to `v1` traps:
+;;
+;; * Now: write to `v0`, then trap
+;;
+;; * If the first store was treated as dead and removed: no stores, just trap
+function %f(i64, i64) {
+    region0 = 0 "R0"
+    region1 = 1 "R1"
+block0(v0: i64, v1: i64):
+    v2 = iconst.i32 11
+    store aligned region0 notrap v2, v0
+    v3 = iconst.i32 22
+    store aligned region1 user1 v3, v1
+    v4 = iconst.i32 33
+    store aligned region0 notrap v4, v0
+    return
+}
+
+; function %f(i64, i64) fast {
+;     region0 = 0 "R0"
+;     region1 = 1 "R1"
+;
+; block0(v0: i64, v1: i64):
+;     v2 = iconst.i32 11
+;     store notrap aligned region0 v2, v0  ; v2 = 11
+;     v3 = iconst.i32 22
+;     store user1 aligned region1 v3, v1  ; v3 = 22
+;     v4 = iconst.i32 33
+;     store notrap aligned region0 v4, v0  ; v4 = 33
+;     return
+; }
+

--- a/cranelift/filetests/filetests/alias/not-dead-would-store-before-trap.clif
+++ b/cranelift/filetests/filetests/alias/not-dead-would-store-before-trap.clif
@@ -1,0 +1,38 @@
+test optimize precise-output
+set opt_level=speed
+target aarch64
+
+;; The first store is not dead because removing it would not preserve the set of
+;; memory stores made when writing to `v0` traps:
+;;
+;; * Before: no writes, just trap with `user1`
+;;
+;; * After, if we treated the first store as dead: write to `v1`, then trap with
+;;   `user1`
+function %f(i64, i64) {
+    region0 = 0 "R0"
+    region1 = 1 "R1"
+block0(v0: i64, v1: i64):
+    v2 = iconst.i32 11
+    store aligned region0 user1 v2, v0
+    v3 = iconst.i32 22
+    store aligned region1 notrap v3, v1
+    v4 = iconst.i32 33
+    store aligned region0 user1 v4, v0
+    return
+}
+
+; function %f(i64, i64) fast {
+;     region0 = 0 "R0"
+;     region1 = 1 "R1"
+;
+; block0(v0: i64, v1: i64):
+;     v2 = iconst.i32 11
+;     store user1 aligned region0 v2, v0  ; v2 = 11
+;     v3 = iconst.i32 22
+;     store notrap aligned region1 v3, v1  ; v3 = 22
+;     v4 = iconst.i32 33
+;     store user1 aligned region0 v4, v0  ; v4 = 33
+;     return
+; }
+

--- a/cranelift/filetests/filetests/alias/store-to-load-forwarding-from-dead-store.clif
+++ b/cranelift/filetests/filetests/alias/store-to-load-forwarding-from-dead-store.clif
@@ -1,0 +1,74 @@
+test optimize precise-output
+set opt_level=speed
+target aarch64
+
+function %f(i64, i64) -> i64 {
+    region0 = 0 "R0"
+block0(v0: i64, v1: i64):
+    v2 = iconst.i64 1
+    v3 = iadd v1, v2
+    store notrap aligned region0 v3, v0
+
+    ;; `v4` should be rewritten into an alias of `v3` via store-to-load
+    ;; forwarding, and should NOT mark `region0` as observed. Then, when we
+    ;; process the second store below, we should be able to eliminate the first
+    ;; store as dead.
+    v4 = load.i64 notrap aligned region0 v0
+
+    v5 = iadd v3, v2
+    store notrap aligned region0 v5, v0
+
+    return v4
+}
+
+; function %f(i64, i64) -> i64 fast {
+;     region0 = 0 "R0"
+;
+; block0(v0: i64, v1: i64):
+;     v7 = iconst.i64 2
+;     v12 = iadd v1, v7  ; v7 = 2
+;     store notrap aligned region0 v12, v0
+;     v2 = iconst.i64 1
+;     v3 = iadd v1, v2  ; v2 = 1
+;     return v3
+; }
+
+;; TODO: we cannot do both store-to-load forwarding and dead-store elimination
+;; across blocks yet. This would require multiple iterations of the analysis.
+function %f(i64, i64) -> i64 {
+    region0 = 0 "R0"
+block0(v0: i64, v1: i64):
+    v2 = iconst.i64 1
+    v3 = iadd v1, v2
+    store notrap aligned region0 v3, v0
+    jump block1
+
+block1:
+    v4 = load.i64 notrap aligned region0 v0
+    jump block2
+
+block2:
+    v5 = iadd v3, v2
+    store notrap aligned region0 v5, v0
+    return v4
+}
+
+; function %f(i64, i64) -> i64 fast {
+;     region0 = 0 "R0"
+;
+; block0(v0: i64, v1: i64):
+;     v2 = iconst.i64 1
+;     v3 = iadd v1, v2  ; v2 = 1
+;     store notrap aligned region0 v3, v0
+;     jump block1
+;
+; block1:
+;     jump block2
+;
+; block2:
+;     v7 = iconst.i64 2
+;     v12 = iadd.i64 v1, v7  ; v7 = 2
+;     store notrap aligned region0 v12, v0
+;     v14 = iadd.i64 v1, v2  ; v2 = 1
+;     return v14
+; }

--- a/cranelift/filetests/filetests/isa/riscv64/issue-12811.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/issue-12811.clif
@@ -3417,44 +3417,36 @@ block2:
 ;   addi t6,t6,32
 ;   trap_if stk_ovf##(sp ult t6)
 ;   addi sp,sp,-16
-;   sd s8,8(sp)
+;   sd s7,8(sp)
 ; block0:
 ;   li a1,0
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
-;   li a3,4
-;   sd a3,0(a1)
-;   sd zero,0(a1)
-;   sd a3,0(a1)
+;   sw zero,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
 ;   li a2,1
 ;   sd a2,0(a1)
+;   sw zero,0(a1)
+;   sd a2,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   li a3,1
+;   sw a3,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
 ;   sd a2,0(a1)
 ;   sw zero,0(a1)
-;   sd a3,0(a1)
-;   sd a2,0(a1)
-;   li a5,1
-;   sw a5,0(a1)
-;   sw zero,0(a1)
 ;   sd zero,0(a1)
-;   sw zero,0(a1)
-;   sd zero,0(a1)
-;   sw zero,0(a1)
-;   sd zero,0(a1)
-;   sw zero,0(a1)
-;   sd zero,0(a1)
-;   sw zero,0(a1)
-;   sd zero,0(a1)
-;   sw zero,0(a1)
-;   sw a5,0(a1)
-;   sd a3,0(a1)
-;   sd zero,0(a1)
-;   sw zero,0(a1)
-;   sd a2,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
@@ -3462,73 +3454,49 @@ block2:
 ;   sw zero,0(a1)
 ;   li a4,9
 ;   sd a4,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd a2,0(a1)
+;   sw zero,0(a1)
+;   sd a2,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   li a4,4
+;   sd a4,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   li a5,8
+;   sd a5,0(a1)
+;   sw zero,0(a1)
+;   sd a5,0(a1)
+;   sw a3,0(a1)
+;   sd a2,0(a1)
+;   sw a3,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw a3,0(a1)
+;   sd zero,0(a1)
+;   sw a3,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
 ;   sd a4,0(a1)
-;   li a4,13
-;   sw a4,0(a1)
 ;   sw zero,0(a1)
-;   sd zero,0(a1)
-;   sw zero,0(a1)
-;   sd zero,0(a1)
-;   sw zero,0(a1)
-;   sd zero,0(a1)
-;   sd a3,0(a1)
 ;   sd a2,0(a1)
-;   sw zero,0(a1)
+;   sw a3,0(a1)
 ;   sd zero,0(a1)
-;   sd a2,0(a1)
-;   sw zero,0(a1)
-;   sw a5,0(a1)
-;   sw zero,0(a1)
-;   sw a5,0(a1)
-;   sw zero,0(a1)
+;   sw a3,0(a1)
 ;   sd zero,0(a1)
-;   sw zero,0(a1)
-;   sd zero,0(a1)
-;   sd a2,0(a1)
-;   sd a3,0(a1)
-;   sw zero,0(a1)
-;   sd zero,0(a1)
-;   sw zero,0(a1)
-;   sd zero,0(a1)
-;   li a4,8
-;   sd a4,0(a1)
-;   sw a5,0(a1)
-;   sw zero,0(a1)
-;   sd a3,0(a1)
-;   sd a4,0(a1)
-;   sw a5,0(a1)
-;   sd a2,0(a1)
-;   sw a5,0(a1)
-;   sd zero,0(a1)
-;   sw zero,0(a1)
-;   sd zero,0(a1)
-;   sw zero,0(a1)
-;   sd zero,0(a1)
-;   sw a5,0(a1)
-;   sd a2,0(a1)
-;   sd zero,0(a1)
-;   sw zero,0(a1)
-;   sw a5,0(a1)
-;   sd zero,0(a1)
-;   sw zero,0(a1)
-;   sd a3,0(a1)
 ;   sw zero,0(a1)
 ;   sd a2,0(a1)
 ;   sw zero,0(a1)
-;   sw a5,0(a1)
-;   sd zero,0(a1)
-;   sw a5,0(a1)
-;   sd zero,0(a1)
-;   sw zero,0(a1)
-;   sd zero,0(a1)
-;   sd a2,0(a1)
-;   sw zero,0(a1)
-;   sd zero,0(a1)
-;   sd a2,0(a1)
-;   sd zero,0(a1)
-;   sd a4,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
@@ -3539,42 +3507,27 @@ block2:
 ;   li t0,3
 ;   sw t0,0(a1)
 ;   sd a2,0(a1)
-;   sb a5,0(a1)
+;   sb a3,0(a1)
 ;   sw zero,0(a1)
-;   sd a3,0(a1)
 ;   sd zero,0(a1)
-;   sw a5,0(a1)
 ;   sw zero,0(a1)
-;   sw a5,0(a1)
+;   sd zero,0(a1)
 ;   sw zero,0(a1)
 ;   sd a4,0(a1)
+;   sw a3,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
-;   sw a5,0(a1)
-;   sw zero,0(a1)
-;   sd a2,0(a1)
-;   sd a3,0(a1)
-;   sw a5,0(a1)
-;   sd a2,0(a1)
-;   sd zero,0(a1)
-;   sw zero,0(a1)
-;   li t2,8
-;   sw t2,0(a1)
-;   sw zero,0(a1)
-;   sd a4,0(a1)
-;   sw zero,0(a1)
-;   sw a5,0(a1)
+;   sd a5,0(a1)
+;   sw a3,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
-;   sw a5,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
 ;   sd a2,0(a1)
-;   sw a5,0(a1)
 ;   sw zero,0(a1)
 ;   sd a2,0(a1)
 ;   sw zero,0(a1)
@@ -3591,7 +3544,6 @@ block2:
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
-;   sw t2,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
@@ -3642,31 +3594,26 @@ block2:
 ;   sd a2,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
-;   sd a2,0(a1)
-;   sd a4,0(a1)
-;   sd zero,0(a1)
-;   sw zero,0(a1)
-;   sd a3,0(a1)
-;   sd zero,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
+;   sw zero,0(a1)
 ;   sd a2,0(a1)
 ;   j label1
 ; block1:
 ;   lui a1,435789
-;   addi a1,a1,3
-;   sext.w a1,a1
+;   addi a2,a1,3
+;   sext.w a1,a2
 ;   trap_if user11##(a1 ne zero)
 ;   j label2
 ; block2:
-;   lui a1,154029
-;   addi a1,a1,-1574
-;   sext.w a1,a1
-;   trap_if user11##(a1 ne zero)
+;   lui a2,154029
+;   addi a4,a2,-1574
+;   sext.w a3,a4
+;   trap_if user11##(a3 ne zero)
 ;   j label3
 ; block3:
 ;   j label4
@@ -3735,8 +3682,8 @@ block2:
 ;   j label28
 ; block28:
 ;   lui a1,296162
-;   addi a2,a1,-1144
-;   sext.w a1,a2
+;   addi a1,a1,-1144
+;   sext.w a1,a1
 ;   trap_if user11##(a1 ne zero)
 ;   j label29
 ; block29:
@@ -3746,8 +3693,8 @@ block2:
 ; block31:
 ;   j label32
 ; block32:
-;   lui a5,69861
-;   addi a1,a5,-1634
+;   lui a1,69861
+;   addi a1,a1,-1634
 ;   sext.w a1,a1
 ;   trap_if user11##(a1 ne zero)
 ;   j label33
@@ -3774,452 +3721,370 @@ block2:
 ; block39:
 ;   j label40
 ; block40:
-;   ld a2,[const(253)]
+;   ld a2,[const(213)]
 ;   li a1,0
 ;   sd a2,0(a1)
-;   ld a2,[const(252)]
-;   sd a2,0(a1)
-;   ld a2,[const(251)]
-;   sd a2,0(a1)
-;   ld a2,[const(250)]
-;   sd a2,0(a1)
-;   ld a2,[const(249)]
-;   sd a2,0(a1)
-;   ld a2,[const(248)]
-;   sd a2,0(a1)
-;   ld a2,[const(247)]
+;   ld a2,[const(212)]
 ;   sd zero,0(a2)
-;   ld a2,[const(246)]
-;   sd a2,0(a1)
-;   ld a2,[const(245)]
-;   sd a2,0(a1)
-;   ld a2,[const(244)]
-;   sd a2,0(a1)
-;   ld a2,[const(243)]
-;   sd a2,0(a1)
-;   ld a2,[const(242)]
+;   ld a2,[const(211)]
 ;   sd a2,0(a1)
 ;   li a2,1
-;   ld a3,[const(241)]
+;   ld a3,[const(210)]
 ;   sd a2,0(a3)
-;   ld a3,[const(240)]
+;   ld a3,[const(209)]
 ;   sd a3,0(a1)
-;   ld a3,[const(239)]
-;   sd a3,0(a1)
-;   ld a3,[const(238)]
-;   sd a3,0(a1)
-;   ld a3,[const(237)]
-;   sd a3,0(a1)
-;   ld a3,[const(236)]
+;   ld a3,[const(208)]
 ;   sd zero,0(a3)
-;   ld a3,[const(235)]
+;   ld a3,[const(207)]
 ;   sd a3,0(a1)
-;   ld a3,[const(234)]
-;   sd a3,0(a1)
-;   ld a3,[const(233)]
-;   sd a3,0(a1)
-;   ld a3,[const(232)]
-;   sd a3,0(a1)
-;   ld a3,[const(231)]
-;   sd a3,0(a1)
-;   ld a3,[const(230)]
-;   sd a3,0(a1)
-;   ld a3,[const(229)]
+;   ld a3,[const(206)]
 ;   sd zero,0(a3)
-;   ld a3,[const(228)]
+;   ld a3,[const(205)]
 ;   sd zero,0(a3)
-;   ld a3,[const(227)]
+;   ld a3,[const(204)]
 ;   sd a3,0(a1)
-;   ld a3,[const(226)]
+;   ld a3,[const(203)]
 ;   sd a2,0(a3)
-;   ld a3,[const(225)]
+;   ld a3,[const(202)]
 ;   sd a3,0(a1)
-;   ld a3,[const(224)]
-;   sd a3,0(a1)
-;   ld a3,[const(223)]
-;   sd a3,0(a1)
-;   ld a3,[const(222)]
+;   ld a3,[const(201)]
 ;   sd zero,0(a3)
-;   ld a3,[const(221)]
-;   sd a3,0(a1)
-;   ld a3,[const(220)]
-;   sd a3,0(a1)
-;   ld a3,[const(219)]
-;   sd a3,0(a1)
-;   ld a3,[const(218)]
-;   sd a3,0(a1)
-;   ld a3,[const(217)]
-;   sd a3,0(a1)
-;   ld a3,[const(216)]
-;   sd a3,0(a1)
-;   ld a3,[const(215)]
-;   sd a3,0(a1)
-;   ld a3,[const(214)]
-;   sd a3,0(a1)
-;   ld a3,[const(213)]
+;   ld a3,[const(200)]
 ;   sd a3,0(a1)
 ;   li a3,1
-;   ld a4,[const(212)]
+;   ld a4,[const(199)]
 ;   sw a3,0(a4)
-;   ld a4,[const(211)]
+;   ld a4,[const(198)]
 ;   sd a4,0(a1)
-;   ld a4,[const(210)]
-;   sd a4,0(a1)
-;   ld a4,[const(209)]
+;   ld a4,[const(197)]
 ;   sd zero,0(a4)
-;   ld a4,[const(208)]
+;   sd zero,0(a1)
+;   li a5,0
+;   sw zero,0(a1)
+;   ld a4,[const(196)]
 ;   sd a4,0(a1)
-;   ld a4,[const(207)]
+;   sw zero,0(a1)
+;   ld a4,[const(195)]
 ;   sd a4,0(a1)
-;   ld a4,[const(206)]
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   ld a4,[const(194)]
+;   ld s7,[const(193)]
+;   sd a4,0(s7)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   ld a4,[const(192)]
+;   sd a4,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   ld a4,[const(191)]
+;   sd zero,0(a4)
+;   sw zero,0(a1)
+;   ld a4,[const(190)]
+;   sd a4,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   ld a4,[const(189)]
+;   sd a4,0(a1)
+;   sw zero,0(a1)
+;   ld a4,[const(188)]
+;   sd zero,0(a4)
+;   ld a4,[const(187)]
+;   sd a4,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   ld a4,[const(186)]
+;   sd a4,0(a1)
+;   sw zero,0(a1)
+;   ld a4,[const(185)]
+;   sd a4,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   ld a4,[const(184)]
+;   sd a4,0(a1)
+;   sw zero,0(a1)
+;   ld a4,[const(183)]
+;   sd a4,0(a1)
+;   sw zero,0(a1)
+;   ld a4,[const(182)]
+;   sd a4,0(a1)
+;   ld a4,[const(181)]
+;   ld a4,0(a4)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   ld a4,[const(180)]
+;   sd a4,0(a1)
+;   ld a4,[const(179)]
+;   sd a4,0(a1)
+;   sw zero,0(a1)
+;   ld a4,[const(178)]
+;   sd a4,0(a1)
+;   ld a4,[const(177)]
+;   sd a4,0(a1)
+;   sw zero,0(a1)
+;   ld a4,[const(176)]
 ;   sd a4,0(a1)
 ;   sd zero,0(a1)
-;   li a4,0
 ;   sw zero,0(a1)
+;   ld a4,[const(175)]
+;   sd a4,0(a1)
 ;   sd zero,0(a1)
-;   ld a5,[const(205)]
-;   sd a5,0(a1)
 ;   sw zero,0(a1)
-;   ld a5,[const(204)]
-;   sd a5,0(a1)
-;   sw zero,0(a1)
-;   ld a5,[const(203)]
-;   sd a5,0(a1)
-;   ld a5,[const(202)]
-;   sd a5,0(a1)
-;   sd zero,0(a1)
-;   sw zero,0(a1)
-;   sd zero,0(a1)
-;   ld a5,[const(201)]
-;   ld s8,[const(200)]
-;   sd a5,0(s8)
-;   sw zero,0(a1)
-;   sd zero,0(a1)
-;   sw zero,0(a1)
-;   sd zero,0(a1)
-;   sw zero,0(a1)
-;   sd zero,0(a1)
-;   sw zero,0(a1)
-;   ld a5,[const(199)]
-;   sd a5,0(a1)
-;   sw zero,0(a1)
-;   sd zero,0(a1)
-;   sw zero,0(a1)
-;   sd zero,0(a1)
-;   sw zero,0(a1)
-;   ld a5,[const(198)]
-;   sd zero,0(a5)
-;   sw zero,0(a1)
-;   ld a5,[const(197)]
-;   sd a5,0(a1)
-;   sw zero,0(a1)
-;   ld a5,[const(196)]
-;   sd a5,0(a1)
-;   sd zero,0(a1)
-;   sw zero,0(a1)
-;   sd zero,0(a1)
-;   sw zero,0(a1)
-;   ld a5,[const(195)]
-;   sd a5,0(a1)
-;   ld a5,[const(194)]
-;   sd a5,0(a1)
-;   sw zero,0(a1)
-;   ld a5,[const(193)]
-;   sd zero,0(a5)
-;   ld a5,[const(192)]
-;   sd a5,0(a1)
-;   sw zero,0(a1)
-;   ld a5,[const(191)]
-;   sd a5,0(a1)
-;   sd zero,0(a1)
-;   sw zero,0(a1)
-;   sd zero,0(a1)
-;   sw zero,0(a1)
-;   sd zero,0(a1)
-;   sw zero,0(a1)
-;   sd zero,0(a1)
-;   sw zero,0(a1)
-;   ld a5,[const(190)]
-;   sd a5,0(a1)
-;   sd zero,0(a1)
-;   sw zero,0(a1)
-;   ld a5,[const(189)]
-;   sd a5,0(a1)
-;   ld a5,[const(188)]
-;   sd a5,0(a1)
-;   sw zero,0(a1)
-;   ld a5,[const(187)]
-;   sd a5,0(a1)
-;   ld a5,[const(186)]
-;   sd a5,0(a1)
-;   sw zero,0(a1)
-;   sd zero,0(a1)
-;   sw zero,0(a1)
-;   sd zero,0(a1)
-;   ld a5,[const(185)]
-;   sd a5,0(a1)
-;   sw zero,0(a1)
-;   ld a5,[const(184)]
-;   sd a5,0(a1)
-;   sw zero,0(a1)
-;   ld a5,[const(183)]
-;   sd a5,0(a1)
-;   ld a5,[const(182)]
-;   sd a5,0(a1)
-;   ld a5,[const(181)]
-;   ld a5,0(a5)
-;   sd zero,0(a1)
-;   sw zero,0(a1)
-;   ld a5,[const(180)]
-;   sd a5,0(a1)
-;   ld a5,[const(179)]
-;   sd a5,0(a1)
-;   sw zero,0(a1)
-;   ld a5,[const(178)]
-;   sd a5,0(a1)
-;   ld a5,[const(177)]
-;   sd a5,0(a1)
-;   sw zero,0(a1)
-;   ld a5,[const(176)]
-;   sd a5,0(a1)
-;   sd zero,0(a1)
-;   sw zero,0(a1)
-;   ld a5,[const(175)]
-;   sd a5,0(a1)
-;   sd zero,0(a1)
-;   sw zero,0(a1)
-;   ld a5,[const(174)]
-;   sd a5,0(a1)
+;   ld a4,[const(174)]
+;   sd a4,0(a1)
 ;   sd zero,0(a1)
-;   ld a5,[const(173)]
-;   sd zero,0(a5)
+;   ld a4,[const(173)]
+;   sd zero,0(a4)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
-;   ld a5,[const(172)]
-;   sd a5,0(a1)
+;   ld a4,[const(172)]
+;   sd a4,0(a1)
 ;   sw zero,0(a1)
-;   ld a5,[const(171)]
-;   sd a5,0(a1)
+;   ld a4,[const(171)]
+;   sd a4,0(a1)
 ;   sw zero,0(a1)
-;   ld a5,[const(170)]
-;   sd a5,0(a1)
+;   ld a4,[const(170)]
+;   sd a4,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
-;   ld a5,[const(169)]
-;   sd a5,0(a1)
+;   ld a4,[const(169)]
+;   sd a4,0(a1)
 ;   sw zero,0(a1)
-;   ld a5,[const(168)]
-;   sd a5,0(a1)
+;   ld a4,[const(168)]
+;   sd a4,0(a1)
 ;   sw zero,0(a1)
-;   ld a5,[const(167)]
-;   sd a5,0(a1)
+;   ld a4,[const(167)]
+;   sd a4,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
-;   ld a5,[const(166)]
-;   sd a5,0(a1)
+;   ld a4,[const(166)]
+;   sd a4,0(a1)
 ;   sw zero,0(a1)
-;   ld a5,[const(165)]
-;   sd a5,0(a1)
+;   ld a4,[const(165)]
+;   sd a4,0(a1)
 ;   sw zero,0(a1)
-;   ld a5,[const(164)]
-;   sd a5,0(a1)
+;   ld a4,[const(164)]
+;   sd a4,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
-;   ld a5,[const(163)]
-;   sd a5,0(a1)
-;   ld a5,[const(162)]
-;   sd a5,0(a1)
+;   ld a4,[const(163)]
+;   sd a4,0(a1)
+;   ld a4,[const(162)]
+;   sd a4,0(a1)
 ;   sd zero,0(a1)
-;   ld a5,[const(161)]
-;   ld a5,0(a5)
+;   ld a4,[const(161)]
+;   ld a4,0(a4)
 ;   sw zero,0(a1)
-;   ld a5,[const(160)]
-;   sd a5,0(a1)
-;   ld a5,[const(159)]
-;   sd a5,0(a1)
+;   ld a4,[const(160)]
+;   sd a4,0(a1)
+;   ld a4,[const(159)]
+;   sd a4,0(a1)
 ;   sw zero,0(a1)
-;   ld a5,[const(158)]
-;   sd a5,0(a1)
+;   ld a4,[const(158)]
+;   sd a4,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
-;   ld a5,[const(157)]
-;   sd a5,0(a1)
+;   ld a4,[const(157)]
+;   sd a4,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
-;   ld a5,[const(156)]
-;   sd a5,0(a1)
+;   ld a4,[const(156)]
+;   sd a4,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
-;   ld a5,[const(155)]
-;   sd a5,0(a1)
+;   ld a4,[const(155)]
+;   sd a4,0(a1)
 ;   sw zero,0(a1)
-;   ld a5,[const(154)]
-;   sd a5,0(a1)
+;   ld a4,[const(154)]
+;   sd a4,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
-;   ld a5,[const(153)]
-;   sd a5,0(a1)
+;   ld a4,[const(153)]
+;   sd a4,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
-;   ld a5,[const(152)]
-;   sd a5,0(a1)
+;   ld a4,[const(152)]
+;   sd a4,0(a1)
 ;   sw zero,0(a1)
-;   ld a5,[const(151)]
-;   sd a5,0(a1)
-;   ld a5,[const(150)]
-;   sd a5,0(a1)
+;   ld a4,[const(151)]
+;   sd a4,0(a1)
+;   ld a4,[const(150)]
+;   sd a4,0(a1)
 ;   sw zero,0(a1)
-;   ld a5,[const(149)]
-;   sd a5,0(a1)
-;   ld a5,[const(148)]
-;   sd zero,0(a5)
+;   ld a4,[const(149)]
+;   sd a4,0(a1)
+;   ld a4,[const(148)]
+;   sd zero,0(a4)
 ;   sw zero,0(a1)
-;   ld a5,[const(147)]
-;   sd a5,0(a1)
+;   ld a4,[const(147)]
+;   sd a4,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
-;   ld a5,[const(146)]
-;   sd a5,0(a1)
+;   ld a4,[const(146)]
+;   sd a4,0(a1)
 ;   sw zero,0(a1)
-;   ld a5,[const(145)]
-;   sd a5,0(a1)
-;   ld a5,[const(144)]
-;   sd a5,0(a1)
+;   ld a4,[const(145)]
+;   sd a4,0(a1)
+;   ld a4,[const(144)]
+;   sd a4,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
-;   ld a5,[const(143)]
-;   sd a5,0(a1)
+;   ld a4,[const(143)]
+;   sd a4,0(a1)
 ;   sw zero,0(a1)
-;   ld a5,[const(142)]
-;   sd a5,0(a1)
+;   ld a4,[const(142)]
+;   sd a4,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
-;   ld a5,[const(141)]
-;   sd a5,0(a1)
+;   ld a4,[const(141)]
+;   sd a4,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
-;   ld a5,[const(140)]
-;   sd a5,0(a1)
-;   ld a5,[const(139)]
-;   sd a5,0(a1)
+;   ld a4,[const(140)]
+;   sd a4,0(a1)
+;   ld a4,[const(139)]
+;   sd a4,0(a1)
 ;   sw zero,0(a1)
-;   ld a5,[const(138)]
-;   sd a5,0(a1)
-;   ld a5,[const(137)]
-;   sd a5,0(a1)
+;   ld a4,[const(138)]
+;   sd a4,0(a1)
+;   ld a4,[const(137)]
+;   sd a4,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
-;   ld a5,[const(136)]
-;   sd a5,0(a1)
+;   ld a4,[const(136)]
+;   sd a4,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
-;   ld a5,[const(135)]
-;   sd a5,0(a1)
+;   ld a4,[const(135)]
+;   sd a4,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
-;   ld a5,[const(134)]
-;   sd a5,0(a1)
-;   ld a5,[const(133)]
-;   sd a5,0(a1)
+;   ld a4,[const(134)]
+;   sd a4,0(a1)
+;   ld a4,[const(133)]
+;   sd a4,0(a1)
 ;   sw zero,0(a1)
-;   ld a5,[const(132)]
-;   sd a5,0(a1)
+;   ld a4,[const(132)]
+;   sd a4,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
-;   ld a5,[const(131)]
-;   sd a5,0(a1)
-;   ld a5,[const(130)]
-;   sd a5,0(a1)
+;   ld a4,[const(131)]
+;   sd a4,0(a1)
+;   ld a4,[const(130)]
+;   sd a4,0(a1)
 ;   sw zero,0(a1)
-;   ld a5,[const(129)]
-;   sd a5,0(a1)
-;   ld a5,[const(128)]
-;   sd a5,0(a1)
+;   ld a4,[const(129)]
+;   sd a4,0(a1)
+;   ld a4,[const(128)]
+;   sd a4,0(a1)
 ;   sw zero,0(a1)
-;   ld a5,[const(127)]
-;   sd a5,0(a1)
-;   ld a5,[const(126)]
-;   sd a5,0(a1)
+;   ld a4,[const(127)]
+;   sd a4,0(a1)
+;   ld a4,[const(126)]
+;   sd a4,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
-;   ld a5,[const(125)]
-;   sd a5,0(a1)
+;   ld a4,[const(125)]
+;   sd a4,0(a1)
 ;   sw zero,0(a1)
-;   ld a5,[const(124)]
-;   sd a5,0(a1)
-;   ld a5,[const(123)]
-;   sd a5,0(a1)
-;   ld a5,[const(122)]
-;   sd a5,0(a1)
-;   ld a5,[const(121)]
-;   sd a5,0(a1)
+;   ld a4,[const(124)]
+;   sd a4,0(a1)
+;   ld a4,[const(123)]
+;   sd a4,0(a1)
+;   ld a4,[const(122)]
+;   sd a4,0(a1)
+;   ld a4,[const(121)]
+;   sd a4,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
-;   ld a5,[const(120)]
-;   sd a5,0(a1)
+;   ld a4,[const(120)]
+;   sd a4,0(a1)
 ;   sw zero,0(a1)
-;   ld a5,[const(119)]
-;   sd a5,0(a1)
-;   ld a5,[const(118)]
-;   sd a5,0(a1)
+;   ld a4,[const(119)]
+;   sd a4,0(a1)
+;   ld a4,[const(118)]
+;   sd a4,0(a1)
 ;   sw zero,0(a1)
-;   ld a5,[const(117)]
-;   sd a5,0(a1)
-;   ld a5,[const(116)]
-;   sd a5,0(a1)
+;   ld a4,[const(117)]
+;   sd a4,0(a1)
+;   ld a4,[const(116)]
+;   sd a4,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
-;   ld a5,[const(115)]
-;   sd a5,0(a1)
+;   ld a4,[const(115)]
+;   sd a4,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
-;   ld a5,[const(114)]
-;   sd a5,0(a1)
+;   ld a4,[const(114)]
+;   sd a4,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
-;   ld a5,[const(113)]
-;   sd a5,0(a1)
+;   ld a4,[const(113)]
+;   sd a4,0(a1)
 ;   sw zero,0(a1)
-;   ld a5,[const(112)]
-;   sd a5,0(a1)
-;   ld a5,[const(111)]
-;   sd a5,0(a1)
+;   ld a4,[const(112)]
+;   sd a4,0(a1)
+;   ld a4,[const(111)]
+;   sd a4,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
-;   ld a5,[const(110)]
-;   sd a5,0(a1)
-;   ld a5,[const(109)]
-;   sd a5,0(a1)
+;   ld a4,[const(110)]
+;   sd a4,0(a1)
+;   ld a4,[const(109)]
+;   sd a4,0(a1)
 ;   sw zero,0(a1)
-;   ld a5,[const(108)]
-;   sd a5,0(a1)
+;   ld a4,[const(108)]
+;   sd a4,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
@@ -4227,17 +4092,17 @@ block2:
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
-;   ld a5,[const(107)]
-;   sd a5,0(a1)
+;   ld a4,[const(107)]
+;   sd a4,0(a1)
 ;   sw zero,0(a1)
-;   ld a5,[const(106)]
-;   sd a2,0(a5)
+;   ld a4,[const(106)]
+;   sd a2,0(a4)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
-;   ld a5,[const(105)]
-;   sd zero,0(a5)
+;   ld a4,[const(105)]
+;   sd zero,0(a4)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
@@ -4245,97 +4110,97 @@ block2:
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
-;   ld a5,[const(104)]
-;   sd a5,0(a1)
+;   ld a4,[const(104)]
+;   sd a4,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
-;   ld a5,[const(103)]
-;   sd a5,0(a1)
+;   ld a4,[const(103)]
+;   sd a4,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
-;   ld a5,[const(102)]
-;   sd zero,0(a5)
+;   ld a4,[const(102)]
+;   sd zero,0(a4)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
-;   ld a5,[const(101)]
-;   sd a5,0(a1)
-;   ld a5,[const(100)]
-;   sd a5,0(a1)
+;   ld a4,[const(101)]
+;   sd a4,0(a1)
+;   ld a4,[const(100)]
+;   sd a4,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
-;   ld a5,[const(99)]
-;   sd a2,0(a5)
-;   ld a5,[const(98)]
-;   sd a5,0(a1)
+;   ld a4,[const(99)]
+;   sd a2,0(a4)
+;   ld a4,[const(98)]
+;   sd a4,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
-;   ld a5,[const(97)]
-;   sd a5,0(a1)
+;   ld a4,[const(97)]
+;   sd a4,0(a1)
 ;   sw zero,0(a1)
-;   ld a5,[const(96)]
-;   sd a5,0(a1)
-;   ld a5,[const(95)]
-;   sd a5,0(a1)
+;   ld a4,[const(96)]
+;   sd a4,0(a1)
+;   ld a4,[const(95)]
+;   sd a4,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
-;   ld a5,[const(94)]
-;   sd a5,0(a1)
+;   ld a4,[const(94)]
+;   sd a4,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
-;   ld a5,[const(93)]
-;   sd a2,0(a5)
-;   ld a5,[const(92)]
-;   sd a5,0(a1)
+;   ld a4,[const(93)]
+;   sd a2,0(a4)
+;   ld a4,[const(92)]
+;   sd a4,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
-;   ld a5,[const(91)]
-;   sd a5,0(a1)
+;   ld a4,[const(91)]
+;   sd a4,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
-;   lui a5,309522
-;   addi a5,a5,-111
-;   ld a6,[const(90)]
-;   sw a5,0(a6)
+;   lui a4,309522
+;   addi a4,a4,-111
+;   ld t0,[const(90)]
+;   sw a4,0(t0)
 ;   sw zero,0(a1)
-;   ld a5,[const(89)]
-;   sd a5,0(a1)
-;   ld a5,[const(88)]
-;   sd a5,0(a1)
+;   ld a4,[const(89)]
+;   sd a4,0(a1)
+;   ld a4,[const(88)]
+;   sd a4,0(a1)
 ;   sw zero,0(a1)
-;   ld a5,[const(87)]
-;   sd a5,0(a1)
+;   ld a4,[const(87)]
+;   sd a4,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
-;   ld a5,[const(86)]
-;   sd a5,0(a1)
+;   ld a4,[const(86)]
+;   sd a4,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
-;   ld a5,[const(85)]
-;   sd a5,0(a1)
-;   ld a5,[const(84)]
-;   sd a5,0(a1)
+;   ld a4,[const(85)]
+;   sd a4,0(a1)
+;   ld a4,[const(84)]
+;   sd a4,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
-;   ld a5,[const(83)]
-;   sd a5,0(a1)
+;   ld a4,[const(83)]
+;   sd a4,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
@@ -4349,48 +4214,48 @@ block2:
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
-;   ld a5,[const(82)]
-;   sd a5,0(a1)
+;   ld a4,[const(82)]
+;   sd a4,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
-;   ld a5,[const(81)]
-;   sd a5,0(a1)
-;   ld a5,[const(80)]
-;   sd a5,0(a1)
+;   ld a4,[const(81)]
+;   sd a4,0(a1)
+;   ld a4,[const(80)]
+;   sd a4,0(a1)
 ;   sw zero,0(a1)
-;   ld a5,[const(79)]
-;   sd a5,0(a1)
+;   ld a4,[const(79)]
+;   sd a4,0(a1)
 ;   sd zero,0(a1)
-;   ld a5,[const(78)]
-;   sd a5,0(a1)
+;   ld a4,[const(78)]
+;   sd a4,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
-;   ld a5,[const(77)]
-;   sd a5,0(a1)
+;   ld a4,[const(77)]
+;   sd a4,0(a1)
 ;   sw zero,0(a1)
-;   ld a5,[const(76)]
-;   sd a5,0(a1)
+;   ld a4,[const(76)]
+;   sd a4,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
-;   ld a5,[const(75)]
-;   sd a5,0(a1)
+;   ld a4,[const(75)]
+;   sd a4,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
-;   ld a5,[const(74)]
-;   sd a5,0(a1)
-;   ld a5,[const(73)]
-;   sd a5,0(a1)
+;   ld a4,[const(74)]
+;   sd a4,0(a1)
+;   ld a4,[const(73)]
+;   sd a4,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
-;   ld a5,[const(72)]
-;   sd a5,0(a1)
+;   ld a4,[const(72)]
+;   sd a4,0(a1)
 ;   sw zero,0(a1)
-;   ld a5,[const(71)]
-;   sd a5,0(a1)
+;   ld a4,[const(71)]
+;   sd a4,0(a1)
 ;   sw zero,0(a1)
-;   ld a5,[const(70)]
-;   sd a5,0(a1)
+;   ld a4,[const(70)]
+;   sd a4,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
@@ -4401,80 +4266,80 @@ block2:
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
-;   ld a5,[const(69)]
-;   sd a5,0(a1)
+;   ld a4,[const(69)]
+;   sd a4,0(a1)
 ;   sd zero,0(a1)
-;   ld a5,[const(68)]
-;   sd a5,0(a1)
-;   ld a5,[const(67)]
-;   lw a5,0(a5)
+;   ld a4,[const(68)]
+;   sd a4,0(a1)
+;   ld a4,[const(67)]
+;   lw a4,0(a4)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
-;   ld a5,[const(66)]
-;   sd a5,0(a1)
+;   ld a4,[const(66)]
+;   sd a4,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
-;   ld a5,[const(65)]
-;   sd a5,0(a1)
+;   ld a4,[const(65)]
+;   sd a4,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
-;   ld a5,[const(64)]
-;   sd a5,0(a1)
+;   ld a4,[const(64)]
+;   sd a4,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
-;   ld a5,[const(63)]
-;   sd a5,0(a1)
+;   ld a4,[const(63)]
+;   sd a4,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
-;   ld a5,[const(62)]
-;   sd a5,0(a1)
+;   ld a4,[const(62)]
+;   sd a4,0(a1)
 ;   sw zero,0(a1)
-;   ld a5,[const(61)]
-;   sd a5,0(a1)
-;   ld a5,[const(60)]
-;   sd a5,0(a1)
+;   ld a4,[const(61)]
+;   sd a4,0(a1)
+;   ld a4,[const(60)]
+;   sd a4,0(a1)
 ;   sw zero,0(a1)
-;   ld a5,[const(59)]
-;   sd a5,0(a1)
+;   ld a4,[const(59)]
+;   sd a4,0(a1)
 ;   sd zero,0(a1)
-;   ld a5,[const(58)]
-;   sw zero,0(a5)
+;   ld a4,[const(58)]
+;   sw zero,0(a4)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
-;   ld a5,[const(57)]
-;   sd a5,0(a1)
+;   ld a4,[const(57)]
+;   sd a4,0(a1)
 ;   sw zero,0(a1)
-;   ld a5,[const(56)]
-;   sd a5,0(a1)
-;   ld a5,[const(55)]
-;   sw a3,0(a5)
+;   ld a4,[const(56)]
+;   sd a4,0(a1)
+;   ld a4,[const(55)]
+;   sw a3,0(a4)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
-;   ld a5,[const(54)]
-;   sd a5,0(a1)
+;   ld a4,[const(54)]
+;   sd a4,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
-;   ld a5,[const(53)]
-;   sd a5,0(a1)
+;   ld a4,[const(53)]
+;   sd a4,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
-;   ld a5,[const(52)]
-;   sd a2,0(a5)
+;   ld a4,[const(52)]
+;   sd a2,0(a4)
 ;   sw zero,0(a1)
-;   ld a5,[const(51)]
-;   sd a5,0(a1)
-;   ld a5,[const(50)]
-;   sd a5,0(a1)
+;   ld a4,[const(51)]
+;   sd a4,0(a1)
+;   ld a4,[const(50)]
+;   sd a4,0(a1)
 ;   sw zero,0(a1)
-;   ld a5,[const(49)]
-;   sd a5,0(a1)
+;   ld a4,[const(49)]
+;   sd a4,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
@@ -4482,21 +4347,21 @@ block2:
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
-;   sb a4,0(a1)
+;   sb a5,0(a1)
 ;   sw zero,0(a1)
-;   ld a5,[const(48)]
-;   sd a5,0(a1)
+;   ld a4,[const(48)]
+;   sd a4,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
-;   ld a5,[const(47)]
-;   sd a5,0(a1)
-;   ld a5,[const(46)]
-;   sd a5,0(a1)
+;   ld a4,[const(47)]
+;   sd a4,0(a1)
+;   ld a4,[const(46)]
+;   sd a4,0(a1)
 ;   sw zero,0(a1)
-;   ld a5,[const(45)]
-;   sd a5,0(a1)
-;   ld a5,[const(44)]
-;   sd a5,0(a1)
+;   ld a4,[const(45)]
+;   sd a4,0(a1)
+;   ld a4,[const(44)]
+;   sd a4,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
@@ -4504,82 +4369,82 @@ block2:
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
-;   ld a5,[const(43)]
-;   sd a5,0(a1)
-;   ld a5,[const(42)]
-;   sd a2,0(a5)
+;   ld a4,[const(43)]
+;   sd a4,0(a1)
+;   ld a4,[const(42)]
+;   sd a2,0(a4)
 ;   sw zero,0(a1)
-;   ld a5,[const(41)]
-;   sd a5,0(a1)
+;   ld a4,[const(41)]
+;   sd a4,0(a1)
 ;   sw zero,0(a1)
-;   ld a5,[const(40)]
-;   sd a5,0(a1)
+;   ld a4,[const(40)]
+;   sd a4,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
-;   ld a5,[const(39)]
-;   sd a5,0(a1)
+;   ld a4,[const(39)]
+;   sd a4,0(a1)
 ;   sd zero,0(a1)
-;   sb a4,0(a1)
+;   sb a5,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
-;   ld a5,[const(38)]
-;   sd a5,0(a1)
+;   ld a4,[const(38)]
+;   sd a4,0(a1)
 ;   sw zero,0(a1)
-;   ld a5,[const(37)]
-;   sd a5,0(a1)
+;   ld a4,[const(37)]
+;   sd a4,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
-;   ld a5,[const(36)]
-;   sd a5,0(a1)
-;   ld a5,[const(35)]
-;   sd a2,0(a5)
+;   ld a4,[const(36)]
+;   sd a4,0(a1)
+;   ld a4,[const(35)]
+;   sd a2,0(a4)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
-;   lw a5,0(a1)
+;   lw a4,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
-;   ld a5,[const(34)]
-;   sd a5,0(a1)
+;   ld a4,[const(34)]
+;   sd a4,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
-;   ld a5,[const(33)]
-;   sd a5,0(a1)
+;   ld a4,[const(33)]
+;   sd a4,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
-;   ld a5,[const(32)]
-;   sd a5,0(a1)
+;   ld a4,[const(32)]
+;   sd a4,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
-;   ld a5,[const(31)]
-;   sd a5,0(a1)
+;   ld a4,[const(31)]
+;   sd a4,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
-;   ld a5,[const(30)]
-;   sd a2,0(a5)
-;   ld a5,[const(29)]
-;   sd zero,0(a5)
+;   ld a4,[const(30)]
+;   sd a2,0(a4)
+;   ld a4,[const(29)]
+;   sd zero,0(a4)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
-;   sb a4,0(a1)
+;   sb a5,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
-;   ld a5,[const(28)]
-;   sd a5,0(a1)
+;   ld a4,[const(28)]
+;   sd a4,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
-;   ld a5,[const(27)]
-;   sd a5,0(a1)
+;   ld a4,[const(27)]
+;   sd a4,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
-;   sb a4,0(a1)
+;   sb a5,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
@@ -4590,69 +4455,69 @@ block2:
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
-;   sb a4,0(a1)
+;   sb a5,0(a1)
 ;   sw zero,0(a1)
-;   ld a5,[const(26)]
-;   sd a5,0(a1)
+;   ld a4,[const(26)]
+;   sd a4,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
-;   ld a5,[const(25)]
-;   sd a5,0(a1)
+;   ld a4,[const(25)]
+;   sd a4,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
-;   ld a5,[const(24)]
-;   sd a5,0(a1)
+;   ld a4,[const(24)]
+;   sd a4,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
-;   sb a4,0(a1)
+;   sb a5,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
-;   ld a5,[const(23)]
-;   sd a5,0(a1)
+;   ld a4,[const(23)]
+;   sd a4,0(a1)
 ;   sw zero,0(a1)
-;   ld a5,[const(22)]
-;   sd a5,0(a1)
+;   ld a4,[const(22)]
+;   sd a4,0(a1)
 ;   sw zero,0(a1)
-;   ld a5,[const(21)]
-;   sd a5,0(a1)
+;   ld a4,[const(21)]
+;   sd a4,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
-;   ld a5,[const(20)]
-;   sd a5,0(a1)
-;   ld a5,[const(19)]
-;   sd a5,0(a1)
+;   ld a4,[const(20)]
+;   sd a4,0(a1)
+;   ld a4,[const(19)]
+;   sd a4,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
-;   ld a5,[const(18)]
-;   sd a5,0(a1)
+;   ld a4,[const(18)]
+;   sd a4,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
-;   ld a5,[const(17)]
-;   sd zero,0(a5)
-;   sb a4,0(a1)
+;   ld a4,[const(17)]
+;   sd zero,0(a4)
+;   sb a5,0(a1)
 ;   sw zero,0(a1)
-;   ld a5,[const(16)]
-;   sd a5,0(a1)
+;   ld a4,[const(16)]
+;   sd a4,0(a1)
 ;   sw zero,0(a1)
-;   ld a5,[const(15)]
-;   sd a5,0(a1)
-;   ld a5,[const(14)]
-;   sd a5,0(a1)
+;   ld a4,[const(15)]
+;   sd a4,0(a1)
+;   ld a4,[const(14)]
+;   sd a4,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
-;   ld a5,[const(13)]
-;   sd a5,0(a1)
+;   ld a4,[const(13)]
+;   sd a4,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
 ;   sb a3,0(a1)
 ;   sw zero,0(a1)
-;   ld a3,[const(12)]
-;   sd a3,0(a1)
+;   ld a4,[const(12)]
+;   sd a4,0(a1)
 ;   ld a3,[const(11)]
 ;   sd a3,0(a1)
 ;   sw zero,0(a1)
@@ -4664,7 +4529,7 @@ block2:
 ;   sd a3,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
-;   sb a4,0(a1)
+;   sb a5,0(a1)
 ;   sw zero,0(a1)
 ;   ld a3,[const(8)]
 ;   sd a2,0(a3)
@@ -4733,44 +4598,36 @@ block2:
 ;   bgeu sp, t6, 6
 ;   c.unimp ; trap: stk_ovf
 ;   c.addi16sp sp, -0x10
-;   c.sdsp s8, 8(sp)
+;   c.sdsp s7, 8(sp)
 ; block1: ; offset 0x1e
 ;   c.li a1, 0
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
-;   c.li a3, 4
-;   c.sd a3, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   c.sd a3, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   c.li a2, 1
 ;   c.sd a2, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   c.sd a2, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   c.li a3, 1
+;   c.sw a3, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   c.sd a2, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
-;   c.sd a3, 0(a1) ; trap: heap_oob
-;   c.sd a2, 0(a1) ; trap: heap_oob
-;   c.li a5, 1
-;   c.sw a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   c.sw a5, 0(a1) ; trap: heap_oob
-;   c.sd a3, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   c.sd a2, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
@@ -4778,73 +4635,49 @@ block2:
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   c.li a4, 9
 ;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   c.sd a2, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   c.sd a2, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   c.li a4, 4
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   c.li a5, 8
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   c.sw a3, 0(a1) ; trap: heap_oob
+;   c.sd a2, 0(a1) ; trap: heap_oob
+;   c.sw a3, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   c.sw a3, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   c.sw a3, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   c.sd a4, 0(a1) ; trap: heap_oob
-;   c.li a4, 0xd
-;   c.sw a4, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   c.sd a3, 0(a1) ; trap: heap_oob
 ;   c.sd a2, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
+;   c.sw a3, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
-;   c.sd a2, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   c.sw a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   c.sw a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
+;   c.sw a3, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   c.sd a2, 0(a1) ; trap: heap_oob
-;   c.sd a3, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   c.li a4, 8
-;   c.sd a4, 0(a1) ; trap: heap_oob
-;   c.sw a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   c.sd a3, 0(a1) ; trap: heap_oob
-;   c.sd a4, 0(a1) ; trap: heap_oob
-;   c.sw a5, 0(a1) ; trap: heap_oob
-;   c.sd a2, 0(a1) ; trap: heap_oob
-;   c.sw a5, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   c.sw a5, 0(a1) ; trap: heap_oob
-;   c.sd a2, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   c.sw a5, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   c.sd a3, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   c.sd a2, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
-;   c.sw a5, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   c.sw a5, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   c.sd a2, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   c.sd a2, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   c.sd a4, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
@@ -4855,42 +4688,27 @@ block2:
 ;   c.li t0, 3
 ;   sw t0, 0(a1) ; trap: heap_oob
 ;   c.sd a2, 0(a1) ; trap: heap_oob
-;   sb a5, 0(a1) ; trap: heap_oob
+;   sb a3, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
-;   c.sd a3, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
-;   c.sw a5, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
-;   c.sw a5, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   c.sd a4, 0(a1) ; trap: heap_oob
+;   c.sw a3, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
-;   c.sw a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   c.sd a2, 0(a1) ; trap: heap_oob
-;   c.sd a3, 0(a1) ; trap: heap_oob
-;   c.sw a5, 0(a1) ; trap: heap_oob
-;   c.sd a2, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   c.li t2, 8
-;   sw t2, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   c.sd a4, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   c.sw a5, 0(a1) ; trap: heap_oob
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   c.sw a3, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
-;   c.sw a5, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   c.sd a2, 0(a1) ; trap: heap_oob
-;   c.sw a5, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   c.sd a2, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
@@ -4907,7 +4725,6 @@ block2:
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
-;   sw t2, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
@@ -4958,244 +4775,249 @@ block2:
 ;   c.sd a2, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
 ;   c.sd a2, 0(a1) ; trap: heap_oob
-;   c.sd a4, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   c.sd a3, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   c.sd a2, 0(a1) ; trap: heap_oob
-; block2: ; offset 0x342
+; block2: ; offset 0x2ac
 ;   lui a1, 0x6a64d
-;   c.addi a1, 3
-;   c.addiw a1, 0
+;   addi a2, a1, 3
+;   sext.w a1, a2
 ;   beqz a1, 6
 ;   c.unimp ; trap: user11
-; block3: ; offset 0x350
-;   lui a1, 0x259ad
-;   addi a1, a1, -0x626
-;   c.addiw a1, 0
-;   beqz a1, 6
+; block3: ; offset 0x2be
+;   lui a2, 0x259ad
+;   addi a4, a2, -0x626
+;   sext.w a3, a4
+;   beqz a3, 6
 ;   c.unimp ; trap: user11
-; block4: ; offset 0x360
+; block4: ; offset 0x2d0
 ;   c.li a1, 1
 ;   c.addiw a1, 0
 ;   beqz a1, 6
 ;   c.unimp ; trap: user11
-; block5: ; offset 0x36a
+; block5: ; offset 0x2da
 ;   lui a1, 0x7c7d9
 ;   addi a1, a1, -0xc1
 ;   c.addiw a1, 0
 ;   beqz a1, 6
 ;   c.unimp ; trap: user11
-; block6: ; offset 0x37a
+; block6: ; offset 0x2ea
 ;   lui a1, 0x5b1f2
 ;   addi a1, a1, 0x6e3
 ;   c.addiw a1, 0
 ;   beqz a1, 6
 ;   c.unimp ; trap: user11
-; block7: ; offset 0x38a
+; block7: ; offset 0x2fa
 ;   lui a1, 0x6f8d1
 ;   addi a1, a1, -0x144
 ;   c.addiw a1, 0
 ;   beqz a1, 6
 ;   c.unimp ; trap: user11
-; block8: ; offset 0x39a
+; block8: ; offset 0x30a
 ;   lui a1, 0x484e2
-;   addi a2, a1, -0x478
-;   sext.w a1, a2
-;   beqz a1, 6
-;   c.unimp ; trap: user11
-; block9: ; offset 0x3ac
-;   lui a5, 0x110e5
-;   addi a1, a5, -0x662
+;   addi a1, a1, -0x478
 ;   c.addiw a1, 0
 ;   beqz a1, 6
 ;   c.unimp ; trap: user11
-; block10: ; offset 0x3bc
+; block9: ; offset 0x31a
+;   lui a1, 0x110e5
+;   addi a1, a1, -0x662
+;   c.addiw a1, 0
+;   beqz a1, 6
+;   c.unimp ; trap: user11
+; block10: ; offset 0x32a
 ;   lui a1, 0x71fd2
 ;   addi a1, a1, 0x446
 ;   c.addiw a1, 0
 ;   beqz a1, 6
 ;   c.unimp ; trap: user11
-; block11: ; offset 0x3cc
+; block11: ; offset 0x33a
 ;   lui a1, 0x8237d
 ;   addi a1, a1, 0x5b7
 ;   c.addiw a1, 0
 ;   beqz a1, 6
 ;   c.unimp ; trap: user11
-; block12: ; offset 0x3dc
+; block12: ; offset 0x34a
 ;   auipc a2, 0
-;   ld a2, 0x1ec(a2)
+;   ld a2, 0x276(a2)
 ;   c.li a1, 0
 ;   c.sd a2, 0(a1) ; trap: heap_oob
 ;   auipc a2, 0
-;   ld a2, 0x1e8(a2)
-;   c.sd a2, 0(a1) ; trap: heap_oob
-;   auipc a2, 0
-;   ld a2, 0x1e6(a2)
-;   c.sd a2, 0(a1) ; trap: heap_oob
-;   auipc a2, 0
-;   ld a2, 0x1e4(a2)
-;   c.sd a2, 0(a1) ; trap: heap_oob
-;   auipc a2, 0
-;   ld a2, 0x1e2(a2)
-;   c.sd a2, 0(a1) ; trap: heap_oob
-;   auipc a2, 0
-;   ld a2, 0x1e0(a2)
-;   c.sd a2, 0(a1) ; trap: heap_oob
-;   auipc a2, 0
-;   ld a2, 0x1de(a2)
+;   ld a2, 0x272(a2)
 ;   sd zero, 0(a2) ; trap: heap_oob
 ;   auipc a2, 0
-;   ld a2, 0x1da(a2)
-;   c.sd a2, 0(a1) ; trap: heap_oob
-;   auipc a2, 0
-;   ld a2, 0x1d8(a2)
-;   c.sd a2, 0(a1) ; trap: heap_oob
-;   auipc a2, 0
-;   ld a2, 0x1d6(a2)
-;   c.sd a2, 0(a1) ; trap: heap_oob
-;   auipc a2, 0
-;   ld a2, 0x1d4(a2)
-;   c.sd a2, 0(a1) ; trap: heap_oob
-;   auipc a2, 0
-;   ld a2, 0x1d2(a2)
+;   ld a2, 0x26e(a2)
 ;   c.sd a2, 0(a1) ; trap: heap_oob
 ;   c.li a2, 1
 ;   auipc a3, 0
-;   ld a3, 0x1ce(a3)
+;   ld a3, 0x26a(a3)
 ;   c.sd a2, 0(a3) ; trap: heap_oob
 ;   auipc a3, 0
-;   ld a3, 0x1cc(a3)
+;   ld a3, 0x268(a3)
 ;   c.sd a3, 0(a1) ; trap: heap_oob
 ;   auipc a3, 0
-;   ld a3, 0x1ca(a3)
-;   c.sd a3, 0(a1) ; trap: heap_oob
-;   auipc a3, 0
-;   ld a3, 0x1c8(a3)
-;   c.sd a3, 0(a1) ; trap: heap_oob
-;   auipc a3, 0
-;   ld a3, 0x1c6(a3)
-;   c.sd a3, 0(a1) ; trap: heap_oob
-;   auipc a3, 0
-;   ld a3, 0x1c4(a3)
+;   ld a3, 0x266(a3)
 ;   sd zero, 0(a3) ; trap: heap_oob
 ;   auipc a3, 0
-;   ld a3, 0x1c0(a3)
+;   ld a3, 0x262(a3)
 ;   c.sd a3, 0(a1) ; trap: heap_oob
 ;   auipc a3, 0
-;   ld a3, 0x1be(a3)
-;   c.sd a3, 0(a1) ; trap: heap_oob
-;   auipc a3, 0
-;   ld a3, 0x1bc(a3)
-;   c.sd a3, 0(a1) ; trap: heap_oob
-;   auipc a3, 0
-;   ld a3, 0x1ba(a3)
-;   c.sd a3, 0(a1) ; trap: heap_oob
-;   auipc a3, 0
-;   ld a3, 0x1b8(a3)
-;   c.sd a3, 0(a1) ; trap: heap_oob
-;   auipc a3, 0
-;   ld a3, 0x1b6(a3)
-;   c.sd a3, 0(a1) ; trap: heap_oob
-;   auipc a3, 0
-;   ld a3, 0x1b4(a3)
+;   ld a3, 0x260(a3)
 ;   sd zero, 0(a3) ; trap: heap_oob
 ;   auipc a3, 0
-;   ld a3, 0x1b0(a3)
+;   ld a3, 0x25c(a3)
 ;   sd zero, 0(a3) ; trap: heap_oob
 ;   auipc a3, 0
-;   ld a3, 0x1ac(a3)
+;   ld a3, 0x258(a3)
 ;   c.sd a3, 0(a1) ; trap: heap_oob
 ;   auipc a3, 0
-;   ld a3, 0x1aa(a3)
+;   ld a3, 0x256(a3)
 ;   c.sd a2, 0(a3) ; trap: heap_oob
 ;   auipc a3, 0
-;   ld a3, 0x1a8(a3)
+;   ld a3, 0x254(a3)
 ;   c.sd a3, 0(a1) ; trap: heap_oob
 ;   auipc a3, 0
-;   ld a3, 0x1a6(a3)
-;   c.sd a3, 0(a1) ; trap: heap_oob
-;   auipc a3, 0
-;   ld a3, 0x1a4(a3)
-;   c.sd a3, 0(a1) ; trap: heap_oob
-;   auipc a3, 0
-;   ld a3, 0x1a2(a3)
+;   ld a3, 0x252(a3)
 ;   sd zero, 0(a3) ; trap: heap_oob
 ;   auipc a3, 0
-;   ld a3, 0x19e(a3)
-;   c.sd a3, 0(a1) ; trap: heap_oob
-;   auipc a3, 0
-;   ld a3, 0x19c(a3)
-;   c.sd a3, 0(a1) ; trap: heap_oob
-;   auipc a3, 0
-;   ld a3, 0x19a(a3)
-;   c.sd a3, 0(a1) ; trap: heap_oob
-;   auipc a3, 0
-;   ld a3, 0x198(a3)
-;   c.sd a3, 0(a1) ; trap: heap_oob
-;   auipc a3, 0
-;   ld a3, 0x196(a3)
-;   c.sd a3, 0(a1) ; trap: heap_oob
-;   auipc a3, 0
-;   ld a3, 0x194(a3)
-;   c.sd a3, 0(a1) ; trap: heap_oob
-;   auipc a3, 0
-;   ld a3, 0x192(a3)
-;   c.sd a3, 0(a1) ; trap: heap_oob
-;   auipc a3, 0
-;   ld a3, 0x190(a3)
-;   c.sd a3, 0(a1) ; trap: heap_oob
-;   auipc a3, 0
-;   ld a3, 0x18e(a3)
+;   ld a3, 0x24e(a3)
 ;   c.sd a3, 0(a1) ; trap: heap_oob
 ;   c.li a3, 1
 ;   auipc a4, 0
-;   ld a4, 0x18a(a4)
+;   ld a4, 0x24a(a4)
 ;   c.sw a3, 0(a4) ; trap: heap_oob
 ;   auipc a4, 0
-;   ld a4, 0x188(a4)
+;   ld a4, 0x248(a4)
 ;   c.sd a4, 0(a1) ; trap: heap_oob
 ;   auipc a4, 0
-;   ld a4, 0x186(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0x184(a4)
+;   ld a4, 0x246(a4)
 ;   sd zero, 0(a4) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   c.li a5, 0
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0x238(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0x232(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0x220(a4)
+;   auipc s7, 0
+;   ld s7, 0x220(s7)
+;   sd a4, 0(s7) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0x200(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0x1ea(a4)
+;   sd zero, 0(a4) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0x1e2(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0x1cc(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0x1c6(a4)
+;   sd zero, 0(a4) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0x1c2(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0x194(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0x18e(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
 ;   auipc a4, 0
 ;   ld a4, 0x180(a4)
 ;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
 ;   auipc a4, 0
-;   ld a4, 0x17e(a4)
-;   c.j 0x17e
+;   ld a4, 0x17a(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0x174(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0x172(a4)
+;   c.ld a4, 0(a4) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0x168(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0x166(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0x160(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0x15e(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0x158(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0x14e(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0x144(a4)
+;   c.j 0x144
 ;   c.unimp
-;   c.unimp
-;   c.fldsp fs5, 0x1e0(sp)
-;   .byte 0xc3, 0xd1
-;   c.bnez a0, -4
-;   c.sdsp t6, 0x198(sp)
-;   c.andi a1, 0xe
-;   c.addi s3, -0x15
-;   .byte 0xa3, 0xe7
-;   c.swsp t2, 0x68(sp)
-;   fnmsub.d ft6, ft9, fs9, fs0, rne
-;   .byte 0x62, 0x80
-;   c.bnez a3, 0xaa
-;   c.bnez s1, 0x16
-;   c.mv t6, s5
-;   c.lwsp t1, 0xf4(sp)
-;   c.slli s2, 0x39
-;   c.ld s0, 0x78(a2)
-;   .byte 0x9b, 0xb8
-;   c.bnez a4, 0x2c
-;   c.j 0x3a2
 ;   c.lw a2, 0xc(a4)
 ;   c.sd s0, 0x70(s0)
 ;   c.slli a7, 1
@@ -5204,22 +5026,6 @@ block2:
 ;   c.sd a1, 0xb0(a0)
 ;   c.unimp
 ;   c.unimp
-;   c.j 0x4a2
-;   .byte 0x2f, 0xc4
-;   c.srli s1, 4
-;   c.ldsp s2, 0x1c8(sp)
-;   c.slli s9, 0x15
-;   c.lui s5, 0xffffa
-;   c.lwsp t0, 0xf8(sp)
-;   c.fsd fa5, 0x98(a1)
-;   c.lui t5, 0xffff5
-;   c.li s11, 0x1c
-;   c.fld fa0, 0x18(a0)
-;   c.beqz a2, -0x90
-;   c.fld fa1, 0xb0(a1)
-;   c.j 0x28
-;   c.addi a0, -0x10
-;   c.addi s7, -0x1b
 ;   .byte 0xcb, 0x5d
 ;   c.addi4spn s0, sp, 0x384
 ;   c.fldsp fs2, 0x1c0(sp)
@@ -5228,17 +5034,6 @@ block2:
 ;   c.j 0x6ac
 ;   c.unimp
 ;   c.unimp
-;   c.jr sp
-;   c.fsdsp ft1, 0x70(sp)
-;   c.addi4spn a3, sp, 0x114
-;   c.bnez a0, -0x100
-;   c.lw s0, 0x48(a2)
-;   .byte 0xaf, 0x72
-;   .byte 0x69, 0x60
-;   c.fldsp ft11, 0x78(sp)
-;   bge a1, s6, -0x786
-;   c.ld a1, 8(a0)
-;   .byte 0x4b, 0x69
 ;   c.bnez s1, 0x22
 ;   .byte 0x6b, 0x42
 ;   c.li a5, 0xc
@@ -5247,25 +5042,6 @@ block2:
 ;   .byte 0x0f, 0xdb
 ;   c.unimp
 ;   c.unimp
-;   c.fldsp fa0, 0x98(sp)
-;   c.fsdsp fs10, 0x140(sp)
-;   c.beqz a4, 0x16
-;   c.sd a5, 0x90(a0)
-;   .byte 0xcc, 0x9b
-;   c.mv a1, t5
-;   .byte 0xdf, 0xe6
-;   fmsub.d fa6, fs10, fs7, fs4, rdn
-;   .byte 0x1d, 0x40
-;   c.sd a0, 0x40(s1)
-;   c.beqz a3, -0xbe
-;   c.fsd fa4, 0x80(a2)
-;   .byte 0x63, 0xbb
-;   c.addi4spn a1, sp, 0x394
-;   .byte 0x8f, 0xf1
-;   c.ldsp a2, 0x158(sp)
-;   c.j 0x6ec
-;   c.addi4spn a5, sp, 0x348
-;   c.addiw a2, -0xb
 ;   c.fldsp ft5, 0x118(sp)
 ;   c.ldsp a6, 0x148(sp)
 ;   .byte 0x0b, 0xf7
@@ -5285,14 +5061,6 @@ block2:
 ;   c.swsp t1, 0xa4(sp)
 ;   c.unimp
 ;   c.unimp
-;   .byte 0xc7, 0x02
-;   c.addiw a5, -0xd
-;   c.fsd fa0, 8(a4)
-;   c.swsp s0, 0x4c(sp)
-;   c.lui s0, 0xfffef
-;   c.fsd fa2, 0xf8(a3)
-;   c.lw a5, 0x6c(a3)
-;   c.addi4spn a5, sp, 0x1c4
 ;   c.addiw s6, 0xd
 ;   c.slli t1, 0x2e
 ;   c.beqz a2, 0x50
@@ -5301,35 +5069,6 @@ block2:
 ;   c.fsdsp fs8, 0x148(sp)
 ;   c.unimp
 ;   c.unimp
-;   c.sdsp s9, 0xe8(sp)
-;   c.li ra, 0xa
-;   c.sd a3, 0x58(a0)
-;   c.sw a4, 0x6c(a0)
-;   c.swsp s0, 0x6c(sp)
-;   c.addi s1, 6
-;   c.mv a2, t4
-;   c.slli s10, 2
-;   c.bnez s0, 0xbc
-;   .byte 0xeb, 0x9c
-;   c.ldsp tp, 0x1c8(sp)
-;   fmadd.d ft0, fa4, fs6, ft1
-;   c.swsp s2, 0x98(sp)
-;   c.sub a0, s0
-;   c.beqz s0, 0x7c
-;   c.lw a1, 0x58(a1)
-;   .byte 0x9f, 0x96
-;   c.sdsp s8, 0x90(sp)
-;   c.addi4spn a1, sp, 0x2cc
-;   bge s4, a5, -0x9d0
-;   c.srli a3, 0x17
-;   c.beqz a5, -0xe
-;   c.addiw a7, 0xc
-;   c.fsdsp fa1, 0x1b0(sp)
-;   c.mv s11, a6
-;   fnmsub.d ft1, ft8, ft6, ft11
-;   c.ld a0, 0x80(a4)
-;   c.lw a4, 0x50(a3)
-;   .byte 0xb3, 0xa7
 ;   c.addi s5, -0x1d
 ;   .byte 0x77, 0x3f
 ;   c.addi s2, -0x1f
@@ -5338,10 +5077,6 @@ block2:
 ;   c.bnez s0, 0xca
 ;   c.unimp
 ;   c.unimp
-;   c.lui t2, 0xffff0
-;   c.beqz a5, 0xce
-;   c.fldsp fa1, 0xa8(sp)
-;   c.ld a1, 0x28(a1)
 ;   c.beqz s0, 0x7e
 ;   c.j 0x646
 ;   c.slli s7, 0xf
@@ -5350,56 +5085,6 @@ block2:
 ;   .byte 0x5f, 0xe2
 ;   c.unimp
 ;   c.unimp
-;   andi s7, t4, -0x73b
-;   c.and s1, a0
-;   .byte 0xe7, 0xdc
-;   c.swsp t2, 0xd0(sp)
-;   c.fsdsp fa5, 0x30(sp)
-;   c.li t0, 8
-;   c.sw a3, 0x24(a1)
-;   c.sd a4, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0x8e(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   c.li a4, 0
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 0
-;   ld a5, 0x7e(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 0
-;   ld a5, 0x78(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 0
-;   ld a5, 0x72(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   auipc a5, 0
-;   ld a5, 0x70(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 0
-;   ld a5, 0x62(a5)
-;   auipc s8, 0
-;   ld s8, 0x62(s8)
-;   sd a5, 0(s8) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 0
-;   ld a5, 0x42(a5)
-;   c.j 0x42
-;   fmadd.d fs0, fs7, fs11, fs6, rne
-;   c.lwsp a7, 0x64(sp)
-;   c.bnez a1, 0xb2
 ;   c.li t5, -0x11
 ;   c.li tp, 0x13
 ;   c.sw s0, 0x14(s1)
@@ -5407,14 +5092,6 @@ block2:
 ;   .byte 0x53, 0x6e
 ;   .byte 0x32, 0x50
 ;   auipc s6, 0x751cd
-;   c.slli t4, 0x2a
-;   .byte 0xdb, 0x19
-;   c.addi4spn a1, sp, 0x2a8
-;   c.sd s0, 0x78(a4)
-;   c.sw a2, 0x54(a1)
-;   c.addi4spn a0, sp, 0x2b8
-;   .byte 0xd3, 0x44
-;   c.beqz a5, 0xbc
 ;   c.lwsp ra, 0xdc(sp)
 ;   c.beqz a4, -0xc4
 ;   bltu t3, t1, 0x970
@@ -5426,63 +5103,6 @@ block2:
 ;   c.addiw t5, -0x10
 ;   c.addi4spn a1, sp, 0x88
 ;   c.fsdsp fa1, 0x90(sp)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 0
-;   ld a5, 0xba(a5)
-;   sd zero, 0(a5) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 0
-;   ld a5, 0xb2(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 0
-;   ld a5, 0xac(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 0
-;   ld a5, 0x9a(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   auipc a5, 0
-;   ld a5, 0x98(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 0
-;   ld a5, 0x92(a5)
-;   sd zero, 0(a5) ; trap: heap_oob
-;   auipc a5, 0
-;   ld a5, 0x8e(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 0
-;   ld a5, 0x88(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 0
-;   ld a5, 0x66(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 0
-;   ld a5, 0x5c(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   auipc a5, 0
-;   ld a5, 0x5a(a5)
-;   c.j 0x5a
 ;   andi s2, s2, -0x1cd
 ;   c.unimp
 ;   c.unimp
@@ -5490,14 +5110,6 @@ block2:
 ;   c.ld a1, 0(s1)
 ;   c.beqz a1, 0xea
 ;   c.beqz a5, 0xd4
-;   c.sdsp a2, 0x68(sp)
-;   c.addi4spn a0, sp, 0x3e0
-;   c.addiw a5, 0xd
-;   c.sd a1, 0xd0(s1)
-;   c.lui s1, 8
-;   c.sdsp t4, 0xa8(sp)
-;   c.ld s0, 0xe8(s0)
-;   .byte 0x67, 0x35
 ;   c.fsdsp ft10, 0x130(sp)
 ;   c.ld a4, 0x28(a5)
 ;   c.sw a5, 0x50(a0)
@@ -5509,45 +5121,9 @@ block2:
 ;   c.lw s0, 0x78(a1)
 ;   c.bnez a1, 0x72
 ;   c.lwsp ra, 0x7c(sp)
-;   ld a6, 0x2ac(a7)
-;   c.ld a5, 0x20(a2)
-;   c.fld fs0, 0xb8(s0)
-;   c.slli s5, 0x1b
-;   c.ld a1, 0xe8(a4)
-;   c.ld a2, 0x70(a4)
-;   .byte 0x5b, 0x19
-;   jal s10, 0x6b48a
-;   .byte 0x78, 0x96
-;   .byte 0xc3, 0x26
 ;   c.sdsp a6, 0x1c8(sp)
 ;   .byte 0x8c, 0x9d
 ;   fmsub.d fs3, fa4, ft5, fs4, rne
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 0
-;   ld a5, 0x42(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   auipc a5, 0
-;   ld a5, 0x40(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 0
-;   ld a5, 0x2e(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 0
-;   ld a5, 0x28(a5)
-;   c.j 0x28
-;   c.unimp
-;   c.unimp
-;   c.unimp
-;   c.srai s0, 0x1d
-;   c.slli s9, 8
-;   .byte 0x04, 0x94
-;   .byte 0xab, 0x36
 ;   .byte 0x4f, 0xa4
 ;   c.fldsp fs9, 0x158(sp)
 ;   c.fld fs1, 0x98(a5)
@@ -5559,38 +5135,12 @@ block2:
 ;   c.fsd fa1, 0x10(a5)
 ;   addi t2, a4, 0x44b
 ;   c.swsp t6, 0x5c(sp)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 0
-;   ld a5, 0x22(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   auipc a5, 0
-;   ld a5, 0x20(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   auipc a5, 0
-;   ld a5, 0x1e(a5)
-;   c.ld a5, 0(a5) ; trap: heap_oob
-;   c.j 0x1c
-;   c.unimp
-;   .byte 0x33, 0xf7
-;   c.lw a2, 0x28(a4)
-;   ori gp, s2, 0x376
 ;   c.fld fa3, 0xa0(s1)
 ;   c.sd a4, 0xc8(s1)
 ;   .byte 0xa7, 0x75
 ;   c.sd s1, 0xd0(a0)
 ;   c.j -0x4be
 ;   .byte 0x23, 0xc2
-;   c.unimp
-;   c.unimp
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 0
-;   ld a5, 0x18(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   auipc a5, 0
-;   ld a5, 0x16(a5)
-;   c.j 0x16
 ;   c.unimp
 ;   c.unimp
 ;   c.mv a4, t3
@@ -5601,1023 +5151,104 @@ block2:
 ;   c.fsdsp fs0, 0x38(sp)
 ;   c.fsdsp ft7, 0x88(sp)
 ;   c.beqz s1, 0x5a
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   c.j 2
-;   auipc a5, 0
-;   ld a5, 0x10(a5)
-;   c.j 0x10
-;   c.unimp
-;   c.unimp
-;   c.unimp
 ;   c.beqz s0, -0x100
 ;   .byte 0xdf, 0xec
 ;   c.lwsp t0, 0x70(sp)
 ;   c.lui t6, 0xfffe6
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   c.j 2
-;   auipc a5, 0
-;   ld a5, 0xc(a5)
-;   c.j 0xc
-;   c.unimp
 ;   c.fld fa1, 0x58(a0)
 ;   c.lw a1, 0x24(a5)
 ;   c.fldsp fa2, 0x60(sp)
 ;   c.beqz a2, -0x36
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   c.j 2
-;   sw zero, 0(a1) ; trap: heap_oob
-;   c.j 2
-;   auipc a5, 0
-;   ld a5, 0xe(a5)
-;   c.j 0xe
-;   c.unimp
-;   c.unimp
 ;   c.fsd fs0, 0xf8(s1)
 ;   c.sd s1, 0x40(s0)
 ;   c.sub a5, a4
 ;   c.swsp a5, 0x78(sp)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   c.j 2
-;   sd zero, 0(a1) ; trap: heap_oob
-;   c.j 2
-;   sw zero, 0(a1) ; trap: heap_oob
-;   c.j 2
-;   auipc a5, 0
-;   ld a5, 0x10(a5)
-;   c.j 0x10
-;   c.unimp
-;   c.unimp
-;   c.unimp
 ;   c.fsd fa4, 0x70(a1)
 ;   c.ld a2, 0x60(s0)
 ;   .byte 0xf0, 0x96
 ;   c.fsdsp fa0, 0x180(sp)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   c.j 2
-;   sd zero, 0(a1) ; trap: heap_oob
-;   c.j 2
-;   sw zero, 0(a1) ; trap: heap_oob
-;   c.j 2
-;   auipc a5, 0
-;   ld a5, 0x10(a5)
-;   c.j 0x10
-;   c.unimp
-;   c.unimp
-;   c.unimp
 ;   c.fld fa4, 0x70(a0)
 ;   c.swsp t0, 0x60(sp)
 ;   c.j 0x44c
 ;   c.addi4spn s1, sp, 0x3ac
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   c.j 2
+;   c.sd a4, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
-;   c.j 2
-;   auipc a5, 0
-;   ld a5, 0xe(a5)
-;   c.j 0xe
-;   c.unimp
-;   c.unimp
+;   auipc a4, 0
+;   ld a4, 0xda(a4)
+;   sd zero, 0(a4) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0xc6(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0xc0(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0xba(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0xb0(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0xaa(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0xa4(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0x96(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0x90(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0x8a(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0x80(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0x7e(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0x78(a4)
+;   c.ld a4, 0(a4) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0x72(a4)
+;   c.j 0x72
 ;   c.j -0x648
 ;   .byte 0x73, 0xca
 ;   c.unimp
 ;   c.unimp
-;   sd zero, 0(a5) ; trap: heap_oob
-;   c.j 2
-;   sd zero, 0(a1) ; trap: heap_oob
-;   c.j 2
-;   sw zero, 0(a1) ; trap: heap_oob
-;   c.j 2
-;   sd zero, 0(a1) ; trap: heap_oob
-;   c.j 2
-;   sw zero, 0(a1) ; trap: heap_oob
-;   c.j 2
-;   auipc a5, 0
-;   ld a5, 0xa(a5)
-;   c.j 0xa
 ;   auipc t6, 0x4769
 ;   fnmadd.d fa5, ft1, fa6, fs9, rup
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   c.j 2
-;   sw zero, 0(a1) ; trap: heap_oob
-;   c.j 2
-;   auipc a5, 0
-;   ld a5, 0xe(a5)
-;   c.j 0xe
-;   c.unimp
-;   c.unimp
 ;   fmsub.s ft4, fs5, fa0, fa6, rdn
 ;   c.ld a1, 0x78(a4)
 ;   c.beqz a1, 0x5c
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   c.j 2
-;   sw zero, 0(a1) ; trap: heap_oob
-;   c.j 2
-;   auipc a5, 0
-;   ld a5, 0xe(a5)
-;   c.j 0xe
-;   c.unimp
-;   c.unimp
 ;   csrrw s0, 3434, s3
 ;   fnmsub.s ft4, ft9, ft5, ft8
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   c.j 2
-;   sd zero, 0(a1) ; trap: heap_oob
-;   c.j 2
-;   sw zero, 0(a1) ; trap: heap_oob
-;   c.j 2
-;   auipc a5, 0
-;   ld a5, 0x18(a5)
-;   c.j 4
-;   c.unimp
-;   auipc t6, 0
-;   jalr zero, t6, 0x14
-;   c.unimp
-;   c.unimp
 ;   c.beqz a1, 0xb6
 ;   .byte 0xbf, 0x7f
 ;   c.fsdsp ft7, 0x180(sp)
 ;   c.bnez a1, 0x3c
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x39e(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x3a4(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x3b2(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x3b8(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x3be(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x3c8(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x3ca(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x3d0(a5)
-;   c.ld a5, 0(a5) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x3d6(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x3d8(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x3de(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x3ec(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x3fa(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x410(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x416(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x424(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x42e(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x434(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x436(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x43c(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x43e(a5)
-;   sd zero, 0(a5) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x446(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x45c(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x462(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x464(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x47e(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x484(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x48e(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x49c(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x49e(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x4a4(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x4a6(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x4b0(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x4be(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x4c8(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x4ca(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x4d0(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x4e2(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x4e4(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x4ea(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x4ec(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x4f2(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x4f4(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x4fe(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x504(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x506(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x508(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x50a(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x51c(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x522(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x524(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x52a(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x52c(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x542(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x550(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x55a(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x560(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x562(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x570(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x572(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x578(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x596(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x59c(a5)
-;   c.sd a2, 0(a5) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x5ae(a5)
-;   sd zero, 0(a5) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x5ce(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x5e4(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x5f2(a5)
-;   sd zero, 0(a5) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x602(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x604(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x60e(a5)
-;   c.sd a2, 0(a5) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x610(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x61a(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x620(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x622(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x63c(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x64a(a5)
-;   c.sd a2, 0(a5) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x64c(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x65e(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   lui a5, 0x4b912
-;   addi a5, a5, -0x6f
-;   auipc a6, 1
-;   ld a6, -0x678(a6)
-;   sw a5, 0(a6) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x680(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x682(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x688(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x696(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x6a0(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x6a2(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x6b8(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x6ee(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x6fc(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x6fe(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x704(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x70a(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x714(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x71a(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x724(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x72e(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x730(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x73a(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x740(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x746(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x770(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x776(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x778(a5)
-;   c.lw a5, 0(a5) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x782(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x78c(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x796(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x7a4(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x7ae(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x7b4(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x7b6(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x7bc(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x7c2(a5)
-;   sw zero, 0(a5) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x7da(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x7e0(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x7e2(a5)
-;   c.sw a3, 0(a5) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x7ec(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x7fe(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 0
-;   ld a5, 0x7f4(a5)
-;   c.sd a2, 0(a5) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 0
-;   ld a5, 0x7ee(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   auipc a5, 0
-;   ld a5, 0x7ec(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 0
-;   ld a5, 0x7e6(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sb a4, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 0
-;   ld a5, 0x7c0(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 0
-;   ld a5, 0x7b6(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   auipc a5, 0
-;   ld a5, 0x7b4(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 0
-;   ld a5, 0x7ae(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   auipc a5, 0
-;   ld a5, 0x7ac(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 0
-;   ld a5, 0x78e(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   auipc a5, 0
-;   ld a5, 0x78c(a5)
-;   c.sd a2, 0(a5) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 0
-;   ld a5, 0x786(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 0
-;   ld a5, 0x780(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 0
-;   ld a5, 0x776(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sb a4, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 0
-;   ld a5, 0x764(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 0
-;   ld a5, 0x75e(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 0
-;   ld a5, 0x754(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   auipc a5, 0
-;   ld a5, 0x752(a5)
-;   c.sd a2, 0(a5) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   c.lw a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 0
-;   ld a5, 0x73e(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 0
-;   ld a5, 0x734(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 0
-;   ld a5, 0x726(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 0
-;   ld a5, 0x71c(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 0
-;   ld a5, 0x702(a5)
-;   c.sd a2, 0(a5) ; trap: heap_oob
-;   auipc a5, 0
-;   ld a5, 0x700(a5)
-;   sd zero, 0(a5) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sb a4, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 0
-;   ld a5, 0x6e4(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 0
-;   ld a5, 0x6d6(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sb a4, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sb a4, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 0
-;   ld a5, 0x694(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 0
-;   ld a5, 0x68a(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 0
-;   ld a5, 0x680(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sb a4, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 0
-;   ld a5, 0x662(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 0
-;   ld a5, 0x65c(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 0
-;   ld a5, 0x656(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 0
-;   ld a5, 0x644(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   auipc a5, 0
-;   ld a5, 0x642(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 0
-;   ld a5, 0x638(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 0
-;   ld a5, 0x62a(a5)
-;   sd zero, 0(a5) ; trap: heap_oob
-;   sb a4, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 0
-;   ld a5, 0x61e(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 0
-;   ld a5, 0x618(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   auipc a5, 0
-;   ld a5, 0x616(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 0
-;   ld a5, 0x60c(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sb a3, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a3, 0
-;   ld a3, 0x5fa(a3)
-;   c.sd a3, 0(a1) ; trap: heap_oob
-;   auipc a3, 0
-;   ld a3, 0x5f8(a3)
-;   c.sd a3, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a3, 0
-;   ld a3, 0x5ee(a3)
-;   c.sd a3, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a3, 0
-;   ld a3, 0x5e8(a3)
-;   c.sd a3, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sb a4, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a3, 0
-;   ld a3, 0x5d6(a3)
-;   c.sd a2, 0(a3) ; trap: heap_oob
-;   auipc a2, 0
-;   ld a2, 0x5d4(a2)
-;   c.sd a2, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a2, 0
-;   ld a2, 0x5ce(a2)
-;   c.sd a2, 0(a1) ; trap: heap_oob
-;   auipc a2, 0
-;   ld a2, 0x5cc(a2)
-;   c.lui a3, 4
-;   addi a3, a3, -0x720
-;   c.sd a2, 0(a3) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a2, 0
-;   ld a2, 0x5b4(a2)
-;   c.lui a3, 4
-;   addi a3, a3, -0x6a4
-;   c.sd a2, 0(a3) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a2, 0
-;   ld a2, 0x59c(a2)
-;   c.lui a3, 4
-;   addi a3, a3, -0x5f0
-;   c.sd a2, 0(a3) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a2, 0
-;   ld a2, 0x588(a2)
-;   c.lui a3, 4
-;   addi a3, a3, -0x638
-;   c.sd a2, 0(a3) ; trap: heap_oob
-;   auipc a2, 0
-;   ld a2, 0x580(a2)
-;   c.lui a3, 4
-;   addi a3, a3, -0x640
-;   c.sd a2, 0(a3) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a2, 0
-;   ld a2, 0x570(a2)
-;   c.lui a3, 4
-;   addi a3, a3, -0x59c
-;   c.sd a2, 0(a3) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   c.j 4
-;   c.j 0xa
-;   auipc t6, 0
-;   jalr zero, t6, 0x558
-;   auipc t6, 0
-;   jalr zero, t6, 0x550
 ;   c.slli s10, 0x39
 ;   c.fldsp ft8, 0x80(sp)
 ;   c.slli t1, 0x3d
@@ -6653,6 +5284,59 @@ block2:
 ;   c.beqz a2, 0x9a
 ;   c.sd a5, 0x50(a1)
 ;   c.fsdsp fa3, 0x1d8(sp)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0xb6(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0xb0(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0xa2(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0x94(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0x7e(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0x78(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0x6a(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0x60(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0x5a(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0x58(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   c.j 0x56
+;   c.unimp
+;   c.unimp
 ;   .byte 0x33, 0x10
 ;   c.mv s1, s3
 ;   c.addiw a7, -0xa
@@ -6690,6 +5374,33 @@ block2:
 ;   c.fld fa5, 0x40(a5)
 ;   c.sw a4, 0x3c(s0)
 ;   c.fld fa1, 0x30(a1)
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0x5c(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0x5a(a4)
+;   sd zero, 0(a4) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0x52(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0x3c(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0x36(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0x34(a4)
+;   c.j 0x34
+;   c.unimp
 ;   c.fld fa2, 0xf0(a0)
 ;   c.fsdsp ft3, 0x1f0(sp)
 ;   c.mv s4, a6
@@ -6711,13 +5422,45 @@ block2:
 ;   .byte 0xd3, 0xbf
 ;   .byte 0x8f, 0xc1
 ;   c.lui s6, 0xfffe5
-;   jal s2, -0x20d7a
+;   jal s2, -0x701e8 ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0x1e(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0x18(a4)
+;   c.j 0x18
+;   c.unimp
+;   c.unimp
+;   c.unimp
+;   c.j 0xba
 ;   fnmsub.d fs2, fs11, fs7, fa3, rmm
 ;   c.swsp a7, 0x3c(sp)
 ;   c.sd a1, 0x60(a4)
 ;   .byte 0xc7, 0x21
 ;   c.swsp ra, 0x6c(sp)
 ;   c.sd a4, 0x20(a5)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0x26(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0x18(a4)
+;   c.j 0x18
+;   c.unimp
+;   c.unimp
+;   c.unimp
 ;   .byte 0xbf, 0x97
 ;   .byte 0x67, 0x98
 ;   .byte 0x55, 0x9e
@@ -6725,50 +5468,845 @@ block2:
 ;   c.lwsp s3, 0x40(sp)
 ;   c.fsdsp ft5, 0x38(sp)
 ;   .byte 0xc7, 0xd9
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0xe(a4)
+;   c.j 0xe
+;   c.unimp
+;   c.unimp
 ;   c.lui a2, 0xfffe5
 ;   c.ld s0, 0x80(s0)
 ;   c.addiw s1, -6
 ;   c.sd a0, 0xd0(a2)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0xa(a4)
+;   c.j 0xa
 ;   c.lw a5, 0x44(a2)
 ;   c.addi a1, -0x19
 ;   .byte 0x7f, 0xda
 ;   c.addiw t5, 3
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   c.j 2
+;   auipc a4, 0
+;   ld a4, 0xc(a4)
+;   c.j 0xc
+;   c.unimp
 ;   c.li ra, 1
 ;   c.add a1, s7
 ;   .byte 0xeb, 0x32
 ;   c.addi4spn a0, sp, 0x3a0
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   c.j 2
+;   sw zero, 0(a1) ; trap: heap_oob
+;   c.j 2
+;   sd zero, 0(a1) ; trap: heap_oob
+;   c.j 2
+;   auipc a4, 0
+;   ld a4, 0x10(a4)
+;   c.j 0x10
+;   c.unimp
+;   c.unimp
+;   c.unimp
 ;   c.sd s1, 0x48(a0)
 ;   c.slli a6, 0x1d
 ;   c.srai a2, 0x19
 ;   c.addi s6, 0x16
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   c.j 2
+;   sw zero, 0(a1) ; trap: heap_oob
+;   c.j 2
+;   sd zero, 0(a1) ; trap: heap_oob
+;   c.j 2
+;   sw zero, 0(a1) ; trap: heap_oob
+;   c.j 2
+;   auipc a4, 0
+;   ld a4, 0xa(a4)
+;   c.j 0xa
 ;   c.addi a3, -0x14
 ;   c.lwsp a2, 0x4c(sp)
 ;   c.fsdsp ft6, 0x18(sp)
 ;   .byte 0x7b, 0x1f
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   c.j 2
+;   sd zero, 0(a1) ; trap: heap_oob
+;   c.j 2
+;   sw zero, 0(a1) ; trap: heap_oob
+;   c.j 2
+;   auipc a4, 0
+;   ld a4, 0x10(a4)
+;   c.j 0x10
+;   c.unimp
+;   c.unimp
+;   c.unimp
 ;   c.mv s9, a4
 ;   .byte 0x3f, 0x74
 ;   c.lui t1, 0xfffea
 ;   c.beqz s1, 0xdc
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   c.j 2
+;   auipc a4, 0
+;   ld a4, 0xc(a4)
+;   c.j 0xc
+;   c.unimp
 ;   c.li tp, -6
 ;   c.addi4spn a3, sp, 0x1f8
 ;   c.sdsp s6, 0x90(sp)
 ;   c.addi gp, 0x1b
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   c.j 2
+;   sw zero, 0(a1) ; trap: heap_oob
+;   c.j 2
+;   auipc a4, 0
+;   ld a4, 0xe(a4)
+;   c.j 0xe
+;   c.unimp
+;   c.unimp
 ;   c.li a4, 0x1b
 ;   c.sd a2, 8(a5)
 ;   c.ld s0, 0x20(a3)
 ;   c.addi t4, -0x10
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   c.j 2
+;   sd zero, 0(a1) ; trap: heap_oob
+;   c.j 2
+;   sw zero, 0(a1) ; trap: heap_oob
+;   c.j 2
+;   sd zero, 0(a1) ; trap: heap_oob
+;   c.j 2
+;   sw zero, 0(a1) ; trap: heap_oob
+;   c.j 2
+;   auipc a4, 0
+;   ld a4, 0xc(a4)
+;   c.j 0xc
+;   c.unimp
 ;   c.ld s1, 0x30(a5)
 ;   c.li s3, -0x10
 ;   c.add s8, a0
 ;   c.fld fa0, 0x38(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   c.j 2
+;   auipc a4, 0
+;   ld a4, 0xc(a4)
+;   c.j 0xc
+;   c.unimp
 ;   c.fld fs0, 0x30(a4)
 ;   .byte 0xd7, 0x5e
 ;   .byte 0xd7, 0x7b
 ;   c.bnez a3, 0x52
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   c.j 2
+;   sw zero, 0(a1) ; trap: heap_oob
+;   c.j 2
+;   auipc a4, 0
+;   ld a4, 0x16(a4)
+;   c.j 2
+;   auipc t6, 0
+;   jalr zero, t6, 0x14
+;   c.unimp
+;   c.unimp
 ;   c.sdsp s3, 0x190(sp)
 ;   c.j 0x622
 ;   c.andi a1, 0xa
-;   flw fa7, -0x6ff(tp)
+;   flw fa7, -0x1e7(a6) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x62a(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x630(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x632(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x63c(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x642(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x644(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x646(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x648(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x65a(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x660(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x662(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x668(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x66a(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x680(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x68e(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x698(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x69e(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x6a0(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x6ae(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x6b0(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x6b6(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x6d4(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x6da(a4)
+;   c.sd a2, 0(a4) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x6ec(a4)
+;   sd zero, 0(a4) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x70c(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x722(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x730(a4)
+;   sd zero, 0(a4) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x740(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x742(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x74c(a4)
+;   c.sd a2, 0(a4) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x74e(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x758(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x75e(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x760(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x77a(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x788(a4)
+;   c.sd a2, 0(a4) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x78a(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x79c(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   lui a4, 0x4b912
+;   addi a4, a4, -0x6f
+;   auipc t0, 1
+;   ld t0, -0x7b6(t0)
+;   sw a4, 0(t0) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x7be(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x7c0(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x7c6(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x7d4(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x7de(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x7e0(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x7f6(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0x7d4(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0x7c6(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0x7c4(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0x7be(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0x7b8(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0x7ae(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0x7a8(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0x79e(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0x794(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0x792(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0x788(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0x782(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0x77c(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0x752(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0x74c(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0x74a(a4)
+;   c.lw a4, 0(a4) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0x740(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0x736(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0x72c(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0x71e(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0x714(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0x70e(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0x70c(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0x706(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0x700(a4)
+;   sw zero, 0(a4) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0x6e8(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0x6e2(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0x6e0(a4)
+;   c.sw a3, 0(a4) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0x6d6(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0x6c4(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0x6b6(a4)
+;   c.sd a2, 0(a4) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0x6b0(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0x6ae(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0x6a8(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sb a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0x682(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0x678(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0x676(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0x670(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0x66e(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0x650(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0x64e(a4)
+;   c.sd a2, 0(a4) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0x648(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0x642(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0x638(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sb a5, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0x626(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0x620(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0x616(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0x614(a4)
+;   c.sd a2, 0(a4) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   c.lw a4, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0x600(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0x5f6(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0x5e8(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0x5de(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0x5c4(a4)
+;   c.sd a2, 0(a4) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0x5c2(a4)
+;   sd zero, 0(a4) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sb a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0x5a6(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0x598(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sb a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sb a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0x556(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0x54c(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0x542(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sb a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0x524(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0x51e(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0x518(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0x506(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0x504(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0x4fa(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0x4ec(a4)
+;   sd zero, 0(a4) ; trap: heap_oob
+;   sb a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0x4e0(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0x4da(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0x4d8(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0x4ce(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sb a3, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0x4bc(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   auipc a3, 0
+;   ld a3, 0x4ba(a3)
+;   c.sd a3, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a3, 0
+;   ld a3, 0x4b0(a3)
+;   c.sd a3, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a3, 0
+;   ld a3, 0x4aa(a3)
+;   c.sd a3, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sb a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a3, 0
+;   ld a3, 0x498(a3)
+;   c.sd a2, 0(a3) ; trap: heap_oob
+;   auipc a2, 0
+;   ld a2, 0x496(a2)
+;   c.sd a2, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a2, 0
+;   ld a2, 0x490(a2)
+;   c.sd a2, 0(a1) ; trap: heap_oob
+;   auipc a2, 0
+;   ld a2, 0x48e(a2)
+;   c.lui a3, 4
+;   addi a3, a3, -0x720
+;   c.sd a2, 0(a3) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a2, 0
+;   ld a2, 0x476(a2)
+;   c.lui a3, 4
+;   addi a3, a3, -0x6a4
+;   c.sd a2, 0(a3) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a2, 0
+;   ld a2, 0x45e(a2)
+;   c.lui a3, 4
+;   addi a3, a3, -0x5f0
+;   c.sd a2, 0(a3) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a2, 0
+;   ld a2, 0x44a(a2)
+;   c.lui a3, 4
+;   addi a3, a3, -0x638
+;   c.sd a2, 0(a3) ; trap: heap_oob
+;   auipc a2, 0
+;   ld a2, 0x442(a2)
+;   c.lui a3, 4
+;   addi a3, a3, -0x640
+;   c.sd a2, 0(a3) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a2, 0
+;   ld a2, 0x432(a2)
+;   c.lui a3, 4
+;   addi a3, a3, -0x59c
+;   c.sd a2, 0(a3) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   c.j 6
+;   c.j 0xc
+;   c.unimp
+;   auipc t6, 0
+;   jalr zero, t6, 0x418
+;   auipc t6, 0
+;   jalr zero, t6, 0x410
+;   .byte 0x12, 0x90
 ;   c.fldsp fa4, 0x1a0(sp)
 ;   c.lw a1, 0x58(a2)
 ;   c.mv s10, a2
@@ -7247,7 +6785,7 @@ block2:
 ;   c.addi4spn s0, sp, 0x84
 ;   andi a7, s11, -0x6ab
 ;   c.swsp t5, 0xb4(sp)
-; block13: ; offset 0x1d28
+; block13: ; offset 0x19b8
 ;   c.li a2, 1
 ;   c.li a3, 2
 ;   c.mv a1, a0

--- a/cranelift/filetests/src/test_alias_analysis.rs
+++ b/cranelift/filetests/src/test_alias_analysis.rs
@@ -34,6 +34,7 @@ impl SubTest for TestAliasAnalysis {
         let mut comp_ctx = cranelift_codegen::Context::for_function(func.into_owned());
 
         comp_ctx.flowgraph();
+        comp_ctx.compute_post_dom_tree();
         comp_ctx
             .replace_redundant_loads()
             .map_err(|e| crate::pretty_anyhow_error(&comp_ctx.func, Into::into(e)))?;

--- a/tests/disas/component-model/direct-adapter-calls-inlining.wat
+++ b/tests/disas/component-model/direct-adapter-calls-inlining.wat
@@ -104,8 +104,6 @@
 ;;                                 block9:
 ;;                                     v11 = load.i64 notrap aligned readonly can_move region3 v3+112
 ;;                                     v12 = load.i32 notrap aligned region4 v11
-;;                                     v8 = iconst.i32 0
-;;                                     store notrap aligned region4 v8, v11  ; v8 = 0
 ;;                                     store notrap aligned region4 v12, v11
 ;;                                     jump block13
 ;;
@@ -116,8 +114,6 @@
 ;;                                     jump block12
 ;;
 ;;                                 block12:
-;;                                     v35 = iconst.i32 0
-;;                                     store notrap aligned region4 v35, v9  ; v35 = 0
 ;;                                     store.i32 notrap aligned region4 v10, v9
 ;;                                     jump block7
 ;;

--- a/tests/disas/component-model/direct-adapter-calls-x64.wat
+++ b/tests/disas/component-model/direct-adapter-calls-x64.wat
@@ -87,7 +87,7 @@
 ;;       movq    0x18(%r10), %r10
 ;;       addq    $0x60, %r10
 ;;       cmpq    %rsp, %r10
-;;       ja      0x140
+;;       ja      0x147
 ;;   79: subq    $0x50, %rsp
 ;;       movq    %rbx, 0x20(%rsp)
 ;;       movq    %r12, 0x28(%rsp)
@@ -109,21 +109,24 @@
 ;;       movq    (%rsp), %rsi
 ;;       callq   *%rax
 ;;       ├─╼ exception frame offset: SP = FP - 0x50
-;;       ╰─╼ exception handler: default handler, context at [SP+0x0], handler=0x12b
-;;       jmp     0x129
+;;       ╰─╼ exception handler: default handler, context at [SP+0x0], handler=0x132
+;;       jmp     0x130
 ;;   d5: movq    (%rsp), %rsi
 ;;       movq    0x70(%rsi), %rax
 ;;       movl    (%rax), %ecx
-;;       movl    $0, (%rax)
 ;;       movl    %ecx, (%rax)
 ;;       movq    0x48(%rsi), %rdi
 ;;       callq   0
 ;;       ├─╼ exception frame offset: SP = FP - 0x50
-;;       ╰─╼ exception handler: default handler, context at [SP+0x0], handler=0x12b
-;;       movq    0x10(%rsp), %rcx
-;;       movl    $0, (%rcx)
-;;       movq    8(%rsp), %rdx
-;;       movl    %edx, (%rcx)
+;;       ╰─╼ exception handler: default handler, context at [SP+0x0], handler=0xef
+;;       jmp     0xf7
+;;   ef: movq    %rax, %rdx
+;;       jmp     0x132
+;;   f7: movq    %rax, %rdx
+;;       movq    8(%rsp), %rcx
+;;       movq    0x10(%rsp), %rax
+;;       movl    %ecx, (%rax)
+;;       movq    %rdx, %rax
 ;;       movq    0x20(%rsp), %rbx
 ;;       movq    0x28(%rsp), %r12
 ;;       movq    0x30(%rsp), %r13
@@ -133,12 +136,12 @@
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;  124: jmp     0x12b
-;;  129: ud2
-;;  12b: movq    (%rsp), %rsi
-;;  12f: movq    0x58(%rsi), %rax
-;;  133: movq    0x68(%rsi), %rdi
-;;  137: movl    $0x31, %edx
-;;  13c: callq   *%rax
-;;  13e: ud2
-;;  140: ud2
+;;  12b: jmp     0x132
+;;  130: ud2
+;;  132: movq    (%rsp), %rsi
+;;  136: movq    0x58(%rsi), %rcx
+;;  13a: movq    0x68(%rsi), %rdi
+;;  13e: movl    $0x31, %edx
+;;  143: callq   *%rcx
+;;  145: ud2
+;;  147: ud2

--- a/tests/disas/component-model/direct-adapter-calls.wat
+++ b/tests/disas/component-model/direct-adapter-calls.wat
@@ -133,15 +133,11 @@
 ;;                                 block7:
 ;; @008e                               v11 = load.i64 notrap aligned readonly can_move region2 v0+112
 ;; @008e                               v12 = load.i32 notrap aligned region3 v11
-;; @0075                               v3 = iconst.i32 0
-;; @0094                               store notrap aligned region3 v3, v11  ; v3 = 0
 ;; @009a                               store notrap aligned region3 v12, v11
 ;; @009c                               v16 = load.i64 notrap aligned readonly can_move region4 v0+72
 ;; @009c                               try_call fn0(v16, v0, v2), sig1, block10(ret0), [ context v0, default: block6(exn0) ]
 ;;
 ;;                                 block10(v17: i32):
-;;                                     v24 = iconst.i32 0
-;; @00a2                               store notrap aligned region3 v24, v6  ; v24 = 0
 ;; @00a8                               store.i32 notrap aligned region3 v7, v6
 ;; @00aa                               jump block5
 ;;
@@ -149,10 +145,10 @@
 ;; @00ab                               jump block2
 ;;
 ;;                                 block3:
-;;                                     v25 = load.i64 notrap aligned readonly can_move region5 v0+88
-;;                                     v26 = load.i64 notrap aligned readonly can_move region4 v0+104
+;;                                     v24 = load.i64 notrap aligned readonly can_move region5 v0+88
+;;                                     v25 = load.i64 notrap aligned readonly can_move region4 v0+104
 ;; @00ae                               v21 = iconst.i32 49
-;; @00b0                               call_indirect sig0, v25(v26, v0, v21)  ; v21 = 49
+;; @00b0                               call_indirect sig0, v24(v25, v0, v21)  ; v21 = 49
 ;; @00b2                               trap user12
 ;;
 ;;                                 block2:

--- a/tests/disas/component-model/sync-adapter-calls.wat
+++ b/tests/disas/component-model/sync-adapter-calls.wat
@@ -149,7 +149,6 @@
 ;;                                     store notrap aligned region5 v19, v20+136
 ;;                                     v26 = load.i64 notrap aligned readonly can_move region3 v3+176
 ;;                                     v27 = load.i32 notrap aligned region4 v26
-;;                                     store notrap aligned region4 v8, v26  ; v8 = 0
 ;;                                     store notrap aligned region4 v27, v26
 ;;                                     jump block17
 ;;
@@ -169,8 +168,6 @@
 ;;                                     jump block15
 ;;
 ;;                                 block15:
-;;                                     v61 = iconst.i32 0
-;;                                     store notrap aligned region4 v61, v9  ; v61 = 0
 ;;                                     store.i32 notrap aligned region4 v10, v9
 ;;                                     store.i32 notrap aligned region4 v12, v11
 ;;                                     jump block7
@@ -179,10 +176,10 @@
 ;;                                     jump block4
 ;;
 ;;                                 block5:
-;;                                     v62 = load.i64 notrap aligned readonly can_move region14 v3+88
-;;                                     v63 = load.i64 notrap aligned readonly can_move region2 v3+104
+;;                                     v61 = load.i64 notrap aligned readonly can_move region14 v3+88
+;;                                     v62 = load.i64 notrap aligned readonly can_move region2 v3+104
 ;;                                     v48 = iconst.i32 49
-;;                                     call_indirect sig1, v62(v63, v3, v48)  ; v48 = 49
+;;                                     call_indirect sig1, v61(v62, v3, v48)  ; v48 = 49
 ;;                                     trap user12
 ;;
 ;;                                 block4:
@@ -272,7 +269,6 @@
 ;; @00f0                               store notrap aligned region6 v19, v20+136
 ;; @00f2                               v26 = load.i64 notrap aligned readonly can_move region2 v0+176
 ;; @00f2                               v27 = load.i32 notrap aligned region3 v26
-;; @00f8                               store notrap aligned region3 v3, v26  ; v3 = 0
 ;; @00fe                               store notrap aligned region3 v27, v26
 ;; @0100                               jump block15
 ;;
@@ -292,8 +288,6 @@
 ;; @0104                               jump block13
 ;;
 ;;                                 block13:
-;;                                     v55 = iconst.i32 0
-;; @0108                               store notrap aligned region3 v55, v6  ; v55 = 0
 ;; @010e                               store.i32 notrap aligned region3 v7, v6
 ;; @0112                               store.i32 notrap aligned region3 v12, v11
 ;; @0114                               jump block5
@@ -302,10 +296,10 @@
 ;; @0115                               jump block2
 ;;
 ;;                                 block3:
-;;                                     v56 = load.i64 notrap aligned readonly can_move region5 v0+88
-;;                                     v57 = load.i64 notrap aligned readonly can_move region4 v0+104
+;;                                     v55 = load.i64 notrap aligned readonly can_move region5 v0+88
+;;                                     v56 = load.i64 notrap aligned readonly can_move region4 v0+104
 ;; @0118                               v49 = iconst.i32 49
-;; @011a                               call_indirect sig0, v56(v57, v0, v49)  ; v49 = 49
+;; @011a                               call_indirect sig0, v55(v56, v0, v49)  ; v49 = 49
 ;; @011c                               trap user12
 ;;
 ;;                                 block2:

--- a/tests/disas/gc/drc/array-new-fixed-of-gc-refs.wat
+++ b/tests/disas/gc/drc/array-new-fixed-of-gc-refs.wat
@@ -63,8 +63,7 @@
 ;; @0025                               brif v58, block3, block2
 ;;
 ;;                                 block2:
-;;                                     v197 = load.i32 notrap aligned region9 v202
-;; @0025                               v59 = uextend.i64 v197
+;; @0025                               v59 = uextend.i64 v201
 ;; @0025                               v62 = iadd.i64 v20, v59
 ;; @0025                               v63 = iconst.i64 8
 ;; @0025                               v64 = iadd v62, v63  ; v63 = 8
@@ -75,12 +74,11 @@
 ;; @0025                               jump block3
 ;;
 ;;                                 block3:
-;;                                     v193 = load.i32 notrap aligned region9 v202
 ;; @0025                               v46 = uextend.i64 v45
 ;; @0025                               v49 = iadd.i64 v20, v46
 ;;                                     v206 = iconst.i64 12
 ;; @0025                               v52 = isub v49, v206  ; v206 = 12
-;; @0025                               store user2 little region5 v193, v52
+;; @0025                               store.i32 user2 little region5 v201, v52
 ;;                                     v305 = iadd.i64 v22, v23  ; v23 = 24
 ;; @0025                               v81 = load.i32 user2 readonly region5 v305
 ;;                                     v306 = iconst.i32 1
@@ -106,8 +104,7 @@
 ;; @0025                               brif v107, block5, block4
 ;;
 ;;                                 block4:
-;;                                     v187 = load.i32 notrap aligned region8 v203
-;; @0025                               v108 = uextend.i64 v187
+;; @0025                               v108 = uextend.i64 v191
 ;; @0025                               v111 = iadd.i64 v20, v108
 ;;                                     v311 = iconst.i64 8
 ;; @0025                               v113 = iadd v111, v311  ; v311 = 8
@@ -118,14 +115,13 @@
 ;; @0025                               jump block5
 ;;
 ;;                                 block5:
-;;                                     v183 = load.i32 notrap aligned region8 v203
 ;; @0025                               v95 = uextend.i64 v94
 ;; @0025                               v98 = iadd.i64 v20, v95
 ;;                                     v269 = iconst.i32 32
 ;; @0025                               v99 = isub.i32 v90, v269  ; v269 = 32
 ;; @0025                               v100 = uextend.i64 v99
 ;; @0025                               v101 = isub v98, v100
-;; @0025                               store user2 little region5 v183, v101
+;; @0025                               store.i32 user2 little region5 v191, v101
 ;;                                     v313 = iadd.i64 v22, v23  ; v23 = 24
 ;; @0025                               v130 = load.i32 user2 readonly region5 v313
 ;;                                     v314 = iconst.i32 2
@@ -151,8 +147,7 @@
 ;; @0025                               brif v156, block7, block6
 ;;
 ;;                                 block6:
-;;                                     v177 = load.i32 notrap aligned region7 v204
-;; @0025                               v157 = uextend.i64 v177
+;; @0025                               v157 = uextend.i64 v181
 ;; @0025                               v160 = iadd.i64 v20, v157
 ;;                                     v326 = iconst.i64 8
 ;; @0025                               v162 = iadd v160, v326  ; v326 = 8
@@ -163,14 +158,13 @@
 ;; @0025                               jump block7
 ;;
 ;;                                 block7:
-;;                                     v173 = load.i32 notrap aligned region7 v204
 ;; @0025                               v144 = uextend.i64 v143
 ;; @0025                               v147 = iadd.i64 v20, v144
 ;;                                     v299 = iconst.i32 36
 ;; @0025                               v148 = isub.i32 v139, v299  ; v299 = 36
 ;; @0025                               v149 = uextend.i64 v148
 ;; @0025                               v150 = isub v147, v149
-;; @0025                               store user2 little region5 v173, v150
+;; @0025                               store.i32 user2 little region5 v181, v150
 ;; @0029                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/idempotent-store.wat
+++ b/tests/disas/idempotent-store.wat
@@ -29,7 +29,7 @@
 ;; @0029                               v5 = load.i64 notrap aligned readonly can_move region2 v0+56
 ;; @0029                               v4 = uextend.i64 v2
 ;; @0029                               v6 = iadd v5, v4
-;; @0029                               store little region4 v3, v6
+;; @0030                               store little region4 v3, v6
 ;; @0033                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/x64-store-imm.wat
+++ b/tests/disas/x64-store-imm.wat
@@ -4,23 +4,70 @@
 (module
   (global $g (mut i32) (i32.const 0))
 
-  (func $foo
+  ;; All of these should result in the constant being folded into the `mov`
+  ;; instruction as an immediate operand, not materialized into a register.
+  (func $f0
     (global.set $g (i32.const 0))
+  )
+  (func $f1
     (global.set $g (i32.const 1))
+  )
+  (func $f2
     (global.set $g (i32.const -1))
+  )
+  (func $f3
     (global.set $g (i32.const -10))
+  )
+  (func $f4
     (global.set $g (i32.const 100000))
+  )
+  (func $f5
     (global.set $g (i32.const 0x8fff_ffff))
   )
 )
-;; wasm[0]::function[0]::foo:
+;; wasm[0]::function[0]::f0:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       movl    $0, 0x30(%rdi)
+;;       movq    %rbp, %rsp
+;;       popq    %rbp
+;;       retq
+;;
+;; wasm[0]::function[1]::f1:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
 ;;       movl    $1, 0x30(%rdi)
+;;       movq    %rbp, %rsp
+;;       popq    %rbp
+;;       retq
+;;
+;; wasm[0]::function[2]::f2:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
 ;;       movl    $0xffffffff, 0x30(%rdi)
+;;       movq    %rbp, %rsp
+;;       popq    %rbp
+;;       retq
+;;
+;; wasm[0]::function[3]::f3:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
 ;;       movl    $0xfffffff6, 0x30(%rdi)
+;;       movq    %rbp, %rsp
+;;       popq    %rbp
+;;       retq
+;;
+;; wasm[0]::function[4]::f4:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
 ;;       movl    $0x186a0, 0x30(%rdi)
+;;       movq    %rbp, %rsp
+;;       popq    %rbp
+;;       retq
+;;
+;; wasm[0]::function[5]::f5:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
 ;;       movl    $0x8fffffff, 0x30(%rdi)
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp


### PR DESCRIPTION
This commit adds an "observed?" bit to every alias region in the alias analysis's `LastStores` data. Loads from a region set the bit, as do instructions that act as memory fences, like calls. When we see a store to a region that hasn't been observed, and the store is to the same memory location as the last store to that region, then the last store is dead and can be removed. This integrates with alias analysis's existing single forwards pass that is fused with the egraph pass; it doesn't require additional passes or iterations. However, because it is a single pass and not a fixed point, updates do not cascade, and removing a dead store does not then recompute `LastStores` and reveal that (for example) the dead store's killer is an idempotent store which could also be removed. See the new `check-unset-reset-flag.clif` filetest, which roughly reflects what component-model fused adapters do with the `MAY_LEAVE` flag, for an example of this behavior.

Fixes https://github.com/bytecodealliance/wasmtime/issues/4167

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
